### PR TITLE
fixed session durations of more than 1 day

### DIFF
--- a/authentik/stages/user_login/stage.py
+++ b/authentik/stages/user_login/stage.py
@@ -33,7 +33,7 @@ class UserLoginStageView(StageView):
             backend=backend,
         )
         delta = timedelta_from_string(self.executor.current_stage.session_duration)
-        if delta.seconds == 0:
+        if delta.total_seconds() == 0:
             self.request.session.set_expiry(0)
         else:
             self.request.session.set_expiry(delta)


### PR DESCRIPTION
datetime.timedelta internally uses days, seconds and microseconds ([see here](https://docs.python.org/3/library/datetime.html#datetime.timedelta)), therefore a duration of one day is stored as days=1,seconds=0, which triggers your check.
This commit uses the total_seconds() function, which converts the timedelta object to a floating number of seconds.