### PR TITLE
LDAP: use username instead of name for user dn

### DIFF
--- a/outpost/pkg/ldap/instance_search.go
+++ b/outpost/pkg/ldap/instance_search.go
@@ -117,7 +117,7 @@ func (pi *ProviderInstance) Search(bindDN string, searchReq ldap.SearchRequest, 
 
 			attrs = append(attrs, AKAttrsToLDAP(u.Attributes)...)
 
-			dn := fmt.Sprintf("cn=%s,%s", *u.Name, pi.UserDN)
+			dn := fmt.Sprintf("cn=%s,%s", *u.Username, pi.UserDN)
 			entries = append(entries, &ldap.Entry{DN: dn, Attributes: attrs})
 		}
 	}


### PR DESCRIPTION
The current implementation of the LDAP provider returns users like this:
```
dn: cn=Andreas Egli,ou=users,dc=mydomain,dc=com
cn: andreas
name: Andreas Egli
```
Note that the dn contains the display name instead of the username. Therefore, the reported dn can't be used to log in to the LDAP server. This pull request changes the dn to use the cn, so that the returned data looks like this:

```
dn: cn=andreas,ou=users,dc=mydomain,dc=com
cn: andreas
name: Andreas Egli
```