### PR TITLE
Fix docker-compose.yml links in Installation instructions

### DIFF
--- a/website/docs/installation/docker-compose.md
+++ b/website/docs/installation/docker-compose.md
@@ -12,7 +12,7 @@ This installation method is for test-setups and small-scale productive setups.
 
 ## Preparation
 
-Download the latest `docker-compose.yml` from [here](https://raw.githubusercontent.com/goauthentik/authentik/version-2021.4/docker-compose.yml). Place it in a directory of your choice.
+Download the latest `docker-compose.yml` from [here](https://raw.githubusercontent.com/goauthentik/authentik/master/docker-compose.yml). Place it in a directory of your choice.
 
 To optionally enable error-reporting, run `echo AUTHENTIK_ERROR_REPORTING__ENABLED=true >> .env`
 


### PR DESCRIPTION
I spent at least an hour debugging today while setting up a new installation because the "latest" `docker-compose.yml` file linked in [these](https://goauthentik.io/docs/installation/docker-compose#preparation) instructions is actually pointing to `version-2021.4` , and the _real_ latest version (`2021.5`) has changed the ports of the container to 9000/9443.

I've updated the link to point to `master` instead, that way it doesn't need to be updated with each release to stay "latest".

I recommend changing the wording of your Release Notes as well for future releases. They currently say:

```
Download the latest docker-compose file from [here](https://raw.githubusercontent.com/goauthentik/authentik/version-2021.5/docker-compose.yml)
```

But what does latest mean here? Is it based on the current time? Or the time at which the release notes were done?

A one-word change makes it more clear:

```
Download the 2021.5 docker-compose file from [here](https://raw.githubusercontent.com/goauthentik/authentik/version-2021.5/docker-compose.yml)
```