### PR TITLE
Fix typo in migrations for authenticator_webauthn

### DIFF
--- a/authentik/stages/authenticator_webauthn/migrations/0002_default_setup_flow.py
+++ b/authentik/stages/authenticator_webauthn/migrations/0002_default_setup_flow.py
@@ -18,16 +18,16 @@ def create_default_setup_flow(apps: Apps, schema_editor: BaseDatabaseSchemaEdito
     db_alias = schema_editor.connection.alias
 
     flow, _ = Flow.objects.using(db_alias).update_or_create(
-        slug="default-authenticator-webuahtn-setup",
+        slug="default-authenticator-webauthn-setup",
         designation=FlowDesignation.STAGE_CONFIGURATION,
         defaults={
-            "name": "default-authenticator-webuahtn-setup",
+            "name": "default-authenticator-webauthn-setup",
             "title": "Setup WebAuthn",
         },
     )
 
     stage, _ = AuthenticateWebAuthnStage.objects.using(db_alias).update_or_create(
-        name="default-authenticator-webuahtn-setup"
+        name="default-authenticator-webauthn-setup"
     )
 
     FlowStageBinding.objects.using(db_alias).update_or_create(


### PR DESCRIPTION
There's a small typo in 0002_default_setup_flow.py, where "webauthn" was spelled as "webuahtn".
![image](https://user-images.githubusercontent.com/12488860/120244909-8c6fe580-c239-11eb-89e4-a38f3d511917.png)
