### PR TITLE
update docs to work with proxy

### DIFF
--- a/website/docs/integrations/services/grafana/index.mdx
+++ b/website/docs/integrations/services/grafana/index.mdx
@@ -56,6 +56,7 @@ environment:
     GF_AUTH_OAUTH_AUTO_LOGIN: "true"
     # Optionally map user groups to Grafana roles
     GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH: "contains(groups[*], 'Grafana Admins') && 'Admin' || contains(groups[*], 'Grafana Editors') && 'Editor' || 'Viewer'"
+    GF_SERVER_ROOT_URL: grafana.company  
 ```
   </TabItem>
   <TabItem value="standalone">


### PR DESCRIPTION
When using Grafana with a proxy like Traefik, Authentik gaves me redirect URl errors. This is because Grafana is using a localhost adres.  Adding the env 'GF_SERVER_ROOT_URL'  to the docs will fix the issue.