### PR TITLE
root: celery requires additional parameters when tls is enabled

### DIFF
--- a/authentik/lib/default.yml
+++ b/authentik/lib/default.yml
@@ -16,6 +16,7 @@ redis:
   port: 6379
   password: ''
   tls: false
+  tls_reqs: "none"
   cache_db: 0
   message_queue_db: 1
   ws_db: 2

--- a/authentik/root/settings.py
+++ b/authentik/root/settings.py
@@ -189,8 +189,10 @@ REST_FRAMEWORK = {
 }
 
 REDIS_PROTOCOL_PREFIX = "redis://"
+REDIS_CELERY_TLS_REQUIREMENTS = ""
 if CONFIG.y_bool("redis.tls", False):
     REDIS_PROTOCOL_PREFIX = "rediss://"
+    REDIS_CELERY_TLS_REQUIREMENTS = f"?ssl_cert_reqs={CONFIG.y('redis.tls_reqs')}"
 
 CACHES = {
     "default": {
@@ -340,11 +342,13 @@ CELERY_BROKER_URL = (
     f"{REDIS_PROTOCOL_PREFIX}:"
     f"{CONFIG.y('redis.password')}@{CONFIG.y('redis.host')}:"
     f"{int(CONFIG.y('redis.port'))}/{CONFIG.y('redis.message_queue_db')}"
+    f"{REDIS_CELERY_TLS_REQUIREMENTS}"
 )
 CELERY_RESULT_BACKEND = (
     f"{REDIS_PROTOCOL_PREFIX}:"
     f"{CONFIG.y('redis.password')}@{CONFIG.y('redis.host')}:"
     f"{int(CONFIG.y('redis.port'))}/{CONFIG.y('redis.message_queue_db')}"
+    f"{REDIS_CELERY_TLS_REQUIREMENTS}"
 )
 
 # Database backup


### PR DESCRIPTION
Celery needed a little bit more work for TLS to actually work on it.