### PR TITLE
docs: Forward authentication proxy and Grafana considerations

### DIFF
--- a/website/docs/integrations/services/grafana/index.mdx
+++ b/website/docs/integrations/services/grafana/index.mdx
@@ -95,3 +95,7 @@ contains(groups[*], 'Grafana Admins') && 'Admin' || contains(groups[*], 'Grafana
 ```
 
 For more information on group/role mappings, see [Grafana's docs](https://grafana.com/docs/grafana/latest/auth/generic-oauth/#role-mapping).
+
+### Grafana Configuration Considerations
+
+Make sure in your configuration that `root_url` is set correctly, otherwise your redirect url might get processed incorrectly. For example, if your grafana instance is running on the default configuration and is accesible behind a reverse proxy at `https://grafana.company`, your redirect url will end up looking like this, `https://grafana.company:3000`.

--- a/website/docs/integrations/services/grafana/index.mdx
+++ b/website/docs/integrations/services/grafana/index.mdx
@@ -99,3 +99,10 @@ For more information on group/role mappings, see [Grafana's docs](https://grafan
 ### Grafana Configuration Considerations
 
 Make sure in your configuration that `root_url` is set correctly, otherwise your redirect url might get processed incorrectly. For example, if your grafana instance is running on the default configuration and is accesible behind a reverse proxy at `https://grafana.company`, your redirect url will end up looking like this, `https://grafana.company:3000`.
+If you get `user does not belong to org` error when trying to log into grafana for the first time via OAuth, check if you have an organization with the ID of `1`, if not, then you have to add the following to your grafana config:
+
+```ini
+[users]
+auto_assign_org = true
+auto_assign_org_id = <id-of-your-default-organization>
+```

--- a/website/docs/providers/proxy/forward_auth.mdx
+++ b/website/docs/providers/proxy/forward_auth.mdx
@@ -58,6 +58,13 @@ server {
     ssl_certificate         /etc/ssl/certs/ssl-cert-snakeoil.pem;
     ssl_certificate_key     /etc/ssl/private/ssl-cert-snakeoil.key;
 
+    # Increase buffer size for large headers
+    # This is needed only if you get 'upstream sent too big header while reading response header from upstream' error when trying to access an application protected by goauthentik
+    proxy_buffers 8 16k;
+    proxy_buffer_size 32k;
+    fastcgi_buffers 16 16k;
+    fastcgi_buffer_size 32k;
+
     location / {
         # Put your proxy_pass to your application here
         # proxy_pass          http://localhost:5000;
@@ -80,9 +87,6 @@ server {
         proxy_set_header    Host $host;
         add_header          Set-Cookie $auth_cookie;
         auth_request_set    $auth_cookie $upstream_http_set_cookie;
-        # Increase buffer size for large headers
-        proxy_buffers       8 16k;
-        proxy_buffer_size   16k;
     }
 
     # Special location for when the /auth endpoint returns a 401,


### PR DESCRIPTION
# Details
* **Does this resolve an issue?**
N/A

## Changes
### New Features
N/A

### Breaking Changes
N/A

## Additional
- Updates nginx configration for proxy buffers to be in the `server` block instead of `location`
- Covers an edge-case when the default grafana organization does not have the id of `1`
- Takes into consideration the `root_url` grafana config which results in a malformed redirect url
