### PR TITLE
root: Require PG_PASS to be set

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     networks:
       - internal
     environment:
-      - POSTGRES_PASSWORD=${PG_PASS:-thisisnotagoodpassword}
+      - POSTGRES_PASSWORD=${PG_PASS:?database password required}
       - POSTGRES_USER=${PG_USER:-authentik}
       - POSTGRES_DB=${PG_DB:-authentik}
     env_file:


### PR DESCRIPTION
This raises an error when `PG_PASS` is not set (see [variable substitution](https://docs.docker.com/compose/compose-file/compose-file-v3/#variable-substitution)).

docker-compose recently changed the way `.env` files are searched for (see for example https://github.com/docker/compose/issues/8347) and with the current setup, authentik will not work anyway without a password set.