### PR TITLE
Fix docker-compose example

### DIFF
--- a/website/docs/troubleshooting/emails.md
+++ b/website/docs/troubleshooting/emails.md
@@ -13,7 +13,7 @@ If you omit the `-s` parameter, the email will be sent using the global settings
 To run this command with docker-compose, use
 
 ```
-docker-compose exec -it worker ./manage.py test_email [...]
+docker-compose exec worker ./manage.py test_email [...]
 ```
 
 To run this command with Kubernetes, use


### PR DESCRIPTION
`docker-compose exec` by default allocates a tty and does not support `-it`.

See https://docs.docker.com/compose/reference/exec/