### PR TITLE
Updating token url to new google url

### DIFF
--- a/authentik/sources/oauth/types/google.py
+++ b/authentik/sources/oauth/types/google.py
@@ -38,5 +38,5 @@ class GoogleType(SourceType):
     slug = "google"
 
     authorization_url = "https://accounts.google.com/o/oauth2/auth"
-    access_token_url = "https://accounts.google.com/o/oauth2/token"  # nosec
+    access_token_url = "https://oauth2.googleapis.com/token"  # nosec
     profile_url = "https://www.googleapis.com/oauth2/v1/userinfo"


### PR DESCRIPTION
The token url of the config goes to a 404
Google changed it, you can see it in their [open-id config](https://accounts.google.com/.well-known/openid-configuration)
I only changed the token url to reflect the new changes,
not doing so make authentik fallback to default auth