### PR TITLE
website/docs: add warning for example flows

### DIFF
--- a/website/docs/flow/examples.md
+++ b/website/docs/flow/examples.md
@@ -6,6 +6,10 @@ title: Example Flows
 You can apply theses flows multiple times to stay updated, however this will discard all changes you've made.
 :::
 
+:::info
+The example flows provided below will **override** the default flows, please review the contents of the example flow before importing and consider exporting the affected existing flows first.
+:::
+
 ## Enrollment (2 Stage)
 
 Flow: right-click [here](/flows/enrollment-2-stage.akflow) and save the file.


### PR DESCRIPTION
# Details
Add warning indicating example flows will override the default flows