### PR TITLE
website/docs: fix typos and grammar

### DIFF
--- a/website/docs/installation/configuration.md
+++ b/website/docs/installation/configuration.md
@@ -48,14 +48,14 @@ To use an S3-compatible storage, set the following settings.
 - `AUTHENTIK_REDIS__OUTPOST_SESSION_DB`: Database for sessions for the embedded outpost, defaults to 3
 - `AUTHENTIK_REDIS__CACHE_TIMEOUT`: Timeout for cached data until it expires in seconds, defaults to 300
 - `AUTHENTIK_REDIS__CACHE_TIMEOUT_FLOWS`: Timeout for cached flow plans until they expire in seconds, defaults to 300
-- `AUTHENTIK_REDIS__CACHE_TIMEOUT_POLICIES`: Timeout for cached polices until they expire in seconds, defaults to 300
+- `AUTHENTIK_REDIS__CACHE_TIMEOUT_POLICIES`: Timeout for cached policies until they expire in seconds, defaults to 300
 - `AUTHENTIK_REDIS__CACHE_TIMEOUT_REPUTATION`: Timeout for cached reputation until they expire in seconds, defaults to 300
 
 ## authentik Settings
 
 ### AUTHENTIK_SECRET_KEY
 
-Secret key used for cookie singing and unique user IDs, don't change this after the first install.
+Secret key used for cookie signing and unique user IDs, don't change this after the first install.
 
 ### AUTHENTIK_LOG_LEVEL
 

--- a/website/docs/installation/docker-compose.md
+++ b/website/docs/installation/docker-compose.md
@@ -31,7 +31,7 @@ echo "AUTHENTIK_ERROR_REPORTING__ENABLED=true" >> .env
 
 ## Email configuration (optional, but recommended)
 
-It is also recommended to configure global email credentials. These are used by authentik to notify you about alerts, configuration issues. They can also be used by [Email stages](flow/stages/email/index.md) to send verification/recovery emails.
+It is also recommended to configure global email credentials. These are used by authentik to notify you about alerts and configuration issues. They can also be used by [Email stages](flow/stages/email/index.md) to send verification/recovery emails.
 
 Append this block to your `.env` file
 

--- a/website/docs/maintenance/backups/index.md
+++ b/website/docs/maintenance/backups/index.md
@@ -25,7 +25,7 @@ This will dump the current database into the `./backups` folder. By defaults, th
 ### Restore
 
 :::warning
-Currently, it is only supported to restore backups into the same version they have been taken from. Different versions *might* work, but this is not guarantee.
+Currently, it is only supported to restore backups into the same version they have been taken from. Different versions *might* work, but this is not guaranteed.
 Instead, install the version the backup was taken with, restore the backup and then upgrade.
 :::
 

--- a/website/docs/outposts/embedded/embedded.md
+++ b/website/docs/outposts/embedded/embedded.md
@@ -18,7 +18,7 @@ On a fresh authentik install, your Outpost list will look like this:
 
 ![](./stock.png)
 
-Click the edit button on the right of the colum, and set the value of `authentik_host` to the URL you want to login with.
+Click the edit button on the right of the column, and set the value of `authentik_host` to the URL you want to login with.
 Make sure to set it to full URL, only configuring a hostname or FQDN will not work.
 
 ### Routing

--- a/website/docs/outposts/outposts.md
+++ b/website/docs/outposts/outposts.md
@@ -10,10 +10,10 @@ Upon creation, a service account and a token is generated. The service account o
 
 authentik can manage the deployment, updating and general lifecycle of an Outpost. To communicate with the underlying platforms on which the outpost is deployed, authentik has "Service Connections".
 
-- If you've deployed authentik on docker-compose, authentik automatically create a Service Connection for the local docker socket.
+- If you've deployed authentik on docker-compose, authentik automatically creates a Service Connection for the local docker socket.
 - If you've deployed authentik on Kubernetes, with `kubernetesIntegration` set to true (default), authentik automatically creates a Service Connection for the local Kubernetes Cluster.
 
-To deploy an outpost with these service connections, simply selected them during the creation of an Outpost. A background task is started, which creates the container/deployment. You can see that Status on the System Tasks page.
+To deploy an outpost with these service connections, simply select them during the creation of an Outpost. A background task is started, which creates the container/deployment. You can see that Status on the System Tasks page.
 
 To deploy an outpost manually, see:
 

--- a/website/docs/outposts/upgrading.md
+++ b/website/docs/outposts/upgrading.md
@@ -6,6 +6,6 @@ In the Outpost Overview list, you'll see if any deployed outposts are out of dat
 
 ![](./upgrading_outdated.png)
 
-To upgrade the Outpost to the latest version, simple adjust the docker tag of the outpost the the new version.
+To upgrade the Outpost to the latest version, simply adjust the docker tag of the outpost to the new version.
 
 Since the configuration is managed by authentik, that's all you have to do.

--- a/website/docs/providers/ldap.md
+++ b/website/docs/providers/ldap.md
@@ -12,7 +12,7 @@ You can configure an LDAP Provider for applications that don't support any newer
 Note: This provider requires the deployment of the [LDAP Outpost](../outposts/outposts.md)
 :::
 
-All users and groups in authentik's database are searchable. Currently, there is a limited support for filters (you can only search for objectClass), but this will be expanded in further releases.
+All users and groups in authentik's database are searchable. Currently, there is limited support for filters (you can only search for objectClass), but this will be expanded in further releases.
 
 Binding against the LDAP Server uses a flow in the background. This allows you to use the same policies and flows as you do for web-based logins. The only limitation is that currently only identification and password stages are supported, due to how LDAP works.
 

--- a/website/docs/providers/proxy/forward_auth.mdx
+++ b/website/docs/providers/proxy/forward_auth.mdx
@@ -3,7 +3,7 @@ title: Forward auth
 ---
 
 Using forward auth uses your existing reverse proxy to do the proxying, and only uses the
-authentik outpost to check authentication and authoirzation.
+authentik outpost to check authentication and authorization.
 
 To use forward auth instead of proxying, you have to change a couple of settings.
 In the Proxy Provider, make sure to use one of the Forward auth modes.
@@ -28,7 +28,7 @@ applications to different users.
 The only configuration difference between single application and domain level is the host you specify.
 
 For single application, you'd use the domain which the application is running on, and only /akprox
-is redirect to the outpost.
+is redirected to the outpost.
 
 For domain level, you'd use the same domain as authentik.
 

--- a/website/docs/tenants.md
+++ b/website/docs/tenants.md
@@ -2,7 +2,7 @@
 title: Tenants
 ---
 
-authentik support soft multi-tennancy. This means that you can configure several options depending on domain, but all the objects like applications, providers, etc, are still global. This can be handy to use the same authentik instance, but branded differently for different domains.
+authentik support soft multi-tenancy. This means that you can configure several options depending on domain, but all the objects like applications, providers, etc, are still global. This can be handy to use the same authentik instance, but branded differently for different domains.
 
 The main settings that tenants influence are flows and branding.
 


### PR DESCRIPTION
Corrects minor documentation typos and grammar. No substantial changes to the documentation content otherwise.