### PR TITLE
🐛 Fix failing traefik healthcheck

### DIFF
--- a/authentik/providers/proxy/controllers/docker.py
+++ b/authentik/providers/proxy/controllers/docker.py
@@ -29,6 +29,11 @@ class ProxyDockerController(DockerController):
         labels[f"traefik.http.routers.{traefik_name}-router.rule"] = f"Host({','.join(hosts)})"
         labels[f"traefik.http.routers.{traefik_name}-router.tls"] = "true"
         labels[f"traefik.http.routers.{traefik_name}-router.service"] = f"{traefik_name}-service"
-        labels[f"traefik.http.services.{traefik_name}-service.loadbalancer.healthcheck.path"] = "/"
+        labels[
+            f"traefik.http.services.{traefik_name}-service.loadbalancer.healthcheck.path"
+        ] = "/akprox/ping"
+        labels[
+            f"traefik.http.services.{traefik_name}-service.loadbalancer.healthcheck.port"
+        ] = "9300"
         labels[f"traefik.http.services.{traefik_name}-service.loadbalancer.server.port"] = "9000"
         return labels


### PR DESCRIPTION

# Details
* **Does this resolve an issue?**
This fixes an issue where Traefik would not forward traffic to a proxy outpost. Traefik would perform a healthcheck on port 9000 and get a `400 Bad Request` and consider the backend/service down.

## Changes
### New Features
* Updates the docker container labels for traefik to align to the healthcheck, that is `*:9300/akprox/ping`
