### PR TITLE
✏️ Fix typo 'username address' -> 'username'

### DIFF
--- a/authentik/core/migrations/0020_source_user_matching_mode.py
+++ b/authentik/core/migrations/0020_source_user_matching_mode.py
@@ -26,7 +26,7 @@ class Migration(migrations.Migration):
                     ),
                     (
                         "username_link",
-                        "Link to a user with identical username address. Can have security implications when a username is used with another source.",
+                        "Link to a user with identical username. Can have security implications when a username is used with another source.",
                     ),
                     (
                         "username_deny",

--- a/authentik/core/models.py
+++ b/authentik/core/models.py
@@ -283,7 +283,7 @@ class SourceUserMatchingModes(models.TextChoices):
     )
     USERNAME_LINK = "username_link", _(
         (
-            "Link to a user with identical username address. Can have security implications "
+            "Link to a user with identical username. Can have security implications "
             "when a username is used with another source."
         )
     )

--- a/web/src/locales/en.po
+++ b/web/src/locales/en.po
@@ -2331,8 +2331,8 @@ msgstr "Link to a user with identical email address. Can have security implicati
 
 #: src/pages/sources/oauth/OAuthSourceForm.ts
 #: src/pages/sources/plex/PlexSourceForm.ts
-msgid "Link to a user with identical username address. Can have security implications when a username is used with another source."
-msgstr "Link to a user with identical username address. Can have security implications when a username is used with another source."
+msgid "Link to a user with identical username. Can have security implications when a username is used with another source."
+msgstr "Link to a user with identical username. Can have security implications when a username is used with another source."
 
 #: src/pages/stages/invitation/InvitationListLink.ts
 msgid "Link to use the invitation."

--- a/web/src/locales/pseudo-LOCALE.po
+++ b/web/src/locales/pseudo-LOCALE.po
@@ -2323,7 +2323,7 @@ msgstr ""
 
 #: src/pages/sources/oauth/OAuthSourceForm.ts
 #: src/pages/sources/plex/PlexSourceForm.ts
-msgid "Link to a user with identical username address. Can have security implications when a username is used with another source."
+msgid "Link to a user with identical username. Can have security implications when a username is used with another source."
 msgstr ""
 
 #: src/pages/stages/invitation/InvitationListLink.ts

--- a/web/src/pages/sources/oauth/OAuthSourceForm.ts
+++ b/web/src/pages/sources/oauth/OAuthSourceForm.ts
@@ -219,7 +219,7 @@ export class OAuthSourceForm extends ModelForm<OAuthSource, string> {
                         ?selected=${this.instance?.userMatchingMode ===
                         UserMatchingModeEnum.UsernameLink}
                     >
-                        ${t`Link to a user with identical username address. Can have security implications when a username is used with another source.`}
+                        ${t`Link to a user with identical username. Can have security implications when a username is used with another source.`}
                     </option>
                     <option
                         value=${UserMatchingModeEnum.UsernameDeny}

--- a/web/src/pages/sources/plex/PlexSourceForm.ts
+++ b/web/src/pages/sources/plex/PlexSourceForm.ts
@@ -204,7 +204,7 @@ export class PlexSourceForm extends ModelForm<PlexSource, string> {
                         ?selected=${this.instance?.userMatchingMode ===
                         UserMatchingModeEnum.UsernameLink}
                     >
-                        ${t`Link to a user with identical username address. Can have security implications when a username is used with another source.`}
+                        ${t`Link to a user with identical username. Can have security implications when a username is used with another source.`}
                     </option>
                     <option
                         value=${UserMatchingModeEnum.UsernameDeny}


### PR DESCRIPTION
# Details
* **Does this resolve an issue?**
Fix typo, `username address` should just be `username`

<img width="561" alt="Fullscreen_26_9_21__11_42" src="https://user-images.githubusercontent.com/939704/134804475-04ad601d-cc48-4c6e-8220-a9dd1c92ec07.png">

