### PR TITLE
Use fully qualified names to get base images.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Lock python dependencies
-FROM python:3.9-slim-buster as locker
+FROM docker.io/python:3.9-slim-buster as locker
 
 COPY ./Pipfile /app/
 COPY ./Pipfile.lock /app/
@@ -11,7 +11,7 @@ RUN pip install pipenv && \
     pipenv lock -r --dev-only > requirements-dev.txt
 
 # Stage 2: Build website
-FROM node as website-builder
+FROM docker.io/node as website-builder
 
 COPY ./website /static/
 
@@ -19,7 +19,7 @@ ENV NODE_ENV=production
 RUN cd /static && npm i && npm run build-docs-only
 
 # Stage 3: Build webui
-FROM node as web-builder
+FROM docker.io/node as web-builder
 
 COPY ./web /static/
 
@@ -27,7 +27,7 @@ ENV NODE_ENV=production
 RUN cd /static && npm i && npm run build
 
 # Stage 4: Build go proxy
-FROM golang:1.17.1 AS builder
+FROM docker.io/golang:1.17.1 AS builder
 
 WORKDIR /work
 
@@ -47,7 +47,7 @@ COPY ./go.sum /work/go.sum
 RUN go build -o /work/authentik ./cmd/server/main.go
 
 # Stage 5: Run
-FROM python:3.9-slim-buster
+FROM docker.io/python:3.9-slim-buster
 
 WORKDIR /
 COPY --from=locker /app/requirements.txt /

--- a/ldap.Dockerfile
+++ b/ldap.Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM golang:1.17.1 AS builder
+FROM docker.io/golang:1.17.1 AS builder
 
 WORKDIR /go/src/goauthentik.io
 

--- a/proxy.Dockerfile
+++ b/proxy.Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build website
-FROM node as web-builder
+FROM docker.io/node as web-builder
 
 COPY ./web /static/
 
@@ -7,7 +7,7 @@ ENV NODE_ENV=production
 RUN cd /static && npm i && npm run build
 
 # Stage 2: Build
-FROM golang:1.17.1 AS builder
+FROM docker.io/golang:1.17.1 AS builder
 
 WORKDIR /go/src/goauthentik.io
 


### PR DESCRIPTION
Signed-off-by: Steven Armstrong <steven@armstrong.cc>

# Details

The current authentik Dockerfile does not work out of the box with podman.
```
podman build --pull \
   --tag docker.io/asteven/authentik:2021.9.3 \
   --tag docker.io/asteven/authentik:latest .
[1/5] STEP 1/5: FROM python:3.9-slim-buster AS locker
[2/5] STEP 1/4: FROM node AS website-builder
Error: error creating build container: short-name "python:3.9-slim-buster" did not resolve to an alias and no unqualified-search registries are de
fined in "/etc/containers/registries.conf"
```

Additionally, and more importantly, using short names to pull container images is potentially dangerous as explained in this [article from redhat](https://www.redhat.com/en/blog/be-careful-when-pulling-images-short-name).


## Changes
Prefix all docker images with "docker.io/"
