### PR TITLE
web: Fixed accidental change to package lock

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7010,7 +7010,7 @@
         "node_modules/require-from-string": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/view==",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -13786,7 +13786,7 @@
         "require-from-string": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/view=="
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
         },
         "require-main-filename": {
             "version": "2.0.0",


### PR DESCRIPTION
# Details
* **Does this resolve an issue?**
Currently can't complete installing the requirements for building web, due to 8dd77793a0f64f6ca41cbf1a3d33f01be54d25df accidently changing the ending of the integrity from `vEw==` to `view==`.
This change fixed this by reverting to what it was previously.