### PR TITLE
providers/ldap: use RDN when using posixGroup's memberUid attribute

### DIFF
--- a/authentik/sources/ldap/sync/membership.py
+++ b/authentik/sources/ldap/sync/membership.py
@@ -39,11 +39,17 @@ class MembershipLDAPSynchronizer(BaseLDAPSynchronizer):
             if not ak_group:
                 continue
 
+            membership_mapping_attribute = LDAP_DISTINGUISHED_NAME
+            if self._source.group_membership_field == "memberUid":
+                # If memberships are based on the posixGroup's 'memberUid'
+                # attribute we use the RDN instead of the FDN to lookup members.
+                membership_mapping_attribute = LDAP_UNIQUENESS
+
             users = User.objects.filter(
-                Q(**{f"attributes__{LDAP_DISTINGUISHED_NAME}__in": members})
+                Q(**{f"attributes__{membership_mapping_attribute}__in": members})
                 | Q(
                     **{
-                        f"attributes__{LDAP_DISTINGUISHED_NAME}__isnull": True,
+                        f"attributes__{membership_mapping_attribute}__isnull": True,
                         "ak_groups__in": [ak_group],
                     }
                 )

--- a/authentik/sources/ldap/tests/mock_slapd.py
+++ b/authentik/sources/ldap/tests/mock_slapd.py
@@ -77,5 +77,24 @@ def mock_slapd_connection(password: str) -> Connection:
             "objectClass": "person",
         },
     )
+    # Group with posixGroup and memberUid
+    connection.strategy.add_entry(
+        "cn=group-posix,ou=groups,dc=goauthentik,dc=io",
+        {
+            "cn": "group-posix",
+            "objectClass": "posixGroup",
+            "memberUid": ["user-posix"],
+        },
+    )
+    # User with posixAccount
+    connection.strategy.add_entry(
+        "cn=user-posix,ou=users,dc=goauthentik,dc=io",
+        {
+            "userPassword": password,
+            "uid": "user-posix",
+            "cn": "user-posix",
+            "objectClass": "posixAccount",
+        },
+    )
     connection.bind()
     return connection

--- a/web/src/pages/sources/ldap/LDAPSourceForm.ts
+++ b/web/src/pages/sources/ldap/LDAPSourceForm.ts
@@ -355,7 +355,7 @@ export class LDAPSourceForm extends ModelForm<LDAPSource, string> {
                             required
                         />
                         <p class="pf-c-form__helper-text">
-                            ${t`Field which contains members of a group.`}
+                            ${t`Field which contains members of a group. Note that if using the "memberUid" field, the value is assumed to contain a relative distinguished name. e.g. 'memberUid=some-user' instead of 'memberUid=cn=some-user,ou=groups,...'`}
                         </p>
                     </ak-form-element-horizontal>
                     <ak-form-element-horizontal


### PR DESCRIPTION
# Details
* **Does this resolve an issue?**
Resolves #1436

## Changes
### New Features
* Uses the RDN instead of the FDN when establishing group memberships based on posixGroup's 'memberUid' attribute.