### PR TITLE
docs/install: Fix typo on L91

### DIFF
--- a/website/docs/installation/docker-compose.md
+++ b/website/docs/installation/docker-compose.md
@@ -88,7 +88,7 @@ The docker-compose project contains the following containers:
 
 - server
 
-    This is the backend service, which does all the logic, runs the API and the actual SSO part. It also runs the frontend, hosts the JS/CSS files, and also servers the files you've uploaded for icons/etc.
+    This is the backend service, which does all the logic, runs the API and the actual SSO part. It also runs the frontend, hosts the JS/CSS files, and also serves the files you've uploaded for icons/etc.
 
 - worker
 


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/master/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details
* **Does this resolve an issue?**
No

## Changes
### New Features
Does not add a feature

### Breaking Changes
Does not introduce any breaking changes 

## Additional
This is a change to the documentation and simply fixes a typo in the Docker Compose install docs.
