### PR TITLE
website/integrations: Add Provider/HedgeDoc

### DIFF
--- a/website/integrations/services/hedgedoc/index.md
+++ b/website/integrations/services/hedgedoc/index.md
@@ -7,7 +7,7 @@ title: HedgeDoc
 From https://github.com/hedgedoc/hedgedoc
 
 :::note
-hedgedoc lets you create real-time collaborative markdown notes.
+HedgeDoc lets you create real-time collaborative markdown notes.
 :::
 
 ## Preparation

--- a/website/integrations/services/hedgedoc/index.md
+++ b/website/integrations/services/hedgedoc/index.md
@@ -1,0 +1,47 @@
+---
+title: HedgeDoc
+---
+
+## What is HedgeDoc
+
+From https://github.com/hedgedoc/hedgedoc
+
+:::note
+hedgedoc lets you create real-time collaborative markdown notes.
+:::
+
+## Preparation
+
+The following placeholders will be used:
+
+- `hedgedoc.company` is the FQDN of the HedgeDoc install.
+- `authentik.company` is the FQDN of the authentik install.
+
+Create an application in authentik. Create an OAuth2/OpenID provider with the following parameters:
+
+- Client Type: `Confidential`
+- JWT Algorithm: `RS256`
+- Scopes: OpenID, Email and Profile
+- RSA Key: Select any available key
+- Redirect URIs: `https://hedgedoc.company/auth/oauth2/callback`
+
+Note the Client ID and Client Secret values. Create an application, using the provider you've created above.
+
+## HedgeDoc
+
+You need to set the following `env` Variables for Docker based installations.
+
+Set the following values:
+
+```yaml
+CMD_OAUTH2_PROVIDERNAME: 'Authentik'
+CMD_OAUTH2_CLIENT_ID: '<Client ID from above>'
+CMD_OAUTH2_CLIENT_SECRET: '<Client Secret from above>'
+CMD_OAUTH2_SCOPE: 'openid email profile'
+CMD_OAUTH2_USER_PROFILE_URL: 'https://authentik.company/application/o/userinfo/'
+CMD_OAUTH2_TOKEN_URL: 'https://authentik.company/application/o/token/'
+CMD_OAUTH2_AUTHORIZATION_URL: 'https://authentik.company/application/o/authorize/'
+CMD_OAUTH2_USER_PROFILE_USERNAME_ATTR: 'preferred_username'
+CMD_OAUTH2_USER_PROFILE_DISPLAY_NAME_ATTR: 'name'
+CMD_OAUTH2_USER_PROFILE_EMAIL_ATTR: 'email'
+```

--- a/website/sidebarsIntegrations.js
+++ b/website/sidebarsIntegrations.js
@@ -34,6 +34,7 @@ module.exports = {
                 "services/gitlab/index",
                 "services/grafana/index",
                 "services/harbor/index",
+                "services/hedgedoc/index",
                 "services/home-assistant/index",
                 "services/matrix-synapse/index",
                 "services/minio/index",


### PR DESCRIPTION
# Details
Adds page to the website with instructions for configuring HedgeDoc

## Changes
### New Features
* Instructions for setting up HedgeDoc with the OAuth2/OpenID Provider