### PR TITLE
policies/expression: fix ak_user_has_authenticator evaluation when not specifying optional device_type

### DIFF
--- a/authentik/policies/expression/evaluator.py
+++ b/authentik/policies/expression/evaluator.py
@@ -44,13 +44,14 @@ class PolicyEvaluator(BaseEvaluator):
     ) -> bool:
         """Check if a user has any authenticator devices, optionally matching *device_type*"""
         user_devices = devices_for_user(user)
-        if device_type:
-            for device in user_devices:
+        for device in user_devices:
+            if device_type:
                 device_class = device.__class__.__name__.lower().replace("device", "")
                 if device_class == device_type:
                     return True
-            return False
-        return len(user_devices) > 0
+            else:
+                return True
+        return False
 
     def set_policy_request(self, request: PolicyRequest):
         """Update context based on policy request (if http request is given, update that too)"""

--- a/authentik/policies/expression/evaluator.py
+++ b/authentik/policies/expression/evaluator.py
@@ -44,14 +44,13 @@ class PolicyEvaluator(BaseEvaluator):
     ) -> bool:
         """Check if a user has any authenticator devices, optionally matching *device_type*"""
         user_devices = devices_for_user(user)
-        for device in user_devices:
-            if device_type:
+        if device_type:
+            for device in user_devices:
                 device_class = device.__class__.__name__.lower().replace("device", "")
                 if device_class == device_type:
                     return True
-            else:
-                return True
-        return False
+            return False
+        return len(list(user_devices)) > 0
 
     def set_policy_request(self, request: PolicyRequest):
         """Update context based on policy request (if http request is given, update that too)"""


### PR DESCRIPTION
## Details
Using ak_user_has_authenticator in an Expression Policy without providing a value for the optional device_type parameter currently results in an error "object of type 'generator' has no len()".  The django-otp framework's devices_for_user function returns a generator instead of a fleshed-out list, so len() is not applicable on the returned value from devices_for_user.

## Changes
Restructures the evaluation of the returned value from devices_for_user, keeping the current behavior when device_type is specified, but also taking advantage of the generator to return immediately after the first value is generated when device_type is not specified.