### PR TITLE
Updated bookstack integration docs page

### DIFF
--- a/website/integrations/services/bookstack/index.md
+++ b/website/integrations/services/bookstack/index.md
@@ -101,3 +101,9 @@ BookStack will attempt to match the SAML user to an existing BookStack user base
 :::note
 SAML Group Sync is supported by Bookstack.  Review the BookStack documentation on the required Environment variables.  https://www.bookstackapp.com/docs/admin/saml2-auth/
 :::
+
+:::note
+In some cases you might need to define the full SAML property name.
+i.e.: `SAML2_GROUP_ATTRIBUTE="http://schemas.xmlsoap.org/claims/Group"`
+See https://github.com/BookStackApp/BookStack/issues/3109 for more details.
+:::


### PR DESCRIPTION
In some cases one might need to define the full SAML property to enable proper group sync. (see: https://github.com/BookStackApp/BookStack/issues/3109 )
The changes in this PR add a note to the BookStack integrations page for Authentik which tells the user this might be required.


# Details
* **Does this resolve an issue?**
No, it's related to an issue I created in BookStack (https://github.com/BookStackApp/BookStack/issues/3109)

## Changes
### New Features
No Software features - just a docs addition.

### Breaking Changes
N/A

## Additional
It's merely a clarification on the required SAML Mappings for BookStack
