### PR TITLE
outposts/ldap: Fix more case sensitivity issues.

### DIFF
--- a/internal/outpost/ldap/bind/direct/direct.go
+++ b/internal/outpost/ldap/bind/direct/direct.go
@@ -16,6 +16,7 @@ import (
 	"goauthentik.io/internal/outpost/ldap/flags"
 	"goauthentik.io/internal/outpost/ldap/metrics"
 	"goauthentik.io/internal/outpost/ldap/server"
+	"goauthentik.io/internal/outpost/ldap/utils"
 )
 
 const ContextUserKey = "ak_user"
@@ -35,7 +36,7 @@ func NewDirectBinder(si server.LDAPServerInstance) *DirectBinder {
 }
 
 func (db *DirectBinder) GetUsername(dn string) (string, error) {
-	if !strings.HasSuffix(strings.ToLower(dn), strings.ToLower(db.si.GetBaseDN())) {
+	if !utils.HasSuffixNoCase(dn, db.si.GetBaseDN()) {
 		return "", errors.New("invalid base DN")
 	}
 	dns, err := goldap.ParseDN(dn)

--- a/internal/outpost/ldap/instance.go
+++ b/internal/outpost/ldap/instance.go
@@ -140,26 +140,26 @@ func (pi *ProviderInstance) GetNeededObjects(scope int, baseDN string, filterOC 
 	// If our requested base DN doesn't match any of the container DNs, then
 	// we're probably loading a user or group. If it does, then make sure our
 	// scope will eventually take us to users or groups.
-	if (baseDN == pi.BaseDN || strings.HasSuffix(baseDN, pi.UserDN)) && utils.IncludeObjectClass(filterOC, ldapConstants.GetUserOCs()) {
+	if (strings.EqualFold(baseDN, pi.BaseDN) || utils.HasSuffixNoCase(baseDN, pi.UserDN)) && utils.IncludeObjectClass(filterOC, ldapConstants.GetUserOCs()) {
 		if baseDN != pi.UserDN && baseDN != pi.BaseDN ||
-			baseDN == pi.BaseDN && scope > 1 ||
-			baseDN == pi.UserDN && scope > 0 {
+			strings.EqualFold(baseDN, pi.BaseDN) && scope > 1 ||
+			strings.EqualFold(baseDN, pi.UserDN) && scope > 0 {
 			needUsers = true
 		}
 	}
 
-	if (baseDN == pi.BaseDN || strings.HasSuffix(baseDN, pi.GroupDN)) && utils.IncludeObjectClass(filterOC, ldapConstants.GetGroupOCs()) {
+	if (strings.EqualFold(baseDN, pi.BaseDN) || utils.HasSuffixNoCase(baseDN, pi.GroupDN)) && utils.IncludeObjectClass(filterOC, ldapConstants.GetGroupOCs()) {
 		if baseDN != pi.GroupDN && baseDN != pi.BaseDN ||
-			baseDN == pi.BaseDN && scope > 1 ||
-			baseDN == pi.GroupDN && scope > 0 {
+			strings.EqualFold(baseDN, pi.BaseDN) && scope > 1 ||
+			strings.EqualFold(baseDN, pi.GroupDN) && scope > 0 {
 			needGroups = true
 		}
 	}
 
-	if (baseDN == pi.BaseDN || strings.HasSuffix(baseDN, pi.VirtualGroupDN)) && utils.IncludeObjectClass(filterOC, ldapConstants.GetVirtualGroupOCs()) {
+	if (strings.EqualFold(baseDN, pi.BaseDN) || utils.HasSuffixNoCase(baseDN, pi.VirtualGroupDN)) && utils.IncludeObjectClass(filterOC, ldapConstants.GetVirtualGroupOCs()) {
 		if baseDN != pi.VirtualGroupDN && baseDN != pi.BaseDN ||
-			baseDN == pi.BaseDN && scope > 1 ||
-			baseDN == pi.VirtualGroupDN && scope > 0 {
+			strings.EqualFold(baseDN, pi.BaseDN) && scope > 1 ||
+			strings.EqualFold(baseDN, pi.VirtualGroupDN) && scope > 0 {
 			needUsers = true
 		}
 	}

--- a/internal/outpost/ldap/search/request.go
+++ b/internal/outpost/ldap/search/request.go
@@ -26,7 +26,6 @@ type Request struct {
 func NewRequest(bindDN string, searchReq ldap.SearchRequest, conn net.Conn) (*Request, *sentry.Span) {
 	rid := uuid.New().String()
 	bindDN = strings.ToLower(bindDN)
-	searchReq.BaseDN = strings.ToLower(searchReq.BaseDN)
 	span := sentry.StartSpan(context.TODO(), "authentik.providers.ldap.search", sentry.TransactionName("authentik.providers.ldap.search"))
 	span.Description = fmt.Sprintf("%s (%s)", searchReq.BaseDN, ldap.ScopeMap[searchReq.Scope])
 	span.SetTag("request_uid", rid)

--- a/internal/outpost/ldap/utils/utils.go
+++ b/internal/outpost/ldap/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"reflect"
+	"strings"
 
 	"github.com/nmcclain/ldap"
 	log "github.com/sirupsen/logrus"
@@ -116,4 +117,8 @@ func GetContainerEntry(filterOC string, dn string, ou string) *ldap.Entry {
 	}
 
 	return nil
+}
+
+func HasSuffixNoCase(s1 string, s2 string) bool {
+	return strings.HasSuffix(strings.ToLower(s1), strings.ToLower(s2))
 }

--- a/internal/outpost/ldap/utils/utils_group.go
+++ b/internal/outpost/ldap/utils/utils_group.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"strings"
+
 	goldap "github.com/go-ldap/ldap/v3"
 	ber "github.com/nmcclain/asn1-ber"
 	"github.com/nmcclain/ldap"
@@ -41,7 +43,7 @@ func parseFilterForGroupSingle(req api.ApiCoreGroupsListRequest, f *ber.Packet) 
 	// Switch on type of the value, then check the key
 	switch vv := v.(type) {
 	case string:
-		switch k {
+		switch strings.ToLower(k.(string)) {
 		case "cn":
 			return req.Name(vv), false
 		case "member":
@@ -54,7 +56,7 @@ func parseFilterForGroupSingle(req api.ApiCoreGroupsListRequest, f *ber.Packet) 
 			username := userDN.RDNs[0].Attributes[0].Value
 			// If the DN's first ou is virtual-groups, ignore this filter
 			if len(userDN.RDNs) > 1 {
-				if userDN.RDNs[1].Attributes[0].Value == constants.OUVirtualGroups || userDN.RDNs[1].Attributes[0].Value == constants.OUGroups {
+				if strings.EqualFold(userDN.RDNs[1].Attributes[0].Value, constants.OUVirtualGroups) || strings.EqualFold(userDN.RDNs[1].Attributes[0].Value, constants.OUGroups) {
 					// Since we know we're not filtering anything, skip this request
 					return req, true
 				}


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/master/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details
* **Does this resolve an issue?**
Resolves #2120

## Changes
* All LDAP comparisons are now done using case insensitive methods.

### Breaking Changes
* Multiple LDAP providers with Base DNs that only differ by case will break.
   Which provider a given LDAP query will use when providers differ only in case undefined.

