### PR TITLE
Fix goauthentik.io URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ DigitalOcean provides development and testing resources for authentik.
     </a>
 </p>
 
-Netlify hosts the [goauthentik.io](goauthentik.io) site.
+Netlify hosts the [goauthentik.io](https://goauthentik.io) site.


### PR DESCRIPTION
There was a broken url at the bottom of the README. This PR prepends `https://` to it to fix it.
