### PR TITLE
docs(kubernetes.md): default to upgrade with install flag set

### DIFF
--- a/website/docs/installation/kubernetes.md
+++ b/website/docs/installation/kubernetes.md
@@ -41,7 +41,7 @@ Afterwards, run these commands to install authentik:
 ```
 helm repo add authentik https://charts.goauthentik.io
 helm repo update
-helm install authentik authentik/authentik -f values.yaml
+helm upgrade --install authentik authentik/authentik -f values.yaml
 ```
 
 This installation automatically applies database migrations on startup. After the installation is done, navigate to the `https://<ingress you've specified>/if/flow/initial-setup/`, to set a password for the akadmin user.


### PR DESCRIPTION
Changes the `helm install` step to do an upgrade, with the install flag set. This way, the same command can be run to later change values
