### PR TITLE
Enable 'secure' option for pwgen

### DIFF
--- a/website/docs/installation/docker-compose.md
+++ b/website/docs/installation/docker-compose.md
@@ -21,8 +21,8 @@ If this is a fresh authentik install run the following commands to generate a pa
 sudo apt-get install -y pwgen
 # Because of a PostgreSQL limitation, only passwords up to 99 chars are supported
 # See https://www.postgresql.org/message-id/09512C4F-8CB9-4021-B455-EF4C4F0D55A0@amazon.com
-echo "PG_PASS=$(pwgen 40 1)" >> .env
-echo "AUTHENTIK_SECRET_KEY=$(pwgen 50 1)" >> .env
+echo "PG_PASS=$(pwgen -s 40 1)" >> .env
+echo "AUTHENTIK_SECRET_KEY=$(pwgen -s 50 1)" >> .env
 # Skip if you don't want to enable error reporting
 echo "AUTHENTIK_ERROR_REPORTING__ENABLED=true" >> .env
 ```

--- a/website/docs/installation/kubernetes.md
+++ b/website/docs/installation/kubernetes.md
@@ -4,7 +4,7 @@ title: Kubernetes installation
 
 authentik is installed using a helm-chart.
 
-To install authentik using the helm chart, generate a password for the database and the cache, using `pwgen` or `openssl rand -base64 36`.
+To install authentik using the helm chart, generate a password for the database and the cache, using `pwgen -s 50 1` or `openssl rand -base64 36`.
 
 Create a values.yaml file with a minimum of these settings:
 


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/master/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details
* **Does this resolve an issue?**
Resolves #

## Changes
### New Features
* Enables "-s"(secure) option in pwgen

### Breaking Changes
* None

## Additional
As per the [pwgen manual](https://linux.die.net/man/1/pwgen), the "-s"(secure) option instructs pwgen to generate completely random passwords, where as the default for pwgen is to generate more memorable passwords. Since the passwords generated in this part of the installation process are to be "remembered" by the dot env file, I believe that users may benefit from the additional entropy provided by the "-s" option in pwgen.

EDIT: Deleted unnecessary commas.
