### PR TITLE
Remove extra trailing bracket in example code

### DIFF
--- a/website/integrations/services/matrix-synapse/index.md
+++ b/website/integrations/services/matrix-synapse/index.md
@@ -49,6 +49,6 @@ oidc_providers:
       - "email"
     user_mapping_provider:
       config:
-        localpart_template: "{{ user.preferred_username }}}"
+        localpart_template: "{{ user.preferred_username }}"
         display_name_template: "{{ user.name|capitalize }}"
 ```


### PR DESCRIPTION
In the sample code, there was an extra training "}" in the localpart_template causing all usernames to be appended with "=7D" before the server designation, such as:

@[Username]=7D:[ServerName]