### PR TITLE
Avoiding NIL entries

### DIFF
--- a/internal/outpost/ldap/search/direct/direct.go
+++ b/internal/outpost/ldap/search/direct/direct.go
@@ -252,7 +252,7 @@ func (ds *DirectSearcher) Search(req *search.Request) (ldap.ServerSearchResult, 
 	if scope >= 0 && (strings.EqualFold(req.BaseDN, ds.si.GetBaseDN()) || utils.HasSuffixNoCase(req.BaseDN, ds.si.GetBaseVirtualGroupDN())) {
 		singlevg := utils.HasSuffixNoCase(req.BaseDN, ","+ds.si.GetBaseVirtualGroupDN())
 
-		if !singlevg || utils.IncludeObjectClass(filterOC, constants.GetContainerOCs()) {
+		if !singlevg && utils.IncludeObjectClass(filterOC, constants.GetContainerOCs()) {
 			entries = append(entries, utils.GetContainerEntry(filterOC, ds.si.GetBaseVirtualGroupDN(), constants.OUVirtualGroups))
 			scope -= 1
 		}


### PR DESCRIPTION
Hello,

when fetching objects via ldap, the ldap outpost ran into a NIL error in one of the used libraries, due to NIL being added to the entries.
I am not sure, whether this PR fixes the issue in a ldap standard conformant way, but the logic checking for IncludeObjectClass in the outer if and again in utils.GetContainerEntry seems redundant to me.

