### PR TITLE
providers/oauth2: impl `/user/teams` endpoint for Github OAuth2

### DIFF
--- a/authentik/providers/oauth2/views/github.py
+++ b/authentik/providers/oauth2/views/github.py
@@ -1,8 +1,8 @@
 """authentik pretend GitHub Views"""
-from copy import copy
 
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.views import View
+from django.utils.text import slugify
 
 from authentik.providers.oauth2.models import RefreshToken
 
@@ -70,60 +70,58 @@ class GitHubUserTeamsView(View):
         """Emulate GitHub's /user/teams API Endpoint"""
         user = token.user
 
-        org_tpl = {
-            "id": 0,
-            "node_id": "",
-            "url": "",
-            "html_url": "",
-            "name": "",
-            "slug": "",
-            "description": "",
-            "privacy": "",
-            "permission": "",
-            "members_url": "",
-            "repositories_url": "",
-            "parent": None,
-            "members_count": 0,
-            "repos_count": 0,
-            "created_at": "",
-            "updated_at": "",
-            "organization": {
-                "login": "github",
-                "id": 1,
-                "node_id": "",
-                "url": "",
-                "repos_url": "",
-                "events_url": "",
-                "hooks_url": "",
-                "issues_url": "",
-                "members_url": "",
-                "public_members_url": "",
-                "avatar_url": "",
-                "description": "",
-                "name": "Authentik",
-                "company": "",
-                "blog": "",
-                "location": "",
-                "email": "",
-                "is_verified": True,
-                "has_organization_projects": True,
-                "has_repository_projects": True,
-                "public_repos": 0,
-                "public_gists": 0,
-                "followers": 0,
-                "following": 0,
-                "html_url": "",
-                "created_at": "",
-                "updated_at": "",
-                "type": "Organization"
-            }
-        }
-
         orgs_response = []
         for org in user.ak_groups.all():
-            _org = copy(org_tpl)
+            _org = {
+                "id": 0,
+                "node_id": "",
+                "url": "",
+                "html_url": "",
+                "name": "",
+                "slug": "",
+                "description": "",
+                "privacy": "",
+                "permission": "",
+                "members_url": "",
+                "repositories_url": "",
+                "parent": None,
+                "members_count": 0,
+                "repos_count": 0,
+                "created_at": "",
+                "updated_at": "",
+                "organization": {
+                    "login": "github",
+                    "id": 1,
+                    "node_id": "",
+                    "url": "",
+                    "repos_url": "",
+                    "events_url": "",
+                    "hooks_url": "",
+                    "issues_url": "",
+                    "members_url": "",
+                    "public_members_url": "",
+                    "avatar_url": "",
+                    "description": "",
+                    "name": "Authentik",
+                    "company": "",
+                    "blog": "",
+                    "location": "",
+                    "email": "",
+                    "is_verified": True,
+                    "has_organization_projects": True,
+                    "has_repository_projects": True,
+                    "public_repos": 0,
+                    "public_gists": 0,
+                    "followers": 0,
+                    "following": 0,
+                    "html_url": "",
+                    "created_at": "",
+                    "updated_at": "",
+                    "type": "Organization"
+                }
+            }
             _org["id"] = str(org.pk)
-            _org["slug"] = org.name.replace(" ", "-").lower()
+            _org["slug"] = slugify(org.name)
             _org["name"] = org.name
             orgs_response.append(_org)
         return JsonResponse(orgs_response, safe=False)

--- a/authentik/providers/oauth2/views/github.py
+++ b/authentik/providers/oauth2/views/github.py
@@ -1,4 +1,6 @@
 """authentik pretend GitHub Views"""
+from copy import copy
+
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.views import View
 
@@ -66,4 +68,63 @@ class GitHubUserTeamsView(View):
     # pylint: disable=unused-argument
     def get(self, request: HttpRequest, token: RefreshToken) -> HttpResponse:
         """Emulate GitHub's /user/teams API Endpoint"""
-        return JsonResponse([], safe=False)
+        user = token.user
+
+        org_tpl = {
+            "id": 0,
+            "node_id": "",
+            "url": "",
+            "html_url": "",
+            "name": "",
+            "slug": "",
+            "description": "",
+            "privacy": "",
+            "permission": "",
+            "members_url": "",
+            "repositories_url": "",
+            "parent": None,
+            "members_count": 0,
+            "repos_count": 0,
+            "created_at": "",
+            "updated_at": "",
+            "organization": {
+                "login": "github",
+                "id": 1,
+                "node_id": "",
+                "url": "",
+                "repos_url": "",
+                "events_url": "",
+                "hooks_url": "",
+                "issues_url": "",
+                "members_url": "",
+                "public_members_url": "",
+                "avatar_url": "",
+                "description": "",
+                "name": "Authentik",
+                "company": "",
+                "blog": "",
+                "location": "",
+                "email": "",
+                "is_verified": True,
+                "has_organization_projects": True,
+                "has_repository_projects": True,
+                "public_repos": 0,
+                "public_gists": 0,
+                "followers": 0,
+                "following": 0,
+                "html_url": "",
+                "created_at": "",
+                "updated_at": "",
+                "type": "Organization"
+            }
+        }
+
+        orgs_response = []
+        for org in user.ak_groups.all():
+            _org = copy(org_tpl)
+            _org["id"] = str(org.pk)
+            _org["slug"] = org.name.replace(" ", "-").lower()
+            _org["name"] = org.name
+            orgs_response.append(_org)
+        return JsonResponse(orgs_response, safe=False)
+    

--- a/authentik/providers/oauth2/views/github.py
+++ b/authentik/providers/oauth2/views/github.py
@@ -1,8 +1,8 @@
 """authentik pretend GitHub Views"""
 
 from django.http import HttpRequest, HttpResponse, JsonResponse
-from django.views import View
 from django.utils.text import slugify
+from django.views import View
 
 from authentik.providers.oauth2.models import RefreshToken
 
@@ -117,9 +117,8 @@ class GitHubUserTeamsView(View):
                     "html_url": "",
                     "created_at": "",
                     "updated_at": "",
-                    "type": "Organization"
-                }
+                    "type": "Organization",
+                },
             }
             orgs_response.append(_org)
         return JsonResponse(orgs_response, safe=False)
-    

--- a/authentik/providers/oauth2/views/github.py
+++ b/authentik/providers/oauth2/views/github.py
@@ -73,7 +73,7 @@ class GitHubUserTeamsView(View):
         orgs_response = []
         for org in user.ak_groups.all():
             _org = {
-                "id": str(org.pk),
+                "id": org.pk.int,
                 "node_id": "",
                 "url": "",
                 "html_url": "",

--- a/authentik/providers/oauth2/views/github.py
+++ b/authentik/providers/oauth2/views/github.py
@@ -73,7 +73,7 @@ class GitHubUserTeamsView(View):
         orgs_response = []
         for org in user.ak_groups.all():
             _org = {
-                "id": org.pk.int,
+                "id": org.num_pk,
                 "node_id": "",
                 "url": "",
                 "html_url": "",

--- a/authentik/providers/oauth2/views/github.py
+++ b/authentik/providers/oauth2/views/github.py
@@ -90,7 +90,7 @@ class GitHubUserTeamsView(View):
                 "created_at": "",
                 "updated_at": "",
                 "organization": {
-                    "login": "github",
+                    "login": slugify(request.tenant.branding_title),
                     "id": 1,
                     "node_id": "",
                     "url": "",
@@ -102,7 +102,7 @@ class GitHubUserTeamsView(View):
                     "public_members_url": "",
                     "avatar_url": "",
                     "description": "",
-                    "name": "Authentik",
+                    "name": request.tenant.branding_title,
                     "company": "",
                     "blog": "",
                     "location": "",

--- a/authentik/providers/oauth2/views/github.py
+++ b/authentik/providers/oauth2/views/github.py
@@ -73,12 +73,12 @@ class GitHubUserTeamsView(View):
         orgs_response = []
         for org in user.ak_groups.all():
             _org = {
-                "id": 0,
+                "id": str(org.pk),
                 "node_id": "",
                 "url": "",
                 "html_url": "",
-                "name": "",
-                "slug": "",
+                "name": org.name,
+                "slug": slugify(org.name),
                 "description": "",
                 "privacy": "",
                 "permission": "",
@@ -120,9 +120,6 @@ class GitHubUserTeamsView(View):
                     "type": "Organization"
                 }
             }
-            _org["id"] = str(org.pk)
-            _org["slug"] = slugify(org.name)
-            _org["name"] = org.name
             orgs_response.append(_org)
         return JsonResponse(orgs_response, safe=False)
     


### PR DESCRIPTION
## Changes
### New Features
This commit adds a functional `/user/teams` endpoint for the emulated Github OAuth2 service.
The teams a user is part of are based on the user's groups in Authentik.

Team slugs are generated based off of the team's name converted to lowercase and replacing spaces with dashes. This was done to more closely match the Github API. If you'd like to see any changes, please let me know!