### PR TITLE
Documentation: minor improvements

### DIFF
--- a/website/docs/core/certificates.md
+++ b/website/docs/core/certificates.md
@@ -39,7 +39,7 @@ You can also bind mount single files into the folder, as long as they fall under
     Otherwise it will be imported as certificate.
 
 - If the file is called `fullchain.pem` or `privkey.pem` (the output naming of certbot), they will get the name of the parent folder.
-- Files can be in any arbitrary file structure, and can have extension.
+- Files can be in any arbitrary file structure, and can have any extension.
 - If the path contains `archive`, the files will be ignored (to better support certbot setups).
 
 ```
@@ -47,10 +47,10 @@ certs/
 ├── baz
 │   └── bar.baz
 │       ├── fullchain.pem
-│       └── privkey.key
+│       └── privkey.pem
 ├── foo.bar
 │   ├── fullchain.pem
-│   └── privkey.key
+│   └── privkey.pem
 ├── foo.key
 └── foo.pem
 ```

--- a/website/docs/core/terminology.md
+++ b/website/docs/core/terminology.md
@@ -44,8 +44,6 @@ See [Property Mappings](./property-mappings/)
 
 ### Outpost
 
-An outpost is a separate component of authentik, which can be deployed anywhere, regardless of the authentik deployment. The outpost offers services that aren't implemented directly into the authentik core, like Reverse Proxying.
-
-Currently there is only a reverse-proxy outpost, in the future there will be more different outpost types.
+An outpost is a separate component of authentik, which can be deployed anywhere, regardless of the authentik deployment. The outpost offers services that aren't implemented directly into the authentik core, e.g. Reverse Proxying.
 
 See [Outposts](./outposts/)


### PR DESCRIPTION
Correct minor findings in certificates description
and remove an outpost sentence as because it doesn't add any value here