### PR TITLE
web: add missing checkbox element in user settings

### DIFF
--- a/web/src/user/user-settings/details/stages/prompt/PromptStage.ts
+++ b/web/src/user/user-settings/details/stages/prompt/PromptStage.ts
@@ -1,16 +1,39 @@
 import { t } from "@lingui/macro";
 
-import { TemplateResult, html } from "lit";
+import { CSSResult, TemplateResult, html } from "lit";
 import { customElement } from "lit/decorators.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 
-import { StagePrompt } from "@goauthentik/api";
+import PFCheck from "@patternfly/patternfly/components/Check/check.css";
+
+import { PromptTypeEnum, StagePrompt } from "@goauthentik/api";
 
 import "../../../../../elements/forms/HorizontalFormElement";
 import { PromptStage } from "../../../../../flows/stages/prompt/PromptStage";
 
 @customElement("ak-user-stage-prompt")
 export class UserSettingsPromptStage extends PromptStage {
+    static get styles(): CSSResult[] {
+        return super.styles.concat([PFCheck]);
+    }
+
+    renderPromptInner(prompt: StagePrompt, placeholderAsValue: boolean): string {
+        switch (prompt.type) {
+            // Checkbox requires slightly different rendering here due to the use of horizontal form elements
+            case PromptTypeEnum.Checkbox:
+                return `<input
+                    type="checkbox"
+                    class="pf-c-check__input"
+                    name="${prompt.fieldKey}"
+                    ?checked=${prompt.placeholder !== ""}
+                    ?required=${prompt.required}
+                    style="vertical-align: bottom"
+                />`;
+            default:
+                return super.renderPromptInner(prompt, placeholderAsValue);
+        }
+    }
+
     renderField(prompt: StagePrompt): TemplateResult {
         const errors = (this.challenge?.responseErrors || {})[prompt.fieldKey];
         return html`


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/master/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details
* **Does this resolve an issue?**
Minor: checkbox is missing in user settings.

## Changes
### New Features
* Add checkbox element to user settings `PrompStage`.
* Add required CSS elements to style it correctly.


## Additional
The default `PromptStage` handles checkboxes different in `renderField`, the user settings one does not do this and cannot do it whilst maintaining horizontal styling. This change extends the existing `renderPromptInner` to add checkbox support for this edge case.

There may be a better way of doing this, this is my first contribution, all be it minor, so very much learning the frameworks and codebase.
