### PR TITLE
Add Warning for Intranet Users

### DIFF
--- a/website/integrations/sources/apple/index.md
+++ b/website/integrations/sources/apple/index.md
@@ -10,6 +10,10 @@ Allows users to authenticate using their Apple ID.
 An Apple developer account is required for this.
 :::
 
+:::warning
+Apple only allows OAuth with public internet facing URIs, this will not work for intranet
+:::
+
 The following placeholders will be used:
 
 -   `authentik.company` is the FQDN of the authentik install.


### PR DESCRIPTION
I was am using Authentik as a intranet only source of authentication. I went thru all the steps list here (including paying $99) and at the VERY end; the apple developer website tells you....Only public URIs are allowed and more than likely only valid TLDs, because mine is atypical.

```
There is a problem with the request entity

authentik.<domainname>.<non-standard TLD> - Domain not eligible
```
