### PR TITLE
docs: Fix misconfiguration causing POST requests behing Nginx to timeout

### DIFF
--- a/website/docs/providers/proxy/_nginx_proxy_manager.md
+++ b/website/docs/providers/proxy/_nginx_proxy_manager.md
@@ -40,6 +40,10 @@ location /outpost.goauthentik.io {
     proxy_set_header    X-Original-URL $scheme://$http_host$request_uri;
     add_header          Set-Cookie $auth_cookie;
     auth_request_set    $auth_cookie $upstream_http_set_cookie;
+
+    # required for POST requests to work
+    proxy_pass_request_body off;
+    proxy_set_header Content-Length "";
 }
 
 # Special location for when the /auth endpoint returns a 401,

--- a/website/docs/providers/proxy/_nginx_standalone.md
+++ b/website/docs/providers/proxy/_nginx_standalone.md
@@ -46,6 +46,10 @@ server {
         proxy_set_header    X-Original-URL $scheme://$http_host$request_uri;
         add_header          Set-Cookie $auth_cookie;
         auth_request_set    $auth_cookie $upstream_http_set_cookie;
+
+        # required for POST requests to work
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
     }
 
     # Special location for when the /auth endpoint returns a 401,


### PR DESCRIPTION
Update docs: Fixes an Nginx misconfiguration where POST requests will not receive a response, leading to HTTP error 504 timeout