### PR TITLE
stages/authentiactor_validate: cookies

### DIFF
--- a/authentik/providers/oauth2/views/token.py
+++ b/authentik/providers/oauth2/views/token.py
@@ -9,7 +9,7 @@ from typing import Any, Optional
 from django.http import HttpRequest, HttpResponse
 from django.utils.timezone import datetime, now
 from django.views import View
-from jwt import InvalidTokenError, PyJWK, decode
+from jwt import PyJWK, PyJWTError, decode
 from sentry_sdk.hub import Hub
 from structlog.stdlib import get_logger
 
@@ -302,8 +302,8 @@ class TokenParams:
                         "verify_aud": False,
                     },
                 )
-            except (InvalidTokenError, ValueError, TypeError) as last_exc:
-                LOGGER.warning("failed to validate jwt", last_exc=last_exc)
+            except (PyJWTError, ValueError, TypeError) as exc:
+                LOGGER.warning("failed to validate jwt", exc=exc)
         # TODO: End remove block
 
         source: Optional[OAuthSource] = None
@@ -325,7 +325,7 @@ class TokenParams:
                     )
                 # AttributeError is raised when the configured JWK is a private key
                 # and not a public key
-                except (InvalidTokenError, ValueError, TypeError, AttributeError) as exc:
+                except (PyJWTError, ValueError, TypeError, AttributeError) as exc:
                     LOGGER.warning("failed to validate jwt", exc=exc)
 
         if not token:

--- a/authentik/stages/authenticator_validate/challenge.py
+++ b/authentik/stages/authenticator_validate/challenge.py
@@ -91,13 +91,13 @@ def select_challenge_sms(request: HttpRequest, device: SMSDevice):
     device.stage.send(device.token, device)
 
 
-def validate_challenge_code(code: str, request: HttpRequest, user: User) -> str:
+def validate_challenge_code(code: str, request: HttpRequest, user: User) -> Device:
     """Validate code-based challenges. We test against every device, on purpose, as
     the user mustn't choose between totp and static devices."""
     device = match_token(user, code)
     if not device:
         raise ValidationError(_("Invalid Token"))
-    return code
+    return device
 
 
 # pylint: disable=unused-argument
@@ -129,7 +129,7 @@ def validate_challenge_webauthn(data: dict, request: HttpRequest, user: User) ->
     return device
 
 
-def validate_challenge_duo(device_pk: int, request: HttpRequest, user: User) -> int:
+def validate_challenge_duo(device_pk: int, request: HttpRequest, user: User) -> Device:
     """Duo authentication"""
     device = get_object_or_404(DuoDevice, pk=device_pk)
     if device.user != user:
@@ -148,4 +148,4 @@ def validate_challenge_duo(device_pk: int, request: HttpRequest, user: User) -> 
     if response["result"] == "deny":
         raise ValidationError("Duo denied access")
     device.save()
-    return device_pk
+    return device

--- a/authentik/stages/authenticator_validate/tests/test_duo.py
+++ b/authentik/stages/authenticator_validate/tests/test_duo.py
@@ -45,9 +45,7 @@ class AuthenticatorValidateStageDuoTests(FlowTestCase):
             "authentik.stages.authenticator_duo.models.AuthenticatorDuoStage.client",
             duo_mock,
         ):
-            self.assertEqual(
-                duo_device.pk, validate_challenge_duo(duo_device.pk, request, self.user)
-            )
+            self.assertEqual(duo_device, validate_challenge_duo(duo_device.pk, request, self.user))
         with patch(
             "authentik.stages.authenticator_duo.models.AuthenticatorDuoStage.client",
             failed_duo_mock,

--- a/authentik/stages/authenticator_validate/tests/test_totp.py
+++ b/authentik/stages/authenticator_validate/tests/test_totp.py
@@ -15,6 +15,7 @@ from authentik.stages.authenticator_validate.challenge import (
     validate_challenge_code,
 )
 from authentik.stages.authenticator_validate.models import AuthenticatorValidateStage, DeviceClasses
+from authentik.stages.authenticator_validate.stage import COOKIE_NAME_MFA
 from authentik.stages.identification.models import IdentificationStage, UserFields
 
 
@@ -27,7 +28,7 @@ class AuthenticatorValidateStageTOTPTests(FlowTestCase):
 
     def test_last_auth_threshold(self):
         """Test last_auth_threshold"""
-        conf_stage = IdentificationStage.objects.create(
+        ident_stage = IdentificationStage.objects.create(
             name="conf",
             user_fields=[
                 UserFields.USERNAME,
@@ -47,9 +48,9 @@ class AuthenticatorValidateStageTOTPTests(FlowTestCase):
             not_configured_action=NotConfiguredAction.CONFIGURE,
             device_classes=[DeviceClasses.TOTP],
         )
-        stage.configuration_stages.set([conf_stage])
+        stage.configuration_stages.set([ident_stage])
         flow = Flow.objects.create(name="test", slug="test", title="test")
-        FlowStageBinding.objects.create(target=flow, stage=conf_stage, order=0)
+        FlowStageBinding.objects.create(target=flow, stage=ident_stage, order=0)
         FlowStageBinding.objects.create(target=flow, stage=stage, order=1)
 
         response = self.client.post(
@@ -69,7 +70,7 @@ class AuthenticatorValidateStageTOTPTests(FlowTestCase):
 
     def test_last_auth_threshold_valid(self):
         """Test last_auth_threshold"""
-        conf_stage = IdentificationStage.objects.create(
+        ident_stage = IdentificationStage.objects.create(
             name="conf",
             user_fields=[
                 UserFields.USERNAME,
@@ -79,19 +80,15 @@ class AuthenticatorValidateStageTOTPTests(FlowTestCase):
             user=self.user,
             confirmed=True,
         )
-        # Verify token once here to set last_t etc
-        totp = TOTP(device.bin_key)
-        sleep(1)
-        self.assertTrue(device.verify_token(totp.token()))
         stage = AuthenticatorValidateStage.objects.create(
             name="foo",
             last_auth_threshold="hours=1",
             not_configured_action=NotConfiguredAction.CONFIGURE,
             device_classes=[DeviceClasses.TOTP],
         )
-        stage.configuration_stages.set([conf_stage])
+        stage.configuration_stages.set([ident_stage])
         flow = Flow.objects.create(name="test", slug="test", title="test")
-        FlowStageBinding.objects.create(target=flow, stage=conf_stage, order=0)
+        FlowStageBinding.objects.create(target=flow, stage=ident_stage, order=0)
         FlowStageBinding.objects.create(target=flow, stage=stage, order=1)
 
         response = self.client.post(
@@ -101,8 +98,15 @@ class AuthenticatorValidateStageTOTPTests(FlowTestCase):
         self.assertEqual(response.status_code, 302)
         response = self.client.get(
             reverse("authentik_api:flow-executor", kwargs={"flow_slug": flow.slug}),
-            follow=True,
         )
+        # Verify token once here to set last_t etc
+        totp = TOTP(device.bin_key)
+        sleep(1)
+        response = self.client.post(
+            reverse("authentik_api:flow-executor", kwargs={"flow_slug": flow.slug}),
+            {"code": str(totp.token())},
+        )
+        self.assertIn(COOKIE_NAME_MFA, response.cookies)
         self.assertStageResponse(response, component="xak-flow-redirect", to="/")
 
     def test_device_challenge_totp(self):

--- a/authentik/stages/authenticator_webauthn/stage.py
+++ b/authentik/stages/authenticator_webauthn/stage.py
@@ -104,6 +104,7 @@ class AuthenticatorWebAuthnStageView(ChallengeStageView):
         )
 
         self.request.session["challenge"] = registration_options.challenge
+        self.request.session.save()
         return AuthenticatorWebAuthnChallenge(
             data={
                 "type": ChallengeTypes.NATIVE.value,

--- a/web/src/api/Users.ts
+++ b/web/src/api/Users.ts
@@ -31,10 +31,11 @@ export function me(): Promise<SessionUser> {
                     avatar: "",
                     uid: "",
                     username: "",
-                    name: ""
+                    name: "",
+                    settings: {},
                 }
             };
-            if (ex.status === 401 || ex.status === 403) {
+            if (ex.response.status === 401 || ex.response.status === 403) {
                 window.location.assign("/");
             }
             return defaultUser;


### PR DESCRIPTION
instead of checking the server-side last_t attribute of the device, set a signed JWT cookie with expiry per device

#2828