### PR TITLE
root: cleanup session keys to use common format

### DIFF
--- a/authentik/core/api/users.py
+++ b/authentik/core/api/users.py
@@ -43,7 +43,10 @@ from authentik.api.decorators import permission_required
 from authentik.core.api.groups import GroupSerializer
 from authentik.core.api.used_by import UsedByMixin
 from authentik.core.api.utils import LinkSerializer, PassiveSerializer, is_dict
-from authentik.core.middleware import SESSION_IMPERSONATE_ORIGINAL_USER, SESSION_IMPERSONATE_USER
+from authentik.core.middleware import (
+    SESSION_KEY_IMPERSONATE_ORIGINAL_USER,
+    SESSION_KEY_IMPERSONATE_USER,
+)
 from authentik.core.models import (
     USER_ATTRIBUTE_SA,
     USER_ATTRIBUTE_TOKEN_EXPIRING,
@@ -336,9 +339,9 @@ class UserViewSet(UsedByMixin, ModelViewSet):
         serializer = SessionUserSerializer(
             data={"user": UserSelfSerializer(instance=request.user, context=context).data}
         )
-        if SESSION_IMPERSONATE_USER in request._request.session:
+        if SESSION_KEY_IMPERSONATE_USER in request._request.session:
             serializer.initial_data["original"] = UserSelfSerializer(
-                instance=request._request.session[SESSION_IMPERSONATE_ORIGINAL_USER],
+                instance=request._request.session[SESSION_KEY_IMPERSONATE_ORIGINAL_USER],
                 context=context,
             ).data
         self.request.session.save()
@@ -368,7 +371,7 @@ class UserViewSet(UsedByMixin, ModelViewSet):
         except (ValidationError, IntegrityError) as exc:
             LOGGER.debug("Failed to set password", exc=exc)
             return Response(status=400)
-        if user.pk == request.user.pk and SESSION_IMPERSONATE_USER not in self.request.session:
+        if user.pk == request.user.pk and SESSION_KEY_IMPERSONATE_USER not in self.request.session:
             LOGGER.debug("Updating session hash after password change")
             update_session_auth_hash(self.request, user)
         return Response(status=204)

--- a/authentik/core/middleware.py
+++ b/authentik/core/middleware.py
@@ -7,8 +7,8 @@ from uuid import uuid4
 from django.http import HttpRequest, HttpResponse
 from sentry_sdk.api import set_tag
 
-SESSION_IMPERSONATE_USER = "authentik_impersonate_user"
-SESSION_IMPERSONATE_ORIGINAL_USER = "authentik_impersonate_original_user"
+SESSION_KEY_IMPERSONATE_USER = "authentik/impersonate/user"
+SESSION_KEY_IMPERSONATE_ORIGINAL_USER = "authentik/impersonate/original_user"
 LOCAL = local()
 RESPONSE_HEADER_ID = "X-authentik-id"
 KEY_AUTH_VIA = "auth_via"
@@ -25,10 +25,10 @@ class ImpersonateMiddleware:
 
     def __call__(self, request: HttpRequest) -> HttpResponse:
         # No permission checks are done here, they need to be checked before
-        # SESSION_IMPERSONATE_USER is set.
+        # SESSION_KEY_IMPERSONATE_USER is set.
 
-        if SESSION_IMPERSONATE_USER in request.session:
-            request.user = request.session[SESSION_IMPERSONATE_USER]
+        if SESSION_KEY_IMPERSONATE_USER in request.session:
+            request.user = request.session[SESSION_KEY_IMPERSONATE_USER]
             # Ensure that the user is active, otherwise nothing will work
             request.user.is_active = True
 

--- a/authentik/events/models.py
+++ b/authentik/events/models.py
@@ -23,7 +23,10 @@ from requests import RequestException
 from structlog.stdlib import get_logger
 
 from authentik import __version__
-from authentik.core.middleware import SESSION_IMPERSONATE_ORIGINAL_USER, SESSION_IMPERSONATE_USER
+from authentik.core.middleware import (
+    SESSION_KEY_IMPERSONATE_ORIGINAL_USER,
+    SESSION_KEY_IMPERSONATE_USER,
+)
 from authentik.core.models import ExpiringModel, Group, PropertyMapping, User
 from authentik.events.geo import GEOIP_READER
 from authentik.events.utils import cleanse_dict, get_user, model_to_dict, sanitize_dict
@@ -233,15 +236,15 @@ class Event(ExpiringModel):
         if hasattr(request, "user"):
             original_user = None
             if hasattr(request, "session"):
-                original_user = request.session.get(SESSION_IMPERSONATE_ORIGINAL_USER, None)
+                original_user = request.session.get(SESSION_KEY_IMPERSONATE_ORIGINAL_USER, None)
             self.user = get_user(request.user, original_user)
         if user:
             self.user = get_user(user)
         # Check if we're currently impersonating, and add that user
         if hasattr(request, "session"):
-            if SESSION_IMPERSONATE_ORIGINAL_USER in request.session:
-                self.user = get_user(request.session[SESSION_IMPERSONATE_ORIGINAL_USER])
-                self.user["on_behalf_of"] = get_user(request.session[SESSION_IMPERSONATE_USER])
+            if SESSION_KEY_IMPERSONATE_ORIGINAL_USER in request.session:
+                self.user = get_user(request.session[SESSION_KEY_IMPERSONATE_ORIGINAL_USER])
+                self.user["on_behalf_of"] = get_user(request.session[SESSION_KEY_IMPERSONATE_USER])
         # User 255.255.255.255 as fallback if IP cannot be determined
         self.client_ip = get_client_ip(request)
         # Apply GeoIP Data, when enabled

--- a/authentik/flows/stage.py
+++ b/authentik/flows/stage.py
@@ -60,6 +60,9 @@ class StageView(View):
             return self.executor.plan.context[PLAN_CONTEXT_PENDING_USER]
         return self.request.user
 
+    def cleanup(self):
+        """Cleanup session"""
+
 
 class ChallengeStageView(StageView):
     """Stage view which response with a challenge"""

--- a/authentik/flows/views/executor.py
+++ b/authentik/flows/views/executor.py
@@ -49,7 +49,7 @@ from authentik.flows.planner import (
     FlowPlan,
     FlowPlanner,
 )
-from authentik.flows.stage import AccessDeniedChallengeView
+from authentik.flows.stage import AccessDeniedChallengeView, StageView
 from authentik.lib.sentry import SentryIgnoredException
 from authentik.lib.utils.errors import exception_to_string
 from authentik.lib.utils.reflection import all_subclasses, class_to_path
@@ -59,11 +59,11 @@ from authentik.tenants.models import Tenant
 LOGGER = get_logger()
 # Argument used to redirect user after login
 NEXT_ARG_NAME = "next"
-SESSION_KEY_PLAN = "authentik_flows_plan"
-SESSION_KEY_APPLICATION_PRE = "authentik_flows_application_pre"
-SESSION_KEY_GET = "authentik_flows_get"
-SESSION_KEY_POST = "authentik_flows_post"
-SESSION_KEY_HISTORY = "authentik_flows_history"
+SESSION_KEY_PLAN = "authentik/flows/plan"
+SESSION_KEY_APPLICATION_PRE = "authentik/flows/application_pre"
+SESSION_KEY_GET = "authentik/flows/get"
+SESSION_KEY_POST = "authentik/flows/post"
+SESSION_KEY_HISTORY = "authentik/flows/history"
 QS_KEY_TOKEN = "flow_token"  # nosec
 
 
@@ -380,6 +380,8 @@ class FlowExecutorView(APIView):
             "f(exec): Stage ok",
             stage_class=class_to_path(self.current_stage_view.__class__),
         )
+        if isinstance(self.current_stage_view, StageView):
+            self.current_stage_view.cleanup()
         self.request.session.get(SESSION_KEY_HISTORY, []).append(deepcopy(self.plan))
         self.plan.pop()
         self.request.session[SESSION_KEY_PLAN] = self.plan
@@ -416,6 +418,8 @@ class FlowExecutorView(APIView):
             SESSION_KEY_APPLICATION_PRE,
             SESSION_KEY_PLAN,
             SESSION_KEY_GET,
+            # We might need the initial POST payloads for later requests
+            # SESSION_KEY_POST,
             # We don't delete the history on purpose, as a user might
             # still be inspecting it.
             # It's only deleted on a fresh executions

--- a/authentik/providers/oauth2/views/authorize.py
+++ b/authentik/providers/oauth2/views/authorize.py
@@ -69,7 +69,7 @@ from authentik.stages.user_login.stage import USER_LOGIN_AUTHENTICATED
 LOGGER = get_logger()
 
 PLAN_CONTEXT_PARAMS = "params"
-SESSION_NEEDS_LOGIN = "authentik_oauth2_needs_login"
+SESSION_KEY_NEEDS_LOGIN = "authentik/providers/oauth2/needs_login"
 
 ALLOWED_PROMPT_PARAMS = {PROMPT_NONE, PROMPT_CONSENT, PROMPT_LOGIN}
 
@@ -326,13 +326,13 @@ class AuthorizationFlowInitView(PolicyAccessView):
         # If prompt=login, we need to re-authenticate the user regardless
         if (
             PROMPT_LOGIN in self.params.prompt
-            and SESSION_NEEDS_LOGIN not in self.request.session
+            and SESSION_KEY_NEEDS_LOGIN not in self.request.session
             # To prevent the user from having to double login when prompt is set to login
             # and the user has just signed it. This session variable is set in the UserLoginStage
             # and is (quite hackily) removed from the session in applications's API's List method
             and USER_LOGIN_AUTHENTICATED not in self.request.session
         ):
-            self.request.session[SESSION_NEEDS_LOGIN] = True
+            self.request.session[SESSION_KEY_NEEDS_LOGIN] = True
             return self.handle_no_permission()
         # Regardless, we start the planner and return to it
         planner = FlowPlanner(self.provider.authorization_flow)

--- a/authentik/providers/saml/tests/test_auth_n_request.py
+++ b/authentik/providers/saml/tests/test_auth_n_request.py
@@ -19,7 +19,7 @@ from authentik.sources.saml.processors.constants import (
     SAML_NAME_ID_FORMAT_EMAIL,
     SAML_NAME_ID_FORMAT_UNSPECIFIED,
 )
-from authentik.sources.saml.processors.request import SESSION_REQUEST_ID, RequestProcessor
+from authentik.sources.saml.processors.request import SESSION_KEY_REQUEST_ID, RequestProcessor
 from authentik.sources.saml.processors.response import ResponseProcessor
 
 POST_REQUEST = (
@@ -142,7 +142,7 @@ class TestAuthNRequest(TestCase):
         request = request_proc.build_auth_n()
 
         # change the request ID
-        http_request.session[SESSION_REQUEST_ID] = "test"
+        http_request.session[SESSION_KEY_REQUEST_ID] = "test"
         http_request.session.save()
 
         # To get an assertion we need a parsed request (parsed by provider)

--- a/authentik/providers/saml/views/flows.py
+++ b/authentik/providers/saml/views/flows.py
@@ -34,7 +34,7 @@ REQUEST_KEY_SAML_SIG_ALG = "SigAlg"
 REQUEST_KEY_SAML_RESPONSE = "SAMLResponse"
 REQUEST_KEY_RELAY_STATE = "RelayState"
 
-SESSION_KEY_AUTH_N_REQUEST = "authn_request"
+SESSION_KEY_AUTH_N_REQUEST = "authentik/providers/saml/authn_request"
 
 # This View doesn't have a URL on purpose, as its called by the FlowExecutor
 class SAMLFlowFinalView(ChallengeStageView):
@@ -106,3 +106,6 @@ class SAMLFlowFinalView(ChallengeStageView):
     def challenge_valid(self, response: ChallengeResponse) -> HttpResponse:
         # We'll never get here since the challenge redirects to the SP
         return HttpResponseBadRequest()
+
+    def cleanup(self):
+        self.request.session.pop(SESSION_KEY_AUTH_N_REQUEST, None)

--- a/authentik/sources/oauth/clients/oauth2.py
+++ b/authentik/sources/oauth/clients/oauth2.py
@@ -11,7 +11,7 @@ from structlog.stdlib import get_logger
 from authentik.sources.oauth.clients.base import BaseOAuthClient
 
 LOGGER = get_logger()
-SESSION_OAUTH_PKCE = "oauth_pkce"
+SESSION_KEY_OAUTH_PKCE = "authentik/sources/oauth/pkce"
 
 
 class OAuth2Client(BaseOAuthClient):
@@ -70,8 +70,8 @@ class OAuth2Client(BaseOAuthClient):
             "code": code,
             "grant_type": "authorization_code",
         }
-        if SESSION_OAUTH_PKCE in self.request.session:
-            args["code_verifier"] = self.request.session[SESSION_OAUTH_PKCE]
+        if SESSION_KEY_OAUTH_PKCE in self.request.session:
+            args["code_verifier"] = self.request.session[SESSION_KEY_OAUTH_PKCE]
         try:
             access_token_url = self.source.type.access_token_url or ""
             if self.source.type.urls_customizable and self.source.access_token_url:

--- a/authentik/sources/oauth/types/twitter.py
+++ b/authentik/sources/oauth/types/twitter.py
@@ -2,7 +2,7 @@
 from typing import Any
 
 from authentik.lib.generators import generate_id
-from authentik.sources.oauth.clients.oauth2 import SESSION_OAUTH_PKCE
+from authentik.sources.oauth.clients.oauth2 import SESSION_KEY_OAUTH_PKCE
 from authentik.sources.oauth.types.azure_ad import AzureADClient
 from authentik.sources.oauth.types.manager import MANAGER, SourceType
 from authentik.sources.oauth.views.callback import OAuthCallback
@@ -13,10 +13,10 @@ class TwitterOAuthRedirect(OAuthRedirect):
     """Twitter OAuth2 Redirect"""
 
     def get_additional_parameters(self, source):  # pragma: no cover
-        self.request.session[SESSION_OAUTH_PKCE] = generate_id()
+        self.request.session[SESSION_KEY_OAUTH_PKCE] = generate_id()
         return {
             "scope": ["users.read", "tweet.read"],
-            "code_challenge": self.request.session[SESSION_OAUTH_PKCE],
+            "code_challenge": self.request.session[SESSION_KEY_OAUTH_PKCE],
             "code_challenge_method": "plain",
         }
 

--- a/authentik/sources/plex/plex.py
+++ b/authentik/sources/plex/plex.py
@@ -11,8 +11,6 @@ from authentik.lib.utils.http import get_http_session
 from authentik.sources.plex.models import PlexSource, PlexSourceConnection
 
 LOGGER = get_logger()
-SESSION_ID_KEY = "PLEX_ID"
-SESSION_CODE_KEY = "PLEX_CODE"
 
 
 class PlexAuth:

--- a/authentik/sources/saml/processors/request.py
+++ b/authentik/sources/saml/processors/request.py
@@ -19,7 +19,7 @@ from authentik.sources.saml.processors.constants import (
     SIGN_ALGORITHM_TRANSFORM_MAP,
 )
 
-SESSION_REQUEST_ID = "authentik_source_saml_request_id"
+SESSION_KEY_REQUEST_ID = "authentik/sources/saml/request_id"
 
 
 class RequestProcessor:
@@ -38,7 +38,7 @@ class RequestProcessor:
         self.http_request = request
         self.relay_state = relay_state
         self.request_id = get_random_id()
-        self.http_request.session[SESSION_REQUEST_ID] = self.request_id
+        self.http_request.session[SESSION_KEY_REQUEST_ID] = self.request_id
         self.issue_instant = get_time_string()
 
     def get_issuer(self) -> Element:

--- a/authentik/sources/saml/processors/response.py
+++ b/authentik/sources/saml/processors/response.py
@@ -45,7 +45,7 @@ from authentik.sources.saml.processors.constants import (
     SAML_NAME_ID_FORMAT_WINDOWS,
     SAML_NAME_ID_FORMAT_X509,
 )
-from authentik.sources.saml.processors.request import SESSION_REQUEST_ID
+from authentik.sources.saml.processors.request import SESSION_KEY_REQUEST_ID
 from authentik.stages.password.stage import PLAN_CONTEXT_AUTHENTICATION_BACKEND
 from authentik.stages.prompt.stage import PLAN_CONTEXT_PROMPT
 from authentik.stages.user_login.stage import BACKEND_INBUILT
@@ -119,11 +119,11 @@ class ResponseProcessor:
             seen_ids.append(self._root.attrib["ID"])
             cache.set(CACHE_SEEN_REQUEST_ID % self._source.pk, seen_ids)
             return
-        if SESSION_REQUEST_ID not in request.session or "InResponseTo" not in self._root.attrib:
+        if SESSION_KEY_REQUEST_ID not in request.session or "InResponseTo" not in self._root.attrib:
             raise MismatchedRequestID(
                 "Missing InResponseTo and IdP-initiated Logins are not allowed"
             )
-        if request.session[SESSION_REQUEST_ID] != self._root.attrib["InResponseTo"]:
+        if request.session[SESSION_KEY_REQUEST_ID] != self._root.attrib["InResponseTo"]:
             raise MismatchedRequestID("Mismatched request ID")
 
     def _handle_name_id_transient(self, request: HttpRequest) -> HttpResponse:

--- a/authentik/stages/authenticator_duo/stage.py
+++ b/authentik/stages/authenticator_duo/stage.py
@@ -18,8 +18,8 @@ from authentik.stages.authenticator_duo.models import AuthenticatorDuoStage, Duo
 
 LOGGER = get_logger()
 
-SESSION_KEY_DUO_USER_ID = "authentik_stages_authenticator_duo_user_id"
-SESSION_KEY_DUO_ACTIVATION_CODE = "authentik_stages_authenticator_duo_activation_code"
+SESSION_KEY_DUO_USER_ID = "authentik/stages/authenticator_duo/user_id"
+SESSION_KEY_DUO_ACTIVATION_CODE = "authentik/stages/authenticator_duo/activation_code"
 
 
 class AuthenticatorDuoChallenge(WithUserInfoChallenge):
@@ -95,3 +95,7 @@ class AuthenticatorDuoStageView(ChallengeStageView):
         else:
             return self.executor.stage_invalid("Device with Credential ID already exists.")
         return self.executor.stage_ok()
+
+    def cleanup(self):
+        self.request.session.pop(SESSION_KEY_DUO_USER_ID)
+        self.request.session.pop(SESSION_KEY_DUO_ACTIVATION_CODE)

--- a/authentik/stages/authenticator_sms/tests.py
+++ b/authentik/stages/authenticator_sms/tests.py
@@ -8,7 +8,7 @@ from authentik.core.models import User
 from authentik.flows.challenge import ChallengeTypes
 from authentik.flows.models import Flow, FlowDesignation, FlowStageBinding
 from authentik.stages.authenticator_sms.models import AuthenticatorSMSStage, SMSProviders
-from authentik.stages.authenticator_sms.stage import SESSION_SMS_DEVICE
+from authentik.stages.authenticator_sms.stage import SESSION_KEY_SMS_DEVICE
 
 
 class AuthenticatorSMSStageTests(APITestCase):
@@ -85,7 +85,7 @@ class AuthenticatorSMSStageTests(APITestCase):
                 data={
                     "component": "ak-stage-authenticator-sms",
                     "phone_number": "foo",
-                    "code": int(self.client.session[SESSION_SMS_DEVICE].token),
+                    "code": int(self.client.session[SESSION_KEY_SMS_DEVICE].token),
                 },
             )
             self.assertEqual(response.status_code, 200)

--- a/authentik/stages/authenticator_validate/tests/test_stage.py
+++ b/authentik/stages/authenticator_validate/tests/test_stage.py
@@ -13,7 +13,7 @@ from authentik.lib.tests.utils import dummy_get_response
 from authentik.stages.authenticator_validate.api import AuthenticatorValidateStageSerializer
 from authentik.stages.authenticator_validate.models import AuthenticatorValidateStage
 from authentik.stages.authenticator_validate.stage import (
-    SESSION_DEVICE_CHALLENGES,
+    SESSION_KEY_DEVICE_CHALLENGES,
     AuthenticatorValidationChallengeResponse,
 )
 from authentik.stages.identification.models import IdentificationStage, UserFields
@@ -83,7 +83,7 @@ class AuthenticatorValidateStageTests(FlowTestCase):
 
         middleware = SessionMiddleware(dummy_get_response)
         middleware.process_request(request)
-        request.session[SESSION_DEVICE_CHALLENGES] = [
+        request.session[SESSION_KEY_DEVICE_CHALLENGES] = [
             {
                 "device_class": "static",
                 "device_uid": "1",

--- a/authentik/stages/password/stage.py
+++ b/authentik/stages/password/stage.py
@@ -30,7 +30,7 @@ LOGGER = get_logger()
 PLAN_CONTEXT_AUTHENTICATION_BACKEND = "user_backend"
 PLAN_CONTEXT_METHOD = "auth_method"
 PLAN_CONTEXT_METHOD_ARGS = "auth_method_args"
-SESSION_INVALID_TRIES = "user_invalid_tries"
+SESSION_KEY_INVALID_TRIES = "authentik/stages/password/user_invalid_tries"
 
 
 def authenticate(request: HttpRequest, backends: list[str], **credentials: Any) -> Optional[User]:
@@ -100,16 +100,16 @@ class PasswordStageView(ChallengeStageView):
         return challenge
 
     def challenge_invalid(self, response: PasswordChallengeResponse) -> HttpResponse:
-        if SESSION_INVALID_TRIES not in self.request.session:
-            self.request.session[SESSION_INVALID_TRIES] = 0
-        self.request.session[SESSION_INVALID_TRIES] += 1
+        if SESSION_KEY_INVALID_TRIES not in self.request.session:
+            self.request.session[SESSION_KEY_INVALID_TRIES] = 0
+        self.request.session[SESSION_KEY_INVALID_TRIES] += 1
         current_stage: PasswordStage = self.executor.current_stage
         if (
-            self.request.session[SESSION_INVALID_TRIES]
+            self.request.session[SESSION_KEY_INVALID_TRIES]
             > current_stage.failed_attempts_before_cancel
         ):
             LOGGER.debug("User has exceeded maximum tries")
-            del self.request.session[SESSION_INVALID_TRIES]
+            del self.request.session[SESSION_KEY_INVALID_TRIES]
             return self.executor.stage_invalid()
         return super().challenge_invalid(response)
 

--- a/authentik/stages/user_write/stage.py
+++ b/authentik/stages/user_write/stage.py
@@ -9,7 +9,7 @@ from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
 from structlog.stdlib import get_logger
 
-from authentik.core.middleware import SESSION_IMPERSONATE_USER
+from authentik.core.middleware import SESSION_KEY_IMPERSONATE_USER
 from authentik.core.models import USER_ATTRIBUTE_SOURCES, User, UserSourceConnection
 from authentik.core.sources.stage import PLAN_CONTEXT_SOURCES_CONNECTION
 from authentik.flows.planner import PLAN_CONTEXT_PENDING_USER
@@ -117,7 +117,7 @@ class UserWriteStageView(StageView):
         if (
             any("password" in x for x in data.keys())
             and self.request.user.pk == user.pk
-            and SESSION_IMPERSONATE_USER not in self.request.session
+            and SESSION_KEY_IMPERSONATE_USER not in self.request.session
         ):
             should_update_session = True
         self.update_user(user)


### PR DESCRIPTION
use common format for all session keys (constants beginning with SESSION_KEY and values matching the module)