### PR TITLE
*: don't dispatch tasks on startup of server

### DIFF
--- a/authentik/admin/apps.py
+++ b/authentik/admin/apps.py
@@ -12,7 +12,4 @@ class AuthentikAdminConfig(AppConfig):
     verbose_name = "authentik Admin"
 
     def ready(self):
-        from authentik.admin.tasks import clear_update_notifications
-
-        clear_update_notifications.delay()
         import_module("authentik.admin.signals")

--- a/authentik/managed/apps.py
+++ b/authentik/managed/apps.py
@@ -8,9 +8,3 @@ class AuthentikManagedConfig(AppConfig):
     name = "authentik.managed"
     label = "authentik_managed"
     verbose_name = "authentik Managed"
-
-    def ready(self) -> None:
-        from authentik.managed.tasks import managed_reconcile
-
-        # pyright: reportGeneralTypeIssues=false
-        managed_reconcile.delay()  # pylint: disable=no-value-for-parameter

--- a/authentik/outposts/apps.py
+++ b/authentik/outposts/apps.py
@@ -2,7 +2,6 @@
 from importlib import import_module
 
 from django.apps import AppConfig
-from django.db import ProgrammingError
 from structlog.stdlib import get_logger
 
 LOGGER = get_logger()
@@ -18,10 +17,3 @@ class AuthentikOutpostConfig(AppConfig):
     def ready(self):
         import_module("authentik.outposts.signals")
         import_module("authentik.outposts.managed")
-        try:
-            from authentik.outposts.tasks import outpost_controller_all, outpost_local_connection
-
-            outpost_local_connection.delay()
-            outpost_controller_all.delay()
-        except ProgrammingError:
-            pass

--- a/authentik/providers/proxy/apps.py
+++ b/authentik/providers/proxy/apps.py
@@ -12,8 +12,4 @@ class AuthentikProviderProxyConfig(AppConfig):
     verbose_name = "authentik Providers.Proxy"
 
     def ready(self) -> None:
-        from authentik.providers.proxy.tasks import proxy_set_defaults
-
         import_module("authentik.providers.proxy.managed")
-
-        proxy_set_defaults.delay()

--- a/authentik/root/celery.py
+++ b/authentik/root/celery.py
@@ -10,8 +10,10 @@ from celery.signals import (
     task_internal_error,
     task_postrun,
     task_prerun,
+    worker_ready,
 )
 from django.conf import settings
+from django.db import ProgrammingError
 from structlog.stdlib import get_logger
 
 from authentik.core.middleware import LOCAL
@@ -72,6 +74,29 @@ def task_error_hook(task_id, exception: Exception, traceback, *args, **kwargs):
     LOGGER.warning("Task failure", exc=exception)
     if before_send({}, {"exc_info": (None, exception, None)}) is not None:
         Event.new(EventAction.SYSTEM_EXCEPTION, message=exception_to_string(exception)).save()
+
+
+@worker_ready.connect
+def worker_ready_hook(*args, **kwargs):
+    """Run certain tasks on worker start"""
+    from authentik.admin.tasks import clear_update_notifications
+    from authentik.managed.tasks import managed_reconcile
+    from authentik.outposts.tasks import outpost_controller_all, outpost_local_connection
+    from authentik.providers.proxy.tasks import proxy_set_defaults
+
+    tasks = [
+        clear_update_notifications,
+        outpost_local_connection,
+        outpost_controller_all,
+        proxy_set_defaults,
+        managed_reconcile,
+    ]
+    LOGGER.info("Dispatching startup tasks...")
+    for task in tasks:
+        try:
+            task.delay()
+        except ProgrammingError as exc:
+            LOGGER.warning("Startup task failed", task=task, exc=exc)
 
 
 # Using a string here means the worker doesn't have to serialize

--- a/authentik/sources/oauth/apps.py
+++ b/authentik/sources/oauth/apps.py
@@ -34,6 +34,5 @@ class AuthentikSourceOAuthConfig(AppConfig):
         for source_type in AUTHENTIK_SOURCES_OAUTH_TYPES:
             try:
                 import_module(source_type)
-                LOGGER.debug("Loaded OAuth Source Type", type=source_type)
             except ImportError as exc:
-                LOGGER.debug(str(exc))
+                LOGGER.warning("Failed to load OAuth Source", exc=exc)

--- a/website/docs/releases/v2022.6.md
+++ b/website/docs/releases/v2022.6.md
@@ -27,6 +27,24 @@ slug: "2022.6"
 
 ## Minor changes/fixes
 
+-   api: migrate to openapi generator v6 (#2968)
+-   api: update API browser to match admin UI and auto-switch theme
+-   core: improve loading speed of flow background
+-   ensure all viewsets have filter and search and add tests (#2946)
+-   flows: fix re-imports of entries with identical PK re-creating objects
+-   lifecycle: cleanup prometheus metrics, remove PII (#2972)
+-   policies: fix incorrect bound_to count
+-   providers/oauth2: add configuration error event when wrong redirect uri is used in token request
+-   providers/oauth2: handle attribute errors when validation JWK contains private key
+-   providers/oauth2: only set expiry on user when it was freshly created
+-   providers/oauth2: regex-escape URLs when set to blank
+-   root: Add docker-compose postgresql and redis healthchecks (#2958)
+-   root: disable session_save_every_request as it causes race conditions
+-   web/elements: fix top-right dialog close button not resetting form
+-   web/elements: fix used_by refreshing for all elements when using DeleteBulkForm
+-   web/user: fix static prompt fields being rendered with label
+-   web/user: improve ux for restarting user settings flow
+
 ## Upgrading
 
 This release does not introduce any new requirements.


### PR DESCRIPTION
Signed-off-by: Jens Langhammer <jens.langhammer@beryju.org>

Cleanup the log output during server start, and remove duplicate tasks when more than one server instance runs