### PR TITLE
events: use custom login failed signal, also send for mfa errors, add stage and more to context

### DIFF
--- a/authentik/core/signals.py
+++ b/authentik/core/signals.py
@@ -12,6 +12,8 @@ from django.http.request import HttpRequest
 
 # Arguments: user: User, password: str
 password_changed = Signal()
+# Arguments: credentials: dict[str, any], request: HttpRequest, stage: Stage
+login_failed = Signal()
 
 if TYPE_CHECKING:
     from authentik.core.models import AuthenticatedSession, User

--- a/authentik/events/signals.py
+++ b/authentik/events/signals.py
@@ -81,10 +81,15 @@ def on_user_write(sender, request: HttpRequest, user: User, data: dict[str, Any]
 @receiver(login_failed)
 # pylint: disable=unused-argument
 def on_login_failed(
-    sender, credentials: dict[str, str], request: HttpRequest, stage: Optional[Stage] = None, **_
+    signal,
+    sender,
+    credentials: dict[str, str],
+    request: HttpRequest,
+    stage: Optional[Stage] = None,
+    **kwargs,
 ):
     """Failed Login, authentik custom event"""
-    thread = EventNewThread(EventAction.LOGIN_FAILED, request, **credentials, stage=stage)
+    thread = EventNewThread(EventAction.LOGIN_FAILED, request, **credentials, stage=stage, **kwargs)
     thread.run()
 
 

--- a/authentik/events/signals.py
+++ b/authentik/events/signals.py
@@ -2,15 +2,16 @@
 from threading import Thread
 from typing import Any, Optional
 
-from django.contrib.auth.signals import user_logged_in, user_logged_out, user_login_failed
+from django.contrib.auth.signals import user_logged_in, user_logged_out
 from django.db.models.signals import post_save, pre_delete
 from django.dispatch import receiver
 from django.http import HttpRequest
 
 from authentik.core.models import User
-from authentik.core.signals import password_changed
+from authentik.core.signals import login_failed, password_changed
 from authentik.events.models import Event, EventAction
 from authentik.events.tasks import event_notification_handler, gdpr_cleanup
+from authentik.flows.models import Stage
 from authentik.flows.planner import PLAN_CONTEXT_SOURCE, FlowPlan
 from authentik.flows.views.executor import SESSION_KEY_PLAN
 from authentik.stages.invitation.models import Invitation
@@ -77,11 +78,13 @@ def on_user_write(sender, request: HttpRequest, user: User, data: dict[str, Any]
     thread.run()
 
 
-@receiver(user_login_failed)
+@receiver(login_failed)
 # pylint: disable=unused-argument
-def on_user_login_failed(sender, credentials: dict[str, str], request: HttpRequest, **_):
-    """Failed Login"""
-    thread = EventNewThread(EventAction.LOGIN_FAILED, request, **credentials)
+def on_login_failed(
+    sender, credentials: dict[str, str], request: HttpRequest, stage: Optional[Stage] = None, **_
+):
+    """Failed Login, authentik custom event"""
+    thread = EventNewThread(EventAction.LOGIN_FAILED, request, **credentials, stage=stage)
     thread.run()
 
 

--- a/authentik/flows/stage.py
+++ b/authentik/flows/stage.py
@@ -23,6 +23,7 @@ from authentik.flows.challenge import (
 )
 from authentik.flows.models import InvalidResponseAction
 from authentik.flows.planner import PLAN_CONTEXT_APPLICATION, PLAN_CONTEXT_PENDING_USER
+from authentik.lib.utils.reflection import class_to_path
 
 if TYPE_CHECKING:
     from authentik.flows.views.executor import FlowExecutorView
@@ -44,7 +45,7 @@ class StageView(View):
         current_stage = getattr(self.executor, "current_stage", None)
         self.logger = get_logger().bind(
             stage=getattr(current_stage, "name", None),
-            stage_view=self,
+            stage_view=class_to_path(type(self)),
         )
         super().__init__(**kwargs)
 

--- a/authentik/policies/reputation/signals.py
+++ b/authentik/policies/reputation/signals.py
@@ -1,10 +1,11 @@
 """authentik reputation request signals"""
-from django.contrib.auth.signals import user_logged_in, user_login_failed
+from django.contrib.auth.signals import user_logged_in
 from django.core.cache import cache
 from django.dispatch import receiver
 from django.http import HttpRequest
 from structlog.stdlib import get_logger
 
+from authentik.core.signals import login_failed
 from authentik.lib.config import CONFIG
 from authentik.lib.utils.http import get_client_ip
 from authentik.policies.reputation.models import CACHE_KEY_PREFIX
@@ -35,7 +36,7 @@ def update_score(request: HttpRequest, identifier: str, amount: int):
     save_reputation.delay()
 
 
-@receiver(user_login_failed)
+@receiver(login_failed)
 # pylint: disable=unused-argument
 def handle_failed_login(sender, request, credentials, **_):
     """Lower Score for failed login attempts"""

--- a/authentik/stages/authenticator_validate/challenge.py
+++ b/authentik/stages/authenticator_validate/challenge.py
@@ -18,6 +18,8 @@ from webauthn.helpers.structs import AuthenticationCredential
 
 from authentik.core.api.utils import PassiveSerializer
 from authentik.core.models import User
+from authentik.core.signals import login_failed
+from authentik.flows.stage import StageView
 from authentik.lib.utils.http import get_client_ip
 from authentik.stages.authenticator_duo.models import AuthenticatorDuoStage, DuoDevice
 from authentik.stages.authenticator_sms.models import SMSDevice
@@ -92,24 +94,31 @@ def select_challenge_sms(request: HttpRequest, device: SMSDevice):
     device.stage.send(device.token, device)
 
 
-def validate_challenge_code(code: str, request: HttpRequest, user: User) -> Device:
+def validate_challenge_code(code: str, stage: StageView, user: User) -> Device:
     """Validate code-based challenges. We test against every device, on purpose, as
     the user mustn't choose between totp and static devices."""
     device = match_token(user, code)
     if not device:
+        login_failed.send(
+            sender=__name__,
+            credentials={"username": user.username},
+            request=stage.request,
+            stage=stage.executor.current_stage,
+        )
         raise ValidationError(_("Invalid Token"))
     return device
 
 
 # pylint: disable=unused-argument
-def validate_challenge_webauthn(data: dict, request: HttpRequest, user: User) -> Device:
+def validate_challenge_webauthn(data: dict, stage: StageView, user: User) -> Device:
     """Validate WebAuthn Challenge"""
+    request = stage.request
     challenge = request.session.get(SESSION_KEY_WEBAUTHN_CHALLENGE)
     credential_id = data.get("id")
 
     device = WebAuthnDevice.objects.filter(credential_id=credential_id).first()
     if not device:
-        raise ValidationError("Device does not exist.")
+        raise Http404()
 
     try:
         authentication_verification = verify_authentication_response(
@@ -121,16 +130,22 @@ def validate_challenge_webauthn(data: dict, request: HttpRequest, user: User) ->
             credential_current_sign_count=device.sign_count,
             require_user_verification=False,
         )
-
     except InvalidAuthenticationResponse as exc:
         LOGGER.warning("Assertion failed", exc=exc)
+        login_failed.send(
+            sender=__name__,
+            credentials={"username": user.username},
+            request=stage.request,
+            stage=stage.executor.current_stage,
+            device=device,
+        )
         raise ValidationError("Assertion failed") from exc
 
     device.set_sign_count(authentication_verification.new_sign_count)
     return device
 
 
-def validate_challenge_duo(device_pk: int, request: HttpRequest, user: User) -> Device:
+def validate_challenge_duo(device_pk: int, stage: StageView, user: User) -> Device:
     """Duo authentication"""
     device = get_object_or_404(DuoDevice, pk=device_pk)
     if device.user != user:
@@ -140,13 +155,19 @@ def validate_challenge_duo(device_pk: int, request: HttpRequest, user: User) -> 
     response = stage.client.auth(
         "auto",
         user_id=device.duo_user_id,
-        ipaddr=get_client_ip(request),
+        ipaddr=get_client_ip(stage.request),
         type="authentik Login request",
         display_username=user.username,
         device="auto",
     )
     # {'result': 'allow', 'status': 'allow', 'status_msg': 'Success. Logging you in...'}
     if response["result"] == "deny":
+        login_failed.send(
+            sender=__name__,
+            credentials={"username": user.username},
+            request=stage.request,
+            stage=stage.executor.current_stage,
+        )
         raise ValidationError("Duo denied access")
     device.save()
     return device

--- a/authentik/stages/authenticator_validate/challenge.py
+++ b/authentik/stages/authenticator_validate/challenge.py
@@ -23,6 +23,7 @@ from authentik.flows.stage import StageView
 from authentik.lib.utils.http import get_client_ip
 from authentik.stages.authenticator_duo.models import AuthenticatorDuoStage, DuoDevice
 from authentik.stages.authenticator_sms.models import SMSDevice
+from authentik.stages.authenticator_validate.models import DeviceClasses
 from authentik.stages.authenticator_webauthn.models import WebAuthnDevice
 from authentik.stages.authenticator_webauthn.stage import SESSION_KEY_WEBAUTHN_CHALLENGE
 from authentik.stages.authenticator_webauthn.utils import get_origin, get_rp_id
@@ -104,6 +105,7 @@ def validate_challenge_code(code: str, stage: StageView, user: User) -> Device:
             credentials={"username": user.username},
             request=stage.request,
             stage=stage.executor.current_stage,
+            device_class=DeviceClasses.TOTP.value,
         )
         raise ValidationError(_("Invalid Token"))
     return device
@@ -138,6 +140,7 @@ def validate_challenge_webauthn(data: dict, stage: StageView, user: User) -> Dev
             request=stage.request,
             stage=stage.executor.current_stage,
             device=device,
+            device_class=DeviceClasses.WEBAUTHN.value,
         )
         raise ValidationError("Assertion failed") from exc
 
@@ -167,6 +170,7 @@ def validate_challenge_duo(device_pk: int, stage: StageView, user: User) -> Devi
             credentials={"username": user.username},
             request=stage.request,
             stage=stage.executor.current_stage,
+            device_class=DeviceClasses.DUO.value,
         )
         raise ValidationError("Duo denied access")
     device.save()

--- a/authentik/stages/authenticator_validate/models.py
+++ b/authentik/stages/authenticator_validate/models.py
@@ -14,7 +14,7 @@ class DeviceClasses(models.TextChoices):
     """Device classes this stage can validate"""
 
     # device class must match Device's class name so StaticDevice -> static
-    STATIC = "static"
+    STATIC = "static", _("Static")
     TOTP = "totp", _("TOTP")
     WEBAUTHN = "webauthn", _("WebAuthn")
     DUO = "duo", _("Duo")

--- a/authentik/stages/authenticator_validate/stage.py
+++ b/authentik/stages/authenticator_validate/stage.py
@@ -85,9 +85,7 @@ class AuthenticatorValidationChallengeResponse(ChallengeResponse):
     def validate_code(self, code: str) -> str:
         """Validate code-based response, raise error if code isn't allowed"""
         self._challenge_allowed([DeviceClasses.TOTP, DeviceClasses.STATIC, DeviceClasses.SMS])
-        self.device = validate_challenge_code(
-            code, self.stage.request, self.stage.get_pending_user()
-        )
+        self.device = validate_challenge_code(code, self.stage, self.stage.get_pending_user())
         return code
 
     def validate_webauthn(self, webauthn: dict) -> dict:
@@ -95,14 +93,14 @@ class AuthenticatorValidationChallengeResponse(ChallengeResponse):
         or response is invalid"""
         self._challenge_allowed([DeviceClasses.WEBAUTHN])
         self.device = validate_challenge_webauthn(
-            webauthn, self.stage.request, self.stage.get_pending_user()
+            webauthn, self.stage, self.stage.get_pending_user()
         )
         return webauthn
 
     def validate_duo(self, duo: int) -> int:
         """Initiate Duo authentication"""
         self._challenge_allowed([DeviceClasses.DUO])
-        self.device = validate_challenge_duo(duo, self.stage.request, self.stage.get_pending_user())
+        self.device = validate_challenge_duo(duo, self.stage, self.stage.get_pending_user())
         return duo
 
     def validate_selected_challenge(self, challenge: dict) -> dict:

--- a/authentik/stages/authenticator_validate/tests/test_sms.py
+++ b/authentik/stages/authenticator_validate/tests/test_sms.py
@@ -7,6 +7,7 @@ from django.urls.base import reverse
 from authentik.core.tests.utils import create_test_admin_user
 from authentik.flows.models import Flow, FlowStageBinding, NotConfiguredAction
 from authentik.flows.tests import FlowTestCase
+from authentik.lib.generators import generate_id
 from authentik.stages.authenticator_sms.models import AuthenticatorSMSStage, SMSDevice, SMSProviders
 from authentik.stages.authenticator_validate.models import AuthenticatorValidateStage, DeviceClasses
 from authentik.stages.authenticator_validate.stage import COOKIE_NAME_MFA
@@ -28,7 +29,7 @@ class AuthenticatorValidateStageSMSTests(FlowTestCase):
     def test_last_auth_threshold(self):
         """Test last_auth_threshold"""
         ident_stage = IdentificationStage.objects.create(
-            name="conf",
+            name=generate_id(),
             user_fields=[
                 UserFields.USERNAME,
             ],
@@ -40,7 +41,7 @@ class AuthenticatorValidateStageSMSTests(FlowTestCase):
         )
 
         stage = AuthenticatorValidateStage.objects.create(
-            name="foo",
+            name=generate_id(),
             last_auth_threshold="milliseconds=0",
             not_configured_action=NotConfiguredAction.CONFIGURE,
             device_classes=[DeviceClasses.SMS],
@@ -65,7 +66,7 @@ class AuthenticatorValidateStageSMSTests(FlowTestCase):
     def test_last_auth_threshold_valid(self):
         """Test last_auth_threshold"""
         ident_stage = IdentificationStage.objects.create(
-            name="conf",
+            name=generate_id(),
             user_fields=[
                 UserFields.USERNAME,
             ],
@@ -77,7 +78,7 @@ class AuthenticatorValidateStageSMSTests(FlowTestCase):
         )
 
         stage = AuthenticatorValidateStage.objects.create(
-            name="foo",
+            name=generate_id(),
             last_auth_threshold="hours=1",
             not_configured_action=NotConfiguredAction.CONFIGURE,
             device_classes=[DeviceClasses.SMS],
@@ -120,7 +121,7 @@ class AuthenticatorValidateStageSMSTests(FlowTestCase):
     def test_sms_hashed(self):
         """Test hashed SMS device"""
         ident_stage = IdentificationStage.objects.create(
-            name="conf",
+            name=generate_id(),
             user_fields=[
                 UserFields.USERNAME,
             ],
@@ -133,7 +134,7 @@ class AuthenticatorValidateStageSMSTests(FlowTestCase):
         )
 
         stage = AuthenticatorValidateStage.objects.create(
-            name="foo",
+            name=generate_id(),
             last_auth_threshold="hours=1",
             not_configured_action=NotConfiguredAction.DENY,
             device_classes=[DeviceClasses.SMS],

--- a/authentik/stages/authenticator_validate/tests/test_stage.py
+++ b/authentik/stages/authenticator_validate/tests/test_stage.py
@@ -9,6 +9,7 @@ from authentik.flows.models import Flow, FlowStageBinding, NotConfiguredAction
 from authentik.flows.stage import StageView
 from authentik.flows.tests import FlowTestCase
 from authentik.flows.views.executor import FlowExecutorView
+from authentik.lib.generators import generate_id
 from authentik.lib.tests.utils import dummy_get_response
 from authentik.stages.authenticator_validate.api import AuthenticatorValidateStageSerializer
 from authentik.stages.authenticator_validate.models import AuthenticatorValidateStage
@@ -29,13 +30,13 @@ class AuthenticatorValidateStageTests(FlowTestCase):
     def test_not_configured_action(self):
         """Test not_configured_action"""
         conf_stage = IdentificationStage.objects.create(
-            name="conf",
+            name=generate_id(),
             user_fields=[
                 UserFields.USERNAME,
             ],
         )
         stage = AuthenticatorValidateStage.objects.create(
-            name="foo",
+            name=generate_id(),
             not_configured_action=NotConfiguredAction.CONFIGURE,
         )
         stage.configuration_stages.set([conf_stage])
@@ -67,12 +68,12 @@ class AuthenticatorValidateStageTests(FlowTestCase):
         """Test serializer validation"""
         self.client.force_login(self.user)
         serializer = AuthenticatorValidateStageSerializer(
-            data={"name": "foo", "not_configured_action": NotConfiguredAction.CONFIGURE}
+            data={"name": generate_id(), "not_configured_action": NotConfiguredAction.CONFIGURE}
         )
         self.assertFalse(serializer.is_valid())
         self.assertIn("not_configured_action", serializer.errors)
         serializer = AuthenticatorValidateStageSerializer(
-            data={"name": "foo", "not_configured_action": NotConfiguredAction.DENY}
+            data={"name": generate_id(), "not_configured_action": NotConfiguredAction.DENY}
         )
         self.assertTrue(serializer.is_valid())
 

--- a/authentik/stages/identification/stage.py
+++ b/authentik/stages/identification/stage.py
@@ -127,6 +127,7 @@ class IdentificationChallengeResponse(ChallengeResponse):
                 user = authenticate(
                     self.stage.request,
                     current_stage.password_stage.backends,
+                    current_stage,
                     username=self.pre_user.username,
                     password=password,
                 )


### PR DESCRIPTION
closes #3027

Signed-off-by: Jens Langhammer <jens.langhammer@beryju.org>
