### PR TITLE
website/docs: expand nginx reverse-proxy setup

### DIFF
--- a/website/docs/installation/reverse-proxy.md
+++ b/website/docs/installation/reverse-proxy.md
@@ -2,40 +2,75 @@
 title: Reverse-proxy
 ---
 
-If you want to access authentik behind a reverse-proxy, use a config like this. It is important that Websocket is enabled, so that Outposts can connect.
+:::info
+Since authentik uses WebSockets to communicate with Outposts, it does not support HTTP/1.0 reverse-proxies. The HTTP/1.0 specification does not officially support WebSockets or protocol upgrades, though some clients may allow it.
+:::
+
+If you want to access authentik behind a reverse-proxy, there are a few headers that must be passed upstream:
+- `X-Forwarded-Proto`: Tells authentik and Proxy Providers if they are being served over a HTTPS connection.
+- `X-Forwarded-For`: Without this, authentik will not know the IP addresses of clients.
+- `Host`: Required for various security checks, WebSocket handshake, and Outpost and Proxy Provider communication.
+- `Connection: Upgrade` and `Upgrade: WebSocket`: Required for requests to the `/ws/client/` endpoint under HTTP/1.1, to upgrade to the WebSocket protcol.
+
+The following nginx configuration can be used as a starting point for your own configuration.
 
 ```
+# Upstream where your authentik server is hosted.
+upstream authentik {
+    server <hostname of your authentik server>:9443;
+    # Improve performance by keeping some connections alive.
+    # https://nginx.org/r/keepalive
+    keepalive 10;
+}
+
+# Provided by default in most Linux package distributions.
 map $http_upgrade $connection_upgrade {
     default upgrade;
     ''      close;
 }
 
 server {
-    # Server config
+    # HTTP server config
     listen 80;
     server_name sso.domain.tld;
 
-    # 301 to SSL
+    # 301 redirect to HTTPS
     location / {
             return 301 https://$host$request_uri;
     }
 }
 server {
-    # Server config
+    # HTTPS server config
     listen 443 ssl http2;
     server_name sso.domain.tld;
 
-    # SSL Certs
+    # TLS certificates
     ssl_certificate /etc/letsencrypt/live/domain.tld/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/domain.tld/privkey.pem;
 
     # Proxy site
     location / {
-        proxy_pass https://<hostname of your authentik server>:9443;
+        proxy_pass https://authentik;
         proxy_http_version 1.1;
-        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        # This needs to be set inside the location block, very important.
+        proxy_set_header Host $host;
+        # Use HTTP/1.1 keepalive by unsetting the Connection header.
+        # It is set to "close" by default.
+        # https://nginx.org/r/proxy_set_header
+        proxy_set_header Connection "";
+    }
+
+    # WebSocket
+    location /ws/client/ {
+        # Including this as a sub-block in the above location block does not
+        # allow us to inherit headers due to nginx's inheritance model.
+        # https://blog.martinfjordvald.com/understanding-the-nginx-configuration-inheritance-model/
+        proxy_pass https://authentik;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # This needs to be set to upgrade WebSocket proto, very important.
+        # https://www.nginx.com/blog/websocket-nginx/
         proxy_set_header Host $host;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;

--- a/website/docs/installation/reverse-proxy.md
+++ b/website/docs/installation/reverse-proxy.md
@@ -10,7 +10,7 @@ If you want to access authentik behind a reverse-proxy, there are a few headers 
 - `X-Forwarded-Proto`: Tells authentik and Proxy Providers if they are being served over a HTTPS connection.
 - `X-Forwarded-For`: Without this, authentik will not know the IP addresses of clients.
 - `Host`: Required for various security checks, WebSocket handshake, and Outpost and Proxy Provider communication.
-- `Connection: Upgrade` and `Upgrade: WebSocket`: Required for requests to the `/ws/client/` endpoint under HTTP/1.1, to upgrade to the WebSocket protcol.
+- `Connection: Upgrade` and `Upgrade: WebSocket`: Required to upgrade protocols for requests to the WebSocket endpoints under HTTP/1.1.
 
 The following nginx configuration can be used as a starting point for your own configuration.
 
@@ -19,14 +19,13 @@ The following nginx configuration can be used as a starting point for your own c
 upstream authentik {
     server <hostname of your authentik server>:9443;
     # Improve performance by keeping some connections alive.
-    # https://nginx.org/r/keepalive
     keepalive 10;
 }
 
-# Provided by default in most Linux package distributions.
-map $http_upgrade $connection_upgrade {
+# Upgrade WebSocket if requested, otherwise use keepalive
+map $http_upgrade $connection_upgrade_keepalive {
     default upgrade;
-    ''      close;
+    ''      '';
 }
 
 server {
@@ -55,25 +54,8 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;
-        # Use HTTP/1.1 keepalive by unsetting the Connection header.
-        # It is set to "close" by default.
-        # https://nginx.org/r/proxy_set_header
-        proxy_set_header Connection "";
-    }
-
-    # WebSocket
-    location /ws/client/ {
-        # Including this as a sub-block in the above location block does not
-        # allow us to inherit headers due to nginx's inheritance model.
-        # https://blog.martinfjordvald.com/understanding-the-nginx-configuration-inheritance-model/
-        proxy_pass https://authentik;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        # This needs to be set to upgrade WebSocket proto, very important.
-        # https://www.nginx.com/blog/websocket-nginx/
-        proxy_set_header Host $host;
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Connection $connection_upgrade_keepalive;
     }
 }
 ```


### PR DESCRIPTION
## Changes
Clean up the reverse-proxy documentation to provide a bit more information and rationale. The original nginx configuration was also not able to use keepalive connections to authentik since the `Connection: close` header would more than likely be sent with every request that wasn't a WebSocket handshake, since `$http_upgrade` will be empty most of the time.

## Additional
Could cut down on the wordiness but I wanted to be verbose.