### PR TITLE
providers/proxy: no exposed urls

### DIFF
--- a/authentik/providers/proxy/models.py
+++ b/authentik/providers/proxy/models.py
@@ -25,7 +25,7 @@ def _get_callback_url(uri: str) -> str:
     return "\n".join(
         [
             urljoin(uri, "outpost.goauthentik.io/callback"),
-            uri + "\?X-authentik-oauth-callback=true",
+            uri + "\?X-authentik-auth-callback=true",
         ]
     )
 

--- a/authentik/providers/proxy/models.py
+++ b/authentik/providers/proxy/models.py
@@ -25,7 +25,7 @@ def _get_callback_url(uri: str) -> str:
     return "\n".join(
         [
             urljoin(uri, "outpost.goauthentik.io/callback"),
-            uri + "\?X-authentik-auth-callback=true",
+            uri + "?X-authentik-auth-callback=true",
         ]
     )
 

--- a/authentik/providers/proxy/models.py
+++ b/authentik/providers/proxy/models.py
@@ -22,7 +22,12 @@ def get_cookie_secret():
 
 
 def _get_callback_url(uri: str) -> str:
-    return urljoin(uri, "outpost.goauthentik.io/callback")
+    return "\n".join(
+        [
+            urljoin(uri, "outpost.goauthentik.io/callback"),
+            uri + "\?X-authentik-oauth-callback=true",
+        ]
+    )
 
 
 class ProxyMode(models.TextChoices):

--- a/authentik/providers/proxy/models.py
+++ b/authentik/providers/proxy/models.py
@@ -14,6 +14,7 @@ from authentik.outposts.models import OutpostModel
 from authentik.providers.oauth2.models import ClientTypes, OAuth2Provider, ScopeMapping
 
 SCOPE_AK_PROXY = "ak_proxy"
+OUTPOST_CALLBACK_SIGNATURE = "X-authentik-auth-callback"
 
 
 def get_cookie_secret():
@@ -24,8 +25,9 @@ def get_cookie_secret():
 def _get_callback_url(uri: str) -> str:
     return "\n".join(
         [
-            urljoin(uri, "outpost.goauthentik.io/callback"),
-            uri + "?X-authentik-auth-callback=true",
+            urljoin(uri, "outpost.goauthentik.io/callback")
+            + f"\\?{OUTPOST_CALLBACK_SIGNATURE}=true",
+            uri + f"\\?{OUTPOST_CALLBACK_SIGNATURE}=true",
         ]
     )
 

--- a/internal/outpost/proxyv2/application/application.go
+++ b/internal/outpost/proxyv2/application/application.go
@@ -35,7 +35,7 @@ type Application struct {
 	Cert                 *tls.Certificate
 	UnauthenticatedRegex []*regexp.Regexp
 
-	endpint       OIDCEndpoint
+	endpoint      OIDCEndpoint
 	oauthConfig   oauth2.Config
 	tokenVerifier *oidc.IDTokenVerifier
 	outpostName   string
@@ -93,7 +93,7 @@ func NewApplication(p api.ProxyOutpostConfig, c *http.Client, cs *ak.CryptoStore
 		Host:           externalHost.Host,
 		log:            muxLogger,
 		outpostName:    ak.Outpost.Name,
-		endpint:        endpoint,
+		endpoint:       endpoint,
 		oauthConfig:    oauth2Config,
 		tokenVerifier:  verifier,
 		proxyConfig:    p,
@@ -211,14 +211,14 @@ func (a *Application) handleSignOut(rw http.ResponseWriter, r *http.Request) {
 	//TODO: Token revocation
 	s, err := a.sessions.Get(r, constants.SessionName)
 	if err != nil {
-		http.Redirect(rw, r, a.endpint.EndSessionEndpoint, http.StatusFound)
+		http.Redirect(rw, r, a.endpoint.EndSessionEndpoint, http.StatusFound)
 		return
 	}
 	s.Options.MaxAge = -1
 	err = s.Save(r, rw)
 	if err != nil {
-		http.Redirect(rw, r, a.endpint.EndSessionEndpoint, http.StatusFound)
+		http.Redirect(rw, r, a.endpoint.EndSessionEndpoint, http.StatusFound)
 		return
 	}
-	http.Redirect(rw, r, a.endpint.EndSessionEndpoint, http.StatusFound)
+	http.Redirect(rw, r, a.endpoint.EndSessionEndpoint, http.StatusFound)
 }

--- a/internal/outpost/proxyv2/application/application.go
+++ b/internal/outpost/proxyv2/application/application.go
@@ -76,7 +76,7 @@ func NewApplication(p api.ProxyOutpostConfig, c *http.Client, cs *ak.CryptoStore
 	redirectUri, _ := url.Parse(p.ExternalHost)
 	redirectUri.Path = path.Join(redirectUri.Path, "/outpost.goauthentik.io/callback")
 	redirectUri.RawQuery = url.Values{
-		callbackSignature: []string{"true"},
+		CallbackSignature: []string{"true"},
 	}.Encode()
 
 	// Configure an OpenID Connect aware OAuth2 client.
@@ -148,7 +148,7 @@ func NewApplication(p api.ProxyOutpostConfig, c *http.Client, cs *ak.CryptoStore
 	mux.Use(sentryhttp.New(sentryhttp.Options{}).Handle)
 	mux.Use(func(inner http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if _, set := r.URL.Query()[callbackSignature]; set {
+			if _, set := r.URL.Query()[CallbackSignature]; set {
 				a.handleAuthCallback(w, r)
 			} else {
 				inner.ServeHTTP(w, r)

--- a/internal/outpost/proxyv2/application/application.go
+++ b/internal/outpost/proxyv2/application/application.go
@@ -147,15 +147,15 @@ func NewApplication(p api.ProxyOutpostConfig, c *http.Client, cs *ak.CryptoStore
 	mux.Use(func(inner http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if _, set := r.URL.Query()[callbackSignature]; set {
-				a.handleCallback(w, r)
+				a.handleAuthCallback(w, r)
 			} else {
 				inner.ServeHTTP(w, r)
 			}
 		})
 	})
 
-	mux.HandleFunc("/outpost.goauthentik.io/start", a.handleRedirect)
-	mux.HandleFunc("/outpost.goauthentik.io/callback", a.handleCallback)
+	mux.HandleFunc("/outpost.goauthentik.io/start", a.handleAuthStart)
+	mux.HandleFunc("/outpost.goauthentik.io/callback", a.handleAuthCallback)
 	mux.HandleFunc("/outpost.goauthentik.io/sign_out", a.handleSignOut)
 	switch *p.Mode.Get() {
 	case api.PROXYMODE_PROXY:

--- a/internal/outpost/proxyv2/application/application.go
+++ b/internal/outpost/proxyv2/application/application.go
@@ -8,6 +8,7 @@ import (
 	"html/template"
 	"net/http"
 	"net/url"
+	"path"
 	"regexp"
 	"strings"
 	"time"
@@ -73,6 +74,7 @@ func NewApplication(p api.ProxyOutpostConfig, c *http.Client, cs *ak.CryptoStore
 	})
 
 	redirectUri, _ := url.Parse(p.ExternalHost)
+	redirectUri.Path = path.Join(redirectUri.Path, "/outpost.goauthentik.io/callback")
 	redirectUri.RawQuery = url.Values{
 		callbackSignature: []string{"true"},
 	}.Encode()

--- a/internal/outpost/proxyv2/application/mode_common.go
+++ b/internal/outpost/proxyv2/application/mode_common.go
@@ -13,8 +13,6 @@ import (
 	"goauthentik.io/internal/constants"
 )
 
-var hasReportedMisconfiguration = false
-
 func (a *Application) addHeaders(headers http.Header, c *Claims) {
 	// https://goauthentik.io/docs/providers/proxy/proxy
 
@@ -105,9 +103,6 @@ func (a *Application) getNginxForwardUrl(r *http.Request) (*url.URL, error) {
 func (a *Application) ReportMisconfiguration(r *http.Request, msg string, fields map[string]interface{}) {
 	fields["message"] = msg
 	a.log.WithFields(fields).Error("Reporting configuration error")
-	if hasReportedMisconfiguration {
-		return
-	}
 	req := api.EventRequest{
 		Action:   api.EVENTACTIONS_CONFIGURATION_ERROR,
 		App:      "authentik.providers.proxy", // must match python apps.py name
@@ -117,8 +112,6 @@ func (a *Application) ReportMisconfiguration(r *http.Request, msg string, fields
 	_, _, err := a.ak.Client.EventsApi.EventsEventsCreate(context.Background()).EventRequest(req).Execute()
 	if err != nil {
 		a.log.WithError(err).Warning("failed to report configuration error")
-	} else {
-		hasReportedMisconfiguration = true
 	}
 }
 

--- a/internal/outpost/proxyv2/application/mode_common.go
+++ b/internal/outpost/proxyv2/application/mode_common.go
@@ -24,7 +24,7 @@ func (a *Application) addHeaders(headers http.Header, c *Claims) {
 	headers.Set("X-authentik-jwt", c.RawToken)
 
 	// System headers
-	headers.Set("X-authentik-meta-jwks", a.endpint.JwksUri)
+	headers.Set("X-authentik-meta-jwks", a.endpoint.JwksUri)
 	headers.Set("X-authentik-meta-outpost", a.outpostName)
 	headers.Set("X-authentik-meta-provider", a.proxyConfig.Name)
 	headers.Set("X-authentik-meta-app", a.proxyConfig.AssignedApplicationSlug)

--- a/internal/outpost/proxyv2/application/mode_forward.go
+++ b/internal/outpost/proxyv2/application/mode_forward.go
@@ -3,12 +3,9 @@ package application
 import (
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 
-	"goauthentik.io/api/v3"
 	"goauthentik.io/internal/outpost/proxyv2/constants"
-	"goauthentik.io/internal/utils/web"
 )
 
 const (
@@ -40,7 +37,7 @@ func (a *Application) forwardHandleTraefik(rw http.ResponseWriter, r *http.Reque
 		http.Error(rw, "configuration error", http.StatusInternalServerError)
 		return
 	}
-
+	// Check if we're authenticated, or the request path is on the allowlist
 	claims, err := a.getClaims(r)
 	if claims != nil && err == nil {
 		a.addHeaders(rw.Header(), claims)
@@ -51,22 +48,12 @@ func (a *Application) forwardHandleTraefik(rw http.ResponseWriter, r *http.Reque
 		a.log.Trace("path can be accessed without authentication")
 		return
 	}
-	if strings.HasPrefix(r.Header.Get("X-Forwarded-Uri"), "/outpost.goauthentik.io") {
-		a.log.WithField("url", r.URL.String()).Trace("path begins with /outpost.goauthentik.io, allowing access")
-		return
+	tr := r.Clone(r.Context())
+	tr.URL = fwd
+	if _, callbackSet := fwd.Query()[callbackSignature]; callbackSet {
+		a.handleCallback(rw, tr)
 	}
-	host := ""
-	// Optional suffix, which is appended to the URL
-	if *a.proxyConfig.Mode.Get() == api.PROXYMODE_FORWARD_SINGLE {
-		host = web.GetHost(r)
-	} else if *a.proxyConfig.Mode.Get() == api.PROXYMODE_FORWARD_DOMAIN {
-		eh, err := url.Parse(a.proxyConfig.ExternalHost)
-		if err != nil {
-			a.log.WithField("host", a.proxyConfig.ExternalHost).WithError(err).Warning("invalid external_host")
-		} else {
-			host = eh.Host
-		}
-	}
+	a.handleRedirect(rw, r)
 	// set the redirect flag to the current URL we have, since we redirect
 	// to a (possibly) different domain, but we want to be redirected back
 	// to the application
@@ -76,17 +63,9 @@ func (a *Application) forwardHandleTraefik(rw http.ResponseWriter, r *http.Reque
 		s.Values[constants.SessionRedirect] = fwd.String()
 		err = s.Save(r, rw)
 		if err != nil {
-			a.log.WithError(err).Warning("failed to save session before redirect")
+			a.log.WithError(err).Warning("failed to save session")
 		}
 	}
-
-	proto := r.Header.Get("X-Forwarded-Proto")
-	if proto != "" {
-		proto = proto + ":"
-	}
-	rdFinal := fmt.Sprintf("%s//%s%s", proto, host, "/outpost.goauthentik.io/start")
-	a.log.WithField("url", rdFinal).Debug("Redirecting to login")
-	http.Redirect(rw, r, rdFinal, http.StatusTemporaryRedirect)
 }
 
 func (a *Application) forwardHandleCaddy(rw http.ResponseWriter, r *http.Request) {
@@ -200,7 +179,7 @@ func (a *Application) forwardHandleEnvoy(rw http.ResponseWriter, r *http.Request
 	a.log.WithField("header", r.Header).Trace("tracing headers for debug")
 	r.URL.Path = strings.TrimPrefix(r.URL.Path, envoyPrefix)
 	fwd := r.URL
-
+	// Check if we're authenticated, or the request path is on the allowlist
 	claims, err := a.getClaims(r)
 	if claims != nil && err == nil {
 		a.addHeaders(rw.Header(), claims)
@@ -211,22 +190,10 @@ func (a *Application) forwardHandleEnvoy(rw http.ResponseWriter, r *http.Request
 		a.log.Trace("path can be accessed without authentication")
 		return
 	}
-	if strings.HasPrefix(r.URL.Path, "/outpost.goauthentik.io") {
-		a.log.WithField("url", r.URL.String()).Trace("path begins with /outpost.goauthentik.io, allowing access")
-		return
+	if _, callbackSet := fwd.Query()[callbackSignature]; callbackSet {
+		a.handleCallback(rw, r)
 	}
-	host := ""
-	// Optional suffix, which is appended to the URL
-	if *a.proxyConfig.Mode.Get() == api.PROXYMODE_FORWARD_SINGLE {
-		host = web.GetHost(r)
-	} else if *a.proxyConfig.Mode.Get() == api.PROXYMODE_FORWARD_DOMAIN {
-		eh, err := url.Parse(a.proxyConfig.ExternalHost)
-		if err != nil {
-			a.log.WithField("host", a.proxyConfig.ExternalHost).WithError(err).Warning("invalid external_host")
-		} else {
-			host = eh.Host
-		}
-	}
+	a.handleRedirect(rw, r)
 	// set the redirect flag to the current URL we have, since we redirect
 	// to a (possibly) different domain, but we want to be redirected back
 	// to the application
@@ -239,7 +206,4 @@ func (a *Application) forwardHandleEnvoy(rw http.ResponseWriter, r *http.Request
 			a.log.WithError(err).Warning("failed to save session before redirect")
 		}
 	}
-	rdFinal := fmt.Sprintf("//%s%s", host, "/outpost.goauthentik.io/start")
-	a.log.WithField("url", rdFinal).Debug("Redirecting to login")
-	http.Redirect(rw, r, rdFinal, http.StatusTemporaryRedirect)
 }

--- a/internal/outpost/proxyv2/application/mode_forward.go
+++ b/internal/outpost/proxyv2/application/mode_forward.go
@@ -51,9 +51,9 @@ func (a *Application) forwardHandleTraefik(rw http.ResponseWriter, r *http.Reque
 	tr := r.Clone(r.Context())
 	tr.URL = fwd
 	if _, callbackSet := fwd.Query()[callbackSignature]; callbackSet {
-		a.handleCallback(rw, tr)
+		a.handleAuthCallback(rw, tr)
 	}
-	a.handleRedirect(rw, r)
+	a.handleAuthStart(rw, r)
 	// set the redirect flag to the current URL we have, since we redirect
 	// to a (possibly) different domain, but we want to be redirected back
 	// to the application
@@ -191,9 +191,9 @@ func (a *Application) forwardHandleEnvoy(rw http.ResponseWriter, r *http.Request
 		return
 	}
 	if _, callbackSet := fwd.Query()[callbackSignature]; callbackSet {
-		a.handleCallback(rw, r)
+		a.handleAuthCallback(rw, r)
 	}
-	a.handleRedirect(rw, r)
+	a.handleAuthStart(rw, r)
 	// set the redirect flag to the current URL we have, since we redirect
 	// to a (possibly) different domain, but we want to be redirected back
 	// to the application

--- a/internal/outpost/proxyv2/application/mode_forward.go
+++ b/internal/outpost/proxyv2/application/mode_forward.go
@@ -50,9 +50,6 @@ func (a *Application) forwardHandleTraefik(rw http.ResponseWriter, r *http.Reque
 	}
 	tr := r.Clone(r.Context())
 	tr.URL = fwd
-	if _, callbackSet := fwd.Query()[callbackSignature]; callbackSet {
-		a.handleAuthCallback(rw, tr)
-	}
 	a.handleAuthStart(rw, r)
 	// set the redirect flag to the current URL we have, since we redirect
 	// to a (possibly) different domain, but we want to be redirected back
@@ -189,9 +186,6 @@ func (a *Application) forwardHandleEnvoy(rw http.ResponseWriter, r *http.Request
 	} else if claims == nil && a.IsAllowlisted(fwd) {
 		a.log.Trace("path can be accessed without authentication")
 		return
-	}
-	if _, callbackSet := fwd.Query()[callbackSignature]; callbackSet {
-		a.handleAuthCallback(rw, r)
 	}
 	a.handleAuthStart(rw, r)
 	// set the redirect flag to the current URL we have, since we redirect

--- a/internal/outpost/proxyv2/application/mode_forward_caddy_test.go
+++ b/internal/outpost/proxyv2/application/mode_forward_caddy_test.go
@@ -1,8 +1,10 @@
 package application
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,11 +45,16 @@ func TestForwardHandleCaddy_Single_Headers(t *testing.T) {
 	rr := httptest.NewRecorder()
 	a.forwardHandleCaddy(rr, req)
 
-	assert.Equal(t, rr.Code, http.StatusTemporaryRedirect)
+	assert.Equal(t, http.StatusFound, rr.Code)
 	loc, _ := rr.Result().Location()
-	assert.Equal(t, loc.String(), "http://test.goauthentik.io/outpost.goauthentik.io/start")
-
 	s, _ := a.sessions.Get(req, constants.SessionName)
+	shouldUrl := url.Values{
+		"client_id":     []string{*a.proxyConfig.ClientId},
+		"redirect_uri":  []string{"https://ext.t.goauthentik.io/outpost.goauthentik.io/callback?X-authentik-auth-callback=true"},
+		"response_type": []string{"code"},
+		"state":         []string{s.Values[constants.SessionOAuthState].([]string)[0]},
+	}
+	assert.Equal(t, fmt.Sprintf("http://fake-auth.t.goauthentik.io/auth?%s", shouldUrl.Encode()), loc.String())
 	assert.Equal(t, "http://test.goauthentik.io/app", s.Values[constants.SessionRedirect])
 }
 
@@ -123,10 +130,15 @@ func TestForwardHandleCaddy_Domain_Header(t *testing.T) {
 	rr := httptest.NewRecorder()
 	a.forwardHandleCaddy(rr, req)
 
-	assert.Equal(t, http.StatusTemporaryRedirect, rr.Code)
+	assert.Equal(t, http.StatusFound, rr.Code)
 	loc, _ := rr.Result().Location()
-	assert.Equal(t, "http://auth.test.goauthentik.io/outpost.goauthentik.io/start", loc.String())
-
 	s, _ := a.sessions.Get(req, constants.SessionName)
+	shouldUrl := url.Values{
+		"client_id":     []string{*a.proxyConfig.ClientId},
+		"redirect_uri":  []string{"https://ext.t.goauthentik.io/outpost.goauthentik.io/callback?X-authentik-auth-callback=true"},
+		"response_type": []string{"code"},
+		"state":         []string{s.Values[constants.SessionOAuthState].([]string)[0]},
+	}
+	assert.Equal(t, fmt.Sprintf("http://fake-auth.t.goauthentik.io/auth?%s", shouldUrl.Encode()), loc.String())
 	assert.Equal(t, "http://test.goauthentik.io/app", s.Values[constants.SessionRedirect])
 }

--- a/internal/outpost/proxyv2/application/mode_forward_envoy_test.go
+++ b/internal/outpost/proxyv2/application/mode_forward_envoy_test.go
@@ -1,8 +1,10 @@
 package application
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,11 +29,16 @@ func TestForwardHandleEnvoy_Single_Headers(t *testing.T) {
 	rr := httptest.NewRecorder()
 	a.forwardHandleEnvoy(rr, req)
 
-	assert.Equal(t, rr.Code, http.StatusTemporaryRedirect)
+	assert.Equal(t, http.StatusFound, rr.Code)
 	loc, _ := rr.Result().Location()
-	assert.Equal(t, loc.String(), "//test.goauthentik.io/outpost.goauthentik.io/start")
-
 	s, _ := a.sessions.Get(req, constants.SessionName)
+	shouldUrl := url.Values{
+		"client_id":     []string{*a.proxyConfig.ClientId},
+		"redirect_uri":  []string{"https://ext.t.goauthentik.io/outpost.goauthentik.io/callback?X-authentik-auth-callback=true"},
+		"response_type": []string{"code"},
+		"state":         []string{s.Values[constants.SessionOAuthState].([]string)[0]},
+	}
+	assert.Equal(t, fmt.Sprintf("http://fake-auth.t.goauthentik.io/auth?%s", shouldUrl.Encode()), loc.String())
 	assert.Equal(t, "http://test.goauthentik.io/app", s.Values[constants.SessionRedirect])
 }
 
@@ -89,10 +96,16 @@ func TestForwardHandleEnvoy_Domain_Header(t *testing.T) {
 	rr := httptest.NewRecorder()
 	a.forwardHandleEnvoy(rr, req)
 
-	assert.Equal(t, http.StatusTemporaryRedirect, rr.Code)
+	assert.Equal(t, http.StatusFound, rr.Code)
 	loc, _ := rr.Result().Location()
-	assert.Equal(t, "//auth.test.goauthentik.io/outpost.goauthentik.io/start", loc.String())
-
 	s, _ := a.sessions.Get(req, constants.SessionName)
+
+	shouldUrl := url.Values{
+		"client_id":     []string{*a.proxyConfig.ClientId},
+		"redirect_uri":  []string{"https://ext.t.goauthentik.io/outpost.goauthentik.io/callback?X-authentik-auth-callback=true"},
+		"response_type": []string{"code"},
+		"state":         []string{s.Values[constants.SessionOAuthState].([]string)[0]},
+	}
+	assert.Equal(t, fmt.Sprintf("http://fake-auth.t.goauthentik.io/auth?%s", shouldUrl.Encode()), loc.String())
 	assert.Equal(t, "http://test.goauthentik.io/app", s.Values[constants.SessionRedirect])
 }

--- a/internal/outpost/proxyv2/application/mode_forward_nginx_test.go
+++ b/internal/outpost/proxyv2/application/mode_forward_nginx_test.go
@@ -39,7 +39,7 @@ func TestForwardHandleNginx_Single_Headers(t *testing.T) {
 	rr := httptest.NewRecorder()
 	a.forwardHandleNginx(rr, req)
 
-	assert.Equal(t, rr.Code, http.StatusUnauthorized)
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
 
 	s, _ := a.sessions.Get(req, constants.SessionName)
 	assert.Equal(t, "http://test.goauthentik.io/app", s.Values[constants.SessionRedirect])
@@ -53,7 +53,7 @@ func TestForwardHandleNginx_Single_URI(t *testing.T) {
 	rr := httptest.NewRecorder()
 	a.forwardHandleNginx(rr, req)
 
-	assert.Equal(t, rr.Code, http.StatusUnauthorized)
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
 
 	s, _ := a.sessions.Get(req, constants.SessionName)
 	assert.Equal(t, "/app", s.Values[constants.SessionRedirect])

--- a/internal/outpost/proxyv2/application/oauth.go
+++ b/internal/outpost/proxyv2/application/oauth.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	redirectParam = "rd"
+	redirectParam     = "rd"
+	callbackSignature = "X-authentik-oauth-callback"
 )
 
 func (a *Application) checkRedirectParam(r *http.Request) (string, bool) {

--- a/internal/outpost/proxyv2/application/oauth.go
+++ b/internal/outpost/proxyv2/application/oauth.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	redirectParam     = "rd"
-	callbackSignature = "X-authentik-auth-callback"
+	CallbackSignature = "X-authentik-auth-callback"
 )
 
 func (a *Application) checkRedirectParam(r *http.Request) (string, bool) {

--- a/internal/outpost/proxyv2/application/oauth.go
+++ b/internal/outpost/proxyv2/application/oauth.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	redirectParam     = "rd"
-	callbackSignature = "X-authentik-oauth-callback"
+	callbackSignature = "X-authentik-auth-callback"
 )
 
 func (a *Application) checkRedirectParam(r *http.Request) (string, bool) {
@@ -42,7 +42,7 @@ func (a *Application) checkRedirectParam(r *http.Request) (string, bool) {
 	return u.String(), true
 }
 
-func (a *Application) handleRedirect(rw http.ResponseWriter, r *http.Request) {
+func (a *Application) handleAuthStart(rw http.ResponseWriter, r *http.Request) {
 	newState := base64.RawURLEncoding.EncodeToString(securecookie.GenerateRandomKey(32))
 	s, err := a.sessions.Get(r, constants.SessionName)
 	if err != nil {
@@ -66,7 +66,7 @@ func (a *Application) handleRedirect(rw http.ResponseWriter, r *http.Request) {
 	http.Redirect(rw, r, a.oauthConfig.AuthCodeURL(newState), http.StatusFound)
 }
 
-func (a *Application) handleCallback(rw http.ResponseWriter, r *http.Request) {
+func (a *Application) handleAuthCallback(rw http.ResponseWriter, r *http.Request) {
 	s, err := a.sessions.Get(r, constants.SessionName)
 	if err != nil {
 		a.log.WithError(err).Trace("failed to get session")

--- a/internal/outpost/proxyv2/application/test.go
+++ b/internal/outpost/proxyv2/application/test.go
@@ -22,6 +22,11 @@ func newTestApplication() *Application {
 			BasicAuthEnabled:           api.PtrBool(true),
 			BasicAuthUserAttribute:     api.PtrString("username"),
 			BasicAuthPasswordAttribute: api.PtrString("password"),
+			OidcConfiguration: api.ProxyOutpostConfigOidcConfiguration{
+				AuthorizationEndpoint: "http://fake-auth.t.goauthentik.io/auth",
+				TokenEndpoint:         "http://fake-auth.t.goauthentik.io/token",
+				UserinfoEndpoint:      "http://fake-auth.t.goauthentik.io/userinfo",
+			},
 		},
 		http.DefaultClient,
 		nil,

--- a/internal/web/proxy.go
+++ b/internal/web/proxy.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"goauthentik.io/internal/outpost/proxyv2/application"
 	"goauthentik.io/internal/utils/sentry"
 	"goauthentik.io/internal/utils/web"
 )
@@ -52,7 +53,8 @@ func (ws *WebServer) configureProxy() {
 		}
 		before := time.Now()
 		if ws.ProxyServer != nil {
-			if ws.ProxyServer.HandleHost(rw, r) {
+			_, oauthCallbackSet := r.URL.Query()[application.CallbackSignature]
+			if ws.ProxyServer.HandleHost(rw, r) || oauthCallbackSet {
 				Requests.With(prometheus.Labels{
 					"dest": "embedded_outpost",
 				}).Observe(float64(time.Since(before)))

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -39,12 +39,12 @@ func NewWebServer(g *gounicorn.GoUnicorn) *WebServer {
 	mainHandler.Use(sentryhttp.New(sentryhttp.Options{}).Handle)
 	mainHandler.Use(handlers.ProxyHeaders)
 	mainHandler.Use(handlers.CompressHandler)
-	logginRouter := mainHandler.NewRoute().Subrouter()
-	logginRouter.Use(web.NewLoggingHandler(l, nil))
+	loggingHandler := mainHandler.NewRoute().Subrouter()
+	loggingHandler.Use(web.NewLoggingHandler(l, nil))
 
 	ws := &WebServer{
 		m:   mainHandler,
-		lh:  logginRouter,
+		lh:  loggingHandler,
 		log: l,
 		p:   g,
 	}


### PR DESCRIPTION
This PR greatly simplifies the Forward auth setup for traefik and envoy. It'll remove the requirement `/outpost.goauthentik.io` to be openly accessible, which makes setup easier and decreases attack surface.
For traefik/envoy it'll work like:
- User sends initial request
- Auth subrequest is sent
- 302 is returned directly to core authentik OAuth login flow
- User finishes flow, is redirected back with `X-authentik-auth-callback` query parameter set
- Outpost recognises the parameter being passed forward to it and finishes the authentication flow
- Outpost redirects to initial URL user opened

Sadly, nginx still doesn't support getting a 302 from an auth subrequest without writing the 302 redirect in the nginx config, so nginx will require `/outpost.goauthentik.io/start` to be publicly accessible (which is still a bit better)

---

Since this only lowers the requirements it shouldn't be a breaking change, but needs more testing with traefik and nginx 