### PR TITLE
lifecycle: make worker wait for migrations to be done

### DIFF
--- a/authentik/managed/tasks.py
+++ b/authentik/managed/tasks.py
@@ -11,7 +11,11 @@ from authentik.events.monitored_tasks import (
 from authentik.managed.manager import ObjectManager
 
 
-@CELERY_APP.task(bind=True, base=MonitoredTask)
+@CELERY_APP.task(
+    bind=True,
+    base=MonitoredTask,
+    retry_backoff=True,
+)
 @prefill_task
 def managed_reconcile(self: MonitoredTask):
     """Run ObjectManager to ensure objects are up-to-date"""
@@ -22,3 +26,4 @@ def managed_reconcile(self: MonitoredTask):
         )
     except DatabaseError as exc:  # pragma: no cover
         self.set_status(TaskResult(TaskResultStatus.WARNING, [str(exc)]))
+        self.retry()

--- a/lifecycle/ak
+++ b/lifecycle/ak
@@ -44,6 +44,11 @@ if [[ "$1" == "server" ]]; then
     /authentik-proxy
 elif [[ "$1" == "worker" ]]; then
     wait_for_db
+    # Check if the migration lock is set, and exit if so
+    # the orchestrator should restart this container, and this prevents
+    # errors when startup tasks are attempted to be run without
+    # migrations in place
+    python -m lifecycle.migrate check_lock
     echo "worker" > $MODE_FILE
     check_if_root "celery -A authentik.root.celery worker -Ofair --max-tasks-per-child=1 --autoscale 3,1 -E -B -s /tmp/celerybeat-schedule -Q authentik,authentik_scheduled,authentik_events"
 elif [[ "$1" == "bash" ]]; then


### PR DESCRIPTION
closes #3243 and others

this should make the initial startup less error prone