### PR TITLE
Make LDAP outpost ports configureable via env

### DIFF
--- a/internal/outpost/ldap/ldap.go
+++ b/internal/outpost/ldap/ldap.go
@@ -49,7 +49,8 @@ func (ls *LDAPServer) Type() string {
 }
 
 func (ls *LDAPServer) StartLDAPServer() error {
-	listen := utils.GetEnv("AUTHENTIK_LDAP_PORT", "0.0.0.0:3389")
+	host := "0.0.0.0:"
+	listen := utils.GetEnv("AUTHENTIK_LDAP_PORT", host+"3389")
 
 	ln, err := net.Listen("tcp", listen)
 	if err != nil {

--- a/internal/outpost/ldap/ldap.go
+++ b/internal/outpost/ldap/ldap.go
@@ -50,7 +50,7 @@ func (ls *LDAPServer) Type() string {
 
 func (ls *LDAPServer) StartLDAPServer() error {
 	host := "0.0.0.0:"
-	listen := utils.GetEnv("AUTHENTIK_LDAP_PORT", host+"3389")
+	listen := host + utils.GetEnv("AUTHENTIK_LDAP_PORT", "3389")
 
 	ln, err := net.Listen("tcp", listen)
 	if err != nil {

--- a/internal/outpost/ldap/ldap.go
+++ b/internal/outpost/ldap/ldap.go
@@ -10,6 +10,7 @@ import (
 	"goauthentik.io/internal/crypto"
 	"goauthentik.io/internal/outpost/ak"
 	"goauthentik.io/internal/outpost/ldap/metrics"
+	"goauthentik.io/internal/utils"
 
 	"github.com/nmcclain/ldap"
 )
@@ -48,7 +49,7 @@ func (ls *LDAPServer) Type() string {
 }
 
 func (ls *LDAPServer) StartLDAPServer() error {
-	listen := "0.0.0.0:3389"
+	listen := utils.GetEnv("AUTHENTIK_LDAP_PORT", "0.0.0.0:3389")
 
 	ln, err := net.Listen("tcp", listen)
 	if err != nil {

--- a/internal/outpost/ldap/ldap_tls.go
+++ b/internal/outpost/ldap/ldap_tls.go
@@ -2,6 +2,7 @@ package ldap
 
 import (
 	"crypto/tls"
+	"goauthentik.io/internal/utils"
 	"net"
 
 	"github.com/pires/go-proxyproto"
@@ -28,7 +29,7 @@ func (ls *LDAPServer) getCertificates(info *tls.ClientHelloInfo) (*tls.Certifica
 }
 
 func (ls *LDAPServer) StartLDAPTLSServer() error {
-	listen := "0.0.0.0:6636"
+	listen := utils.GetEnv("AUTHENTIK_LDAPS_PORT", "0.0.0.0:6636")
 	tlsConfig := &tls.Config{
 		MinVersion:     tls.VersionTLS12,
 		MaxVersion:     tls.VersionTLS12,

--- a/internal/outpost/ldap/ldap_tls.go
+++ b/internal/outpost/ldap/ldap_tls.go
@@ -30,7 +30,7 @@ func (ls *LDAPServer) getCertificates(info *tls.ClientHelloInfo) (*tls.Certifica
 
 func (ls *LDAPServer) StartLDAPTLSServer() error {
 	host := "0.0.0.0:"
-	listen := utils.GetEnv("AUTHENTIK_LDAPS_PORT", host+"6636")
+	listen := host + utils.GetEnv("AUTHENTIK_LDAPS_PORT", "6636")
 	tlsConfig := &tls.Config{
 		MinVersion:     tls.VersionTLS12,
 		MaxVersion:     tls.VersionTLS12,

--- a/internal/outpost/ldap/ldap_tls.go
+++ b/internal/outpost/ldap/ldap_tls.go
@@ -29,7 +29,8 @@ func (ls *LDAPServer) getCertificates(info *tls.ClientHelloInfo) (*tls.Certifica
 }
 
 func (ls *LDAPServer) StartLDAPTLSServer() error {
-	listen := utils.GetEnv("AUTHENTIK_LDAPS_PORT", "0.0.0.0:6636")
+	host := "0.0.0.0:"
+	listen := utils.GetEnv("AUTHENTIK_LDAPS_PORT", host+"6636")
 	tlsConfig := &tls.Config{
 		MinVersion:     tls.VersionTLS12,
 		MaxVersion:     tls.VersionTLS12,

--- a/internal/outpost/ldap/metrics/metrics.go
+++ b/internal/outpost/ldap/metrics/metrics.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"goauthentik.io/internal/utils"
 	"net/http"
 
 	log "github.com/sirupsen/logrus"
@@ -31,7 +32,8 @@ func RunServer() {
 		rw.WriteHeader(204)
 	})
 	m.Path("/metrics").Handler(promhttp.Handler())
-	listen := "0.0.0.0:9300"
+	host := "0.0.0.0"
+	listen := utils.GetEnv("AUTHENTIK_METRICS_PORT", host+"9300")
 	l.WithField("listen", listen).Info("Starting Metrics server")
 	err := http.ListenAndServe(listen, m)
 	if err != nil {

--- a/internal/outpost/ldap/metrics/metrics.go
+++ b/internal/outpost/ldap/metrics/metrics.go
@@ -32,8 +32,8 @@ func RunServer() {
 		rw.WriteHeader(204)
 	})
 	m.Path("/metrics").Handler(promhttp.Handler())
-	host := "0.0.0.0"
-	listen := utils.GetEnv("AUTHENTIK_METRICS_PORT", host+"9300")
+	host := "0.0.0.0:"
+	listen := host + utils.GetEnv("AUTHENTIK_METRICS_PORT", "9300")
 	l.WithField("listen", listen).Info("Starting Metrics server")
 	err := http.ListenAndServe(listen, m)
 	if err != nil {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,0 +1,10 @@
+package utils
+
+import "os"
+
+func GetEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
+}


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details
Resolves #3360

## Changes
### New Features
* Added ability to configure LDAP outpost ports via env variables AUTHENTIK_LDAP_PORT and AUTHENTIK_LDAPS_PORT. Will faillback to original ones if not set.
