### PR TITLE
docs(vikunja): fix config typo

### DIFF
--- a/website/integrations/services/vikunja/index.md
+++ b/website/integrations/services/vikunja/index.md
@@ -68,7 +68,7 @@ auth:
   # Take a look at the [default config file](https://github.com/go-vikunja/api/blob/main/config.yml.sample) for more information about how to configure openid authentication.
   openid:
     # Enable or disable OpenID Connect authentication
-    enabled: truefo
+    enabled: true
     # A list of enabled providers
     providers:
       # The name of the provider as it will appear in the frontend.


### PR DESCRIPTION
Fixing configuration typo `truefo` -> `true`

Signed-off-by: Kyle Brown <blackbarn@gmail.com>

<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details
* **Does this resolve an issue?**
Resolves (no pre-existing issue)

## Changes
Fixes typo in vikunja documentation
