### PR TITLE
Proposal and fix for issue #3359 and #3415 authentik redirect to wrong internal port

### DIFF
--- a/website/docs/providers/proxy/_nginx_proxy_manager.md
+++ b/website/docs/providers/proxy/_nginx_proxy_manager.md
@@ -6,6 +6,7 @@ For Nginx Proxy Manager you can use this snippet
 # header from upstream' error when trying to access an application protected by goauthentik
 proxy_buffers 8 16k;
 proxy_buffer_size 32k;
+port_in_redirect off;
 
 location / {
     # Put your proxy_pass to your application here

--- a/website/docs/providers/proxy/_nginx_proxy_manager.md
+++ b/website/docs/providers/proxy/_nginx_proxy_manager.md
@@ -6,6 +6,8 @@ For Nginx Proxy Manager you can use this snippet
 # header from upstream' error when trying to access an application protected by goauthentik
 proxy_buffers 8 16k;
 proxy_buffer_size 32k;
+
+# Make sure not to redirect traffic to a port 4443
 port_in_redirect off;
 
 location / {


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
When trying to go to my app like sonarr.....it redirect it to a port app.domain:4443/outpost..... And not the auth.domain:9000/outpost.

**Describe the solution you'd like**
By adding `port_in_redirect off` in the configuration for the NginxProxyManager (NPM), will avoid a redirect to port 4443.

**Describe alternatives you've considered**
N/A

**Additional context**
N/A





Signed-off-by: Zolo <39656359+zolodev@users.noreply.github.com>

<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details
* **Does this resolve an issue?**
Yes, Resolves #3359 and #3415

## Changes
### New Features
* N/A

### Breaking Changes
* N/A

## Additional
Credit to @adtwomey for the fix.
