### PR TITLE
blueprints: add generic export next to flow exporter

### DIFF
--- a/authentik/blueprints/management/commands/export_blueprint.py
+++ b/authentik/blueprints/management/commands/export_blueprint.py
@@ -1,0 +1,17 @@
+"""Export blueprint of current authentik install"""
+from django.core.management.base import BaseCommand, no_translations
+from structlog.stdlib import get_logger
+
+from authentik.blueprints.v1.exporter import Exporter
+
+LOGGER = get_logger()
+
+
+class Command(BaseCommand):
+    """Export blueprint of current authentik install"""
+
+    @no_translations
+    def handle(self, *args, **options):
+        """Export blueprint of current authentik install"""
+        exporter = Exporter()
+        self.stdout.write(exporter.export_to_string())

--- a/authentik/blueprints/tests/test_bundled.py
+++ b/authentik/blueprints/tests/test_bundled.py
@@ -1,10 +1,8 @@
 """test packaged blueprints"""
-from glob import glob
 from pathlib import Path
 from typing import Callable
 
 from django.test import TransactionTestCase
-from django.utils.text import slugify
 
 from authentik.blueprints.tests import apply_blueprint
 from authentik.blueprints.v1.importer import Importer
@@ -24,14 +22,13 @@ def blueprint_tester(file_name: str) -> Callable:
     """This is used instead of subTest for better visibility"""
 
     def tester(self: TestBundled):
-        with open(file_name, "r", encoding="utf8") as flow_yaml:
-            importer = Importer(flow_yaml.read())
+        with open(file_name, "r", encoding="utf8") as blueprint:
+            importer = Importer(blueprint.read())
         self.assertTrue(importer.validate()[0])
         self.assertTrue(importer.apply())
 
     return tester
 
 
-for flow_file in glob("blueprints/**/*.yaml", recursive=True):
-    method_name = slugify(Path(flow_file).stem).replace("-", "_").replace(".", "_")
-    setattr(TestBundled, f"test_flow_{method_name}", blueprint_tester(flow_file))
+for blueprint_file in Path("blueprints/").glob("**/*.yaml"):
+    setattr(TestBundled, f"test_blueprint_{blueprint_file}", blueprint_tester(blueprint_file))

--- a/authentik/blueprints/tests/test_v1.py
+++ b/authentik/blueprints/tests/test_v1.py
@@ -1,7 +1,7 @@
 """Test blueprints v1"""
 from django.test import TransactionTestCase
 
-from authentik.blueprints.v1.exporter import Exporter
+from authentik.blueprints.v1.exporter import FlowExporter
 from authentik.blueprints.v1.importer import Importer, transaction_rollback
 from authentik.flows.models import Flow, FlowDesignation, FlowStageBinding
 from authentik.lib.generators import generate_id
@@ -70,7 +70,7 @@ class TestBlueprintsV1(TransactionTestCase):
                 order=0,
             )
 
-            exporter = Exporter(flow)
+            exporter = FlowExporter(flow)
             export = exporter.export()
             self.assertEqual(len(export.entries), 3)
             export_yaml = exporter.export_to_string()
@@ -126,7 +126,7 @@ class TestBlueprintsV1(TransactionTestCase):
             fsb = FlowStageBinding.objects.create(target=flow, stage=user_login, order=0)
             PolicyBinding.objects.create(policy=flow_policy, target=fsb, order=0)
 
-            exporter = Exporter(flow)
+            exporter = FlowExporter(flow)
             export_yaml = exporter.export_to_string()
 
         importer = Importer(export_yaml)
@@ -169,7 +169,7 @@ class TestBlueprintsV1(TransactionTestCase):
 
             FlowStageBinding.objects.create(target=flow, stage=first_stage, order=0)
 
-            exporter = Exporter(flow)
+            exporter = FlowExporter(flow)
             export_yaml = exporter.export_to_string()
 
         importer = Importer(export_yaml)

--- a/authentik/blueprints/v1/exporter.py
+++ b/authentik/blueprints/v1/exporter.py
@@ -39,12 +39,13 @@ class Exporter:
             for obj in model.objects.all():
                 yield BlueprintEntry.from_model(obj)
 
-    def _pre_export(self):
+    def _pre_export(self, blueprint: Blueprint):
         """Hook to run anything pre-export"""
 
     def export(self) -> Blueprint:
         """Create a list of all objects and create a blueprint"""
         blueprint = Blueprint()
+        self._pre_export(blueprint)
         blueprint.metadata = BlueprintMetadata(
             name=_("authentik Export - %(date)s" % {"date": str(now())}),
             labels={
@@ -75,7 +76,7 @@ class FlowExporter(Exporter):
         self.with_policies = True
         self.with_stage_prompts = True
 
-    def _pre_export(self):
+    def _pre_export(self, blueprint: Blueprint):
         if not self.with_policies:
             return
         self.pbm_uuids = [self.flow.pbm_uuid]

--- a/authentik/blueprints/v1/labels.py
+++ b/authentik/blueprints/v1/labels.py
@@ -2,3 +2,4 @@
 
 LABEL_AUTHENTIK_SYSTEM = "blueprints.goauthentik.io/system"
 LABEL_AUTHENTIK_INSTANTIATE = "blueprints.goauthentik.io/instantiate"
+LABEL_AUTHENTIK_GENERATED = "blueprints.goauthentik.io/generated"

--- a/authentik/flows/api/flows.py
+++ b/authentik/flows/api/flows.py
@@ -20,7 +20,7 @@ from rest_framework.viewsets import ModelViewSet
 from structlog.stdlib import get_logger
 
 from authentik.api.decorators import permission_required
-from authentik.blueprints.v1.exporter import Exporter
+from authentik.blueprints.v1.exporter import FlowExporter
 from authentik.blueprints.v1.importer import Importer
 from authentik.core.api.used_by import UsedByMixin
 from authentik.core.api.utils import (
@@ -198,7 +198,7 @@ class FlowViewSet(UsedByMixin, ModelViewSet):
     def export(self, request: Request, slug: str) -> Response:
         """Export flow to .yaml file"""
         flow = self.get_object()
-        exporter = Exporter(flow)
+        exporter = FlowExporter(flow)
         response = HttpResponse(content=exporter.export_to_string())
         response["Content-Disposition"] = f'attachment; filename="{flow.slug}.yaml"'
         return response


### PR DESCRIPTION
This adds the ability to create a blueprint from the currently created objects in a given authentik install.