### PR TITLE
website/docs: Added mention of how to force 2fa

### DIFF
--- a/website/docs/flow/examples/flows.md
+++ b/website/docs/flow/examples/flows.md
@@ -28,7 +28,9 @@ You'll probably have to adjust the Email stage and set your connection details.
 
 Flow: right-click [here](/blueprints/example/flows-login-2fa.yaml) and save the file.
 
-Login flow which follows the default pattern (username/email, then password), but also checks for the user's OTP token, if they have one configured
+Login flow which follows the default pattern (username/email, then password), but also checks for the user's OTP token, if they have one configured.
+
+You can force two-factor authentication by editing the Not configured action in the Authenticator Validation Stage.
 
 ## Login with conditional Captcha
 
@@ -36,7 +38,7 @@ Flow: right-click [here](/blueprints/example/flows-login-conditional-captcha.yam
 
 Login flow which conditionally shows the users a captcha, based on the reputation of their IP and Username.
 
-By default, the captcha test keys are used. You can get a proper key [here](https://www.google.com/recaptcha/intro/v3.html)
+By default, the captcha test keys are used. You can get a proper key [here](https://www.google.com/recaptcha/intro/v3.html).
 
 ## Recovery with email verification
 
@@ -48,7 +50,7 @@ Recovery flow, the user is sent an email after they've identified themselves. Af
 
 Flow: right-click [here](/blueprints/example/flows-unenrollment.yaml) and save the file.
 
-Flow for users to delete their account,
+Flow for users to delete their account.
 
 :::warning
 This is done without any warning.

--- a/website/docs/flow/examples/flows.md
+++ b/website/docs/flow/examples/flows.md
@@ -30,7 +30,7 @@ Flow: right-click [here](/blueprints/example/flows-login-2fa.yaml) and save the 
 
 Login flow which follows the default pattern (username/email, then password), but also checks for the user's OTP token, if they have one configured.
 
-You can force two-factor authentication by editing the Not configured action in the Authenticator Validation Stage.
+You can force two-factor authentication by editing the *Not configured action* in the Authenticator Validation Stage.
 
 ## Login with conditional Captcha
 


### PR DESCRIPTION
Added mention of how to force 2fa and fixed some punctuation's.

Signed-off-by: Joeri Colman <colmanjoeri@msn.com>

<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details
* **Does this resolve an issue?**
Resolves #802

## Changes
### New Features
* No new features.

### Breaking Changes
* No breaking changes.

## Additional
After setting up 2fa using the example I found it hard to find how this could be enforced for all users. After searching google and then the closed issues I found #802 which finally explained how.
