### PR TITLE
Documentation: Improving 'Portainer' section

### DIFF
--- a/website/integrations/services/portainer/index.md
+++ b/website/integrations/services/portainer/index.md
@@ -20,7 +20,7 @@ This is based on authentik 2021.7.3 and Portainer 2.6.x-CE. Portainer 2.6 suppor
 
 The following placeholders will be used:
 
--   `port.company` is the FQDN of Portainer.
+-   `portainer.company` is the FQDN of Portainer.
 -   `authentik.company` is the FQDN of authentik.
 
 ### Step 1 - authentik
@@ -33,10 +33,11 @@ Only settings that have been modified from default have been listed.
 
 **Protocol Settings**
 
+
 -   Name: Portainer
 -   Client ID: Copy and Save this for Later
 -   Client Secret: Copy and Save this for later
--   Redirect URIs/Origins: `https://port.company`
+-   Redirect URIs/Origins: `https://portainer.company/`
 
 ### Step 2 - Portainer
 
@@ -46,7 +47,7 @@ In Portainer, under _Settings_, _Authentication_, Select _OAuth_ and _Custom_
 -   Client Secret: Client Secret from step 1
 -   Authorization URL: `https://authentik.company/application/o/authorize/`
 -   Access Token URL: `https://authentik.company/application/o/token/`
--   Redirect URL: `https://port.company`
+-   Redirect URL: `https://portainer.company`
 -   Resource URL: `https://authentik.company/application/o/userinfo/`
 -   Logout URL: `https://authentik.company/application/o/portainer/end-session/`
 -   User Identifier: `email`
@@ -65,7 +66,7 @@ In authentik, create an application which uses this provider. Optionally apply a
 -   Name: Portainer
 -   Slug: portainer
 -   Provider: Portainer
--   Launch URL: https://port.company
+-   Launch URL: https://portainer.company
 
 ## Notes
 

--- a/website/integrations/services/portainer/index.md
+++ b/website/integrations/services/portainer/index.md
@@ -33,7 +33,6 @@ Only settings that have been modified from default have been listed.
 
 **Protocol Settings**
 
-
 -   Name: Portainer
 -   Client ID: Copy and Save this for Later
 -   Client Secret: Copy and Save this for later


### PR DESCRIPTION
Adding in a / at the end of the redirect url is crucial and failing to do so will cause a 'Redirect URL' error thrown in by authentik.
I also find it more clear to use 'portainer.company' instead of 'port.company'.


Signed-off-by: Matthieu B <66959271+mtthidoteu@users.noreply.github.com>

<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details
* **Does this resolve an issue?**
Resolves #

## Changes
### New Features
* Adds feature which does x, y, and z.

### Breaking Changes
* Adds breaking change which causes \<issue\>.

## Additional
Any further notes or comments you want to make.
