### PR TITLE
Note about setup with self-signed certificates

### DIFF
--- a/website/integrations/services/wiki-js/index.md
+++ b/website/integrations/services/wiki-js/index.md
@@ -66,7 +66,6 @@ You do not have to enable "Allow self-registration" and select a group to which 
 If you're using self-signed certificates for authentik, you need to set the root certificate of your CA as trusted in WikiJS by setting the NODE_EXTRA_CA_CERTS variable as explained here: https://github.com/Requarks/wiki/discussions/3387.
 :::
 
-
 ### Step 5
 
 In authentik, create an application which uses this provider. Optionally apply access restrictions to the application using policy bindings.

--- a/website/integrations/services/wiki-js/index.md
+++ b/website/integrations/services/wiki-js/index.md
@@ -62,6 +62,11 @@ In Wiki.js, configure the authentication strategy with these settings:
 You do not have to enable "Allow self-registration" and select a group to which new users should be assigned, but if you don't you will have to manually provision users in Wiki.js and ensure that their usernames match the username they have in authentik.
 :::
 
+:::note
+If you're using self-signed certificates for authentik, you need to set the root certificate of your CA as trusted in WikiJS by setting the NODE_EXTRA_CA_CERTS variable as explained here: https://github.com/Requarks/wiki/discussions/3387.
+:::
+
+
 ### Step 5
 
 In authentik, create an application which uses this provider. Optionally apply access restrictions to the application using policy bindings.


### PR DESCRIPTION
Added a note with info about using self-signed certificates with authentik.

Signed-off-by: sathrudi <85929245+sathrudi@users.noreply.github.com>

# Details
Just added a note about WikiJS configuration when using authentik with self-signed certs.

## Additional
When using self-signed certificates for authentik, WikiJS gives an error "Failed to obtain access token". This is caused by the root certificate of the authentik SSLcert not being trusted by WikiJS as detailed here: https://github.com/Requarks/wiki/discussions/3387
