### PR TITLE
web: set default value for cert select inputs

### DIFF
--- a/web/src/pages/outposts/ServiceConnectionDockerForm.ts
+++ b/web/src/pages/outposts/ServiceConnectionDockerForm.ts
@@ -98,7 +98,12 @@ export class ServiceConnectionDockerForm extends ModelForm<DockerServiceConnecti
                                     </option>`;
                                 });
                             }),
-                        html`<option>${t`Loading...`}</option>`,
+                        html`<option
+                            value="${ifDefined(this.instance?.tlsVerification)}"
+                            ?selected=${this.instance?.tlsVerification !== undefined}
+                        >
+                            ${t`Loading...`}
+                        </option>`,
                     )}
                 </select>
                 <p class="pf-c-form__helper-text">
@@ -128,7 +133,12 @@ export class ServiceConnectionDockerForm extends ModelForm<DockerServiceConnecti
                                     </option>`;
                                 });
                             }),
-                        html`<option>${t`Loading...`}</option>`,
+                        html`<option
+                            value="${ifDefined(this.instance?.tlsAuthentication)}"
+                            ?selected=${this.instance?.tlsAuthentication !== undefined}
+                        >
+                            ${t`Loading...`}
+                        </option>`,
                     )}
                 </select>
                 <p class="pf-c-form__helper-text">

--- a/web/src/pages/outposts/ServiceConnectionDockerForm.ts
+++ b/web/src/pages/outposts/ServiceConnectionDockerForm.ts
@@ -99,7 +99,7 @@ export class ServiceConnectionDockerForm extends ModelForm<DockerServiceConnecti
                                 });
                             }),
                         html`<option
-                            value="${ifDefined(this.instance?.tlsVerification)}"
+                            value=${ifDefined(this.instance?.tlsVerification)}
                             ?selected=${this.instance?.tlsVerification !== undefined}
                         >
                             ${t`Loading...`}
@@ -134,7 +134,7 @@ export class ServiceConnectionDockerForm extends ModelForm<DockerServiceConnecti
                                 });
                             }),
                         html`<option
-                            value="${ifDefined(this.instance?.tlsAuthentication)}"
+                            value=${ifDefined(this.instance?.tlsAuthentication)}
                             ?selected=${this.instance?.tlsAuthentication !== undefined}
                         >
                             ${t`Loading...`}

--- a/web/src/pages/outposts/ServiceConnectionDockerForm.ts
+++ b/web/src/pages/outposts/ServiceConnectionDockerForm.ts
@@ -99,7 +99,7 @@ export class ServiceConnectionDockerForm extends ModelForm<DockerServiceConnecti
                                 });
                             }),
                         html`<option
-                            value=${ifDefined(this.instance?.tlsVerification)}
+                            value=${ifDefined(this.instance?.tlsVerification || undefined)}
                             ?selected=${this.instance?.tlsVerification !== undefined}
                         >
                             ${t`Loading...`}
@@ -134,7 +134,7 @@ export class ServiceConnectionDockerForm extends ModelForm<DockerServiceConnecti
                                 });
                             }),
                         html`<option
-                            value=${ifDefined(this.instance?.tlsAuthentication)}
+                            value=${ifDefined(this.instance?.tlsAuthentication || undefined)}
                             ?selected=${this.instance?.tlsAuthentication !== undefined}
                         >
                             ${t`Loading...`}

--- a/web/src/pages/providers/ldap/LDAPProviderForm.ts
+++ b/web/src/pages/providers/ldap/LDAPProviderForm.ts
@@ -194,7 +194,7 @@ export class LDAPProviderFormPage extends ModelForm<LDAPProvider, number> {
                                         });
                                     }),
                                 html`<option
-                                    value=${ifDefined(this.instance?.certificate)}
+                                    value=${ifDefined(this.instance?.certificate || undefined)}
                                     ?selected=${this.instance?.certificate !== undefined}
                                 >
                                     ${t`Loading...`}

--- a/web/src/pages/providers/ldap/LDAPProviderForm.ts
+++ b/web/src/pages/providers/ldap/LDAPProviderForm.ts
@@ -193,7 +193,12 @@ export class LDAPProviderFormPage extends ModelForm<LDAPProvider, number> {
                                             </option>`;
                                         });
                                     }),
-                                html`<option>${t`Loading...`}</option>`,
+                                html`<option
+                                    value="${ifDefined(this.instance?.certificate)}"
+                                    ?selected=${this.instance?.certificate !== undefined}
+                                >
+                                    ${t`Loading...`}
+                                </option>`,
                             )}
                         </select>
                         <p class="pf-c-form__helper-text">

--- a/web/src/pages/providers/ldap/LDAPProviderForm.ts
+++ b/web/src/pages/providers/ldap/LDAPProviderForm.ts
@@ -194,7 +194,7 @@ export class LDAPProviderFormPage extends ModelForm<LDAPProvider, number> {
                                         });
                                     }),
                                 html`<option
-                                    value="${ifDefined(this.instance?.certificate)}"
+                                    value=${ifDefined(this.instance?.certificate)}
                                     ?selected=${this.instance?.certificate !== undefined}
                                 >
                                     ${t`Loading...`}

--- a/web/src/pages/providers/oauth2/OAuth2ProviderForm.ts
+++ b/web/src/pages/providers/oauth2/OAuth2ProviderForm.ts
@@ -205,7 +205,7 @@ ${this.instance?.redirectUris}</textarea
                                         });
                                     }),
                                 html`<option
-                                    value=${ifDefined(this.instance?.signingKey)}
+                                    value=${ifDefined(this.instance?.signingKey || undefined)}
                                     ?selected=${this.instance?.signingKey !== undefined}
                                 >
                                     ${t`Loading...`}

--- a/web/src/pages/providers/oauth2/OAuth2ProviderForm.ts
+++ b/web/src/pages/providers/oauth2/OAuth2ProviderForm.ts
@@ -205,7 +205,7 @@ ${this.instance?.redirectUris}</textarea
                                         });
                                     }),
                                 html`<option
-                                    value="${ifDefined(this.instance?.signingKey)}"
+                                    value=${ifDefined(this.instance?.signingKey)}
                                     ?selected=${this.instance?.signingKey !== undefined}
                                 >
                                     ${t`Loading...`}

--- a/web/src/pages/providers/oauth2/OAuth2ProviderForm.ts
+++ b/web/src/pages/providers/oauth2/OAuth2ProviderForm.ts
@@ -204,7 +204,12 @@ ${this.instance?.redirectUris}</textarea
                                             </option>`;
                                         });
                                     }),
-                                html`<option>${t`Loading...`}</option>`,
+                                html`<option
+                                    value="${ifDefined(this.instance?.signingKey)}"
+                                    ?selected=${this.instance?.signingKey !== undefined}
+                                >
+                                    ${t`Loading...`}
+                                </option>`,
                             )}
                         </select>
                         <p class="pf-c-form__helper-text">${t`Key used to sign the tokens.`}</p>

--- a/web/src/pages/providers/proxy/ProxyProviderForm.ts
+++ b/web/src/pages/providers/proxy/ProxyProviderForm.ts
@@ -358,7 +358,7 @@ export class ProxyProviderFormPage extends ModelForm<ProxyProvider, number> {
                                         });
                                     }),
                                 html`<option
-                                    value="${ifDefined(this.instance?.certificate)}"
+                                    value=${ifDefined(this.instance?.certificate)}
                                     ?selected=${this.instance?.certificate !== undefined}
                                 >
                                     ${t`Loading...`}

--- a/web/src/pages/providers/proxy/ProxyProviderForm.ts
+++ b/web/src/pages/providers/proxy/ProxyProviderForm.ts
@@ -357,7 +357,12 @@ export class ProxyProviderFormPage extends ModelForm<ProxyProvider, number> {
                                             </option>`;
                                         });
                                     }),
-                                html`<option>${t`Loading...`}</option>`,
+                                html`<option
+                                    value="${ifDefined(this.instance?.certificate)}"
+                                    ?selected=${this.instance?.certificate !== undefined}
+                                >
+                                    ${t`Loading...`}
+                                </option>`,
                             )}
                         </select>
                     </ak-form-element-horizontal>

--- a/web/src/pages/providers/proxy/ProxyProviderForm.ts
+++ b/web/src/pages/providers/proxy/ProxyProviderForm.ts
@@ -358,7 +358,7 @@ export class ProxyProviderFormPage extends ModelForm<ProxyProvider, number> {
                                         });
                                     }),
                                 html`<option
-                                    value=${ifDefined(this.instance?.certificate)}
+                                    value=${ifDefined(this.instance?.certificate || undefined)}
                                     ?selected=${this.instance?.certificate !== undefined}
                                 >
                                     ${t`Loading...`}

--- a/web/src/pages/providers/saml/SAMLProviderForm.ts
+++ b/web/src/pages/providers/saml/SAMLProviderForm.ts
@@ -170,7 +170,7 @@ export class SAMLProviderFormPage extends ModelForm<SAMLProvider, number> {
                                         });
                                     }),
                                 html`<option
-                                    value=${ifDefined(this.instance?.signingKp)}
+                                    value=${ifDefined(this.instance?.signingKp || undefined)}
                                     ?selected=${this.instance?.signingKp !== undefined}
                                 >
                                     ${t`Loading...`}
@@ -209,7 +209,7 @@ export class SAMLProviderFormPage extends ModelForm<SAMLProvider, number> {
                                         });
                                     }),
                                 html`<option
-                                    value=${ifDefined(this.instance?.verificationKp)}
+                                    value=${ifDefined(this.instance?.verificationKp || undefined)}
                                     ?selected=${this.instance?.verificationKp !== undefined}
                                 >
                                     ${t`Loading...`}

--- a/web/src/pages/providers/saml/SAMLProviderForm.ts
+++ b/web/src/pages/providers/saml/SAMLProviderForm.ts
@@ -169,7 +169,12 @@ export class SAMLProviderFormPage extends ModelForm<SAMLProvider, number> {
                                             </option>`;
                                         });
                                     }),
-                                html`<option>${t`Loading...`}</option>`,
+                                html`<option
+                                    value="${ifDefined(this.instance?.signingKp)}"
+                                    ?selected=${this.instance?.signingKp !== undefined}
+                                >
+                                    ${t`Loading...`}
+                                </option>`,
                             )}
                         </select>
                         <p class="pf-c-form__helper-text">
@@ -203,7 +208,12 @@ export class SAMLProviderFormPage extends ModelForm<SAMLProvider, number> {
                                             </option>`;
                                         });
                                     }),
-                                html`<option>${t`Loading...`}</option>`,
+                                html`<option
+                                    value="${ifDefined(this.instance?.verificationKp)}"
+                                    ?selected=${this.instance?.verificationKp !== undefined}
+                                >
+                                    ${t`Loading...`}
+                                </option>`,
                             )}
                         </select>
                         <p class="pf-c-form__helper-text">

--- a/web/src/pages/providers/saml/SAMLProviderForm.ts
+++ b/web/src/pages/providers/saml/SAMLProviderForm.ts
@@ -170,7 +170,7 @@ export class SAMLProviderFormPage extends ModelForm<SAMLProvider, number> {
                                         });
                                     }),
                                 html`<option
-                                    value="${ifDefined(this.instance?.signingKp)}"
+                                    value=${ifDefined(this.instance?.signingKp)}
                                     ?selected=${this.instance?.signingKp !== undefined}
                                 >
                                     ${t`Loading...`}
@@ -209,7 +209,7 @@ export class SAMLProviderFormPage extends ModelForm<SAMLProvider, number> {
                                         });
                                     }),
                                 html`<option
-                                    value="${ifDefined(this.instance?.verificationKp)}"
+                                    value=${ifDefined(this.instance?.verificationKp)}
                                     ?selected=${this.instance?.verificationKp !== undefined}
                                 >
                                     ${t`Loading...`}

--- a/web/src/pages/sources/ldap/LDAPSourceForm.ts
+++ b/web/src/pages/sources/ldap/LDAPSourceForm.ts
@@ -174,7 +174,7 @@ export class LDAPSourceForm extends ModelForm<LDAPSource, string> {
                                         });
                                     }),
                                 html`<option
-                                    value=${ifDefined(this.instance?.peerCertificate)}
+                                    value=${ifDefined(this.instance?.peerCertificate || undefined)}
                                     ?selected=${this.instance?.peerCertificate !== undefined}
                                 >
                                     ${t`Loading...`}

--- a/web/src/pages/sources/ldap/LDAPSourceForm.ts
+++ b/web/src/pages/sources/ldap/LDAPSourceForm.ts
@@ -174,7 +174,7 @@ export class LDAPSourceForm extends ModelForm<LDAPSource, string> {
                                         });
                                     }),
                                 html`<option
-                                    value="${ifDefined(this.instance?.peerCertificate)}"
+                                    value=${ifDefined(this.instance?.peerCertificate)}
                                     ?selected=${this.instance?.peerCertificate !== undefined}
                                 >
                                     ${t`Loading...`}

--- a/web/src/pages/sources/ldap/LDAPSourceForm.ts
+++ b/web/src/pages/sources/ldap/LDAPSourceForm.ts
@@ -173,7 +173,12 @@ export class LDAPSourceForm extends ModelForm<LDAPSource, string> {
                                             </option>`;
                                         });
                                     }),
-                                html`<option>${t`Loading...`}</option>`,
+                                html`<option
+                                    value="${ifDefined(this.instance?.peerCertificate)}"
+                                    ?selected=${this.instance?.peerCertificate !== undefined}
+                                >
+                                    ${t`Loading...`}
+                                </option>`,
                             )}
                         </select>
                         <p class="pf-c-form__helper-text">

--- a/web/src/pages/sources/saml/SAMLSourceForm.ts
+++ b/web/src/pages/sources/saml/SAMLSourceForm.ts
@@ -163,7 +163,7 @@ export class SAMLSourceForm extends ModelForm<SAMLSource, string> {
                                         });
                                     }),
                                 html`<option
-                                    value=${ifDefined(this.instance?.signingKp)}
+                                    value=${ifDefined(this.instance?.signingKp || undefined)}
                                     ?selected=${this.instance?.signingKp !== undefined}
                                 >
                                     ${t`Loading...`}

--- a/web/src/pages/sources/saml/SAMLSourceForm.ts
+++ b/web/src/pages/sources/saml/SAMLSourceForm.ts
@@ -163,7 +163,7 @@ export class SAMLSourceForm extends ModelForm<SAMLSource, string> {
                                         });
                                     }),
                                 html`<option
-                                    value="${ifDefined(this.instance?.signingKp)}"
+                                    value=${ifDefined(this.instance?.signingKp)}
                                     ?selected=${this.instance?.signingKp !== undefined}
                                 >
                                     ${t`Loading...`}

--- a/web/src/pages/sources/saml/SAMLSourceForm.ts
+++ b/web/src/pages/sources/saml/SAMLSourceForm.ts
@@ -162,7 +162,12 @@ export class SAMLSourceForm extends ModelForm<SAMLSource, string> {
                                             </option>`;
                                         });
                                     }),
-                                html`<option>${t`Loading...`}</option>`,
+                                html`<option
+                                    value="${ifDefined(this.instance?.signingKp)}"
+                                    ?selected=${this.instance?.signingKp !== undefined}
+                                >
+                                    ${t`Loading...`}
+                                </option>`,
                             )}
                         </select>
                         <p class="pf-c-form__helper-text">

--- a/web/src/pages/tenants/TenantForm.ts
+++ b/web/src/pages/tenants/TenantForm.ts
@@ -379,7 +379,7 @@ export class TenantForm extends ModelForm<Tenant, string> {
                                         });
                                     }),
                                 html`<option
-                                    value="${ifDefined(this.instance?.webCertificate)}"
+                                    value=${ifDefined(this.instance?.webCertificate)}
                                     ?selected=${this.instance?.webCertificate !== undefined}
                                 >
                                     ${t`Loading...`}

--- a/web/src/pages/tenants/TenantForm.ts
+++ b/web/src/pages/tenants/TenantForm.ts
@@ -379,7 +379,7 @@ export class TenantForm extends ModelForm<Tenant, string> {
                                         });
                                     }),
                                 html`<option
-                                    value=${ifDefined(this.instance?.webCertificate)}
+                                    value=${ifDefined(this.instance?.webCertificate || undefined)}
                                     ?selected=${this.instance?.webCertificate !== undefined}
                                 >
                                     ${t`Loading...`}

--- a/web/src/pages/tenants/TenantForm.ts
+++ b/web/src/pages/tenants/TenantForm.ts
@@ -378,7 +378,12 @@ export class TenantForm extends ModelForm<Tenant, string> {
                                             </option>`;
                                         });
                                     }),
-                                html`<option>${t`Loading...`}</option>`,
+                                html`<option
+                                    value="${ifDefined(this.instance?.webCertificate)}"
+                                    ?selected=${this.instance?.webCertificate !== undefined}
+                                >
+                                    ${t`Loading...`}
+                                </option>`,
                             )}
                         </select>
                     </ak-form-element-horizontal>


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details
* **Does this resolve an issue?**
No

## Changes
### New Features
* adds value/selected attribute to the fallback option part in the `until` directives used where certificate-key pairs are specified in the web interface

## Additional
Requesting a single `CertificateKeyPair` from the API can take up to 800ms (likely because it loads the private key/certificate every time the entity is loaded). This causes considerable slow-down when loading the Certificate-Key Pairs page. Additionally any forms that have select inputs that accept certificate-key pairs (e.g. SAML provider) will be blocked from submission until the request to retrieve every keypair is completed. 
If you attempt to submit a form with a cert input before the CertificateKeyPair request has completed then the associated keypair uuid will be lost. This PR solves this by setting the fallback option's value to the selected key-pair.

Perhaps a better solution would be to only request the columns that are needed for display however I don't think that is possible at the moment.