### PR TITLE
web: fix scrolling in modals in low-height views

### DIFF
--- a/web/src/common/styles/authentik.css
+++ b/web/src/common/styles/authentik.css
@@ -106,6 +106,11 @@ html > form > input {
     margin-bottom: 6px;
 }
 
+/* Fix scrolling in modals in low-height viewports on Chromium */
+.pf-c-modal-box__body {
+    overflow: hidden;
+}
+
 @media (prefers-color-scheme: dark) {
     .ak-static-page h1 {
         color: var(--ak-dark-foreground);


### PR DESCRIPTION
# Details
* **Does this resolve an issue?**
No

## Changes
### New Features
* Adds explicit `overflow: hidden` to `.pf-c-modal-box__body`

## Additional
The default styling for `modal-box__body` has `overflow: hidden auto`. Having `overflow-y: auto` breaks scrolling with the scroll wheel in modals in low-height viewports (<900px?) on Chromium (at least M105). Setting it to `overflow: hidden` will allow scrolling with the scroll wheel while focused on the modal body.