### PR TITLE
Docs: Fix letsencrypt folder

### DIFF
--- a/website/docs/core/certificates.md
+++ b/website/docs/core/certificates.md
@@ -84,8 +84,7 @@ services:
     certbot:
         image: certbot/dns-route53:v1.22.0
         volumes:
-            - ./letsencrypt:/etc/letsencrypt
-            - ../authentik/certs/:/etc/letsencrypt/live
+            - ./certs/:/etc/letsencrypt
         # Variables depending on DNS Plugin
         environment:
             AWS_ACCESS_KEY_ID: ...


### PR DESCRIPTION
When the docs were changed to the docker-compose.override.yaml version, the change wasnt 100% completed, by still including the "..authentik" folder part in the volumes.

Addtionally, it doesnt work to only mount the /live letsencrypt folder in the worker, as it will be a symlink that the worker wont have access to (as its outside the container context). So this reverts the change to the previous version where the complete /etc/letsencrypt folder gets mounted in /certs

Signed-off-by: Philipp Rintz <13933258+p-rintz@users.noreply.github.com>

<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details
* **Does this resolve an issue?**
No

## Changes
### New Features
No Feature, only documentation change.

### Breaking Changes
No breaking change, only documentation change.

## Additional
Any further notes or comments you want to make.
