### PR TITLE
root: decrease default token size to 60 chars for compatibility

### DIFF
--- a/authentik/lib/default.yml
+++ b/authentik/lib/default.yml
@@ -77,7 +77,7 @@ default_user_change_username: true
 
 gdpr_compliance: true
 cert_discovery_dir: /certs
-default_token_length: 128
+default_token_length: 60
 impersonation: true
 
 blueprints_dir: /blueprints

--- a/website/docs/installation/configuration.md
+++ b/website/docs/installation/configuration.md
@@ -215,7 +215,7 @@ When enabled, all the events caused by a user will be deleted upon the user's de
 Requires authentik 2022.4.1
 :::
 
-Configure the length of generated tokens. Defaults to 128.
+Configure the length of generated tokens. Defaults to 60.
 
 ### `AUTHENTIK_IMPERSONATION`
 


### PR DESCRIPTION
Signed-off-by: Jens Langhammer <jens.langhammer@beryju.org>

#2614

<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details
* **Does this resolve an issue?**
Resolves #

## Changes
### New Features
* Adds feature which does x, y, and z.

### Breaking Changes
* Adds breaking change which causes \<issue\>.

## Additional
Any further notes or comments you want to make.
