### PR TITLE
website/integrations: add missing step to create mappings

### DIFF
--- a/website/integrations/services/minio/index.md
+++ b/website/integrations/services/minio/index.md
@@ -19,7 +19,7 @@ The following placeholders will be used:
 -   `minio.company` is the FQDN of the MinIO install.
 -   `authentik.company` is the FQDN of the authentik install.
 
-Under _Property Mappings_, create a _Scope Mapping_. Give it a name like "OIDC-Scope-minio". Set the scope name to `minio` and the expression to the following
+Under _Customization_ -> _Property Mappings_, create a _Scope Mapping_. Give it a name like "OIDC-Scope-minio". Set the scope name to `minio` and the expression to the following
 
 ```python
 return {

--- a/website/integrations/services/rancher/index.md
+++ b/website/integrations/services/rancher/index.md
@@ -20,7 +20,7 @@ The following placeholders will be used:
 -   `rancher.company` is the FQDN of the Rancher install.
 -   `authentik.company` is the FQDN of the authentik install.
 
-Under _Property Mappings_, create a _SAML Property Mapping_. Give it a name like "SAML Rancher User ID". Set the SAML name to `rancherUidUsername` and the expression to the following
+Under _Customization_ -> _Property Mappings_, create a _SAML Property Mapping_. Give it a name like "SAML Rancher User ID". Set the SAML name to `rancherUidUsername` and the expression to the following
 
 ```python
 return f"{user.pk}-{user.username}"

--- a/website/integrations/services/roundcube/index.md
+++ b/website/integrations/services/roundcube/index.md
@@ -25,7 +25,7 @@ The following placeholders will be used:
 Create a new oauth2 Scope Mapping which does not return the 'group' values and associate this mapping
 in the provider settings instead of the default oauth mapping.
 
-Under _Property Mappings_, create a _Scope Mapping_. Give it a name like "oauth2-Scope-dovecot". Set the scope name to `dovecotprofile` and the expression to the following
+Under _Customization_ -> _Property Mappings_, create a _Scope Mapping_. Give it a name like "oauth2-Scope-dovecot". Set the scope name to `dovecotprofile` and the expression to the following
 
 ```
 return {

--- a/website/integrations/services/vmware-vcenter/index.md
+++ b/website/integrations/services/vmware-vcenter/index.md
@@ -35,7 +35,7 @@ Since vCenter only allows OpenID-Connect in combination with Active Directory, i
 
 ### Step 1
 
-Under _Property Mappings_, create a _Scope Mapping_. Give it a name like "OIDC-Scope-VMware-vCenter". Set the scope name to `openid` and the expression to the following
+Under _Customisation_ > _Property Mappings_, create a _Scope Mapping_. Give it a name like "OIDC-Scope-VMware-vCenter". Set the scope name to `openid` and the expression to the following
 
 ```python
 return {

--- a/website/integrations/services/vmware-vcenter/index.md
+++ b/website/integrations/services/vmware-vcenter/index.md
@@ -35,7 +35,7 @@ Since vCenter only allows OpenID-Connect in combination with Active Directory, i
 
 ### Step 1
 
-Under _Customisation_ > _Property Mappings_, create a _Scope Mapping_. Give it a name like "OIDC-Scope-VMware-vCenter". Set the scope name to `openid` and the expression to the following
+Under _Customization_ -> _Property Mappings_, create a _Scope Mapping_. Give it a name like "OIDC-Scope-VMware-vCenter". Set the scope name to `openid` and the expression to the following
 
 ```python
 return {


### PR DESCRIPTION
# Added "Customisation" menu helper under "Step 1" in "VMware vCenter" Integration Guide

Signed-off-by: Nick Baughman <baughmann1@gmail.com>

<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details
The [vCenter Integration Guide](https://goauthentik.io/integrations/services/vmware-vcenter/) seems out of date based on what I'm looking at. 

I'm brand new to Authentik so maybe I'm just doing something wrong? There also seems to be other issues with this specific guide that I'm not yet knowledgeable about Authentik to fix, namely  an outdated screenshot in Step 3 and a missing menu name in Section 2 (where is "Sources" exactly?). If I find the answer to these I will update this guide accordingly.

# Resolves
New users with latest version of Authentik unable to find the "Property Mappings" menu item without digging through the menus.

