### PR TITLE
internal: allow Sentry DSN to be configured by end user

### DIFF
--- a/authentik/lib/sentry.py
+++ b/authentik/lib/sentry.py
@@ -34,7 +34,7 @@ from authentik.lib.utils.http import authentik_user_agent
 from authentik.lib.utils.reflection import class_to_path, get_env
 
 LOGGER = get_logger()
-SENTRY_DSN = "https://a579bb09306d4f8b8d8847c052d3a1d3@sentry.beryju.org/8"
+DEFAULT_SENTRY_DSN = "https://a579bb09306d4f8b8d8847c052d3a1d3@sentry.beryju.org/8"
 
 
 class SentryWSMiddleware(BaseMiddleware):
@@ -63,6 +63,7 @@ class SentryTransport(HttpTransport):
 
 def sentry_init(**sentry_init_kwargs):
     """Configure sentry SDK"""
+    sentry_dsn = CONFIG.y("error_reporting.sentry_dsn", DEFAULT_SENTRY_DSN)
     sentry_env = CONFIG.y("error_reporting.environment", "customer")
     kwargs = {
         "environment": sentry_env,
@@ -71,7 +72,7 @@ def sentry_init(**sentry_init_kwargs):
     kwargs.update(**sentry_init_kwargs)
     # pylint: disable=abstract-class-instantiated
     sentry_sdk_init(
-        dsn=SENTRY_DSN,
+        dsn=sentry_dsn,
         integrations=[
             DjangoIntegration(transaction_style="function_name"),
             CeleryIntegration(),

--- a/website/docs/installation/configuration.md
+++ b/website/docs/installation/configuration.md
@@ -89,13 +89,25 @@ Disable the inbuilt update-checker. Defaults to `false`.
 
 -   `AUTHENTIK_ERROR_REPORTING__ENABLED`
 
-    Enable error reporting. Defaults to `false`.
+    Enable error reporting to Sentry. Defaults to `false`.
 
-    Error reports are sent to https://sentry.beryju.org, and are used for debugging and general feedback. Anonymous performance data is also sent.
+-   `AUTHENTIK_ERROR_REPORTING__SENTRY_DSN`
+
+    Sets the DSN for the Sentry API endpoint. Defaults to `https://sentry.beryju.org`.
+
+    When error reporting is enabled, the default Sentry DSN will allow the authentik developers to
+    receive error reports and anonymous performance data, which is used for general feedback about
+    authentik, and in some cases, may be used for debugging purposes.
+
+    Users can create their own hosted Sentry account (or self-host Sentry) and opt to collect this
+    data themselves.
 
 -   `AUTHENTIK_ERROR_REPORTING__ENVIRONMENT`
 
-    Unique environment that is attached to your error reports, should be set to your email address for example. Defaults to `customer`.
+    The environment tag associated with all data sent to Sentry. Defaults to `customer`.
+    
+    When error reporting has been enabled to aid in debugging issues, this should be set to a unique
+    value, such as an e-mail address.
 
 -   `AUTHENTIK_ERROR_REPORTING__SEND_PII`
 


### PR DESCRIPTION
## Details

The existing Sentry instrumentation is fairly valuable for performance optimization purposes, but having Sentry hard-coded to report to `https://sentry.beryju.org` makes it a pain to override during local development.

## Changes

### New Features

* Allow the Sentry DSN to be overridden via `AUTHENTIK_ERROR_REPORTING__SENTRY_DSN`.

## Additional

I updated the configuration docs to list the new configuration setting, and _slightly_ tweaked the wording of the surrounding documentation to explain the dichotomy between the default DSN -- useful for debugging issues in collaboration with authentik devs, anonymous performance data, etc -- and specifying a custom one.