### PR TITLE
Feature/simple group serializer

### DIFF
--- a/authentik/core/api/users.py
+++ b/authentik/core/api/users.py
@@ -73,6 +73,27 @@ from authentik.tenants.models import Tenant
 
 LOGGER = get_logger()
 
+class SimpleGroupSerializer(ModelSerializer):
+    """Group Serializer"""
+
+    attributes = JSONField(validators=[is_dict], required=False)
+    parent_name = CharField(source="parent.name", read_only=True)
+
+    num_pk = IntegerField(read_only=True)
+
+    class Meta:
+
+        model = Group
+        fields = [
+            "pk",
+            "num_pk",
+            "name",
+            "is_superuser",
+            "parent",
+            "parent_name",
+            "attributes",
+        ]
+
 
 class UserSerializer(ModelSerializer):
     """User Serializer"""
@@ -83,7 +104,7 @@ class UserSerializer(ModelSerializer):
     groups = PrimaryKeyRelatedField(
         allow_empty=True, many=True, source="ak_groups", queryset=Group.objects.all()
     )
-    groups_obj = ListSerializer(child=GroupSerializer(), read_only=True, source="ak_groups")
+    groups_obj = ListSerializer(child=SimpleGroupSerializer(), read_only=True, source="ak_groups")
     uid = CharField(read_only=True)
     username = CharField(max_length=150)
 

--- a/authentik/core/api/users.py
+++ b/authentik/core/api/users.py
@@ -73,13 +73,11 @@ from authentik.tenants.models import Tenant
 LOGGER = get_logger()
 
 
-class SimpleGroupSerializer(ModelSerializer):
-    """Group Serializer"""
+class UserGroupSerializer(ModelSerializer):
+    """Simplified Group Serializer for user's groups"""
 
-    attributes = JSONField(validators=[is_dict], required=False)
+    attributes = JSONField(required=False)
     parent_name = CharField(source="parent.name", read_only=True)
-
-    num_pk = IntegerField(read_only=True)
 
     class Meta:
 
@@ -104,7 +102,7 @@ class UserSerializer(ModelSerializer):
     groups = PrimaryKeyRelatedField(
         allow_empty=True, many=True, source="ak_groups", queryset=Group.objects.all()
     )
-    groups_obj = ListSerializer(child=SimpleGroupSerializer(), read_only=True, source="ak_groups")
+    groups_obj = ListSerializer(child=UserGroupSerializer(), read_only=True, source="ak_groups")
     uid = CharField(read_only=True)
     username = CharField(max_length=150)
 

--- a/authentik/core/api/users.py
+++ b/authentik/core/api/users.py
@@ -46,7 +46,6 @@ from structlog.stdlib import get_logger
 
 from authentik.admin.api.metrics import CoordinateSerializer
 from authentik.api.decorators import permission_required
-from authentik.core.api.groups import GroupSerializer
 from authentik.core.api.used_by import UsedByMixin
 from authentik.core.api.utils import LinkSerializer, PassiveSerializer, is_dict
 from authentik.core.middleware import (
@@ -72,6 +71,7 @@ from authentik.stages.email.utils import TemplateEmailMessage
 from authentik.tenants.models import Tenant
 
 LOGGER = get_logger()
+
 
 class SimpleGroupSerializer(ModelSerializer):
     """Group Serializer"""

--- a/schema.yml
+++ b/schema.yml
@@ -36800,59 +36800,6 @@ components:
       - http://www.w3.org/2001/04/xmldsig-more#rsa-sha512
       - http://www.w3.org/2000/09/xmldsig#dsa-sha1
       type: string
-    SimpleGroup:
-      type: object
-      description: Group Serializer
-      properties:
-        pk:
-          type: string
-          format: uuid
-          readOnly: true
-          title: Group uuid
-        num_pk:
-          type: integer
-          readOnly: true
-        name:
-          type: string
-          maxLength: 80
-        is_superuser:
-          type: boolean
-          description: Users added to this group will be superusers.
-        parent:
-          type: string
-          format: uuid
-          nullable: true
-        parent_name:
-          type: string
-          readOnly: true
-        attributes:
-          type: object
-          additionalProperties: {}
-      required:
-      - name
-      - num_pk
-      - parent_name
-      - pk
-    SimpleGroupRequest:
-      type: object
-      description: Group Serializer
-      properties:
-        name:
-          type: string
-          minLength: 1
-          maxLength: 80
-        is_superuser:
-          type: boolean
-          description: Users added to this group will be superusers.
-        parent:
-          type: string
-          format: uuid
-          nullable: true
-        attributes:
-          type: object
-          additionalProperties: {}
-      required:
-      - name
     Source:
       type: object
       description: Source Serializer
@@ -37530,7 +37477,7 @@ components:
         groups_obj:
           type: array
           items:
-            $ref: '#/components/schemas/SimpleGroup'
+            $ref: '#/components/schemas/UserGroup'
           readOnly: true
         email:
           type: string
@@ -37632,6 +37579,59 @@ components:
       - username
       - upn
       type: string
+    UserGroup:
+      type: object
+      description: Simplified Group Serializer for user's groups
+      properties:
+        pk:
+          type: string
+          format: uuid
+          readOnly: true
+          title: Group uuid
+        num_pk:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 80
+        is_superuser:
+          type: boolean
+          description: Users added to this group will be superusers.
+        parent:
+          type: string
+          format: uuid
+          nullable: true
+        parent_name:
+          type: string
+          readOnly: true
+        attributes:
+          type: object
+          additionalProperties: {}
+      required:
+      - name
+      - num_pk
+      - parent_name
+      - pk
+    UserGroupRequest:
+      type: object
+      description: Simplified Group Serializer for user's groups
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 80
+        is_superuser:
+          type: boolean
+          description: Users added to this group will be superusers.
+        parent:
+          type: string
+          format: uuid
+          nullable: true
+        attributes:
+          type: object
+          additionalProperties: {}
+      required:
+      - name
     UserLoginStage:
       type: object
       description: UserLoginStage Serializer

--- a/schema.yml
+++ b/schema.yml
@@ -36800,6 +36800,59 @@ components:
       - http://www.w3.org/2001/04/xmldsig-more#rsa-sha512
       - http://www.w3.org/2000/09/xmldsig#dsa-sha1
       type: string
+    SimpleGroup:
+      type: object
+      description: Group Serializer
+      properties:
+        pk:
+          type: string
+          format: uuid
+          readOnly: true
+          title: Group uuid
+        num_pk:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 80
+        is_superuser:
+          type: boolean
+          description: Users added to this group will be superusers.
+        parent:
+          type: string
+          format: uuid
+          nullable: true
+        parent_name:
+          type: string
+          readOnly: true
+        attributes:
+          type: object
+          additionalProperties: {}
+      required:
+      - name
+      - num_pk
+      - parent_name
+      - pk
+    SimpleGroupRequest:
+      type: object
+      description: Group Serializer
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 80
+        is_superuser:
+          type: boolean
+          description: Users added to this group will be superusers.
+        parent:
+          type: string
+          format: uuid
+          nullable: true
+        attributes:
+          type: object
+          additionalProperties: {}
+      required:
+      - name
     Source:
       type: object
       description: Source Serializer
@@ -37477,7 +37530,7 @@ components:
         groups_obj:
           type: array
           items:
-            $ref: '#/components/schemas/Group'
+            $ref: '#/components/schemas/SimpleGroup'
           readOnly: true
         email:
           type: string


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details
This PR introduces a new serializer for retrieving groups of users. 

Background: In our instance over 500 users are assigned in a single group which results in very poor performance.
Debugging showed that this is due to the use of the user_obj, which results a query of over 500 users for a single user. Especially in the UI and the LDAP backend this results in a huge burst query on the database.

* **Does this resolve an issue?**
Resolves #3884

## Changes
### New Features
* Adds a serializer "SimpleGroupSerializer" as part of the core/api/users routes


## Additional
I tried to test locally, however the setup (I only use docker) has proven to be very difficult.
