### PR TITLE
change email to username

### DIFF
--- a/website/integrations/services/portainer/index.md
+++ b/website/integrations/services/portainer/index.md
@@ -49,7 +49,7 @@ In Portainer, under _Settings_, _Authentication_, Select _OAuth_ and _Custom_
 -   Redirect URL: `https://portainer.company`
 -   Resource URL: `https://authentik.company/application/o/userinfo/`
 -   Logout URL: `https://authentik.company/application/o/portainer/end-session/`
--   User Identifier: `preferred_username`
+-   User Identifier: `preferred_username` (Or `email` if you want to use email addresses as identifiers)
 -   Scopes: `email openid profile`
 
 :::note

--- a/website/integrations/services/portainer/index.md
+++ b/website/integrations/services/portainer/index.md
@@ -49,7 +49,7 @@ In Portainer, under _Settings_, _Authentication_, Select _OAuth_ and _Custom_
 -   Redirect URL: `https://portainer.company`
 -   Resource URL: `https://authentik.company/application/o/userinfo/`
 -   Logout URL: `https://authentik.company/application/o/portainer/end-session/`
--   User Identifier: `email`
+-   User Identifier: `preferred_username`
 -   Scopes: `email openid profile`
 
 :::note


### PR DESCRIPTION
change the current settings from username as email to username.

Signed-off-by: Zakaria aourzag <z.aourzag@gmail.com>

<!--
👋 Hello there! Welcome.


# Details



changed portainer identifier to preferred_username
