### PR TITLE
Fixed bug causing blueprint instance context be discarded

### DIFF
--- a/authentik/blueprints/v1/importer.py
+++ b/authentik/blueprints/v1/importer.py
@@ -85,11 +85,11 @@ class Importer:
             self.__import = from_dict(Blueprint, import_dict)
         except DaciteError as exc:
             raise EntryInvalidError from exc
-        context = {}
-        always_merger.merge(context, self.__import.context)
+        ctx = {}
+        always_merger.merge(ctx, self.__import.context)
         if context:
-            always_merger.merge(context, context)
-        self.__import.context = context
+            always_merger.merge(ctx, context)
+        self.__import.context = ctx
 
     @property
     def blueprint(self) -> Blueprint:


### PR DESCRIPTION
Fixed a bug causing blueprint instance context to be discarded (instead of merged over the default blueprint context) when applying a blueprint. 

# Details
* **Does this resolve an issue?**
N/A. Submitted a pull request without opening an issue.

## Changes
### New Features
N/A

### Breaking Changes
N/A

## Additional
After experiencing the bug I though I was doing something wrong at first so I started reading the code. Found the cause accidentally while doing that. 

Sorry that I am not providing any tests for this! I had limited time to spend on this and I did not understand the test system of authentik well enough to know where and how to write a test for this.

I am hoping that this is a simple enough change to not require any tests. That said I will be happy to write some if someone can provide me with some guidance.