### PR TITLE
Fix: Using the same http transport as the api

### DIFF
--- a/internal/outpost/ak/global.go
+++ b/internal/outpost/ak/global.go
@@ -16,6 +16,7 @@ import (
 )
 
 var initialSetup = false
+var tlsTransport *http.RoundTripper = nil
 
 func doGlobalSetup(outpost api.Outpost, globalConfig *api.Config) {
 	l := log.WithField("logger", "authentik.outpost")
@@ -70,15 +71,19 @@ func doGlobalSetup(outpost api.Outpost, globalConfig *api.Config) {
 
 // GetTLSTransport Get a TLS transport instance, that skips verification if configured via environment variables.
 func GetTLSTransport() http.RoundTripper {
+	if tlsTransport != nil {
+		return *tlsTransport
+	}
 	value, set := os.LookupEnv("AUTHENTIK_INSECURE")
 	if !set {
 		value = "false"
 	}
-	tlsTransport, err := httptransport.TLSTransport(httptransport.TLSClientOptions{
+	tmp, err := httptransport.TLSTransport(httptransport.TLSClientOptions{
 		InsecureSkipVerify: strings.ToLower(value) == "true",
 	})
 	if err != nil {
 		panic(err)
 	}
-	return tlsTransport
+	tlsTransport = &tmp
+	return *tlsTransport
 }

--- a/internal/outpost/flow/executor.go
+++ b/internal/outpost/flow/executor.go
@@ -14,9 +14,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	log "github.com/sirupsen/logrus"
 	"goauthentik.io/api/v3"
-	"goauthentik.io/internal/constants"
-	"goauthentik.io/internal/outpost/ak"
-	"goauthentik.io/internal/utils/web"
 )
 
 var (
@@ -60,7 +57,7 @@ func NewFlowExecutor(ctx context.Context, flowSlug string, refConfig *api.Config
 		l.WithError(err).Warning("Failed to create cookiejar")
 		panic(err)
 	}
-	transport := web.NewUserAgentTransport(constants.OutpostUserAgent(), web.NewTracingTransport(rsp.Context(), ak.GetTLSTransport()))
+	transport := refConfig.HTTPClient.Transport
 	fe := &FlowExecutor{
 		Params:    url.Values{},
 		Answers:   make(map[StageComponent]string),

--- a/internal/outpost/flow/executor.go
+++ b/internal/outpost/flow/executor.go
@@ -14,6 +14,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	log "github.com/sirupsen/logrus"
 	"goauthentik.io/api/v3"
+	"goauthentik.io/internal/constants"
+	"goauthentik.io/internal/outpost/ak"
+	"goauthentik.io/internal/utils/web"
 )
 
 var (
@@ -57,7 +60,7 @@ func NewFlowExecutor(ctx context.Context, flowSlug string, refConfig *api.Config
 		l.WithError(err).Warning("Failed to create cookiejar")
 		panic(err)
 	}
-	transport := refConfig.HTTPClient.Transport
+	transport := web.NewUserAgentTransport(constants.OutpostUserAgent(), web.NewTracingTransport(rsp.Context(), ak.GetTLSTransport()))
 	fe := &FlowExecutor{
 		Params:    url.Values{},
 		Answers:   make(map[StageComponent]string),


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details
Resolves #3995

## Changes
### New Features
* Use existing HTTP Transport instead of creating a new one for the FlowExecutor

### Breaking Changes
-

## Additional
-
