### PR TITLE
Fix small error in Invitation stage docs

### DIFF
--- a/website/docs/flow/stages/invitation/index.md
+++ b/website/docs/flow/stages/invitation/index.md
@@ -6,7 +6,7 @@ This stage can be used to invite users. You can use this to enroll users with pr
 
 If the option `Continue Flow without Invitation` is enabled, this stage will continue even when no invitation token is present.
 
-To check if a user has used an invitation within a policy, you can check `request.context.invitation_in_effect`.
+To check if a user has used an invitation within a policy, you can check `request.context.get("invitation_in_effect", False)`.
 
 To use an invitation, use the URL `https://authentik.tld/if/flow/your-enrollment-flow/?itoken=invitation-token`.
 


### PR DESCRIPTION
The `.get` is there to ensure the policy won't throw an error if the key is not there (which can happen if the policy is executed before an Invitation stage).

Signed-off-by: sdimovv <36302090+sdimovv@users.noreply.github.com>

<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details
* **Does this resolve an issue?**
N/A

## Changes
### New Features
N/A

### Breaking Changes
N/A

## Additional
N/A
