### PR TITLE
Allow specifying a redis URL directly

### DIFF
--- a/authentik/root/settings.py
+++ b/authentik/root/settings.py
@@ -195,7 +195,7 @@ _redis_url = (
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": f"{_redis_url}/{CONFIG.y('redis.db')}",
+        "LOCATION": CONFIG.y('redis.url') or f"{_redis_url}/{CONFIG.y('redis.db')}",
         "TIMEOUT": int(CONFIG.y("redis.cache_timeout", 300)),
         "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient"},
         "KEY_PREFIX": "authentik_cache",


### PR DESCRIPTION
# Details
* **Does this resolve an issue?**
I ran into this when trying to set up Authentik in my homelab. Specifically, I'm making a dedicated tiny computer run some security-sensitive software (Authentik, Vault, step-ca) and I'm hoping to minimize the number of listening TCP sockets.

## Changes
### New Features
* Support overriding the generated cache location with a provided URL

## Additional
This is meant for a couple of more advanced use cases:

* Allows specifying a UNIX socket path to Redis
* Can use a specific user name (rather than the `default` user) allowing for more granular ACLs in Redis 6+

As a side effect, any future keyword arguments to `redis-py` can be passed in immediately before there are specific environment variables for each of them.


Signed-off-by: No GUI <14547+nogweii@users.noreply.github.com>