### PR TITLE
providers/ldap: updates documentation related to issue #4038

### DIFF
--- a/website/docs/providers/ldap/generic_setup.md
+++ b/website/docs/providers/ldap/generic_setup.md
@@ -64,7 +64,7 @@ Note: The `default-authentication-flow` validates MFA by default, and currently 
    ![](./general_setup17.png)
 
 :::info
-The LDAP Outpost selects different providers based on their Base DN. Adding multiple providers with the same Base DN will result in inconsistent access 
+The LDAP Outpost selects different providers based on their Base DN. Adding multiple providers with the same Base DN will result in inconsistent access
 :::
 
 ### ldapsearch Test

--- a/website/docs/providers/ldap/generic_setup.md
+++ b/website/docs/providers/ldap/generic_setup.md
@@ -63,6 +63,10 @@ Note: The `default-authentication-flow` validates MFA by default, and currently 
 1. Create (or update) the LDAP Outpost under _Applications_ -> _Outposts_ -> _Create_. Set the Type to `LDAP` and choose the `LDAP` application created in the previous step.
    ![](./general_setup17.png)
 
+:::info
+The LDAP Outpost selects different providers based on their Base DN. Adding multiple providers with the same Base DN will result in inconsistent access 
+:::
+
 ### ldapsearch Test
 
 Test connectivity by using ldapsearch.


### PR DESCRIPTION
# Details
* **Does this resolve an issue?**
Resolves #4038

## Changes
### Documentation
* Updates the `providers/ldap` documentation with a note about assigning multiple providers with the same Base DN to the outpost

## Additional
Just a small little change to the documentation, but hopefully it should make things a little bit clearer

Signed-off-by: John Arrandale <bootsie227@gmail.com>