### PR TITLE
web: fix authentification with Plex on iOS

### DIFF
--- a/web/src/admin/sources/plex/PlexSourceForm.ts
+++ b/web/src/admin/sources/plex/PlexSourceForm.ts
@@ -95,7 +95,7 @@ export class PlexSourceForm extends ModelForm<PlexSource, string> {
 
     async doAuth(): Promise<void> {
         const authInfo = await PlexAPIClient.getPin(this.instance?.clientId || "");
-        const authWindow = popupCenterScreen(authInfo.authUrl, "plex auth", 550, 700);
+        const authWindow = await popupCenterScreen(authInfo.authUrl, "plex auth", 550, 700);
         PlexAPIClient.pinPoll(this.instance?.clientId || "", authInfo.pin.id).then((token) => {
             authWindow?.close();
             this.plexToken = token;

--- a/web/src/admin/sources/plex/PlexSourceForm.ts
+++ b/web/src/admin/sources/plex/PlexSourceForm.ts
@@ -62,7 +62,7 @@ export class PlexSourceForm extends ModelForm<PlexSource, string> {
     send = async (data: PlexSource): Promise<PlexSource> => {
         data.plexToken = this.plexToken || "";
         let source: PlexSource;
-        if (this.instance) {
+        if (this.instance?.pk) {
             source = await new SourcesApi(DEFAULT_CONFIG).sourcesPlexUpdate({
                 slug: this.instance.slug,
                 plexSourceRequest: data,

--- a/web/src/common/helpers/plex.ts
+++ b/web/src/common/helpers/plex.ts
@@ -23,15 +23,24 @@ export const DEFAULT_HEADERS = {
     "X-Plex-Device-Vendor": "goauthentik.io",
 };
 
-export function popupCenterScreen(url: string, title: string, w: number, h: number): Window | null {
+export async function popupCenterScreen(
+    url: string,
+    title: string,
+    w: number,
+    h: number,
+): Window | null {
     const top = (screen.height - h) / 4,
         left = (screen.width - w) / 2;
-    const popup = window.open(
-        url,
-        title,
-        `scrollbars=yes,width=${w},height=${h},top=${top},left=${left}`,
-    );
-    return popup;
+    return new Promise((resolve) => {
+        setTimeout(() => {
+            const popup = window.open(
+                url,
+                title,
+                `scrollbars=yes,width=${w},height=${h},top=${top},left=${left}`,
+            );
+            resolve(popup);
+        });
+    });
 }
 
 export class PlexAPIClient {

--- a/web/src/common/helpers/plex.ts
+++ b/web/src/common/helpers/plex.ts
@@ -28,7 +28,7 @@ export async function popupCenterScreen(
     title: string,
     w: number,
     h: number,
-): Window | null {
+): Promise<Window | null> {
     const top = (screen.height - h) / 4,
         left = (screen.width - w) / 2;
     return new Promise((resolve) => {

--- a/web/src/flow/sources/plex/PlexLoginInit.ts
+++ b/web/src/flow/sources/plex/PlexLoginInit.ts
@@ -36,7 +36,7 @@ export class PlexLoginInit extends BaseStage<
 
     async firstUpdated(): Promise<void> {
         const authInfo = await PlexAPIClient.getPin(this.challenge?.clientId || "");
-        const authWindow = popupCenterScreen(authInfo.authUrl, "plex auth", 550, 700);
+        const authWindow = await popupCenterScreen(authInfo.authUrl, "plex auth", 550, 700);
         PlexAPIClient.pinPoll(this.challenge?.clientId || "", authInfo.pin.id).then((token) => {
             authWindow?.close();
             new SourcesApi(DEFAULT_CONFIG)

--- a/web/src/user/user-settings/sources/SourceSettingsPlex.ts
+++ b/web/src/user/user-settings/sources/SourceSettingsPlex.ts
@@ -23,7 +23,7 @@ export class SourceSettingsPlex extends BaseUserSettings {
 
     async doPlex(): Promise<void> {
         const authInfo = await PlexAPIClient.getPin(this.configureUrl || "");
-        const authWindow = popupCenterScreen(authInfo.authUrl, "plex auth", 550, 700);
+        const authWindow = await popupCenterScreen(authInfo.authUrl, "plex auth", 550, 700);
         PlexAPIClient.pinPoll(this.configureUrl || "", authInfo.pin.id).then((token) => {
             authWindow?.close();
             new SourcesApi(DEFAULT_CONFIG).sourcesPlexRedeemTokenAuthenticatedCreate({


### PR DESCRIPTION
# Details
Resolves #3822.
This has been tested on iOS 16 on my iPhone.

## Changes
## Additional
Create the popup window for Plex in the main thread using `setTimeout`. This is done to fix iOS authentication, since it's not allowed to create a window from an async function on safari.
