### PR TITLE
Change Kubernetes ingress apiVersion out of beta

### DIFF
--- a/website/docs/providers/proxy/_nginx_ingress.md
+++ b/website/docs/providers/proxy/_nginx_ingress.md
@@ -7,17 +7,17 @@ metadata:
     name: authentik-outpost
 spec:
     rules:
-    - host: app.company
-      http:
-          paths: /outpost.goauthentik.io
-          pathType: Prefix
-          backend:
-              # Or, to use an external Outpost, create an ExternalName service and reference that here.
-              # See https://kubernetes.io/docs/concepts/services-networking/service/#externalname
-              service:
-                  name: ak-outpost-example-outpost
-                  port:
-                      number: 9000
+        - host: app.company
+          http:
+              paths: /outpost.goauthentik.io
+              pathType: Prefix
+              backend:
+                  # Or, to use an external Outpost, create an ExternalName service and reference that here.
+                  # See https://kubernetes.io/docs/concepts/services-networking/service/#externalname
+                  service:
+                      name: ak-outpost-example-outpost
+                      port:
+                          number: 9000
 ```
 
 This ingress handles authentication requests, and the sign-in flow.

--- a/website/docs/providers/proxy/_nginx_ingress.md
+++ b/website/docs/providers/proxy/_nginx_ingress.md
@@ -1,21 +1,23 @@
 Create a new ingress for the outpost
 
 ```yaml
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
     name: authentik-outpost
 spec:
     rules:
-        - host: app.company
-          http:
-              paths:
-                  - backend:
-                        # Or, to use an external Outpost, create an ExternalName service and reference that here.
-                        # See https://kubernetes.io/docs/concepts/services-networking/service/#externalname
-                        serviceName: ak-outpost-example-outpost
-                        servicePort: 9000
-                    path: /outpost.goauthentik.io
+    - host: app.company
+      http:
+          paths: /outpost.goauthentik.io
+          pathType: Prefix
+          backend:
+              # Or, to use an external Outpost, create an ExternalName service and reference that here.
+              # See https://kubernetes.io/docs/concepts/services-networking/service/#externalname
+              service:
+                  name: ak-outpost-example-outpost
+                  port:
+                      number: 9000
 ```
 
 This ingress handles authentication requests, and the sign-in flow.


### PR DESCRIPTION
# Details
* **Does this resolve an issue?**

Using ingress with type `networking.k8s.io/v1beta1` is no longer allowed since ingress is out of beta. This updates the documentation with a valid ingress spec.
