### PR TITLE
Always add generic message to failing zxcvbn password policy

### DIFF
--- a/authentik/policies/password/models.py
+++ b/authentik/policies/password/models.py
@@ -151,7 +151,7 @@ class PasswordPolicy(Policy):
         LOGGER.debug("password failed", check="zxcvbn", score=results["score"])
         result = PolicyResult(results["score"] > self.zxcvbn_score_threshold)
         if not result.passing:
-            result.messages += tuple((_("Password is too weak."), ))
+            result.messages += tuple((_("Password is too weak."),))
         if isinstance(results["feedback"]["warning"], list):
             result.messages += tuple(results["feedback"]["warning"])
         if isinstance(results["feedback"]["suggestions"], list):

--- a/authentik/policies/password/models.py
+++ b/authentik/policies/password/models.py
@@ -150,6 +150,8 @@ class PasswordPolicy(Policy):
         results = zxcvbn(password[:100], user_inputs)
         LOGGER.debug("password failed", check="zxcvbn", score=results["score"])
         result = PolicyResult(results["score"] > self.zxcvbn_score_threshold)
+        if not result.passing:
+            result.messages += tuple(_("Password is too weak."))
         if isinstance(results["feedback"]["warning"], list):
             result.messages += tuple(results["feedback"]["warning"])
         if isinstance(results["feedback"]["suggestions"], list):

--- a/authentik/policies/password/models.py
+++ b/authentik/policies/password/models.py
@@ -151,7 +151,7 @@ class PasswordPolicy(Policy):
         LOGGER.debug("password failed", check="zxcvbn", score=results["score"])
         result = PolicyResult(results["score"] > self.zxcvbn_score_threshold)
         if not result.passing:
-            result.messages += tuple(_("Password is too weak."))
+            result.messages += tuple((_("Password is too weak."), ))
         if isinstance(results["feedback"]["warning"], list):
             result.messages += tuple(results["feedback"]["warning"])
         if isinstance(results["feedback"]["suggestions"], list):


### PR DESCRIPTION
Depending on the settings, sometimes a password policy that checks a password with the zxcvbn tool can fail without any message.

For example:
```
$ echo  'Awdccdw1234' | zxcvbn | jq | grep "feedback" -A 5 -B 1
Password: 
  "score": 3,
  "feedback": {
    "warning": "",
    "suggestions": []
  }
}
```

As seen above the tool does not produce any warnings or suggestions for the given password, but if the password policy is set to have a zxcvbn threshold of 3, the policy will silently fail without communicating the reason to the user. 

There are two ways to handle this:
1. Always add a generic "password is too weak" message when the policy fails.
2. Check if there are any suggestions or warnings from the zxcvbn tool and only add the generic message if not.

I personally prefer 1. This way the generic message will  be shown whenever the policy fails, and will get combined with extra "tips" whenever zxcvbn has some.



Signed-off-by: sdimovv <36302090+sdimovv@users.noreply.github.com>

<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details
* **Does this resolve an issue?**
N/A

## Changes
### New Features
* Improve password policy messages 

### Breaking Changes
N/A

## Additional
N/A
