### PR TITLE
Fixed bug causing filtering with an empty query

### DIFF
--- a/authentik/blueprints/tests/test_v1.py
+++ b/authentik/blueprints/tests/test_v1.py
@@ -26,6 +26,13 @@ class TestBlueprintsV1(TransactionTestCase):
             )
         )
         self.assertFalse(importer.validate()[0])
+        importer = Importer(
+            (
+                '{"version": 1, "entries": [{"identifiers": {"attributes": {"key": "value"}}, '
+                '"attrs": {}, "model": "authentik_core.User"}]}'
+            )
+        )
+        self.assertFalse(importer.validate()[0])
 
     def test_export_validate_import(self):
         """Test export and validate it"""

--- a/authentik/blueprints/v1/importer.py
+++ b/authentik/blueprints/v1/importer.py
@@ -156,8 +156,6 @@ class Importer:
                     f"Serializer errors {serializer.errors}", serializer_errors=serializer.errors
                 ) from exc
             return serializer
-        if entry.identifiers == {}:
-            raise EntryInvalidError("No identifiers")
 
         # If we try to validate without referencing a possible instance
         # we'll get a duplicate error, hence we load the model here and return
@@ -169,7 +167,12 @@ class Importer:
             if isinstance(value, dict) and "pk" in value:
                 del updated_identifiers[key]
                 updated_identifiers[f"{key}"] = value["pk"]
-        existing_models = model.objects.filter(self.__query_from_identifier(updated_identifiers))
+        
+        query = self.__query_from_identifier(updated_identifiers)
+        if not query:
+            raise EntryInvalidError("No or invalid identifiers")
+            
+        existing_models = model.objects.filter(query)
 
         serializer_kwargs = {}
         model_instance = existing_models.first()

--- a/authentik/blueprints/v1/importer.py
+++ b/authentik/blueprints/v1/importer.py
@@ -141,6 +141,7 @@ class Importer:
 
         return main_query | sub_query
 
+    # pylint: disable-msg=too-many-locals
     def _validate_single(self, entry: BlueprintEntry) -> Optional[BaseSerializer]:
         """Validate a single entry"""
         model_app_label, model_name = entry.model.split(".")


### PR DESCRIPTION
Fixed bug allowing blueprint import to filter for existing models using an empty query.

The code only checks if the `identifiers` dict is empty, but `__query_from_identifier` skips identifier member values of type `dict` or keys == `pk`, so it is possible to produce an empty query if an `identifier` consists of just `dict` type members or "pk" key. 

Example:
```
...
- model: authentik_core.group
  identifiers:
    attributes:
      key: value
  attrs:
    name: my_group
...
```

The above is a perfectly valid blueprint entry and will pass all validation checks, but when applied will cause the `__query_from_identifier`  to produce an empty query (`Q()`), which will then cause all groups to be returned from the DB. Then the first of those groups will be replaced with the data from the blueprint instance.

Signed-off-by: sdimovv <36302090+sdimovv@users.noreply.github.com>

<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details
* **Does this resolve an issue?**
N/A

## Changes
### New Features
N/A

### Breaking Changes
N/A

## Additional
N/A
