### PR TITLE
LDAP gracefully deleting sessions on authentik

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,6 @@ htmlcov
 dist/**
 build/**
 build_docs/**
+__pycache__
+.venv
+gen-images

--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,4 @@ media/
 
 .idea/
 /gen-*/
+.vscode

--- a/cmd/ldap/server.go
+++ b/cmd/ldap/server.go
@@ -52,12 +52,6 @@ func main() {
 
 	ex := common.Init()
 	defer common.Defer()
-	go func() {
-		for {
-			<-ex
-			os.Exit(0)
-		}
-	}()
 
 	ac := ak.NewAPIController(*akURLActual, akToken)
 	if ac == nil {
@@ -65,14 +59,17 @@ func main() {
 	}
 	defer ac.Shutdown()
 
-	ac.Server = ldap.NewServer(ac)
+	server := ldap.NewServer(ac)
+	ac.Server = server
 
 	err = ac.Start()
 	if err != nil {
 		log.WithError(err).Panic("Failed to run server")
 	}
-
-	for {
-		<-ex
-	}
+	//wait for exit
+	<-ex
+	//cleanup
+	log.Info("Server shutdown")
+	server.Cleanup()
+	log.Info("Cleanup completed")
 }

--- a/internal/outpost/ak/api.go
+++ b/internal/outpost/ak/api.go
@@ -41,6 +41,7 @@ type APIController struct {
 	wsConn              *websocket.Conn
 	lastWsReconnect     time.Time
 	wsIsReconnecting    bool
+	isShuttingDown      bool
 	wsBackoffMultiplier int
 	refreshHandlers     []func()
 

--- a/internal/outpost/ak/api_ws.go
+++ b/internal/outpost/ak/api_ws.go
@@ -67,6 +67,7 @@ func (ac *APIController) initWS(akURL url.URL, outpostUUID string) error {
 
 // Shutdown Gracefully stops all workers, disconnects from websocket
 func (ac *APIController) Shutdown() {
+	ac.isShuttingDown = true
 	// Cleanly close the connection by sending a close message and then
 	// waiting (with timeout) for the server to close the connection.
 	err := ac.wsConn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
@@ -124,6 +125,9 @@ func (ac *APIController) startWSHandler() {
 		}
 		err := ac.wsConn.ReadJSON(&wsMsg)
 		if err != nil {
+			if ac.isShuttingDown {
+				return
+			}
 			ConnectionStatus.With(prometheus.Labels{
 				"outpost_name": ac.Outpost.Name,
 				"outpost_type": ac.Server.Type(),

--- a/internal/outpost/flow/executor.go
+++ b/internal/outpost/flow/executor.go
@@ -14,9 +14,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	log "github.com/sirupsen/logrus"
 	"goauthentik.io/api/v3"
-	"goauthentik.io/internal/constants"
-	"goauthentik.io/internal/outpost/ak"
-	"goauthentik.io/internal/utils/web"
 )
 
 var (
@@ -60,7 +57,7 @@ func NewFlowExecutor(ctx context.Context, flowSlug string, refConfig *api.Config
 		l.WithError(err).Warning("Failed to create cookiejar")
 		panic(err)
 	}
-	transport := web.NewUserAgentTransport(constants.OutpostUserAgent(), web.NewTracingTransport(rsp.Context(), ak.GetTLSTransport()))
+	transport := refConfig.HTTPClient.Transport
 	fe := &FlowExecutor{
 		Params:    url.Values{},
 		Answers:   make(map[StageComponent]string),

--- a/internal/outpost/flow/executor.go
+++ b/internal/outpost/flow/executor.go
@@ -14,6 +14,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	log "github.com/sirupsen/logrus"
 	"goauthentik.io/api/v3"
+	"goauthentik.io/internal/constants"
+	"goauthentik.io/internal/outpost/ak"
+	"goauthentik.io/internal/utils/web"
 )
 
 var (
@@ -57,7 +60,7 @@ func NewFlowExecutor(ctx context.Context, flowSlug string, refConfig *api.Config
 		l.WithError(err).Warning("Failed to create cookiejar")
 		panic(err)
 	}
-	transport := refConfig.HTTPClient.Transport
+	transport := web.NewUserAgentTransport(constants.OutpostUserAgent(), web.NewTracingTransport(rsp.Context(), ak.GetTLSTransport()))
 	fe := &FlowExecutor{
 		Params:    url.Values{},
 		Answers:   make(map[StageComponent]string),

--- a/internal/outpost/flow/logout.go
+++ b/internal/outpost/flow/logout.go
@@ -1,0 +1,28 @@
+package flow
+
+import (
+	"fmt"
+	"net/http"
+
+	log "github.com/sirupsen/logrus"
+	"goauthentik.io/api/v3"
+)
+
+type LogoutFunc func(*http.Cookie, *api.Configuration)
+
+func Logout(session *http.Cookie, c *api.Configuration) {
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s://%s/api/v3/flows/executor/default-invalidation-flow/", c.Scheme, c.Host), nil)
+	req.Header.Set("UserAgent", c.UserAgent)
+	if err != nil {
+		log.WithField("err", err).Warn("Could not create request to invalidate session")
+		return
+	}
+	req.AddCookie(session)
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		log.WithField("err", err).Error("Could not execute request")
+		return
+	}
+	defer res.Body.Close()
+	log.Debug("Logout completed")
+}

--- a/internal/outpost/ldap/bind/binder.go
+++ b/internal/outpost/ldap/bind/binder.go
@@ -6,4 +6,5 @@ type Binder interface {
 	GetUsername(string) (string, error)
 	Bind(username string, req *Request) (ldap.LDAPResultCode, error)
 	TimerFlowCacheExpiry()
+	Cleanup()
 }

--- a/internal/outpost/ldap/bind/direct/direct.go
+++ b/internal/outpost/ldap/bind/direct/direct.go
@@ -75,7 +75,7 @@ func (db *DirectBinder) BindNoClean(username string, req *bind.Request) (ldap.LD
 			"app":          db.si.GetAppSlug(),
 		}).Inc()
 		req.Log().WithError(err).Warning("failed to execute flow")
-		return ldap.LDAPResultProtocolError, nil, nil
+		return ldap.LDAPResultInvalidCredentials, nil, nil
 	}
 	if !passed {
 		metrics.RequestsRejected.With(prometheus.Labels{

--- a/internal/outpost/ldap/bind/memory/memory.go
+++ b/internal/outpost/ldap/bind/memory/memory.go
@@ -137,8 +137,8 @@ func (sb *SessionBinder) Bind(username string, req *bind.Request) (ldap.LDAPResu
 	}
 	logger.Debug("No session found for user, executing flow")
 	result, err, cookie := sb.DirectBinder.BindNoClean(username, req)
-	// Only cache the result if there's been an error
-	if err == nil {
+	// Only cache the result if there was no error and we succeeded
+	if err == nil && result == ldap.LDAPResultSuccess {
 		if cookie == nil {
 			//login did succeed, but cookie died?!
 			logger.Error("user session not set after bind")

--- a/internal/outpost/ldap/bind/memory/memory.go
+++ b/internal/outpost/ldap/bind/memory/memory.go
@@ -1,11 +1,14 @@
 package memory
 
 import (
+	"context"
+	"sync"
 	"time"
 
 	ttlcache "github.com/jellydator/ttlcache/v3"
 	"github.com/nmcclain/ldap"
 	log "github.com/sirupsen/logrus"
+	"goauthentik.io/internal/outpost/flow"
 	"goauthentik.io/internal/outpost/ldap/bind"
 	"goauthentik.io/internal/outpost/ldap/bind/direct"
 	"goauthentik.io/internal/outpost/ldap/server"
@@ -16,24 +19,58 @@ type Credentials struct {
 	Password string
 }
 
+type LoginResult struct {
+	ldap.LDAPResultCode
+	Username   string
+	ValidUntil time.Time
+}
+
 type SessionBinder struct {
 	direct.DirectBinder
-	si       server.LDAPServerInstance
-	log      *log.Entry
-	sessions *ttlcache.Cache[Credentials, ldap.LDAPResultCode]
+	si        server.LDAPServerInstance
+	log       *log.Entry
+	sessions  *ttlcache.Cache[Credentials, LoginResult]
+	bindMutex map[string]*sync.Mutex
 }
+
+var defaultTTL = time.Second * 20
 
 func NewSessionBinder(si server.LDAPServerInstance, oldBinder bind.Binder) *SessionBinder {
 	sb := &SessionBinder{
-		si:  si,
-		log: log.WithField("logger", "authentik.outpost.ldap.binder.session"),
+		si:        si,
+		log:       log.WithField("logger", "authentik.outpost.ldap.binder.session"),
+		bindMutex: map[string]*sync.Mutex{},
 	}
 	if oldSb, ok := oldBinder.(*SessionBinder); ok {
 		sb.DirectBinder = oldSb.DirectBinder
 		sb.sessions = oldSb.sessions
+		sb.bindMutex = oldSb.bindMutex
 		sb.log.Info("re-initialised session binder")
 	} else {
-		sb.sessions = ttlcache.New(ttlcache.WithDisableTouchOnHit[Credentials, ldap.LDAPResultCode]())
+		sb.sessions = ttlcache.New(
+			ttlcache.WithTTL[Credentials, LoginResult](time.Second),
+			ttlcache.WithDisableTouchOnHit[Credentials, LoginResult](),
+		)
+		sb.sessions.OnEviction(func(_ context.Context, reason ttlcache.EvictionReason, item *ttlcache.Item[Credentials, LoginResult]) {
+			//check if there is something to evict
+			dn := item.Key().DN
+			username := item.Value().Username
+			f := sb.si.GetFlags(dn)
+			if f == nil {
+				return
+			}
+			cookie := f.Session
+			//get mutex
+			sb.lockUser(username, "evict")
+			go func() {
+				flow.Logout(cookie, sb.si.GetAPIClient().GetConfig())
+				sb.log.WithField("username", username).Debug("Session closed")
+			}()
+			//remove flags
+			sb.si.DeleteFlags(dn)
+			sb.unlockUser(username, "evict")
+			sb.log.WithField("username", username).Debug("Close session registered")
+		})
 		sb.DirectBinder = *direct.NewDirectBinder(si)
 		go sb.sessions.Start()
 		sb.log.Info("initialised session binder")
@@ -41,28 +78,97 @@ func NewSessionBinder(si server.LDAPServerInstance, oldBinder bind.Binder) *Sess
 	return sb
 }
 
+func (sb *SessionBinder) lockUser(username, id string) {
+	if sb.bindMutex[username] == nil {
+		sb.bindMutex[username] = new(sync.Mutex)
+	}
+	sb.bindMutex[username].Lock()
+	sb.log.WithField("lock", sb.bindMutex[username]).WithField("username", username).WithField("requestId", id).Debug("Aquired lock!")
+}
+
+func (sb *SessionBinder) unlockUser(username, id string) {
+	if sb.bindMutex[username] == nil {
+		sb.log.WithField("username", username).WithField("requestId", id).Warn("No lock existent to unlock!")
+		return
+	}
+	sb.bindMutex[username].Unlock()
+	sb.log.WithField("username", username).WithField("requestId", id).Debug("Released lock!")
+}
+
 func (sb *SessionBinder) Bind(username string, req *bind.Request) (ldap.LDAPResultCode, error) {
-	item := sb.sessions.Get(Credentials{
+	//avoid eviction of current session, if
+	sb.lockUser(username, req.ID())
+	defer func() {
+		sb.unlockUser(username, req.ID())
+	}()
+	creds := Credentials{
 		DN:       req.BindDN,
 		Password: req.BindPW,
-	})
-	if item != nil {
-		sb.log.WithField("bindDN", req.BindDN).Info("authenticated from session")
-		return item.Value(), nil
 	}
-	sb.log.Debug("No session found for user, executing flow")
-	result, err := sb.DirectBinder.Bind(username, req)
+	logger := sb.log.WithFields(log.Fields{
+		"username":  username,
+		"bindDN":    req.BindDN,
+		"requestId": req.ID(),
+	})
+	item := sb.sessions.Get(creds)
+	if item != nil {
+		//if Now() < ValidUntil -> still valid
+		stillValid := time.Now().Before(item.Value().ValidUntil)
+		logger.WithFields(log.Fields{
+			"valid": stillValid,
+			"now":   time.Now(),
+			"until": item.Value().ValidUntil,
+		}).Info("authenticated from session")
+		if stillValid {
+			//we have a hit -> increase ttl
+			sb.sessions.Touch(creds)
+			return item.Value().LDAPResultCode, nil
+		}
+		logger.Info("Re-log in user to extend session")
+		//The token has expired, but it is still here, because somebody was actively using it
+		//so -> logout -> login -> reset!
+		fl := sb.si.GetFlags(req.BindDN)
+		logger.WithField("flags", fl).Debug("Aquired flags")
+		//logout the user -> destroys the session on the server side
+		if fl != nil && fl.Session != nil {
+			flow.Logout(fl.Session, sb.si.GetAPIClient().GetConfig())
+		}
+		//always delete the flags, just to be sure here
+		sb.si.DeleteFlags(req.BindDN)
+		//now continue with normal login flow
+		logger.Debug("Continue with login after session delete")
+	}
+	logger.Debug("No session found for user, executing flow")
+	result, err, cookie := sb.DirectBinder.BindNoClean(username, req)
 	// Only cache the result if there's been an error
 	if err == nil {
-		flags := sb.si.GetFlags(req.BindDN)
-		if flags == nil {
-			sb.log.Error("user flags not set after bind")
+		if cookie == nil {
+			//login did succeed, but cookie died?!
+			logger.Error("user session not set after bind")
 			return result, err
 		}
-		sb.sessions.Set(Credentials{
+		creds := Credentials{
 			DN:       req.BindDN,
 			Password: req.BindPW,
-		}, result, time.Until(flags.Session.Expires))
+		}
+		ttl := time.Until(cookie.Expires)
+		//check if the cookie actually expires
+		if cookie.MaxAge == 0 {
+			ttl = defaultTTL
+		}
+		sb.sessions.Set(creds, LoginResult{result, username, time.Now().Add(time.Second)}, ttl)
+		logger.WithField("ttl", ttl).Info("Stored in sessions for later use with timeout")
+	}
+	if err != nil && cookie != nil {
+		//force logout
+		flow.Logout(cookie, sb.si.GetAPIClient().GetConfig())
 	}
 	return result, err
+}
+
+func (sb *SessionBinder) Cleanup() {
+	//terminate the session cleanup process
+	sb.sessions.Stop()
+	//evict all sessions
+	sb.sessions.DeleteAll()
 }

--- a/internal/outpost/ldap/instance.go
+++ b/internal/outpost/ldap/instance.go
@@ -84,6 +84,14 @@ func (pi *ProviderInstance) SetFlags(dn string, flag flags.UserFlags) {
 	pi.boundUsersMutex.Unlock()
 }
 
+func (pi *ProviderInstance) DeleteFlags(dn string) {
+	pi.boundUsersMutex.Lock()
+	if pi.boundUsers[dn] != nil {
+		delete(pi.boundUsers, dn)
+	}
+	pi.boundUsersMutex.Unlock()
+}
+
 func (pi *ProviderInstance) GetAppSlug() string {
 	return pi.appSlug
 }

--- a/internal/outpost/ldap/ldap.go
+++ b/internal/outpost/ldap/ldap.go
@@ -48,6 +48,12 @@ func (ls *LDAPServer) Type() string {
 	return "ldap"
 }
 
+func (ls *LDAPServer) Cleanup() {
+	for _, p := range ls.providers {
+		p.binder.Cleanup()
+	}
+}
+
 func (ls *LDAPServer) StartLDAPServer() error {
 	listen := config.Get().Listen.LDAP
 

--- a/internal/outpost/ldap/server/base.go
+++ b/internal/outpost/ldap/server/base.go
@@ -33,6 +33,7 @@ type LDAPServerInstance interface {
 
 	GetFlags(dn string) *flags.UserFlags
 	SetFlags(dn string, flags flags.UserFlags)
+	DeleteFlags(dn string)
 
 	GetBaseEntry() *ldap.Entry
 	GetNeededObjects(int, string, string) (bool, bool)


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details
This PR resolves an issue with the current LDAP implementation not executing a logout flow on the authentik server. This results in an ever increasing list of `authenticated_sessions` and resulting in unused cookie sessions on the server.

Furthermore this PR resolves a nasty race condition that occurs if an sessions is invalidated and in parallel a login occurs. The result is that a session exists where the `Pk=0` which in turn is not able to answer any search queries. For users this is inconvenient but this also occurs for service accounts as well. Then the ldap is not usable until the next invalidation.


## Changes
### New Features
* Adds a logout execution flow (should be better parameterized)
* Adds the option to delete the flags assigned to a user
* Adds ttlcache expiry handling
* Extends non-caching login flow to immediately invalidate a session after login (cookie will be thrown away by ldap anyways)
* Adds locks for each user when using session binder

### Breaking Changes
No breaking changes are known

## Additional
* I think it would be good to make the session TTL configurable in the LDAP server. Ideally this would be pushed by the authentik server to the ldap outpost and be part of the config

Feedback is very much welcome :)
