### PR TITLE
docs: fix instruction links on integration pages

### DIFF
--- a/website/integrations/sources/apple/index.md
+++ b/website/integrations/sources/apple/index.md
@@ -69,5 +69,5 @@ The following placeholders will be used:
 Save, and you now have Apple as a source.
 
 :::note
-For more details on how-to have the new source display on the Login Page see [here](../).
+For more details on how-to have the new source display on the Login Page see [here](../general#add-sources-to-default-login-page).
 :::

--- a/website/integrations/sources/azure-ad/index.md
+++ b/website/integrations/sources/azure-ad/index.md
@@ -48,5 +48,5 @@ If you kept the default _Supported account types_ selection of _Single tenant_, 
 Save, and you now have Azure AD as a source.
 
 :::note
-For more details on how-to have the new source display on the Login Page see [here](../).
+For more details on how-to have the new source display on the Login Page see [here](../general#add-sources-to-default-login-page).
 :::

--- a/website/integrations/sources/discord/index.md
+++ b/website/integrations/sources/discord/index.md
@@ -50,5 +50,5 @@ Here is an example of a complete authentik Discord OAuth Source
 Save, and you now have Discord as a source.
 
 :::note
-For more details on how-to have the new source display on the Login Page see [here](../).
+For more details on how-to have the new source display on the Login Page see [here](../general#add-sources-to-default-login-page).
 :::

--- a/website/integrations/sources/github/index.md
+++ b/website/integrations/sources/github/index.md
@@ -47,7 +47,7 @@ Here is an example of a complete authentik Github OAuth Source
 Save, and you now have Github as a source.
 
 :::note
-For more details on how-to have the new source display on the Login Page see [here](../).
+For more details on how-to have the new source display on the Login Page see [here](../general#add-sources-to-default-login-page).
 :::
 
 ### Checking for membership of a GitHub Organisation

--- a/website/integrations/sources/google/index.md
+++ b/website/integrations/sources/google/index.md
@@ -79,5 +79,5 @@ Here is an example of a complete authentik Google OAuth Source
 Save, and you now have Google as a source.
 
 :::note
-For more details on how-to have the new source display on the Login Page see [here](../).
+For more details on how-to have the new source display on the Login Page see [here](../general#add-sources-to-default-login-page).
 :::

--- a/website/integrations/sources/mailcow/index.md
+++ b/website/integrations/sources/mailcow/index.md
@@ -50,5 +50,5 @@ Here is an example of a complete authentik Mailcow OAuth Source
 Save, and you now have Mailcow as a source.
 
 :::note
-For more details on how-to have the new source display on the Login Page see [here](../).
+For more details on how-to have the new source display on the Login Page see [here](../general#add-sources-to-default-login-page).
 :::

--- a/website/integrations/sources/plex/index.md
+++ b/website/integrations/sources/plex/index.md
@@ -21,3 +21,7 @@ Add _Plex_ as a _source_
 -   Decide if _anyone_ with a plex account can authenticate or only friends you share with
 
 Save, and you now have Plex as a source.
+
+:::note
+For more details on how-to have the new source display on the Login Page see [here](../general#add-sources-to-default-login-page).
+:::

--- a/website/integrations/sources/twitch/index.md
+++ b/website/integrations/sources/twitch/index.md
@@ -56,5 +56,5 @@ Here is an example of a complete authentik Twitch OAuth Source
 Save, and you now have Twitch as a source.
 
 :::note
-For more details on how-to have the new source display on the Login Page see [here](../).
+For more details on how-to have the new source display on the Login Page see [here](../general#add-sources-to-default-login-page).
 :::

--- a/website/integrations/sources/twitter/index.md
+++ b/website/integrations/sources/twitter/index.md
@@ -44,5 +44,5 @@ You will need to create a new project, and OAuth credentials in the Twitter Deve
 5. **Consumer Secret:** Your Client Secret from step 25
 
 :::note
-For more details on how-to have the new source display on the Login Page see [here](../).
+For more details on how-to have the new source display on the Login Page see [here](../general#add-sources-to-default-login-page).
 :::


### PR DESCRIPTION
# Details
* **Does this resolve an issue?**
I noticed that the links in integrations/sources for adding a source to the login page all point to integrations/, which has no instructions to speak of, rather than integrations/sources/general where they are actually located. Figured I would spare others a bit of searching 😄 


## Additional
Also added the link to the Plex page, since it was the only one lacking it I assume this was an oversight.
