### PR TITLE
Fix typo in ldap source documentation

### DIFF
--- a/website/integrations/sources/ldap/index.md
+++ b/website/integrations/sources/ldap/index.md
@@ -40,4 +40,4 @@ LDAP property mappings can be used to convert the raw LDAP response into an auth
 
 By default, authentik ships with some pre-configured mappings for the most common LDAP setups.
 
-You can assign the value of a mapping to any user attribute, or save it as a custom attribute by prefixing the object field with `attribute.` Keep in mind though, data types from the LDAP server will be carried over. This means that with some implementations, where fields ar stored as array in LDAP, they will be saved as array in authentik. To prevent this, use the built-in `list_flatten` function.
+You can assign the value of a mapping to any user attribute, or save it as a custom attribute by prefixing the object field with `attribute.` Keep in mind though, data types from the LDAP server will be carried over. This means that with some implementations, where fields are stored as array in LDAP, they will be saved as array in authentik. To prevent this, use the built-in `list_flatten` function.


### PR DESCRIPTION
Signed-off-by: Nils K <24257556+septatrix@users.noreply.github.com>

PS:  
I just read the commit message style guide. Should I prefix the commit message with `sources/ldap: ` or is that not necessary for this small documentation fix?