### PR TITLE
Update HTTP(S) port configurations

### DIFF
--- a/website/docs/installation/configuration.md
+++ b/website/docs/installation/configuration.md
@@ -47,8 +47,8 @@ kubectl exec -it deployment/authentik-worker -c authentik -- ak dump_config
 
 ## Listen Setting
 
--   `AUTHENTIK_LISTEN__HTTP`: Listening address:port (e.g. `0.0.0.0:9000`) for HTTP (Server and Proxy outpost)
--   `AUTHENTIK_LISTEN__HTTPS`: Listening address:port (e.g. `0.0.0.0:9443`) for HTTPS (Server and Proxy outpost)
+-   `AUTHENTIK_PORT_HTTP`: Listening address:port (e.g. `0.0.0.0:9000`) for HTTP (Server and Proxy outpost)
+-   `AUTHENTIK_PORT_HTTPS`: Listening address:port (e.g. `0.0.0.0:9443`) for HTTPS (Server and Proxy outpost)
 -   `AUTHENTIK_LISTEN__LDAP`: Listening address:port (e.g. `0.0.0.0:3389`) for LDAP (LDAP outpost)
 -   `AUTHENTIK_LISTEN__LDAPS`: Listening address:port (e.g. `0.0.0.0:6636`) for LDAPS (LDAP outpost)
 -   `AUTHENTIK_LISTEN__METRICS`: Listening address:port (e.g. `0.0.0.0:9300`) for Prometheus metrics (All)


### PR DESCRIPTION
Signed-off-by: Dániel Görbe <mail@danielgorbe.com>

<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details
* **Does this resolve an issue?**
Only update the documentation

The [Configuration page](https://goauthentik.io/docs/installation/configuration#listen-setting) in the documentation has invalid (or at least ignored on  2022.11.3) configuration options `AUTHENTIK_LISTEN__HTTP`/`AUTHENTIK_LISTEN__HTTPS`.

## Changes
### New Features
* Updates the documentation

### Breaking Changes
* Adds breaking change which causes \<issue\>.

## Additional
Any further notes or comments you want to make.
