### PR TITLE
docs: Clarify request.user and add link to Django docs

### DIFF
--- a/website/docs/policies/expression.mdx
+++ b/website/docs/policies/expression.mdx
@@ -61,12 +61,12 @@ import Objects from "../expressions/_objects.md";
     -   `request.user`: The current user, against which the policy is applied. See [User](../user-group/user.md#object-attributes)
 
         :::warning
-        When a policy is executed in the context of a flow, this will be set to the previously authenticated user, i.e. when used with an authentication flow this will be set to _AnonymousUser_.
-
-        In flows, `context['pending_user']` should be used instead.
+        When a policy is executed in the context of a flow, this will be set to the user responsible for the request, and will not change for the duration of the flow. For that reason, using this value in authentication flow policies may not return the expected user. Use `context['pending_user']` instead; User Identification and other stages update this value during flow execution.
+        
+        If the user is not authenticated, this will be set to [`AnonymousUser`](https://docs.djangoproject.com/en/3.0/ref/contrib/auth/#django.contrib.auth.models.AnonymousUser).
         :::
 
-    -   `request.http_request`: The Django HTTP Request. See ([Django documentation](https://docs.djangoproject.com/en/3.0/ref/request-response/#httprequest-objects))
+    -   `request.http_request`: The Django HTTP Request. See [Django documentation](https://docs.djangoproject.com/en/3.0/ref/request-response/#httprequest-objects).
     -   `request.obj`: A Django Model instance. This is only set if the policy is ran against an object.
     -   `request.context`: A dictionary with dynamic data. This depends on the origin of the execution.
 

--- a/website/docs/policies/expression.mdx
+++ b/website/docs/policies/expression.mdx
@@ -61,12 +61,12 @@ import Objects from "../expressions/_objects.md";
     -   `request.user`: The current user, against which the policy is applied. See [User](../user-group/user.md#object-attributes)
 
         :::warning
-        When a policy is executed in the context of a flow, this will be set to the user responsible for the request, and will not change for the duration of the flow. For that reason, using this value in authentication flow policies may not return the expected user. Use `context['pending_user']` instead; User Identification and other stages update this value during flow execution.
-        
-        If the user is not authenticated, this will be set to [`AnonymousUser`](https://docs.djangoproject.com/en/3.0/ref/contrib/auth/#django.contrib.auth.models.AnonymousUser).
+        When a policy is executed in the context of a flow, this will be set to the user initiaing request, and will only be changed by a `user_login` stage. For that reason, using this value in authentication flow policies may not return the expected user. Use `context['pending_user']` instead; User Identification and other stages update this value during flow execution.
+
+        If the user is not authenticated, this will be set to a user called _AnonymousUser_, which is an instance of [authentik.core.models.User](https://docs.djangoproject.com/en/4.1/ref/contrib/auth/#django.contrib.auth.models.User) (authentik uses django-guardian for per-object permissions, [see](https://django-guardian.readthedocs.io/en/stable/)).
         :::
 
-    -   `request.http_request`: The Django HTTP Request. See [Django documentation](https://docs.djangoproject.com/en/3.0/ref/request-response/#httprequest-objects).
+    -   `request.http_request`: The Django HTTP Request. See [Django documentation](https://docs.djangoproject.com/en/4.1/ref/request-response/#httprequest-objects).
     -   `request.obj`: A Django Model instance. This is only set if the policy is ran against an object.
     -   `request.context`: A dictionary with dynamic data. This depends on the origin of the execution.
 


### PR DESCRIPTION
This part of the documentation seemed confusing. Also added link to Django documentation about `AnonymousUser`.