### PR TITLE
website/integrations: Update pgAdmin documentation

### DIFF
--- a/website/integrations/services/pgadmin/index.md
+++ b/website/integrations/services/pgadmin/index.md
@@ -13,7 +13,7 @@ pgAdmin is a management tool for PostgreSQL and derivative relational databases 
 :::
 
 :::note
-This is based on authentik 2022.3.3 and pgAdmin4 v6.19
+This is based on authentik 2022.3.3 and pgAdmin4 snapshot
 :::
 
 ## Preparation
@@ -80,7 +80,7 @@ In the code above the following placeholders have been used:
 -   `<display-name>`: The name that is displayed on the Login Button
 -   `<client-id>`: The Client ID from step 1
 -   `<client-secret>`: The Client Secret from step 1
--   `<app-slug>`: The App Slug from step 2
+-   `<app-slug>`: The App Slug from step 2, it should be `pgadmin` if you did not change it
 -   `<fontawesome-icon>`: An icon name from [fontawesome](https://fontawesome.com). Only brand icons seem to be supported. This icon is displayed in front of the `<display-name>`. E.g.: _fa-github_.
 -   `<button-color>`: Sets the color of the Login Button. Should be in Hex format, E.g.: _#fd4b2d_
 

--- a/website/integrations/services/pgadmin/index.md
+++ b/website/integrations/services/pgadmin/index.md
@@ -13,7 +13,7 @@ pgAdmin is a management tool for PostgreSQL and derivative relational databases 
 :::
 
 :::note
-This is based on authentik 2022.3.3 and pgAdmin4 v6.7
+This is based on authentik 2022.3.3 and pgAdmin4 v6.19
 :::
 
 ## Preparation
@@ -68,6 +68,7 @@ OAUTH2_CONFIG = [{
 	'OAUTH2_AUTHORIZATION_URL' : 'https://authentik.company/application/o/authorize/',
 	'OAUTH2_API_BASE_URL' : 'https://authentik.company/',
 	'OAUTH2_USERINFO_ENDPOINT' : 'https://authentik.company/application/o/userinfo/',
+	'OAUTH2_SERVER_METADATA_URL' : 'https://authentik.company/application/o/<app-slug>/.well-known/openid-configuration',
 	'OAUTH2_SCOPE' : 'openid email profile',
 	'OAUTH2_ICON' : '<fontawesome-icon>',
 	'OAUTH2_BUTTON_COLOR' : '<button-color>'
@@ -79,6 +80,7 @@ In the code above the following placeholders have been used:
 -   `<display-name>`: The name that is displayed on the Login Button
 -   `<client-id>`: The Client ID from step 1
 -   `<client-secret>`: The Client Secret from step 1
+-   `<app-slug>`: The App Slug from step 2
 -   `<fontawesome-icon>`: An icon name from [fontawesome](https://fontawesome.com). Only brand icons seem to be supported. This icon is displayed in front of the `<display-name>`. E.g.: _fa-github_.
 -   `<button-color>`: Sets the color of the Login Button. Should be in Hex format, E.g.: _#fd4b2d_
 

--- a/website/integrations/services/pgadmin/index.md
+++ b/website/integrations/services/pgadmin/index.md
@@ -13,7 +13,7 @@ pgAdmin is a management tool for PostgreSQL and derivative relational databases 
 :::
 
 :::note
-This is based on authentik 2022.3.3 and pgAdmin4 snapshot
+This is based on authentik 2022.3.3 and pgAdmin4 6.19
 :::
 
 ## Preparation


### PR DESCRIPTION
Signed-off-by: Antoine <antoine+github@jiveoff.fr>

# Details
In the latest version of pgAdmin4, it would return a `missing jwks_uri` error upon connecting with OAuth2.

## Changes
* Adds the `OAUTH2_SERVER_METADATA_URL` option for the pgAdmin config_local file.

## Additional
For Docker users:
The `OAUTH2_SERVER_METADATA_URL` option in the config_local file is only available on the snapshot image since it has been fixed [here](https://github.com/pgadmin-org/pgadmin4/commit/acc26744e342212d681be43e5eedbec1f0c63ded).