### PR TITLE
website/integrations: Update pfSense docs

### DIFF
--- a/website/integrations/services/pfsense/index.md
+++ b/website/integrations/services/pfsense/index.md
@@ -72,7 +72,7 @@ Change the following fields
 -   Port value: 389
 -   Transport: Standard TCP
 -   Base DN: `DC=ldap,DC=goauthentik,DC=io`
--   Authentication containers: `OU=users;DC=ldap;DC=goauthentik;DC=io`
+-   Authentication containers: `OU=users,DC=ldap,DC=goauthentik,DC=io`
 -   Bind anonymous: **unticked**
 -   Bind credentials:
     -   User DN: `cn=pfsense-user,ou=users,dc=ldap,dc=goauthentik,dc=io`

--- a/website/integrations/services/pfsense/index.md
+++ b/website/integrations/services/pfsense/index.md
@@ -72,12 +72,12 @@ Change the following fields
 -   Port value: 389
 -   Transport: Standard TCP
 -   Base DN: `DC=ldap,DC=goauthentik,DC=io`
--   Authentication containers: `OU=users,DC=ldap,DC=goauthentik,DC=io`
+-   Authentication containers: `OU=users;DC=ldap;DC=goauthentik;DC=io`
 -   Bind anonymous: **unticked**
 -   Bind credentials:
     -   User DN: `cn=pfsense-user,ou=users,dc=ldap,dc=goauthentik,dc=io`
     -   Password: `<pfsense-user password from step 2>`
--   Extended Query: &(objectClass=user)
+-   Group member attribute: memberOf
 -   Allow unauthenticated bind: **unticked**
 
 ## pfSense secure setup (with SSL)

--- a/website/integrations/services/pfsense/index.md
+++ b/website/integrations/services/pfsense/index.md
@@ -77,7 +77,7 @@ Change the following fields
 -   Bind credentials:
     -   User DN: `cn=pfsense-user,ou=users,dc=ldap,dc=goauthentik,dc=io`
     -   Password: `<pfsense-user password from step 2>`
--   Group member attribute: memberOf
+-   Group member attribute: 'memberOf'
 -   Allow unauthenticated bind: **unticked**
 
 ## pfSense secure setup (with SSL)

--- a/website/integrations/services/pfsense/index.md
+++ b/website/integrations/services/pfsense/index.md
@@ -77,7 +77,7 @@ Change the following fields
 -   Bind credentials:
     -   User DN: `cn=pfsense-user,ou=users,dc=ldap,dc=goauthentik,dc=io`
     -   Password: `<pfsense-user password from step 2>`
--   Group member attribute: 'memberOf'
+-   Group member attribute: `memberOf`
 -   Allow unauthenticated bind: **unticked**
 
 ## pfSense secure setup (with SSL)


### PR DESCRIPTION
Removed need to enable ExtendedQuery, changed format of Authentication Containers to use semi-colons per note in pfSense, and added setting for Group member attribute (to allow users to not have to create pfsense users individually)

Signed-off-by: bjk525 <34558980+bjk525@users.noreply.github.com>

<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details
* **Does this resolve an issue?**
Resolves #

## Changes
### New Features
* Adds feature which does x, y, and z.

### Breaking Changes
* Adds breaking change which causes \<issue\>.

## Additional
Any further notes or comments you want to make.
