### PR TITLE
blueprints: Add `!Enumerate`, `!Value` and `!Index` tags

### DIFF
--- a/authentik/blueprints/tests/fixtures/tags.yaml
+++ b/authentik/blueprints/tests/fixtures/tags.yaml
@@ -3,6 +3,9 @@ context:
     foo: bar
     policy_property: name
     policy_property_value: foo-bar-baz-qux
+    sequence:
+    - foo
+    - bar
 entries:
     - model: !Format ["%s", authentik_sources_oauth.oauthsource]
       state: !Format ["%s", present]
@@ -92,6 +95,41 @@ entries:
                   ]
               if_true_simple: !If [!Context foo, true, text]
               if_false_simple: !If [null, false, 2]
+              for: !For [
+                  !Context sequence,
+                  [
+                      !For [
+                          !ForItem 1,
+                          {
+                              key1: [
+                                  !Format ["str: %s, letter: %s", !ForItem 1, !ForItem 0],
+                                  !ForItem 1,
+                                  !ForItem 0,
+                                  !For [
+                                      !ForItem 2,
+                                      {
+                                        inner_inner_for_item: !Format ["%s", !ForItem 0]
+                                      }
+                                  ]
+                              ],
+                              key2: !ForItem 0
+                          }
+                      ],
+                      !For [
+                          !ForItem 1,
+                          {
+                              key1: {
+                                  inner_key1: !Format ["letter: %s, str: %s", !ForItem 0, !ForItem 1],
+                                  inner_key2: !ForItem 0,
+                                  inner_key3: !ForItem 1
+                              },
+                              key2: !ForItem 0
+                          }
+                      ],
+                      !ForItem 0,
+                      !Format ["%s-%s", !Context foo, !ForItem 0]
+                  ]
+              ]
       identifiers:
           name: test
       conditions:

--- a/authentik/blueprints/tests/fixtures/tags.yaml
+++ b/authentik/blueprints/tests/fixtures/tags.yaml
@@ -98,53 +98,53 @@ entries:
                   ]
               if_true_simple: !If [!Context foo, true, text]
               if_false_simple: !If [null, false, 2]
-              for_mapping: !For [
+              for_mapping: !Enumerate [
                   !Context mapping,
                   MAP,
-                  [!Format ["prefix-%s", !ForItemIndex 0], !Format ["other-prefix-%s", !ForItem 0]]
+                  [!Format ["prefix-%s", !Index 0], !Format ["other-prefix-%s", !Value 0]]
               ]
-              for_sequence: !For [
+              for_sequence: !Enumerate [
                   !Context mapping,
                   SEQ,
-                  !Format ["%s: %s", !ForItemIndex 0, !ForItem 0]
+                  !Format ["%s: %s", !Index 0, !Value 0]
               ]
-              for_sequence_complex: !For [
+              for_sequence_complex: !Enumerate [
                   !Context sequence,
                   SEQ,
                   [
-                      !For [
-                          !ForItem 1,
+                      !Enumerate [
+                          !Value 1,
                           SEQ,
                           {
                               key1: [
-                                  !Format ["str: %s, str_index: %d, letter: %s", !ForItem 1, !ForItemIndex 1, !ForItem 0],
-                                  !ForItem 1,
-                                  !ForItem 0,
-                                  !For [
-                                      !ForItem 2,
+                                  !Format ["str: %s, str_index: %d, letter: %s", !Value 1, !Index 1, !Value 0],
+                                  !Value 1,
+                                  !Value 0,
+                                  !Enumerate [
+                                      !Value 2,
                                       SEQ,
                                       {
-                                        inner_inner_for_item: !Format ["%d-%s", !ForItemIndex 0, !ForItem 0]
+                                        inner_inner_for_item: !Format ["%d-%s", !Index 0, !Value 0]
                                       }
                                   ]
                               ],
-                              key2: !ForItem 0
+                              key2: !Value 0
                           }
                       ],
-                      !For [
-                          !ForItem 1,
+                      !Enumerate [
+                          !Value 1,
                           SEQ,
                           {
                               key1: {
-                                  inner_key1: !Format ["letter: %s, str: %s, str_index: %d", !ForItem 0, !ForItem 1, !ForItemIndex 1],
-                                  inner_key2: !ForItem 0,
-                                  inner_key3: !ForItem 1
+                                  inner_key1: !Format ["letter: %s, str: %s, str_index: %d", !Value 0, !Value 1, !Index 1],
+                                  inner_key2: !Value 0,
+                                  inner_key3: !Value 1
                               },
-                              key2: !ForItem 0
+                              key2: !Value 0
                           }
                       ],
-                      !ForItem 0,
-                      !Format ["%s-%s", !Context foo, !ForItem 0]
+                      !Value 0,
+                      !Format ["%s-%s", !Context foo, !Value 0]
                   ]
               ]
       identifiers:

--- a/authentik/blueprints/tests/fixtures/tags.yaml
+++ b/authentik/blueprints/tests/fixtures/tags.yaml
@@ -6,6 +6,9 @@ context:
     sequence:
     - foo
     - bar
+    mapping:
+      key1: value
+      key2: 2
 entries:
     - model: !Format ["%s", authentik_sources_oauth.oauthsource]
       state: !Format ["%s", present]
@@ -95,7 +98,11 @@ entries:
                   ]
               if_true_simple: !If [!Context foo, true, text]
               if_false_simple: !If [null, false, 2]
-              for: !For [
+              for_mapping: !For [
+                  !Context mapping,
+                  !Format ["%s: %s", !ForItemIndex 0, !ForItem 0]
+              ]
+              for_sequence: !For [
                   !Context sequence,
                   [
                       !For [

--- a/authentik/blueprints/tests/fixtures/tags.yaml
+++ b/authentik/blueprints/tests/fixtures/tags.yaml
@@ -102,13 +102,13 @@ entries:
                           !ForItem 1,
                           {
                               key1: [
-                                  !Format ["str: %s, letter: %s", !ForItem 1, !ForItem 0],
+                                  !Format ["str: %s, str_index: %d, letter: %s", !ForItem 1, !ForItemIndex 1, !ForItem 0],
                                   !ForItem 1,
                                   !ForItem 0,
                                   !For [
                                       !ForItem 2,
                                       {
-                                        inner_inner_for_item: !Format ["%s", !ForItem 0]
+                                        inner_inner_for_item: !Format ["%d-%s", !ForItemIndex 0, !ForItem 0]
                                       }
                                   ]
                               ],
@@ -119,7 +119,7 @@ entries:
                           !ForItem 1,
                           {
                               key1: {
-                                  inner_key1: !Format ["letter: %s, str: %s", !ForItem 0, !ForItem 1],
+                                  inner_key1: !Format ["letter: %s, str: %s, str_index: %d", !ForItem 0, !ForItem 1, !ForItemIndex 1],
                                   inner_key2: !ForItem 0,
                                   inner_key3: !ForItem 1
                               },

--- a/authentik/blueprints/tests/fixtures/tags.yaml
+++ b/authentik/blueprints/tests/fixtures/tags.yaml
@@ -100,13 +100,21 @@ entries:
               if_false_simple: !If [null, false, 2]
               for_mapping: !For [
                   !Context mapping,
-                  !Format ["%s: %s", !ForItemIndex 0, !ForItem 0]
+                  MAP,
+                  [!Format ["prefix-%s", !ForItemIndex 0], !Format ["other-prefix-%s", !ForItem 0]]
               ]
               for_sequence: !For [
+                  !Context mapping,
+                  SEQ,
+                  !Format ["%s: %s", !ForItemIndex 0, !ForItem 0]
+              ]
+              for_sequence_complex: !For [
                   !Context sequence,
+                  SEQ,
                   [
                       !For [
                           !ForItem 1,
+                          SEQ,
                           {
                               key1: [
                                   !Format ["str: %s, str_index: %d, letter: %s", !ForItem 1, !ForItemIndex 1, !ForItem 0],
@@ -114,6 +122,7 @@ entries:
                                   !ForItem 0,
                                   !For [
                                       !ForItem 2,
+                                      SEQ,
                                       {
                                         inner_inner_for_item: !Format ["%d-%s", !ForItemIndex 0, !ForItem 0]
                                       }
@@ -124,6 +133,7 @@ entries:
                       ],
                       !For [
                           !ForItem 1,
+                          SEQ,
                           {
                               key1: {
                                   inner_key1: !Format ["letter: %s, str: %s, str_index: %d", !ForItem 0, !ForItem 1, !ForItemIndex 1],

--- a/authentik/blueprints/tests/fixtures/tags.yaml
+++ b/authentik/blueprints/tests/fixtures/tags.yaml
@@ -98,53 +98,47 @@ entries:
                   ]
               if_true_simple: !If [!Context foo, true, text]
               if_false_simple: !If [null, false, 2]
-              for_mapping: !Enumerate [
+              enumerate_mapping_to_mapping: !Enumerate [
                   !Context mapping,
                   MAP,
                   [!Format ["prefix-%s", !Index 0], !Format ["other-prefix-%s", !Value 0]]
               ]
-              for_sequence: !Enumerate [
+              enumerate_mapping_to_sequence: !Enumerate [
                   !Context mapping,
                   SEQ,
-                  !Format ["%s: %s", !Index 0, !Value 0]
+                  !Format ["prefixed-pair-%s-%s", !Index 0, !Value 0]
               ]
-              for_sequence_complex: !Enumerate [
+              enumerate_sequence_to_sequence: !Enumerate [
                   !Context sequence,
                   SEQ,
+                  !Format ["prefixed-items-%s-%s", !Index 0, !Value 0]
+              ]
+              enumerate_sequence_to_mapping: !Enumerate [
+                  !Context sequence,
+                  MAP,
+                  [!Format ["index: %d", !Index 0], !Value 0]
+              ]
+              nested_complex_enumeration: !Enumerate [
+                  !Context sequence,
+                  MAP,
                   [
+                      !Index 0,
                       !Enumerate [
-                          !Value 1,
-                          SEQ,
-                          {
-                              key1: [
-                                  !Format ["str: %s, str_index: %d, letter: %s", !Value 1, !Index 1, !Value 0],
-                                  !Value 1,
-                                  !Value 0,
-                                  !Enumerate [
-                                      !Value 2,
-                                      SEQ,
-                                      {
-                                        inner_inner_for_item: !Format ["%d-%s", !Index 0, !Value 0]
-                                      }
-                                  ]
-                              ],
-                              key2: !Value 0
-                          }
-                      ],
-                      !Enumerate [
-                          !Value 1,
-                          SEQ,
-                          {
-                              key1: {
-                                  inner_key1: !Format ["letter: %s, str: %s, str_index: %d", !Value 0, !Value 1, !Index 1],
-                                  inner_key2: !Value 0,
-                                  inner_key3: !Value 1
-                              },
-                              key2: !Value 0
-                          }
-                      ],
-                      !Value 0,
-                      !Format ["%s-%s", !Context foo, !Value 0]
+                          !Context mapping,
+                          MAP,
+                          [
+                              !Format ["%s", !Index 0],
+                              [
+                                  !Enumerate [!Value 2, SEQ, !Format ["prefixed-%s", !Value 0]],
+                                  {
+                                    outer_value: !Value 1,
+                                    outer_index: !Index 1,
+                                    middle_value: !Value 0,
+                                    middle_index: !Index 0
+                                  }
+                              ]
+                          ]
+                      ]
                   ]
               ]
       identifiers:

--- a/authentik/blueprints/tests/test_v1.py
+++ b/authentik/blueprints/tests/test_v1.py
@@ -162,7 +162,11 @@ class TestBlueprintsV1(TransactionTestCase):
                     "if_false_complex": ["list", "with", "items", "foo-bar"],
                     "if_true_simple": True,
                     "if_false_simple": 2,
-                    "for": [
+                    "for_mapping": [
+                        "key1: value",
+                        "key2: 2"
+                    ],
+                    "for_sequence": [
                         [
                             [
                                 {

--- a/authentik/blueprints/tests/test_v1.py
+++ b/authentik/blueprints/tests/test_v1.py
@@ -168,16 +168,13 @@ class TestBlueprintsV1(TransactionTestCase):
                     },
                     "enumerate_mapping_to_sequence": [
                         "prefixed-pair-key1-value",
-                        "prefixed-pair-key2-2"
+                        "prefixed-pair-key2-2",
                     ],
                     "enumerate_sequence_to_sequence": [
                         "prefixed-items-0-foo",
-                        "prefixed-items-1-bar"
+                        "prefixed-items-1-bar",
                     ],
-                    "enumerate_sequence_to_mapping": {
-                        "index: 0": "foo",
-                        "index: 1": "bar"
-                    },
+                    "enumerate_sequence_to_mapping": {"index: 0": "foo", "index: 1": "bar"},
                     "nested_complex_enumeration": {
                         "0": {
                             "key1": [
@@ -187,7 +184,7 @@ class TestBlueprintsV1(TransactionTestCase):
                                     "outer_index": 0,
                                     "middle_value": "value",
                                     "middle_index": "key1",
-                                }
+                                },
                             ],
                             "key2": [
                                 ["prefixed-f", "prefixed-o", "prefixed-o"],
@@ -196,8 +193,8 @@ class TestBlueprintsV1(TransactionTestCase):
                                     "outer_index": 0,
                                     "middle_value": 2,
                                     "middle_index": "key2",
-                                }
-                            ]
+                                },
+                            ],
                         },
                         "1": {
                             "key1": [
@@ -207,7 +204,7 @@ class TestBlueprintsV1(TransactionTestCase):
                                     "outer_index": 1,
                                     "middle_value": "value",
                                     "middle_index": "key1",
-                                }
+                                },
                             ],
                             "key2": [
                                 ["prefixed-b", "prefixed-a", "prefixed-r"],
@@ -216,10 +213,10 @@ class TestBlueprintsV1(TransactionTestCase):
                                     "outer_index": 1,
                                     "middle_value": 2,
                                     "middle_index": "key2",
-                                }
-                            ]
+                                },
+                            ],
                         },
-                    }
+                    },
                 }
             )
         )

--- a/authentik/blueprints/tests/test_v1.py
+++ b/authentik/blueprints/tests/test_v1.py
@@ -162,6 +162,150 @@ class TestBlueprintsV1(TransactionTestCase):
                     "if_false_complex": ["list", "with", "items", "foo-bar"],
                     "if_true_simple": True,
                     "if_false_simple": 2,
+                    "for": [
+                        [
+                            [
+                                {
+                                    "key1": [
+                                        "str: foo, letter: f",
+                                        "foo",
+                                        "f",
+                                        [
+                                            { "inner_inner_for_item": "f" },
+                                            { "inner_inner_for_item": "o" },
+                                            { "inner_inner_for_item": "o" }
+                                        ]
+                                    ],
+                                    "key2":  "f"
+                                },
+                                {
+                                    "key1": [
+                                        "str: foo, letter: o",
+                                        "foo",
+                                        "o",
+                                        [
+                                            { "inner_inner_for_item": "f" },
+                                            { "inner_inner_for_item": "o" },
+                                            { "inner_inner_for_item": "o" }
+                                        ]
+                                    ],
+                                    "key2":  "o"
+                                },
+                                {
+                                    "key1": [
+                                        "str: foo, letter: o",
+                                        "foo",
+                                        "o",
+                                        [
+                                            { "inner_inner_for_item": "f" },
+                                            { "inner_inner_for_item": "o" },
+                                            { "inner_inner_for_item": "o" }
+                                        ]
+                                    ],
+                                    "key2":  "o"
+                                }
+                            ],
+                            [
+                                {
+                                    "key1": {
+                                        "inner_key1": "letter: f, str: foo",
+                                        "inner_key2": "f",
+                                        "inner_key3": "foo",
+                                    },
+                                    "key2": "f"
+                                },
+                                {
+                                    "key1": {
+                                        "inner_key1": "letter: o, str: foo",
+                                        "inner_key2": "o",
+                                        "inner_key3": "foo",
+                                    },
+                                    "key2": "o"
+                                },
+                                {
+                                    "key1": {
+                                        "inner_key1": "letter: o, str: foo",
+                                        "inner_key2": "o",
+                                        "inner_key3": "foo",
+                                    },
+                                    "key2": "o"
+                                },
+                            ],
+                            "foo",
+                            "bar-foo"
+                        ],
+                        [
+                            [
+                                {
+                                    "key1": [
+                                        "str: bar, letter: b",
+                                        "bar",
+                                        "b",
+                                        [
+                                            { "inner_inner_for_item": "b" },
+                                            { "inner_inner_for_item": "a" },
+                                            { "inner_inner_for_item": "r" }
+                                        ]
+                                    ],
+                                    "key2":  "b"
+                                },
+                                {
+                                    "key1": [
+                                        "str: bar, letter: a",
+                                        "bar",
+                                        "a",
+                                        [
+                                            { "inner_inner_for_item": "b" },
+                                            { "inner_inner_for_item": "a" },
+                                            { "inner_inner_for_item": "r" }
+                                        ]
+                                    ],
+                                    "key2":  "a"
+                                },
+                                {
+                                    "key1": [
+                                        "str: bar, letter: r",
+                                        "bar",
+                                        "r",
+                                        [
+                                            { "inner_inner_for_item": "b" },
+                                            { "inner_inner_for_item": "a" },
+                                            { "inner_inner_for_item": "r" }
+                                        ]
+                                    ],
+                                    "key2":  "r"
+                                }
+                            ],
+                            [
+                                {
+                                    "key1": {
+                                        "inner_key1": "letter: b, str: bar",
+                                        "inner_key2": "b",
+                                        "inner_key3": "bar",
+                                    },
+                                    "key2": "b"
+                                },
+                                {
+                                    "key1": {
+                                        "inner_key1": "letter: a, str: bar",
+                                        "inner_key2": "a",
+                                        "inner_key3": "bar",
+                                    },
+                                    "key2": "a"
+                                },
+                                {
+                                    "key1": {
+                                        "inner_key1": "letter: r, str: bar",
+                                        "inner_key2": "r",
+                                        "inner_key3": "bar",
+                                    },
+                                    "key2": "r"
+                                },
+                            ],
+                            "bar",
+                            "bar-bar"
+                        ]
+                    ]
                 }
             )
         )

--- a/authentik/blueprints/tests/test_v1.py
+++ b/authentik/blueprints/tests/test_v1.py
@@ -162,158 +162,64 @@ class TestBlueprintsV1(TransactionTestCase):
                     "if_false_complex": ["list", "with", "items", "foo-bar"],
                     "if_true_simple": True,
                     "if_false_simple": 2,
-                    "for_mapping": {
+                    "enumerate_mapping_to_mapping": {
                         "prefix-key1": "other-prefix-value",
                         "prefix-key2": "other-prefix-2",
                     },
-                    "for_sequence": [
-                        "key1: value",
-                        "key2: 2"
+                    "enumerate_mapping_to_sequence": [
+                        "prefixed-pair-key1-value",
+                        "prefixed-pair-key2-2"
                     ],
-                    "for_sequence_complex": [
-                        [
-                            [
+                    "enumerate_sequence_to_sequence": [
+                        "prefixed-items-0-foo",
+                        "prefixed-items-1-bar"
+                    ],
+                    "enumerate_sequence_to_mapping": {
+                        "index: 0": "foo",
+                        "index: 1": "bar"
+                    },
+                    "nested_complex_enumeration": {
+                        "0": {
+                            "key1": [
+                                ["prefixed-f", "prefixed-o", "prefixed-o"],
                                 {
-                                    "key1": [
-                                        "str: foo, str_index: 0, letter: f",
-                                        "foo",
-                                        "f",
-                                        [
-                                            { "inner_inner_for_item": "0-f" },
-                                            { "inner_inner_for_item": "1-o" },
-                                            { "inner_inner_for_item": "2-o" }
-                                        ]
-                                    ],
-                                    "key2":  "f"
-                                },
-                                {
-                                    "key1": [
-                                        "str: foo, str_index: 0, letter: o",
-                                        "foo",
-                                        "o",
-                                        [
-                                            { "inner_inner_for_item": "0-f" },
-                                            { "inner_inner_for_item": "1-o" },
-                                            { "inner_inner_for_item": "2-o" }
-                                        ]
-                                    ],
-                                    "key2":  "o"
-                                },
-                                {
-                                    "key1": [
-                                        "str: foo, str_index: 0, letter: o",
-                                        "foo",
-                                        "o",
-                                        [
-                                            { "inner_inner_for_item": "0-f" },
-                                            { "inner_inner_for_item": "1-o" },
-                                            { "inner_inner_for_item": "2-o" }
-                                        ]
-                                    ],
-                                    "key2":  "o"
+                                    "outer_value": "foo",
+                                    "outer_index": 0,
+                                    "middle_value": "value",
+                                    "middle_index": "key1",
                                 }
                             ],
-                            [
+                            "key2": [
+                                ["prefixed-f", "prefixed-o", "prefixed-o"],
                                 {
-                                    "key1": {
-                                        "inner_key1": "letter: f, str: foo, str_index: 0",
-                                        "inner_key2": "f",
-                                        "inner_key3": "foo",
-                                    },
-                                    "key2": "f"
-                                },
+                                    "outer_value": "foo",
+                                    "outer_index": 0,
+                                    "middle_value": 2,
+                                    "middle_index": "key2",
+                                }
+                            ]
+                        },
+                        "1": {
+                            "key1": [
+                                ["prefixed-b", "prefixed-a", "prefixed-r"],
                                 {
-                                    "key1": {
-                                        "inner_key1": "letter: o, str: foo, str_index: 0",
-                                        "inner_key2": "o",
-                                        "inner_key3": "foo",
-                                    },
-                                    "key2": "o"
-                                },
-                                {
-                                    "key1": {
-                                        "inner_key1": "letter: o, str: foo, str_index: 0",
-                                        "inner_key2": "o",
-                                        "inner_key3": "foo",
-                                    },
-                                    "key2": "o"
-                                },
-                            ],
-                            "foo",
-                            "bar-foo"
-                        ],
-                        [
-                            [
-                                {
-                                    "key1": [
-                                        "str: bar, str_index: 1, letter: b",
-                                        "bar",
-                                        "b",
-                                        [
-                                            { "inner_inner_for_item": "0-b" },
-                                            { "inner_inner_for_item": "1-a" },
-                                            { "inner_inner_for_item": "2-r" }
-                                        ]
-                                    ],
-                                    "key2":  "b"
-                                },
-                                {
-                                    "key1": [
-                                        "str: bar, str_index: 1, letter: a",
-                                        "bar",
-                                        "a",
-                                        [
-                                            { "inner_inner_for_item": "0-b" },
-                                            { "inner_inner_for_item": "1-a" },
-                                            { "inner_inner_for_item": "2-r" }
-                                        ]
-                                    ],
-                                    "key2":  "a"
-                                },
-                                {
-                                    "key1": [
-                                        "str: bar, str_index: 1, letter: r",
-                                        "bar",
-                                        "r",
-                                        [
-                                            { "inner_inner_for_item": "0-b" },
-                                            { "inner_inner_for_item": "1-a" },
-                                            { "inner_inner_for_item": "2-r" }
-                                        ]
-                                    ],
-                                    "key2":  "r"
+                                    "outer_value": "bar",
+                                    "outer_index": 1,
+                                    "middle_value": "value",
+                                    "middle_index": "key1",
                                 }
                             ],
-                            [
+                            "key2": [
+                                ["prefixed-b", "prefixed-a", "prefixed-r"],
                                 {
-                                    "key1": {
-                                        "inner_key1": "letter: b, str: bar, str_index: 1",
-                                        "inner_key2": "b",
-                                        "inner_key3": "bar",
-                                    },
-                                    "key2": "b"
-                                },
-                                {
-                                    "key1": {
-                                        "inner_key1": "letter: a, str: bar, str_index: 1",
-                                        "inner_key2": "a",
-                                        "inner_key3": "bar",
-                                    },
-                                    "key2": "a"
-                                },
-                                {
-                                    "key1": {
-                                        "inner_key1": "letter: r, str: bar, str_index: 1",
-                                        "inner_key2": "r",
-                                        "inner_key3": "bar",
-                                    },
-                                    "key2": "r"
-                                },
-                            ],
-                            "bar",
-                            "bar-bar"
-                        ]
-                    ]
+                                    "outer_value": "bar",
+                                    "outer_index": 1,
+                                    "middle_value": 2,
+                                    "middle_index": "key2",
+                                }
+                            ]
+                        },
+                    }
                 }
             )
         )

--- a/authentik/blueprints/tests/test_v1.py
+++ b/authentik/blueprints/tests/test_v1.py
@@ -162,11 +162,15 @@ class TestBlueprintsV1(TransactionTestCase):
                     "if_false_complex": ["list", "with", "items", "foo-bar"],
                     "if_true_simple": True,
                     "if_false_simple": 2,
-                    "for_mapping": [
+                    "for_mapping": {
+                        "prefix-key1": "other-prefix-value",
+                        "prefix-key2": "other-prefix-2",
+                    },
+                    "for_sequence": [
                         "key1: value",
                         "key2: 2"
                     ],
-                    "for_sequence": [
+                    "for_sequence_complex": [
                         [
                             [
                                 {

--- a/authentik/blueprints/tests/test_v1.py
+++ b/authentik/blueprints/tests/test_v1.py
@@ -167,39 +167,39 @@ class TestBlueprintsV1(TransactionTestCase):
                             [
                                 {
                                     "key1": [
-                                        "str: foo, letter: f",
+                                        "str: foo, str_index: 0, letter: f",
                                         "foo",
                                         "f",
                                         [
-                                            { "inner_inner_for_item": "f" },
-                                            { "inner_inner_for_item": "o" },
-                                            { "inner_inner_for_item": "o" }
+                                            { "inner_inner_for_item": "0-f" },
+                                            { "inner_inner_for_item": "1-o" },
+                                            { "inner_inner_for_item": "2-o" }
                                         ]
                                     ],
                                     "key2":  "f"
                                 },
                                 {
                                     "key1": [
-                                        "str: foo, letter: o",
+                                        "str: foo, str_index: 0, letter: o",
                                         "foo",
                                         "o",
                                         [
-                                            { "inner_inner_for_item": "f" },
-                                            { "inner_inner_for_item": "o" },
-                                            { "inner_inner_for_item": "o" }
+                                            { "inner_inner_for_item": "0-f" },
+                                            { "inner_inner_for_item": "1-o" },
+                                            { "inner_inner_for_item": "2-o" }
                                         ]
                                     ],
                                     "key2":  "o"
                                 },
                                 {
                                     "key1": [
-                                        "str: foo, letter: o",
+                                        "str: foo, str_index: 0, letter: o",
                                         "foo",
                                         "o",
                                         [
-                                            { "inner_inner_for_item": "f" },
-                                            { "inner_inner_for_item": "o" },
-                                            { "inner_inner_for_item": "o" }
+                                            { "inner_inner_for_item": "0-f" },
+                                            { "inner_inner_for_item": "1-o" },
+                                            { "inner_inner_for_item": "2-o" }
                                         ]
                                     ],
                                     "key2":  "o"
@@ -208,7 +208,7 @@ class TestBlueprintsV1(TransactionTestCase):
                             [
                                 {
                                     "key1": {
-                                        "inner_key1": "letter: f, str: foo",
+                                        "inner_key1": "letter: f, str: foo, str_index: 0",
                                         "inner_key2": "f",
                                         "inner_key3": "foo",
                                     },
@@ -216,7 +216,7 @@ class TestBlueprintsV1(TransactionTestCase):
                                 },
                                 {
                                     "key1": {
-                                        "inner_key1": "letter: o, str: foo",
+                                        "inner_key1": "letter: o, str: foo, str_index: 0",
                                         "inner_key2": "o",
                                         "inner_key3": "foo",
                                     },
@@ -224,7 +224,7 @@ class TestBlueprintsV1(TransactionTestCase):
                                 },
                                 {
                                     "key1": {
-                                        "inner_key1": "letter: o, str: foo",
+                                        "inner_key1": "letter: o, str: foo, str_index: 0",
                                         "inner_key2": "o",
                                         "inner_key3": "foo",
                                     },
@@ -238,39 +238,39 @@ class TestBlueprintsV1(TransactionTestCase):
                             [
                                 {
                                     "key1": [
-                                        "str: bar, letter: b",
+                                        "str: bar, str_index: 1, letter: b",
                                         "bar",
                                         "b",
                                         [
-                                            { "inner_inner_for_item": "b" },
-                                            { "inner_inner_for_item": "a" },
-                                            { "inner_inner_for_item": "r" }
+                                            { "inner_inner_for_item": "0-b" },
+                                            { "inner_inner_for_item": "1-a" },
+                                            { "inner_inner_for_item": "2-r" }
                                         ]
                                     ],
                                     "key2":  "b"
                                 },
                                 {
                                     "key1": [
-                                        "str: bar, letter: a",
+                                        "str: bar, str_index: 1, letter: a",
                                         "bar",
                                         "a",
                                         [
-                                            { "inner_inner_for_item": "b" },
-                                            { "inner_inner_for_item": "a" },
-                                            { "inner_inner_for_item": "r" }
+                                            { "inner_inner_for_item": "0-b" },
+                                            { "inner_inner_for_item": "1-a" },
+                                            { "inner_inner_for_item": "2-r" }
                                         ]
                                     ],
                                     "key2":  "a"
                                 },
                                 {
                                     "key1": [
-                                        "str: bar, letter: r",
+                                        "str: bar, str_index: 1, letter: r",
                                         "bar",
                                         "r",
                                         [
-                                            { "inner_inner_for_item": "b" },
-                                            { "inner_inner_for_item": "a" },
-                                            { "inner_inner_for_item": "r" }
+                                            { "inner_inner_for_item": "0-b" },
+                                            { "inner_inner_for_item": "1-a" },
+                                            { "inner_inner_for_item": "2-r" }
                                         ]
                                     ],
                                     "key2":  "r"
@@ -279,7 +279,7 @@ class TestBlueprintsV1(TransactionTestCase):
                             [
                                 {
                                     "key1": {
-                                        "inner_key1": "letter: b, str: bar",
+                                        "inner_key1": "letter: b, str: bar, str_index: 1",
                                         "inner_key2": "b",
                                         "inner_key3": "bar",
                                     },
@@ -287,7 +287,7 @@ class TestBlueprintsV1(TransactionTestCase):
                                 },
                                 {
                                     "key1": {
-                                        "inner_key1": "letter: a, str: bar",
+                                        "inner_key1": "letter: a, str: bar, str_index: 1",
                                         "inner_key2": "a",
                                         "inner_key3": "bar",
                                     },
@@ -295,7 +295,7 @@ class TestBlueprintsV1(TransactionTestCase):
                                 },
                                 {
                                     "key1": {
-                                        "inner_key1": "letter: r, str: bar",
+                                        "inner_key1": "letter: r, str: bar, str_index: 1",
                                         "inner_key2": "r",
                                         "inner_key3": "bar",
                                     },

--- a/authentik/blueprints/v1/common.py
+++ b/authentik/blueprints/v1/common.py
@@ -1,6 +1,6 @@
 """transfer common classes"""
 from collections import OrderedDict
-from copy import deepcopy
+from copy import copy
 from dataclasses import asdict, dataclass, field, is_dataclass
 from enum import Enum
 from functools import reduce
@@ -111,7 +111,7 @@ class BlueprintEntry:
 
     def tag_resolver(self, value: Any, blueprint: "Blueprint") -> Any:
         """Check if we have any special tags that need handling"""
-        val = deepcopy(value)
+        val = copy(value)
 
         if isinstance(value, YAMLTagContext):
             self.__tag_contexts.append(value)

--- a/authentik/blueprints/v1/common.py
+++ b/authentik/blueprints/v1/common.py
@@ -436,7 +436,8 @@ class Enumerate(YAMLTag, YAMLTagContext):
 
         if not isinstance(iterable, Iterable):
             raise EntryInvalidError(
-                f"{self.__class__.__name__}'s iterable must be an iterable such as a sequence or a mapping"
+                f"{self.__class__.__name__}'s iterable must be an iterable "
+                "such as a sequence or a mapping"
             )
 
         if isinstance(iterable, Mapping):
@@ -492,8 +493,8 @@ class EnumeratedItem(YAMLTag):
                     f"{self.__class__.__name__} tags are only usable "
                     f"inside an {Enumerate.__name__} tag"
                 )
-            else:
-                raise EntryInvalidError(f"{self.__class__.__name__} tag: {exc}")
+
+            raise EntryInvalidError(f"{self.__class__.__name__} tag: {exc}")
 
         return context_tag.get_context(entry, blueprint)
 

--- a/authentik/blueprints/v1/common.py
+++ b/authentik/blueprints/v1/common.py
@@ -481,16 +481,14 @@ class EnumeratedItem(YAMLTag):
             context_tag: Enumerate = entry._get_tag_context(
                 depth=self.depth, context_tag_type=Enumerate
             )
-        except ValueError:
+        except ValueError as exc:
             if self.depth == 0:
                 raise EntryInvalidError(
                     f"{self.__class__.__name__} tags are only usable "
                     f"inside an {Enumerate.__name__} tag"
                 )
             else:
-                raise EntryInvalidError(
-                    f"Invalid {self.__class__.__name__} tag depth: {self.depth}"
-                )
+                raise EntryInvalidError(f"{self.__class__.__name__} tag: {exc}")
 
         return context_tag.get_context(entry, blueprint)
 

--- a/authentik/blueprints/v1/common.py
+++ b/authentik/blueprints/v1/common.py
@@ -6,7 +6,7 @@ from enum import Enum
 from functools import reduce
 from operator import ixor
 from os import getenv
-from typing import Any, Iterable, Literal, Optional, Union
+from typing import Any, Iterable, Literal, Mapping, Optional, Union
 from uuid import UUID
 
 from django.apps import apps
@@ -455,11 +455,21 @@ class For(YAMLTag, YAMLTagContext):
         else:
             iterable = self.iterable
 
+        if not isinstance(iterable, Iterable):
+            raise EntryInvalidError(
+                f"{self.__class__.__name__}'s iterable must be an iterable such as a sequence or a mapping"
+        )
+
+        if isinstance(iterable, Mapping):
+            iterable = tuple(iterable.items())
+        else:
+            iterable = tuple(enumerate(iterable))
+
         result = []
 
         self.__current_context = None
 
-        for item in tuple(enumerate(iterable)):
+        for item in iterable:
             self.__current_context = item
             result.append(entry.tag_resolver(self.item_body, blueprint))
 

--- a/authentik/blueprints/v1/common.py
+++ b/authentik/blueprints/v1/common.py
@@ -400,17 +400,11 @@ class ForItem(YAMLTag):
     """Get the current item of a For tag context"""
 
     depth: int
-    attr: Optional[str]
 
     # pylint: disable=unused-argument
-    def __init__(self, loader: "BlueprintLoader", node: ScalarNode | SequenceNode) -> None:
+    def __init__(self, loader: "BlueprintLoader", node: ScalarNode) -> None:
         super().__init__()
-        self.attr = None
-        if isinstance(node, ScalarNode):
-            self.depth = int(node.value)
-        if isinstance(node, SequenceNode):
-            self.depth = int(node.value[0].value)
-            self.attr = str(node.value[1].value)
+        self.depth = int(node.value)
 
     def resolve(self, entry: BlueprintEntry, blueprint: Blueprint) -> Any:
         try:
@@ -421,15 +415,7 @@ class ForItem(YAMLTag):
             else:
                 raise EntryInvalidError(f"Invalid ForItem tag depth: {self.depth}")
 
-        item = context_tag.get_context(entry, blueprint)
-
-        if self.attr:
-            try:
-                item = getattr(item, self.attr)
-            except AttributeError as exc:
-                raise EntryInvalidError(exc)
-
-        return item
+        return context_tag.get_context(entry, blueprint)
 
 
 class For(YAMLTag, YAMLTagContext):

--- a/website/developer-docs/blueprints/v1/tags.md
+++ b/website/developer-docs/blueprints/v1/tags.md
@@ -162,9 +162,9 @@ Minimal examples:
 
 ```
 configuration_stages: !Enumerate [
-    !Context list_of_totp_stage_names,
+    !Context map_of_totp_stage_names_and_types,
     SEQ, # Output a sequence
-    !Find [authentik_stages_authenticator_totp.authenticatortotpstage, [name, !Value 0]] # The value of each item in the sequence
+    !Find [!Format ["authentik_stages_authenticator_%s.authenticator%sstage", !Index 0, Index 0], [name, !Value 0]] # The value of each item in the sequence
 ]
 ```
 
@@ -172,14 +172,14 @@ The above example will resolve to something like this:
 
 ```
 configuration_stages:
-- !Find [authentik_stages_authenticator_totp.authenticatortotpstage, [name, <stage_name_1>]]
-- !Find [authentik_stages_authenticator_static.authenticatorstaticstage, [name, <stage_name_2>]]
+- !Find [authentik_stages_authenticator_<stage_type_1>.authenticator<stage_type_1>stage, [name, <stage_name_1>]]
+- !Find [authentik_stages_authenticator_<stage_type_2>.authenticator<stage_type_2>stage, [name, <stage_name_2>]]
 ```
 
 Similarly, a mapping can be generated like so:
 
 ```
-configuration_stages: !Enumerate [
+example: !Enumerate [
     !Context list_of_totp_stage_names,
     MAP, # Output a map
     [
@@ -192,7 +192,7 @@ configuration_stages: !Enumerate [
 The above example will resolve to something like this:
 
 ```
-configuration_stages:
+example:
   0: <stage_name_1>
   1: <stage_name_2>
 ```

--- a/website/developer-docs/blueprints/v1/tags.md
+++ b/website/developer-docs/blueprints/v1/tags.md
@@ -118,9 +118,9 @@ This tag takes 3 arguments:
 !Enumerate [<iterable>, <output_object_type>, <single_item_yaml>]
 ```
 
-- **iterable**: Any Python iterable or a custom tag that resolves to such iterable
-- **output_object_type**: "SEQ" or "MAP". Controls whether the returned YAML will be a mapping or a sequence.
-- **single_item_yaml**: The YAML to use to create a single entry in output object
+-   **iterable**: Any Python iterable or a custom tag that resolves to such iterable
+-   **output_object_type**: "SEQ" or "MAP". Controls whether the returned YAML will be a mapping or a sequence.
+-   **single_item_yaml**: The YAML to use to create a single entry in output object
 
 2. `!Index`
 
@@ -134,7 +134,7 @@ This tag takes 1 argument:
 !Index <depth>
 ```
 
-- **depth**: Must be >= 0. A depth of 0 refers to the `!Enumerate` tag this tag is located in. A depth of 1 refers to one `!Enumerate` tag above that (to be used when multiple `!Enumerate` tags are nested inside each other).
+-   **depth**: Must be >= 0. A depth of 0 refers to the `!Enumerate` tag this tag is located in. A depth of 1 refers to one `!Enumerate` tag above that (to be used when multiple `!Enumerate` tags are nested inside each other).
 
 Accesses the `!Enumerate` tag's iterable and resolves to the index of the item currently being iterated (in case `!Enumerate` is iterating over a sequence), or the mapping key (in case `!Enumerate` is iterating over a mapping).
 
@@ -152,12 +152,11 @@ This tag takes 1 argument:
 !Value <depth>
 ```
 
-- **depth**: Must be >= 0. A depth of 0 refers to the `!Enumerate` tag this tag is located in. A depth of 1 refers to one `!Enumerate` tag above that (to be used when multiple `!Enumerate` tags are nested inside each other).
+-   **depth**: Must be >= 0. A depth of 0 refers to the `!Enumerate` tag this tag is located in. A depth of 1 refers to one `!Enumerate` tag above that (to be used when multiple `!Enumerate` tags are nested inside each other).
 
 Accesses the `!Enumerate` tag's iterable and resolves to the value of the item currently being iterated.
 
 For example, given a sequence like this - `["a", "b", "c"]`, this tag will resolve to `a` on the first `!Enumerate` tag iteration, `b` on the second and so on. If given a mapping like this - `{"key1": "value1", "key2": "value2", "key3": "value3"}`, it will first resolve to `value1`, then to `value2` and so on.
-
 
 Minimal examples:
 

--- a/website/developer-docs/blueprints/v1/tags.md
+++ b/website/developer-docs/blueprints/v1/tags.md
@@ -108,9 +108,9 @@ Normally, it should be used to define complex conditions for use with an `!If` t
 
 #### `!Enumerate`, `!Index` and `!Value`
 
-These tags collectively make it possible to iterate over objects which support it. Any iterable python object is supported. Such objects are sequences, mappings and even strings.
+These tags collectively make it possible to iterate over objects which support iteration. Any iterable Python object is supported. Such objects are sequences (`[]`), mappings (`{}`) and even strings.
 
-1. Enumerate tag:
+1. `!Enumerate` tag:
 
 This tag takes 3 arguments:
 
@@ -118,13 +118,13 @@ This tag takes 3 arguments:
 !Enumerate [<iterable>, <output_object_type>, <single_item_yaml>]
 ```
 
--   **iterable**: Any Python iterable or a custom tag that resolves to such iterable
--   **output_object_type**: "SEQ" or "MAP". Controls whether the returned YAML will be a mapping or a sequence.
--   **single_item_yaml**: The YAML to use to create a single entry in output object
+-   **iterable**: Any Python iterable or custom tag that resolves to such iterable
+-   **output_object_type**: `SEQ` or `MAP`. Controls whether the returned YAML will be a mapping or a sequence.
+-   **single_item_yaml**: The YAML to use to create a single entry in the output object
 
-2. `!Index`
+2. `!Index` tag:
 
-:::warning
+:::info
 This tag is only valid inside an `!Enumerate` tag
 :::
 
@@ -140,9 +140,9 @@ Accesses the `!Enumerate` tag's iterable and resolves to the index of the item c
 
 For example, given a sequence like this - `["a", "b", "c"]`, this tag will resolve to `0` on the first `!Enumerate` tag iteration, `1` on the second and so on. However, if given a mapping like this - `{"key1": "value1", "key2": "value2", "key3": "value3"}`, it will first resolve to `key1`, then to `key2` and so on.
 
-3. `!Value`
+3. `!Value` tag:
 
-:::warning
+:::info
 This tag is only valid inside an `!Enumerate` tag
 :::
 
@@ -181,10 +181,10 @@ Similarly, a mapping can be generated like so:
 ```
 configuration_stages: !Enumerate [
     !Context list_of_totp_stage_names,
-    MAP, # Output a mao
+    MAP, # Output a map
     [
-        !Index 0, # The key to assign for each entry
-        !Value 0, # The value to assign of each entry
+        !Index 0, # The key to assign to each entry
+        !Value 0, # The value to assign to each entry
     ]
 ]
 ```
@@ -198,6 +198,10 @@ configuration_stages:
 ```
 
 Full example:
+
+:::warning
+Note that an `!Enumeration` tag's iterable can never be an `!Item` or `!Value` tag with a depth of `0`. Minimum depth allowed is `1`. This is because a depth of `0` refers to the `!Enumeration` tag the `!Item` or `!Value` tag is in, and an `!Enumeration` tag cannot iterate over itself.
+:::
 
 ```
 example: !Enumerate [

--- a/website/developer-docs/blueprints/v1/tags.md
+++ b/website/developer-docs/blueprints/v1/tags.md
@@ -164,7 +164,7 @@ Minimal examples:
 configuration_stages: !Enumerate [
     !Context map_of_totp_stage_names_and_types,
     SEQ, # Output a sequence
-    !Find [!Format ["authentik_stages_authenticator_%s.authenticator%sstage", !Index 0, Index 0], [name, !Value 0]] # The value of each item in the sequence
+    !Find [!Format ["authentik_stages_authenticator_%s.authenticator%sstage", !Index 0, !Index 0], [name, !Value 0]] # The value of each item in the sequence
 ]
 ```
 


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details
* **Does this resolve an issue?**
N/A

## Changes
### New Features
* Add `!Enumerate`, `!Value` and `!Index` tags

### Breaking Changes
N/A

## Additional
These tags collectively make it possible to iterate over objects which support iteration. Any iterable Python object is supported. Such as sequences (`[]`), mappings (`{}`) and even strings.

Example:


```
configuration_stages: !Enumerate [
    !Context map_of_totp_stage_names_and_types,
    SEQ, # Output a sequence
    !Find [!Format ["authentik_stages_authenticator_%s.authenticator%sstage", !Index 0, !Index 0], [name, !Value 0]] # The value of each item in the sequence
]
```

The above example will resolve to something like this:

```
configuration_stages:
- !Find [authentik_stages_authenticator_<stage_type_1>.authenticator<stage_type_1>stage, [name, <stage_name_1>]]
- !Find [authentik_stages_authenticator_<stage_type_2>.authenticator<stage_type_2>stage, [name, <stage_name_2>]]
```
 
See doc changes for more detail and examples.

### Implementation detail
The changes add a new base class called `YAMLTagContext`, which introduces the ability for tags to have their own contexts.

In the case of this PR, the tag context is used in the `!Enumerate` tag, to hold the currently iterated item of a sequence/mapping or any other iterable.

Accessing this context from other (nested) tags however proved challenging. I managed to keep the overall `.resolve()` interface the same, but I had to introduce a new hidden attribute (`self.__tag_contexts`) and private method (`self._get_tag_context()`) to the `BlueprintEntry` class.  Those can be used to access any parent tag's context from a tag that is nested inside it. The `_get_tag_context()` method  is private because it is only useful during tag resolution. It returns an empty list when not resolving tags.