### PR TITLE
blueprints: add mapping to sync active state from userAccountControl

### DIFF
--- a/blueprints/system/sources-ldap.yaml
+++ b/blueprints/system/sources-ldap.yaml
@@ -53,6 +53,14 @@ entries:
       object_field: "attributes.sn"
       expression: |
         return list_flatten(ldap.get('sn'))
+  - identifiers:
+      managed: goauthentik.io/sources/ldap/ms-active
+    model: authentik_sources_ldap.ldappropertymapping
+    attrs:
+      name: "authentik default Active Directory Mapping: active"
+      object_field: "attributes.active"
+      expression: |
+        return ldap.get('userAccountControl') & 2 == 0
   # OpenLDAP specific mappings
   - identifiers:
       managed: goauthentik.io/sources/ldap/openldap-uid

--- a/website/docs/property-mappings/index.md
+++ b/website/docs/property-mappings/index.md
@@ -12,6 +12,7 @@ SAML Property Mappings allow you embed information into the SAML AuthN request. 
 
 LDAP Property Mappings are used when you define a LDAP Source. These mappings define which LDAP property maps to which authentik property. By default, the following mappings are created:
 
+-   authentik default Active Directory Mapping: active
 -   authentik default Active Directory Mapping: givenName
 -   authentik default Active Directory Mapping: sAMAccountName
 -   authentik default Active Directory Mapping: sn


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details
* **Does this resolve an issue?**
*None*

## Changes
### New Features
* Adds a blueprint to sync the [ADS_UF_ACCOUNT_DISABLE](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/dd302fd1-0aa7-406b-ad91-2a6b35738557) bit from `userAccountControl` in Active Directory to user's active property in authentik.

### Breaking Changes
*None*

## Additional
I think it is reasonable for an application with Active Directory user sync to also support syncing the account locked/disable state. With this blueprint it should become more easy for others to get this property synced.