### PR TITLE
Fix TOTP issuer mangling

### DIFF
--- a/authentik/stages/authenticator_totp/stage.py
+++ b/authentik/stages/authenticator_totp/stage.py
@@ -16,6 +16,7 @@ from authentik.flows.challenge import (
 from authentik.flows.stage import ChallengeStageView
 from authentik.stages.authenticator_totp.models import AuthenticatorTOTPStage
 from authentik.stages.authenticator_totp.settings import OTP_TOTP_ISSUER
+from urllib.parse import quote
 
 SESSION_TOTP_DEVICE = "totp_device"
 
@@ -56,7 +57,7 @@ class AuthenticatorTOTPStageView(ChallengeStageView):
             data={
                 "type": ChallengeTypes.NATIVE.value,
                 "config_url": device.config_url.replace(
-                    OTP_TOTP_ISSUER, slugify(self.request.tenant.branding_title)
+                    OTP_TOTP_ISSUER, quote(self.request.tenant.branding_title)
                 ),
             }
         )

--- a/authentik/stages/authenticator_totp/stage.py
+++ b/authentik/stages/authenticator_totp/stage.py
@@ -1,7 +1,8 @@
 """TOTP Setup stage"""
+from urllib.parse import quote
+
 from django.http import HttpRequest, HttpResponse
 from django.http.request import QueryDict
-from urllib.parse import quote
 from django.utils.translation import gettext_lazy as _
 from django_otp.plugins.otp_totp.models import TOTPDevice
 from rest_framework.fields import CharField, IntegerField

--- a/authentik/stages/authenticator_totp/stage.py
+++ b/authentik/stages/authenticator_totp/stage.py
@@ -1,7 +1,7 @@
 """TOTP Setup stage"""
 from django.http import HttpRequest, HttpResponse
 from django.http.request import QueryDict
-from django.utils.text import slugify
+from urllib.parse import quote
 from django.utils.translation import gettext_lazy as _
 from django_otp.plugins.otp_totp.models import TOTPDevice
 from rest_framework.fields import CharField, IntegerField
@@ -16,7 +16,6 @@ from authentik.flows.challenge import (
 from authentik.flows.stage import ChallengeStageView
 from authentik.stages.authenticator_totp.models import AuthenticatorTOTPStage
 from authentik.stages.authenticator_totp.settings import OTP_TOTP_ISSUER
-from urllib.parse import quote
 
 SESSION_TOTP_DEVICE = "totp_device"
 


### PR DESCRIPTION
The TOTP issuer field gets populated from the tenant's branding title, but it's passed through django.utils.text.slugify, which excessively strips many useful characters from the tenant's branding title.

The issuer field only needs to be URL quoted, which is what this patch does.

Ideally the branding title should be written unquoted to OTP_TOTP_ISSUER, and django_otp will perform the URL quoting itself. I'm not sure how to set OTP_TOTP_ISSUER though.