### PR TITLE
fix a typo in email template main content

### DIFF
--- a/authentik/stages/email/templates/email/password_reset.html
+++ b/authentik/stages/email/templates/email/password_reset.html
@@ -17,7 +17,7 @@
             <tr>
                 <td class="content-block">
                     {% blocktrans %}
-                    You recently requested to change your password for you authentik account. Use the button below to set a new password.
+                    You recently requested to change your password for your authentik account. Use the button below to set a new password.
                     {% endblocktrans %}
                 </td>
             </tr>


### PR DESCRIPTION
Signed-off-by: Loan J <joliveau.loan@gmail.com>

fixes a typo in the email template content