### PR TITLE
stages/prompt: set UUID to be a string

### DIFF
--- a/authentik/stages/prompt/migrations/0009_prompt_name.py
+++ b/authentik/stages/prompt/migrations/0009_prompt_name.py
@@ -16,7 +16,7 @@ def set_generated_name(apps: Apps, schema_editor: BaseDatabaseSchemaEditor):
         if stage:
             name += "_" + stage.name
         else:
-            name += "_" + uuid4()
+            name += "_" + str(uuid4())
         prompt.name = name
         prompt.save()
 


### PR DESCRIPTION
Signed-off-by: Aaron Carson <aaron@aaroncarson.co.uk>

<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details
* **Does this resolve an issue?**
Resolves [a thread in Discord](https://discord.com/channels/809154715984199690/1069323169548206111/1069323391544332349)

## Changes
- DB migrations fail to apply in the current `gh-next` build. This fixes that.
```
  File "/authentik/stages/prompt/migrations/0009_prompt_name.py", line 19, in set_generated_name
    name += "_" + uuid4()
            ~~~~^~~~~~~~~
TypeError: can only concatenate str (not "UUID") to str
```
