### PR TITLE
Cast User.pk to string when using it for token 'sub' value

### DIFF
--- a/authentik/providers/oauth2/models.py
+++ b/authentik/providers/oauth2/models.py
@@ -487,7 +487,7 @@ class RefreshToken(SerializerModel, ExpiringModel, BaseGrantModel):
         if self.provider.sub_mode == SubModes.HASHED_USER_ID:
             sub = user.uid
         elif self.provider.sub_mode == SubModes.USER_ID:
-            sub = user.pk
+            sub = str(user.pk)
         elif self.provider.sub_mode == SubModes.USER_EMAIL:
             sub = user.email
         elif self.provider.sub_mode == SubModes.USER_USERNAME:


### PR DESCRIPTION
`sub` is expected to be a string, but `User.pk` is an int, so without this fix you get the following exception when generating a token:

```Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/asgiref/sync.py", line 472, in thread_handler
    raise exc_info[1]
  File "/usr/local/lib/python3.11/site-packages/django/core/handlers/base.py", line 253, in _get_response_async
    response = await wrapped_callback(
               ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/asgiref/sync.py", line 435, in __call__
    ret = await asyncio.wait_for(future, timeout=None)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/asyncio/tasks.py", line 442, in wait_for
    return await fut
           ^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/asgiref/current_thread_executor.py", line 22, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/asgiref/sync.py", line 476, in thread_handler
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/views/generic/base.py", line 103, in view
    return self.dispatch(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/utils/decorators.py", line 46, in _wrapper
    return bound_method(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/authentik/providers/oauth2/views/token.py", line 398, in dispatch
    response = super().dispatch(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/views/generic/base.py", line 142, in dispatch
    return handler(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/authentik/providers/oauth2/views/token.py", line 430, in post
    return TokenResponse(self.create_code_response())
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/authentik/providers/oauth2/views/token.py", line 475, in create_code_response
    "id_token": self.provider.encode(refresh_token.id_token.to_dict()),
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/authentik/providers/oauth2/models.py", line 453, in id_token
    return from_dict(IDToken, raw_token)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/dacite/core.py", line 69, in from_dict
    raise WrongTypeError(field_path=field.name, field_type=field_type, value=value)
dacite.exceptions.WrongTypeError: wrong value type for field "sub" - should be "typing.Optional[str]" instead of value "1" of type "int"
```