### PR TITLE
providers/saml: fix mismatched SAML SLO Urls

### DIFF
--- a/authentik/providers/saml/urls.py
+++ b/authentik/providers/saml/urls.py
@@ -23,12 +23,12 @@ urlpatterns = [
     ),
     # SLO Bindings
     path(
-        "<slug:application_slug>/slo/redirect/",
+        "<slug:application_slug>/slo/binding/redirect/",
         slo.SAMLSLOBindingRedirectView.as_view(),
         name="slo-redirect",
     ),
     path(
-        "<slug:application_slug>/slo/post/",
+        "<slug:application_slug>/slo/binding/post/",
         slo.SAMLSLOBindingPOSTView.as_view(),
         name="slo-post",
     ),

--- a/website/integrations/services/nextcloud/index.md
+++ b/website/integrations/services/nextcloud/index.md
@@ -52,7 +52,7 @@ Set the following values:
 -   Optional display name of the identity provider (default: "SSO & SAML log in"): `authentik`
 -   Identifier of the IdP entity (must be a URI): `https://authentik.company`
 -   URL Target of the IdP where the SP will send the Authentication Request Message: `https://authentik.company/application/saml/<application-slug>/sso/binding/redirect/`
--   URL Location of IdP where the SP will send the SLO Request: `https://authentik.company/application/saml/<application-slug>/slo/redirect/`
+-   URL Location of IdP where the SP will send the SLO Request: `https://authentik.company/application/saml/<application-slug>/slo/binding/redirect`
 -   Public X.509 certificate of the IdP: Copy the PEM of the Selected Signing Certificate
 
 Under Attribute mapping, set these values:

--- a/website/integrations/services/nextcloud/index.md
+++ b/website/integrations/services/nextcloud/index.md
@@ -52,7 +52,7 @@ Set the following values:
 -   Optional display name of the identity provider (default: "SSO & SAML log in"): `authentik`
 -   Identifier of the IdP entity (must be a URI): `https://authentik.company`
 -   URL Target of the IdP where the SP will send the Authentication Request Message: `https://authentik.company/application/saml/<application-slug>/sso/binding/redirect/`
--   URL Location of IdP where the SP will send the SLO Request: `https://authentik.company/application/saml/<application-slug>/slo/binding/redirect`
+-   URL Location of IdP where the SP will send the SLO Request: `https://authentik.company/application/saml/<application-slug>/slo/redirect/`
 -   Public X.509 certificate of the IdP: Copy the PEM of the Selected Signing Certificate
 
 Under Attribute mapping, set these values:


### PR DESCRIPTION
# Details
According to the source code:

https://github.com/goauthentik/authentik/blob/b225f6f3ff6cbd5b0d69304c36ed30b81a45aa5d/authentik/providers/saml/urls.py#L25-L29

Notice no `/binding/`

## Changes
### New Features
N/A

### Breaking Changes
N/A

## Additional
N/A
