### PR TITLE
website/integrations: Fix Nextcloud SAM UID value setting

### DIFF
--- a/website/integrations/services/nextcloud/index.md
+++ b/website/integrations/services/nextcloud/index.md
@@ -48,7 +48,7 @@ In Nextcloud, ensure that the `SSO & SAML Authentication` app is installed. Navi
 
 Set the following values:
 
--   Attribute to map the UID to.: `http://schemas.goauthentik.io/2021/02/saml/username`
+-   Attribute to map the UID to: `http://schemas.goauthentik.io/2021/02/saml/uid`
 -   Optional display name of the identity provider (default: "SSO & SAML log in"): `authentik`
 -   Identifier of the IdP entity (must be a URI): `https://authentik.company`
 -   URL Target of the IdP where the SP will send the Authentication Request Message: `https://authentik.company/application/saml/<application-slug>/sso/binding/redirect/`


### PR DESCRIPTION
# Details
Currently the docs say to set the Nextcloud SAML UID to the user's username. This should not be done because the username may be mutable. This means that:
1. If the user changes their username, they will be considered a different user from Nextcloud's perspective and therefore lose their data
2. If a user changes their username, and then another user adopts their old username, they will effectively impersonate the original user in Nextcloud.

## Changes
Changed the docs to use authentik's SAML UID property (instead of username). That in turn will make authentik return the user's PK, which is immutable.

### Breaking Changes

N/A

## Additional
N/A
