### PR TITLE
root: fix config load order to include /etc/authentik/config.yml

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,7 +18,7 @@ var cfg *Config
 func Get() *Config {
 	if cfg == nil {
 		c := defaultConfig()
-		c.Setup("./authentik/lib/default.yml", "./local.env.yml")
+		c.Setup("./authentik/lib/default.yml", "/etc/authentik/config.yml", "./local.env.yml")
 		cfg = c
 	}
 	return cfg


### PR DESCRIPTION
# Details
This PR adds `/etc/authentik/config.yml` into the configuration load order for the Go parts of authentik, as the Python parts load it.