### PR TITLE
Better InlineFileField

### DIFF
--- a/authentik/stages/prompt/tests.py
+++ b/authentik/stages/prompt/tests.py
@@ -137,6 +137,14 @@ class TestPromptStage(FlowTestCase):
             InlineFileField().to_internal_value("data:mine/type;base64,Zm9vqwer"),
             "data:mine/type;base64,Zm9vqwer",
         )
+        with self.assertRaises(ValidationError):
+            InlineFileField(max_length=2).to_internal_value("data:mine/type;base64,Zm9vqwer")
+        with self.assertRaises(ValidationError):
+            InlineFileField(max_file_length=2).to_internal_value("data:mine/type;base64,Zm9vqwer")
+        with self.assertRaises(ValidationError):
+            InlineFileField(file_types=(".png", ".jpg")).to_internal_value(
+                "data:mine/type;base64,Zm9vqwer"
+            )
 
     def test_render(self):
         """Test render of form, check if all prompts are rendered correctly"""


### PR DESCRIPTION
# Details
The goal of this PR is to improve the `InlineFileField` by adding new features such as support for max file size, accepted file types etc. (see below)

## Changes
- [x] Add support for specifying max file size and allowed file types to the `InlineFileField`
- [ ]  Modify the `Prompt` model to support storing configuration for the the new `InlineFileField` options
- [ ]  Modify the front end to  support configuring the new file field options

#### Bonus features (or bugs, not sure):
- [ ]  Add ability to clear the current value of a `InlineFileField` by a user. For example if used in the user settings flow as a way to set an avatar - add an ability to delete this avatar (clear the field)
- [ ]  Add ability to detect the mime type of the data in the front end and render an appropriate container instead of the default "upload a file" field.  For example if it is an image - render the image inside an `<img>` tag that when clicked allows to upload a new image or something similar.

## Additional
**I need some guidance to finish this.** 

For example, I am currently stuck on how to best modify the `Prompt` model. I originally added these 2 new fields, but I don't think that is the best solution as they will only be valid/relevant when the field  is of type "file".
```python
file_types = ArrayField(
    models.CharField(
        max_length=25,
        choices=((value, value[1:]) for value in mimetypes.types_map.keys()),
    ),
    default=tuple,
    help_text=_("Allowed file types"),
)
file_size = models.PositiveBigIntegerField(default=0, help_text=_("Max file size in bytes"))
```
