### PR TITLE
Allow tokens to be set to a specific value via the API

### DIFF
--- a/authentik/core/api/tokens.py
+++ b/authentik/core/api/tokens.py
@@ -53,6 +53,7 @@ class TokenSerializer(ManagedSerializer, ModelSerializer):
             "intent",
             "user",
             "user_obj",
+            "key",
             "description",
             "expires",
             "expiring",
@@ -65,7 +66,7 @@ class TokenSerializer(ManagedSerializer, ModelSerializer):
 class TokenViewSerializer(PassiveSerializer):
     """Show token's current key"""
 
-    key = CharField(read_only=True)
+    key = CharField(read_only=False)
 
 
 class TokenViewSet(UsedByMixin, ModelViewSet):


### PR DESCRIPTION
Necessary for blueprints to be able to implement features like `AK_ADMIN_PASS`, that is setting tokens via ENV variables.  This is necessary in order to do fully automated installs of outposts.

