### PR TITLE
core: Fix bug causing whitespace only names to raise exception when generating avatars

### DIFF
--- a/authentik/lib/avatars.py
+++ b/authentik/lib/avatars.py
@@ -154,7 +154,7 @@ def generate_avatar_from_name(
 
 def avatar_mode_generated(user: "User", mode: str) -> Optional[str]:
     """Wrapper that converts generated avatar to base64 svg"""
-    svg = generate_avatar_from_name(user.name if user.name != "" else "a k")
+    svg = generate_avatar_from_name(user.name if user.name.strip() != "" else "a k")
     return f"data:image/svg+xml;base64,{b64encode(svg.encode('utf-8')).decode('utf-8')}"
 
 


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details
* **Does this resolve an issue?**
Resolves #4744 

## Changes
### New Features
N/A

### Breaking Changes
N/A

## Additional
N/A
