### PR TITLE
website/integrations: Automatic sign-in to HedgeDoc

### DIFF
--- a/website/integrations/services/hedgedoc/index.md
+++ b/website/integrations/services/hedgedoc/index.md
@@ -19,7 +19,7 @@ The following placeholders will be used:
 -   `hedgedoc.company` is the FQDN of the HedgeDoc install.
 -   `authentik.company` is the FQDN of the authentik install.
 
-Create an application in authentik. Create an OAuth2/OpenID provider with the following parameters:
+Create an OAuth2/OpenID provider with the following parameters:
 
 -   Client Type: `Confidential`
 -   Scopes: OpenID, Email and Profile
@@ -27,6 +27,10 @@ Create an application in authentik. Create an OAuth2/OpenID provider with the fo
 -   Redirect URIs: `https://hedgedoc.company/auth/oauth2/callback`
 
 Note the Client ID and Client Secret values. Create an application, using the provider you've created above.
+To be logged in immediately if you click on the application, set:
+
+-   Launch URL: `https://hedgedoc.company/auth/oauth2`
+
 
 ## HedgeDoc
 

--- a/website/integrations/services/hedgedoc/index.md
+++ b/website/integrations/services/hedgedoc/index.md
@@ -31,7 +31,6 @@ To be logged in immediately if you click on the application, set:
 
 -   Launch URL: `https://hedgedoc.company/auth/oauth2`
 
-
 ## HedgeDoc
 
 You need to set the following `env` Variables for Docker based installations.


### PR DESCRIPTION
Following the HedgeDoc guides, if you clicks on a HedgeDoc application, you then still have to click “Sign-in” and “Sign in via authentik” to actually get signed in.

This patch suggests adding a launch URL to the application which will cause users to automatically get signed in.