### PR TITLE
website/docs: Corrected typo and added Note about port number if using Istio/Kubern…

### DIFF
--- a/website/docs/providers/proxy/forward_auth.mdx
+++ b/website/docs/providers/proxy/forward_auth.mdx
@@ -107,7 +107,7 @@ import TraefikIngress from "./_traefik_ingress.md";
   </TabItem>
 </Tabs>
 
-## Enovy (Istio)
+## Envoy (Istio)
 
 :::info
 Requires authentik 2022.6
@@ -116,6 +116,9 @@ Requires authentik 2022.6
 :::info
 Support for this is still in preview, please report bugs on [GitHub](https://github.com/goauthentik/authentik/issues).
 :::
+
+:::info
+If you are using Istio and Kubernetes, use the port number that is exposed for your cluster.
 
 <Tabs
   defaultValue="envoy-istio"

--- a/website/docs/providers/proxy/forward_auth.mdx
+++ b/website/docs/providers/proxy/forward_auth.mdx
@@ -119,7 +119,7 @@ Support for this is still in preview, please report bugs on [GitHub](https://git
 
 :::info
 If you are using Istio and Kubernetes, use the port number that is exposed for your cluster.
-
+:::
 <Tabs
   defaultValue="envoy-istio"
   values={[

--- a/website/docs/providers/proxy/forward_auth.mdx
+++ b/website/docs/providers/proxy/forward_auth.mdx
@@ -120,6 +120,7 @@ Support for this is still in preview, please report bugs on [GitHub](https://git
 :::info
 If you are using Istio and Kubernetes, use the port number that is exposed for your cluster.
 :::
+
 <Tabs
   defaultValue="envoy-istio"
   values={[


### PR DESCRIPTION


# Details
@BeryJu I was reading [this article](https://prevue.ch/news/2022-10-11-istio-authentik/) about a fellow setting up authentik, using Istio and Kubernetes. I wanted to somehow add a heads up about the port number, but I am not confident that I got it right. Is it only if there are custom decisions being made that the port number has to be for the cluster?

