### PR TITLE
website/docs: reformat headings in Forward auth

### DIFF
--- a/website/docs/providers/proxy/forward_auth.mdx
+++ b/website/docs/providers/proxy/forward_auth.mdx
@@ -43,7 +43,7 @@ _app.company_ is used as a placeholder for the external domain for the applicati
 _outpost.company_ is used as a placeholder for the outpost. When using the embedded outpost, this can be the same as _authentik.company_
 :::
 
-## Nginx
+### Nginx
 
 <Tabs
   defaultValue="standalone-nginx"
@@ -75,7 +75,7 @@ import NginxProxyManager from "./_nginx_proxy_manager.md";
   </TabItem>
 </Tabs>
 
-## Traefik
+### Traefik
 
 <Tabs
   defaultValue="standalone-traefik"
@@ -107,7 +107,7 @@ import TraefikIngress from "./_traefik_ingress.md";
   </TabItem>
 </Tabs>
 
-## Envoy (Istio)
+### Envoy (Istio)
 
 :::info
 Requires authentik 2022.6
@@ -135,7 +135,7 @@ import EnvoyIstio from "./_envoy_istio.md";
   </TabItem>
 </Tabs>
 
-## Caddy
+### Caddy
 
 :::info
 Requires authentik 2022.8


### PR DESCRIPTION
Reformat from ## to ### to show child sections under Domain level
