### PR TITLE
providers/scim: handle ServiceProviderConfig 404

### DIFF
--- a/authentik/providers/scim/clients/base.py
+++ b/authentik/providers/scim/clients/base.py
@@ -88,8 +88,8 @@ class SCIMClient(Generic[T, SchemaType]):
             return ServiceProviderConfiguration.parse_obj(
                 self._request("GET", "/ServiceProviderConfig")
             )
-        except ValidationError as exc:
-            self.logger.warning("ServiceProviderConfig invalid", exc=exc)
+        except (ValidationError, SCIMRequestException) as exc:
+            self.logger.warning("failed to get ServiceProviderConfig", exc=exc)
             return default_config
 
     def write(self, obj: T):


### PR DESCRIPTION
some service providers don't implement /ServiceProviderConfig which currently causes the client to fail to initialise, it should just fallback to the default config