### PR TITLE
website/docs: forward-auth page, add list of links

### DIFF
--- a/website/docs/providers/proxy/forward_auth.mdx
+++ b/website/docs/providers/proxy/forward_auth.mdx
@@ -28,7 +28,7 @@ This mode differs from the _Forward auth (single application)_ mode in the follo
 -   You don't have to configure an application in authentik for each domain
 -   Users don't have to authorize multiple times
 
-There are however also some downsides, mainly the fact that you **can't** restrict individual applications to different users.
+There are, however, also some downsides, mainly the fact that you **can't** restrict individual applications to different users.
 
 ## Configuration templates
 For configuration templates for each web server, refer to the following:

--- a/website/docs/providers/proxy/forward_auth.mdx
+++ b/website/docs/providers/proxy/forward_auth.mdx
@@ -7,11 +7,18 @@ Using forward auth uses your existing reverse proxy to do the proxying, and only
 To use forward auth instead of proxying, you have to change a couple of settings.
 In the Proxy Provider, make sure to use one of the Forward auth modes.
 
-## Single application
+## Forward auth modes
+The only configuration difference between single application mode and domain level mode is the host that you specify.
+
+For single application, you'd use the domain that the application is running on, and only `/outpost.goauthentik.io` is redirected to the outpost.
+
+For domain level, you'd use the same domain as authentik.
+
+### Single application
 
 Single application mode works for a single application hosted on its dedicated subdomain. This has the advantage that you can still do per-application access policies in authentik.
 
-## Domain level
+### Domain level
 
 To use forward auth instead of proxying, you have to change a couple of settings.
 In the Proxy Provider, make sure to use the _Forward auth (domain level)_ mode.
@@ -23,8 +30,9 @@ This mode differs from the _Forward auth (single application)_ mode in the follo
 
 There are however also some downsides, mainly the fact that you **can't** restrict individual applications to different users.
 
-The only configuration difference between single application and domain level is the host you specify.
+## Configuration templates
+For configuration templates for each web server, refer to the following:
 
-For single application, you'd use the domain which the application is running on, and only `/outpost.goauthentik.io` is redirected to the outpost.
-
-For domain level, you'd use the same domain as authentik.
+import DocCardList from "@theme/DocCardList";
+import { useCurrentSidebarCategory } from "@docusaurus/theme-common";
+<DocCardList items={useCurrentSidebarCategory().items} />

--- a/website/docs/providers/proxy/forward_auth.mdx
+++ b/website/docs/providers/proxy/forward_auth.mdx
@@ -8,6 +8,7 @@ To use forward auth instead of proxying, you have to change a couple of settings
 In the Proxy Provider, make sure to use one of the Forward auth modes.
 
 ## Forward auth modes
+
 The only configuration difference between single application mode and domain level mode is the host that you specify.
 
 For single application, you'd use the domain that the application is running on, and only `/outpost.goauthentik.io` is redirected to the outpost.
@@ -31,8 +32,10 @@ This mode differs from the _Forward auth (single application)_ mode in the follo
 There are, however, also some downsides, mainly the fact that you **can't** restrict individual applications to different users.
 
 ## Configuration templates
+
 For configuration templates for each web server, refer to the following:
 
 import DocCardList from "@theme/DocCardList";
 import { useCurrentSidebarCategory } from "@docusaurus/theme-common";
+
 <DocCardList items={useCurrentSidebarCategory().items} />


### PR DESCRIPTION
## Changes
Added list of web server-specific pages, and reformatted to try and separate list of config templates from the sections about single-app or domain-level.
