### PR TITLE
website/integrations: Changes to reverse proxy information for grafana

### DIFF
--- a/website/integrations/services/grafana/index.mdx
+++ b/website/integrations/services/grafana/index.mdx
@@ -101,7 +101,7 @@ For more information on group/role mappings, see [Grafana's docs](https://grafan
 
 ### Grafana Configuration Considerations
 
-Make sure in your configuration that `root_url` is set correctly, otherwise your redirect url might get processed incorrectly. For example, if your grafana instance is running on the default configuration and is accessible behind a reverse proxy at `https://grafana.company`, your redirect url will end up looking like this, `https://grafana.company:3000`.
+Make sure in your configuration that `root_url` is set correctly, otherwise your redirect url might get processed incorrectly. For example, if your grafana instance is running on the default configuration and is accessible behind a reverse proxy at `https://grafana.company`, your redirect url will end up looking like this, `https://grafana.company/`.
 If you get `user does not belong to org` error when trying to log into grafana for the first time via OAuth, check if you have an organization with the ID of `1`, if not, then you have to add the following to your grafana config:
 
 ```ini


### PR DESCRIPTION
Changed to remove the port at the end of the domain for root_url, if grafana is behind a reverse proxy and is reachable at its ip or at https://grafana.company it would not than be accessible by that port. 

Until the root_url was changed in grafana.ini to https://grafana.company/ gives the following error  The request fails due to a missing, invalid, or mismatching redirection URI (redirect_uri).

This was tested using:
authentik 2023.3.0
grafana 9.3.6
nginx proxy manager 2.9.19

<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details
* **Does this resolve an issue?**
Resolves #

## Changes
### New Features
* Adds feature which does x, y, and z.

### Breaking Changes
* Adds breaking change which causes \<issue\>.

## Additional
Any further notes or comments you want to make.
