### PR TITLE
website/docs: Fix detail and improve latest changelog regarding SCIM

### DIFF
--- a/website/docs/releases/2023/v2023.3.md
+++ b/website/docs/releases/2023/v2023.3.md
@@ -11,7 +11,9 @@ slug: "/releases/2023.3"
     This feature is still in technical preview, so please report any Bugs you run into on [GitHub](https://github.com/goauthentik/authentik/issues).
     :::
 
-    authentik can now provision users from other IT systems via the SCIM (System for Cross-domain Identity Management) protocol. The provider synchronizes Users, Groups and the user membership. Objects are synced both when they are saved and based on a pre-defined schedule in the background.
+    authentik can now provision users into other IT systems via the SCIM (System for Cross-domain Identity Management) protocol. The provider synchronizes Users, Groups and the user membership. Objects are synced both when they are saved and based on a pre-defined schedule in the background.
+    
+    Documentation: https://goauthentik.io/docs/providers/scim/
 
 -   Theming improvements
 

--- a/website/docs/releases/2023/v2023.3.md
+++ b/website/docs/releases/2023/v2023.3.md
@@ -12,7 +12,7 @@ slug: "/releases/2023.3"
     :::
 
     authentik can now provision users into other IT systems via the SCIM (System for Cross-domain Identity Management) protocol. The provider synchronizes Users, Groups and the user membership. Objects are synced both when they are saved and based on a pre-defined schedule in the background.
-    
+
     Documentation: https://goauthentik.io/docs/providers/scim/
 
 -   Theming improvements


### PR DESCRIPTION
# Details

Resolves an issue in the wording of the new SCIM feature

## Changes

I found the wording confusing ("sync from" vs. "sync into" as being used in the docs). I also added a direct link to the regarding documentation page.