### PR TITLE
website/integrations: add detail to MinIO docs

### DIFF
--- a/website/integrations/services/minio/index.md
+++ b/website/integrations/services/minio/index.md
@@ -19,6 +19,10 @@ The following placeholders will be used:
 -   `minio.company` is the FQDN of the MinIO install.
 -   `authentik.company` is the FQDN of the authentik install.
 
+### Mapping to MinIO policies
+
+The primary way to manage access in MinIO is via [policies](https://min.io/docs/minio/linux/administration/identity-access-management/policy-based-access-control.html#minio-policy). We need to configure authentik to return a list of which MinIO policies should be applied to a user.
+
 Under _Customization_ -> _Property Mappings_, create a _Scope Mapping_. Give it a name like "OIDC-Scope-minio". Set the scope name to `minio` and the expression to the following
 
 ```python
@@ -27,9 +31,27 @@ return {
 }
 ```
 
+This mapping will result in the default MinIO `readwrite` policy being applied to all users. If you want to create a more granular mapping based on authentik groups, use an expression like this
+
+```python
+if ak_is_group_member(request.user, name="Minio admins"):
+  return {
+      "policy": "consoleAdmin",
+}
+elif ak_is_group_member(request.user, name="Minio users"):
+  return {
+      "policy": ["readonly", "my-custom-policy"]
+}
+return None
+```
+
+Note that you can assign multiple policies to a user by returning a list, and returning `None` will map no policies to the user, resulting in no access to the MinIO instance. For more information on writing expressions, see [Expressions](../../../docs/property-mappings/expression.mdx) and [User](../../../docs/user-group/user.md#object-attributes) docs.
+
+### Creating application and provider
+
 Create an application in authentik. Create an _OAuth2/OpenID Provider_ with the following parameters:
 
--   Client Type: `Public`
+-   Client Type: `Confidential`
 -   Scopes: OpenID, Email, Profile and the scope you created above
 -   Signing Key: Select any available key
 -   Redirect URIs: `https://minio.company/oauth_callback`
@@ -42,5 +64,8 @@ Note the Client ID and Client Secret values. Create an application, using the pr
 ~ mc admin config set myminio identity_openid \
   config_url="https://authentik.company/application/o/<applicaiton-slug>/.well-known/openid-configuration" \
   client_id="<client id from above>" \
+  client_secret="<client secret from above>" \
   scopes="openid,profile,email,minio"
 ```
+
+The [upstream MinIO docs on OIDC](https://min.io/docs/minio/linux/reference/minio-mc-admin/mc-admin-config.html#openid-identity-management) indicate that the `client_secret` (and thus confidential client type) are optional depending on provider. Experimentally with a single-node MinIO instance, the client secret was required and worked without further issue.

--- a/website/integrations/services/minio/index.md
+++ b/website/integrations/services/minio/index.md
@@ -45,7 +45,7 @@ elif ak_is_group_member(request.user, name="Minio users"):
 return None
 ```
 
-Note that you can assign multiple policies to a user by returning a list, and returning `None` will map no policies to the user, resulting in no access to the MinIO instance. For more information on writing expressions, see [Expressions](../../../docs/property-mappings/expression.mdx) and [User](../../../docs/user-group/user.md#object-attributes) docs.
+Note that you can assign multiple policies to a user by returning a list, and returning `None` will map no policies to the user, resulting in no access to the MinIO instance. For more information on writing expressions, see [Expressions](../../../docs/property-mappings/expression) and [User](../../../docs/user-group/user#object-attributes) docs.
 
 ### Creating application and provider
 


### PR DESCRIPTION
# Details

## Changes

Add more information and reference links for the Scope Mapping, to clarify how it's used.

Also update to reflect that MinIO seems to require a Confidential client type now.

## Additional

The [upstream MinIO docs on OIDC](https://min.io/docs/minio/linux/reference/minio-mc-admin/mc-admin-config.html#openid-identity-management) indicate that the client secret (and thus confidential client type) are optional depending on provider. Experimentally with my single-node MinIO instance, the client secret was required and worked without further issue.