### PR TITLE
web/elements: only render form once instance is loaded

### DIFF
--- a/web/src/admin/applications/ApplicationForm.ts
+++ b/web/src/admin/applications/ApplicationForm.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_CONFIG, config } from "@goauthentik/common/api/config";
 import { first, groupBy } from "@goauthentik/common/utils";
+import { rootInterface } from "@goauthentik/elements/Base";
 import "@goauthentik/elements/forms/FormGroup";
 import "@goauthentik/elements/forms/HorizontalFormElement";
 import "@goauthentik/elements/forms/ModalForm";
@@ -13,7 +14,6 @@ import { t } from "@lingui/macro";
 import { TemplateResult, html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
-import { until } from "lit/directives/until.js";
 
 import {
     Application,
@@ -195,70 +195,58 @@ export class ApplicationForm extends ModelForm<Application, string> {
                             ${t`If checked, the launch URL will open in a new browser tab or window from the user's application library.`}
                         </p>
                     </ak-form-element-horizontal>
-                    ${until(
-                        config().then((c) => {
-                            if (c.capabilities.includes(CapabilitiesEnum.SaveMedia)) {
-                                return html`<ak-form-element-horizontal
-                                        label=${t`Icon`}
-                                        name="metaIcon"
-                                    >
-                                        <input type="file" value="" class="pf-c-form-control" />
-                                        ${this.instance?.metaIcon
-                                            ? html`
-                                                  <p class="pf-c-form__helper-text">
-                                                      ${t`Currently set to:`}
-                                                      ${this.instance?.metaIcon}
-                                                  </p>
-                                              `
-                                            : html``}
-                                    </ak-form-element-horizontal>
-                                    ${this.instance?.metaIcon
-                                        ? html`
-                                              <ak-form-element-horizontal>
-                                                  <label class="pf-c-switch">
-                                                      <input
-                                                          class="pf-c-switch__input"
-                                                          type="checkbox"
-                                                          @change=${(ev: Event) => {
-                                                              const target =
-                                                                  ev.target as HTMLInputElement;
-                                                              this.clearIcon = target.checked;
-                                                          }}
-                                                      />
-                                                      <span class="pf-c-switch__toggle">
-                                                          <span class="pf-c-switch__toggle-icon">
-                                                              <i
-                                                                  class="fas fa-check"
-                                                                  aria-hidden="true"
-                                                              ></i>
-                                                          </span>
-                                                      </span>
-                                                      <span class="pf-c-switch__label">
-                                                          ${t`Clear icon`}
-                                                      </span>
-                                                  </label>
-                                                  <p class="pf-c-form__helper-text">
-                                                      ${t`Delete currently set icon.`}
-                                                  </p>
-                                              </ak-form-element-horizontal>
-                                          `
-                                        : html``}`;
-                            }
-                            return html`<ak-form-element-horizontal
-                                label=${t`Icon`}
-                                name="metaIcon"
-                            >
-                                <input
-                                    type="text"
-                                    value="${first(this.instance?.metaIcon, "")}"
-                                    class="pf-c-form-control"
-                                />
-                                <p class="pf-c-form__helper-text">
-                                    ${t`Either input a full URL, a relative path, or use 'fa://fa-test' to use the Font Awesome icon "fa-test".`}
-                                </p>
-                            </ak-form-element-horizontal>`;
-                        }),
-                    )}
+                    ${rootInterface()?.config?.capabilities.includes(CapabilitiesEnum.SaveMedia)
+                        ? html`<ak-form-element-horizontal label=${t`Icon`} name="metaIcon">
+                                  <input type="file" value="" class="pf-c-form-control" />
+                                  ${this.instance?.metaIcon
+                                      ? html`
+                                            <p class="pf-c-form__helper-text">
+                                                ${t`Currently set to:`} ${this.instance?.metaIcon}
+                                            </p>
+                                        `
+                                      : html``}
+                              </ak-form-element-horizontal>
+                              ${this.instance?.metaIcon
+                                  ? html`
+                                        <ak-form-element-horizontal>
+                                            <label class="pf-c-switch">
+                                                <input
+                                                    class="pf-c-switch__input"
+                                                    type="checkbox"
+                                                    @change=${(ev: Event) => {
+                                                        const target =
+                                                            ev.target as HTMLInputElement;
+                                                        this.clearIcon = target.checked;
+                                                    }}
+                                                />
+                                                <span class="pf-c-switch__toggle">
+                                                    <span class="pf-c-switch__toggle-icon">
+                                                        <i
+                                                            class="fas fa-check"
+                                                            aria-hidden="true"
+                                                        ></i>
+                                                    </span>
+                                                </span>
+                                                <span class="pf-c-switch__label">
+                                                    ${t`Clear icon`}
+                                                </span>
+                                            </label>
+                                            <p class="pf-c-form__helper-text">
+                                                ${t`Delete currently set icon.`}
+                                            </p>
+                                        </ak-form-element-horizontal>
+                                    `
+                                  : html``}`
+                        : html`<ak-form-element-horizontal label=${t`Icon`} name="icon">
+                              <input
+                                  type="text"
+                                  value="${first(this.instance?.metaIcon, "")}"
+                                  class="pf-c-form-control"
+                              />
+                              <p class="pf-c-form__helper-text">
+                                  ${t`Either input a full URL, a relative path, or use 'fa://fa-test' to use the Font Awesome icon "fa-test".`}
+                              </p>
+                          </ak-form-element-horizontal>`}
                     <ak-form-element-horizontal label=${t`Publisher`} name="metaPublisher">
                         <input
                             type="text"

--- a/web/src/admin/events/RuleForm.ts
+++ b/web/src/admin/events/RuleForm.ts
@@ -120,7 +120,7 @@ export class RuleForm extends ModelForm<NotificationRule, string> {
                 <ak-radio
                     .options=${[
                         {
-                            label: "Alert",
+                            label: t`Alert`,
                             value: SeverityEnum.Alert,
                             default: true,
                         },

--- a/web/src/admin/events/TransportForm.ts
+++ b/web/src/admin/events/TransportForm.ts
@@ -2,6 +2,7 @@ import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
 import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/forms/HorizontalFormElement";
 import { ModelForm } from "@goauthentik/elements/forms/ModelForm";
+import "@goauthentik/elements/forms/Radio";
 import "@goauthentik/elements/forms/SearchSelect";
 
 import { t } from "@lingui/macro";
@@ -56,35 +57,6 @@ export class TransportForm extends ModelForm<NotificationTransport, string> {
         }
     };
 
-    renderTransportModes(): TemplateResult {
-        return html`
-            <option
-                value=${NotificationTransportModeEnum.Local}
-                ?selected=${this.instance?.mode === NotificationTransportModeEnum.Local}
-            >
-                ${t`Local (notifications will be created within authentik)`}
-            </option>
-            <option
-                value=${NotificationTransportModeEnum.Email}
-                ?selected=${this.instance?.mode === NotificationTransportModeEnum.Email}
-            >
-                ${t`Email`}
-            </option>
-            <option
-                value=${NotificationTransportModeEnum.Webhook}
-                ?selected=${this.instance?.mode === NotificationTransportModeEnum.Webhook}
-            >
-                ${t`Webhook (generic)`}
-            </option>
-            <option
-                value=${NotificationTransportModeEnum.WebhookSlack}
-                ?selected=${this.instance?.mode === NotificationTransportModeEnum.WebhookSlack}
-            >
-                ${t`Webhook (Slack/Discord)`}
-            </option>
-        `;
-    }
-
     onModeChange(mode: string | undefined): void {
         if (
             mode === NotificationTransportModeEnum.Webhook ||
@@ -107,15 +79,32 @@ export class TransportForm extends ModelForm<NotificationTransport, string> {
                 />
             </ak-form-element-horizontal>
             <ak-form-element-horizontal label=${t`Mode`} ?required=${true} name="mode">
-                <select
-                    class="pf-c-form-control"
-                    @change=${(ev: Event) => {
-                        const current = (ev.target as HTMLInputElement).value;
-                        this.onModeChange(current);
+                <ak-radio
+                    @change=${(ev: CustomEvent<NotificationTransportModeEnum>) => {
+                        this.onModeChange(ev.detail);
                     }}
+                    .options=${[
+                        {
+                            label: t`Local (notifications will be created within authentik)`,
+                            value: NotificationTransportModeEnum.Local,
+                            default: true,
+                        },
+                        {
+                            label: t`Email`,
+                            value: NotificationTransportModeEnum.Email,
+                        },
+                        {
+                            label: t`Webhook (generic)`,
+                            value: NotificationTransportModeEnum.Webhook,
+                        },
+                        {
+                            label: t`Webhook (Slack/Discord)`,
+                            value: NotificationTransportModeEnum.WebhookSlack,
+                        },
+                    ]}
+                    .value=${this.instance?.mode}
                 >
-                    ${this.renderTransportModes()}
-                </select>
+                </ak-radio>
             </ak-form-element-horizontal>
             <ak-form-element-horizontal
                 ?hidden=${!this.showWebhook}

--- a/web/src/admin/flows/FlowForm.ts
+++ b/web/src/admin/flows/FlowForm.ts
@@ -2,6 +2,7 @@ import { DesignationToLabel, LayoutToLabel } from "@goauthentik/admin/flows/util
 import { AuthenticationEnum } from "@goauthentik/api/dist/models/AuthenticationEnum";
 import { DEFAULT_CONFIG, config } from "@goauthentik/common/api/config";
 import { first } from "@goauthentik/common/utils";
+import { rootInterface } from "@goauthentik/elements/Base";
 import "@goauthentik/elements/forms/FormGroup";
 import "@goauthentik/elements/forms/HorizontalFormElement";
 import { ModelForm } from "@goauthentik/elements/forms/ModelForm";
@@ -12,7 +13,6 @@ import { t } from "@lingui/macro";
 import { TemplateResult, html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
-import { until } from "lit/directives/until.js";
 
 import {
     CapabilitiesEnum,
@@ -315,73 +315,62 @@ export class FlowForm extends ModelForm<Flow, string> {
                             </option>
                         </select>
                     </ak-form-element-horizontal>
-                    ${until(
-                        config().then((c) => {
-                            if (c.capabilities.includes(CapabilitiesEnum.SaveMedia)) {
-                                return html`<ak-form-element-horizontal
-                                        label=${t`Background`}
-                                        name="background"
-                                    >
-                                        <input type="file" value="" class="pf-c-form-control" />
-                                        ${this.instance?.background
-                                            ? html`
-                                                  <p class="pf-c-form__helper-text">
-                                                      ${t`Currently set to:`}
-                                                      ${this.instance?.background}
-                                                  </p>
-                                              `
-                                            : html``}
-                                        <p class="pf-c-form__helper-text">
-                                            ${t`Background shown during execution.`}
-                                        </p>
-                                    </ak-form-element-horizontal>
-                                    ${this.instance?.background
-                                        ? html`
-                                              <ak-form-element-horizontal>
-                                                  <label class="pf-c-switch">
-                                                      <input
-                                                          class="pf-c-switch__input"
-                                                          type="checkbox"
-                                                          @change=${(ev: Event) => {
-                                                              const target =
-                                                                  ev.target as HTMLInputElement;
-                                                              this.clearBackground = target.checked;
-                                                          }}
-                                                      />
-                                                      <span class="pf-c-switch__toggle">
-                                                          <span class="pf-c-switch__toggle-icon">
-                                                              <i
-                                                                  class="fas fa-check"
-                                                                  aria-hidden="true"
-                                                              ></i>
-                                                          </span>
-                                                      </span>
-                                                      <span class="pf-c-switch__label">
-                                                          ${t`Clear icon`}
-                                                      </span>
-                                                  </label>
-                                                  <p class="pf-c-form__helper-text">
-                                                      ${t`Delete currently set background image.`}
-                                                  </p>
-                                              </ak-form-element-horizontal>
-                                          `
-                                        : html``}`;
-                            }
-                            return html`<ak-form-element-horizontal
-                                label=${t`Background`}
-                                name="background"
-                            >
-                                <input
-                                    type="text"
-                                    value="${first(this.instance?.background, "")}"
-                                    class="pf-c-form-control"
-                                />
-                                <p class="pf-c-form__helper-text">
-                                    ${t`Background shown during execution.`}
-                                </p>
-                            </ak-form-element-horizontal>`;
-                        }),
-                    )}
+                    ${rootInterface()?.config?.capabilities.includes(CapabilitiesEnum.SaveMedia)
+                        ? html`<ak-form-element-horizontal label=${t`Background`} name="background">
+                                  <input type="file" value="" class="pf-c-form-control" />
+                                  ${this.instance?.background
+                                      ? html`
+                                            <p class="pf-c-form__helper-text">
+                                                ${t`Currently set to:`} ${this.instance?.background}
+                                            </p>
+                                        `
+                                      : html``}
+
+                                  <p class="pf-c-form__helper-text">
+                                      ${t`Background shown during execution.`}
+                                  </p>
+                              </ak-form-element-horizontal>
+                              ${this.instance?.background
+                                  ? html`
+                                        <ak-form-element-horizontal>
+                                            <label class="pf-c-switch">
+                                                <input
+                                                    class="pf-c-switch__input"
+                                                    type="checkbox"
+                                                    @change=${(ev: Event) => {
+                                                        const target =
+                                                            ev.target as HTMLInputElement;
+                                                        this.clearBackground = target.checked;
+                                                    }}
+                                                />
+                                                <span class="pf-c-switch__toggle">
+                                                    <span class="pf-c-switch__toggle-icon">
+                                                        <i
+                                                            class="fas fa-check"
+                                                            aria-hidden="true"
+                                                        ></i>
+                                                    </span>
+                                                </span>
+                                                <span class="pf-c-switch__label">
+                                                    ${t`Clear background`}
+                                                </span>
+                                            </label>
+                                            <p class="pf-c-form__helper-text">
+                                                ${t`Delete currently set background image.`}
+                                            </p>
+                                        </ak-form-element-horizontal>
+                                    `
+                                  : html``}`
+                        : html`<ak-form-element-horizontal label=${t`Icon`} name="icon">
+                              <input
+                                  type="text"
+                                  value="${first(this.instance?.background, "")}"
+                                  class="pf-c-form-control"
+                              />
+                              <p class="pf-c-form__helper-text">
+                                  ${t`Background shown during execution.`}
+                              </p>
+                          </ak-form-element-horizontal>`}
                 </div>
             </ak-form-group>
         </form>`;

--- a/web/src/admin/policies/event_matcher/EventMatcherPolicyForm.ts
+++ b/web/src/admin/policies/event_matcher/EventMatcherPolicyForm.ts
@@ -10,9 +10,15 @@ import { t } from "@lingui/macro";
 import { TemplateResult, html } from "lit";
 import { customElement } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
-import { until } from "lit/directives/until.js";
 
-import { AdminApi, EventMatcherPolicy, EventsApi, PoliciesApi, TypeCreate } from "@goauthentik/api";
+import {
+    AdminApi,
+    App,
+    EventMatcherPolicy,
+    EventsApi,
+    PoliciesApi,
+    TypeCreate,
+} from "@goauthentik/api";
 
 @customElement("ak-policy-event-matcher-form")
 export class EventMatcherPolicyForm extends ModelForm<EventMatcherPolicy, string> {
@@ -21,6 +27,12 @@ export class EventMatcherPolicyForm extends ModelForm<EventMatcherPolicy, string
             policyUuid: pk,
         });
     }
+
+    async load(): Promise<void> {
+        this.apps = await new AdminApi(DEFAULT_CONFIG).adminAppsList();
+    }
+
+    apps?: App[];
 
     getSuccessMessage(): string {
         if (this.instance) {
@@ -118,19 +130,14 @@ export class EventMatcherPolicyForm extends ModelForm<EventMatcherPolicy, string
                             <option value="" ?selected=${this.instance?.app === undefined}>
                                 ---------
                             </option>
-                            ${until(
-                                new AdminApi(DEFAULT_CONFIG).adminAppsList().then((apps) => {
-                                    return apps.map((app) => {
-                                        return html`<option
-                                            value=${app.name}
-                                            ?selected=${this.instance?.app === app.name}
-                                        >
-                                            ${app.label}
-                                        </option>`;
-                                    });
-                                }),
-                                html`<option>${t`Loading...`}</option>`,
-                            )}
+                            ${this.apps?.map((app) => {
+                                return html`<option
+                                    value=${app.name}
+                                    ?selected=${this.instance?.app === app.name}
+                                >
+                                    ${app.label}
+                                </option>`;
+                            })}
                         </select>
                         <p class="pf-c-form__helper-text">
                             ${t`Match events created by selected application. When left empty, all applications are matched.`}

--- a/web/src/admin/providers/radius/RadiusProviderForm.ts
+++ b/web/src/admin/providers/radius/RadiusProviderForm.ts
@@ -9,9 +9,9 @@ import "@goauthentik/elements/forms/SearchSelect";
 
 import { t } from "@lingui/macro";
 
-import { customElement } from "lit-element";
-import { TemplateResult, html } from "lit-html";
+import { TemplateResult, html } from "lit";
 import { ifDefined } from "lit-html/directives/if-defined.js";
+import { customElement } from "lit/decorators.js";
 
 import {
     Flow,

--- a/web/src/admin/providers/radius/RadiusProviderViewPage.ts
+++ b/web/src/admin/providers/radius/RadiusProviderViewPage.ts
@@ -11,7 +11,8 @@ import "@goauthentik/elements/events/ObjectChangelog";
 
 import { t } from "@lingui/macro";
 
-import { CSSResult, TemplateResult, customElement, html, property } from "lit-element";
+import { CSSResult, TemplateResult, html } from "lit";
+import { customElement, property } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFCard from "@patternfly/patternfly/components/Card/card.css";

--- a/web/src/admin/providers/scim/SCIMProviderForm.ts
+++ b/web/src/admin/providers/scim/SCIMProviderForm.ts
@@ -11,12 +11,12 @@ import { t } from "@lingui/macro";
 import { TemplateResult, html } from "lit";
 import { customElement } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
-import { until } from "lit/directives/until.js";
 
 import {
     CoreApi,
     CoreGroupsListRequest,
     Group,
+    PaginatedSCIMMappingList,
     PropertymappingsApi,
     ProvidersApi,
     SCIMProvider,
@@ -29,6 +29,16 @@ export class SCIMProviderFormPage extends ModelForm<SCIMProvider, number> {
             id: pk,
         });
     }
+
+    async load(): Promise<void> {
+        this.propertyMappings = await new PropertymappingsApi(
+            DEFAULT_CONFIG,
+        ).propertymappingsScimList({
+            ordering: "managed",
+        });
+    }
+
+    propertyMappings?: PaginatedSCIMMappingList;
 
     getSuccessMessage(): string {
         if (this.instance) {
@@ -147,36 +157,26 @@ export class SCIMProviderFormPage extends ModelForm<SCIMProvider, number> {
                         name="propertyMappings"
                     >
                         <select class="pf-c-form-control" multiple>
-                            ${until(
-                                new PropertymappingsApi(DEFAULT_CONFIG)
-                                    .propertymappingsScimList({
-                                        ordering: "managed",
-                                    })
-                                    .then((mappings) => {
-                                        return mappings.results.map((mapping) => {
-                                            let selected = false;
-                                            if (!this.instance?.propertyMappings) {
-                                                selected =
-                                                    mapping.managed ===
-                                                        "goauthentik.io/providers/scim/user" ||
-                                                    false;
-                                            } else {
-                                                selected = Array.from(
-                                                    this.instance?.propertyMappings,
-                                                ).some((su) => {
-                                                    return su == mapping.pk;
-                                                });
-                                            }
-                                            return html`<option
-                                                value=${ifDefined(mapping.pk)}
-                                                ?selected=${selected}
-                                            >
-                                                ${mapping.name}
-                                            </option>`;
-                                        });
-                                    }),
-                                html`<option>${t`Loading...`}</option>`,
-                            )}
+                            ${this.propertyMappings?.results.map((mapping) => {
+                                let selected = false;
+                                if (!this.instance?.propertyMappings) {
+                                    selected =
+                                        mapping.managed === "goauthentik.io/providers/scim/user" ||
+                                        false;
+                                } else {
+                                    selected = Array.from(this.instance?.propertyMappings).some(
+                                        (su) => {
+                                            return su == mapping.pk;
+                                        },
+                                    );
+                                }
+                                return html`<option
+                                    value=${ifDefined(mapping.pk)}
+                                    ?selected=${selected}
+                                >
+                                    ${mapping.name}
+                                </option>`;
+                            })}
                         </select>
                         <p class="pf-c-form__helper-text">
                             ${t`Property mappings used to user mapping.`}
@@ -191,35 +191,25 @@ export class SCIMProviderFormPage extends ModelForm<SCIMProvider, number> {
                         name="propertyMappingsGroup"
                     >
                         <select class="pf-c-form-control" multiple>
-                            ${until(
-                                new PropertymappingsApi(DEFAULT_CONFIG)
-                                    .propertymappingsScimList({
-                                        ordering: "managed",
-                                    })
-                                    .then((mappings) => {
-                                        return mappings.results.map((mapping) => {
-                                            let selected = false;
-                                            if (!this.instance?.propertyMappingsGroup) {
-                                                selected =
-                                                    mapping.managed ===
-                                                    "goauthentik.io/providers/scim/group";
-                                            } else {
-                                                selected = Array.from(
-                                                    this.instance?.propertyMappingsGroup,
-                                                ).some((su) => {
-                                                    return su == mapping.pk;
-                                                });
-                                            }
-                                            return html`<option
-                                                value=${ifDefined(mapping.pk)}
-                                                ?selected=${selected}
-                                            >
-                                                ${mapping.name}
-                                            </option>`;
-                                        });
-                                    }),
-                                html`<option>${t`Loading...`}</option>`,
-                            )}
+                            ${this.propertyMappings?.results.map((mapping) => {
+                                let selected = false;
+                                if (!this.instance?.propertyMappingsGroup) {
+                                    selected =
+                                        mapping.managed === "goauthentik.io/providers/scim/group";
+                                } else {
+                                    selected = Array.from(
+                                        this.instance?.propertyMappingsGroup,
+                                    ).some((su) => {
+                                        return su == mapping.pk;
+                                    });
+                                }
+                                return html`<option
+                                    value=${ifDefined(mapping.pk)}
+                                    ?selected=${selected}
+                                >
+                                    ${mapping.name}
+                                </option>`;
+                            })}
                         </select>
                         <p class="pf-c-form__helper-text">
                             ${t`Property mappings used to group creation.`}

--- a/web/src/admin/sources/oauth/OAuthSourceForm.ts
+++ b/web/src/admin/sources/oauth/OAuthSourceForm.ts
@@ -2,6 +2,7 @@ import { RenderFlowOption } from "@goauthentik/admin/flows/utils";
 import { UserMatchingModeToLabel } from "@goauthentik/admin/sources/oauth/utils";
 import { DEFAULT_CONFIG, config } from "@goauthentik/common/api/config";
 import { first } from "@goauthentik/common/utils";
+import { rootInterface } from "@goauthentik/elements/Base";
 import "@goauthentik/elements/CodeMirror";
 import "@goauthentik/elements/forms/FormGroup";
 import "@goauthentik/elements/forms/HorizontalFormElement";
@@ -13,7 +14,6 @@ import { t } from "@lingui/macro";
 import { TemplateResult, html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
-import { until } from "lit/directives/until.js";
 
 import {
     CapabilitiesEnum,
@@ -315,63 +315,52 @@ export class OAuthSourceForm extends ModelForm<OAuthSource, string> {
                     ${t`Path template for users created. Use placeholders like \`%(slug)s\` to insert the source slug.`}
                 </p>
             </ak-form-element-horizontal>
-            ${until(
-                config().then((c) => {
-                    if (c.capabilities.includes(CapabilitiesEnum.SaveMedia)) {
-                        return html`<ak-form-element-horizontal label=${t`Icon`} name="icon">
-                                <input type="file" value="" class="pf-c-form-control" />
-                                ${this.instance?.icon
-                                    ? html`
-                                          <p class="pf-c-form__helper-text">
-                                              ${t`Currently set to:`} ${this.instance?.icon}
-                                          </p>
-                                      `
-                                    : html``}
-                            </ak-form-element-horizontal>
-                            ${this.instance?.icon
-                                ? html`
-                                      <ak-form-element-horizontal>
-                                          <label class="pf-c-switch">
-                                              <input
-                                                  class="pf-c-switch__input"
-                                                  type="checkbox"
-                                                  @change=${(ev: Event) => {
-                                                      const target = ev.target as HTMLInputElement;
-                                                      this.clearIcon = target.checked;
-                                                  }}
-                                              />
-                                              <span class="pf-c-switch__toggle">
-                                                  <span class="pf-c-switch__toggle-icon">
-                                                      <i
-                                                          class="fas fa-check"
-                                                          aria-hidden="true"
-                                                      ></i>
-                                                  </span>
-                                              </span>
-                                              <span class="pf-c-switch__label">
-                                                  ${t`Clear icon`}
-                                              </span>
-                                          </label>
-
-                                          <p class="pf-c-form__helper-text">
-                                              ${t`Delete currently set icon.`}
-                                          </p>
-                                      </ak-form-element-horizontal>
-                                  `
-                                : html``}`;
-                    }
-                    return html`<ak-form-element-horizontal label=${t`Icon`} name="icon">
-                        <input
-                            type="text"
-                            value="${first(this.instance?.icon, "")}"
-                            class="pf-c-form-control"
-                        />
-                        <p class="pf-c-form__helper-text">
-                            ${t`Either input a full URL, a relative path, or use 'fa://fa-test' to use the Font Awesome icon "fa-test".`}
-                        </p>
-                    </ak-form-element-horizontal>`;
-                }),
-            )}
+            ${rootInterface()?.config?.capabilities.includes(CapabilitiesEnum.SaveMedia)
+                ? html`<ak-form-element-horizontal label=${t`Icon`} name="icon">
+                          <input type="file" value="" class="pf-c-form-control" />
+                          ${this.instance?.icon
+                              ? html`
+                                    <p class="pf-c-form__helper-text">
+                                        ${t`Currently set to:`} ${this.instance?.icon}
+                                    </p>
+                                `
+                              : html``}
+                      </ak-form-element-horizontal>
+                      ${this.instance?.icon
+                          ? html`
+                                <ak-form-element-horizontal>
+                                    <label class="pf-c-switch">
+                                        <input
+                                            class="pf-c-switch__input"
+                                            type="checkbox"
+                                            @change=${(ev: Event) => {
+                                                const target = ev.target as HTMLInputElement;
+                                                this.clearIcon = target.checked;
+                                            }}
+                                        />
+                                        <span class="pf-c-switch__toggle">
+                                            <span class="pf-c-switch__toggle-icon">
+                                                <i class="fas fa-check" aria-hidden="true"></i>
+                                            </span>
+                                        </span>
+                                        <span class="pf-c-switch__label"> ${t`Clear icon`} </span>
+                                    </label>
+                                    <p class="pf-c-form__helper-text">
+                                        ${t`Delete currently set icon.`}
+                                    </p>
+                                </ak-form-element-horizontal>
+                            `
+                          : html``}`
+                : html`<ak-form-element-horizontal label=${t`Icon`} name="icon">
+                      <input
+                          type="text"
+                          value="${first(this.instance?.icon, "")}"
+                          class="pf-c-form-control"
+                      />
+                      <p class="pf-c-form__helper-text">
+                          ${t`Either input a full URL, a relative path, or use 'fa://fa-test' to use the Font Awesome icon "fa-test".`}
+                      </p>
+                  </ak-form-element-horizontal>`}
 
             <ak-form-group .expanded=${true}>
                 <span slot="header"> ${t`Protocol settings`} </span>

--- a/web/src/admin/sources/plex/PlexSourceForm.ts
+++ b/web/src/admin/sources/plex/PlexSourceForm.ts
@@ -3,6 +3,7 @@ import { UserMatchingModeToLabel } from "@goauthentik/admin/sources/oauth/utils"
 import { DEFAULT_CONFIG, config } from "@goauthentik/common/api/config";
 import { PlexAPIClient, PlexResource, popupCenterScreen } from "@goauthentik/common/helpers/plex";
 import { first, randomString } from "@goauthentik/common/utils";
+import { rootInterface } from "@goauthentik/elements/Base";
 import "@goauthentik/elements/forms/FormGroup";
 import "@goauthentik/elements/forms/HorizontalFormElement";
 import { ModelForm } from "@goauthentik/elements/forms/ModelForm";
@@ -13,7 +14,6 @@ import { t } from "@lingui/macro";
 import { TemplateResult, html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
-import { until } from "lit/directives/until.js";
 
 import {
     CapabilitiesEnum,
@@ -267,63 +267,52 @@ export class PlexSourceForm extends ModelForm<PlexSource, string> {
                     ${t`Path template for users created. Use placeholders like \`%(slug)s\` to insert the source slug.`}
                 </p>
             </ak-form-element-horizontal>
-            ${until(
-                config().then((c) => {
-                    if (c.capabilities.includes(CapabilitiesEnum.SaveMedia)) {
-                        return html`<ak-form-element-horizontal label=${t`Icon`} name="icon">
-                                <input type="file" value="" class="pf-c-form-control" />
-                                ${this.instance?.icon
-                                    ? html`
-                                          <p class="pf-c-form__helper-text">
-                                              ${t`Currently set to:`} ${this.instance?.icon}
-                                          </p>
-                                      `
-                                    : html``}
-                            </ak-form-element-horizontal>
-                            ${this.instance?.icon
-                                ? html`
-                                      <ak-form-element-horizontal>
-                                          <label class="pf-c-switch">
-                                              <input
-                                                  class="pf-c-switch__input"
-                                                  type="checkbox"
-                                                  @change=${(ev: Event) => {
-                                                      const target = ev.target as HTMLInputElement;
-                                                      this.clearIcon = target.checked;
-                                                  }}
-                                              />
-                                              <span class="pf-c-switch__toggle">
-                                                  <span class="pf-c-switch__toggle-icon">
-                                                      <i
-                                                          class="fas fa-check"
-                                                          aria-hidden="true"
-                                                      ></i>
-                                                  </span>
-                                              </span>
-                                              <span class="pf-c-switch__label">
-                                                  ${t`Clear icon`}
-                                              </span>
-                                          </label>
-                                          <p class="pf-c-form__helper-text">
-                                              ${t`Delete currently set icon.`}
-                                          </p>
-                                      </ak-form-element-horizontal>
-                                  `
-                                : html``}`;
-                    }
-                    return html`<ak-form-element-horizontal label=${t`Icon`} name="icon">
-                        <input
-                            type="text"
-                            value="${first(this.instance?.icon, "")}"
-                            class="pf-c-form-control"
-                        />
-                        <p class="pf-c-form__helper-text">
-                            ${t`Either input a full URL, a relative path, or use 'fa://fa-test' to use the Font Awesome icon "fa-test".`}
-                        </p>
-                    </ak-form-element-horizontal>`;
-                }),
-            )}
-
+            ${rootInterface()?.config?.capabilities.includes(CapabilitiesEnum.SaveMedia)
+                ? html`<ak-form-element-horizontal label=${t`Icon`} name="icon">
+                          <input type="file" value="" class="pf-c-form-control" />
+                          ${this.instance?.icon
+                              ? html`
+                                    <p class="pf-c-form__helper-text">
+                                        ${t`Currently set to:`} ${this.instance?.icon}
+                                    </p>
+                                `
+                              : html``}
+                      </ak-form-element-horizontal>
+                      ${this.instance?.icon
+                          ? html`
+                                <ak-form-element-horizontal>
+                                    <label class="pf-c-switch">
+                                        <input
+                                            class="pf-c-switch__input"
+                                            type="checkbox"
+                                            @change=${(ev: Event) => {
+                                                const target = ev.target as HTMLInputElement;
+                                                this.clearIcon = target.checked;
+                                            }}
+                                        />
+                                        <span class="pf-c-switch__toggle">
+                                            <span class="pf-c-switch__toggle-icon">
+                                                <i class="fas fa-check" aria-hidden="true"></i>
+                                            </span>
+                                        </span>
+                                        <span class="pf-c-switch__label"> ${t`Clear icon`} </span>
+                                    </label>
+                                    <p class="pf-c-form__helper-text">
+                                        ${t`Delete currently set icon.`}
+                                    </p>
+                                </ak-form-element-horizontal>
+                            `
+                          : html``}`
+                : html`<ak-form-element-horizontal label=${t`Icon`} name="icon">
+                      <input
+                          type="text"
+                          value="${first(this.instance?.icon, "")}"
+                          class="pf-c-form-control"
+                      />
+                      <p class="pf-c-form__helper-text">
+                          ${t`Either input a full URL, a relative path, or use 'fa://fa-test' to use the Font Awesome icon "fa-test".`}
+                      </p>
+                  </ak-form-element-horizontal>`}
             <ak-form-group .expanded=${true}>
                 <span slot="header"> ${t`Protocol settings`} </span>
                 <div slot="body" class="pf-c-form">

--- a/web/src/admin/sources/saml/SAMLSourceForm.ts
+++ b/web/src/admin/sources/saml/SAMLSourceForm.ts
@@ -2,6 +2,7 @@ import { RenderFlowOption } from "@goauthentik/admin/flows/utils";
 import { UserMatchingModeToLabel } from "@goauthentik/admin/sources/oauth/utils";
 import { DEFAULT_CONFIG, config } from "@goauthentik/common/api/config";
 import { first } from "@goauthentik/common/utils";
+import { rootInterface } from "@goauthentik/elements/Base";
 import "@goauthentik/elements/forms/FormGroup";
 import "@goauthentik/elements/forms/HorizontalFormElement";
 import { ModelForm } from "@goauthentik/elements/forms/ModelForm";
@@ -13,7 +14,6 @@ import { t } from "@lingui/macro";
 import { TemplateResult, html } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
-import { until } from "lit/directives/until.js";
 
 import {
     BindingTypeEnum,
@@ -161,62 +161,52 @@ export class SAMLSourceForm extends ModelForm<SAMLSource, string> {
                     </option>
                 </select>
             </ak-form-element-horizontal>
-            ${until(
-                config().then((c) => {
-                    if (c.capabilities.includes(CapabilitiesEnum.SaveMedia)) {
-                        return html`<ak-form-element-horizontal label=${t`Icon`} name="icon">
-                                <input type="file" value="" class="pf-c-form-control" />
-                                ${this.instance?.icon
-                                    ? html`
-                                          <p class="pf-c-form__helper-text">
-                                              ${t`Currently set to:`} ${this.instance?.icon}
-                                          </p>
-                                      `
-                                    : html``}
-                            </ak-form-element-horizontal>
-                            ${this.instance?.icon
-                                ? html`
-                                      <ak-form-element-horizontal>
-                                          <label class="pf-c-switch">
-                                              <input
-                                                  class="pf-c-switch__input"
-                                                  type="checkbox"
-                                                  @change=${(ev: Event) => {
-                                                      const target = ev.target as HTMLInputElement;
-                                                      this.clearIcon = target.checked;
-                                                  }}
-                                              />
-                                              <span class="pf-c-switch__toggle">
-                                                  <span class="pf-c-switch__toggle-icon">
-                                                      <i
-                                                          class="fas fa-check"
-                                                          aria-hidden="true"
-                                                      ></i>
-                                                  </span>
-                                              </span>
-                                              <span class="pf-c-switch__label">
-                                                  ${t`Clear icon`}
-                                              </span>
-                                          </label>
-                                          <p class="pf-c-form__helper-text">
-                                              ${t`Delete currently set icon.`}
-                                          </p>
-                                      </ak-form-element-horizontal>
-                                  `
-                                : html``}`;
-                    }
-                    return html`<ak-form-element-horizontal label=${t`Icon`} name="icon">
-                        <input
-                            type="text"
-                            value="${first(this.instance?.icon, "")}"
-                            class="pf-c-form-control"
-                        />
-                        <p class="pf-c-form__helper-text">
-                            ${t`Either input a full URL, a relative path, or use 'fa://fa-test' to use the Font Awesome icon "fa-test".`}
-                        </p>
-                    </ak-form-element-horizontal>`;
-                }),
-            )}
+            ${rootInterface()?.config?.capabilities.includes(CapabilitiesEnum.SaveMedia)
+                ? html`<ak-form-element-horizontal label=${t`Icon`} name="icon">
+                          <input type="file" value="" class="pf-c-form-control" />
+                          ${this.instance?.icon
+                              ? html`
+                                    <p class="pf-c-form__helper-text">
+                                        ${t`Currently set to:`} ${this.instance?.icon}
+                                    </p>
+                                `
+                              : html``}
+                      </ak-form-element-horizontal>
+                      ${this.instance?.icon
+                          ? html`
+                                <ak-form-element-horizontal>
+                                    <label class="pf-c-switch">
+                                        <input
+                                            class="pf-c-switch__input"
+                                            type="checkbox"
+                                            @change=${(ev: Event) => {
+                                                const target = ev.target as HTMLInputElement;
+                                                this.clearIcon = target.checked;
+                                            }}
+                                        />
+                                        <span class="pf-c-switch__toggle">
+                                            <span class="pf-c-switch__toggle-icon">
+                                                <i class="fas fa-check" aria-hidden="true"></i>
+                                            </span>
+                                        </span>
+                                        <span class="pf-c-switch__label"> ${t`Clear icon`} </span>
+                                    </label>
+                                    <p class="pf-c-form__helper-text">
+                                        ${t`Delete currently set icon.`}
+                                    </p>
+                                </ak-form-element-horizontal>
+                            `
+                          : html``}`
+                : html`<ak-form-element-horizontal label=${t`Icon`} name="icon">
+                      <input
+                          type="text"
+                          value="${first(this.instance?.icon, "")}"
+                          class="pf-c-form-control"
+                      />
+                      <p class="pf-c-form__helper-text">
+                          ${t`Either input a full URL, a relative path, or use 'fa://fa-test' to use the Font Awesome icon "fa-test".`}
+                      </p>
+                  </ak-form-element-horizontal>`}
 
             <ak-form-group .expanded=${true}>
                 <span slot="header"> ${t`Protocol settings`} </span>

--- a/web/src/elements/Base.ts
+++ b/web/src/elements/Base.ts
@@ -1,6 +1,6 @@
-import { tenant } from "@goauthentik/common/api/config";
+import { config, tenant } from "@goauthentik/common/api/config";
 import { EVENT_LOCALE_CHANGE, EVENT_THEME_CHANGE } from "@goauthentik/common/constants";
-import { uiConfig } from "@goauthentik/common/ui/config";
+import { UIConfig, uiConfig } from "@goauthentik/common/ui/config";
 
 import { LitElement } from "lit";
 import { state } from "lit/decorators.js";
@@ -9,7 +9,7 @@ import AKGlobal from "@goauthentik/common/styles/authentik.css";
 import ThemeDark from "@goauthentik/common/styles/theme-dark.css";
 import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
-import { CurrentTenant, UiThemeEnum } from "@goauthentik/api";
+import { Config, CurrentTenant, UiThemeEnum } from "@goauthentik/api";
 
 export function rootInterface(): Interface | undefined {
     const el = Array.from(document.body.querySelectorAll("*")).filter(
@@ -171,10 +171,17 @@ export class Interface extends AKElement {
     @state()
     tenant?: CurrentTenant;
 
+    @state()
+    uiConfig?: UIConfig;
+
+    @state()
+    config?: Config;
+
     constructor() {
         super();
         document.adoptedStyleSheets = [...document.adoptedStyleSheets, PFBase];
         tenant().then((tenant) => (this.tenant = tenant));
+        config().then((config) => (this.config = config));
     }
 
     _activateTheme(root: AdoptedStyleSheetsElement, theme: UiThemeEnum): void {
@@ -183,7 +190,9 @@ export class Interface extends AKElement {
     }
 
     async getTheme(): Promise<UiThemeEnum> {
-        const config = await uiConfig();
-        return config.theme?.base || UiThemeEnum.Automatic;
+        if (!this.uiConfig) {
+            this.uiConfig = await uiConfig();
+        }
+        return this.uiConfig.theme?.base || UiThemeEnum.Automatic;
     }
 }

--- a/web/src/elements/Base.ts
+++ b/web/src/elements/Base.ts
@@ -11,11 +11,11 @@ import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 import { Config, CurrentTenant, UiThemeEnum } from "@goauthentik/api";
 
-export function rootInterface(): Interface | undefined {
+export function rootInterface<T extends Interface>(): T | undefined {
     const el = Array.from(document.body.querySelectorAll("*")).filter(
         (el) => el instanceof Interface,
     );
-    return el[0] as Interface;
+    return el[0] as T;
 }
 
 let css: Promise<string[]> | undefined;

--- a/web/src/elements/forms/Form.ts
+++ b/web/src/elements/forms/Form.ts
@@ -214,11 +214,11 @@ export abstract class Form<T> extends AKElement {
 
     async submit(ev: Event): Promise<unknown | undefined> {
         ev.preventDefault();
-        const data = this.serializeForm();
-        if (!data) {
-            return;
-        }
         try {
+            const data = this.serializeForm();
+            if (!data) {
+                return;
+            }
             const response = await this.send(data);
             showMessage({
                 level: MessageLevel.success,

--- a/web/src/elements/forms/Form.ts
+++ b/web/src/elements/forms/Form.ts
@@ -7,7 +7,7 @@ import { SearchSelect } from "@goauthentik/elements/forms/SearchSelect";
 import { showMessage } from "@goauthentik/elements/messages/MessageContainer";
 
 import { CSSResult, TemplateResult, css, html } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import { customElement, property, state } from "lit/decorators.js";
 
 import PFAlert from "@patternfly/patternfly/components/Alert/alert.css";
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
@@ -36,16 +36,15 @@ export interface KeyUnknown {
 }
 
 @customElement("ak-form")
-export class Form<T> extends AKElement {
+export abstract class Form<T> extends AKElement {
+    abstract send(data: T): Promise<unknown>;
+
     viewportCheck = true;
 
     @property()
     successMessage = "";
 
-    @property()
-    send!: (data: T) => Promise<unknown>;
-
-    @property({ attribute: false })
+    @state()
     nonFieldErrors?: string[];
 
     static get styles(): CSSResult[] {

--- a/web/src/elements/forms/Form.ts
+++ b/web/src/elements/forms/Form.ts
@@ -22,7 +22,7 @@ import { ResponseError, ValidationError } from "@goauthentik/api";
 
 export class PreventFormSubmit {
     // Stub class which can be returned by form elements to prevent the form from submitting
-    constructor(public message: string) {}
+    constructor(public message: string, public element?: HorizontalFormElement) {}
 }
 
 export class APIError extends Error {
@@ -176,17 +176,15 @@ export abstract class Form<T> extends AKElement {
                 json[element.name] = inputElement.checked;
             } else if (inputElement.tagName.toLowerCase() === "ak-search-select") {
                 const select = inputElement as unknown as SearchSelect<unknown>;
-                let value: unknown;
                 try {
-                    value = select.toForm();
-                } catch {
-                    console.debug("authentik/form: SearchSelect.value error");
-                    return;
+                    const value = select.toForm();
+                    json[element.name] = value;
+                } catch (exc) {
+                    if (exc instanceof PreventFormSubmit) {
+                        throw new PreventFormSubmit(exc.message, element);
+                    }
+                    throw exc;
                 }
-                if (value instanceof PreventFormSubmit) {
-                    throw new Error(value.message);
-                }
-                json[element.name] = value;
             } else {
                 this.serializeFieldRecursive(inputElement, inputElement.value, json);
             }
@@ -214,30 +212,27 @@ export abstract class Form<T> extends AKElement {
         parent[nameElements[nameElements.length - 1]] = value;
     }
 
-    submit(ev: Event): Promise<unknown> | undefined {
+    async submit(ev: Event): Promise<unknown | undefined> {
         ev.preventDefault();
         const data = this.serializeForm();
         if (!data) {
             return;
         }
-        return this.send(data)
-            .then((r) => {
-                showMessage({
-                    level: MessageLevel.success,
-                    message: this.getSuccessMessage(),
-                });
-                this.dispatchEvent(
-                    new CustomEvent(EVENT_REFRESH, {
-                        bubbles: true,
-                        composed: true,
-                    }),
-                );
-                return r;
-            })
-            .catch(async (ex: Error | ResponseError) => {
-                if (!(ex instanceof ResponseError)) {
-                    throw ex;
-                }
+        try {
+            const response = await this.send(data);
+            showMessage({
+                level: MessageLevel.success,
+                message: this.getSuccessMessage(),
+            });
+            this.dispatchEvent(
+                new CustomEvent(EVENT_REFRESH, {
+                    bubbles: true,
+                    composed: true,
+                }),
+            );
+            return response;
+        } catch (ex) {
+            if (ex instanceof ResponseError) {
                 let msg = ex.response.statusText;
                 if (ex.response.status > 399 && ex.response.status < 500) {
                     const errorMessage: ValidationError = await ex.response.json();
@@ -276,9 +271,14 @@ export abstract class Form<T> extends AKElement {
                     message: msg,
                     level: MessageLevel.error,
                 });
-                // rethrow the error so the form doesn't close
-                throw ex;
-            });
+            }
+            if (ex instanceof PreventFormSubmit && ex.element) {
+                ex.element.errorMessages = [ex.message];
+                ex.element.invalid = true;
+            }
+            // rethrow the error so the form doesn't close
+            throw ex;
+        }
     }
 
     renderForm(): TemplateResult {

--- a/web/src/elements/forms/ModelForm.ts
+++ b/web/src/elements/forms/ModelForm.ts
@@ -18,9 +18,14 @@ export abstract class ModelForm<T, PKT extends string | number> extends Form<T> 
         if (this.viewportCheck && !this.isInViewport) {
             return;
         }
+        if (this._isLoading) {
+            return;
+        }
+        this._isLoading = true;
         this.load().then(() => {
             this.loadInstance(value).then((instance) => {
                 this.instance = instance;
+                this._isLoading = false;
                 this.requestUpdate();
             });
         });
@@ -32,6 +37,8 @@ export abstract class ModelForm<T, PKT extends string | number> extends Form<T> 
     private _initialLoad = false;
     // Keep track if we've done the general data loading of load()
     private _initialDataLoad = false;
+
+    private _isLoading = false;
 
     @property({ attribute: false })
     instance?: T = this.defaultInstance;
@@ -69,8 +76,9 @@ export abstract class ModelForm<T, PKT extends string | number> extends Form<T> 
         if (this._instancePk && !this._initialLoad && viewportVisible) {
             this.instancePk = this._instancePk;
             this._initialLoad = true;
-        }
-        if (!this._initialDataLoad && viewportVisible) {
+        } else if (!this._initialDataLoad && viewportVisible) {
+            // else if since if the above case triggered that will also call this.load(), so
+            // ensure we don't load again
             this.load().then(() => {
                 this._initialDataLoad = true;
                 // Class attributes changed in this.load() might not be @property()

--- a/web/src/elements/forms/ModelForm.ts
+++ b/web/src/elements/forms/ModelForm.ts
@@ -1,7 +1,8 @@
 import { EVENT_REFRESH } from "@goauthentik/common/constants";
+import "@goauthentik/elements/EmptyState";
 import { Form } from "@goauthentik/elements/forms/Form";
 
-import { TemplateResult } from "lit";
+import { TemplateResult, html } from "lit";
 import { property } from "lit/decorators.js";
 
 export abstract class ModelForm<T, PKT extends string | number> extends Form<T> {
@@ -43,6 +44,13 @@ export abstract class ModelForm<T, PKT extends string | number> extends Form<T> 
     resetForm(): void {
         this.instance = undefined;
         this._initialLoad = false;
+    }
+
+    renderVisible(): TemplateResult {
+        if (!this.instance) {
+            return html`<ak-empty-state ?loading=${true}></ak-empty-state>`;
+        }
+        return super.renderVisible();
     }
 
     render(): TemplateResult {

--- a/web/src/elements/forms/ModelForm.ts
+++ b/web/src/elements/forms/ModelForm.ts
@@ -73,6 +73,9 @@ export abstract class ModelForm<T, PKT extends string | number> extends Form<T> 
         if (!this._initialDataLoad && viewportVisible) {
             this.load().then(() => {
                 this._initialDataLoad = true;
+                // Class attributes changed in this.load() might not be @property()
+                // or @state() so let's trigger a re-render to be sure we get updated
+                this.requestUpdate();
             });
         }
         return super.render();

--- a/web/src/elements/forms/ModelForm.ts
+++ b/web/src/elements/forms/ModelForm.ts
@@ -47,7 +47,7 @@ export abstract class ModelForm<T, PKT extends string | number> extends Form<T> 
     }
 
     renderVisible(): TemplateResult {
-        if (!this.instance) {
+        if (this._instancePk && !this.instance) {
             return html`<ak-empty-state ?loading=${true}></ak-empty-state>`;
         }
         return super.renderVisible();

--- a/web/src/elements/forms/ProxyForm.ts
+++ b/web/src/elements/forms/ProxyForm.ts
@@ -4,7 +4,7 @@ import { TemplateResult, html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 @customElement("ak-proxy-form")
-export class ProxyForm extends Form<unknown> {
+export abstract class ProxyForm extends Form<unknown> {
     @property()
     type!: string;
 

--- a/web/src/elements/forms/ProxyForm.ts
+++ b/web/src/elements/forms/ProxyForm.ts
@@ -39,7 +39,9 @@ export abstract class ProxyForm extends Form<unknown> {
         if (this.type in this.typeMap) {
             elementName = this.typeMap[this.type];
         }
-        this.innerElement = document.createElement(elementName) as Form<unknown>;
+        if (!this.innerElement) {
+            this.innerElement = document.createElement(elementName) as Form<unknown>;
+        }
         this.innerElement.viewportCheck = this.viewportCheck;
         for (const k in this.args) {
             this.innerElement.setAttribute(k, this.args[k] as string);

--- a/web/src/elements/forms/ProxyForm.ts
+++ b/web/src/elements/forms/ProxyForm.ts
@@ -16,7 +16,7 @@ export abstract class ProxyForm extends Form<unknown> {
 
     innerElement?: Form<unknown>;
 
-    submit(ev: Event): Promise<unknown> | undefined {
+    async submit(ev: Event): Promise<unknown | undefined> {
         return this.innerElement?.submit(ev);
     }
 

--- a/web/src/elements/forms/Radio.ts
+++ b/web/src/elements/forms/Radio.ts
@@ -25,11 +25,6 @@ export class Radio<T> extends AKElement {
     @property()
     value?: T;
 
-    @property({ attribute: false })
-    onChange: (value: T) => void = () => {
-        return;
-    };
-
     static get styles(): CSSResult[] {
         return [
             PFBase,
@@ -63,7 +58,13 @@ export class Radio<T> extends AKElement {
                         id=${elId}
                         @change=${() => {
                             this.value = opt.value;
-                            this.onChange(opt.value);
+                            this.dispatchEvent(
+                                new CustomEvent("change", {
+                                    bubbles: true,
+                                    composed: true,
+                                    detail: opt.value,
+                                }),
+                            );
                         }}
                         .checked=${opt.value === this.value}
                     />

--- a/web/src/elements/forms/SearchSelect.ts
+++ b/web/src/elements/forms/SearchSelect.ts
@@ -94,7 +94,7 @@ export class SearchSelect<T> extends AKElement {
 
     toForm(): unknown {
         if (!this.objects) {
-            return new PreventFormSubmit(t`Loading options...`);
+            throw new PreventFormSubmit(t`Loading options...`);
         }
         return this.value(this.selectedObject) || "";
     }

--- a/web/src/elements/wizard/WizardFormPage.ts
+++ b/web/src/elements/wizard/WizardFormPage.ts
@@ -19,7 +19,7 @@ export abstract class WizardForm extends Form<KeyUnknown> {
     @property({ attribute: false })
     nextDataCallback!: (data: KeyUnknown) => Promise<boolean>;
 
-    submit(): Promise<boolean> | undefined {
+    async submit(): Promise<boolean | undefined> {
         const data = this.serializeForm();
         if (!data) {
             return;

--- a/web/src/elements/wizard/WizardFormPage.ts
+++ b/web/src/elements/wizard/WizardFormPage.ts
@@ -13,7 +13,7 @@ import PFInputGroup from "@patternfly/patternfly/components/InputGroup/input-gro
 import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-wizard-form")
-export class WizardForm extends Form<KeyUnknown> {
+export abstract class WizardForm extends Form<KeyUnknown> {
     viewportCheck = false;
 
     @property({ attribute: false })

--- a/web/src/user/UserInterface.ts
+++ b/web/src/user/UserInterface.ts
@@ -5,7 +5,7 @@ import {
     EVENT_WS_MESSAGE,
 } from "@goauthentik/common/constants";
 import { configureSentry } from "@goauthentik/common/sentry";
-import { UIConfig, UserDisplay, uiConfig } from "@goauthentik/common/ui/config";
+import { UserDisplay } from "@goauthentik/common/ui/config";
 import { autoDetectLanguage } from "@goauthentik/common/ui/locale";
 import { me } from "@goauthentik/common/users";
 import { first } from "@goauthentik/common/utils";
@@ -55,9 +55,6 @@ export class UserInterface extends Interface {
 
     @state()
     me?: SessionUser;
-
-    @state()
-    config?: UIConfig;
 
     static get styles(): CSSResult[] {
         return [
@@ -126,7 +123,6 @@ export class UserInterface extends Interface {
 
     async firstUpdated(): Promise<void> {
         this.me = await me();
-        this.config = await uiConfig();
         const notifications = await new EventsApi(DEFAULT_CONFIG).eventsNotificationsList({
             seen: false,
             ordering: "-created",
@@ -137,11 +133,11 @@ export class UserInterface extends Interface {
     }
 
     render(): TemplateResult {
-        if (!this.config || !this.me) {
+        if (!this.uiConfig || !this.me) {
             return html``;
         }
         let userDisplay = "";
-        switch (this.config.navbar.userDisplay) {
+        switch (this.uiConfig.navbar.userDisplay) {
             case UserDisplay.username:
                 userDisplay = this.me.user.username;
                 break;
@@ -155,7 +151,7 @@ export class UserInterface extends Interface {
                 userDisplay = this.me.user.username;
         }
         return html`<div class="pf-c-page">
-            <div class="background-wrapper" style="${this.config.theme.background}"></div>
+            <div class="background-wrapper" style="${this.uiConfig.theme.background}"></div>
             <header class="pf-c-page__header">
                 <div class="pf-c-page__header-brand">
                     <a href="#/" class="pf-c-page__header-brand-link">
@@ -168,7 +164,7 @@ export class UserInterface extends Interface {
                 </div>
                 <div class="pf-c-page__header-tools">
                     <div class="pf-c-page__header-tools-group">
-                        ${this.config.enabledFeatures.apiDrawer
+                        ${this.uiConfig.enabledFeatures.apiDrawer
                             ? html`<div
                                   class="pf-c-page__header-tools-item pf-m-hidden pf-m-visible-on-lg"
                               >
@@ -186,7 +182,7 @@ export class UserInterface extends Interface {
                                   </button>
                               </div>`
                             : html``}
-                        ${this.config.enabledFeatures.notificationDrawer
+                        ${this.uiConfig.enabledFeatures.notificationDrawer
                             ? html`<div
                                   class="pf-c-page__header-tools-item pf-m-hidden pf-m-visible-on-lg"
                               >
@@ -216,7 +212,7 @@ export class UserInterface extends Interface {
                                   </button>
                               </div> `
                             : html``}
-                        ${this.config.enabledFeatures.settings
+                        ${this.uiConfig.enabledFeatures.settings
                             ? html` <div class="pf-c-page__header-tools-item">
                                   <a class="pf-c-button pf-m-plain" type="button" href="#/settings">
                                       <i class="fas fa-cog" aria-hidden="true"></i>


### PR DESCRIPTION
this should fix or mostly prevent inconsistency issues such as #5043 and #4970

ok this PR has actually turned into a larger change, only showing the form once all data is loaded (for multi-selects/etc) and prevents the form from being submitted before all ak-search-selects are loaded

also optimises a couple other minor things and prevents duplicate load requests when opening forms

closes #5043
closes #4970