### PR TITLE
providers/scim: add missing default fields

### DIFF
--- a/authentik/providers/scim/tests/test_membership.py
+++ b/authentik/providers/scim/tests/test_membership.py
@@ -82,9 +82,11 @@ class SCIMMembershipTests(TestCase):
                 mocker.request_history[3].body,
                 {
                     "emails": [],
+                    "active": True,
                     "externalId": user.uid,
                     "name": {"familyName": "", "formatted": "", "givenName": ""},
                     "photos": [],
+                    "displayName": "",
                     "userName": user.username,
                 },
             )
@@ -163,6 +165,8 @@ class SCIMMembershipTests(TestCase):
             self.assertJSONEqual(
                 mocker.request_history[3].body,
                 {
+                    "active": True,
+                    "displayName": "",
                     "emails": [],
                     "externalId": user.uid,
                     "name": {"familyName": "", "formatted": "", "givenName": ""},

--- a/authentik/providers/scim/tests/test_user.py
+++ b/authentik/providers/scim/tests/test_user.py
@@ -61,6 +61,7 @@ class SCIMUserTests(TestCase):
         self.assertJSONEqual(
             mock.request_history[1].body,
             {
+                "active": True,
                 "emails": [
                     {
                         "primary": True,
@@ -74,6 +75,7 @@ class SCIMUserTests(TestCase):
                     "formatted": uid,
                     "givenName": uid,
                 },
+                "displayName": uid,
                 "photos": [],
                 "userName": uid,
             },
@@ -115,6 +117,7 @@ class SCIMUserTests(TestCase):
         self.assertEqual(
             body,
             {
+                "active": True,
                 "emails": [
                     {
                         "primary": True,
@@ -122,6 +125,7 @@ class SCIMUserTests(TestCase):
                         "value": f"{uid}@goauthentik.io",
                     }
                 ],
+                "displayName": uid,
                 "externalId": user.uid,
                 "name": {
                     "familyName": "",
@@ -166,6 +170,7 @@ class SCIMUserTests(TestCase):
         self.assertJSONEqual(
             mock.request_history[1].body,
             {
+                "active": True,
                 "emails": [
                     {
                         "primary": True,
@@ -179,6 +184,7 @@ class SCIMUserTests(TestCase):
                     "formatted": uid,
                     "givenName": uid,
                 },
+                "displayName": uid,
                 "photos": [],
                 "userName": uid,
             },
@@ -232,6 +238,7 @@ class SCIMUserTests(TestCase):
         self.assertJSONEqual(
             mock.request_history[1].body,
             {
+                "active": True,
                 "emails": [
                     {
                         "primary": True,
@@ -245,6 +252,7 @@ class SCIMUserTests(TestCase):
                     "formatted": uid,
                     "givenName": uid,
                 },
+                "displayName": uid,
                 "photos": [],
                 "userName": uid,
             },

--- a/blueprints/system/providers-scim.yaml
+++ b/blueprints/system/providers-scim.yaml
@@ -43,8 +43,10 @@ entries:
                 "givenName": givenName,
                 "familyName": familyName,
             },
+            "displayName": request.user.name,
             "photos": photos,
             "locale": locale,
+            "active": request.user.is_active,
             "emails": emails,
         }
   - identifiers:


### PR DESCRIPTION
Signed-off-by: Jens Langhammer <jens@goauthentik.io>

#4554
