### PR TITLE
lifecycle: also migrate before starting worker, trap exit to cleanup mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,7 +102,7 @@ COPY ./tests /tests
 COPY ./manage.py /
 COPY ./blueprints /blueprints
 COPY ./lifecycle/ /lifecycle
-COPY --from=go-builder /work/authentik /authentik-proxy
+COPY --from=go-builder /work/authentik /bin/authentik
 COPY --from=web-builder /work/web/dist/ /web/dist/
 COPY --from=web-builder /work/web/authentik/ /web/authentik/
 COPY --from=website-builder /work/website/help/ /website/help/

--- a/Makefile
+++ b/Makefile
@@ -50,9 +50,6 @@ lint:
 migrate:
 	python -m lifecycle.migrate
 
-run:
-	go run -v ./cmd/server/
-
 i18n-extract: i18n-extract-core web-extract
 
 i18n-extract-core:

--- a/lifecycle/ak
+++ b/lifecycle/ak
@@ -1,10 +1,13 @@
 #!/bin/bash -e
+MODE_FILE="${TMPDIR}/authentik-mode"
+
 function log {
     printf '{"event": "%s", "level": "info", "logger": "bootstrap"}\n' "$@" > /dev/stderr
 }
 
 function wait_for_db {
     python -m lifecycle.wait_for_db
+    python -m lifecycle.migrate
     log "Bootstrap completed"
 }
 
@@ -31,22 +34,35 @@ function check_if_root {
     chown -R authentik:authentik /media /certs
     chmod ug+rwx /media
     chmod ug+rx /certs
-    exec chpst -u authentik:$GROUP env HOME=/authentik $1
+    chpst -u authentik:$GROUP env HOME=/authentik $1
 }
 
-MODE_FILE="/tmp/authentik-mode"
+function set_mode {
+    echo $1 > $MODE_FILE
+    trap cleanup EXIT
+}
+
+function cleanup {
+    rm -f ${MODE_FILE}
+}
 
 if [[ "$1" == "server" ]]; then
     wait_for_db
-    echo "server" > $MODE_FILE
-    python -m lifecycle.migrate
+    set_mode "server"
+    # If we have bootstrap credentials set, run bootstrap tasks outside of main server
+    # sync, so that we can sure the first start actually has working bootstrap
+    # credentials
     if [[ ! -z "${AUTHENTIK_BOOTSTRAP_PASSWORD}" || ! -z "${AUTHENTIK_BOOTSTRAP_TOKEN}" ]]; then
         python -m manage bootstrap_tasks
     fi
-    exec /authentik-proxy
+    if [[ -x "$(command -v authentik)" ]]; then
+        authentik
+    else
+        go run -v ./cmd/server/
+    fi
 elif [[ "$1" == "worker" ]]; then
     wait_for_db
-    echo "worker" > $MODE_FILE
+    set_mode "worker"
     check_if_root "celery -A authentik.root.celery worker -Ofair --max-tasks-per-child=1 --autoscale 3,1 -E -B -s /tmp/celerybeat-schedule -Q authentik,authentik_scheduled,authentik_events"
 elif [[ "$1" == "worker-status" ]]; then
     wait_for_db

--- a/website/developer-docs/setup/full-dev-environment.md
+++ b/website/developer-docs/setup/full-dev-environment.md
@@ -52,4 +52,4 @@ To format the frontend code, run `make web`.
 
 ## Running
 
-Now that the backend and frontend have been setup and built, you can start authentik by running `make run`. authentik should now be accessible at `http://localhost:9000`.
+Now that the backend and frontend have been setup and built, you can start authentik by running `ak server`. authentik should now be accessible at `http://localhost:9000`.


### PR DESCRIPTION
this prevents any errors in the worker on it's first startup. These errors were not really breaking anything, but are confusing to new users and look bad

also to make the `ak` commands more usable on development setups, cleanup the mode file after exit. With this we can use `ak server` as development startup just like within the container instead of using the makefile.

closes #5122