### PR TITLE
core: extend postgres configuration

### DIFF
--- a/authentik/root/settings.py
+++ b/authentik/root/settings.py
@@ -276,6 +276,10 @@ DATABASES = {
         "USER": CONFIG.y("postgresql.user"),
         "PASSWORD": CONFIG.y("postgresql.password"),
         "PORT": int(CONFIG.y("postgresql.port")),
+        "SSLMODE": CONFIG.y("postgresql.sslmode"),
+        "SSLROOTCERT": CONFIG.y("postgresql.sslrootcert"),
+        "SSLCERT": CONFIG.y("postgresql.sslcert"),
+        "SSLKEY": CONFIG.y("postgresql.sslkey"),
     }
 }
 

--- a/lifecycle/migrate.py
+++ b/lifecycle/migrate.py
@@ -57,6 +57,10 @@ if __name__ == "__main__":
         password=CONFIG.y("postgresql.password"),
         host=CONFIG.y("postgresql.host"),
         port=int(CONFIG.y("postgresql.port")),
+        sslmode=CONFIG.y("postgresql.sslmode"),
+        sslrootcert=CONFIG.y("postgresql.sslrootcert"),
+        sslcert=CONFIG.y("postgresql.sslcert"),
+        sslkey=CONFIG.y("postgresql.sslkey"),
     )
     curr = conn.cursor()
     try:

--- a/lifecycle/wait_for_db.py
+++ b/lifecycle/wait_for_db.py
@@ -29,6 +29,10 @@ while True:
             password=CONFIG.y("postgresql.password"),
             host=CONFIG.y("postgresql.host"),
             port=int(CONFIG.y("postgresql.port")),
+            sslmode=CONFIG.y("postgresql.sslmode"),
+            sslrootcert=CONFIG.y("postgresql.sslrootcert"),
+            sslcert=CONFIG.y("postgresql.sslcert"),
+            sslkey=CONFIG.y("postgresql.sslkey"),
         )
         conn.cursor()
         break

--- a/website/docs/installation/configuration.md
+++ b/website/docs/installation/configuration.md
@@ -33,6 +33,10 @@ kubectl exec -it deployment/authentik-worker -c authentik -- ak dump_config
 -   `AUTHENTIK_POSTGRESQL__PORT`: Database port, defaults to 5432
 -   `AUTHENTIK_POSTGRESQL__PASSWORD`: Database password, defaults to the environment variable `POSTGRES_PASSWORD`
 -   `AUTHENTIK_POSTGRESQL__USE_PGBOUNCER`: Adjust configuration to support connection to PgBouncer
+-   `AUTHENTIK_POSTGRESQL__SSLMODE`: Strictness of ssl verification. Defaults to `verify-ca`
+-   `AUTHENTIK_POSTGRESQL__SSLROOTCERT`: CA root for server ssl verification
+-   `AUTHENTIK_POSTGRESQL__SSLCERT`: Path to x509 client certificate to authenticate to server
+-   `AUTHENTIK_POSTGRESQL__SSLKEY`: Path to private key of `SSLCERT` certificate
 
 ## Redis Settings
 


### PR DESCRIPTION
Add postgres configuration options to control
TLS verification and client certificates.

<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details
* **Does this resolve an issue?**
Resolves None

## Changes
### New Features
* Adds more configuration options to allow connecting to postgres via client certificates.

This is very useful in a k8s setup with cert-manager. All configuration can be public, without leaking secrets.
 
### Breaking Changes
* None

