### PR TITLE
website/docs: separate docker steps

### DIFF
--- a/website/docs/installation/docker-compose.md
+++ b/website/docs/installation/docker-compose.md
@@ -19,8 +19,6 @@ If this is a fresh authentik installation, you need to generate a password and a
 ```shell
 # You can also use openssl instead: `openssl rand -base64 36`
 sudo apt-get install -y pwgen
-# Because of a PostgreSQL limitation, only passwords up to 99 chars are supported
-# See https://www.postgresql.org/message-id/09512C4F-8CB9-4021-B455-EF4C4F0D55A0@amazon.com
 ```
 
 Next, run the following commands to generate a password and secret key and write them to your `.env` file:
@@ -28,12 +26,13 @@ Next, run the following commands to generate a password and secret key and write
 ```shell
 echo "PG_PASS=$(pwgen -s 40 1)" >> .env
 echo "AUTHENTIK_SECRET_KEY=$(pwgen -s 50 1)" >> .env
+# Because of a PostgreSQL limitation, only passwords up to 99 chars are supported
+# See https://www.postgresql.org/message-id/09512C4F-8CB9-4021-B455-EF4C4F0D55A0@amazon.com
 ```
 
 To enable error reporting, run the following command:
 
 ```shell
-# Skip if you don't want to enable error reporting
 echo "AUTHENTIK_ERROR_REPORTING__ENABLED=true" >> .env
 ```
 

--- a/website/docs/installation/docker-compose.md
+++ b/website/docs/installation/docker-compose.md
@@ -28,6 +28,11 @@ Next, run the following commands to generate a password and secret key and write
 ```shell
 echo "PG_PASS=$(pwgen -s 40 1)" >> .env
 echo "AUTHENTIK_SECRET_KEY=$(pwgen -s 50 1)" >> .env
+```
+
+To enable error reporting, run the following command:
+
+```shell
 # Skip if you don't want to enable error reporting
 echo "AUTHENTIK_ERROR_REPORTING__ENABLED=true" >> .env
 ```

--- a/website/docs/installation/docker-compose.md
+++ b/website/docs/installation/docker-compose.md
@@ -14,13 +14,17 @@ This installation method is for test-setups and small-scale production setups.
 
 Download the latest `docker-compose.yml` from [here](https://goauthentik.io/docker-compose.yml). Place it in a directory of your choice.
 
-If this is a fresh authentik install run the following commands to generate a password:
+If this is a fresh authentik installation, you need to generate a password. If you don't already have a password gernerator installed, you can run this command to install **pwgen**, a popular generator:
 
 ```shell
 # You can also use openssl instead: `openssl rand -base64 36`
 sudo apt-get install -y pwgen
 # Because of a PostgreSQL limitation, only passwords up to 99 chars are supported
 # See https://www.postgresql.org/message-id/09512C4F-8CB9-4021-B455-EF4C4F0D55A0@amazon.com
+```
+
+Next, run the following commands to generate a password and write it to your `.env` file:
+
 echo "PG_PASS=$(pwgen -s 40 1)" >> .env
 echo "AUTHENTIK_SECRET_KEY=$(pwgen -s 50 1)" >> .env
 # Skip if you don't want to enable error reporting

--- a/website/docs/installation/docker-compose.md
+++ b/website/docs/installation/docker-compose.md
@@ -14,7 +14,7 @@ This installation method is for test-setups and small-scale production setups.
 
 Download the latest `docker-compose.yml` from [here](https://goauthentik.io/docker-compose.yml). Place it in a directory of your choice.
 
-If this is a fresh authentik installation, you need to generate a password. If you don't already have a password gernerator installed, you can run this command to install **pwgen**, a popular generator:
+If this is a fresh authentik installation, you need to generate a password. If you don't already have a password generator installed, you can run this command to install **pwgen**, a popular generator:
 
 ```shell
 # You can also use openssl instead: `openssl rand -base64 36`

--- a/website/docs/installation/docker-compose.md
+++ b/website/docs/installation/docker-compose.md
@@ -14,7 +14,7 @@ This installation method is for test-setups and small-scale production setups.
 
 Download the latest `docker-compose.yml` from [here](https://goauthentik.io/docker-compose.yml). Place it in a directory of your choice.
 
-If this is a fresh authentik installation, you need to generate a password. If you don't already have a password generator installed, you can run this command to install **pwgen**, a popular generator:
+If this is a fresh authentik installation, you need to generate a password and a secret key. If you don't already have a password generator installed, you can run this command to install **pwgen**, a popular generator:
 
 ```shell
 # You can also use openssl instead: `openssl rand -base64 36`
@@ -23,7 +23,7 @@ sudo apt-get install -y pwgen
 # See https://www.postgresql.org/message-id/09512C4F-8CB9-4021-B455-EF4C4F0D55A0@amazon.com
 ```
 
-Next, run the following commands to generate a password and write it to your `.env` file:
+Next, run the following commands to generate a password and secret key and write them to your `.env` file:
 
 ```shell
 echo "PG_PASS=$(pwgen -s 40 1)" >> .env

--- a/website/docs/installation/docker-compose.md
+++ b/website/docs/installation/docker-compose.md
@@ -25,6 +25,7 @@ sudo apt-get install -y pwgen
 
 Next, run the following commands to generate a password and write it to your `.env` file:
 
+```shell
 echo "PG_PASS=$(pwgen -s 40 1)" >> .env
 echo "AUTHENTIK_SECRET_KEY=$(pwgen -s 50 1)" >> .env
 # Skip if you don't want to enable error reporting

--- a/website/docs/installation/docker-compose.md
+++ b/website/docs/installation/docker-compose.md
@@ -32,7 +32,7 @@ echo "AUTHENTIK_SECRET_KEY=$(pwgen -s 50 1)" >> .env
 echo "AUTHENTIK_ERROR_REPORTING__ENABLED=true" >> .env
 ```
 
-## Email configuration (optional, but recommended)
+## Email configuration (optional but recommended)
 
 It is also recommended to configure global email credentials. These are used by authentik to notify you about alerts and configuration issues. They can also be used by [Email stages](../flow/stages/email/) to send verification/recovery emails.
 


### PR DESCRIPTION
Separated the steps for generating a password and then writing it to the .env file. The steps were not working on a Mac when all together.

Resolves #5186 

