### PR TITLE
Change docker-compose HTTP and HTTPS port variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,8 +47,8 @@ services:
     env_file:
       - .env
     ports:
-      - "${AUTHENTIK_PORT_HTTP:-9000}:9000"
-      - "${AUTHENTIK_PORT_HTTPS:-9443}:9443"
+      - "${COMPOSE_PORT_HTTP:-9000}:9000"
+      - "${COMPOSE_PORT_HTTPS:-9443}:9443"
   worker:
     image: ${AUTHENTIK_IMAGE:-ghcr.io/goauthentik/server}:${AUTHENTIK_TAG:-2023.4.1}
     restart: unless-stopped

--- a/lifecycle/ak
+++ b/lifecycle/ak
@@ -79,7 +79,7 @@ elif [[ "$1" == "test-all" ]]; then
 elif [[ "$1" == "healthcheck" ]]; then
     mode=$(cat $MODE_FILE)
     if [[ $mode == "server" ]]; then
-        exec curl --user-agent "goauthentik.io lifecycle Healthcheck" -I http://${AUTHENTIK_LISTEN__HTTP}/-/health/ready/
+        exec curl --user-agent "goauthentik.io lifecycle Healthcheck" -I "http://${AUTHENTIK_LISTEN__HTTP}/-/health/ready/"
     elif [[ $mode == "worker" ]]; then
         mtime=$(date -r $WORKER_HEARTBEAT +"%s")
         time=$(date +"%s")

--- a/lifecycle/ak
+++ b/lifecycle/ak
@@ -79,7 +79,7 @@ elif [[ "$1" == "test-all" ]]; then
 elif [[ "$1" == "healthcheck" ]]; then
     mode=$(cat $MODE_FILE)
     if [[ $mode == "server" ]]; then
-        exec curl --user-agent "goauthentik.io lifecycle Healthcheck" -I http://localhost:9000/-/health/ready/
+        exec curl --user-agent "goauthentik.io lifecycle Healthcheck" -I http://${AUTHENTIK_LISTEN__HTTP}/-/health/ready/
     elif [[ $mode == "worker" ]]; then
         mtime=$(date -r $WORKER_HEARTBEAT +"%s")
         time=$(date +"%s")

--- a/website/docs/installation/docker-compose.md
+++ b/website/docs/installation/docker-compose.md
@@ -63,8 +63,8 @@ AUTHENTIK_EMAIL__FROM=authentik@localhost
 By default, authentik listens on port 9000 for HTTP and 9443 for HTTPS. To change the default and instead use ports 80 and 443, you can set the following variables in `.env`:
 
 ```shell
-AUTHENTIK_PORT_HTTP=80
-AUTHENTIK_PORT_HTTPS=443
+COMPOSE_PORT_HTTP=80
+COMPOSE_PORT_HTTPS=443
 ```
 
 Be sure to run `docker-compose up -d` to rebuild with the new port numbers.

--- a/website/docs/installation/docker-compose.md
+++ b/website/docs/installation/docker-compose.md
@@ -60,7 +60,7 @@ AUTHENTIK_EMAIL__FROM=authentik@localhost
 
 ## Configure for port 80/443
 
-By default, authentik listens on port 9000 for HTTP and 9443 for HTTPS. To change the default and instead use ports 80 and 443, you can set the following variables in `.env`:
+By default, authentik listens internally on port 9000 for HTTP and 9443 for HTTPS. To change the exposed ports to 80 and 443, you can set the following variables in `.env`:
 
 ```shell
 COMPOSE_PORT_HTTP=80

--- a/website/docs/installation/docker-compose.md
+++ b/website/docs/installation/docker-compose.md
@@ -67,7 +67,7 @@ COMPOSE_PORT_HTTP=80
 COMPOSE_PORT_HTTPS=443
 ```
 
-Be sure to run `docker-compose up -d` to rebuild with the new port numbers.
+See [Configuration](../installation/configuration) to change the internal ports. Be sure to run `docker-compose up -d` to rebuild with the new port numbers.
 
 ## Startup
 


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details
* Resolves https://github.com/goauthentik/authentik/issues/5291

### Breaking Changes
* Changes the `AUTHENTIK_PORT_HTTP` environment variable to `COMPOSE_PORT_HTTP`.
* Changes the `AUTHENTIK_PORT_HTTPS` environment variable to `COMPOSE_PORT_HTTPS`.
