### PR TITLE
web/admin: fix blueprint instance list without metadata or labels

### DIFF
--- a/web/src/admin/blueprints/BlueprintListPage.ts
+++ b/web/src/admin/blueprints/BlueprintListPage.ts
@@ -126,7 +126,11 @@ export class BlueprintListPage extends TablePage<BlueprintInstance> {
     row(item: BlueprintInstance): TemplateResult[] {
         let description = undefined;
         const descKey = "blueprints.goauthentik.io/description";
-        if (Object.hasOwn(item.metadata?.labels ?? new Object(), descKey)) {
+        if (
+            item.metadata &&
+            item.metadata.labels &&
+            Object.hasOwn(item.metadata?.labels, descKey)
+        ) {
             description = item.metadata?.labels[descKey];
         }
         return [

--- a/web/src/admin/blueprints/BlueprintListPage.ts
+++ b/web/src/admin/blueprints/BlueprintListPage.ts
@@ -126,7 +126,7 @@ export class BlueprintListPage extends TablePage<BlueprintInstance> {
     row(item: BlueprintInstance): TemplateResult[] {
         let description = undefined;
         const descKey = "blueprints.goauthentik.io/description";
-        if (Object.hasOwn(item.metadata?.labels, descKey)) {
+        if (Object.hasOwn(item.metadata?.labels ?? new Object(), descKey)) {
             description = item.metadata?.labels[descKey];
         }
         return [


### PR DESCRIPTION
`Object.hasOwn()` throws an exception if the first argument is `null` or `undefined`. This change ensures that the first argument is never `null` or `undefined`.

<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details
This will let the blueprints list load when custom blueprints are added.

## Additional
The underlying issue of setting the metadata column in the blueprints table still needs to be resolved.
