### PR TITLE
Fix ak healthcheck if AUTHENTIK_LISTEN__HTTP is set

### DIFF
--- a/lifecycle/ak
+++ b/lifecycle/ak
@@ -79,7 +79,7 @@ elif [[ "$1" == "test-all" ]]; then
 elif [[ "$1" == "healthcheck" ]]; then
     mode=$(cat $MODE_FILE)
     if [[ $mode == "server" ]]; then
-        exec curl --user-agent "goauthentik.io lifecycle Healthcheck" -I http://localhost:9000/-/health/ready/
+        exec curl --user-agent "goauthentik.io lifecycle Healthcheck" -I "http://${AUTHENTIK_LISTEN__HTTP}/-/health/ready/
     elif [[ $mode == "worker" ]]; then
         mtime=$(date -r $WORKER_HEARTBEAT +"%s")
         time=$(date +"%s")


### PR DESCRIPTION
# Details
The ak healthcheck is hardcoded to localhost:9000. Changing the authentik HTTP listening port via environment variable AUTHENTIK_LISTEN__HTTP to anything else lets the ak healthcheck fail.  The failing healthcheck prevents authentik to start.

Given the purpose of this environment variable, this fix makes sense. However, I cannot find evidence that this environment variable is set by default, if the user does not explicitly specifies it. If that is the case, this PR breaks the healthcheck due to the non-existence of the environment variable. In that case, this environment variable should be set to 0.0.0.0:9000 during startup in my opinion.

