### PR TITLE
ci: add docker tag without timestamp

### DIFF
--- a/.github/actions/comment-pr-instructions/action.yml
+++ b/.github/actions/comment-pr-instructions/action.yml
@@ -35,7 +35,7 @@ runs:
             ```shell
             AUTHENTIK_IMAGE=ghcr.io/goauthentik/dev-server
             AUTHENTIK_TAG=${{ inputs.tag }}
-            AUTHENTIK_OUTPOSTS__CONTAINER_IMAGE_BASE=ghcr.io/goauthentik/dev-%(type)s:${{ inputs.tag }}
+            AUTHENTIK_OUTPOSTS__CONTAINER_IMAGE_BASE=ghcr.io/goauthentik/dev-%(type)s:gh-%(build_hash)s
             ```
 
             For arm64, use these values:
@@ -43,7 +43,7 @@ runs:
             ```shell
             AUTHENTIK_IMAGE=ghcr.io/goauthentik/dev-server
             AUTHENTIK_TAG=${{ inputs.tag }}-arm64
-            AUTHENTIK_OUTPOSTS__CONTAINER_IMAGE_BASE=ghcr.io/goauthentik/dev-%(type)s:${{ inputs.tag }}
+            AUTHENTIK_OUTPOSTS__CONTAINER_IMAGE_BASE=ghcr.io/goauthentik/dev-%(type)s:gh-%(build_hash)s
             ```
 
             Afterwards, run the upgrade commands from the latest release notes.
@@ -56,7 +56,7 @@ runs:
             ```yaml
             authentik:
                 outposts:
-                    container_image_base: ghcr.io/goauthentik/dev-%(type)s:${{ inputs.tag }}
+                    container_image_base: ghcr.io/goauthentik/dev-%(type)s:gh-%(build_hash)s
             image:
                 repository: ghcr.io/goauthentik/dev-server
                 tag: ${{ inputs.tag }}
@@ -67,7 +67,7 @@ runs:
             ```yaml
             authentik:
                 outposts:
-                    container_image_base: ghcr.io/goauthentik/dev-%(type)s:${{ inputs.tag }}
+                    container_image_base: ghcr.io/goauthentik/dev-%(type)s:gh-%(build_hash)s
             image:
                 repository: ghcr.io/goauthentik/dev-server
                 tag: ${{ inputs.tag }}-arm64

--- a/.github/actions/comment-pr-instructions/action.yml
+++ b/.github/actions/comment-pr-instructions/action.yml
@@ -1,5 +1,5 @@
-name: 'Comment usage instructions on PRs'
-description: 'Comment usage instructions on PRs'
+name: "Comment usage instructions on PRs"
+description: "Comment usage instructions on PRs"
 
 inputs:
   tag:
@@ -17,7 +17,7 @@ runs:
       id: fc
       with:
         issue-number: ${{ github.event.pull_request.number }}
-        comment-author: 'github-actions[bot]'
+        comment-author: "github-actions[bot]"
         body-includes: authentik PR Installation instructions
     - name: Create or update comment
       uses: peter-evans/create-or-update-comment@v2
@@ -35,7 +35,7 @@ runs:
             ```shell
             AUTHENTIK_IMAGE=ghcr.io/goauthentik/dev-server
             AUTHENTIK_TAG=${{ inputs.tag }}
-            AUTHENTIK_OUTPOSTS__CONTAINER_IMAGE_BASE=ghcr.io/goauthentik/dev-%(type)s:gh-%(build_hash)s
+            AUTHENTIK_OUTPOSTS__CONTAINER_IMAGE_BASE=ghcr.io/goauthentik/dev-%(type)s:${{ inputs.tag }}
             ```
 
             For arm64, use these values:
@@ -43,7 +43,7 @@ runs:
             ```shell
             AUTHENTIK_IMAGE=ghcr.io/goauthentik/dev-server
             AUTHENTIK_TAG=${{ inputs.tag }}-arm64
-            AUTHENTIK_OUTPOSTS__CONTAINER_IMAGE_BASE=ghcr.io/goauthentik/dev-%(type)s:gh-%(build_hash)s
+            AUTHENTIK_OUTPOSTS__CONTAINER_IMAGE_BASE=ghcr.io/goauthentik/dev-%(type)s:${{ inputs.tag }}
             ```
 
             Afterwards, run the upgrade commands from the latest release notes.
@@ -56,7 +56,7 @@ runs:
             ```yaml
             authentik:
                 outposts:
-                    container_image_base: ghcr.io/goauthentik/dev-%(type)s:gh-%(build_hash)s
+                    container_image_base: ghcr.io/goauthentik/dev-%(type)s:${{ inputs.tag }}
             image:
                 repository: ghcr.io/goauthentik/dev-server
                 tag: ${{ inputs.tag }}
@@ -67,7 +67,7 @@ runs:
             ```yaml
             authentik:
                 outposts:
-                    container_image_base: ghcr.io/goauthentik/dev-%(type)s:gh-%(build_hash)s
+                    container_image_base: ghcr.io/goauthentik/dev-%(type)s:${{ inputs.tag }}
             image:
                 repository: ghcr.io/goauthentik/dev-server
                 tag: ${{ inputs.tag }}-arm64

--- a/.github/actions/comment-pr-instructions/action.yml
+++ b/.github/actions/comment-pr-instructions/action.yml
@@ -1,5 +1,5 @@
-name: "Comment usage instructions on PRs"
-description: "Comment usage instructions on PRs"
+name: 'Comment usage instructions on PRs'
+description: 'Comment usage instructions on PRs'
 
 inputs:
   tag:
@@ -17,7 +17,7 @@ runs:
       id: fc
       with:
         issue-number: ${{ github.event.pull_request.number }}
-        comment-author: "github-actions[bot]"
+        comment-author: 'github-actions[bot]'
         body-includes: authentik PR Installation instructions
     - name: Create or update comment
       uses: peter-evans/create-or-update-comment@v2

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -212,6 +212,7 @@ jobs:
           push: ${{ steps.ev.outputs.shouldBuild == 'true' }}
           tags: |
             ghcr.io/goauthentik/dev-server:gh-${{ steps.ev.outputs.branchNameContainer }}
+            ghcr.io/goauthentik/dev-server:gh-${{ steps.ev.outputs.branchNameContainer }}-${{ steps.ev.outputs.sha }}
             ghcr.io/goauthentik/dev-server:gh-${{ steps.ev.outputs.branchNameContainer }}-${{ steps.ev.outputs.timestamp }}-${{ steps.ev.outputs.shortHash }}
           build-args: |
             GIT_BUILD_HASH=${{ steps.ev.outputs.sha }}
@@ -253,6 +254,7 @@ jobs:
           push: ${{ steps.ev.outputs.shouldBuild == 'true' }}
           tags: |
             ghcr.io/goauthentik/dev-server:gh-${{ steps.ev.outputs.branchNameContainer }}-arm64
+            ghcr.io/goauthentik/dev-server:gh-${{ steps.ev.outputs.branchNameContainer }}-${{ steps.ev.outputs.sha }}-arm64
             ghcr.io/goauthentik/dev-server:gh-${{ steps.ev.outputs.branchNameContainer }}-${{ steps.ev.outputs.timestamp }}-${{ steps.ev.outputs.shortHash }}-arm64
           build-args: |
             GIT_BUILD_HASH=${{ steps.ev.outputs.sha }}

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -254,7 +254,7 @@ jobs:
           push: ${{ steps.ev.outputs.shouldBuild == 'true' }}
           tags: |
             ghcr.io/goauthentik/dev-server:gh-${{ steps.ev.outputs.branchNameContainer }}-arm64
-            ghcr.io/goauthentik/dev-server:gh-${{ steps.ev.outputs.branchNameContainer }}-${{ steps.ev.outputs.sha }}-arm64
+            ghcr.io/goauthentik/dev-server:gh-${{ steps.ev.outputs.sha }}-arm64
             ghcr.io/goauthentik/dev-server:gh-${{ steps.ev.outputs.branchNameContainer }}-${{ steps.ev.outputs.timestamp }}-${{ steps.ev.outputs.shortHash }}-arm64
           build-args: |
             GIT_BUILD_HASH=${{ steps.ev.outputs.sha }}

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -212,7 +212,7 @@ jobs:
           push: ${{ steps.ev.outputs.shouldBuild == 'true' }}
           tags: |
             ghcr.io/goauthentik/dev-server:gh-${{ steps.ev.outputs.branchNameContainer }}
-            ghcr.io/goauthentik/dev-server:gh-${{ steps.ev.outputs.branchNameContainer }}-${{ steps.ev.outputs.sha }}
+            ghcr.io/goauthentik/dev-server:gh-${{ steps.ev.outputs.sha }}
             ghcr.io/goauthentik/dev-server:gh-${{ steps.ev.outputs.branchNameContainer }}-${{ steps.ev.outputs.timestamp }}-${{ steps.ev.outputs.shortHash }}
           build-args: |
             GIT_BUILD_HASH=${{ steps.ev.outputs.sha }}

--- a/.github/workflows/ci-outpost.yml
+++ b/.github/workflows/ci-outpost.yml
@@ -87,7 +87,7 @@ jobs:
           push: ${{ steps.ev.outputs.shouldBuild == 'true' }}
           tags: |
             ghcr.io/goauthentik/dev-${{ matrix.type }}:gh-${{ steps.ev.outputs.branchNameContainer }}
-            ghcr.io/goauthentik/dev-${{ matrix.type }}:gh-${{ steps.ev.outputs.branchNameContainer }}-${{ steps.ev.outputs.sha }}
+            ghcr.io/goauthentik/dev-${{ matrix.type }}:gh-${{ steps.ev.outputs.sha }}
             ghcr.io/goauthentik/dev-${{ matrix.type }}:gh-${{ steps.ev.outputs.branchNameContainer }}-${{ steps.ev.outputs.timestamp }}-${{ steps.ev.outputs.shortHash }}
           file: ${{ matrix.type }}.Dockerfile
           build-args: |

--- a/.github/workflows/ci-outpost.yml
+++ b/.github/workflows/ci-outpost.yml
@@ -60,8 +60,6 @@ jobs:
           - proxy
           - ldap
           - radius
-        arch:
-          - "linux/amd64"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -89,12 +87,13 @@ jobs:
           push: ${{ steps.ev.outputs.shouldBuild == 'true' }}
           tags: |
             ghcr.io/goauthentik/dev-${{ matrix.type }}:gh-${{ steps.ev.outputs.branchNameContainer }}
-            ghcr.io/goauthentik/dev-${{ matrix.type }}:gh-${{ steps.ev.outputs.sha }}
+            ghcr.io/goauthentik/dev-${{ matrix.type }}:gh-${{ steps.ev.outputs.branchNameContainer }}-${{ steps.ev.outputs.sha }}
+            ghcr.io/goauthentik/dev-${{ matrix.type }}:gh-${{ steps.ev.outputs.branchNameContainer }}-${{ steps.ev.outputs.timestamp }}-${{ steps.ev.outputs.shortHash }}
           file: ${{ matrix.type }}.Dockerfile
           build-args: |
             GIT_BUILD_HASH=${{ steps.ev.outputs.sha }}
             VERSION_FAMILY=${{ steps.ev.outputs.versionFamily }}
-          platforms: ${{ matrix.arch }}
+          platforms: linux/amd64,linux/arm64
           context: .
   build-binary:
     timeout-minutes: 120

--- a/.github/workflows/ci-outpost.yml
+++ b/.github/workflows/ci-outpost.yml
@@ -88,7 +88,6 @@ jobs:
           tags: |
             ghcr.io/goauthentik/dev-${{ matrix.type }}:gh-${{ steps.ev.outputs.branchNameContainer }}
             ghcr.io/goauthentik/dev-${{ matrix.type }}:gh-${{ steps.ev.outputs.sha }}
-            ghcr.io/goauthentik/dev-${{ matrix.type }}:gh-${{ steps.ev.outputs.branchNameContainer }}-${{ steps.ev.outputs.timestamp }}-${{ steps.ev.outputs.shortHash }}
           file: ${{ matrix.type }}.Dockerfile
           build-args: |
             GIT_BUILD_HASH=${{ steps.ev.outputs.sha }}


### PR DESCRIPTION
* Add a docker tag to the main dev image with only the branch name and the sha

* Build the outposts dev images for arm64 as well.