### PR TITLE
root: Change docker-compose HTTP and HTTPS port variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,8 +47,8 @@ services:
     env_file:
       - .env
     ports:
-      - "${AUTHENTIK_PORT_HTTP:-9000}:9000"
-      - "${AUTHENTIK_PORT_HTTPS:-9443}:9443"
+      - "${COMPOSE_PORT_HTTP:-9000}:9000"
+      - "${COMPOSE_PORT_HTTPS:-9443}:9443"
   worker:
     image: ${AUTHENTIK_IMAGE:-ghcr.io/goauthentik/server}:${AUTHENTIK_TAG:-2023.4.1}
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 ---
-version: '3.4'
+version: "3.4"
 
 services:
   postgresql:
@@ -14,9 +14,9 @@ services:
     volumes:
       - database:/var/lib/postgresql/data
     environment:
-      - POSTGRES_PASSWORD=${PG_PASS:?database password required}
-      - POSTGRES_USER=${PG_USER:-authentik}
-      - POSTGRES_DB=${PG_DB:-authentik}
+      POSTGRES_PASSWORD: ${PG_PASS:?database password required}
+      POSTGRES_USER: ${PG_USER:-authentik}
+      POSTGRES_DB: ${PG_DB:-authentik}
     env_file:
       - .env
   redis:

--- a/website/docs/installation/docker-compose.md
+++ b/website/docs/installation/docker-compose.md
@@ -63,8 +63,8 @@ AUTHENTIK_EMAIL__FROM=authentik@localhost
 By default, authentik listens internally on port 9000 for HTTP and 9443 for HTTPS. To change the exposed ports to 80 and 443, you can set the following variables in `.env`:
 
 ```shell
-AUTHENTIK_PORT_HTTP=80
-AUTHENTIK_PORT_HTTPS=443
+COMPOSE_PORT_HTTP=80
+COMPOSE_PORT_HTTPS=443
 ```
 
 Be sure to run `docker-compose up -d` to rebuild with the new port numbers.

--- a/website/docs/installation/docker-compose.md
+++ b/website/docs/installation/docker-compose.md
@@ -67,7 +67,7 @@ COMPOSE_PORT_HTTP=80
 COMPOSE_PORT_HTTPS=443
 ```
 
-Be sure to run `docker-compose up -d` to rebuild with the new port numbers.
+See [Configuration](../installation/configuration) to change the internal ports. Be sure to run `docker-compose up -d` to rebuild with the new port numbers.
 
 ## Startup
 

--- a/website/docs/installation/docker-compose.md
+++ b/website/docs/installation/docker-compose.md
@@ -60,7 +60,7 @@ AUTHENTIK_EMAIL__FROM=authentik@localhost
 
 ## Configure for port 80/443
 
-By default, authentik listens on port 9000 for HTTP and 9443 for HTTPS. To change the default and instead use ports 80 and 443, you can set the following variables in `.env`:
+By default, authentik listens internally on port 9000 for HTTP and 9443 for HTTPS. To change the exposed ports to 80 and 443, you can set the following variables in `.env`:
 
 ```shell
 AUTHENTIK_PORT_HTTP=80

--- a/website/docs/releases/2023/v2023.5.md
+++ b/website/docs/releases/2023/v2023.5.md
@@ -11,6 +11,10 @@ slug: "/releases/2023.5"
 
     Additionally, any custom fields based on user attributes will only be represented with their sanitized key, removing any slashes with dashes, and removing periods.
 
+-   Renamed docker-compose environment variables
+
+    To better distinguish settings that configure authentik itself and settings that configure docker-compose, the environment variables `AUTHENTIK_PORT_HTTP` and `AUTHENTIK_PORT_HTTPS` have been renamed to `COMPOSE_PORT_HTTP` and `COMPOSE_PORT_HTTPS` respectively.
+
 ## New features
 
 ## Upgrading


### PR DESCRIPTION
# Details
* Resolves https://github.com/goauthentik/authentik/issues/5291

### Breaking Changes
* Changes the `AUTHENTIK_PORT_HTTP` environment variable to `COMPOSE_PORT_HTTP`.
* Changes the `AUTHENTIK_PORT_HTTPS` environment variable to `COMPOSE_PORT_HTTPS`.
