### PR TITLE
ci: build on branch commit instead of merge commit

### DIFF
--- a/.github/actions/docker-push-variables/action.yml
+++ b/.github/actions/docker-push-variables/action.yml
@@ -51,12 +51,14 @@ runs:
         version_family = ".".join(version.split(".")[:-1])
         safe_branch_name = branch_name.replace("refs/heads/", "").replace("/", "-")
 
+        sha = os.environ["GITHUB_SHA"] if not "${{ github.event.pull_request.head.sha }}" else "${{ github.event.pull_request.head.sha }}"
+
         with open(os.environ["GITHUB_OUTPUT"], "a+", encoding="utf-8") as _output:
             print("branchName=%s" % branch_name, file=_output)
             print("branchNameContainer=%s" % safe_branch_name, file=_output)
             print("timestamp=%s" % int(time()), file=_output)
-            print("sha=%s" % os.environ["GITHUB_SHA"], file=_output)
-            print("shortHash=%s" % os.environ["GITHUB_SHA"][:7], file=_output)
+            print("sha=%s" % sha, file=_output)
+            print("shortHash=%s" % sha[:7], file=_output)
             print("shouldBuild=%s" % should_build, file=_output)
             print("version=%s" % version, file=_output)
             print("versionFamily=%s" % version_family, file=_output)

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -187,6 +187,8 @@ jobs:
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2.1.0
       - name: Set up Docker Buildx
@@ -229,6 +231,8 @@ jobs:
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2.1.0
       - name: Set up Docker Buildx

--- a/.github/workflows/ci-outpost.yml
+++ b/.github/workflows/ci-outpost.yml
@@ -63,6 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2.1.0
       - name: Set up Docker Buildx
@@ -110,6 +112,8 @@ jobs:
         goarch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-go@v4
         with:
           go-version-file: "go.mod"


### PR DESCRIPTION
An alternative would be to still build on a merge commit, but use the SHA from the original branch commit as the docker tag.