### PR TITLE
ci: docker build: enable GHA cache

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,6 @@ htmlcov
 dist/**
 build/**
 build_docs/**
-Dockerfile
+*Dockerfile
 authentik/enterprise
 blueprints/local

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ build_docs/**
 *Dockerfile
 authentik/enterprise
 blueprints/local
+.git

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -220,6 +220,8 @@ jobs:
             GIT_BUILD_HASH=${{ steps.ev.outputs.sha }}
             VERSION=${{ steps.ev.outputs.version }}
             VERSION_FAMILY=${{ steps.ev.outputs.versionFamily }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: Comment on PR
         if: github.event_name == 'pull_request'
         continue-on-error: true
@@ -266,3 +268,5 @@ jobs:
             VERSION=${{ steps.ev.outputs.version }}
             VERSION_FAMILY=${{ steps.ev.outputs.versionFamily }}
           platforms: linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ci-outpost.yml
+++ b/.github/workflows/ci-outpost.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           version: v1.52.2
           args: --timeout 5000s --verbose
-          skip-pkg-cache: true
+          skip-cache: true
   test-unittest:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-outpost.yml
+++ b/.github/workflows/ci-outpost.yml
@@ -99,6 +99,8 @@ jobs:
             VERSION_FAMILY=${{ steps.ev.outputs.versionFamily }}
           platforms: linux/amd64,linux/arm64
           context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
   build-binary:
     timeout-minutes: 120
     needs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,7 @@ RUN apt-get update && \
     apt-get remove --purge -y build-essential pkg-config libxmlsec1-dev libpq-dev python3-dev && \
     apt-get autoremove --purge -y && \
     apt-get clean && \
-    rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/ && \
+    rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/ /root/.cache && \
     adduser --system --no-create-home --uid 1000 --group --home /authentik authentik && \
     mkdir -p /certs /media /blueprints && \
     mkdir -p /authentik/.ssh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,8 @@ RUN --mount=type=bind,target=/go/src/goauthentik.io/go.mod,src=./go.mod \
 COPY ./cmd /go/src/goauthentik.io/cmd
 COPY ./authentik/lib /go/src/goauthentik.io/authentik/lib
 COPY ./web/static.go /go/src/goauthentik.io/web/static.go
-COPY ./web/robots.txt /go/src/goauthentik.io/web/robots.txt
-COPY ./web/security.txt /go/src/goauthentik.io/web/security.txt
+COPY --from=web-builder /work/web/robots.txt /go/src/goauthentik.io/web/robots.txt
+COPY --from=web-builder /work/web/security.txt /go/src/goauthentik.io/web/security.txt
 COPY ./internal /go/src/goauthentik.io/internal
 COPY ./go.mod /go/src/goauthentik.io/go.mod
 COPY ./go.sum /go/src/goauthentik.io/go.sum

--- a/Dockerfile
+++ b/Dockerfile
@@ -110,8 +110,6 @@ LABEL org.opencontainers.image.revision ${GIT_BUILD_HASH}
 
 WORKDIR /
 
-COPY --from=geoip /usr/share/GeoIP /geoip
-
 # We cannot cache this layer otherwise we'll end up with a bigger image
 RUN apt-get update && \
     # Required for runtime
@@ -139,6 +137,7 @@ COPY --from=python-deps /work/venv /venv
 COPY --from=web-builder /work/web/dist/ /web/dist/
 COPY --from=web-builder /work/web/authentik/ /web/authentik/
 COPY --from=website-builder /work/website/help/ /website/help/
+COPY --from=geoip /usr/share/GeoIP /geoip
 
 USER 1000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,9 +75,10 @@ RUN --mount=type=secret,id=GEOIPUPDATE_ACCOUNT_ID \
 # Stage 5: Python dependencies
 FROM docker.io/python:3.11.5-bookworm AS python-deps
 
-WORKDIR /work
+WORKDIR /work/poetry
 
 ENV VENV_PATH="/work/venv" \
+    POETRY_VIRTUALENVS_CREATE=false \
     PATH="/work/venv/bin:$PATH"
 
 RUN --mount=type=cache,target=/var/cache/apt \
@@ -87,11 +88,12 @@ RUN --mount=type=cache,target=/var/cache/apt \
 
 RUN --mount=type=bind,target=./pyproject.toml,src=./pyproject.toml \
     --mount=type=bind,target=./poetry.lock,src=./poetry.lock \
+    --mount=type=cache,target=/root/.cache/pip \
     --mount=type=cache,target=/root/.cache/pypoetry \
     python -m venv /work/venv/ && \
     pip3 install --upgrade pip && \
     pip3 install poetry && \
-    poetry install --only=main
+    poetry install --only=main --no-ansi --no-interaction
 
 # Stage 6: Run
 FROM docker.io/python:3.11.5-slim-bookworm AS final-image

--- a/Dockerfile
+++ b/Dockerfile
@@ -121,7 +121,8 @@ RUN apt-get update && \
     adduser --system --no-create-home --uid 1000 --group --home /authentik authentik && \
     mkdir -p /certs /media /blueprints && \
     mkdir -p /authentik/.ssh && \
-    chown authentik:authentik /certs /media /authentik/.ssh
+    mkdir -p /ak-root && \
+    chown authentik:authentik /certs /media /authentik/.ssh /ak-root
 
 COPY ./authentik/ /authentik
 COPY ./pyproject.toml /
@@ -133,7 +134,7 @@ COPY ./manage.py /
 COPY ./blueprints /blueprints
 COPY ./lifecycle/ /lifecycle
 COPY --from=go-builder /go/authentik /bin/authentik
-COPY --from=python-deps /work/venv /venv
+COPY --from=python-deps /work/venv /ak-root/venv
 COPY --from=web-builder /work/web/dist/ /web/dist/
 COPY --from=web-builder /work/web/authentik/ /web/authentik/
 COPY --from=website-builder /work/website/help/ /website/help/
@@ -144,8 +145,8 @@ USER 1000
 ENV TMPDIR=/dev/shm/ \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    PATH="/venv/bin:$PATH" \
-    VENV_PATH="/venv" \
+    PATH="/ak-root/venv/bin:$PATH" \
+    VENV_PATH="/ak-root/venv" \
     POETRY_VIRTUALENVS_CREATE=false
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=60s --retries=3 CMD [ "/lifecycle/ak", "healthcheck" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -145,7 +145,9 @@ USER 1000
 ENV TMPDIR=/dev/shm/ \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    PATH="/venv/bin:$PATH"
+    PATH="/venv/bin:$PATH" \
+    VENV_PATH="/venv" \
+    POETRY_VIRTUALENVS_CREATE=false
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=60s --retries=3 CMD [ "/lifecycle/ak", "healthcheck" ]
 

--- a/ldap.Dockerfile
+++ b/ldap.Dockerfile
@@ -3,10 +3,10 @@ FROM docker.io/golang:1.21.1-bookworm AS builder
 
 WORKDIR /go/src/goauthentik.io
 
-COPY go.mod .
-COPY go.sum .
-COPY gen-go-api .
-RUN --mount=type=cache,target=/go/pkg/mod \
+RUN --mount=type=bind,target=/go/src/goauthentik.io/go.mod,src=./go.mod \
+    --mount=type=bind,target=/go/src/goauthentik.io/go.sum,src=./go.sum \
+    --mount=type=bind,target=/go/src/goauthentik.io/gen-go-api,src=./gen-go-api \
+    --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
 ENV CGO_ENABLED=0

--- a/ldap.Dockerfile
+++ b/ldap.Dockerfile
@@ -3,9 +3,17 @@ FROM docker.io/golang:1.21.1-bookworm AS builder
 
 WORKDIR /go/src/goauthentik.io
 
-COPY . .
+COPY go.mod .
+COPY go.sum .
+COPY gen-go-api .
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
 ENV CGO_ENABLED=0
-RUN go build -o /go/ldap ./cmd/ldap
+COPY . .
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -o /go/ldap ./cmd/ldap
 
 # Stage 2: Run
 FROM gcr.io/distroless/static-debian11:debug

--- a/lifecycle/ak
+++ b/lifecycle/ak
@@ -55,7 +55,7 @@ function cleanup {
 }
 
 function prepare_debug {
-    pip install --no-cache-dir -r /requirements-dev.txt
+    poetry install --no-ansi --no-interaction
     touch /unittest.xml
     chown authentik:authentik /unittest.xml
 }

--- a/proxy.Dockerfile
+++ b/proxy.Dockerfile
@@ -6,8 +6,9 @@ WORKDIR /static
 
 COPY web/package.json .
 COPY web/package-lock.json .
-RUN --mount=type=cache,target=/static/.npm \
-    npm set cache /static/.npm && \
+RUN --mount=type=bind,target=/static/package.json,src=./web/package.json \
+    --mount=type=bind,target=/static/package-lock.json,src=./web/package-lock.json \
+    --mount=type=cache,target=/root/.npm \
     npm ci --include=dev
 
 COPY web .
@@ -18,10 +19,10 @@ FROM docker.io/golang:1.21.1-bookworm AS builder
 
 WORKDIR /go/src/goauthentik.io
 
-COPY go.mod .
-COPY go.sum .
-COPY gen-go-api .
-RUN --mount=type=cache,target=/go/pkg/mod \
+RUN --mount=type=bind,target=/go/src/goauthentik.io/go.mod,src=./go.mod \
+    --mount=type=bind,target=/go/src/goauthentik.io/go.sum,src=./go.sum \
+    --mount=type=bind,target=/go/src/goauthentik.io/gen-go-api,src=./gen-go-api \
+    --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
 ENV CGO_ENABLED=0

--- a/proxy.Dockerfile
+++ b/proxy.Dockerfile
@@ -1,21 +1,34 @@
 # Stage 1: Build website
 FROM --platform=${BUILDPLATFORM} docker.io/node:20.5 as web-builder
 
-COPY ./web /static/
-
 ENV NODE_ENV=production
 WORKDIR /static
-RUN npm ci --include=dev && npm run build-proxy
+
+COPY web/package.json .
+COPY web/package-lock.json .
+RUN --mount=type=cache,target=/static/.npm \
+    npm set cache /static/.npm && \
+    npm ci --include=dev
+
+COPY web .
+RUN npm run build-proxy
 
 # Stage 2: Build
 FROM docker.io/golang:1.21.1-bookworm AS builder
 
 WORKDIR /go/src/goauthentik.io
 
-COPY . .
+COPY go.mod .
+COPY go.sum .
+COPY gen-go-api .
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 ENV CGO_ENABLED=0
-RUN go build -o /go/proxy ./cmd/proxy
+COPY . .
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -o /go/proxy ./cmd/proxy
 
 # Stage 3: Run
 FROM gcr.io/distroless/static-debian11:debug

--- a/radius.Dockerfile
+++ b/radius.Dockerfile
@@ -3,9 +3,17 @@ FROM docker.io/golang:1.21.1-bookworm AS builder
 
 WORKDIR /go/src/goauthentik.io
 
-COPY . .
+COPY go.mod .
+COPY go.sum .
+COPY gen-go-api .
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
 ENV CGO_ENABLED=0
-RUN go build -o /go/radius ./cmd/radius
+COPY . .
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -o /go/radius ./cmd/radius
 
 # Stage 2: Run
 FROM gcr.io/distroless/static-debian11:debug

--- a/radius.Dockerfile
+++ b/radius.Dockerfile
@@ -3,10 +3,10 @@ FROM docker.io/golang:1.21.1-bookworm AS builder
 
 WORKDIR /go/src/goauthentik.io
 
-COPY go.mod .
-COPY go.sum .
-COPY gen-go-api .
-RUN --mount=type=cache,target=/go/pkg/mod \
+RUN --mount=type=bind,target=/go/src/goauthentik.io/go.mod,src=./go.mod \
+    --mount=type=bind,target=/go/src/goauthentik.io/go.sum,src=./go.sum \
+    --mount=type=bind,target=/go/src/goauthentik.io/gen-go-api,src=./gen-go-api \
+    --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
 ENV CGO_ENABLED=0


### PR DESCRIPTION
Enable build caching for Docker images. Might save a lot of time, at the expense of cache size, which is quite limited at the moment. A lot of the current cache seems to be `golangci-lint`, which we could probably disable as we're already skipping the pkg cache anyway.