### PR TITLE
website: add documentation for AUTHENTIK_REDIS__TLS

### DIFF
--- a/internal/config/struct.go
+++ b/internal/config/struct.go
@@ -30,7 +30,7 @@ type RedisConfig struct {
 	Password               string `yaml:"password" env:"AUTHENTIK_REDIS__PASSWORD"`
 	TLS                    bool   `yaml:"tls" env:"AUTHENTIK_REDIS__TLS"`
 	TLSReqs                string `yaml:"tls_reqs" env:"AUTHENTIK_REDIS__TLS_REQS"`
-	DB                     int    `yaml:"cache_db" env:"AUTHENTIK_REDIS__CACHE_DB"`
+	DB                     int    `yaml:"cache_db" env:"AUTHENTIK_REDIS__DB"`
 	CacheTimeout           int    `yaml:"cache_timeout" env:"AUTHENTIK_REDIS__CACHE_TIMEOUT"`
 	CacheTimeoutFlows      int    `yaml:"cache_timeout_flows" env:"AUTHENTIK_REDIS__CACHE_TIMEOUT_FLOWS"`
 	CacheTimeoutPolicies   int    `yaml:"cache_timeout_policies" env:"AUTHENTIK_REDIS__CACHE_TIMEOUT_POLICIES"`

--- a/website/docs/installation/configuration.md
+++ b/website/docs/installation/configuration.md
@@ -43,6 +43,7 @@ kubectl exec -it deployment/authentik-worker -c authentik -- ak dump_config
 -   `AUTHENTIK_REDIS__HOST`: Hostname of your Redis Server
 -   `AUTHENTIK_REDIS__PORT`: Redis port, defaults to 6379
 -   `AUTHENTIK_REDIS__PASSWORD`: Password for your Redis Server
+-   `AUTHENTIK_REDIS__TLS`: Use TLS to connect to Redis, defaults to false
 -   `AUTHENTIK_REDIS__DB`: Database, defaults to 0
 -   `AUTHENTIK_REDIS__CACHE_TIMEOUT`: Timeout for cached data until it expires in seconds, defaults to 300
 -   `AUTHENTIK_REDIS__CACHE_TIMEOUT_FLOWS`: Timeout for cached flow plans until they expire in seconds, defaults to 300

--- a/website/docs/installation/configuration.md
+++ b/website/docs/installation/configuration.md
@@ -44,6 +44,7 @@ kubectl exec -it deployment/authentik-worker -c authentik -- ak dump_config
 -   `AUTHENTIK_REDIS__PORT`: Redis port, defaults to 6379
 -   `AUTHENTIK_REDIS__PASSWORD`: Password for your Redis Server
 -   `AUTHENTIK_REDIS__TLS`: Use TLS to connect to Redis, defaults to false
+-   `AUTHENTIK_REDIS__TLS_REQS`: Redis TLS requirements, defaults to "none"
 -   `AUTHENTIK_REDIS__DB`: Database, defaults to 0
 -   `AUTHENTIK_REDIS__CACHE_TIMEOUT`: Timeout for cached data until it expires in seconds, defaults to 300
 -   `AUTHENTIK_REDIS__CACHE_TIMEOUT_FLOWS`: Timeout for cached flow plans until they expire in seconds, defaults to 300


### PR DESCRIPTION
This adds documentation for the `AUTHENTIK_REDIS__TLS` configuration variable, which was added in goauthentik/authentik#1147.

See also: goauthentik/helm#151