### PR TITLE
web: Fix label not clickable for checkbox and choice field in prompts

### DIFF
--- a/web/src/flow/stages/prompt/PromptStage.ts
+++ b/web/src/flow/stages/prompt/PromptStage.ts
@@ -170,6 +170,7 @@ export class PromptStage extends BaseStage<PromptChallenge, PromptChallengeRespo
                     prompt.choices
                         ?.map((choice) => {
                             return ` <div class="pf-c-check">
+                                    <label class="pf-c-check__label">
                                     <input
                                         type="radio"
                                         class="pf-c-check__input"
@@ -178,7 +179,7 @@ export class PromptStage extends BaseStage<PromptChallenge, PromptChallengeRespo
                                         required="${prompt.required}"
                                         value="${choice}"
                                     />
-                                    <label class="pf-c-check__label">${choice}</label>
+                                    ${choice}</label>
                                 </div>
                             `;
                         })
@@ -236,6 +237,7 @@ export class PromptStage extends BaseStage<PromptChallenge, PromptChallengeRespo
         // Checkbox is rendered differently
         if (prompt.type === PromptTypeEnum.Checkbox) {
             return html`<div class="pf-c-check">
+                <label class="pf-c-check__label">
                 <input
                     type="checkbox"
                     class="pf-c-check__input"
@@ -243,7 +245,7 @@ export class PromptStage extends BaseStage<PromptChallenge, PromptChallengeRespo
                     ?checked=${prompt.initialValue !== ""}
                     ?required=${prompt.required}
                 />
-                <label class="pf-c-check__label">${prompt.label}</label>
+                ${prompt.label}</label>
                 ${prompt.required
                     ? html`<p class="pf-c-form__helper-text">${t`Required.`}</p>`
                     : html``}

--- a/web/src/flow/stages/prompt/PromptStage.ts
+++ b/web/src/flow/stages/prompt/PromptStage.ts
@@ -13,6 +13,7 @@ import { unsafeHTML } from "lit/directives/unsafe-html.js";
 
 import PFAlert from "@patternfly/patternfly/components/Alert/alert.css";
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
+import PFCheck from "@patternfly/patternfly/components/Check/check.css";
 import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
@@ -38,6 +39,7 @@ export class PromptStage extends BaseStage<PromptChallenge, PromptChallengeRespo
             PFFormControl,
             PFTitle,
             PFButton,
+            PFCheck,
             css`
                 textarea {
                     min-height: 4em;
@@ -170,16 +172,18 @@ export class PromptStage extends BaseStage<PromptChallenge, PromptChallengeRespo
                     prompt.choices
                         ?.map((choice) => {
                             return ` <div class="pf-c-check">
-                                    <label class="pf-c-check__label">
                                     <input
                                         type="radio"
                                         class="pf-c-check__input"
+                                        id="${prompt.fieldKey}"
                                         name="${prompt.fieldKey}"
                                         checked="${prompt.initialValue === choice}"
                                         required="${prompt.required}"
                                         value="${choice}"
                                     />
-                                    ${choice}</label>
+                                    <label class="pf-c-check__label" for="${
+                                        prompt.fieldKey
+                                    }">${choice}</label>
                                 </div>
                             `;
                         })
@@ -237,15 +241,15 @@ export class PromptStage extends BaseStage<PromptChallenge, PromptChallengeRespo
         // Checkbox is rendered differently
         if (prompt.type === PromptTypeEnum.Checkbox) {
             return html`<div class="pf-c-check">
-                <label class="pf-c-check__label">
                 <input
                     type="checkbox"
                     class="pf-c-check__input"
+                    id="${prompt.fieldKey}"
                     name="${prompt.fieldKey}"
                     ?checked=${prompt.initialValue !== ""}
                     ?required=${prompt.required}
                 />
-                ${prompt.label}</label>
+                <label class="pf-c-check__label" for="${prompt.fieldKey}">${prompt.label}</label>
                 ${prompt.required
                     ? html`<p class="pf-c-form__helper-text">${t`Required.`}</p>`
                     : html``}

--- a/web/src/user/user-settings/details/stages/prompt/PromptStage.ts
+++ b/web/src/user/user-settings/details/stages/prompt/PromptStage.ts
@@ -3,20 +3,14 @@ import { PromptStage } from "@goauthentik/flow/stages/prompt/PromptStage";
 
 import { t } from "@lingui/macro";
 
-import { CSSResult, TemplateResult, html } from "lit";
+import { TemplateResult, html } from "lit";
 import { customElement } from "lit/decorators.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
-
-import PFCheck from "@patternfly/patternfly/components/Check/check.css";
 
 import { PromptTypeEnum, StagePrompt } from "@goauthentik/api";
 
 @customElement("ak-user-stage-prompt")
 export class UserSettingsPromptStage extends PromptStage {
-    static get styles(): CSSResult[] {
-        return super.styles.concat(PFCheck);
-    }
-
     renderPromptInner(prompt: StagePrompt): string {
         switch (prompt.type) {
             // Checkbox requires slightly different rendering here due to the use of horizontal form elements


### PR DESCRIPTION
# Details
Labels next to checkboxes and choice field in prompts are not clickable.
Therefor we need to click on the checkbox or choicebox directly which is rather small.

## Changes

### Fix
Wrap the checkbox/choicebox in the HTML label.

### New Features
Labels next to checkboxes and choice fields are now clickable

## Additional
Using this method has some advantages over the [HTML `for` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label?retiredLocale=de#attributes):

- No need to assign an unique id to every checkbox.
- No need to use the extra attribute in the label.
- Delivered page has same usage of storage (yes, `for` would be minor, but it is a fact)

