### PR TITLE
web: fix french 'user' misspell in user settings page

### DIFF
--- a/web/src/locales/fr.po
+++ b/web/src/locales/fr.po
@@ -6499,7 +6499,7 @@ msgstr "Base de données utilisateurs + mots de passe standards"
 
 #: src/user/user-settings/UserSettingsPage.ts
 msgid "User details"
-msgstr "Détails de l'utilisatuer"
+msgstr "Détails de l'utilisateur"
 
 #: src/pages/users/UserViewPage.ts
 msgid "User events"

--- a/web/src/locales/fr_FR.po
+++ b/web/src/locales/fr_FR.po
@@ -7303,7 +7303,7 @@ msgstr "Base de données utilisateurs + mots de passe standards"
 
 #: src/user/user-settings/UserSettingsPage.ts
 msgid "User details"
-msgstr "Détails de l'utilisatuer"
+msgstr "Détails de l'utilisateur"
 
 #: src/admin/users/UserViewPage.ts
 msgid "User events"


### PR DESCRIPTION
Hey!

# Details

Just a simple french locale correction.

## Changes

- Fixed french misspell on word "user". Two letters were swapped.