### PR TITLE
root: configuration reloading

### DIFF
--- a/authentik/lib/default.yml
+++ b/authentik/lib/default.yml
@@ -11,7 +11,11 @@ postgresql:
 listen:
   listen_http: 0.0.0.0:9000
   listen_https: 0.0.0.0:9443
+  listen_ldap: 0.0.0.0:3389
+  listen_ldaps: 0.0.0.0:6636
+  listen_radius: 0.0.0.0:1812
   listen_metrics: 0.0.0.0:9300
+  listen_debug: 0.0.0.0:9900
 
 redis:
   host: localhost
@@ -24,6 +28,9 @@ redis:
   cache_timeout_flows: 300
   cache_timeout_policies: 300
   cache_timeout_reputation: 300
+
+paths:
+  media: ./media
 
 debug: false
 

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -97,6 +97,17 @@ var rootCmd = &cobra.Command{
 		}
 		go web.RunMetricsServer()
 		go attemptStartBackend(g)
+
+		w, err := config.WatchChanges(func() {
+			g.Restart()
+		})
+		if err != nil {
+			l.WithError(err).Warning("failed to start watching for configuration changes, no automatic update will be done")
+		}
+		if w != nil {
+			defer w.Close()
+		}
+
 		ws.Start()
 		<-ex
 		running = false

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/felixge/httpsnoop v1.0.1 // indirect
+	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-asn1-ber/asn1-ber v1.5.4 // indirect
 	github.com/go-http-utils/fresh v0.0.0-20161124030543-7231e26a4b27 // indirect
 	github.com/go-http-utils/headers v0.0.0-20181008091004-fed159eddc2a // indirect

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
+github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/garyburd/redigo v1.6.4 h1:LFu2R3+ZOPgSMWMOL+saa/zXRjw0ID2G8FepO53BGlg=
 github.com/garyburd/redigo v1.6.4/go.mod h1:rTb6epsqigu3kYKBnaF028A7Tf/Aw5s0cqA47doKKqw=
 github.com/getsentry/sentry-go v0.20.0 h1:bwXW98iMRIWxn+4FgPW7vMrjmbym6HblXALmhjHmQaQ=
@@ -486,6 +488,7 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
 golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,34 +55,11 @@ func getConfigPaths() []string {
 
 func Get() *Config {
 	if cfg == nil {
-		c := defaultConfig()
+		c := &Config{}
 		c.Setup(getConfigPaths()...)
 		cfg = c
 	}
 	return cfg
-}
-
-func defaultConfig() *Config {
-	return &Config{
-		Debug: false,
-		Listen: ListenConfig{
-			HTTP:    "0.0.0.0:9000",
-			HTTPS:   "0.0.0.0:9443",
-			LDAP:    "0.0.0.0:3389",
-			LDAPS:   "0.0.0.0:6636",
-			Radius:  "0.0.0.0:1812",
-			Metrics: "0.0.0.0:9300",
-			Debug:   "0.0.0.0:9900",
-		},
-		Paths: PathsConfig{
-			Media: "./media",
-		},
-		LogLevel: "info",
-		ErrorReporting: ErrorReportingConfig{
-			Enabled:    false,
-			SampleRate: 1,
-		},
-	}
 }
 
 func (c *Config) Setup(paths ...string) {

--- a/internal/gounicorn/gounicorn.go
+++ b/internal/gounicorn/gounicorn.go
@@ -1,15 +1,21 @@
 package gounicorn
 
 import (
+	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
 	"runtime"
+	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
 	log "github.com/sirupsen/logrus"
+
 	"goauthentik.io/internal/config"
+	"goauthentik.io/internal/utils"
 	"goauthentik.io/internal/utils/web"
 )
 
@@ -18,6 +24,7 @@ type GoUnicorn struct {
 
 	log     *log.Entry
 	p       *exec.Cmd
+	pidFile *string
 	started bool
 	killed  bool
 	alive   bool
@@ -27,6 +34,7 @@ func New() *GoUnicorn {
 	logger := log.WithField("logger", "authentik.router.unicorn")
 	g := &GoUnicorn{
 		log:             logger,
+		pidFile:         nil,
 		started:         false,
 		killed:          false,
 		alive:           false,
@@ -37,8 +45,13 @@ func New() *GoUnicorn {
 }
 
 func (g *GoUnicorn) initCmd() {
+	pidFile, _ := os.CreateTemp("", "authentik-gunicorn.*.pid")
+	g.pidFile = func() *string { s := pidFile.Name(); return &s }()
 	command := "gunicorn"
 	args := []string{"-c", "./lifecycle/gunicorn.conf.py", "authentik.root.asgi:application"}
+	if g.pidFile != nil {
+		args = append(args, "--pid", *g.pidFile)
+	}
 	if config.Get().Debug {
 		command = "./manage.py"
 		args = []string{"runserver"}
@@ -55,16 +68,13 @@ func (g *GoUnicorn) IsRunning() bool {
 }
 
 func (g *GoUnicorn) Start() error {
-	if g.killed {
-		g.log.Debug("Not restarting gunicorn since we're shutdown")
-		return nil
-	}
 	if g.started {
 		g.initCmd()
 	}
+	g.killed = false
 	g.started = true
 	go g.healthcheck()
-	return g.p.Run()
+	return g.p.Start()
 }
 
 func (g *GoUnicorn) healthcheck() {
@@ -96,8 +106,77 @@ func (g *GoUnicorn) healthcheck() {
 	}
 }
 
+func (g *GoUnicorn) Reload() {
+	g.log.WithField("method", "reload").Info("reloading gunicorn")
+	err := g.p.Process.Signal(syscall.SIGHUP)
+	if err != nil {
+		g.log.WithError(err).Warning("failed to reload gunicorn")
+	}
+}
+
+func (g *GoUnicorn) Restart() {
+	g.log.WithField("method", "restart").Info("restart gunicorn")
+	if g.pidFile == nil {
+		g.log.Warning("pidfile is non existent, cannot restart")
+		return
+	}
+
+	err := g.p.Process.Signal(syscall.SIGUSR2)
+	if err != nil {
+		g.log.WithError(err).Warning("failed to restart gunicorn")
+		return
+	}
+
+	newPidFile := fmt.Sprintf("%s.2", *g.pidFile)
+
+	// Wait for the new PID file to be created
+	for range time.Tick(1 * time.Second) {
+		_, err = os.Stat(newPidFile)
+		if err == nil || !os.IsNotExist(err) {
+			break
+		}
+		g.log.Debugf("waiting for new gunicorn pidfile to appear at %s", newPidFile)
+	}
+	if err != nil {
+		g.log.WithError(err).Warning("failed to find the new gunicorn process, aborting")
+		return
+	}
+
+	newPidB, err := ioutil.ReadFile(newPidFile)
+	if err != nil {
+		g.log.WithError(err).Warning("failed to find the new gunicorn process, aborting")
+		return
+	}
+	newPidS := strings.TrimSpace(string(newPidB[:]))
+	newPid, err := strconv.Atoi(newPidS)
+	if err != nil {
+		g.log.WithError(err).Warning("failed to find the new gunicorn process, aborting")
+		return
+	}
+	g.log.Warningf("new gunicorn PID is %d", newPid)
+
+	newProcess, err := utils.FindProcess(newPid)
+	if newProcess == nil || err != nil {
+		g.log.WithError(err).Warning("failed to find the new gunicorn process, aborting")
+		return
+	}
+
+	// The new process has started, let's gracefully kill the old one
+	g.log.Warningf("killing old gunicorn")
+	err = g.p.Process.Signal(syscall.SIGTERM)
+	if err != nil {
+		g.log.Warning("failed to kill old instance of gunicorn")
+	}
+
+	g.p.Process = newProcess
+
+	// No need to close any files and the .2 pid file is deleted by Gunicorn
+}
+
 func (g *GoUnicorn) Kill() {
-	g.killed = true
+	if !g.started {
+		return
+	}
 	var err error
 	if runtime.GOOS == "darwin" {
 		g.log.WithField("method", "kill").Warning("stopping gunicorn")
@@ -109,4 +188,8 @@ func (g *GoUnicorn) Kill() {
 	if err != nil {
 		g.log.WithError(err).Warning("failed to stop gunicorn")
 	}
+	if g.pidFile != nil {
+		os.Remove(*g.pidFile)
+	}
+	g.killed = true
 }

--- a/internal/gounicorn/gounicorn.go
+++ b/internal/gounicorn/gounicorn.go
@@ -2,7 +2,6 @@ package gounicorn
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -142,7 +141,7 @@ func (g *GoUnicorn) Restart() {
 		return
 	}
 
-	newPidB, err := ioutil.ReadFile(newPidFile)
+	newPidB, err := os.ReadFile(newPidFile)
 	if err != nil {
 		g.log.WithError(err).Warning("failed to find the new gunicorn process, aborting")
 		return

--- a/internal/utils/process.go
+++ b/internal/utils/process.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"syscall"
@@ -21,7 +22,7 @@ func FindProcess(pid int) (*os.Process, error) {
 	if err == nil {
 		return proc, nil
 	}
-	if err.Error() == "os: process already finished" {
+	if errors.Is(err, os.ErrProcessDone) {
 		return nil, nil
 	}
 	errno, ok := err.(syscall.Errno)

--- a/internal/utils/process.go
+++ b/internal/utils/process.go
@@ -1,0 +1,38 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func FindProcess(pid int) (*os.Process, error) {
+	if pid <= 0 {
+		return nil, fmt.Errorf("invalid pid %v", pid)
+	}
+	// The error doesn't mean anything on Unix systems, let's just check manually
+	// that the new gunicorn master has properly started
+	// https://github.com/golang/go/issues/34396
+	proc, err := os.FindProcess(int(pid))
+	if err != nil {
+		return nil, err
+	}
+	err = proc.Signal(syscall.Signal(0))
+	if err == nil {
+		return proc, nil
+	}
+	if err.Error() == "os: process already finished" {
+		return nil, nil
+	}
+	errno, ok := err.(syscall.Errno)
+	if !ok {
+		return nil, err
+	}
+	switch errno {
+	case syscall.ESRCH:
+		return nil, nil
+	case syscall.EPERM:
+		return proc, nil
+	}
+	return nil, err
+}


### PR DESCRIPTION
EDIT: Configuration watching is now implemented. This PR is best reviewed commit by commit, I'll update this description later.

# Details

This is the first step to handle configuration reloading. With those changes, it is already possible to do so, by sending a SIGUSR2 signal to the Go server process. The next step would be to watch for changes to configuration files and call the Restart function of the GoUnicorn instance.

SIGHUP is catched by the go server and forwarded as-is to gunicorn, which causes it to restart its workers. However, that does not trigger a reload of the Django settings, probably because they are already loaded in the master, before creating any of the worker instances.

SIGUSR2, however, can be used to spawn a new gunicorn master process, but handling it is a bit trickier. Please refer to Gunicorn's documentation[0] for details, especially the "Upgrading to a new binary on the fly" section.

As we are now effectively killing the gunicorn processed launched by the server, we need to handle some sort of check to make sure it is still running. That's done by using the already existing healthchecks, making them useful not only for the application start, but also for its lifetime. If a check is failed too many times in a given time period, the gunicorn processed is killed (if necessary) and then restarted.

[0] https://docs.gunicorn.org/en/20.1.0/signals.html

Other relevant links and documentation:

Python library handling the processing swaping upon a SIGUSR2: https://github.com/flupke/rainbow-saddle/

Golang cannot easily check if a process exists on Unix systems: https://github.com/golang/go/issues/34396

## Changes

### New Features

- Support file configuration reloading by sending a SIGUSR2 signal to the `server` process.
- The golang server now automatically restarts (gracefully) the underlying gunicorn process if it fails healthchecks.

### Breaking Changes

Not that I'm aware of.

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)