### PR TITLE
blueprints: ignore hidden files in discovery

### DIFF
--- a/authentik/blueprints/v1/tasks.py
+++ b/authentik/blueprints/v1/tasks.py
@@ -101,7 +101,10 @@ def blueprints_find():
     """Find blueprints and return valid ones"""
     blueprints = []
     root = Path(CONFIG.y("blueprints_dir"))
-    for path in root.glob("**/*.yaml"):
+    for path in root.rglob("**/*.yaml"):
+        # Check if any part in the path starts with a dot and assume a hidden file
+        if any(part for part in path.parts if part.startswith(".")):
+            continue
         LOGGER.debug("found blueprint", path=str(path))
         with open(path, "r", encoding="utf-8") as blueprint_file:
             try:


### PR DESCRIPTION
this is mainly a bugfix for K8s environments when blueprints are mounted with a configmap, as K8s will by default symlink the files to a different folder to provide atomic updates, but without this PR both the symlink and the actual files are discovered, so there's errors as two files with different paths have the same blueprint (cc @rissson)