### PR TITLE
internal: ignore insecure TLS certs

### DIFF
--- a/internal/outpost/ldap/ldap_tls.go
+++ b/internal/outpost/ldap/ldap_tls.go
@@ -44,6 +44,22 @@ func (ls *LDAPServer) StartLDAPTLSServer() error {
 		GetCertificate: ls.getCertificates,
 	}
 
+	// Insecure SWEET32 attack ciphers, TLS config uses a fallback
+	insecureCiphersIds := []uint16{
+		tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+		tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+	}
+	defaultSecureCiphers := []uint16{}
+	for _, cs := range tls.CipherSuites() {
+		csID := cs.ID
+		for _, icsId := range insecureCiphersIds {
+			if csID != icsId {
+				defaultSecureCiphers = append(defaultSecureCiphers, csID)
+			}
+		}
+	}
+	tlsConfig.CipherSuites = defaultSecureCiphers
+
 	ln, err := net.Listen("tcp", listen)
 	if err != nil {
 		ls.log.WithField("listen", listen).WithError(err).Warning("Failed to listen")

--- a/internal/outpost/ldap/ldap_tls.go
+++ b/internal/outpost/ldap/ldap_tls.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pires/go-proxyproto"
 	"goauthentik.io/internal/config"
+	"goauthentik.io/internal/utils"
 )
 
 func (ls *LDAPServer) getCertificates(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
@@ -38,27 +39,8 @@ func (ls *LDAPServer) getCertificates(info *tls.ClientHelloInfo) (*tls.Certifica
 
 func (ls *LDAPServer) StartLDAPTLSServer() error {
 	listen := config.Get().Listen.LDAPS
-	tlsConfig := &tls.Config{
-		MinVersion:     tls.VersionTLS12,
-		MaxVersion:     tls.VersionTLS12,
-		GetCertificate: ls.getCertificates,
-	}
-
-	// Insecure SWEET32 attack ciphers, TLS config uses a fallback
-	insecureCiphersIds := []uint16{
-		tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
-		tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
-	}
-	defaultSecureCiphers := []uint16{}
-	for _, cs := range tls.CipherSuites() {
-		csID := cs.ID
-		for _, icsId := range insecureCiphersIds {
-			if csID != icsId {
-				defaultSecureCiphers = append(defaultSecureCiphers, csID)
-			}
-		}
-	}
-	tlsConfig.CipherSuites = defaultSecureCiphers
+	tlsConfig := utils.GetTLSConfig()
+	tlsConfig.GetCertificate = ls.getCertificates
 
 	ln, err := net.Listen("tcp", listen)
 	if err != nil {

--- a/internal/outpost/proxyv2/proxyv2.go
+++ b/internal/outpost/proxyv2/proxyv2.go
@@ -135,6 +135,22 @@ func (ps *ProxyServer) ServeHTTPS() {
 		GetCertificate: ps.getCertificates,
 	}
 
+	// Insecure SWEET32 attack ciphers, TLS config uses a fallback
+	insecureCiphersIds := []uint16{
+		tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+		tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+	}
+	defaultSecureCiphers := []uint16{}
+	for _, cs := range tls.CipherSuites() {
+		csID := cs.ID
+		for _, icsId := range insecureCiphersIds {
+			if csID != icsId {
+				defaultSecureCiphers = append(defaultSecureCiphers, csID)
+			}
+		}
+	}
+	config.CipherSuites = defaultSecureCiphers
+
 	ln, err := net.Listen("tcp", listenAddress)
 	if err != nil {
 		ps.log.WithError(err).Warning("Failed to listen (TLS)")

--- a/internal/outpost/proxyv2/proxyv2.go
+++ b/internal/outpost/proxyv2/proxyv2.go
@@ -18,6 +18,7 @@ import (
 	"goauthentik.io/internal/outpost/ak"
 	"goauthentik.io/internal/outpost/proxyv2/application"
 	"goauthentik.io/internal/outpost/proxyv2/metrics"
+	"goauthentik.io/internal/utils"
 	sentryutils "goauthentik.io/internal/utils/sentry"
 	"goauthentik.io/internal/utils/web"
 )
@@ -129,27 +130,8 @@ func (ps *ProxyServer) ServeHTTP() {
 // ServeHTTPS constructs a net.Listener and starts handling HTTPS requests
 func (ps *ProxyServer) ServeHTTPS() {
 	listenAddress := config.Get().Listen.HTTPS
-	config := &tls.Config{
-		MinVersion:     tls.VersionTLS12,
-		MaxVersion:     tls.VersionTLS12,
-		GetCertificate: ps.getCertificates,
-	}
-
-	// Insecure SWEET32 attack ciphers, TLS config uses a fallback
-	insecureCiphersIds := []uint16{
-		tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
-		tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
-	}
-	defaultSecureCiphers := []uint16{}
-	for _, cs := range tls.CipherSuites() {
-		csID := cs.ID
-		for _, icsId := range insecureCiphersIds {
-			if csID != icsId {
-				defaultSecureCiphers = append(defaultSecureCiphers, csID)
-			}
-		}
-	}
-	config.CipherSuites = defaultSecureCiphers
+	tlsConfig := utils.GetTLSConfig()
+	tlsConfig.GetCertificate = ps.getCertificates
 
 	ln, err := net.Listen("tcp", listenAddress)
 	if err != nil {
@@ -159,7 +141,7 @@ func (ps *ProxyServer) ServeHTTPS() {
 	proxyListener := &proxyproto.Listener{Listener: web.TCPKeepAliveListener{TCPListener: ln.(*net.TCPListener)}}
 	defer proxyListener.Close()
 
-	tlsListener := tls.NewListener(proxyListener, config)
+	tlsListener := tls.NewListener(proxyListener, tlsConfig)
 	ps.log.WithField("listen", listenAddress).Info("Starting HTTPS server")
 	ps.serve(tlsListener)
 	ps.log.WithField("listen", listenAddress).Info("Stopping HTTPS server")

--- a/internal/utils/tls.go
+++ b/internal/utils/tls.go
@@ -1,0 +1,26 @@
+package utils
+
+import "crypto/tls"
+
+func GetTLSConfig() *tls.Config {
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		MaxVersion: tls.VersionTLS12,
+	}
+
+	// Insecure SWEET32 attack ciphers, TLS config uses a fallback
+	insecureCiphersIds := []uint16{
+		tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+		tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+	}
+	defaultSecureCiphers := []uint16{}
+	for _, cs := range tls.CipherSuites() {
+		for _, icsId := range insecureCiphersIds {
+			if cs.ID != icsId {
+				defaultSecureCiphers = append(defaultSecureCiphers, cs.ID)
+			}
+		}
+	}
+	tlsConfig.CipherSuites = defaultSecureCiphers
+	return tlsConfig
+}

--- a/internal/web/tls.go
+++ b/internal/web/tls.go
@@ -41,6 +41,22 @@ func (ws *WebServer) listenTLS() {
 		GetCertificate: ws.GetCertificate(),
 	}
 
+	// Insecure SWEET32 attack ciphers, TLS config uses a fallback
+	insecureCiphersIds := []uint16{
+		tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+		tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+	}
+	defaultSecureCiphers := []uint16{}
+	for _, cs := range tls.CipherSuites() {
+		csID := cs.ID
+		for _, icsId := range insecureCiphersIds {
+			if csID != icsId {
+				defaultSecureCiphers = append(defaultSecureCiphers, csID)
+			}
+		}
+	}
+	tlsConfig.CipherSuites = defaultSecureCiphers
+
 	ln, err := net.Listen("tcp", config.Get().Listen.HTTPS)
 	if err != nil {
 		ws.log.WithError(err).Warning("failed to listen (TLS)")

--- a/internal/web/tls.go
+++ b/internal/web/tls.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pires/go-proxyproto"
 	"goauthentik.io/internal/config"
 	"goauthentik.io/internal/crypto"
+	"goauthentik.io/internal/utils"
 	"goauthentik.io/internal/utils/web"
 )
 
@@ -35,27 +36,8 @@ func (ws *WebServer) GetCertificate() func(ch *tls.ClientHelloInfo) (*tls.Certif
 
 // ServeHTTPS constructs a net.Listener and starts handling HTTPS requests
 func (ws *WebServer) listenTLS() {
-	tlsConfig := &tls.Config{
-		MinVersion:     tls.VersionTLS12,
-		MaxVersion:     tls.VersionTLS12,
-		GetCertificate: ws.GetCertificate(),
-	}
-
-	// Insecure SWEET32 attack ciphers, TLS config uses a fallback
-	insecureCiphersIds := []uint16{
-		tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
-		tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
-	}
-	defaultSecureCiphers := []uint16{}
-	for _, cs := range tls.CipherSuites() {
-		csID := cs.ID
-		for _, icsId := range insecureCiphersIds {
-			if csID != icsId {
-				defaultSecureCiphers = append(defaultSecureCiphers, csID)
-			}
-		}
-	}
-	tlsConfig.CipherSuites = defaultSecureCiphers
+	tlsConfig := utils.GetTLSConfig()
+	tlsConfig.GetCertificate = ws.GetCertificate()
 
 	ln, err := net.Listen("tcp", config.Get().Listen.HTTPS)
 	if err != nil {


### PR DESCRIPTION
# Details
Remove 3DES fallback TLS Cert.

-   **Does this resolve an issue?**
    Resolves potential SWEET32 attack.

## Changes

Updated TLS Config to exclude vulnerable certs.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [X] Local tests pass (`ak test authentik/`)
-   [X] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
