### PR TITLE
root: switch sentry dsn to our relay

### DIFF
--- a/authentik/lib/default.yml
+++ b/authentik/lib/default.yml
@@ -31,7 +31,7 @@ log_level: info
 
 error_reporting:
   enabled: false
-  sentry_dsn: https://151ba72610234c4c97c5bcff4e1cffd8@o4504163616882688.ingest.sentry.io/4504163677503489
+  sentry_dsn: https://151ba72610234c4c97c5bcff4e1cffd8@authentik.error-reporting.a7k.io/4504163677503489
   environment: customer
   send_pii: false
   sample_rate: 0.1

--- a/website/docs/installation/air-gapped.md
+++ b/website/docs/installation/air-gapped.md
@@ -9,7 +9,7 @@ By default, authentik creates outbound connections to the following URLs:
 -   https://version.goauthentik.io: Periodic update check
 -   https://goauthentik.io: Anonymous analytics on startup
 -   https://secure.gravatar.com: Avatars for users
--   https://o4504163616882688.ingest.sentry.io: Error reporting
+-   https://authentik.error-reporting.a7k.io: Error reporting
 
 To disable these outbound connections, set the following in your `.env` file:
 


### PR DESCRIPTION
# Details

-  Switch Sentry DSN to our relay

## Changes

### New Features

-   authentik no longer creates outbound connections to o4504163616882688.ingest.sentry.io, but to authentik.error-reporting.a7k.io

### Breaking Changes

N/A

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
