### PR TITLE
web: fix loading text not being loaded

### DIFF
--- a/web/src/standalone/api-browser/index.ts
+++ b/web/src/standalone/api-browser/index.ts
@@ -1,6 +1,7 @@
 import { CSRFHeaderName } from "@goauthentik/common/api/middleware";
 import { EVENT_THEME_CHANGE } from "@goauthentik/common/constants";
 import { globalAK } from "@goauthentik/common/global";
+import { autoDetectLanguage } from "@goauthentik/common/ui/locale";
 import { first, getCookie } from "@goauthentik/common/utils";
 import { Interface } from "@goauthentik/elements/Base";
 import { DefaultTenant } from "@goauthentik/elements/sidebar/SidebarBrand";
@@ -11,6 +12,8 @@ import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
 import { UiThemeEnum } from "@goauthentik/api";
+
+autoDetectLanguage();
 
 @customElement("ak-api-browser")
 export class APIBrowser extends Interface {

--- a/web/src/standalone/loading/index.ts
+++ b/web/src/standalone/loading/index.ts
@@ -1,4 +1,5 @@
 import { globalAK } from "@goauthentik/common/global";
+import { autoDetectLanguage } from "@goauthentik/common/ui/locale";
 import { Interface } from "@goauthentik/elements/Base";
 
 import { t } from "@lingui/macro";
@@ -12,6 +13,8 @@ import PFSpinner from "@patternfly/patternfly/components/Spinner/spinner.css";
 import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 import { UiThemeEnum } from "@goauthentik/api";
+
+autoDetectLanguage();
 
 @customElement("ak-loading")
 export class Loading extends Interface {


### PR DESCRIPTION
since the loading page was migrated to a full Lit component/standalone, it was missing an import for the locale module, hence the string wasn't translated 