### PR TITLE
web/flows: don't autoclose in redirect stage if redirecting to non-http protocol

### DIFF
--- a/web/src/flow/providers/oauth2/DeviceCodeFinish.ts
+++ b/web/src/flow/providers/oauth2/DeviceCodeFinish.ts
@@ -1,37 +1,25 @@
 import "@goauthentik/elements/EmptyState";
 import "@goauthentik/flow/FormStatic";
-import { AccessDeniedStage } from "@goauthentik/flow/stages/access_denied/AccessDeniedStage";
+import { BaseStage } from "@goauthentik/flow/stages/base";
 
 import { t } from "@lingui/macro";
 
 import { TemplateResult, html } from "lit";
 import { customElement } from "lit/decorators.js";
 
+import { OAuthDeviceCodeFinishChallenge } from "@goauthentik/api";
+
 @customElement("ak-flow-provider-oauth2-code-finish")
-export class DeviceCodeFinish extends AccessDeniedStage {
+export class DeviceCodeFinish extends BaseStage<
+    OAuthDeviceCodeFinishChallenge,
+    OAuthDeviceCodeFinishChallenge
+> {
     render(): TemplateResult {
         if (!this.challenge) {
             return html`<ak-empty-state ?loading="${true}" header=${t`Loading`}> </ak-empty-state>`;
         }
-        return html`<header class="pf-c-login__main-header">
-                <h1 class="pf-c-title pf-m-3xl">${this.challenge.flowInfo?.title}</h1>
-            </header>
-            <div class="pf-c-login__main-body">
-                <form class="pf-c-form">
-                    <div class="pf-c-form__group">
-                        <p class="big-icon">
-                            <i class="pf-icon pf-icon-ok"></i>
-                        </p>
-                        <h3 class="pf-c-title pf-m-3xl reason">
-                            ${t`You've successfully authenticated your device.`}
-                        </h3>
-                        <hr />
-                        <p>${t`You can close this tab now.`}</p>
-                    </div>
-                </form>
-            </div>
-            <footer class="pf-c-login__main-footer">
-                <ul class="pf-c-login__main-footer-links"></ul>
-            </footer>`;
+        return html`<ak-empty-state icon="fas fa-check" header=${t`You may close this page now.`}>
+            <span slot="body"> ${t`You've successfully authenticated your device.`} </span>
+        </ak-empty-state>`;
     }
 }

--- a/web/src/flow/stages/RedirectStage.ts
+++ b/web/src/flow/stages/RedirectStage.ts
@@ -64,9 +64,6 @@ export class RedirectStage extends BaseStage<RedirectChallenge, FlowChallengeRes
         // As this wouldn't really be a redirect, show a message that the page can be closed
         // and try to close it ourselves
         if (!url.protocol.startsWith("http")) {
-            setTimeout(() => {
-                window.close();
-            }, 500);
             return html`<ak-empty-state
                 icon="fas fa-check"
                 header=${t`You may close this page now.`}


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details

-   **Does this resolve an issue?**
    Resolves #

## Changes

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
