### PR TITLE
events: cleanse http query string in events

### DIFF
--- a/authentik/events/models.py
+++ b/authentik/events/models.py
@@ -219,13 +219,13 @@ class Event(SerializerModel, ExpiringModel):
             self.context["http_request"] = {
                 "path": request.path,
                 "method": request.method,
-                "args": QueryDict(request.META.get("QUERY_STRING", "")),
+                "args": cleanse_dict(QueryDict(request.META.get("QUERY_STRING", ""))),
             }
             # Special case for events created during flow execution
             # since they keep the http query within a wrapped query
             if QS_QUERY in self.context["http_request"]["args"]:
                 wrapped = self.context["http_request"]["args"][QS_QUERY]
-                self.context["http_request"]["args"] = QueryDict(wrapped)
+                self.context["http_request"]["args"] = cleanse_dict(QueryDict(wrapped))
         if hasattr(request, "tenant"):
             tenant: Tenant = request.tenant
             # Because self.created only gets set on save, we can't use it's value here

--- a/authentik/events/tests/test_event.py
+++ b/authentik/events/tests/test_event.py
@@ -1,16 +1,24 @@
 """event tests"""
+from urllib.parse import urlencode
 
 from django.contrib.contenttypes.models import ContentType
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
+from django.views.debug import SafeExceptionReporterFilter
 from guardian.shortcuts import get_anonymous_user
 
 from authentik.core.models import Group
 from authentik.events.models import Event
+from authentik.flows.views.executor import QS_QUERY
+from authentik.lib.generators import generate_id
 from authentik.policies.dummy.models import DummyPolicy
+from authentik.tenants.models import Tenant
 
 
 class TestEvents(TestCase):
     """Test Event"""
+
+    def setUp(self) -> None:
+        self.factory = RequestFactory()
 
     def test_new_with_model(self):
         """Create a new Event passing a model as kwarg"""
@@ -40,3 +48,58 @@ class TestEvents(TestCase):
         model_content_type = ContentType.objects.get_for_model(temp_model)
         self.assertEqual(event.context.get("model").get("app"), model_content_type.app_label)
         self.assertEqual(event.context.get("model").get("pk"), temp_model.pk.hex)
+
+    def test_from_http_basic(self):
+        """Test plain from_http"""
+        event = Event.new("unittest").from_http(self.factory.get("/"))
+        self.assertEqual(
+            event.context, {"http_request": {"args": {}, "method": "GET", "path": "/"}}
+        )
+
+    def test_from_http_clean_querystring(self):
+        """Test cleansing query string"""
+        request = self.factory.get(f"/?token={generate_id()}")
+        event = Event.new("unittest").from_http(request)
+        self.assertEqual(
+            event.context,
+            {
+                "http_request": {
+                    "args": {"token": SafeExceptionReporterFilter.cleansed_substitute},
+                    "method": "GET",
+                    "path": "/",
+                }
+            },
+        )
+
+    def test_from_http_clean_querystring_flow(self):
+        """Test cleansing query string (nested query string like flow executor)"""
+        nested_qs = {"token": generate_id()}
+        request = self.factory.get(f"/?{QS_QUERY}={urlencode(nested_qs)}")
+        event = Event.new("unittest").from_http(request)
+        self.assertEqual(
+            event.context,
+            {
+                "http_request": {
+                    "args": {"token": SafeExceptionReporterFilter.cleansed_substitute},
+                    "method": "GET",
+                    "path": "/",
+                }
+            },
+        )
+
+    def test_from_http_tenant(self):
+        """Test from_http tenant"""
+        # Test tenant
+        request = self.factory.get("/")
+        tenant = Tenant(domain="test-tenant")
+        setattr(request, "tenant", tenant)
+        event = Event.new("unittest").from_http(request)
+        self.assertEqual(
+            event.tenant,
+            {
+                "app": "authentik_tenants",
+                "model_name": "tenant",
+                "name": "Tenant test-tenant",
+                "pk": tenant.pk.hex,
+            },
+        )


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details

-   Ensures query path in event http_request data is cleansed

## Changes

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
