### PR TITLE
blueprints: specify schema for blueprint metadata

### DIFF
--- a/authentik/blueprints/management/commands/make_blueprint_schema.py
+++ b/authentik/blueprints/management/commands/make_blueprint_schema.py
@@ -40,7 +40,10 @@ class Command(BaseCommand):
                     "$id": "#/properties/metadata",
                     "type": "object",
                     "required": ["name"],
-                    "properties": {"name": {"type": "string"}, "labels": {"type": "object"}},
+                    "properties": {
+                        "name": {"type": "string"},
+                        "labels": {"type": "object", "additionalProperties": {"type": "string"}},
+                    },
                 },
                 "context": {
                     "$id": "#/properties/context",

--- a/blueprints/schema.json
+++ b/blueprints/schema.json
@@ -25,7 +25,10 @@
                     "type": "string"
                 },
                 "labels": {
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 }
             }
         },


### PR DESCRIPTION
authentik assumes the metadata labels of a blueprint are key-value pairs where both key and value are strings, so the schema should enforce that too

# Details

-   **Does this resolve an issue?**
    Resolves #

## Changes

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
