### PR TITLE
*: improve configuration error events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,8 @@ install: web-install website-install
 
 dev-reset:
 	dropdb -U postgres -h localhost authentik
+	# Also remove the test-db if it exists
+	dropdb -U postgres -h localhost test_authentik || true
 	createdb -U postgres -h localhost authentik
 	redis-cli -n 0 flushall
 	make migrate

--- a/authentik/providers/oauth2/tests/test_userinfo.py
+++ b/authentik/providers/oauth2/tests/test_userinfo.py
@@ -92,5 +92,5 @@ class TestUserinfo(OAuthTestCase):
         self.assertTrue(events.exists())
         self.assertEqual(
             events.first().context["message"],
-            "Failed to evaluate property-mapping: name 'q' is not defined",
+            "Failed to evaluate property-mapping: 'test'",
         )

--- a/authentik/providers/oauth2/views/userinfo.py
+++ b/authentik/providers/oauth2/views/userinfo.py
@@ -82,9 +82,11 @@ class UserInfoView(View):
             except PropertyMappingExpressionException as exc:
                 Event.new(
                     EventAction.CONFIGURATION_ERROR,
-                    message=f"Failed to evaluate property-mapping: {str(exc)}",
+                    message=f"Failed to evaluate property-mapping: '{scope.name}'",
+                    provider=provider,
                     mapping=scope,
                 ).from_http(self.request)
+                LOGGER.warning("Failed to evaluate property mapping", exc=exc)
             if value is None:
                 continue
             if not isinstance(value, dict):

--- a/authentik/providers/saml/processors/assertion.py
+++ b/authentik/providers/saml/processors/assertion.py
@@ -108,9 +108,11 @@ class AssertionProcessor:
                 # Value error can be raised when assigning invalid data to an attribute
                 Event.new(
                     EventAction.CONFIGURATION_ERROR,
-                    message=f"Failed to evaluate property-mapping: {str(exc)}",
+                    message=f"Failed to evaluate property-mapping: '{mapping.name}'",
+                    provider=self.provider,
                     mapping=mapping,
                 ).from_http(self.http_request)
+                LOGGER.warning("Failed to evaluate property mapping", exc=exc)
                 continue
         return attribute_statement
 
@@ -185,9 +187,14 @@ class AssertionProcessor:
             except PropertyMappingExpressionException as exc:
                 Event.new(
                     EventAction.CONFIGURATION_ERROR,
-                    message=f"Failed to evaluate property-mapping: {str(exc)}",
+                    message=(
+                        "Failed to evaluate property-mapping: "
+                        f"'{self.provider.name_id_mapping.name}'",
+                    ),
+                    provider=self.provider,
                     mapping=self.provider.name_id_mapping,
                 ).from_http(self.http_request)
+                LOGGER.warning("Failed to evaluate property mapping", exc=exc)
                 return name_id
         if name_id.attrib["Format"] == SAML_NAME_ID_FORMAT_EMAIL:
             name_id.text = self.http_request.user.email

--- a/authentik/providers/saml/tests/test_auth_n_request.py
+++ b/authentik/providers/saml/tests/test_auth_n_request.py
@@ -261,5 +261,5 @@ class TestAuthNRequest(TestCase):
         self.assertTrue(events.exists())
         self.assertEqual(
             events.first().context["message"],
-            "Failed to evaluate property-mapping: name 'q' is not defined",
+            "Failed to evaluate property-mapping: 'test'",
         )

--- a/authentik/sources/ldap/sync/base.py
+++ b/authentik/sources/ldap/sync/base.py
@@ -108,7 +108,8 @@ class BaseLDAPSynchronizer:
             except PropertyMappingExpressionException as exc:
                 Event.new(
                     EventAction.CONFIGURATION_ERROR,
-                    message=f"Failed to evaluate property-mapping: {str(exc)}",
+                    message=f"Failed to evaluate property-mapping: '{mapping.name}'",
+                    source=self._source,
                     mapping=mapping,
                 ).save()
                 self._logger.warning("Mapping failed to evaluate", exc=exc, mapping=mapping)

--- a/authentik/sources/ldap/tests/test_sync.py
+++ b/authentik/sources/ldap/tests/test_sync.py
@@ -56,7 +56,7 @@ class LDAPSyncTests(TestCase):
             self.assertFalse(User.objects.filter(username="user1_sn").exists())
         events = Event.objects.filter(
             action=EventAction.CONFIGURATION_ERROR,
-            context__message="Failed to evaluate property-mapping: name 'q' is not defined",
+            context__message="Failed to evaluate property-mapping: 'name'",
         )
         self.assertTrue(events.exists())
 


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details

Makes configuration_error events that are caused by property_mapping_exceptions more useful

instead of having two events with the error message, the configuration_error event includes the mapping's name, and also includes the provider/source and mapping in the context

## Changes

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
