### PR TITLE
events: include event user in webhook notification

### DIFF
--- a/authentik/events/models.py
+++ b/authentik/events/models.py
@@ -353,6 +353,9 @@ class NotificationTransport(SerializerModel):
             "user_email": notification.user.email,
             "user_username": notification.user.username,
         }
+        if notification.event and notification.event.user:
+            default_body["event_user_email"] = notification.event.user.get("email", None)
+            default_body["event_user_username"] = notification.event.user.get("username", None)
         if self.webhook_mapping:
             default_body = sanitize_item(
                 self.webhook_mapping.evaluate(
@@ -437,7 +440,13 @@ class NotificationTransport(SerializerModel):
     def send_email(self, notification: "Notification") -> list[str]:
         """Send notification via global email configuration"""
         subject = "authentik Notification: "
-        key_value = {}
+        key_value = {
+            "user_email": notification.user.email,
+            "user_username": notification.user.username,
+        }
+        if notification.event and notification.event.user:
+            key_value["event_user_email"] = notification.event.user.get("email", None)
+            key_value["event_user_username"] = notification.event.user.get("username", None)
         if notification.event:
             subject += notification.event.action
             for key, value in notification.event.context.items():

--- a/authentik/events/models.py
+++ b/authentik/events/models.py
@@ -391,6 +391,14 @@ class NotificationTransport(SerializerModel):
             },
         ]
         if notification.event:
+            if notification.event.user:
+                fields.append(
+                    {
+                        "title": _("Event user"),
+                        "value": str(notification.event.user.get("username")),
+                        "short": True,
+                    },
+                )
             for key, value in notification.event.context.items():
                 if not isinstance(value, str):
                     continue

--- a/authentik/events/tests/test_transports.py
+++ b/authentik/events/tests/test_transports.py
@@ -52,6 +52,8 @@ class TestEventTransports(TestCase):
                     "severity": "alert",
                     "user_email": self.user.email,
                     "user_username": self.user.username,
+                    "event_user_email": self.user.email,
+                    "event_user_username": self.user.username,
                 },
             )
 

--- a/authentik/events/tests/test_transports.py
+++ b/authentik/events/tests/test_transports.py
@@ -107,6 +107,7 @@ class TestEventTransports(TestCase):
                                     "value": self.user.username,
                                     "short": True,
                                 },
+                                {"short": True, "title": "Event user", "value": self.user.username},
                                 {"title": "foo", "value": "bar,"},
                             ],
                             "footer": f"authentik {get_full_version()}",

--- a/authentik/providers/oauth2/tests/utils.py
+++ b/authentik/providers/oauth2/tests/utils.py
@@ -25,7 +25,6 @@ class OAuthTestCase(TestCase):
     def setUpClass(cls) -> None:
         cls.keypair = create_test_cert()
         super().setUpClass()
-        cls.maxDiff = None
 
     def assert_non_none_or_unset(self, container: dict, key: str):
         """Check that a key, if set, is not none"""

--- a/authentik/root/test_runner.py
+++ b/authentik/root/test_runner.py
@@ -8,6 +8,7 @@ from authentik.lib.config import CONFIG
 from authentik.lib.sentry import sentry_init
 from tests.e2e.utils import get_docker_tag
 
+# globally set maxDiff to none to show full assert error
 TestCase.maxDiff = None
 
 

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -54,8 +54,6 @@ class SeleniumTestCase(StaticLiveServerTestCase):
         if IS_CI:
             print("::group::authentik Logs", file=stderr)
         super().setUp()
-        # pylint: disable=invalid-name
-        self.maxDiff = None
         self.wait_timeout = 60
         self.driver = self._get_driver()
         self.driver.implicitly_wait(30)

--- a/website/docs/events/transports.md
+++ b/website/docs/events/transports.md
@@ -12,8 +12,12 @@ This will send a POST request to the given URL with the following contents:
 {
     "body": "body of the notification message",
     "severity": "severity level as configured in the trigger",
-    "user_email": "user's email",
-    "user_username": "user's username"
+    // User that the notification was created for, i.e. a member of the group selected in the rule
+    "user_email": "notification user's email",
+    "user_username": "notification user's username",
+    // User that created the event
+    "event_user_email": "event user's email",
+    "event_user_username": "event user's username"
 }
 ```
 


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details

The notification currently only has the user the notification was dispatched for, not the user the event was created for

## Changes

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
