### PR TITLE
web/admin: remove redundant markdown notice

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-05 20:11+0000\n"
+"POT-Creation-Date: 2023-05-08 12:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -293,7 +293,7 @@ msgstr ""
 msgid "You're about to sign into %(application)s."
 msgstr ""
 
-#: authentik/crypto/api.py:178
+#: authentik/crypto/api.py:179
 msgid "Subject-alt name"
 msgstr ""
 

--- a/web/src/admin/groups/GroupViewPage.ts
+++ b/web/src/admin/groups/GroupViewPage.ts
@@ -143,7 +143,7 @@ export class GroupViewPage extends AKElement {
                                 ? html`${this.group.attributes?.notes}`
                                 : html`
                                       <p>
-                                          ${t`Edit the notes attribute of this group to add notes here. Markdown is supported.`}
+                                          ${t`Edit the notes attribute of this group to add notes here.`}
                                       </p>
                                   `}
                         </div>

--- a/web/src/admin/users/UserViewPage.ts
+++ b/web/src/admin/users/UserViewPage.ts
@@ -288,7 +288,7 @@ export class UserViewPage extends AKElement {
                                 ? html`${this.user.attributes?.notes}`
                                 : html`
                                       <p>
-                                          ${t`Edit the notes attribute of this user to add notes here. Markdown is supported.`}
+                                          ${t`Edit the notes attribute of this user to add notes here.`}
                                       </p>
                                   `}
                         </div>

--- a/web/src/locales/de.po
+++ b/web/src/locales/de.po
@@ -2353,12 +2353,20 @@ msgid "Edit Stage"
 msgstr "Stufe bearbeiten"
 
 #: src/admin/groups/GroupViewPage.ts
-msgid "Edit the notes attribute of this group to add notes here. Markdown is supported."
+msgid "Edit the notes attribute of this group to add notes here."
+msgstr ""
+
+#: src/admin/groups/GroupViewPage.ts
+#~ msgid "Edit the notes attribute of this group to add notes here. Markdown is supported."
+#~ msgstr ""
+
+#: src/admin/users/UserViewPage.ts
+msgid "Edit the notes attribute of this user to add notes here."
 msgstr ""
 
 #: src/admin/users/UserViewPage.ts
-msgid "Edit the notes attribute of this user to add notes here. Markdown is supported."
-msgstr ""
+#~ msgid "Edit the notes attribute of this user to add notes here. Markdown is supported."
+#~ msgstr ""
 
 #: src/admin/policies/BoundPoliciesList.ts
 msgid "Edit User"
@@ -8037,13 +8045,14 @@ msgid "Yes ({0})"
 msgstr "Ja ({0})"
 
 #: src/flow/providers/oauth2/DeviceCodeFinish.ts
-msgid "You can close this tab now."
-msgstr ""
+#~ msgid "You can close this tab now."
+#~ msgstr ""
 
 #: src/admin/outposts/OutpostForm.ts
 msgid "You can only select providers that match the type of the outpost."
 msgstr "Sie können nur Anbieter auswählen, die zum Typ des Outposts passen."
 
+#: src/flow/providers/oauth2/DeviceCodeFinish.ts
 #: src/flow/stages/RedirectStage.ts
 msgid "You may close this page now."
 msgstr ""

--- a/web/src/locales/en.po
+++ b/web/src/locales/en.po
@@ -2375,12 +2375,20 @@ msgid "Edit Stage"
 msgstr "Edit Stage"
 
 #: src/admin/groups/GroupViewPage.ts
-msgid "Edit the notes attribute of this group to add notes here. Markdown is supported."
-msgstr "Edit the notes attribute of this group to add notes here. Markdown is supported."
+msgid "Edit the notes attribute of this group to add notes here."
+msgstr "Edit the notes attribute of this group to add notes here."
+
+#: src/admin/groups/GroupViewPage.ts
+#~ msgid "Edit the notes attribute of this group to add notes here. Markdown is supported."
+#~ msgstr "Edit the notes attribute of this group to add notes here. Markdown is supported."
 
 #: src/admin/users/UserViewPage.ts
-msgid "Edit the notes attribute of this user to add notes here. Markdown is supported."
-msgstr "Edit the notes attribute of this user to add notes here. Markdown is supported."
+msgid "Edit the notes attribute of this user to add notes here."
+msgstr "Edit the notes attribute of this user to add notes here."
+
+#: src/admin/users/UserViewPage.ts
+#~ msgid "Edit the notes attribute of this user to add notes here. Markdown is supported."
+#~ msgstr "Edit the notes attribute of this user to add notes here. Markdown is supported."
 
 #: src/admin/policies/BoundPoliciesList.ts
 msgid "Edit User"
@@ -8212,13 +8220,14 @@ msgid "Yes ({0})"
 msgstr "Yes ({0})"
 
 #: src/flow/providers/oauth2/DeviceCodeFinish.ts
-msgid "You can close this tab now."
-msgstr "You can close this tab now."
+#~ msgid "You can close this tab now."
+#~ msgstr "You can close this tab now."
 
 #: src/admin/outposts/OutpostForm.ts
 msgid "You can only select providers that match the type of the outpost."
 msgstr "You can only select providers that match the type of the outpost."
 
+#: src/flow/providers/oauth2/DeviceCodeFinish.ts
 #: src/flow/stages/RedirectStage.ts
 msgid "You may close this page now."
 msgstr "You may close this page now."

--- a/web/src/locales/es.po
+++ b/web/src/locales/es.po
@@ -2329,12 +2329,20 @@ msgid "Edit Stage"
 msgstr "Editar etapa"
 
 #: src/admin/groups/GroupViewPage.ts
-msgid "Edit the notes attribute of this group to add notes here. Markdown is supported."
+msgid "Edit the notes attribute of this group to add notes here."
+msgstr ""
+
+#: src/admin/groups/GroupViewPage.ts
+#~ msgid "Edit the notes attribute of this group to add notes here. Markdown is supported."
+#~ msgstr ""
+
+#: src/admin/users/UserViewPage.ts
+msgid "Edit the notes attribute of this user to add notes here."
 msgstr ""
 
 #: src/admin/users/UserViewPage.ts
-msgid "Edit the notes attribute of this user to add notes here. Markdown is supported."
-msgstr ""
+#~ msgid "Edit the notes attribute of this user to add notes here. Markdown is supported."
+#~ msgstr ""
 
 #: src/admin/policies/BoundPoliciesList.ts
 msgid "Edit User"
@@ -8013,13 +8021,14 @@ msgid "Yes ({0})"
 msgstr "Sí ({0})"
 
 #: src/flow/providers/oauth2/DeviceCodeFinish.ts
-msgid "You can close this tab now."
-msgstr ""
+#~ msgid "You can close this tab now."
+#~ msgstr ""
 
 #: src/admin/outposts/OutpostForm.ts
 msgid "You can only select providers that match the type of the outpost."
 msgstr "Solo puede seleccionar proveedores que coincidan con el tipo de puesto avanzado."
 
+#: src/flow/providers/oauth2/DeviceCodeFinish.ts
 #: src/flow/stages/RedirectStage.ts
 msgid "You may close this page now."
 msgstr ""

--- a/web/src/locales/fr_FR.po
+++ b/web/src/locales/fr_FR.po
@@ -2332,12 +2332,20 @@ msgid "Edit Stage"
 msgstr "Éditer l'étap"
 
 #: src/admin/groups/GroupViewPage.ts
-msgid "Edit the notes attribute of this group to add notes here. Markdown is supported."
+msgid "Edit the notes attribute of this group to add notes here."
+msgstr ""
+
+#: src/admin/groups/GroupViewPage.ts
+#~ msgid "Edit the notes attribute of this group to add notes here. Markdown is supported."
+#~ msgstr ""
+
+#: src/admin/users/UserViewPage.ts
+msgid "Edit the notes attribute of this user to add notes here."
 msgstr ""
 
 #: src/admin/users/UserViewPage.ts
-msgid "Edit the notes attribute of this user to add notes here. Markdown is supported."
-msgstr ""
+#~ msgid "Edit the notes attribute of this user to add notes here. Markdown is supported."
+#~ msgstr ""
 
 #: src/admin/policies/BoundPoliciesList.ts
 msgid "Edit User"
@@ -8002,13 +8010,14 @@ msgid "Yes ({0})"
 msgstr "Oui ({0})"
 
 #: src/flow/providers/oauth2/DeviceCodeFinish.ts
-msgid "You can close this tab now."
-msgstr ""
+#~ msgid "You can close this tab now."
+#~ msgstr ""
 
 #: src/admin/outposts/OutpostForm.ts
 msgid "You can only select providers that match the type of the outpost."
 msgstr "Vous pouvez uniquement sélectionner des fournisseurs qui correspondent au type d'avant-poste."
 
+#: src/flow/providers/oauth2/DeviceCodeFinish.ts
 #: src/flow/stages/RedirectStage.ts
 msgid "You may close this page now."
 msgstr ""

--- a/web/src/locales/pl.po
+++ b/web/src/locales/pl.po
@@ -2335,12 +2335,20 @@ msgid "Edit Stage"
 msgstr "Edytuj etap"
 
 #: src/admin/groups/GroupViewPage.ts
-msgid "Edit the notes attribute of this group to add notes here. Markdown is supported."
+msgid "Edit the notes attribute of this group to add notes here."
+msgstr ""
+
+#: src/admin/groups/GroupViewPage.ts
+#~ msgid "Edit the notes attribute of this group to add notes here. Markdown is supported."
+#~ msgstr ""
+
+#: src/admin/users/UserViewPage.ts
+msgid "Edit the notes attribute of this user to add notes here."
 msgstr ""
 
 #: src/admin/users/UserViewPage.ts
-msgid "Edit the notes attribute of this user to add notes here. Markdown is supported."
-msgstr ""
+#~ msgid "Edit the notes attribute of this user to add notes here. Markdown is supported."
+#~ msgstr ""
 
 #: src/admin/policies/BoundPoliciesList.ts
 msgid "Edit User"
@@ -8025,13 +8033,14 @@ msgid "Yes ({0})"
 msgstr "Tak ({0})"
 
 #: src/flow/providers/oauth2/DeviceCodeFinish.ts
-msgid "You can close this tab now."
-msgstr ""
+#~ msgid "You can close this tab now."
+#~ msgstr ""
 
 #: src/admin/outposts/OutpostForm.ts
 msgid "You can only select providers that match the type of the outpost."
 msgstr "Możesz wybrać tylko tych dostawców, którzy pasują do typu placówki."
 
+#: src/flow/providers/oauth2/DeviceCodeFinish.ts
 #: src/flow/stages/RedirectStage.ts
 msgid "You may close this page now."
 msgstr ""

--- a/web/src/locales/pseudo-LOCALE.po
+++ b/web/src/locales/pseudo-LOCALE.po
@@ -2361,12 +2361,20 @@ msgid "Edit Stage"
 msgstr ""
 
 #: src/admin/groups/GroupViewPage.ts
-msgid "Edit the notes attribute of this group to add notes here. Markdown is supported."
+msgid "Edit the notes attribute of this group to add notes here."
+msgstr ""
+
+#: src/admin/groups/GroupViewPage.ts
+#~ msgid "Edit the notes attribute of this group to add notes here. Markdown is supported."
+#~ msgstr ""
+
+#: src/admin/users/UserViewPage.ts
+msgid "Edit the notes attribute of this user to add notes here."
 msgstr ""
 
 #: src/admin/users/UserViewPage.ts
-msgid "Edit the notes attribute of this user to add notes here. Markdown is supported."
-msgstr ""
+#~ msgid "Edit the notes attribute of this user to add notes here. Markdown is supported."
+#~ msgstr ""
 
 #: src/admin/policies/BoundPoliciesList.ts
 msgid "Edit User"
@@ -8160,13 +8168,14 @@ msgid "Yes ({0})"
 msgstr ""
 
 #: src/flow/providers/oauth2/DeviceCodeFinish.ts
-msgid "You can close this tab now."
-msgstr ""
+#~ msgid "You can close this tab now."
+#~ msgstr ""
 
 #: src/admin/outposts/OutpostForm.ts
 msgid "You can only select providers that match the type of the outpost."
 msgstr ""
 
+#: src/flow/providers/oauth2/DeviceCodeFinish.ts
 #: src/flow/stages/RedirectStage.ts
 msgid "You may close this page now."
 msgstr ""

--- a/web/src/locales/tr.po
+++ b/web/src/locales/tr.po
@@ -2329,12 +2329,20 @@ msgid "Edit Stage"
 msgstr "Aşama Alanını Düzenle"
 
 #: src/admin/groups/GroupViewPage.ts
-msgid "Edit the notes attribute of this group to add notes here. Markdown is supported."
+msgid "Edit the notes attribute of this group to add notes here."
+msgstr ""
+
+#: src/admin/groups/GroupViewPage.ts
+#~ msgid "Edit the notes attribute of this group to add notes here. Markdown is supported."
+#~ msgstr ""
+
+#: src/admin/users/UserViewPage.ts
+msgid "Edit the notes attribute of this user to add notes here."
 msgstr ""
 
 #: src/admin/users/UserViewPage.ts
-msgid "Edit the notes attribute of this user to add notes here. Markdown is supported."
-msgstr ""
+#~ msgid "Edit the notes attribute of this user to add notes here. Markdown is supported."
+#~ msgstr ""
 
 #: src/admin/policies/BoundPoliciesList.ts
 msgid "Edit User"
@@ -8013,13 +8021,14 @@ msgid "Yes ({0})"
 msgstr "Evet ({0})"
 
 #: src/flow/providers/oauth2/DeviceCodeFinish.ts
-msgid "You can close this tab now."
-msgstr ""
+#~ msgid "You can close this tab now."
+#~ msgstr ""
 
 #: src/admin/outposts/OutpostForm.ts
 msgid "You can only select providers that match the type of the outpost."
 msgstr "Yalnızca üssün türüne uyan sağlayıcıları seçebilirsiniz."
 
+#: src/flow/providers/oauth2/DeviceCodeFinish.ts
 #: src/flow/stages/RedirectStage.ts
 msgid "You may close this page now."
 msgstr ""

--- a/web/src/locales/zh-Hans.po
+++ b/web/src/locales/zh-Hans.po
@@ -2288,12 +2288,20 @@ msgid "Edit Stage"
 msgstr "编辑阶段"
 
 #: src/admin/groups/GroupViewPage.ts
-msgid "Edit the notes attribute of this group to add notes here. Markdown is supported."
-msgstr "编辑该组的备注属性以在此处添加备注。支持 Markdown。"
+msgid "Edit the notes attribute of this group to add notes here."
+msgstr ""
+
+#: src/admin/groups/GroupViewPage.ts
+#~ msgid "Edit the notes attribute of this group to add notes here. Markdown is supported."
+#~ msgstr "编辑该组的备注属性以在此处添加备注。支持 Markdown。"
 
 #: src/admin/users/UserViewPage.ts
-msgid "Edit the notes attribute of this user to add notes here. Markdown is supported."
-msgstr "编辑该用户的备注属性以在此处添加备注。支持 Markdown。"
+msgid "Edit the notes attribute of this user to add notes here."
+msgstr ""
+
+#: src/admin/users/UserViewPage.ts
+#~ msgid "Edit the notes attribute of this user to add notes here. Markdown is supported."
+#~ msgstr "编辑该用户的备注属性以在此处添加备注。支持 Markdown。"
 
 #: src/admin/policies/BoundPoliciesList.ts
 msgid "Edit User"
@@ -7918,13 +7926,14 @@ msgid "Yes ({0})"
 msgstr "是（{0}）"
 
 #: src/flow/providers/oauth2/DeviceCodeFinish.ts
-msgid "You can close this tab now."
-msgstr "您可以关闭此标签页了。"
+#~ msgid "You can close this tab now."
+#~ msgstr "您可以关闭此标签页了。"
 
 #: src/admin/outposts/OutpostForm.ts
 msgid "You can only select providers that match the type of the outpost."
 msgstr "您只能选择与前哨类型匹配的提供程序。"
 
+#: src/flow/providers/oauth2/DeviceCodeFinish.ts
 #: src/flow/stages/RedirectStage.ts
 msgid "You may close this page now."
 msgstr ""

--- a/web/src/locales/zh-Hant.po
+++ b/web/src/locales/zh-Hant.po
@@ -2337,12 +2337,20 @@ msgid "Edit Stage"
 msgstr "编辑 Stage"
 
 #: src/admin/groups/GroupViewPage.ts
-msgid "Edit the notes attribute of this group to add notes here. Markdown is supported."
+msgid "Edit the notes attribute of this group to add notes here."
+msgstr ""
+
+#: src/admin/groups/GroupViewPage.ts
+#~ msgid "Edit the notes attribute of this group to add notes here. Markdown is supported."
+#~ msgstr ""
+
+#: src/admin/users/UserViewPage.ts
+msgid "Edit the notes attribute of this user to add notes here."
 msgstr ""
 
 #: src/admin/users/UserViewPage.ts
-msgid "Edit the notes attribute of this user to add notes here. Markdown is supported."
-msgstr ""
+#~ msgid "Edit the notes attribute of this user to add notes here. Markdown is supported."
+#~ msgstr ""
 
 #: src/admin/policies/BoundPoliciesList.ts
 msgid "Edit User"
@@ -8023,13 +8031,14 @@ msgid "Yes ({0})"
 msgstr "Yes ({0})"
 
 #: src/flow/providers/oauth2/DeviceCodeFinish.ts
-msgid "You can close this tab now."
-msgstr ""
+#~ msgid "You can close this tab now."
+#~ msgstr ""
 
 #: src/admin/outposts/OutpostForm.ts
 msgid "You can only select providers that match the type of the outpost."
 msgstr "您只能选择与 Outpost 类型匹配的提供商。"
 
+#: src/flow/providers/oauth2/DeviceCodeFinish.ts
 #: src/flow/stages/RedirectStage.ts
 msgid "You may close this page now."
 msgstr ""

--- a/web/src/locales/zh_TW.po
+++ b/web/src/locales/zh_TW.po
@@ -2337,12 +2337,20 @@ msgid "Edit Stage"
 msgstr "编辑 Stage"
 
 #: src/admin/groups/GroupViewPage.ts
-msgid "Edit the notes attribute of this group to add notes here. Markdown is supported."
+msgid "Edit the notes attribute of this group to add notes here."
+msgstr ""
+
+#: src/admin/groups/GroupViewPage.ts
+#~ msgid "Edit the notes attribute of this group to add notes here. Markdown is supported."
+#~ msgstr ""
+
+#: src/admin/users/UserViewPage.ts
+msgid "Edit the notes attribute of this user to add notes here."
 msgstr ""
 
 #: src/admin/users/UserViewPage.ts
-msgid "Edit the notes attribute of this user to add notes here. Markdown is supported."
-msgstr ""
+#~ msgid "Edit the notes attribute of this user to add notes here. Markdown is supported."
+#~ msgstr ""
 
 #: src/admin/policies/BoundPoliciesList.ts
 msgid "Edit User"
@@ -8023,13 +8031,14 @@ msgid "Yes ({0})"
 msgstr "Yes ({0})"
 
 #: src/flow/providers/oauth2/DeviceCodeFinish.ts
-msgid "You can close this tab now."
-msgstr ""
+#~ msgid "You can close this tab now."
+#~ msgstr ""
 
 #: src/admin/outposts/OutpostForm.ts
 msgid "You can only select providers that match the type of the outpost."
 msgstr "您只能选择与 Outpost 类型匹配的提供商。"
 
+#: src/flow/providers/oauth2/DeviceCodeFinish.ts
 #: src/flow/stages/RedirectStage.ts
 msgid "You may close this page now."
 msgstr ""


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details

Initially it was planned to have markdown support in the note fields for users and groups, but due to potential XSS and other security concerns we didn't do that, so remove the notice that it is supported

## Changes

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)
-   [x] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
