### PR TITLE
api: modular urls

### DIFF
--- a/authentik/admin/urls.py
+++ b/authentik/admin/urls.py
@@ -1,0 +1,22 @@
+"""API URLs"""
+from django.urls import path
+
+from authentik.admin.api.meta import AppsViewSet
+from authentik.admin.api.metrics import AdministrationMetricsViewSet
+from authentik.admin.api.system import SystemView
+from authentik.admin.api.tasks import TaskViewSet
+from authentik.admin.api.version import VersionView
+from authentik.admin.api.workers import WorkerView
+
+api_urlpatterns = [
+    ("admin/system_tasks", TaskViewSet, "admin_system_tasks"),
+    ("admin/apps", AppsViewSet, "apps"),
+    path(
+        "admin/metrics/",
+        AdministrationMetricsViewSet.as_view(),
+        name="admin_metrics",
+    ),
+    path("admin/version/", VersionView.as_view(), name="admin_version"),
+    path("admin/workers/", WorkerView.as_view(), name="admin_workers"),
+    path("admin/system/", SystemView.as_view(), name="admin_system"),
+]

--- a/authentik/api/v3/urls.py
+++ b/authentik/api/v3/urls.py
@@ -21,7 +21,7 @@ _other_urls = []
 for _authentik_app in get_apps():
     try:
         api_urls = import_module(f"{_authentik_app.name}.urls")
-    except ModuleNotFoundError:
+    except (ModuleNotFoundError, ImportError):
         continue
     if not hasattr(api_urls, "api_urlpatterns"):
         continue

--- a/authentik/api/v3/urls.py
+++ b/authentik/api/v3/urls.py
@@ -1,269 +1,50 @@
 """api v3 urls"""
+from importlib import import_module
+
 from django.urls import path
+from django.urls.resolvers import URLPattern
 from django.views.decorators.cache import cache_page
 from drf_spectacular.views import SpectacularAPIView
 from rest_framework import routers
+from structlog.stdlib import get_logger
 
-from authentik.admin.api.meta import AppsViewSet
-from authentik.admin.api.metrics import AdministrationMetricsViewSet
-from authentik.admin.api.system import SystemView
-from authentik.admin.api.tasks import TaskViewSet
-from authentik.admin.api.version import VersionView
-from authentik.admin.api.workers import WorkerView
 from authentik.api.v3.config import ConfigView
 from authentik.api.views import APIBrowserView
-from authentik.blueprints.api import BlueprintInstanceViewSet
-from authentik.core.api.applications import ApplicationViewSet
-from authentik.core.api.authenticated_sessions import AuthenticatedSessionViewSet
-from authentik.core.api.devices import AdminDeviceViewSet, DeviceViewSet
-from authentik.core.api.groups import GroupViewSet
-from authentik.core.api.propertymappings import PropertyMappingViewSet
-from authentik.core.api.providers import ProviderViewSet
-from authentik.core.api.sources import SourceViewSet, UserSourceConnectionViewSet
-from authentik.core.api.tokens import TokenViewSet
-from authentik.core.api.users import UserViewSet
-from authentik.crypto.api import CertificateKeyPairViewSet
-from authentik.events.api.events import EventViewSet
-from authentik.events.api.notification_mappings import NotificationWebhookMappingViewSet
-from authentik.events.api.notification_rules import NotificationRuleViewSet
-from authentik.events.api.notification_transports import NotificationTransportViewSet
-from authentik.events.api.notifications import NotificationViewSet
-from authentik.flows.api.bindings import FlowStageBindingViewSet
-from authentik.flows.api.flows import FlowViewSet
-from authentik.flows.api.stages import StageViewSet
-from authentik.flows.views.executor import FlowExecutorView
-from authentik.flows.views.inspector import FlowInspectorView
-from authentik.outposts.api.outposts import OutpostViewSet
-from authentik.outposts.api.service_connections import (
-    DockerServiceConnectionViewSet,
-    KubernetesServiceConnectionViewSet,
-    ServiceConnectionViewSet,
-)
-from authentik.policies.api.bindings import PolicyBindingViewSet
-from authentik.policies.api.policies import PolicyViewSet
-from authentik.policies.dummy.api import DummyPolicyViewSet
-from authentik.policies.event_matcher.api import EventMatcherPolicyViewSet
-from authentik.policies.expiry.api import PasswordExpiryPolicyViewSet
-from authentik.policies.expression.api import ExpressionPolicyViewSet
-from authentik.policies.password.api import PasswordPolicyViewSet
-from authentik.policies.reputation.api import ReputationPolicyViewSet, ReputationViewSet
-from authentik.providers.ldap.api import LDAPOutpostConfigViewSet, LDAPProviderViewSet
-from authentik.providers.oauth2.api.providers import OAuth2ProviderViewSet
-from authentik.providers.oauth2.api.scopes import ScopeMappingViewSet
-from authentik.providers.oauth2.api.tokens import (
-    AccessTokenViewSet,
-    AuthorizationCodeViewSet,
-    RefreshTokenViewSet,
-)
-from authentik.providers.proxy.api import ProxyOutpostConfigViewSet, ProxyProviderViewSet
-from authentik.providers.radius.api import RadiusOutpostConfigViewSet, RadiusProviderViewSet
-from authentik.providers.saml.api.property_mapping import SAMLPropertyMappingViewSet
-from authentik.providers.saml.api.providers import SAMLProviderViewSet
-from authentik.providers.scim.api.property_mapping import SCIMMappingViewSet
-from authentik.providers.scim.api.providers import SCIMProviderViewSet
-from authentik.sources.ldap.api import LDAPPropertyMappingViewSet, LDAPSourceViewSet
-from authentik.sources.oauth.api.source import OAuthSourceViewSet
-from authentik.sources.oauth.api.source_connection import UserOAuthSourceConnectionViewSet
-from authentik.sources.plex.api.source import PlexSourceViewSet
-from authentik.sources.plex.api.source_connection import PlexSourceConnectionViewSet
-from authentik.sources.saml.api.source import SAMLSourceViewSet
-from authentik.sources.saml.api.source_connection import UserSAMLSourceConnectionViewSet
-from authentik.stages.authenticator_duo.api import (
-    AuthenticatorDuoStageViewSet,
-    DuoAdminDeviceViewSet,
-    DuoDeviceViewSet,
-)
-from authentik.stages.authenticator_sms.api import (
-    AuthenticatorSMSStageViewSet,
-    SMSAdminDeviceViewSet,
-    SMSDeviceViewSet,
-)
-from authentik.stages.authenticator_static.api import (
-    AuthenticatorStaticStageViewSet,
-    StaticAdminDeviceViewSet,
-    StaticDeviceViewSet,
-)
-from authentik.stages.authenticator_totp.api import (
-    AuthenticatorTOTPStageViewSet,
-    TOTPAdminDeviceViewSet,
-    TOTPDeviceViewSet,
-)
-from authentik.stages.authenticator_validate.api import AuthenticatorValidateStageViewSet
-from authentik.stages.authenticator_webauthn.api import (
-    AuthenticateWebAuthnStageViewSet,
-    WebAuthnAdminDeviceViewSet,
-    WebAuthnDeviceViewSet,
-)
-from authentik.stages.captcha.api import CaptchaStageViewSet
-from authentik.stages.consent.api import ConsentStageViewSet, UserConsentViewSet
-from authentik.stages.deny.api import DenyStageViewSet
-from authentik.stages.dummy.api import DummyStageViewSet
-from authentik.stages.email.api import EmailStageViewSet
-from authentik.stages.identification.api import IdentificationStageViewSet
-from authentik.stages.invitation.api import InvitationStageViewSet, InvitationViewSet
-from authentik.stages.password.api import PasswordStageViewSet
-from authentik.stages.prompt.api import PromptStageViewSet, PromptViewSet
-from authentik.stages.user_delete.api import UserDeleteStageViewSet
-from authentik.stages.user_login.api import UserLoginStageViewSet
-from authentik.stages.user_logout.api import UserLogoutStageViewSet
-from authentik.stages.user_write.api import UserWriteStageViewSet
-from authentik.tenants.api import TenantViewSet
+from authentik.lib.utils.reflection import get_apps
+
+LOGGER = get_logger()
 
 router = routers.DefaultRouter()
 router.include_format_suffixes = False
 
-router.register("admin/system_tasks", TaskViewSet, basename="admin_system_tasks")
-router.register("admin/apps", AppsViewSet, basename="apps")
+_other_urls = []
+for _authentik_app in get_apps():
+    try:
+        api_urls = import_module(f"{_authentik_app.name}.urls")
+    except ModuleNotFoundError:
+        continue
+    if not hasattr(api_urls, "api_urlpatterns"):
+        continue
+    urls: list = getattr(api_urls, "api_urlpatterns")
+    for url in urls:
+        if isinstance(url, URLPattern):
+            _other_urls.append(url)
+        else:
+            router.register(*url)
+    LOGGER.debug(
+        "Mounted API URLs",
+        app_name=_authentik_app.name,
+    )
 
-router.register("core/authenticated_sessions", AuthenticatedSessionViewSet)
-router.register("core/applications", ApplicationViewSet)
-router.register("core/groups", GroupViewSet)
-router.register("core/users", UserViewSet)
-router.register("core/user_consent", UserConsentViewSet)
-router.register("core/tokens", TokenViewSet)
-router.register("core/tenants", TenantViewSet)
-
-router.register("outposts/instances", OutpostViewSet)
-router.register("outposts/service_connections/all", ServiceConnectionViewSet)
-router.register("outposts/service_connections/docker", DockerServiceConnectionViewSet)
-router.register("outposts/service_connections/kubernetes", KubernetesServiceConnectionViewSet)
-router.register("outposts/proxy", ProxyOutpostConfigViewSet)
-router.register("outposts/ldap", LDAPOutpostConfigViewSet)
-router.register("outposts/radius", RadiusOutpostConfigViewSet)
-
-router.register("flows/instances", FlowViewSet)
-router.register("flows/bindings", FlowStageBindingViewSet)
-
-router.register("crypto/certificatekeypairs", CertificateKeyPairViewSet)
-
-router.register("events/events", EventViewSet)
-router.register("events/notifications", NotificationViewSet)
-router.register("events/transports", NotificationTransportViewSet)
-router.register("events/rules", NotificationRuleViewSet)
-
-router.register("managed/blueprints", BlueprintInstanceViewSet)
-
-router.register("sources/all", SourceViewSet)
-router.register("sources/user_connections/all", UserSourceConnectionViewSet)
-router.register("sources/user_connections/oauth", UserOAuthSourceConnectionViewSet)
-router.register("sources/user_connections/plex", PlexSourceConnectionViewSet)
-router.register("sources/user_connections/saml", UserSAMLSourceConnectionViewSet)
-router.register("sources/ldap", LDAPSourceViewSet)
-router.register("sources/saml", SAMLSourceViewSet)
-router.register("sources/oauth", OAuthSourceViewSet)
-router.register("sources/plex", PlexSourceViewSet)
-
-router.register("policies/all", PolicyViewSet)
-router.register("policies/bindings", PolicyBindingViewSet)
-router.register("policies/expression", ExpressionPolicyViewSet)
-router.register("policies/event_matcher", EventMatcherPolicyViewSet)
-router.register("policies/password_expiry", PasswordExpiryPolicyViewSet)
-router.register("policies/password", PasswordPolicyViewSet)
-router.register("policies/reputation/scores", ReputationViewSet)
-router.register("policies/reputation", ReputationPolicyViewSet)
-
-router.register("providers/all", ProviderViewSet)
-router.register("providers/ldap", LDAPProviderViewSet)
-router.register("providers/proxy", ProxyProviderViewSet)
-router.register("providers/oauth2", OAuth2ProviderViewSet)
-router.register("providers/saml", SAMLProviderViewSet)
-router.register("providers/scim", SCIMProviderViewSet)
-router.register("providers/radius", RadiusProviderViewSet)
-
-router.register("oauth2/authorization_codes", AuthorizationCodeViewSet)
-router.register("oauth2/refresh_tokens", RefreshTokenViewSet)
-router.register("oauth2/access_tokens", AccessTokenViewSet)
-
-router.register("propertymappings/all", PropertyMappingViewSet)
-router.register("propertymappings/ldap", LDAPPropertyMappingViewSet)
-router.register("propertymappings/saml", SAMLPropertyMappingViewSet)
-router.register("propertymappings/scope", ScopeMappingViewSet)
-router.register("propertymappings/notification", NotificationWebhookMappingViewSet)
-router.register("propertymappings/scim", SCIMMappingViewSet)
-
-router.register("authenticators/all", DeviceViewSet, basename="device")
-router.register("authenticators/duo", DuoDeviceViewSet)
-router.register("authenticators/sms", SMSDeviceViewSet)
-router.register("authenticators/static", StaticDeviceViewSet)
-router.register("authenticators/totp", TOTPDeviceViewSet)
-router.register("authenticators/webauthn", WebAuthnDeviceViewSet)
-router.register(
-    "authenticators/admin/all",
-    AdminDeviceViewSet,
-    basename="admin-device",
-)
-router.register(
-    "authenticators/admin/duo",
-    DuoAdminDeviceViewSet,
-    basename="admin-duodevice",
-)
-router.register(
-    "authenticators/admin/sms",
-    SMSAdminDeviceViewSet,
-    basename="admin-smsdevice",
-)
-router.register(
-    "authenticators/admin/static",
-    StaticAdminDeviceViewSet,
-    basename="admin-staticdevice",
-)
-router.register("authenticators/admin/totp", TOTPAdminDeviceViewSet, basename="admin-totpdevice")
-router.register(
-    "authenticators/admin/webauthn",
-    WebAuthnAdminDeviceViewSet,
-    basename="admin-webauthndevice",
-)
-
-router.register("stages/all", StageViewSet)
-router.register("stages/authenticator/duo", AuthenticatorDuoStageViewSet)
-router.register("stages/authenticator/sms", AuthenticatorSMSStageViewSet)
-router.register("stages/authenticator/static", AuthenticatorStaticStageViewSet)
-router.register("stages/authenticator/totp", AuthenticatorTOTPStageViewSet)
-router.register("stages/authenticator/validate", AuthenticatorValidateStageViewSet)
-router.register("stages/authenticator/webauthn", AuthenticateWebAuthnStageViewSet)
-router.register("stages/captcha", CaptchaStageViewSet)
-router.register("stages/consent", ConsentStageViewSet)
-router.register("stages/deny", DenyStageViewSet)
-router.register("stages/email", EmailStageViewSet)
-router.register("stages/identification", IdentificationStageViewSet)
-router.register("stages/invitation/invitations", InvitationViewSet)
-router.register("stages/invitation/stages", InvitationStageViewSet)
-router.register("stages/password", PasswordStageViewSet)
-router.register("stages/prompt/prompts", PromptViewSet)
-router.register("stages/prompt/stages", PromptStageViewSet)
-router.register("stages/user_delete", UserDeleteStageViewSet)
-router.register("stages/user_login", UserLoginStageViewSet)
-router.register("stages/user_logout", UserLogoutStageViewSet)
-router.register("stages/user_write", UserWriteStageViewSet)
-
-router.register("stages/dummy", DummyStageViewSet)
-router.register("policies/dummy", DummyPolicyViewSet)
 
 urlpatterns = (
     [
         path("", APIBrowserView.as_view(), name="schema-browser"),
     ]
     + router.urls
+    + _other_urls
     + [
-        path(
-            "admin/metrics/",
-            AdministrationMetricsViewSet.as_view(),
-            name="admin_metrics",
-        ),
-        path("admin/version/", VersionView.as_view(), name="admin_version"),
-        path("admin/workers/", WorkerView.as_view(), name="admin_workers"),
-        path("admin/system/", SystemView.as_view(), name="admin_system"),
         path("root/config/", ConfigView.as_view(), name="config"),
-        path(
-            "flows/executor/<slug:flow_slug>/",
-            FlowExecutorView.as_view(),
-            name="flow-executor",
-        ),
-        path(
-            "flows/inspector/<slug:flow_slug>/",
-            FlowInspectorView.as_view(),
-            name="flow-inspector",
-        ),
         path("schema/", cache_page(86400)(SpectacularAPIView.as_view()), name="schema"),
     ]
 )

--- a/authentik/blueprints/urls.py
+++ b/authentik/blueprints/urls.py
@@ -1,0 +1,6 @@
+"""API URLs"""
+from authentik.blueprints.api import BlueprintInstanceViewSet
+
+api_urlpatterns = [
+    ("managed/blueprints", BlueprintInstanceViewSet),
+]

--- a/authentik/core/apps.py
+++ b/authentik/core/apps.py
@@ -11,7 +11,6 @@ class AuthentikCoreConfig(ManagedAppConfig):
     label = "authentik_core"
     verbose_name = "authentik Core"
     mountpoint = ""
-    ws_mountpoint = "authentik.core.urls"
     default = True
 
     def reconcile_load_core_signals(self):

--- a/authentik/core/urls.py
+++ b/authentik/core/urls.py
@@ -7,6 +7,15 @@ from django.urls import path
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.generic import RedirectView
 
+from authentik.core.api.applications import ApplicationViewSet
+from authentik.core.api.authenticated_sessions import AuthenticatedSessionViewSet
+from authentik.core.api.devices import AdminDeviceViewSet, DeviceViewSet
+from authentik.core.api.groups import GroupViewSet
+from authentik.core.api.propertymappings import PropertyMappingViewSet
+from authentik.core.api.providers import ProviderViewSet
+from authentik.core.api.sources import SourceViewSet, UserSourceConnectionViewSet
+from authentik.core.api.tokens import TokenViewSet
+from authentik.core.api.users import UserViewSet
 from authentik.core.views import apps, impersonate
 from authentik.core.views.debug import AccessDeniedView
 from authentik.core.views.interface import FlowInterfaceView, InterfaceView
@@ -66,6 +75,24 @@ urlpatterns = [
     path(
         "ws/client/",
         InterfaceView.as_view(template_name="if/admin.html"),
+    ),
+]
+
+api_urlpatterns = [
+    ("core/authenticated_sessions", AuthenticatedSessionViewSet),
+    ("core/applications", ApplicationViewSet),
+    ("core/groups", GroupViewSet),
+    ("core/users", UserViewSet),
+    ("core/tokens", TokenViewSet),
+    ("sources/all", SourceViewSet),
+    ("sources/user_connections/all", UserSourceConnectionViewSet),
+    ("providers/all", ProviderViewSet),
+    ("propertymappings/all", PropertyMappingViewSet),
+    ("authenticators/all", DeviceViewSet, "device"),
+    (
+        "authenticators/admin/all",
+        AdminDeviceViewSet,
+        "admin-device",
     ),
 ]
 

--- a/authentik/crypto/urls.py
+++ b/authentik/crypto/urls.py
@@ -1,0 +1,6 @@
+"""API URLs"""
+from authentik.crypto.api import CertificateKeyPairViewSet
+
+api_urlpatterns = [
+    ("crypto/certificatekeypairs", CertificateKeyPairViewSet),
+]

--- a/authentik/events/urls.py
+++ b/authentik/events/urls.py
@@ -1,0 +1,14 @@
+"""API URLs"""
+from authentik.events.api.events import EventViewSet
+from authentik.events.api.notification_mappings import NotificationWebhookMappingViewSet
+from authentik.events.api.notification_rules import NotificationRuleViewSet
+from authentik.events.api.notification_transports import NotificationTransportViewSet
+from authentik.events.api.notifications import NotificationViewSet
+
+api_urlpatterns = [
+    ("events/events", EventViewSet),
+    ("events/notifications", NotificationViewSet),
+    ("events/transports", NotificationTransportViewSet),
+    ("events/rules", NotificationRuleViewSet),
+    ("propertymappings/notification", NotificationWebhookMappingViewSet),
+]

--- a/authentik/flows/urls.py
+++ b/authentik/flows/urls.py
@@ -1,8 +1,17 @@
 """flow urls"""
 from django.urls import path
 
+from authentik.flows.api.bindings import FlowStageBindingViewSet
+from authentik.flows.api.flows import FlowViewSet
+from authentik.flows.api.stages import StageViewSet
 from authentik.flows.models import FlowDesignation
-from authentik.flows.views.executor import CancelView, ConfigureFlowInitView, ToDefaultFlow
+from authentik.flows.views.executor import (
+    CancelView,
+    ConfigureFlowInitView,
+    FlowExecutorView,
+    ToDefaultFlow,
+)
+from authentik.flows.views.inspector import FlowInspectorView
 
 urlpatterns = [
     path(
@@ -20,5 +29,21 @@ urlpatterns = [
         "-/configure/<uuid:stage_uuid>/",
         ConfigureFlowInitView.as_view(),
         name="configure",
+    ),
+]
+
+api_urlpatterns = [
+    ("flows/instances", FlowViewSet),
+    ("flows/bindings", FlowStageBindingViewSet),
+    ("stages/all", StageViewSet),
+    path(
+        "flows/executor/<slug:flow_slug>/",
+        FlowExecutorView.as_view(),
+        name="flow-executor",
+    ),
+    path(
+        "flows/inspector/<slug:flow_slug>/",
+        FlowInspectorView.as_view(),
+        name="flow-inspector",
     ),
 ]

--- a/authentik/outposts/apps.py
+++ b/authentik/outposts/apps.py
@@ -24,7 +24,6 @@ class AuthentikOutpostConfig(ManagedAppConfig):
     label = "authentik_outposts"
     verbose_name = "authentik Outpost"
     default = True
-    ws_mountpoint = "authentik.outposts.urls"
 
     def reconcile_load_outposts_signals(self):
         """Load outposts signals"""

--- a/authentik/outposts/urls.py
+++ b/authentik/outposts/urls.py
@@ -1,9 +1,22 @@
 """Outpost Websocket URLS"""
 from django.urls import path
 
+from authentik.outposts.api.outposts import OutpostViewSet
+from authentik.outposts.api.service_connections import (
+    DockerServiceConnectionViewSet,
+    KubernetesServiceConnectionViewSet,
+    ServiceConnectionViewSet,
+)
 from authentik.outposts.channels import OutpostConsumer
 from authentik.root.middleware import ChannelsLoggingMiddleware
 
 websocket_urlpatterns = [
     path("ws/outpost/<uuid:pk>/", ChannelsLoggingMiddleware(OutpostConsumer.as_asgi())),
+]
+
+api_urlpatterns = [
+    ("outposts/instances", OutpostViewSet),
+    ("outposts/service_connections/all", ServiceConnectionViewSet),
+    ("outposts/service_connections/docker", DockerServiceConnectionViewSet),
+    ("outposts/service_connections/kubernetes", KubernetesServiceConnectionViewSet),
 ]

--- a/authentik/policies/dummy/urls.py
+++ b/authentik/policies/dummy/urls.py
@@ -1,0 +1,4 @@
+"""API URLs"""
+from authentik.policies.dummy.api import DummyPolicyViewSet
+
+api_urlpatterns = [("policies/dummy", DummyPolicyViewSet)]

--- a/authentik/policies/event_matcher/urls.py
+++ b/authentik/policies/event_matcher/urls.py
@@ -1,0 +1,4 @@
+"""API URLs"""
+from authentik.policies.event_matcher.api import EventMatcherPolicyViewSet
+
+api_urlpatterns = [("policies/event_matcher", EventMatcherPolicyViewSet)]

--- a/authentik/policies/expiry/urls.py
+++ b/authentik/policies/expiry/urls.py
@@ -1,0 +1,4 @@
+"""API URLs"""
+from authentik.policies.expiry.api import PasswordExpiryPolicyViewSet
+
+api_urlpatterns = [("policies/password_expiry", PasswordExpiryPolicyViewSet)]

--- a/authentik/policies/expression/urls.py
+++ b/authentik/policies/expression/urls.py
@@ -1,0 +1,4 @@
+"""API URLs"""
+from authentik.policies.expression.api import ExpressionPolicyViewSet
+
+api_urlpatterns = [("policies/expression", ExpressionPolicyViewSet)]

--- a/authentik/policies/password/urls.py
+++ b/authentik/policies/password/urls.py
@@ -1,0 +1,4 @@
+"""API URLs"""
+from authentik.policies.password.api import PasswordPolicyViewSet
+
+api_urlpatterns = [("policies/password", PasswordPolicyViewSet)]

--- a/authentik/policies/reputation/urls.py
+++ b/authentik/policies/reputation/urls.py
@@ -1,0 +1,7 @@
+"""API URLs"""
+from authentik.policies.reputation.api import ReputationPolicyViewSet, ReputationViewSet
+
+api_urlpatterns = [
+    ("policies/reputation/scores", ReputationViewSet),
+    ("policies/reputation", ReputationPolicyViewSet),
+]

--- a/authentik/policies/urls.py
+++ b/authentik/policies/urls.py
@@ -1,0 +1,8 @@
+"""API URLs"""
+from authentik.policies.api.bindings import PolicyBindingViewSet
+from authentik.policies.api.policies import PolicyViewSet
+
+api_urlpatterns = [
+    ("policies/all", PolicyViewSet),
+    ("policies/bindings", PolicyBindingViewSet),
+]

--- a/authentik/providers/ldap/urls.py
+++ b/authentik/providers/ldap/urls.py
@@ -1,0 +1,7 @@
+"""API URLs"""
+from authentik.providers.ldap.api import LDAPOutpostConfigViewSet, LDAPProviderViewSet
+
+api_urlpatterns = [
+    ("outposts/ldap", LDAPOutpostConfigViewSet),
+    ("providers/ldap", LDAPProviderViewSet),
+]

--- a/authentik/providers/oauth2/urls.py
+++ b/authentik/providers/oauth2/urls.py
@@ -2,6 +2,13 @@
 from django.urls import path
 from django.views.generic.base import RedirectView
 
+from authentik.providers.oauth2.api.providers import OAuth2ProviderViewSet
+from authentik.providers.oauth2.api.scopes import ScopeMappingViewSet
+from authentik.providers.oauth2.api.tokens import (
+    AccessTokenViewSet,
+    AuthorizationCodeViewSet,
+    RefreshTokenViewSet,
+)
 from authentik.providers.oauth2.views.authorize import AuthorizationFlowInitView
 from authentik.providers.oauth2.views.device_backchannel import DeviceView
 from authentik.providers.oauth2.views.introspection import TokenIntrospectionView
@@ -50,4 +57,12 @@ urlpatterns = [
         ProviderInfoView.as_view(),
         name="provider-info",
     ),
+]
+
+api_urlpatterns = [
+    ("providers/oauth2", OAuth2ProviderViewSet),
+    ("propertymappings/scope", ScopeMappingViewSet),
+    ("oauth2/authorization_codes", AuthorizationCodeViewSet),
+    ("oauth2/refresh_tokens", RefreshTokenViewSet),
+    ("oauth2/access_tokens", AccessTokenViewSet),
 ]

--- a/authentik/providers/proxy/urls.py
+++ b/authentik/providers/proxy/urls.py
@@ -1,0 +1,7 @@
+"""API URLs"""
+from authentik.providers.proxy.api import ProxyOutpostConfigViewSet, ProxyProviderViewSet
+
+api_urlpatterns = [
+    ("outposts/proxy", ProxyOutpostConfigViewSet),
+    ("providers/proxy", ProxyProviderViewSet),
+]

--- a/authentik/providers/radius/urls.py
+++ b/authentik/providers/radius/urls.py
@@ -1,0 +1,7 @@
+"""API URLs"""
+from authentik.providers.radius.api import RadiusOutpostConfigViewSet, RadiusProviderViewSet
+
+api_urlpatterns = [
+    ("outposts/radius", RadiusOutpostConfigViewSet),
+    ("providers/radius", RadiusProviderViewSet),
+]

--- a/authentik/providers/saml/urls.py
+++ b/authentik/providers/saml/urls.py
@@ -1,6 +1,8 @@
 """authentik SAML IDP URLs"""
 from django.urls import path
 
+from authentik.providers.saml.api.property_mapping import SAMLPropertyMappingViewSet
+from authentik.providers.saml.api.providers import SAMLProviderViewSet
 from authentik.providers.saml.views import metadata, slo, sso
 
 urlpatterns = [
@@ -38,4 +40,9 @@ urlpatterns = [
         metadata.MetadataDownload.as_view(),
         name="metadata-download",
     ),
+]
+
+api_urlpatterns = [
+    ("propertymappings/saml", SAMLPropertyMappingViewSet),
+    ("providers/saml", SAMLProviderViewSet),
 ]

--- a/authentik/providers/scim/urls.py
+++ b/authentik/providers/scim/urls.py
@@ -1,0 +1,8 @@
+"""API URLs"""
+from authentik.providers.scim.api.property_mapping import SCIMMappingViewSet
+from authentik.providers.scim.api.providers import SCIMProviderViewSet
+
+api_urlpatterns = [
+    ("providers/scim", SCIMProviderViewSet),
+    ("propertymappings/scim", SCIMMappingViewSet),
+]

--- a/authentik/root/websocket.py
+++ b/authentik/root/websocket.py
@@ -9,13 +9,15 @@ LOGGER = get_logger()
 
 websocket_urlpatterns = []
 for _authentik_app in get_apps():
-    mountpoint = getattr(_authentik_app, "ws_mountpoint", None)
-    if not mountpoint:
+    try:
+        api_urls = import_module(f"{_authentik_app.name}.urls")
+    except ModuleNotFoundError:
         continue
-    ws_paths = import_module(mountpoint)
-    websocket_urlpatterns.extend(getattr(ws_paths, "websocket_urlpatterns"))
+    if not hasattr(api_urls, "websocket_urlpatterns"):
+        continue
+    urls: list = getattr(api_urls, "websocket_urlpatterns")
+    websocket_urlpatterns.extend(urls)
     LOGGER.debug(
-        "Mounted URLs",
+        "Mounted Websocket URLs",
         app_name=_authentik_app.name,
-        app_mountpoint=mountpoint,
     )

--- a/authentik/sources/ldap/urls.py
+++ b/authentik/sources/ldap/urls.py
@@ -1,0 +1,7 @@
+"""API URLs"""
+from authentik.sources.ldap.api import LDAPPropertyMappingViewSet, LDAPSourceViewSet
+
+api_urlpatterns = [
+    ("propertymappings/ldap", LDAPPropertyMappingViewSet),
+    ("sources/ldap", LDAPSourceViewSet),
+]

--- a/authentik/sources/oauth/urls.py
+++ b/authentik/sources/oauth/urls.py
@@ -2,6 +2,8 @@
 
 from django.urls import path
 
+from authentik.sources.oauth.api.source import OAuthSourceViewSet
+from authentik.sources.oauth.api.source_connection import UserOAuthSourceConnectionViewSet
 from authentik.sources.oauth.types.registry import RequestKind
 from authentik.sources.oauth.views.dispatcher import DispatcherView
 
@@ -16,4 +18,9 @@ urlpatterns = [
         DispatcherView.as_view(kind=RequestKind.CALLBACK),
         name="oauth-client-callback",
     ),
+]
+
+api_urlpatterns = [
+    ("sources/user_connections/oauth", UserOAuthSourceConnectionViewSet),
+    ("sources/oauth", OAuthSourceViewSet),
 ]

--- a/authentik/sources/plex/urls.py
+++ b/authentik/sources/plex/urls.py
@@ -1,0 +1,8 @@
+"""API URLs"""
+from authentik.sources.plex.api.source import PlexSourceViewSet
+from authentik.sources.plex.api.source_connection import PlexSourceConnectionViewSet
+
+api_urlpatterns = [
+    ("sources/user_connections/plex", PlexSourceConnectionViewSet),
+    ("sources/plex", PlexSourceViewSet),
+]

--- a/authentik/sources/saml/urls.py
+++ b/authentik/sources/saml/urls.py
@@ -1,6 +1,8 @@
 """saml sp urls"""
 from django.urls import path
 
+from authentik.sources.saml.api.source import SAMLSourceViewSet
+from authentik.sources.saml.api.source_connection import UserSAMLSourceConnectionViewSet
 from authentik.sources.saml.views import ACSView, InitiateView, MetadataView, SLOView
 
 urlpatterns = [
@@ -8,4 +10,9 @@ urlpatterns = [
     path("<slug:source_slug>/acs/", ACSView.as_view(), name="acs"),
     path("<slug:source_slug>/slo/", SLOView.as_view(), name="slo"),
     path("<slug:source_slug>/metadata/", MetadataView.as_view(), name="metadata"),
+]
+
+api_urlpatterns = [
+    ("sources/user_connections/saml", UserSAMLSourceConnectionViewSet),
+    ("sources/saml", SAMLSourceViewSet),
 ]

--- a/authentik/stages/authenticator_duo/urls.py
+++ b/authentik/stages/authenticator_duo/urls.py
@@ -1,0 +1,16 @@
+"""API URLs"""
+from authentik.stages.authenticator_duo.api import (
+    AuthenticatorDuoStageViewSet,
+    DuoAdminDeviceViewSet,
+    DuoDeviceViewSet,
+)
+
+api_urlpatterns = [
+    ("authenticators/duo", DuoDeviceViewSet),
+    (
+        "authenticators/admin/duo",
+        DuoAdminDeviceViewSet,
+        "admin-duodevice",
+    ),
+    ("stages/authenticator/duo", AuthenticatorDuoStageViewSet),
+]

--- a/authentik/stages/authenticator_sms/urls.py
+++ b/authentik/stages/authenticator_sms/urls.py
@@ -1,0 +1,16 @@
+"""API URLs"""
+from authentik.stages.authenticator_sms.api import (
+    AuthenticatorSMSStageViewSet,
+    SMSAdminDeviceViewSet,
+    SMSDeviceViewSet,
+)
+
+api_urlpatterns = [
+    ("authenticators/sms", SMSDeviceViewSet),
+    (
+        "authenticators/admin/sms",
+        SMSAdminDeviceViewSet,
+        "admin-smsdevice",
+    ),
+    ("stages/authenticator/sms", AuthenticatorSMSStageViewSet),
+]

--- a/authentik/stages/authenticator_static/urls.py
+++ b/authentik/stages/authenticator_static/urls.py
@@ -1,0 +1,16 @@
+"""API URLs"""
+from authentik.stages.authenticator_static.api import (
+    AuthenticatorStaticStageViewSet,
+    StaticAdminDeviceViewSet,
+    StaticDeviceViewSet,
+)
+
+api_urlpatterns = [
+    ("authenticators/static", StaticDeviceViewSet),
+    (
+        "authenticators/admin/static",
+        StaticAdminDeviceViewSet,
+        "admin-staticdevice",
+    ),
+    ("stages/authenticator/static", AuthenticatorStaticStageViewSet),
+]

--- a/authentik/stages/authenticator_totp/urls.py
+++ b/authentik/stages/authenticator_totp/urls.py
@@ -1,0 +1,12 @@
+"""API URLs"""
+from authentik.stages.authenticator_totp.api import (
+    AuthenticatorTOTPStageViewSet,
+    TOTPAdminDeviceViewSet,
+    TOTPDeviceViewSet,
+)
+
+api_urlpatterns = [
+    ("authenticators/totp", TOTPDeviceViewSet),
+    ("authenticators/admin/totp", TOTPAdminDeviceViewSet, "admin-totpdevice"),
+    ("stages/authenticator/totp", AuthenticatorTOTPStageViewSet),
+]

--- a/authentik/stages/authenticator_validate/urls.py
+++ b/authentik/stages/authenticator_validate/urls.py
@@ -1,0 +1,4 @@
+"""API URLs"""
+from authentik.stages.authenticator_validate.api import AuthenticatorValidateStageViewSet
+
+api_urlpatterns = [("stages/authenticator/validate", AuthenticatorValidateStageViewSet)]

--- a/authentik/stages/authenticator_webauthn/urls.py
+++ b/authentik/stages/authenticator_webauthn/urls.py
@@ -1,0 +1,16 @@
+"""API URLs"""
+from authentik.stages.authenticator_webauthn.api import (
+    AuthenticateWebAuthnStageViewSet,
+    WebAuthnAdminDeviceViewSet,
+    WebAuthnDeviceViewSet,
+)
+
+api_urlpatterns = [
+    ("stages/authenticator/webauthn", AuthenticateWebAuthnStageViewSet),
+    (
+        "authenticators/admin/webauthn",
+        WebAuthnAdminDeviceViewSet,
+        "admin-webauthndevice",
+    ),
+    ("authenticators/webauthn", WebAuthnDeviceViewSet),
+]

--- a/authentik/stages/captcha/urls.py
+++ b/authentik/stages/captcha/urls.py
@@ -1,0 +1,4 @@
+"""API URLs"""
+from authentik.stages.captcha.api import CaptchaStageViewSet
+
+api_urlpatterns = [("stages/captcha", CaptchaStageViewSet)]

--- a/authentik/stages/consent/urls.py
+++ b/authentik/stages/consent/urls.py
@@ -1,0 +1,7 @@
+"""API URLs"""
+from authentik.stages.consent.api import ConsentStageViewSet, UserConsentViewSet
+
+api_urlpatterns = [
+    ("stages/consent", ConsentStageViewSet),
+    ("core/user_consent", UserConsentViewSet),
+]

--- a/authentik/stages/deny/urls.py
+++ b/authentik/stages/deny/urls.py
@@ -1,0 +1,4 @@
+"""API URLs"""
+from authentik.stages.deny.api import DenyStageViewSet
+
+api_urlpatterns = [("stages/deny", DenyStageViewSet)]

--- a/authentik/stages/dummy/urls.py
+++ b/authentik/stages/dummy/urls.py
@@ -1,0 +1,4 @@
+"""API URLs"""
+from authentik.stages.dummy.api import DummyStageViewSet
+
+api_urlpatterns = [("stages/dummy", DummyStageViewSet)]

--- a/authentik/stages/email/urls.py
+++ b/authentik/stages/email/urls.py
@@ -1,0 +1,4 @@
+"""API URLs"""
+from authentik.stages.email.api import EmailStageViewSet
+
+api_urlpatterns = [("stages/email", EmailStageViewSet)]

--- a/authentik/stages/identification/urls.py
+++ b/authentik/stages/identification/urls.py
@@ -1,0 +1,4 @@
+"""API URLs"""
+from authentik.stages.identification.api import IdentificationStageViewSet
+
+api_urlpatterns = [("stages/identification", IdentificationStageViewSet)]

--- a/authentik/stages/invitation/urls.py
+++ b/authentik/stages/invitation/urls.py
@@ -1,0 +1,7 @@
+"""API URLs"""
+from authentik.stages.invitation.api import InvitationStageViewSet, InvitationViewSet
+
+api_urlpatterns = [
+    ("stages/invitation/invitations", InvitationViewSet),
+    ("stages/invitation/stages", InvitationStageViewSet),
+]

--- a/authentik/stages/password/urls.py
+++ b/authentik/stages/password/urls.py
@@ -1,0 +1,4 @@
+"""API URLs"""
+from authentik.stages.password.api import PasswordStageViewSet
+
+api_urlpatterns = [("stages/password", PasswordStageViewSet)]

--- a/authentik/stages/prompt/urls.py
+++ b/authentik/stages/prompt/urls.py
@@ -1,0 +1,7 @@
+"""API URLs"""
+from authentik.stages.prompt.api import PromptStageViewSet, PromptViewSet
+
+api_urlpatterns = [
+    ("stages/prompt/prompts", PromptViewSet),
+    ("stages/prompt/stages", PromptStageViewSet),
+]

--- a/authentik/stages/user_delete/urls.py
+++ b/authentik/stages/user_delete/urls.py
@@ -1,0 +1,4 @@
+"""API URLs"""
+from authentik.stages.user_delete.api import UserDeleteStageViewSet
+
+api_urlpatterns = [("stages/user_delete", UserDeleteStageViewSet)]

--- a/authentik/stages/user_login/urls.py
+++ b/authentik/stages/user_login/urls.py
@@ -1,0 +1,6 @@
+"""API URLs"""
+from authentik.stages.user_login.api import UserLoginStageViewSet
+
+api_urlpatterns = [
+    ("stages/user_login", UserLoginStageViewSet),
+]

--- a/authentik/stages/user_logout/urls.py
+++ b/authentik/stages/user_logout/urls.py
@@ -1,0 +1,4 @@
+"""API URLs"""
+from authentik.stages.user_logout.api import UserLogoutStageViewSet
+
+api_urlpatterns = [("stages/user_logout", UserLogoutStageViewSet)]

--- a/authentik/stages/user_write/urls.py
+++ b/authentik/stages/user_write/urls.py
@@ -1,0 +1,4 @@
+"""API URLs"""
+from authentik.stages.user_write.api import UserWriteStageViewSet
+
+api_urlpatterns = [("stages/user_write", UserWriteStageViewSet)]

--- a/authentik/tenants/urls.py
+++ b/authentik/tenants/urls.py
@@ -1,0 +1,6 @@
+"""API URLs"""
+from authentik.tenants.api import TenantViewSet
+
+api_urlpatterns = [
+    ("core/tenants", TenantViewSet),
+]


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details

In preparation for enterprise (which for now is a django app that is only included in enterprise images), we need to have non-static API URL loading, which doesn't require the API URLs to be defined in a single static file

This moves all API urls to the app's `urls.py` file in the `api_urlpatterns` list, which can take both a tuple of args to `router.register` or a `path()` call for a regular/API view

This doesn't change the schema, and `make gen-build` doesn't show any changes to the schema, as intended

## Changes

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [x] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
