### PR TITLE
providers/oauth2: add user UUID as subject option

### DIFF
--- a/authentik/providers/oauth2/id_token.py
+++ b/authentik/providers/oauth2/id_token.py
@@ -26,6 +26,7 @@ class SubModes(models.TextChoices):
 
     HASHED_USER_ID = "hashed_user_id", _("Based on the Hashed User ID")
     USER_ID = "user_id", _("Based on user ID")
+    USER_UUID = "user_uuid", _("Based on user UUID")
     USER_USERNAME = "user_username", _("Based on the username")
     USER_EMAIL = (
         "user_email",
@@ -96,6 +97,8 @@ class IDToken:
             id_token.sub = token.user.uid
         elif provider.sub_mode == SubModes.USER_ID:
             id_token.sub = str(token.user.pk)
+        elif provider.sub_mode == SubModes.USER_UUID:
+            id_token.sub = str(token.user.uuid)
         elif provider.sub_mode == SubModes.USER_EMAIL:
             id_token.sub = token.user.email
         elif provider.sub_mode == SubModes.USER_USERNAME:

--- a/blueprints/schema.json
+++ b/blueprints/schema.json
@@ -3653,6 +3653,7 @@
                     "enum": [
                         "hashed_user_id",
                         "user_id",
+                        "user_uuid",
                         "user_username",
                         "user_email",
                         "user_upn"
@@ -3766,6 +3767,7 @@
                             "enum": [
                                 "hashed_user_id",
                                 "user_id",
+                                "user_uuid",
                                 "user_username",
                                 "user_email",
                                 "user_upn"
@@ -3957,6 +3959,7 @@
                             "enum": [
                                 "hashed_user_id",
                                 "user_id",
+                                "user_uuid",
                                 "user_username",
                                 "user_email",
                                 "user_upn"
@@ -4152,6 +4155,7 @@
                             "enum": [
                                 "hashed_user_id",
                                 "user_id",
+                                "user_uuid",
                                 "user_username",
                                 "user_email",
                                 "user_upn"

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-08 14:23+0000\n"
+"POT-Creation-Date: 2023-05-09 18:53+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -880,14 +880,18 @@ msgid "Based on user ID"
 msgstr ""
 
 #: authentik/providers/oauth2/id_token.py:29
+msgid "Based on user UUID"
+msgstr ""
+
+#: authentik/providers/oauth2/id_token.py:30
 msgid "Based on the username"
 msgstr ""
 
-#: authentik/providers/oauth2/id_token.py:32
+#: authentik/providers/oauth2/id_token.py:33
 msgid "Based on the User's Email. This is recommended over the UPN method."
 msgstr ""
 
-#: authentik/providers/oauth2/id_token.py:37
+#: authentik/providers/oauth2/id_token.py:38
 msgid ""
 "Based on the User's UPN, only works if user has a 'upn' attribute set. Use "
 "this method only if you have different UPN and Mail domains."

--- a/schema.yml
+++ b/schema.yml
@@ -14893,11 +14893,13 @@ paths:
           - user_id
           - user_upn
           - user_username
+          - user_uuid
         description: |-
           Configure what data should be used as unique User Identifier. For most cases, the default should be fine.
 
           * `hashed_user_id` - Based on the Hashed User ID
           * `user_id` - Based on user ID
+          * `user_uuid` - Based on user UUID
           * `user_username` - Based on the username
           * `user_email` - Based on the User's Email. This is recommended over the UPN method.
           * `user_upn` - Based on the User's UPN, only works if user has a 'upn' attribute set. Use this method only if you have different UPN and Mail domains.
@@ -31547,6 +31549,7 @@ components:
 
             * `hashed_user_id` - Based on the Hashed User ID
             * `user_id` - Based on user ID
+            * `user_uuid` - Based on user UUID
             * `user_username` - Based on the username
             * `user_email` - Based on the User's Email. This is recommended over the UPN method.
             * `user_upn` - Based on the User's UPN, only works if user has a 'upn' attribute set. Use this method only if you have different UPN and Mail domains.
@@ -31651,6 +31654,7 @@ components:
 
             * `hashed_user_id` - Based on the Hashed User ID
             * `user_id` - Based on user ID
+            * `user_uuid` - Based on user UUID
             * `user_username` - Based on the username
             * `user_email` - Based on the User's Email. This is recommended over the UPN method.
             * `user_upn` - Based on the User's UPN, only works if user has a 'upn' attribute set. Use this method only if you have different UPN and Mail domains.
@@ -36546,6 +36550,7 @@ components:
 
             * `hashed_user_id` - Based on the Hashed User ID
             * `user_id` - Based on user ID
+            * `user_uuid` - Based on user UUID
             * `user_username` - Based on the username
             * `user_email` - Based on the User's Email. This is recommended over the UPN method.
             * `user_upn` - Based on the User's UPN, only works if user has a 'upn' attribute set. Use this method only if you have different UPN and Mail domains.
@@ -40466,6 +40471,7 @@ components:
       enum:
       - hashed_user_id
       - user_id
+      - user_uuid
       - user_username
       - user_email
       - user_upn
@@ -40473,6 +40479,7 @@ components:
       description: |-
         * `hashed_user_id` - Based on the Hashed User ID
         * `user_id` - Based on user ID
+        * `user_uuid` - Based on user UUID
         * `user_username` - Based on the username
         * `user_email` - Based on the User's Email. This is recommended over the UPN method.
         * `user_upn` - Based on the User's UPN, only works if user has a 'upn' attribute set. Use this method only if you have different UPN and Mail domains.

--- a/web/src/admin/providers/oauth2/OAuth2ProviderForm.ts
+++ b/web/src/admin/providers/oauth2/OAuth2ProviderForm.ts
@@ -379,6 +379,10 @@ ${this.instance?.redirectUris}</textarea
                                     value: SubModeEnum.UserId,
                                 },
                                 {
+                                    label: t`Based on the User's UUID`,
+                                    value: SubModeEnum.UserUuid,
+                                },
+                                {
                                     label: t`Based on the User's username`,
                                     value: SubModeEnum.UserUsername,
                                 },

--- a/web/src/locales/de.po
+++ b/web/src/locales/de.po
@@ -989,6 +989,10 @@ msgid "Based on the User's username"
 msgstr ""
 
 #: src/admin/providers/oauth2/OAuth2ProviderForm.ts
+msgid "Based on the User's UUID"
+msgstr ""
+
+#: src/admin/providers/oauth2/OAuth2ProviderForm.ts
 #~ msgid "Based on the username"
 #~ msgstr "Basierend auf dem Benutzernamen"
 

--- a/web/src/locales/en.po
+++ b/web/src/locales/en.po
@@ -981,6 +981,10 @@ msgid "Based on the User's username"
 msgstr "Based on the User's username"
 
 #: src/admin/providers/oauth2/OAuth2ProviderForm.ts
+msgid "Based on the User's UUID"
+msgstr "Based on the User's UUID"
+
+#: src/admin/providers/oauth2/OAuth2ProviderForm.ts
 #~ msgid "Based on the username"
 #~ msgstr "Based on the username"
 

--- a/web/src/locales/es.po
+++ b/web/src/locales/es.po
@@ -967,6 +967,10 @@ msgid "Based on the User's username"
 msgstr ""
 
 #: src/admin/providers/oauth2/OAuth2ProviderForm.ts
+msgid "Based on the User's UUID"
+msgstr ""
+
+#: src/admin/providers/oauth2/OAuth2ProviderForm.ts
 #~ msgid "Based on the username"
 #~ msgstr "Basado en el nombre de usuario"
 

--- a/web/src/locales/fr_FR.po
+++ b/web/src/locales/fr_FR.po
@@ -972,6 +972,10 @@ msgid "Based on the User's username"
 msgstr ""
 
 #: src/admin/providers/oauth2/OAuth2ProviderForm.ts
+msgid "Based on the User's UUID"
+msgstr ""
+
+#: src/admin/providers/oauth2/OAuth2ProviderForm.ts
 #~ msgid "Based on the username"
 #~ msgstr "Basé sur le nom d'utilisateur"
 

--- a/web/src/locales/pl.po
+++ b/web/src/locales/pl.po
@@ -971,6 +971,10 @@ msgid "Based on the User's username"
 msgstr ""
 
 #: src/admin/providers/oauth2/OAuth2ProviderForm.ts
+msgid "Based on the User's UUID"
+msgstr ""
+
+#: src/admin/providers/oauth2/OAuth2ProviderForm.ts
 #~ msgid "Based on the username"
 #~ msgstr "Na podstawie nazwy użytkownika"
 

--- a/web/src/locales/pseudo-LOCALE.po
+++ b/web/src/locales/pseudo-LOCALE.po
@@ -973,6 +973,10 @@ msgid "Based on the User's username"
 msgstr ""
 
 #: src/admin/providers/oauth2/OAuth2ProviderForm.ts
+msgid "Based on the User's UUID"
+msgstr ""
+
+#: src/admin/providers/oauth2/OAuth2ProviderForm.ts
 #~ msgid "Based on the username"
 #~ msgstr ""
 

--- a/web/src/locales/tr.po
+++ b/web/src/locales/tr.po
@@ -967,6 +967,10 @@ msgid "Based on the User's username"
 msgstr ""
 
 #: src/admin/providers/oauth2/OAuth2ProviderForm.ts
+msgid "Based on the User's UUID"
+msgstr ""
+
+#: src/admin/providers/oauth2/OAuth2ProviderForm.ts
 #~ msgid "Based on the username"
 #~ msgstr "Kullanıcı adına göre"
 

--- a/web/src/locales/zh-Hans.po
+++ b/web/src/locales/zh-Hans.po
@@ -1,8 +1,8 @@
-# 
+#
 # Translators:
 # Jens L. <jens@beryju.org>, 2023
 # deluxghost, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
@@ -22,9 +22,12 @@ msgstr ""
 #: src/admin/admin-overview/cards/RecentEventsCard.ts
 #: src/admin/applications/ApplicationListPage.ts
 #: src/admin/applications/ApplicationListPage.ts
-#: src/admin/events/EventListPage.ts src/admin/events/EventListPage.ts
-#: src/admin/events/EventViewPage.ts src/admin/events/EventViewPage.ts
-#: src/admin/groups/GroupListPage.ts src/admin/groups/MemberSelectModal.ts
+#: src/admin/events/EventListPage.ts
+#: src/admin/events/EventListPage.ts
+#: src/admin/events/EventViewPage.ts
+#: src/admin/events/EventViewPage.ts
+#: src/admin/groups/GroupListPage.ts
+#: src/admin/groups/MemberSelectModal.ts
 #: src/admin/groups/RelatedGroupList.ts
 #: src/admin/policies/BoundPoliciesList.ts
 #: src/admin/providers/oauth2/OAuth2ProviderViewPage.ts
@@ -35,17 +38,18 @@ msgstr ""
 #: src/admin/providers/oauth2/OAuth2ProviderViewPage.ts
 #: src/admin/providers/oauth2/OAuth2ProviderViewPage.ts
 #: src/admin/stages/invitation/InvitationListPage.ts
-#: src/admin/tokens/TokenListPage.ts src/admin/users/RelatedUserList.ts
-#: src/admin/users/UserListPage.ts src/elements/events/ObjectChangelog.ts
-#: src/elements/events/UserEvents.ts src/elements/user/SessionList.ts
+#: src/admin/tokens/TokenListPage.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
+#: src/elements/events/ObjectChangelog.ts
+#: src/elements/events/UserEvents.ts
+#: src/elements/user/SessionList.ts
 #: src/user/user-settings/tokens/UserTokenList.ts
 msgid "-"
 msgstr "-"
 
 #: src/admin/flows/FlowImportForm.ts
-msgid ""
-".yaml files, which can be found on goauthentik.io and can be exported by "
-"authentik."
+msgid ".yaml files, which can be found on goauthentik.io and can be exported by authentik."
 msgstr ".yaml 文件，可以在 goauthentik.io 上找到，也可以通过 authentik 导出。"
 
 #: src/elements/user/SessionList.ts
@@ -63,7 +67,8 @@ msgstr "（格式：hours=-1;minutes=-2;seconds=-3）。"
 msgid "(Format: hours=1;minutes=2;seconds=3)."
 msgstr "（格式：hours=1;minutes=2;seconds=3）。"
 
-#: src/elements/Expand.ts src/elements/Expand.ts
+#: src/elements/Expand.ts
+#: src/elements/Expand.ts
 #: src/user/user-settings/details/stages/prompt/PromptStage.ts
 msgid "{0}"
 msgstr "{0}"
@@ -80,7 +85,8 @@ msgstr "{0}（\"{1}\"，类型为 {2}）"
 msgid "{0} ({1})"
 msgstr "{0}（{1}）"
 
-#: src/elements/forms/DeleteBulkForm.ts src/elements/forms/DeleteForm.ts
+#: src/elements/forms/DeleteBulkForm.ts
+#: src/elements/forms/DeleteForm.ts
 msgid "{0} ({consequence})"
 msgstr "{0}（{consequence}）"
 
@@ -129,27 +135,19 @@ msgid "0: Too guessable: risky password. (guesses < 10^3)"
 msgstr "0：过于易猜测：密码有风险。（猜测次数 < 10^3）"
 
 #: src/admin/policies/password/PasswordPolicyForm.ts
-msgid ""
-"1: Very guessable: protection from throttled online attacks. (guesses < "
-"10^6)"
+msgid "1: Very guessable: protection from throttled online attacks. (guesses < 10^6)"
 msgstr "1：非常易猜测：可以防范受限的在线攻击。（猜测次数 < 10^6）"
 
 #: src/admin/policies/password/PasswordPolicyForm.ts
-msgid ""
-"2: Somewhat guessable: protection from unthrottled online attacks. (guesses "
-"< 10^8)"
+msgid "2: Somewhat guessable: protection from unthrottled online attacks. (guesses < 10^8)"
 msgstr "2：有些易猜测：可以防范不受限的在线攻击。（猜测次数 < 10^8）"
 
 #: src/admin/policies/password/PasswordPolicyForm.ts
-msgid ""
-"3: Safely unguessable: moderate protection from offline slow-hash scenario. "
-"(guesses < 10^10)"
+msgid "3: Safely unguessable: moderate protection from offline slow-hash scenario. (guesses < 10^10)"
 msgstr "3：难以猜测：适度防范离线慢速哈希场景。（猜测次数 < 10^10）"
 
 #: src/admin/policies/password/PasswordPolicyForm.ts
-msgid ""
-"4: Very unguessable: strong protection from offline slow-hash scenario. "
-"(guesses >= 10^10)"
+msgid "4: Very unguessable: strong protection from offline slow-hash scenario. (guesses >= 10^10)"
 msgstr "4：非常难以猜测：高度防范离线慢速哈希场景。（猜测次数 >= 10^10）  "
 
 #: src/admin/stages/authenticator_totp/AuthenticatorTOTPStageForm.ts
@@ -177,9 +175,7 @@ msgid "A non-removable authenticator, like TouchID or Windows Hello"
 msgstr "不可移除的身份验证器，例如 TouchID 或 Windows Hello"
 
 #: src/admin/policies/dummy/DummyPolicyForm.ts
-msgid ""
-"A policy used for testing. Always returns the same result as specified below"
-" after waiting a random duration."
+msgid "A policy used for testing. Always returns the same result as specified below after waiting a random duration."
 msgstr "用于测试的策略。等待随机时长后，始终返回下面指定的结果。"
 
 #~ msgid "About applications"
@@ -211,29 +207,38 @@ msgid "ACS URL"
 msgstr "ACS URL"
 
 #: src/admin/admin-overview/cards/RecentEventsCard.ts
-#: src/admin/events/EventListPage.ts src/admin/events/EventViewPage.ts
+#: src/admin/events/EventListPage.ts
+#: src/admin/events/EventViewPage.ts
 #: src/admin/policies/event_matcher/EventMatcherPolicyForm.ts
-#: src/elements/events/ObjectChangelog.ts src/elements/events/UserEvents.ts
+#: src/elements/events/ObjectChangelog.ts
+#: src/elements/events/UserEvents.ts
 msgid "Action"
 msgstr "操作"
 
 #: src/admin/applications/ApplicationListPage.ts
 #: src/admin/blueprints/BlueprintListPage.ts
 #: src/admin/crypto/CertificateKeyPairListPage.ts
-#: src/admin/events/EventListPage.ts src/admin/events/RuleListPage.ts
-#: src/admin/events/TransportListPage.ts src/admin/flows/BoundStagesList.ts
-#: src/admin/flows/FlowListPage.ts src/admin/groups/GroupListPage.ts
-#: src/admin/groups/RelatedGroupList.ts src/admin/outposts/OutpostListPage.ts
+#: src/admin/events/EventListPage.ts
+#: src/admin/events/RuleListPage.ts
+#: src/admin/events/TransportListPage.ts
+#: src/admin/flows/BoundStagesList.ts
+#: src/admin/flows/FlowListPage.ts
+#: src/admin/groups/GroupListPage.ts
+#: src/admin/groups/RelatedGroupList.ts
+#: src/admin/outposts/OutpostListPage.ts
 #: src/admin/outposts/ServiceConnectionListPage.ts
 #: src/admin/policies/BoundPoliciesList.ts
 #: src/admin/policies/PolicyListPage.ts
 #: src/admin/property-mappings/PropertyMappingListPage.ts
 #: src/admin/providers/ProviderListPage.ts
 #: src/admin/stages/invitation/InvitationListPage.ts
-#: src/admin/stages/prompt/PromptListPage.ts src/admin/stages/StageListPage.ts
+#: src/admin/stages/prompt/PromptListPage.ts
+#: src/admin/stages/StageListPage.ts
 #: src/admin/system-tasks/SystemTaskListPage.ts
-#: src/admin/tenants/TenantListPage.ts src/admin/tokens/TokenListPage.ts
-#: src/admin/users/RelatedUserList.ts src/admin/users/UserListPage.ts
+#: src/admin/tenants/TenantListPage.ts
+#: src/admin/tokens/TokenListPage.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
 msgid "Actions"
 msgstr "操作"
 
@@ -244,7 +249,8 @@ msgstr "操作"
 msgid "Actions over the last week (per 8 hours)"
 msgstr "过去一周的操作（每 8 小时）"
 
-#: src/admin/users/RelatedUserList.ts src/admin/users/UserListPage.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
 #: src/admin/users/UserViewPage.ts
 msgid "Activate"
 msgstr "激活"
@@ -253,9 +259,12 @@ msgstr "激活"
 msgid "Activate pending user on success"
 msgstr "成功时激活待处理用户"
 
-#: src/admin/groups/MemberSelectModal.ts src/admin/users/RelatedUserList.ts
-#: src/admin/users/RelatedUserList.ts src/admin/users/UserListPage.ts
-#: src/admin/users/UserListPage.ts src/admin/users/UserViewPage.ts
+#: src/admin/groups/MemberSelectModal.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
+#: src/admin/users/UserListPage.ts
+#: src/admin/users/UserViewPage.ts
 msgid "Active"
 msgstr "激活"
 
@@ -268,8 +277,10 @@ msgid "Active Directory User"
 msgstr "Active Directory 用户"
 
 #: src/admin/applications/ProviderSelectModal.ts
-#: src/admin/groups/MemberSelectModal.ts src/admin/groups/RelatedGroupList.ts
-#: src/admin/users/GroupSelectModal.ts src/admin/users/RelatedUserList.ts
+#: src/admin/groups/MemberSelectModal.ts
+#: src/admin/groups/RelatedGroupList.ts
+#: src/admin/users/GroupSelectModal.ts
+#: src/admin/users/RelatedUserList.ts
 msgid "Add"
 msgstr "添加"
 
@@ -339,14 +350,11 @@ msgstr "传递给代理的额外作用域映射。"
 msgid "Additional scopes"
 msgstr "额外的作用域"
 
-#~ msgid ""
-#~ "Additional scopes to be passed to the OAuth Provider, separated by space."
+#~ msgid "Additional scopes to be passed to the OAuth Provider, separated by space."
 #~ msgstr "要传递给 OAuth 提供商的额外作用域，用空格分隔。"
 
 #: src/admin/sources/oauth/OAuthSourceForm.ts
-msgid ""
-"Additional scopes to be passed to the OAuth Provider, separated by space. To"
-" replace existing scopes, prefix with *."
+msgid "Additional scopes to be passed to the OAuth Provider, separated by space. To replace existing scopes, prefix with *."
 msgstr "要传递给 OAuth 提供程序的其他作用域，用空格分隔。要替换已存在的作用域，请添加前缀 *。"
 
 #: src/admin/blueprints/BlueprintForm.ts
@@ -385,14 +393,16 @@ msgstr "高级设置"
 msgid "Affected model:"
 msgstr "受影响的模型："
 
-#: src/admin/events/RuleForm.ts src/admin/events/RuleListPage.ts
+#: src/admin/events/RuleForm.ts
+#: src/admin/events/RuleListPage.ts
 msgid "Alert"
 msgstr "注意"
 
 #~ msgid "Algorithm used to sign the JWT Tokens."
 #~ msgstr "用于签名 JWT 令牌的算法。"
 
-#: src/admin/applications/ApplicationForm.ts src/admin/flows/FlowForm.ts
+#: src/admin/applications/ApplicationForm.ts
+#: src/admin/flows/FlowForm.ts
 #: src/admin/flows/StageBindingForm.ts
 msgid "All policies must match to grant access"
 msgstr "必须匹配所有策略才能授予访问权限"
@@ -404,8 +414,7 @@ msgstr "必须匹配所有策略才能授予访问权限"
 #~ msgstr "ALL，必须匹配所有策略才能包含此阶段访问权限。"
 
 #: src/admin/sources/plex/PlexSourceForm.ts
-msgid ""
-"Allow friends to authenticate via Plex, even if you don't share any servers"
+msgid "Allow friends to authenticate via Plex, even if you don't share any servers"
 msgstr "允许好友通过 Plex 进行身份验证，即使您不共享任何服务器。"
 
 #: src/admin/sources/saml/SAMLSourceForm.ts
@@ -417,9 +426,7 @@ msgid "Allow up to N occurrences in the HIBP database."
 msgstr "HIBP 数据库中最多允许 N 次出现。"
 
 #: src/admin/policies/PolicyListPage.ts
-msgid ""
-"Allow users to use Applications based on properties, enforce Password "
-"Criteria and selectively apply Stages."
+msgid "Allow users to use Applications based on properties, enforce Password Criteria and selectively apply Stages."
 msgstr "允许用户根据属性使用应用程序、强制使用密码标准以及选择性地应用阶段。"
 
 #: src/admin/policies/password/PasswordPolicyForm.ts
@@ -435,9 +442,7 @@ msgid "Allowed servers"
 msgstr "允许的服务器"
 
 #: src/admin/sources/saml/SAMLSourceForm.ts
-msgid ""
-"Allows authentication flows initiated by the IdP. This can be a security "
-"risk, as no validation of the request ID is done."
+msgid "Allows authentication flows initiated by the IdP. This can be a security risk, as no validation of the request ID is done."
 msgstr "允许由 IdP 启动的身份验证流程。这可能存在安全风险，因为未对请求 ID 进行验证。"
 
 #: src/admin/policies/reputation/ReputationPolicyForm.ts
@@ -453,8 +458,7 @@ msgid "Also known as EntityID."
 msgstr "也称为 EntityID。"
 
 #: src/flow/stages/authenticator_duo/AuthenticatorDuoStage.ts
-msgid ""
-"Alternatively, if your current device has Duo installed, click on this link:"
+msgid "Alternatively, if your current device has Duo installed, click on this link:"
 msgstr "或者，如果您当前的设备已安装 Duo，请点击此链接："
 
 #: src/admin/stages/user_write/UserWriteStageForm.ts
@@ -481,7 +485,8 @@ msgstr "设置示例如下所示："
 msgid "Any HTML can be used."
 msgstr "可以使用任何 HTML。"
 
-#: src/admin/applications/ApplicationForm.ts src/admin/flows/FlowForm.ts
+#: src/admin/applications/ApplicationForm.ts
+#: src/admin/flows/FlowForm.ts
 #: src/admin/flows/StageBindingForm.ts
 msgid "Any policy must match to grant access"
 msgstr "必须匹配任意策略才能授予访问权限。"
@@ -531,7 +536,8 @@ msgstr "API Token"
 msgid "API URL"
 msgstr "API URL"
 
-#: src/admin/events/EventInfo.ts src/admin/events/EventViewPage.ts
+#: src/admin/events/EventInfo.ts
+#: src/admin/events/EventViewPage.ts
 #: src/admin/policies/event_matcher/EventMatcherPolicyForm.ts
 msgid "App"
 msgstr "应用"
@@ -608,22 +614,19 @@ msgstr "应用的显示名称。"
 msgid "Application(s)"
 msgstr "应用程序"
 
-#: src/admin/AdminInterface.ts src/admin/AdminInterface.ts
+#: src/admin/AdminInterface.ts
+#: src/admin/AdminInterface.ts
 #: src/admin/applications/ApplicationListPage.ts
 #: src/admin/outposts/OutpostForm.ts
 msgid "Applications"
 msgstr "应用程序"
 
 #: src/admin/applications/wizard/oauth/TypeOAuthApplicationWizardPage.ts
-msgid ""
-"Applications which handle the authentication server-side (for example, "
-"Python, Go, Rust, Java, PHP)"
+msgid "Applications which handle the authentication server-side (for example, Python, Go, Rust, Java, PHP)"
 msgstr "在服务端处理身份验证的应用程序（例如 Python、Go、Rust、Java、PHP）"
 
 #: src/admin/applications/wizard/oauth/TypeOAuthApplicationWizardPage.ts
-msgid ""
-"Applications which redirect users to a non-web callback (for example, "
-"Android, iOS)"
+msgid "Applications which redirect users to a non-web callback (for example, Android, iOS)"
 msgstr "重定向用户到非 Web 回调的应用程序（例如 Android、iOS）"
 
 #: src/elements/wizard/ActionWizardPage.ts
@@ -673,9 +676,7 @@ msgstr "您确定要从以下组中删除用户 {0} 吗？"
 msgid "Are you sure you want to update {0} \"{1}\"?"
 msgstr "您确定要更新 {0} \"{1}\" 吗？"
 
-#~ msgid ""
-#~ "Assertion not valid on or after current time + this value (Format: "
-#~ "hours=1;minutes=2;seconds=3)."
+#~ msgid "Assertion not valid on or after current time + this value (Format: hours=1;minutes=2;seconds=3)."
 #~ msgstr "从当前时间经过多久时或之后，断言无效（格式：hours=1;minutes=2;seconds=3）。"
 
 #: src/admin/providers/saml/SAMLProviderForm.ts
@@ -723,16 +724,13 @@ msgid "Attribute mapping"
 msgstr "属性映射"
 
 #: src/admin/property-mappings/PropertyMappingSAMLForm.ts
-msgid ""
-"Attribute name used for SAML Assertions. Can be a URN OID, a schema "
-"reference, or a any other string. If this property mapping is used for "
-"NameID Property, this field is discarded."
-msgstr ""
-"用于 SAML 断言的属性名称。可以是 URN OID、Schema Reference 或任何其他字符串。如果此属性映射用于 NameID "
-"属性，则会丢弃此字段。"
+msgid "Attribute name used for SAML Assertions. Can be a URN OID, a schema reference, or a any other string. If this property mapping is used for NameID Property, this field is discarded."
+msgstr "用于 SAML 断言的属性名称。可以是 URN OID、Schema Reference 或任何其他字符串。如果此属性映射用于 NameID 属性，则会丢弃此字段。"
 
-#: src/admin/groups/GroupForm.ts src/admin/stages/invitation/InvitationForm.ts
-#: src/admin/tenants/TenantForm.ts src/admin/users/UserForm.ts
+#: src/admin/groups/GroupForm.ts
+#: src/admin/stages/invitation/InvitationForm.ts
+#: src/admin/tenants/TenantForm.ts
+#: src/admin/users/UserForm.ts
 msgid "Attributes"
 msgstr "属性"
 
@@ -752,7 +750,8 @@ msgstr "正在使用 Apple 进行身份验证..."
 msgid "Authenticating with Plex..."
 msgstr "正在使用 Plex 进行身份验证..."
 
-#: src/admin/flows/FlowForm.ts src/admin/flows/utils.ts
+#: src/admin/flows/FlowForm.ts
+#: src/admin/flows/utils.ts
 #: src/admin/providers/proxy/ProxyProviderViewPage.ts
 msgid "Authentication"
 msgstr "身份验证"
@@ -763,7 +762,8 @@ msgstr "身份验证"
 #: src/admin/providers/saml/SAMLProviderForm.ts
 #: src/admin/sources/oauth/OAuthSourceForm.ts
 #: src/admin/sources/plex/PlexSourceForm.ts
-#: src/admin/sources/saml/SAMLSourceForm.ts src/admin/tenants/TenantForm.ts
+#: src/admin/sources/saml/SAMLSourceForm.ts
+#: src/admin/tenants/TenantForm.ts
 msgid "Authentication flow"
 msgstr "身份验证流程"
 
@@ -784,9 +784,7 @@ msgid "Authentication URL"
 msgstr "身份验证 URL"
 
 #: src/admin/applications/wizard/oauth/TypeOAuthApplicationWizardPage.ts
-msgid ""
-"Authentication without user interaction, or machine-to-machine "
-"authentication."
+msgid "Authentication without user interaction, or machine-to-machine authentication."
 msgstr "无需用户操作的身份验证，或 M2M（机器到机器）身份验证。"
 
 #: src/flow/stages/authenticator_validate/AuthenticatorValidateStage.ts
@@ -887,7 +885,8 @@ msgstr "反向通道提供程序"
 msgid "Backends"
 msgstr "后端"
 
-#: src/admin/flows/FlowForm.ts src/admin/flows/FlowForm.ts
+#: src/admin/flows/FlowForm.ts
+#: src/admin/flows/FlowForm.ts
 msgid "Background"
 msgstr "背景"
 
@@ -895,7 +894,8 @@ msgstr "背景"
 msgid "Background image"
 msgstr "背景图片"
 
-#: src/admin/flows/FlowForm.ts src/admin/flows/FlowForm.ts
+#: src/admin/flows/FlowForm.ts
+#: src/admin/flows/FlowForm.ts
 msgid "Background shown during execution."
 msgstr "执行过程中显示的背景。"
 
@@ -942,14 +942,16 @@ msgstr "基于用户 ID"
 msgid "Based on the User's UPN"
 msgstr "基于用户 UPN"
 
-#~ msgid ""
-#~ "Based on the User's UPN, only works if user has a 'upn' attribute set. Use "
-#~ "this method only if you have different UPN and Mail domains."
+#~ msgid "Based on the User's UPN, only works if user has a 'upn' attribute set. Use this method only if you have different UPN and Mail domains."
 #~ msgstr "基于用户的 UPN，仅当用户设置了 'upn' 属性时才有效。仅当您有不同的 UPN 和 Mail 域时才使用此方法。"
 
 #: src/admin/providers/oauth2/OAuth2ProviderForm.ts
 msgid "Based on the User's username"
 msgstr "基于用户名"
+
+#: src/admin/providers/oauth2/OAuth2ProviderForm.ts
+msgid "Based on the User's UUID"
+msgstr ""
 
 #~ msgid "Based on the username"
 #~ msgstr "基于用户名"
@@ -1003,7 +1005,8 @@ msgstr "Bind 密码"
 msgid "Bind stage"
 msgstr "绑定阶段"
 
-#: src/admin/events/EventInfo.ts src/admin/events/EventInfo.ts
+#: src/admin/events/EventInfo.ts
+#: src/admin/events/EventInfo.ts
 msgid "Binding"
 msgstr "绑定"
 
@@ -1019,7 +1022,8 @@ msgstr "蓝图"
 msgid "Blueprint(s)"
 msgstr "蓝图"
 
-#: src/admin/AdminInterface.ts src/admin/blueprints/BlueprintListPage.ts
+#: src/admin/AdminInterface.ts
+#: src/admin/blueprints/BlueprintListPage.ts
 msgid "Blueprints"
 msgstr "蓝图"
 
@@ -1040,35 +1044,28 @@ msgstr "品牌信息显示在页面标题和其他几个地方。"
 #~ msgid "Build hash: {0}"
 #~ msgstr "构建哈希：{0}"
 
-#: src/admin/sources/SourceListPage.ts src/admin/sources/SourceListPage.ts
+#: src/admin/sources/SourceListPage.ts
+#: src/admin/sources/SourceListPage.ts
 msgid "Built-in"
 msgstr "内置"
 
 #: src/admin/applications/wizard/oauth/TypeOAuthAPIApplicationWizardPage.ts
-msgid ""
-"By default, all service accounts can authenticate as this application, as "
-"long as they have a valid token of the type app-password."
+msgid "By default, all service accounts can authenticate as this application, as long as they have a valid token of the type app-password."
 msgstr "默认情况下，所有服务账户都可以作为此应用程序进行身份验证，只要它们拥有 app-password 类型的有效令牌。"
 
 #: src/admin/stages/identification/IdentificationStageForm.ts
-msgid ""
-"By default, only icons are shown for sources. Enable this to show their full"
-" names."
+msgid "By default, only icons are shown for sources. Enable this to show their full names."
 msgstr "默认情况下，只为源显示图标。启用此选项可显示它们的全名。"
 
 #: src/admin/outposts/ServiceConnectionDockerForm.ts
-msgid ""
-"CA which the endpoint's Certificate is verified against. Can be left empty "
-"for no validation."
+msgid "CA which the endpoint's Certificate is verified against. Can be left empty for no validation."
 msgstr "验证端点证书所依据的 CA。可以留空，表示不进行验证。"
 
 #: src/admin/providers/ldap/LDAPProviderForm.ts
 msgid "Cached binding"
 msgstr "缓存绑定"
 
-#~ msgid ""
-#~ "Cached binding, flow is executed and session is cached in memory. Flow is "
-#~ "executed when session expires."
+#~ msgid "Cached binding, flow is executed and session is cached in memory. Flow is executed when session expires."
 #~ msgstr "缓存绑定，流程与会话会在内存中执行与缓存。会话过期时执行流程。"
 
 #~ msgid "Cached flows"
@@ -1081,9 +1078,7 @@ msgstr "缓存绑定"
 msgid "Cached querying"
 msgstr "缓存查询"
 
-#~ msgid ""
-#~ "Cached querying, the outpost holds all users and groups in-memory and will "
-#~ "refresh every 5 Minutes."
+#~ msgid "Cached querying, the outpost holds all users and groups in-memory and will refresh every 5 Minutes."
 #~ msgstr "缓存查询，前哨将所有用户和组保存在内存中，并每 5 分钟刷新一次。"
 
 #: src/admin/providers/proxy/ProxyProviderViewPage.ts
@@ -1094,33 +1089,28 @@ msgstr "Caddy（独立）"
 msgid "Callback URL"
 msgstr "回调 URL"
 
-#~ msgid ""
-#~ "Can be either the username (found in the Users list) or the ID (can be found"
-#~ " in the URL after clicking on a user)."
+#~ msgid "Can be either the username (found in the Users list) or the ID (can be found in the URL after clicking on a user)."
 #~ msgstr "可以为用户名（在用户列表获取）或者 ID（点击用户后在 URL 中获取）。"
 
-#~ msgid ""
-#~ "Can be in the format of 'unix://' when connecting to a local docker daemon, "
-#~ "or 'https://:2376' when connecting to a remote system."
+#~ msgid "Can be in the format of 'unix://' when connecting to a local docker daemon, or 'https://:2376' when connecting to a remote system."
 #~ msgstr "连接到本地 Docker 守护进程时可以采用 'unix://' 格式，或者在连接到远程系统时采用 'https://:2376' 格式。"
 
 #: src/admin/outposts/ServiceConnectionDockerForm.ts
-msgid ""
-"Can be in the format of 'unix://' when connecting to a local docker daemon, "
-"using 'ssh://' to connect via SSH, or 'https://:2376' when connecting to a "
-"remote system."
-msgstr ""
-"连接到本地 Docker 守护进程时可以采用 'unix://' 格式，通过 SSH 连接时采用 'ssh://' 格式，或者在连接到远程系统时采用 "
-"'https://:2376' 格式。"
+msgid "Can be in the format of 'unix://' when connecting to a local docker daemon, using 'ssh://' to connect via SSH, or 'https://:2376' when connecting to a remote system."
+msgstr "连接到本地 Docker 守护进程时可以采用 'unix://' 格式，通过 SSH 连接时采用 'ssh://' 格式，或者在连接到远程系统时采用 'https://:2376' 格式。"
 
 #~ msgid "Can create users"
 #~ msgstr "可创建用户"
 
 #: src/admin/applications/ProviderSelectModal.ts
-#: src/admin/groups/MemberSelectModal.ts src/admin/users/GroupSelectModal.ts
-#: src/admin/users/UserActiveForm.ts src/elements/forms/ConfirmationForm.ts
-#: src/elements/forms/DeleteBulkForm.ts src/elements/forms/DeleteForm.ts
-#: src/elements/forms/ModalForm.ts src/elements/wizard/Wizard.ts
+#: src/admin/groups/MemberSelectModal.ts
+#: src/admin/users/GroupSelectModal.ts
+#: src/admin/users/UserActiveForm.ts
+#: src/elements/forms/ConfirmationForm.ts
+#: src/elements/forms/DeleteBulkForm.ts
+#: src/elements/forms/DeleteForm.ts
+#: src/elements/forms/ModalForm.ts
+#: src/elements/wizard/Wizard.ts
 msgid "Cancel"
 msgstr "取消"
 
@@ -1147,8 +1137,7 @@ msgid "Certificate Subject"
 msgstr "证书主题"
 
 #: src/admin/providers/saml/SAMLProviderForm.ts
-msgid ""
-"Certificate used to sign outgoing Responses going to the Service Provider."
+msgid "Certificate used to sign outgoing Responses going to the Service Provider."
 msgstr "证书，用于签署发送给服务提供程序的传出响应。"
 
 #~ msgid "Certificate-Key Pair"
@@ -1163,9 +1152,7 @@ msgid "Certificate-Key Pairs"
 msgstr "证书密钥对"
 
 #: src/admin/outposts/ServiceConnectionDockerForm.ts
-msgid ""
-"Certificate/Key used for authentication. Can be left empty for no "
-"authentication."
+msgid "Certificate/Key used for authentication. Can be left empty for no authentication."
 msgstr "用于身份验证的证书/密钥。可以留空表示不验证。"
 
 #: src/admin/AdminInterface.ts
@@ -1176,7 +1163,8 @@ msgstr "证书"
 msgid "Change password"
 msgstr "更改密码"
 
-#: src/admin/users/RelatedUserList.ts src/admin/users/UserListPage.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
 msgid "Change status"
 msgstr "更改状态"
 
@@ -1185,7 +1173,8 @@ msgid "Change your password"
 msgstr "更改您的密码"
 
 #: src/admin/applications/ApplicationViewPage.ts
-#: src/admin/flows/FlowViewPage.ts src/admin/groups/GroupViewPage.ts
+#: src/admin/flows/FlowViewPage.ts
+#: src/admin/groups/GroupViewPage.ts
 #: src/admin/providers/ldap/LDAPProviderViewPage.ts
 #: src/admin/providers/oauth2/OAuth2ProviderViewPage.ts
 #: src/admin/providers/proxy/ProxyProviderViewPage.ts
@@ -1282,15 +1271,11 @@ msgstr "复选框"
 #~ "请注意，只有一部分密码哈希值被发送，完整的比较是在客户端完成的。"
 
 #: src/admin/policies/expiry/ExpiryPolicyForm.ts
-msgid ""
-"Checks if the request's user's password has been changed in the last x days,"
-" and denys based on settings."
+msgid "Checks if the request's user's password has been changed in the last x days, and denys based on settings."
 msgstr "检查过去 x 天内请求的用户密码是否已更改，并根据设置拒绝。"
 
 #: src/admin/policies/password/PasswordPolicyForm.ts
-msgid ""
-"Checks the value from the policy request against several rules, mostly used "
-"to ensure password strength."
+msgid "Checks the value from the policy request against several rules, mostly used to ensure password strength."
 msgstr "根据多条规则检查策略请求中的值，这些规则主要用于确保密码强度。"
 
 #: src/common/ui/locale.ts
@@ -1313,8 +1298,10 @@ msgstr "清除背景"
 #~ msgid "Clear background image"
 #~ msgstr "清除背景图片"
 
-#: src/admin/flows/FlowListPage.ts src/admin/flows/FlowListPage.ts
-#: src/admin/policies/PolicyListPage.ts src/admin/policies/PolicyListPage.ts
+#: src/admin/flows/FlowListPage.ts
+#: src/admin/flows/FlowListPage.ts
+#: src/admin/policies/PolicyListPage.ts
+#: src/admin/policies/PolicyListPage.ts
 msgid "Clear cache"
 msgstr "清除缓存"
 
@@ -1353,9 +1340,11 @@ msgid "Client ID"
 msgstr "客户端 ID"
 
 #: src/admin/admin-overview/cards/RecentEventsCard.ts
-#: src/admin/events/EventListPage.ts src/admin/events/EventViewPage.ts
+#: src/admin/events/EventListPage.ts
+#: src/admin/events/EventViewPage.ts
 #: src/admin/policies/event_matcher/EventMatcherPolicyForm.ts
-#: src/elements/events/ObjectChangelog.ts src/elements/events/UserEvents.ts
+#: src/elements/events/ObjectChangelog.ts
+#: src/elements/events/UserEvents.ts
 msgid "Client IP"
 msgstr "客户端 IP"
 
@@ -1374,9 +1363,11 @@ msgid "Client type"
 msgstr "客户端类型"
 
 #: src/admin/outposts/OutpostDeploymentModal.ts
-#: src/admin/users/RelatedUserList.ts src/admin/users/UserListPage.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
 #: src/elements/notifications/NotificationDrawer.ts
-#: src/elements/wizard/Wizard.ts src/flow/FlowInspector.ts
+#: src/elements/wizard/Wizard.ts
+#: src/flow/FlowInspector.ts
 msgid "Close"
 msgstr "关闭"
 
@@ -1400,14 +1391,10 @@ msgid "Confidential"
 msgstr "机密"
 
 #: src/admin/providers/oauth2/OAuth2ProviderForm.ts
-msgid ""
-"Confidential clients are capable of maintaining the confidentiality of their"
-" credentials such as client secrets"
+msgid "Confidential clients are capable of maintaining the confidentiality of their credentials such as client secrets"
 msgstr "机密客户端有能力维护其凭据例如客户端密钥的机密性。"
 
-#~ msgid ""
-#~ "Confidential clients are capable of maintaining the confidentiality of their"
-#~ " credentials. Public clients are incapable."
+#~ msgid "Confidential clients are capable of maintaining the confidentiality of their credentials. Public clients are incapable."
 #~ msgstr "机密客户能够对其凭据进行保密。公共客户端无此能力。"
 
 #: src/admin/outposts/OutpostForm.ts
@@ -1454,14 +1441,10 @@ msgid "Configure how long tokens are valid for."
 msgstr "配置令牌的有效期限。"
 
 #: src/admin/flows/StageBindingForm.ts
-msgid ""
-"Configure how the flow executor should handle an invalid response to a "
-"challenge given by this bound stage."
+msgid "Configure how the flow executor should handle an invalid response to a challenge given by this bound stage."
 msgstr "针对由此绑定阶段提供的质询，配置流程执行器应如何处理对此质询的无效响应。"
 
-#~ msgid ""
-#~ "Configure how the flow executor should handle an invalid response to a "
-#~ "challenge."
+#~ msgid "Configure how the flow executor should handle an invalid response to a challenge."
 #~ msgstr "配置流程执行器应如何处理对质询的无效响应。"
 
 #: src/admin/providers/oauth2/OAuth2ProviderForm.ts
@@ -1469,9 +1452,7 @@ msgid "Configure how the issuer field of the ID Token should be filled."
 msgstr "配置如何填写 ID 令牌的颁发者字段。"
 
 #: src/admin/providers/saml/SAMLProviderForm.ts
-msgid ""
-"Configure how the NameID value will be created. When left empty, the "
-"NameIDPolicy of the incoming request will be respected."
+msgid "Configure how the NameID value will be created. When left empty, the NameIDPolicy of the incoming request will be respected."
 msgstr "配置如何创建 NameID 值。如果留空，将遵守传入请求的 NameIDPolicy。"
 
 #: src/admin/providers/ldap/LDAPProviderForm.ts
@@ -1501,9 +1482,7 @@ msgstr "配置不同域名的可视化设置和默认值。"
 #~ msgstr "配置 WebAuthn"
 
 #: src/admin/providers/oauth2/OAuth2ProviderForm.ts
-msgid ""
-"Configure what data should be used as unique User Identifier. For most "
-"cases, the default should be fine."
+msgid "Configure what data should be used as unique User Identifier. For most cases, the default should be fine."
 msgstr "配置应将哪些数据用作唯一用户标识符。在大多数情况下保持默认值即可。"
 
 #: src/elements/user/UserDevicesList.ts
@@ -1521,9 +1500,7 @@ msgid "Connect to the LDAP Server on port 389:"
 msgstr "通过端口 389 连接到 LDAP 服务器："
 
 #: src/user/user-settings/sources/SourceSettings.ts
-msgid ""
-"Connect your user account to the services listed below, to allow you to "
-"login using the service instead of traditional credentials."
+msgid "Connect your user account to the services listed below, to allow you to login using the service instead of traditional credentials."
 msgstr "将您的用户账户连接到下面列出的服务，以允许您使用该服务而不是传统凭据登录。"
 
 #: src/user/user-settings/UserSettingsPage.ts
@@ -1594,8 +1571,10 @@ msgstr "内容左侧"
 msgid "Content right"
 msgstr "内容右侧"
 
-#: src/admin/blueprints/BlueprintForm.ts src/admin/events/EventInfo.ts
-#: src/admin/events/EventInfo.ts src/admin/events/EventInfo.ts
+#: src/admin/blueprints/BlueprintForm.ts
+#: src/admin/events/EventInfo.ts
+#: src/admin/events/EventInfo.ts
+#: src/admin/events/EventInfo.ts
 #: src/admin/policies/PolicyTestForm.ts
 #: src/admin/property-mappings/PropertyMappingTestForm.ts
 msgid "Context"
@@ -1609,7 +1588,8 @@ msgstr "上下文"
 #: src/flow/stages/authenticator_totp/AuthenticatorTOTPStage.ts
 #: src/flow/stages/authenticator_validate/AuthenticatorValidateStageCode.ts
 #: src/flow/stages/autosubmit/AutosubmitStage.ts
-#: src/flow/stages/consent/ConsentStage.ts src/flow/stages/dummy/DummyStage.ts
+#: src/flow/stages/consent/ConsentStage.ts
+#: src/flow/stages/dummy/DummyStage.ts
 #: src/flow/stages/password/PasswordStage.ts
 #: src/flow/stages/prompt/PromptStage.ts
 msgid "Continue"
@@ -1619,9 +1599,7 @@ msgstr "继续"
 msgid "Continue flow without invitation"
 msgstr "在没有邀请的情况下继续流程"
 
-#~ msgid ""
-#~ "CONTINUE will either follow the ?next parameter or redirect to the default "
-#~ "interface."
+#~ msgid "CONTINUE will either follow the ?next parameter or redirect to the default interface."
 #~ msgstr "CONTINUE 将会遵循 ?next 参数或者重定向到默认接口。"
 
 #: src/admin/property-mappings/PropertyMappingListPage.ts
@@ -1644,7 +1622,8 @@ msgstr "复制下载 URL"
 #~ msgid "Copy Key"
 #~ msgstr "复制密钥"
 
-#: src/admin/users/RelatedUserList.ts src/admin/users/UserListPage.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
 msgid "Copy recovery link"
 msgstr "复制恢复链接"
 
@@ -1655,16 +1634,23 @@ msgstr "复制恢复链接"
 #: src/admin/blueprints/BlueprintListPage.ts
 #: src/admin/crypto/CertificateKeyPairListPage.ts
 #: src/admin/crypto/CertificateKeyPairListPage.ts
-#: src/admin/events/RuleListPage.ts src/admin/events/RuleListPage.ts
-#: src/admin/events/TransportListPage.ts src/admin/events/TransportListPage.ts
-#: src/admin/flows/BoundStagesList.ts src/admin/flows/BoundStagesList.ts
-#: src/admin/flows/FlowListPage.ts src/admin/flows/FlowListPage.ts
-#: src/admin/groups/GroupListPage.ts src/admin/groups/GroupListPage.ts
-#: src/admin/groups/RelatedGroupList.ts src/admin/outposts/OutpostListPage.ts
+#: src/admin/events/RuleListPage.ts
+#: src/admin/events/RuleListPage.ts
+#: src/admin/events/TransportListPage.ts
+#: src/admin/events/TransportListPage.ts
+#: src/admin/flows/BoundStagesList.ts
+#: src/admin/flows/BoundStagesList.ts
+#: src/admin/flows/FlowListPage.ts
+#: src/admin/flows/FlowListPage.ts
+#: src/admin/groups/GroupListPage.ts
+#: src/admin/groups/GroupListPage.ts
+#: src/admin/groups/RelatedGroupList.ts
+#: src/admin/outposts/OutpostListPage.ts
 #: src/admin/outposts/OutpostListPage.ts
 #: src/admin/outposts/ServiceConnectionWizard.ts
 #: src/admin/policies/BoundPoliciesList.ts
-#: src/admin/policies/BoundPoliciesList.ts src/admin/policies/PolicyWizard.ts
+#: src/admin/policies/BoundPoliciesList.ts
+#: src/admin/policies/PolicyWizard.ts
 #: src/admin/property-mappings/PropertyMappingWizard.ts
 #: src/admin/providers/ProviderWizard.ts
 #: src/admin/providers/RelatedApplicationButton.ts
@@ -1675,11 +1661,16 @@ msgstr "复制恢复链接"
 #: src/admin/stages/prompt/PromptListPage.ts
 #: src/admin/stages/prompt/PromptListPage.ts
 #: src/admin/stages/prompt/PromptStageForm.ts
-#: src/admin/stages/prompt/PromptStageForm.ts src/admin/stages/StageWizard.ts
-#: src/admin/tenants/TenantListPage.ts src/admin/tenants/TenantListPage.ts
-#: src/admin/tokens/TokenListPage.ts src/admin/tokens/TokenListPage.ts
-#: src/admin/users/RelatedUserList.ts src/admin/users/RelatedUserList.ts
-#: src/admin/users/UserListPage.ts src/admin/users/UserListPage.ts
+#: src/admin/stages/prompt/PromptStageForm.ts
+#: src/admin/stages/StageWizard.ts
+#: src/admin/tenants/TenantListPage.ts
+#: src/admin/tenants/TenantListPage.ts
+#: src/admin/tokens/TokenListPage.ts
+#: src/admin/tokens/TokenListPage.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
+#: src/admin/users/UserListPage.ts
 #: src/admin/users/UserListPage.ts
 #: src/user/user-settings/tokens/UserTokenList.ts
 #: src/user/user-settings/tokens/UserTokenList.ts
@@ -1689,7 +1680,8 @@ msgstr "创建"
 #: src/admin/outposts/ServiceConnectionWizard.ts
 #: src/admin/policies/PolicyWizard.ts
 #: src/admin/property-mappings/PropertyMappingWizard.ts
-#: src/admin/providers/ProviderWizard.ts src/admin/sources/SourceWizard.ts
+#: src/admin/providers/ProviderWizard.ts
+#: src/admin/sources/SourceWizard.ts
 #: src/admin/stages/StageWizard.ts
 msgid "Create {0}"
 msgstr "创建 {0}"
@@ -1754,7 +1746,8 @@ msgstr "创建应用程序"
 
 #: src/admin/policies/BoundPoliciesList.ts
 #: src/admin/policies/BoundPoliciesList.ts
-#: src/admin/policies/BoundPoliciesList.ts src/admin/policies/PolicyWizard.ts
+#: src/admin/policies/BoundPoliciesList.ts
+#: src/admin/policies/PolicyWizard.ts
 #: src/admin/stages/StageWizard.ts
 msgid "Create Binding"
 msgstr "创建绑定"
@@ -1775,7 +1768,8 @@ msgstr "创建流程"
 msgid "Create group"
 msgstr "创建组"
 
-#: src/admin/groups/GroupListPage.ts src/admin/groups/RelatedGroupList.ts
+#: src/admin/groups/GroupListPage.ts
+#: src/admin/groups/RelatedGroupList.ts
 msgid "Create Group"
 msgstr "创建组"
 
@@ -1784,9 +1778,7 @@ msgid "Create Invitation"
 msgstr "创建邀请"
 
 #: src/admin/stages/invitation/InvitationListPage.ts
-msgid ""
-"Create Invitation Links to enroll Users, and optionally force specific "
-"attributes of their account."
+msgid "Create Invitation Links to enroll Users, and optionally force specific attributes of their account."
 msgstr "创建邀请链接以注册用户，并可选地强制设置其账户的特定属性。"
 
 #: src/admin/events/RuleListPage.ts
@@ -1821,15 +1813,18 @@ msgstr "创建提供程序"
 msgid "Create service account"
 msgstr "创建服务账户"
 
-#: src/admin/users/RelatedUserList.ts src/admin/users/RelatedUserList.ts
-#: src/admin/users/UserListPage.ts src/admin/users/UserListPage.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
+#: src/admin/users/UserListPage.ts
 msgid "Create Service account"
 msgstr "创建服务账户"
 
 #~ msgid "Create Stage"
 #~ msgstr "创建阶段"
 
-#: src/admin/flows/BoundStagesList.ts src/admin/flows/BoundStagesList.ts
+#: src/admin/flows/BoundStagesList.ts
+#: src/admin/flows/BoundStagesList.ts
 msgid "Create Stage binding"
 msgstr "创建阶段绑定"
 
@@ -1843,11 +1838,13 @@ msgstr "创建租户"
 msgid "Create Token"
 msgstr "创建令牌"
 
-#: src/admin/users/RelatedUserList.ts src/admin/users/RelatedUserList.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/RelatedUserList.ts
 msgid "Create user"
 msgstr "创建用户"
 
-#: src/admin/users/RelatedUserList.ts src/admin/users/UserListPage.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
 msgid "Create User"
 msgstr "创建用户"
 
@@ -1871,7 +1868,8 @@ msgid "Created by"
 msgstr "创建者"
 
 #: src/admin/admin-overview/cards/RecentEventsCard.ts
-#: src/admin/events/EventListPage.ts src/elements/events/ObjectChangelog.ts
+#: src/admin/events/EventListPage.ts
+#: src/elements/events/ObjectChangelog.ts
 #: src/elements/events/UserEvents.ts
 msgid "Creation Date"
 msgstr "创建日期"
@@ -1883,7 +1881,8 @@ msgstr "创建日期"
 msgid "Current plan context"
 msgstr "当前计划上下文"
 
-#: src/admin/applications/ApplicationForm.ts src/admin/flows/FlowForm.ts
+#: src/admin/applications/ApplicationForm.ts
+#: src/admin/flows/FlowForm.ts
 #: src/admin/sources/oauth/OAuthSourceForm.ts
 #: src/admin/sources/plex/PlexSourceForm.ts
 #: src/admin/sources/saml/SAMLSourceForm.ts
@@ -1910,7 +1909,8 @@ msgstr "日期"
 msgid "Date Time"
 msgstr "日期时间"
 
-#: src/admin/users/RelatedUserList.ts src/admin/users/UserListPage.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
 #: src/admin/users/UserViewPage.ts
 msgid "Deactivate"
 msgstr "停用"
@@ -1920,14 +1920,11 @@ msgid "Debug"
 msgstr "调试"
 
 #: src/admin/flows/FlowForm.ts
-msgid ""
-"Decides the response when a policy denies access to this flow for a user."
+msgid "Decides the response when a policy denies access to this flow for a user."
 msgstr "当一条策略拒绝用户访问此流程时决定响应。"
 
 #: src/admin/flows/FlowForm.ts
-msgid ""
-"Decides what this Flow is used for. For example, the Authentication flow is "
-"redirect to when an un-authenticated user visits authentik."
+msgid "Decides what this Flow is used for. For example, the Authentication flow is redirect to when an un-authenticated user visits authentik."
 msgstr "决定此流程的用途。例如，当未经身份验证的用户访问 authentik 时，会重定向到身份验证流程。"
 
 #: src/admin/tenants/TenantForm.ts
@@ -1949,27 +1946,37 @@ msgstr "定义如何向用户发送通知，例如电子邮件或 Webhook。"
 #: src/admin/applications/ApplicationListPage.ts
 #: src/admin/blueprints/BlueprintListPage.ts
 #: src/admin/crypto/CertificateKeyPairListPage.ts
-#: src/admin/events/RuleListPage.ts src/admin/events/TransportListPage.ts
-#: src/admin/flows/BoundStagesList.ts src/admin/flows/FlowListPage.ts
-#: src/admin/groups/GroupListPage.ts src/admin/outposts/OutpostListPage.ts
+#: src/admin/events/RuleListPage.ts
+#: src/admin/events/TransportListPage.ts
+#: src/admin/flows/BoundStagesList.ts
+#: src/admin/flows/FlowListPage.ts
+#: src/admin/groups/GroupListPage.ts
+#: src/admin/outposts/OutpostListPage.ts
 #: src/admin/outposts/ServiceConnectionListPage.ts
 #: src/admin/policies/BoundPoliciesList.ts
 #: src/admin/policies/PolicyListPage.ts
 #: src/admin/policies/reputation/ReputationListPage.ts
 #: src/admin/property-mappings/PropertyMappingListPage.ts
-#: src/admin/providers/ProviderListPage.ts src/admin/sources/SourceListPage.ts
+#: src/admin/providers/ProviderListPage.ts
+#: src/admin/sources/SourceListPage.ts
 #: src/admin/stages/invitation/InvitationListPage.ts
-#: src/admin/stages/prompt/PromptListPage.ts src/admin/stages/StageListPage.ts
-#: src/admin/tenants/TenantListPage.ts src/admin/tokens/TokenListPage.ts
-#: src/admin/users/UserListPage.ts src/elements/forms/DeleteBulkForm.ts
-#: src/elements/forms/DeleteForm.ts src/elements/oauth/UserRefreshList.ts
-#: src/elements/user/SessionList.ts src/elements/user/UserConsentList.ts
+#: src/admin/stages/prompt/PromptListPage.ts
+#: src/admin/stages/StageListPage.ts
+#: src/admin/tenants/TenantListPage.ts
+#: src/admin/tokens/TokenListPage.ts
+#: src/admin/users/UserListPage.ts
+#: src/elements/forms/DeleteBulkForm.ts
+#: src/elements/forms/DeleteForm.ts
+#: src/elements/oauth/UserRefreshList.ts
+#: src/elements/user/SessionList.ts
+#: src/elements/user/UserConsentList.ts
 #: src/user/user-settings/mfa/MFADevicesPage.ts
 #: src/user/user-settings/tokens/UserTokenList.ts
 msgid "Delete"
 msgstr "删除"
 
-#: src/elements/forms/DeleteBulkForm.ts src/elements/forms/DeleteForm.ts
+#: src/elements/forms/DeleteBulkForm.ts
+#: src/elements/forms/DeleteForm.ts
 msgid "Delete {0}"
 msgstr "删除 {0}"
 
@@ -2023,44 +2030,35 @@ msgstr "拒绝操作"
 msgid "Deny the user access"
 msgstr "拒绝用户访问"
 
-#~ msgid ""
-#~ "Deprecated. Instead of using this field, configure the JWKS data/URL in "
-#~ "Sources."
+#~ msgid "Deprecated. Instead of using this field, configure the JWKS data/URL in Sources."
 #~ msgstr "已弃用。请在身份来源中配置 JWKS 数据 / URL 代替此字段。"
 
 #: src/admin/applications/ApplicationForm.ts
 #: src/admin/applications/wizard/InitialApplicationWizardPage.ts
 #: src/admin/property-mappings/PropertyMappingScopeForm.ts
-#: src/admin/system-tasks/SystemTaskListPage.ts src/admin/tokens/TokenForm.ts
+#: src/admin/system-tasks/SystemTaskListPage.ts
+#: src/admin/tokens/TokenForm.ts
 #: src/user/user-settings/tokens/UserTokenForm.ts
 msgid "Description"
 msgstr "描述"
 
 #: src/admin/property-mappings/PropertyMappingScopeForm.ts
-msgid ""
-"Description shown to the user when consenting. If left empty, the user won't"
-" be informed."
+msgid "Description shown to the user when consenting. If left empty, the user won't be informed."
 msgstr "同意授权时向用户显示的描述。如果留空，则不会告知用户。"
 
 #: src/admin/users/UserForm.ts
-msgid ""
-"Designates whether this user should be treated as active. Unselect this "
-"instead of deleting accounts."
+msgid "Designates whether this user should be treated as active. Unselect this instead of deleting accounts."
 msgstr "指定是否应将此用户视为活动用户。取消选择此选项，而不是删除帐户。"
 
 #: src/admin/flows/FlowForm.ts
 msgid "Designation"
 msgstr "指定"
 
-#~ msgid ""
-#~ "Detailed health (one instance per column, data is cached so may be out of "
-#~ "data)"
+#~ msgid "Detailed health (one instance per column, data is cached so may be out of data)"
 #~ msgstr "详细健康状况（每列一个实例，数据经过缓存，因此可能会缺少数据）"
 
 #: src/admin/outposts/OutpostListPage.ts
-msgid ""
-"Detailed health (one instance per column, data is cached so may be out of "
-"date)"
+msgid "Detailed health (one instance per column, data is cached so may be out of date)"
 msgstr "详细健康状况（每列一个实例，数据经过缓存，因此可能会过时）"
 
 #: src/admin/sources/oauth/OAuthSourceViewPage.ts
@@ -2068,14 +2066,11 @@ msgid "Details"
 msgstr "详情"
 
 #: src/admin/providers/saml/SAMLProviderForm.ts
-msgid ""
-"Determines how authentik sends the response back to the Service Provider."
+msgid "Determines how authentik sends the response back to the Service Provider."
 msgstr "确定 authentik 如何将响应发送回服务提供程序。"
 
 #: src/admin/stages/user_login/UserLoginStageForm.ts
-msgid ""
-"Determines how long a session lasts. Default of 0 seconds means that the "
-"sessions lasts until the browser is closed."
+msgid "Determines how long a session lasts. Default of 0 seconds means that the sessions lasts until the browser is closed."
 msgstr "确定会话持续多长时间。默认为 0 秒意味着会话持续到浏览器关闭为止。"
 
 #~ msgid "Device"
@@ -2106,9 +2101,7 @@ msgid "Diagram"
 msgstr "流程图"
 
 #: src/admin/stages/user_login/UserLoginStageForm.ts
-msgid ""
-"Different browsers handle session cookies differently, and might not remove "
-"them even when the browser is closed."
+msgid "Different browsers handle session cookies differently, and might not remove them even when the browser is closed."
 msgstr "不同浏览器处理会话 Cookie 的方式不同，即使关闭浏览器，也不能保证它们会被删除。"
 
 #: src/admin/providers/saml/SAMLProviderForm.ts
@@ -2124,23 +2117,17 @@ msgstr "数字"
 msgid "Direct binding"
 msgstr "直接绑定"
 
-#~ msgid ""
-#~ "Direct binding, always execute the configured bind flow to authenticate the "
-#~ "user."
+#~ msgid "Direct binding, always execute the configured bind flow to authenticate the user."
 #~ msgstr "直接绑定，总是执行配置的绑定流程，以验证用户的身份。"
 
 #: src/admin/providers/ldap/LDAPProviderForm.ts
 msgid "Direct querying"
 msgstr "直接查询"
 
-#~ msgid ""
-#~ "Direct querying, always execute the configured bind flow to authenticate the"
-#~ " user."
+#~ msgid "Direct querying, always execute the configured bind flow to authenticate the user."
 #~ msgstr "直接查询，总是执行配置的绑定流程，以验证用户的身份。"
 
-#~ msgid ""
-#~ "Direct querying, always returns the latest data, but slower than cached "
-#~ "querying."
+#~ msgid "Direct querying, always returns the latest data, but slower than cached querying."
 #~ msgstr "直接查询，总是返回最新数据，但比缓存查询慢。"
 
 #: src/admin/AdminInterface.ts
@@ -2181,20 +2168,20 @@ msgstr "断开连接"
 #: src/admin/stages/authenticator_static/AuthenticatorStaticStageForm.ts
 #: src/admin/stages/authenticator_totp/AuthenticatorTOTPStageForm.ts
 #: src/admin/stages/authenticator_webauthn/AuthenticateWebAuthnStageForm.ts
-msgid ""
-"Display name of this authenticator, used by users when they enroll an "
-"authenticator."
+msgid "Display name of this authenticator, used by users when they enroll an authenticator."
 msgstr "此验证器的显示名称，在用户注册验证器时使用。"
 
 #: src/admin/outposts/ServiceConnectionDockerForm.ts
 msgid "Docker URL"
 msgstr "Docker URL"
 
-#: src/admin/blueprints/BlueprintForm.ts src/admin/outposts/OutpostForm.ts
+#: src/admin/blueprints/BlueprintForm.ts
+#: src/admin/outposts/OutpostForm.ts
 msgid "Documentation"
 msgstr "文档"
 
-#: src/admin/tenants/TenantForm.ts src/admin/tenants/TenantListPage.ts
+#: src/admin/tenants/TenantForm.ts
+#: src/admin/tenants/TenantListPage.ts
 #: src/admin/tenants/TenantListPage.ts
 msgid "Domain"
 msgstr "域名"
@@ -2227,23 +2214,17 @@ msgstr "下拉框（固定选项）"
 #~ msgstr "DSA-SHA1"
 
 #: src/admin/providers/ldap/LDAPProviderForm.ts
-msgid ""
-"Due to protocol limitations, this certificate is only used when the outpost "
-"has a single provider, or all providers use the same certificate."
+msgid "Due to protocol limitations, this certificate is only used when the outpost has a single provider, or all providers use the same certificate."
 msgstr "由于协议限制，只在前哨有单个提供程序，或所有提供程序都使用相同证书时才使用此证书。"
 
-#~ msgid ""
-#~ "Due to protocol limitations, this certificate is only used when the outpost "
-#~ "has a single provider."
+#~ msgid "Due to protocol limitations, this certificate is only used when the outpost has a single provider."
 #~ msgstr "由于协议限制，只在前哨有单个提供程序时才使用此证书。"
 
 #~ msgid "Dummy"
 #~ msgstr "占位"
 
 #: src/admin/stages/dummy/DummyStageForm.ts
-msgid ""
-"Dummy stage used for testing. Shows a simple continue button and always "
-"passes."
+msgid "Dummy stage used for testing. Shows a simple continue button and always passes."
 msgstr "用于测试的虚拟阶段。显示一个简单的“继续”按钮，并且始终通过。"
 
 #~ msgid "Duo"
@@ -2297,7 +2278,8 @@ msgstr "根据应用程序 Slug，每个提供程序都有不同的颁发者"
 
 #: src/admin/applications/ApplicationViewPage.ts
 #: src/admin/applications/ApplicationViewPage.ts
-#: src/admin/flows/FlowViewPage.ts src/admin/flows/FlowViewPage.ts
+#: src/admin/flows/FlowViewPage.ts
+#: src/admin/flows/FlowViewPage.ts
 #: src/admin/groups/GroupViewPage.ts
 #: src/admin/providers/ldap/LDAPProviderViewPage.ts
 #: src/admin/providers/oauth2/OAuth2ProviderViewPage.ts
@@ -2313,7 +2295,8 @@ msgstr "根据应用程序 Slug，每个提供程序都有不同的颁发者"
 msgid "Edit"
 msgstr "编辑"
 
-#: src/admin/flows/BoundStagesList.ts src/admin/policies/BoundPoliciesList.ts
+#: src/admin/flows/BoundStagesList.ts
+#: src/admin/policies/BoundPoliciesList.ts
 msgid "Edit Binding"
 msgstr "编辑绑定"
 
@@ -2333,18 +2316,14 @@ msgstr "编辑阶段"
 msgid "Edit the notes attribute of this group to add notes here."
 msgstr "编辑该组的备注属性以在此处添加备注。"
 
-#~ msgid ""
-#~ "Edit the notes attribute of this group to add notes here. Markdown is "
-#~ "supported."
+#~ msgid "Edit the notes attribute of this group to add notes here. Markdown is supported."
 #~ msgstr "编辑该组的备注属性以在此处添加备注。支持 Markdown。"
 
 #: src/admin/users/UserViewPage.ts
 msgid "Edit the notes attribute of this user to add notes here."
 msgstr "编辑该用户的备注属性以在此处添加备注。"
 
-#~ msgid ""
-#~ "Edit the notes attribute of this user to add notes here. Markdown is "
-#~ "supported."
+#~ msgid "Edit the notes attribute of this user to add notes here. Markdown is supported."
 #~ msgstr "编辑该用户的备注属性以在此处添加备注。支持 Markdown。"
 
 #: src/admin/policies/BoundPoliciesList.ts
@@ -2355,9 +2334,7 @@ msgstr "编辑用户"
 #: src/admin/sources/oauth/OAuthSourceForm.ts
 #: src/admin/sources/plex/PlexSourceForm.ts
 #: src/admin/sources/saml/SAMLSourceForm.ts
-msgid ""
-"Either input a full URL, a relative path, or use 'fa://fa-test' to use the "
-"Font Awesome icon \"fa-test\"."
+msgid "Either input a full URL, a relative path, or use 'fa://fa-test' to use the Font Awesome icon \"fa-test\"."
 msgstr "输入完整 URL、相对路径，或者使用 'fa://fa-test' 来使用 Font Awesome 图标 \"fa-test\"。"
 
 #: src/user/LibraryPage.ts
@@ -2366,7 +2343,8 @@ msgstr "没有定义应用程序，或者您无权访问任何应用程序。"
 
 #: src/admin/events/TransportForm.ts
 #: src/admin/stages/identification/IdentificationStageForm.ts
-#: src/admin/users/UserForm.ts src/admin/users/UserViewPage.ts
+#: src/admin/users/UserForm.ts
+#: src/admin/users/UserViewPage.ts
 #: src/flow/stages/identification/IdentificationStage.ts
 msgid "Email"
 msgstr "电子邮箱"
@@ -2379,7 +2357,8 @@ msgstr "电子邮箱地址"
 msgid "Email info:"
 msgstr "电子邮件信息："
 
-#: src/admin/users/RelatedUserList.ts src/admin/users/UserListPage.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
 msgid "Email recovery link"
 msgstr "电子邮件恢复链接"
 
@@ -2402,9 +2381,7 @@ msgstr "嵌入式前哨配置不正确。"
 #~ msgid "Enable"
 #~ msgstr "启用"
 
-#~ msgid ""
-#~ "Enable compatibility mode, increases compatibility with password managers on"
-#~ " mobile devices."
+#~ msgid "Enable compatibility mode, increases compatibility with password managers on mobile devices."
 #~ msgstr "启用兼容模式，增强与移动设备上密码管理器的兼容性。"
 
 #~ msgid "Enable Duo authenticator"
@@ -2435,9 +2412,7 @@ msgid "Enabled"
 msgstr "已启用"
 
 #: src/admin/users/ServiceAccountForm.ts
-msgid ""
-"Enabling this toggle will create a group named after the user, with the user"
-" as member."
+msgid "Enabling this toggle will create a group named after the user, with the user as member."
 msgstr "启用此开关将创建一个以用户命名的组，用户为成员。"
 
 #: src/common/ui/locale.ts
@@ -2506,12 +2481,8 @@ msgstr "在阶段即将呈现给用户时评估策略。"
 msgid "Evaluate policies during the Flow planning process."
 msgstr "在流程规划过程中评估策略。"
 
-#~ msgid ""
-#~ "Evaluate policies during the Flow planning process. Disable this for input-"
-#~ "based policies. Should be used in conjunction with 'Re-evaluate policies', "
-#~ "as with both options disabled, policies are **not** evaluated."
-#~ msgstr ""
-#~ "在流程规划过程中评估策略。对于基于输入的策略，请禁用此选项。应与“重新评估策略”结合使用，因为如果同时禁用这两个选项，则**不**评估策略。"
+#~ msgid "Evaluate policies during the Flow planning process. Disable this for input-based policies. Should be used in conjunction with 'Re-evaluate policies', as with both options disabled, policies are **not** evaluated."
+#~ msgstr "在流程规划过程中评估策略。对于基于输入的策略，请禁用此选项。应与“重新评估策略”结合使用，因为如果同时禁用这两个选项，则**不**评估策略。"
 
 #: src/admin/flows/StageBindingForm.ts
 msgid "Evaluate when flow is planned"
@@ -2563,8 +2534,10 @@ msgstr "示例 JWT 载荷（当前经过身份验证的用户）"
 msgid "Example SAML attributes"
 msgstr "示例 SAML 属性"
 
-#: src/admin/events/EventInfo.ts src/admin/events/EventInfo.ts
-#: src/admin/events/EventInfo.ts src/admin/events/EventInfo.ts
+#: src/admin/events/EventInfo.ts
+#: src/admin/events/EventInfo.ts
+#: src/admin/events/EventInfo.ts
+#: src/admin/events/EventInfo.ts
 msgid "Exception"
 msgstr "异常"
 
@@ -2575,8 +2548,7 @@ msgstr "排除服务账户"
 #~ msgid "Execute"
 #~ msgstr "执行"
 
-#~ msgid ""
-#~ "Execute arbitrary Python code to implement custom checks and validation."
+#~ msgid "Execute arbitrary Python code to implement custom checks and validation."
 #~ msgstr "执行任意 Python 代码以实现自定义检查和验证。"
 
 #: src/admin/flows/FlowViewPage.ts
@@ -2587,8 +2559,7 @@ msgstr "执行流程"
 #~ msgstr "与检视器一起执行"
 
 #: src/admin/policies/expression/ExpressionPolicyForm.ts
-msgid ""
-"Executes the python snippet to determine whether to allow or deny a request."
+msgid "Executes the python snippet to determine whether to allow or deny a request."
 msgstr "执行 Python 代码段以确定是允许还是拒绝请求。"
 
 #: src/admin/policies/dummy/DummyPolicyForm.ts
@@ -2601,12 +2572,14 @@ msgid "Execution logging"
 msgstr "记录执行日志"
 
 #: src/admin/stages/invitation/InvitationForm.ts
-#: src/elements/oauth/UserRefreshList.ts src/elements/user/SessionList.ts
+#: src/elements/oauth/UserRefreshList.ts
+#: src/elements/user/SessionList.ts
 #: src/elements/user/UserConsentList.ts
 msgid "Expires"
 msgstr "过期"
 
-#: src/admin/tokens/TokenForm.ts src/admin/users/ServiceAccountForm.ts
+#: src/admin/tokens/TokenForm.ts
+#: src/admin/users/ServiceAccountForm.ts
 msgid "Expires on"
 msgstr "过期时间"
 
@@ -2614,7 +2587,8 @@ msgstr "过期时间"
 msgid "Expires?"
 msgstr "过期？"
 
-#: src/admin/tokens/TokenForm.ts src/admin/users/ServiceAccountForm.ts
+#: src/admin/tokens/TokenForm.ts
+#: src/admin/users/ServiceAccountForm.ts
 #: src/user/user-settings/tokens/UserTokenList.ts
 #: src/user/user-settings/tokens/UserTokenList.ts
 msgid "Expiring"
@@ -2677,12 +2651,8 @@ msgid "External API URL"
 msgstr "外部 API URL"
 
 #: src/admin/applications/ApplicationListPage.ts
-msgid ""
-"External Applications which use authentik as Identity-Provider, utilizing "
-"protocols like OAuth2 and SAML. All applications are shown here, even ones "
-"you cannot access."
-msgstr ""
-"利用 OAuth2 和 SAML 等协议，使用 authentik 作为身份提供程序的外部应用程序。此处显示了所有应用程序，即使您无法访问的也包括在内。"
+msgid "External Applications which use authentik as Identity-Provider, utilizing protocols like OAuth2 and SAML. All applications are shown here, even ones you cannot access."
+msgstr "利用 OAuth2 和 SAML 等协议，使用 authentik 作为身份提供程序的外部应用程序。此处显示了所有应用程序，即使您无法访问的也包括在内。"
 
 #: src/admin/applications/wizard/proxy/TypeProxyApplicationWizardPage.ts
 msgid "External domain"
@@ -2725,7 +2695,8 @@ msgstr "上个月中每天的失败登录次数"
 #~ msgid "Failed sources"
 #~ msgstr "失败的源"
 
-#: src/elements/forms/DeleteBulkForm.ts src/elements/forms/DeleteForm.ts
+#: src/elements/forms/DeleteBulkForm.ts
+#: src/elements/forms/DeleteForm.ts
 msgid "Failed to delete {0}: {1}"
 msgstr "删除 {0} 失败：{1}"
 
@@ -2755,7 +2726,8 @@ msgstr "更新 {0} 失败：{1}"
 msgid "Favicon"
 msgstr "网站图标"
 
-#: src/admin/AdminInterface.ts src/admin/sources/SourceListPage.ts
+#: src/admin/AdminInterface.ts
+#: src/admin/sources/SourceListPage.ts
 msgid "Federation & Social login"
 msgstr "联结与社交登录"
 
@@ -2783,23 +2755,15 @@ msgstr "包含唯一标识符的字段。"
 #~ msgstr "包含组成员的字段。"
 
 #: src/admin/sources/ldap/LDAPSourceForm.ts
-msgid ""
-"Field which contains members of a group. Note that if using the "
-"\"memberUid\" field, the value is assumed to contain a relative "
-"distinguished name. e.g. 'memberUid=some-user' instead of "
-"'memberUid=cn=some-user,ou=groups,...'"
-msgstr ""
-"包含组成员的字段。请注意，如果使用 \"memberUid\" 字段，则假定该值包含相对可分辨名称。例如，'memberUid=some-user' "
-"而不是 'memberUid=cn=some-user,ou=groups,...'"
+msgid "Field which contains members of a group. Note that if using the \"memberUid\" field, the value is assumed to contain a relative distinguished name. e.g. 'memberUid=some-user' instead of 'memberUid=cn=some-user,ou=groups,...'"
+msgstr "包含组成员的字段。请注意，如果使用 \"memberUid\" 字段，则假定该值包含相对可分辨名称。例如，'memberUid=some-user' 而不是 'memberUid=cn=some-user,ou=groups,...'"
 
 #: src/admin/stages/prompt/PromptStageForm.ts
 msgid "Fields"
 msgstr "字段"
 
 #: src/admin/stages/identification/IdentificationStageForm.ts
-msgid ""
-"Fields a user can identify themselves with. If no fields are selected, the "
-"user will only be able to use sources."
+msgid "Fields a user can identify themselves with. If no fields are selected, the user will only be able to use sources."
 msgstr "用户可以用来标识自己的字段。如果未选择任何字段，则用户将只能使用源。"
 
 #: src/admin/stages/prompt/PromptForm.ts
@@ -2819,14 +2783,13 @@ msgstr "流程"
 msgid "Flow execution"
 msgstr "流程执行"
 
-#: src/flow/FlowInspector.ts src/flow/FlowInspector.ts
+#: src/flow/FlowInspector.ts
+#: src/flow/FlowInspector.ts
 msgid "Flow inspector"
 msgstr "流程检视器"
 
 #: src/admin/providers/ldap/LDAPProviderForm.ts
-msgid ""
-"Flow is executed and session is cached in memory. Flow is executed when "
-"session expires"
+msgid "Flow is executed and session is cached in memory. Flow is executed when session expires"
 msgstr "流程与会话会在内存中执行与缓存。会话过期时执行流程"
 
 #: src/admin/flows/FlowViewPage.ts
@@ -2857,9 +2820,7 @@ msgid "Flow used before authentication."
 msgstr "身份验证之前使用的流程。"
 
 #: src/admin/stages/password/PasswordStageForm.ts
-msgid ""
-"Flow used by an authenticated user to configure their password. If empty, "
-"user will not be able to configure change their password."
+msgid "Flow used by an authenticated user to configure their password. If empty, user will not be able to configure change their password."
 msgstr "经过身份验证的用户用来配置其密码的流程。如果为空，用户将无法配置更改其密码。"
 
 #: src/admin/stages/authenticator_duo/AuthenticatorDuoStageForm.ts
@@ -2867,9 +2828,7 @@ msgstr "经过身份验证的用户用来配置其密码的流程。如果为空
 #: src/admin/stages/authenticator_static/AuthenticatorStaticStageForm.ts
 #: src/admin/stages/authenticator_totp/AuthenticatorTOTPStageForm.ts
 #: src/admin/stages/authenticator_webauthn/AuthenticateWebAuthnStageForm.ts
-msgid ""
-"Flow used by an authenticated user to configure this Stage. If empty, user "
-"will not be able to configure this stage."
+msgid "Flow used by an authenticated user to configure this Stage. If empty, user will not be able to configure this stage."
 msgstr "经过身份验证的用户用来配置此阶段的流程。如果为空，用户将无法配置此阶段。"
 
 #: src/admin/providers/ldap/LDAPProviderForm.ts
@@ -2877,21 +2836,15 @@ msgstr "经过身份验证的用户用来配置此阶段的流程。如果为空
 msgid "Flow used for users to authenticate."
 msgstr "用于验证用户身份的流程。"
 
-#~ msgid ""
-#~ "Flow used for users to authenticate. Currently only identification and "
-#~ "password stages are supported."
+#~ msgid "Flow used for users to authenticate. Currently only identification and password stages are supported."
 #~ msgstr "用于用户进行身份验证的流程。目前仅支持身份识别和密码阶段。"
 
 #: src/admin/tenants/TenantForm.ts
-msgid ""
-"Flow used to authenticate users. If left empty, the first applicable flow "
-"sorted by the slug is used."
+msgid "Flow used to authenticate users. If left empty, the first applicable flow sorted by the slug is used."
 msgstr "用于对用户进行身份验证的流程。如果留空，则使用按 Slug 排序的第一个适用流程。"
 
 #: src/admin/tenants/TenantForm.ts
-msgid ""
-"Flow used to logout. If left empty, the first applicable flow sorted by the "
-"slug is used."
+msgid "Flow used to logout. If left empty, the first applicable flow sorted by the slug is used."
 msgstr "用于登出的流程。如果留空，则使用按 Slug 排序的第一个适用流程。"
 
 #: src/admin/providers/oauth2/OAuth2ProviderForm.ts
@@ -2915,7 +2868,8 @@ msgstr "用户访问此应用程序时使用的流程。"
 msgid "Flow(s)"
 msgstr "流程"
 
-#: src/admin/AdminInterface.ts src/admin/flows/FlowListPage.ts
+#: src/admin/AdminInterface.ts
+#: src/admin/flows/FlowListPage.ts
 #: src/admin/stages/StageListPage.ts
 msgid "Flows"
 msgstr "流程"
@@ -2925,9 +2879,7 @@ msgid "Flows & Stages"
 msgstr "流程与阶段"
 
 #: src/admin/flows/FlowListPage.ts
-msgid ""
-"Flows describe a chain of Stages to authenticate, enroll or recover a user. "
-"Stages are chosen based on policies applied to them."
+msgid "Flows describe a chain of Stages to authenticate, enroll or recover a user. Stages are chosen based on policies applied to them."
 msgstr "流程描述了一系列用于对用户进行身份验证、注册或恢复的阶段。阶段是根据应用于它们的策略来选择的。"
 
 #: src/flow/stages/RedirectStage.ts
@@ -2950,7 +2902,8 @@ msgstr "忘记密码了吗？"
 msgid "Forgot username or password?"
 msgstr "忘记用户名或密码？"
 
-#: src/elements/forms/ModalForm.ts src/elements/wizard/FormWizardPage.ts
+#: src/elements/forms/ModalForm.ts
+#: src/elements/wizard/FormWizardPage.ts
 msgid "Form didn't return a promise for submitting"
 msgstr "表单提交未返回 Promise"
 
@@ -3044,7 +2997,8 @@ msgstr "前往上一页"
 #~ msgstr "前往用户界面"
 
 #: src/admin/applications/ApplicationForm.ts
-#: src/admin/applications/ApplicationListPage.ts src/admin/events/RuleForm.ts
+#: src/admin/applications/ApplicationListPage.ts
+#: src/admin/events/RuleForm.ts
 #: src/admin/policies/PolicyBindingForm.ts
 #: src/admin/policies/PolicyBindingForm.ts
 #: src/admin/providers/scim/SCIMProviderForm.ts
@@ -3053,7 +3007,8 @@ msgstr "前往上一页"
 msgid "Group"
 msgstr "组"
 
-#: src/admin/groups/GroupViewPage.ts src/admin/policies/BoundPoliciesList.ts
+#: src/admin/groups/GroupViewPage.ts
+#: src/admin/policies/BoundPoliciesList.ts
 msgid "Group {0}"
 msgstr "组 {0}"
 
@@ -3062,9 +3017,7 @@ msgid "Group Info"
 msgstr "组信息"
 
 #: src/admin/policies/PolicyBindingForm.ts
-msgid ""
-"Group mappings can only be checked if a user is already logged in when "
-"trying to access this source."
+msgid "Group mappings can only be checked if a user is already logged in when trying to access this source."
 msgstr "组绑定仅会在已登录用户访问此源时检查。"
 
 #: src/admin/sources/ldap/LDAPSourceForm.ts
@@ -3081,15 +3034,16 @@ msgid "Group Property Mappings"
 msgstr "组属性映射"
 
 #: src/admin/groups/GroupListPage.ts
-msgid ""
-"Group users together and give them permissions based on the membership."
+msgid "Group users together and give them permissions based on the membership."
 msgstr "将用户分组在一起，并根据成员资格为他们授予权限。"
 
-#: src/admin/groups/GroupListPage.ts src/admin/groups/RelatedGroupList.ts
+#: src/admin/groups/GroupListPage.ts
+#: src/admin/groups/RelatedGroupList.ts
 msgid "Group(s)"
 msgstr "组"
 
-#: src/admin/AdminInterface.ts src/admin/groups/GroupListPage.ts
+#: src/admin/AdminInterface.ts
+#: src/admin/groups/GroupListPage.ts
 #: src/admin/users/UserViewPage.ts
 msgid "Groups"
 msgstr "组"
@@ -3147,7 +3101,8 @@ msgstr "隐藏管理映射"
 msgid "Hide service-accounts"
 msgstr "隐藏服务账户"
 
-#: src/admin/events/RuleForm.ts src/admin/outposts/OutpostForm.ts
+#: src/admin/events/RuleForm.ts
+#: src/admin/outposts/OutpostForm.ts
 #: src/admin/providers/oauth2/OAuth2ProviderForm.ts
 #: src/admin/providers/oauth2/OAuth2ProviderForm.ts
 #: src/admin/providers/proxy/ProxyProviderForm.ts
@@ -3172,9 +3127,7 @@ msgid "Hostname"
 msgstr "主机名"
 
 #: src/admin/stages/password/PasswordStageForm.ts
-msgid ""
-"How many attempts a user has before the flow is canceled. To lock the user "
-"out, use a reputation policy and a user_write stage."
+msgid "How many attempts a user has before the flow is canceled. To lock the user out, use a reputation policy and a user_write stage."
 msgstr "在取消流程之前，用户可以尝试多少次。要锁定用户，请使用信誉策略和 user_write 阶段。"
 
 #: src/admin/providers/ldap/LDAPProviderViewPage.ts
@@ -3215,7 +3168,8 @@ msgstr "在侧边栏/标题和流程执行器中显示的图标。"
 msgid "Icon shown in the browser tab."
 msgstr "浏览器选项卡中显示的图标。"
 
-#: src/admin/users/RelatedUserList.ts src/admin/users/UserListPage.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
 #: src/elements/forms/DeleteBulkForm.ts
 msgid "ID"
 msgstr "ID"
@@ -3226,8 +3180,10 @@ msgstr "ID 令牌"
 
 #: src/admin/flows/FlowListPage.ts
 #: src/admin/policies/reputation/ReputationListPage.ts
-#: src/admin/system-tasks/SystemTaskListPage.ts src/admin/tokens/TokenForm.ts
-#: src/admin/tokens/TokenListPage.ts src/admin/tokens/TokenListPage.ts
+#: src/admin/system-tasks/SystemTaskListPage.ts
+#: src/admin/tokens/TokenForm.ts
+#: src/admin/tokens/TokenListPage.ts
+#: src/admin/tokens/TokenListPage.ts
 #: src/user/user-settings/tokens/UserTokenForm.ts
 #: src/user/user-settings/tokens/UserTokenList.ts
 #: src/user/user-settings/tokens/UserTokenList.ts
@@ -3238,56 +3194,38 @@ msgstr "标识符"
 #~ msgstr "身份识别与加密"
 
 #: src/admin/stages/authenticator_validate/AuthenticatorValidateStageForm.ts
-msgid ""
-"If any of the devices user of the types selected above have been used within"
-" this duration, this stage will be skipped."
+msgid "If any of the devices user of the types selected above have been used within this duration, this stage will be skipped."
 msgstr "如果上面所选类型的任意设备在此期限内被使用，此阶段会被跳过。"
 
 #: src/admin/applications/ApplicationForm.ts
-msgid ""
-"If checked, the launch URL will open in a new browser tab or window from the"
-" user's application library."
+msgid "If checked, the launch URL will open in a new browser tab or window from the user's application library."
 msgstr "如果勾选，在用户的应用程序库中时，启动 URL 将会在新浏览器标签页或窗口中打开。"
 
 #: src/admin/stages/authenticator_sms/AuthenticatorSMSStageForm.ts
-msgid ""
-"If enabled, only a hash of the phone number will be saved. This can be done "
-"for data-protection reasons. Devices created from a stage with this enabled "
-"cannot be used with the authenticator validation stage."
+msgid "If enabled, only a hash of the phone number will be saved. This can be done for data-protection reasons. Devices created from a stage with this enabled cannot be used with the authenticator validation stage."
 msgstr "如果启用，仅保存电话号码的哈希。这是出于数据保护的原因。如果设备创建自启用此选项的阶段，则无法在验证阶段使用身份验证器。"
 
-#~ msgid ""
-#~ "If enabled, only a hash of the phone number will be saved. This can be done "
-#~ "for data-protection reasons.Devices created from a stage with this enabled "
-#~ "cannot be used with the authenticator validation stage."
+#~ msgid "If enabled, only a hash of the phone number will be saved. This can be done for data-protection reasons.Devices created from a stage with this enabled cannot be used with the authenticator validation stage."
 #~ msgstr "如果启用，仅保存电话号码的哈希。这是出于数据保护的原因。如果设备创建自启用此选项的阶段，则无法在验证阶段使用身份验证器。"
 
 #: src/admin/outposts/ServiceConnectionDockerForm.ts
 #: src/admin/outposts/ServiceConnectionKubernetesForm.ts
-msgid ""
-"If enabled, use the local connection. Required Docker socket/Kubernetes "
-"Integration."
+msgid "If enabled, use the local connection. Required Docker socket/Kubernetes Integration."
 msgstr "如果启用，请使用本地连接。需要 Docker Socket/Kubernetes 集成。"
 
 #: src/admin/applications/ApplicationForm.ts
-msgid ""
-"If left empty, authentik will try to extract the launch URL based on the "
-"selected provider."
+msgid "If left empty, authentik will try to extract the launch URL based on the selected provider."
 msgstr "如果留空，authentik 将尝试根据选定的提供程序提取启动 URL。"
 
 #: src/admin/providers/ldap/LDAPProviderForm.ts
-msgid ""
-"If multiple providers share an outpost, a self-signed certificate is used."
+msgid "If multiple providers share an outpost, a self-signed certificate is used."
 msgstr "如果多个提供程序共享同一个前哨，则使用自签名证书。"
 
-#~ msgid ""
-#~ "If no explicit redirect URIs are specified, any redirect URI is allowed."
+#~ msgid "If no explicit redirect URIs are specified, any redirect URI is allowed."
 #~ msgstr "如果未指定显式重定向 URI，则允许使用任何重定向 URI。"
 
 #: src/admin/providers/oauth2/OAuth2ProviderForm.ts
-msgid ""
-"If no explicit redirect URIs are specified, the first successfully used "
-"redirect URI will be saved."
+msgid "If no explicit redirect URIs are specified, the first successfully used redirect URI will be saved."
 msgstr "如果未指定显式重定向 URI，则将保存第一个成功使用的重定向 URI。"
 
 #: src/flow/sources/plex/PlexLoginInit.ts
@@ -3300,16 +3238,11 @@ msgstr "如果 Plex 没有弹出窗口，则点击下面的按钮。"
 #~ msgstr "如果密码已经超过 X 天未更改，使该用户的密码失效并显示提醒。       "
 
 #: src/admin/stages/user_login/UserLoginStageForm.ts
-msgid ""
-"If set to a duration above 0, the user will have the option to choose to "
-"\"stay signed in\", which will extend their session by the time specified "
-"here."
+msgid "If set to a duration above 0, the user will have the option to choose to \"stay signed in\", which will extend their session by the time specified here."
 msgstr "如果设置时长大于 0，用户可以选择“保持登录”选项，这将使用户的会话延长此处设置的时间。"
 
 #: src/admin/tenants/TenantForm.ts
-msgid ""
-"If set, the OAuth Device Code profile can be used, and the selected flow "
-"will be used to enter the code."
+msgid "If set, the OAuth Device Code profile can be used, and the selected flow will be used to enter the code."
 msgstr "如果设置，则 OAuth 设备代码用户资料可用，并且选定的流程将会用于输入代码。"
 
 #: src/admin/tenants/TenantForm.ts
@@ -3317,48 +3250,35 @@ msgid "If set, users are able to configure details of their profile."
 msgstr "设置后，用户可以配置他们个人资料的详细信息。"
 
 #: src/admin/tenants/TenantForm.ts
-msgid ""
-"If set, users are able to unenroll themselves using this flow. If no flow is"
-" set, option is not shown."
+msgid "If set, users are able to unenroll themselves using this flow. If no flow is set, option is not shown."
 msgstr "如果已设置，则用户可以使用此流程自行删除账户。如果未设置流程，则不显示选项。"
 
 #: src/admin/policies/password/PasswordPolicyForm.ts
-msgid ""
-"If the password's score is less than or equal this value, the policy will "
-"fail."
+msgid "If the password's score is less than or equal this value, the policy will fail."
 msgstr "如果密码分数小于等于此值，则策略失败。"
 
 #: src/admin/stages/invitation/InvitationStageForm.ts
-msgid ""
-"If this flag is set, this Stage will jump to the next Stage when no "
-"Invitation is given. By default this Stage will cancel the Flow when no "
-"invitation is given."
+msgid "If this flag is set, this Stage will jump to the next Stage when no Invitation is given. By default this Stage will cancel the Flow when no invitation is given."
 msgstr "如果设置了此标志，则当没有发出邀请时，此阶段将跳转到下一个阶段。默认情况下，当没有发出邀请时，此阶段将取消流程。"
 
-#: src/admin/tokens/TokenForm.ts src/admin/users/ServiceAccountForm.ts
-msgid ""
-"If this is selected, the token will expire. Upon expiration, the token will "
-"be rotated."
+#: src/admin/tokens/TokenForm.ts
+#: src/admin/users/ServiceAccountForm.ts
+msgid "If this is selected, the token will expire. Upon expiration, the token will be rotated."
 msgstr "如果选择此选项，令牌将能够过期。过期时，令牌将被轮换。"
 
-#~ msgid ""
-#~ "If you are using an Implicit, client-side flow (where the token-endpoint "
-#~ "isn't used), you probably want to increase this time."
+#~ msgid "If you are using an Implicit, client-side flow (where the token-endpoint isn't used), you probably want to increase this time."
 #~ msgstr "如果您使用的是隐式的客户端流程（不使用令牌端点），您可能想增加此时间。"
 
 #: src/admin/outposts/OutpostDeploymentModal.ts
-msgid ""
-"If your authentik Instance is using a self-signed certificate, set this "
-"value."
+msgid "If your authentik Instance is using a self-signed certificate, set this value."
 msgstr "如果您的 authentik 实例正在使用自签名证书，请设置此值。"
 
 #: src/admin/outposts/OutpostDeploymentModal.ts
-msgid ""
-"If your authentik_host setting does not match the URL you want to login "
-"with, add this setting."
+msgid "If your authentik_host setting does not match the URL you want to login with, add this setting."
 msgstr "如果您的 authentik_host 设置与您要登录时使用的网址不匹配，请添加此设置。"
 
-#: src/admin/users/RelatedUserList.ts src/admin/users/UserListPage.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
 #: src/admin/users/UserViewPage.ts
 msgid "Impersonate"
 msgstr "模拟身份"
@@ -3371,15 +3291,14 @@ msgstr "已结束模拟身份"
 msgid "Impersonation started"
 msgstr "已开始模拟身份"
 
-#: src/admin/flows/FlowListPage.ts src/admin/flows/FlowListPage.ts
+#: src/admin/flows/FlowListPage.ts
+#: src/admin/flows/FlowListPage.ts
 #: src/admin/stages/StageListPage.ts
 msgid "Import"
 msgstr "导入"
 
 #: src/admin/crypto/CertificateKeyPairListPage.ts
-msgid ""
-"Import certificates of external providers or create certificates to sign "
-"requests with."
+msgid "Import certificates of external providers or create certificates to sign requests with."
 msgstr "导入外部提供商的证书或创建用于签名请求的证书。"
 
 #: src/admin/stages/StageListPage.ts
@@ -3399,8 +3318,7 @@ msgid "Import SAML Metadata"
 msgstr "导入 SAML 元数据"
 
 #: src/admin/applications/wizard/saml/TypeSAMLApplicationWizardPage.ts
-msgid ""
-"Import the metadata document of the applicaation you want to configure."
+msgid "Import the metadata document of the applicaation you want to configure."
 msgstr "导入您要配置的应用程序的元数据文档。"
 
 #: src/flow/stages/authenticator_validate/AuthenticatorValidateStage.ts
@@ -3408,12 +3326,11 @@ msgid "In case you can't access any other method."
 msgstr "以防万一您无法使用任何其他方法。"
 
 #: src/admin/providers/proxy/ProxyProviderForm.ts
-msgid ""
-"In this case, you'd set the Authentication URL to auth.example.com and "
-"Cookie domain to example.com."
+msgid "In this case, you'd set the Authentication URL to auth.example.com and Cookie domain to example.com."
 msgstr "在这种情况下，您需要将身份验证 URL 设置为 auth.example.com，并将 Cookie 域名设置为 example.com。"
 
-#: src/admin/users/RelatedUserList.ts src/admin/users/UserListPage.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
 msgid "Inactive"
 msgstr "未激活"
 
@@ -3422,9 +3339,7 @@ msgid "Include claims in id_token"
 msgstr "在 id_token 中包含声明"
 
 #: src/admin/providers/oauth2/OAuth2ProviderForm.ts
-msgid ""
-"Include User claims from scopes in the id_token, for applications that don't"
-" access the userinfo endpoint."
+msgid "Include User claims from scopes in the id_token, for applications that don't access the userinfo endpoint."
 msgstr "对于不访问 userinfo 端点的应用程序，将来自作用域的用户声明包含在 id_token 中。"
 
 #: src/admin/flows/FlowForm.ts
@@ -3435,7 +3350,8 @@ msgstr "增强与移动设备与密码管理器的兼容性。"
 msgid "Initial value"
 msgstr "初始值"
 
-#: src/admin/outposts/OutpostForm.ts src/admin/outposts/OutpostListPage.ts
+#: src/admin/outposts/OutpostForm.ts
+#: src/admin/outposts/OutpostListPage.ts
 msgid "Integration"
 msgstr "集成"
 
@@ -3447,7 +3363,8 @@ msgstr "集成密钥"
 #~ msgid "Integrations"
 #~ msgstr "集成"
 
-#: src/admin/tokens/TokenForm.ts src/admin/tokens/TokenListPage.ts
+#: src/admin/tokens/TokenForm.ts
+#: src/admin/tokens/TokenListPage.ts
 #: src/user/user-settings/tokens/UserTokenList.ts
 msgid "Intent"
 msgstr "意图"
@@ -3511,9 +3428,7 @@ msgstr "失效流程"
 #~ msgstr "邀请"
 
 #: src/admin/stages/invitation/InvitationListPage.ts
-msgid ""
-"Invitation not limited to any flow, and can be used with any enrollment "
-"flow."
+msgid "Invitation not limited to any flow, and can be used with any enrollment flow."
 msgstr "邀请没有限制到任何流程，可以用于任何注册流程。"
 
 #: src/admin/events/utils.ts
@@ -3560,9 +3475,7 @@ msgid "JS URL"
 msgstr "JS URL"
 
 #: src/admin/sources/oauth/OAuthSourceForm.ts
-msgid ""
-"JSON Web Key URL. Keys from the URL will be used to validate JWTs from this "
-"source."
+msgid "JSON Web Key URL. Keys from the URL will be used to validate JWTs from this source."
 msgstr "JSON Web Key URL。来自此 URL 的 Key 将被用于验证此身份来源的 JWT。"
 
 #: src/admin/providers/oauth2/OAuth2ProviderViewPage.ts
@@ -3572,31 +3485,23 @@ msgstr "JWKS URL"
 #~ msgid "JWT Algorithm"
 #~ msgstr "JWT 算法"
 
-#~ msgid ""
-#~ "JWTs signed by certificates configured here can be used to authenticate to "
-#~ "the provider."
+#~ msgid "JWTs signed by certificates configured here can be used to authenticate to the provider."
 #~ msgstr "此处配置的证书签名的 JWT 可以用于此提供程序的身份验证。"
 
 #: src/admin/providers/oauth2/OAuth2ProviderForm.ts
 #: src/admin/providers/proxy/ProxyProviderForm.ts
-msgid ""
-"JWTs signed by certificates configured in the selected sources can be used "
-"to authenticate to this provider."
+msgid "JWTs signed by certificates configured in the selected sources can be used to authenticate to this provider."
 msgstr "在选定源中配置的证书签名的 JWT 可以用于此提供程序的身份验证。"
 
 #: src/admin/providers/oauth2/OAuth2ProviderForm.ts
 msgid "Key used to sign the tokens."
 msgstr "用于签名令牌的密钥。"
 
-#~ msgid ""
-#~ "Key used to sign the tokens. Only required when JWT Algorithm is set to "
-#~ "RS256."
+#~ msgid "Key used to sign the tokens. Only required when JWT Algorithm is set to RS256."
 #~ msgstr "用于签名令牌的密钥。仅当 JWT 算法设置为 RS256 时才需要。"
 
 #: src/admin/sources/saml/SAMLSourceForm.ts
-msgid ""
-"Keypair which is used to sign outgoing requests. Leave empty to disable "
-"signing."
+msgid "Keypair which is used to sign outgoing requests. Leave empty to disable signing."
 msgstr "用于签名传出请求的密钥对。留空则禁用签名。"
 
 #: src/admin/outposts/ServiceConnectionKubernetesForm.ts
@@ -3615,12 +3520,15 @@ msgstr "标签会显示在输入侧方/上方。"
 msgid "Last applied"
 msgstr "上次应用"
 
-#: src/elements/user/SessionList.ts src/elements/user/SessionList.ts
+#: src/elements/user/SessionList.ts
+#: src/elements/user/SessionList.ts
 msgid "Last IP"
 msgstr "上次 IP"
 
-#: src/admin/groups/MemberSelectModal.ts src/admin/users/RelatedUserList.ts
-#: src/admin/users/UserListPage.ts src/admin/users/UserViewPage.ts
+#: src/admin/groups/MemberSelectModal.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
+#: src/admin/users/UserViewPage.ts
 msgid "Last login"
 msgstr "上次登录"
 
@@ -3658,7 +3566,8 @@ msgid "Layout"
 msgstr "布局"
 
 #: src/admin/applications/wizard/TypeApplicationWizardPage.ts
-#: src/admin/outposts/OutpostForm.ts src/admin/outposts/OutpostListPage.ts
+#: src/admin/outposts/OutpostForm.ts
+#: src/admin/outposts/OutpostListPage.ts
 msgid "LDAP"
 msgstr "LDAP"
 
@@ -3701,20 +3610,14 @@ msgid "Link"
 msgstr "链接"
 
 #: src/admin/sources/oauth/utils.ts
-msgid ""
-"Link to a user with identical email address. Can have security implications "
-"when a source doesn't validate email addresses"
+msgid "Link to a user with identical email address. Can have security implications when a source doesn't validate email addresses"
 msgstr "链接到电子邮件地址相同的用户。当源不验证电子邮件地址时，可能会有安全隐患"
 
 #: src/admin/sources/oauth/utils.ts
-msgid ""
-"Link to a user with identical username. Can have security implications when "
-"a username is used with another source"
+msgid "Link to a user with identical username. Can have security implications when a username is used with another source"
 msgstr "链接到用户名相同的用户。当其他源使用相同用户名时，可能会有安全隐患"
 
-#~ msgid ""
-#~ "Link to a user with identical username. Can have security implications when "
-#~ "a username is used with another source."
+#~ msgid "Link to a user with identical username. Can have security implications when a username is used with another source."
 #~ msgstr "链接到用户名相同的用户。当其他源使用相同用户名时，可能会有安全隐患。"
 
 #: src/admin/stages/invitation/InvitationListLink.ts
@@ -3741,8 +3644,10 @@ msgstr "加载服务器"
 
 #: src/admin/applications/ApplicationViewPage.ts
 #: src/admin/applications/ApplicationViewPage.ts
-#: src/admin/events/EventViewPage.ts src/elements/table/Table.ts
-#: src/flow/FlowExecutor.ts src/flow/FlowInspector.ts
+#: src/admin/events/EventViewPage.ts
+#: src/elements/table/Table.ts
+#: src/flow/FlowExecutor.ts
+#: src/flow/FlowInspector.ts
 #: src/flow/providers/oauth2/DeviceCode.ts
 #: src/flow/providers/oauth2/DeviceCodeFinish.ts
 #: src/flow/stages/access_denied/AccessDeniedStage.ts
@@ -3755,12 +3660,16 @@ msgstr "加载服务器"
 #: src/flow/stages/authenticator_validate/AuthenticatorValidateStageDuo.ts
 #: src/flow/stages/autosubmit/AutosubmitStage.ts
 #: src/flow/stages/captcha/CaptchaStage.ts
-#: src/flow/stages/consent/ConsentStage.ts src/flow/stages/dummy/DummyStage.ts
-#: src/flow/stages/email/EmailStage.ts src/flow/stages/FlowErrorStage.ts
+#: src/flow/stages/consent/ConsentStage.ts
+#: src/flow/stages/dummy/DummyStage.ts
+#: src/flow/stages/email/EmailStage.ts
+#: src/flow/stages/FlowErrorStage.ts
 #: src/flow/stages/identification/IdentificationStage.ts
 #: src/flow/stages/password/PasswordStage.ts
-#: src/flow/stages/prompt/PromptStage.ts src/flow/stages/RedirectStage.ts
-#: src/flow/stages/user_login/UserLoginStage.ts src/user/LibraryPage.ts
+#: src/flow/stages/prompt/PromptStage.ts
+#: src/flow/stages/RedirectStage.ts
+#: src/flow/stages/user_login/UserLoginStage.ts
+#: src/user/LibraryPage.ts
 #: src/user/user-settings/details/stages/prompt/PromptStage.ts
 #: src/user/user-settings/details/UserSettingsFlowExecutor.ts
 #: src/user/user-settings/details/UserSettingsFlowExecutor.ts
@@ -3773,8 +3682,10 @@ msgid "Loading options..."
 msgstr "正在加载选项…"
 
 #: src/admin/stages/invitation/InvitationListLink.ts
-#: src/elements/forms/SearchSelect.ts src/elements/Spinner.ts
-#: src/standalone/loading/index.ts src/standalone/loading/index.ts
+#: src/elements/forms/SearchSelect.ts
+#: src/elements/Spinner.ts
+#: src/standalone/loading/index.ts
+#: src/standalone/loading/index.ts
 msgid "Loading..."
 msgstr "正在加载……"
 
@@ -3796,7 +3707,8 @@ msgstr "本地路径"
 #~ msgstr "区域设置"
 
 #: src/admin/applications/ApplicationCheckAccessForm.ts
-#: src/admin/flows/FlowImportForm.ts src/admin/policies/PolicyTestForm.ts
+#: src/admin/flows/FlowImportForm.ts
+#: src/admin/policies/PolicyTestForm.ts
 msgid "Log messages"
 msgstr "日志消息"
 
@@ -3813,9 +3725,7 @@ msgid "Login"
 msgstr "登录"
 
 #: src/admin/sources/ldap/LDAPSourceForm.ts
-msgid ""
-"Login password is synced from LDAP into authentik automatically. Enable this"
-" option only to write password changes in authentik back to LDAP."
+msgid "Login password is synced from LDAP into authentik automatically. Enable this option only to write password changes in authentik back to LDAP."
 msgstr "登录密码会自动从 LDAP 同步到 authentik。启用此选项可将 authentik 中的密码更改写回至 LDAP。"
 
 #: src/flow/stages/identification/IdentificationStage.ts
@@ -3901,40 +3811,31 @@ msgid "Mark newly created users as inactive."
 msgstr "将新创建的用户标记为未激活。"
 
 #: src/admin/policies/event_matcher/EventMatcherPolicyForm.ts
-msgid ""
-"Match created events with this action type. When left empty, all action "
-"types will be matched."
+msgid "Match created events with this action type. When left empty, all action types will be matched."
 msgstr "将创建的事件与此操作类型匹配。留空时，所有操作类型都将匹配。"
 
 #: src/admin/policies/event_matcher/EventMatcherPolicyForm.ts
-msgid ""
-"Match events created by selected application. When left empty, all "
-"applications are matched."
+msgid "Match events created by selected application. When left empty, all applications are matched."
 msgstr "匹配选定应用程序创建的事件。如果留空，则匹配所有应用程序。"
 
 #: src/admin/policies/event_matcher/EventMatcherPolicyForm.ts
-msgid ""
-"Matches an event against a set of criteria. If any of the configured values "
-"match, the policy passes."
+msgid "Matches an event against a set of criteria. If any of the configured values match, the policy passes."
 msgstr "根据一组条件匹配事件。如果任何配置的值匹配，则策略将通过。"
 
 #: src/admin/policies/event_matcher/EventMatcherPolicyForm.ts
-msgid ""
-"Matches Event's Client IP (strict matching, for network matching use an "
-"Expression Policy."
+msgid "Matches Event's Client IP (strict matching, for network matching use an Expression Policy."
 msgstr "匹配事件的客户端 IP（严格匹配，要网络匹配请使用表达式策略）。"
 
 #: src/admin/tenants/TenantForm.ts
-msgid ""
-"Matching is done based on domain suffix, so if you enter domain.tld, "
-"foo.domain.tld will still match."
+msgid "Matching is done based on domain suffix, so if you enter domain.tld, foo.domain.tld will still match."
 msgstr "根据域名后缀完成匹配，因此，如果您输入 domain.tld，foo.domain.tld 仍将匹配。"
 
 #: src/admin/policies/expiry/ExpiryPolicyForm.ts
 msgid "Maximum age (in days)"
 msgstr "最长使用期限（单位为天）"
 
-#: src/admin/groups/GroupListPage.ts src/admin/users/GroupSelectModal.ts
+#: src/admin/groups/GroupListPage.ts
+#: src/admin/users/GroupSelectModal.ts
 msgid "Members"
 msgstr "成员"
 
@@ -3945,13 +3846,12 @@ msgstr "消息"
 #~ msgid "MESSAGE will notify the user the flow isn't applicable."
 #~ msgstr "MESSAGE 会通知用户此流程不适用。"
 
-#~ msgid ""
-#~ "MESSAGE_CONTINUE will follow the ?next parameter if set, otherwise show a "
-#~ "message."
+#~ msgid "MESSAGE_CONTINUE will follow the ?next parameter if set, otherwise show a message."
 #~ msgstr "MESSAGE_CONTINUE 会首先遵循 ?next 参数，如果不存在则显示一条消息。"
 
 #: src/admin/applications/ApplicationCheckAccessForm.ts
-#: src/admin/events/EventInfo.ts src/admin/policies/PolicyTestForm.ts
+#: src/admin/events/EventInfo.ts
+#: src/admin/policies/PolicyTestForm.ts
 #: src/admin/system-tasks/SystemTaskListPage.ts
 msgid "Messages"
 msgstr "消息"
@@ -3998,7 +3898,8 @@ msgstr "最低大写字符数"
 msgid "Minimum length"
 msgstr "最小长度"
 
-#: src/admin/events/TransportForm.ts src/admin/events/TransportListPage.ts
+#: src/admin/events/TransportForm.ts
+#: src/admin/events/TransportListPage.ts
 #: src/admin/providers/proxy/ProxyProviderViewPage.ts
 #: src/admin/stages/consent/ConsentStageForm.ts
 msgid "Mode"
@@ -4049,13 +3950,20 @@ msgstr "我的应用"
 #: src/admin/crypto/CertificateKeyPairForm.ts
 #: src/admin/crypto/CertificateKeyPairListPage.ts
 #: src/admin/crypto/CertificateKeyPairListPage.ts
-#: src/admin/events/EventInfo.ts src/admin/events/RuleForm.ts
-#: src/admin/events/RuleListPage.ts src/admin/events/TransportForm.ts
-#: src/admin/events/TransportListPage.ts src/admin/flows/BoundStagesList.ts
-#: src/admin/flows/FlowForm.ts src/admin/flows/FlowListPage.ts
-#: src/admin/groups/GroupForm.ts src/admin/groups/GroupListPage.ts
-#: src/admin/groups/GroupViewPage.ts src/admin/groups/MemberSelectModal.ts
-#: src/admin/groups/RelatedGroupList.ts src/admin/outposts/OutpostForm.ts
+#: src/admin/events/EventInfo.ts
+#: src/admin/events/RuleForm.ts
+#: src/admin/events/RuleListPage.ts
+#: src/admin/events/TransportForm.ts
+#: src/admin/events/TransportListPage.ts
+#: src/admin/flows/BoundStagesList.ts
+#: src/admin/flows/FlowForm.ts
+#: src/admin/flows/FlowListPage.ts
+#: src/admin/groups/GroupForm.ts
+#: src/admin/groups/GroupListPage.ts
+#: src/admin/groups/GroupViewPage.ts
+#: src/admin/groups/MemberSelectModal.ts
+#: src/admin/groups/RelatedGroupList.ts
+#: src/admin/outposts/OutpostForm.ts
 #: src/admin/outposts/OutpostListPage.ts
 #: src/admin/outposts/ServiceConnectionDockerForm.ts
 #: src/admin/outposts/ServiceConnectionKubernetesForm.ts
@@ -4120,9 +4028,12 @@ msgstr "我的应用"
 #: src/admin/stages/user_login/UserLoginStageForm.ts
 #: src/admin/stages/user_logout/UserLogoutStageForm.ts
 #: src/admin/stages/user_write/UserWriteStageForm.ts
-#: src/admin/users/GroupSelectModal.ts src/admin/users/RelatedUserList.ts
-#: src/admin/users/UserForm.ts src/admin/users/UserListPage.ts
-#: src/admin/users/UserViewPage.ts src/elements/forms/DeleteBulkForm.ts
+#: src/admin/users/GroupSelectModal.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserForm.ts
+#: src/admin/users/UserListPage.ts
+#: src/admin/users/UserViewPage.ts
+#: src/elements/forms/DeleteBulkForm.ts
 #: src/elements/user/UserDevicesList.ts
 #: src/user/user-settings/mfa/MFADeviceForm.ts
 #: src/user/user-settings/mfa/MFADevicesPage.ts
@@ -4224,15 +4135,20 @@ msgstr "Nginx（独立）"
 #: src/admin/applications/ApplicationCheckAccessForm.ts
 #: src/admin/blueprints/BlueprintListPage.ts
 #: src/admin/crypto/CertificateKeyPairListPage.ts
-#: src/admin/flows/FlowImportForm.ts src/admin/groups/GroupListPage.ts
-#: src/admin/groups/MemberSelectModal.ts src/admin/groups/RelatedGroupList.ts
+#: src/admin/flows/FlowImportForm.ts
+#: src/admin/groups/GroupListPage.ts
+#: src/admin/groups/MemberSelectModal.ts
+#: src/admin/groups/RelatedGroupList.ts
 #: src/admin/outposts/ServiceConnectionListPage.ts
 #: src/admin/policies/BoundPoliciesList.ts
 #: src/admin/policies/PolicyTestForm.ts
 #: src/admin/providers/proxy/ProxyProviderViewPage.ts
-#: src/admin/tenants/TenantListPage.ts src/admin/tokens/TokenListPage.ts
-#: src/admin/users/GroupSelectModal.ts src/admin/users/RelatedUserList.ts
-#: src/admin/users/UserListPage.ts src/elements/oauth/UserRefreshList.ts
+#: src/admin/tenants/TenantListPage.ts
+#: src/admin/tokens/TokenListPage.ts
+#: src/admin/users/GroupSelectModal.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
+#: src/elements/oauth/UserRefreshList.ts
 #: src/elements/user/UserDevicesList.ts
 #: src/flow/stages/user_login/UserLoginStage.ts
 #: src/user/user-settings/tokens/UserTokenList.ts
@@ -4255,11 +4171,13 @@ msgid "No Applications available."
 msgstr "没有可用的应用程序。"
 
 #: src/admin/admin-overview/cards/RecentEventsCard.ts
-#: src/elements/events/ObjectChangelog.ts src/elements/events/UserEvents.ts
+#: src/elements/events/ObjectChangelog.ts
+#: src/elements/events/UserEvents.ts
 msgid "No Events found."
 msgstr "未找到事件。"
 
-#: src/elements/forms/ModalForm.ts src/elements/wizard/FormWizardPage.ts
+#: src/elements/forms/ModalForm.ts
+#: src/elements/wizard/FormWizardPage.ts
 msgid "No form found"
 msgstr "未找到表单"
 
@@ -4268,16 +4186,19 @@ msgid "No integration active"
 msgstr "没有激活的集成"
 
 #: src/admin/applications/ApplicationCheckAccessForm.ts
-#: src/admin/flows/FlowImportForm.ts src/admin/policies/PolicyTestForm.ts
+#: src/admin/flows/FlowImportForm.ts
+#: src/admin/policies/PolicyTestForm.ts
 msgid "No log messages."
 msgstr "没有日志消息。"
 
 #: src/admin/admin-overview/cards/RecentEventsCard.ts
-#: src/elements/events/ObjectChangelog.ts src/elements/events/UserEvents.ts
+#: src/elements/events/ObjectChangelog.ts
+#: src/elements/events/UserEvents.ts
 msgid "No matching events could be found."
 msgstr "未找到匹配的事件"
 
-#: src/elements/table/Table.ts src/elements/table/TablePage.ts
+#: src/elements/table/Table.ts
+#: src/elements/table/TablePage.ts
 msgid "No objects found."
 msgstr "未找到对象。"
 
@@ -4293,7 +4214,8 @@ msgstr "未绑定策略。"
 msgid "No preference is sent"
 msgstr "不发送偏好"
 
-#: src/admin/users/RelatedUserList.ts src/admin/users/UserListPage.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
 msgid "No recovery flow is configured."
 msgstr "未配置恢复流程。"
 
@@ -4372,11 +4294,13 @@ msgstr "不被任何其他对象使用。"
 msgid "Not you?"
 msgstr "不是您？"
 
-#: src/admin/groups/GroupViewPage.ts src/admin/users/UserViewPage.ts
+#: src/admin/groups/GroupViewPage.ts
+#: src/admin/users/UserViewPage.ts
 msgid "Notes"
 msgstr "备注"
 
-#: src/admin/events/RuleForm.ts src/admin/events/RuleListPage.ts
+#: src/admin/events/RuleForm.ts
+#: src/admin/events/RuleListPage.ts
 msgid "Notice"
 msgstr "通知"
 
@@ -4387,7 +4311,8 @@ msgstr "通知"
 msgid "Notification rule(s)"
 msgstr "通知规则"
 
-#: src/admin/AdminInterface.ts src/admin/events/RuleListPage.ts
+#: src/admin/AdminInterface.ts
+#: src/admin/events/RuleListPage.ts
 msgid "Notification Rules"
 msgstr "通知规则"
 
@@ -4395,7 +4320,8 @@ msgstr "通知规则"
 msgid "Notification transport(s)"
 msgstr "通知传输"
 
-#: src/admin/AdminInterface.ts src/admin/events/TransportListPage.ts
+#: src/admin/AdminInterface.ts
+#: src/admin/events/TransportListPage.ts
 msgid "Notification Transports"
 msgstr "通知传输"
 
@@ -4441,7 +4367,8 @@ msgstr "OAuth 源 {0}"
 msgid "OAuth2/OIDC"
 msgstr "OAuth2/OIDC"
 
-#: src/admin/events/EventInfo.ts src/admin/events/EventInfo.ts
+#: src/admin/events/EventInfo.ts
+#: src/admin/events/EventInfo.ts
 msgid "Object"
 msgstr "对象"
 
@@ -4453,7 +4380,8 @@ msgstr "对象字段"
 msgid "Object uniqueness field"
 msgstr "对象唯一性字段"
 
-#: src/elements/forms/DeleteBulkForm.ts src/elements/forms/DeleteForm.ts
+#: src/elements/forms/DeleteBulkForm.ts
+#: src/elements/forms/DeleteForm.ts
 msgid "object will be DELETED"
 msgstr "对象将被删除"
 
@@ -4473,8 +4401,7 @@ msgstr "OCI URL，格式为 oci://registry.domain.tld/path/to/manifest。"
 msgid "Offset after which consent expires."
 msgstr "同意过期后的偏移。"
 
-#~ msgid ""
-#~ "Offset after which consent expires. (Format: hours=1;minutes=2;seconds=3)."
+#~ msgid "Offset after which consent expires. (Format: hours=1;minutes=2;seconds=3)."
 #~ msgstr "经过多少偏移量后同意授权过期。（格式：hours=1;minutes=2;seconds=3）。"
 
 #: src/admin/sources/oauth/OAuthSourceForm.ts
@@ -4486,9 +4413,7 @@ msgid "OIDC JWKS URL"
 msgstr "OIDC JWKS URL"
 
 #: src/admin/sources/oauth/OAuthSourceForm.ts
-msgid ""
-"OIDC well-known configuration URL. Can be used to automatically configure "
-"the URLs above."
+msgid "OIDC well-known configuration URL. Can be used to automatically configure the URLs above."
 msgstr "OIDC Well-known 配置 URL。可用于自动配置上述 URL。"
 
 #: src/admin/sources/oauth/OAuthSourceForm.ts
@@ -4500,8 +4425,10 @@ msgid "OK"
 msgstr "好的"
 
 #: src/admin/admin-overview/cards/RecentEventsCard.ts
-#: src/admin/events/EventListPage.ts src/admin/events/EventViewPage.ts
-#: src/elements/events/ObjectChangelog.ts src/elements/events/UserEvents.ts
+#: src/admin/events/EventListPage.ts
+#: src/admin/events/EventViewPage.ts
+#: src/elements/events/ObjectChangelog.ts
+#: src/elements/events/UserEvents.ts
 msgid "On behalf of {0}"
 msgstr "代表 {0}"
 
@@ -4513,9 +4440,7 @@ msgstr "仅使策略失败，不使用户的密码失效"
 #~ msgstr "仅使策略失败，不使用户的密码失效。"
 
 #: src/admin/events/TransportForm.ts
-msgid ""
-"Only send notification once, for example when sending a webhook into a chat "
-"channel."
+msgid "Only send notification once, for example when sending a webhook into a chat channel."
 msgstr "仅发送一次通知，例如在向聊天频道发送 Webhook 时。"
 
 #: src/admin/providers/scim/SCIMProviderForm.ts
@@ -4554,9 +4479,7 @@ msgid "OpenID Configuration URL"
 msgstr "OpenID 配置 URL"
 
 #: src/admin/stages/invitation/InvitationForm.ts
-msgid ""
-"Optional data which is loaded into the flow's 'prompt_data' context "
-"variable. YAML or JSON."
+msgid "Optional data which is loaded into the flow's 'prompt_data' context variable. YAML or JSON."
 msgstr "加载到流程的 'prompt_data' 上下文变量中的可选数据。YAML 或 JSON。"
 
 #: src/admin/stages/identification/IdentificationStageForm.ts
@@ -4564,16 +4487,11 @@ msgid "Optional enrollment flow, which is linked at the bottom of the page."
 msgstr "可选注册流程，链接在页面底部。"
 
 #: src/admin/stages/identification/IdentificationStageForm.ts
-msgid ""
-"Optional passwordless flow, which is linked at the bottom of the page. When "
-"configured, users can use this flow to authenticate with a WebAuthn "
-"authenticator, without entering any details."
+msgid "Optional passwordless flow, which is linked at the bottom of the page. When configured, users can use this flow to authenticate with a WebAuthn authenticator, without entering any details."
 msgstr "可选的无密码流程，链接在页面底部。配置后，用户可以使用此流程通过 WebAuthn 身份验证器进行验证，无需输入任何详细信息。"
 
 #: src/admin/crypto/CertificateKeyPairForm.ts
-msgid ""
-"Optional Private Key. If this is set, you can use this keypair for "
-"encryption."
+msgid "Optional Private Key. If this is set, you can use this keypair for encryption."
 msgstr "可选私钥。如果设置，则可以使用此密钥对来加密。"
 
 #: src/admin/stages/identification/IdentificationStageForm.ts
@@ -4589,9 +4507,7 @@ msgid "Optional, comma-separated SubjectAlt Names."
 msgstr "可选，逗号分隔的替代名称。"
 
 #: src/admin/applications/ApplicationForm.ts
-msgid ""
-"Optionally enter a group name. Applications with identical groups are shown "
-"grouped together."
+msgid "Optionally enter a group name. Applications with identical groups are shown grouped together."
 msgstr "输入可选的分组名称。分组相同的应用程序会显示在一起。 "
 
 #~ msgid "Optionally pre-fill the input value"
@@ -4630,13 +4546,8 @@ msgstr ""
 msgid "Optionally set the 'FriendlyName' value of the Assertion attribute."
 msgstr "可选，设置断言属性的 'FriendlyName' 值。"
 
-#~ msgid ""
-#~ "Optionally set this to your parent domain, if you want authentication and "
-#~ "authorization to happen on a domain level. If you're running applications as"
-#~ " app1.domain.tld, app2.domain.tld, set this to 'domain.tld'."
-#~ msgstr ""
-#~ "如果您希望在域名级别进行身份验证和授权，可以选择将其设置为您的父域名。如果您运行应用 "
-#~ "app1.domain.tld、app2.domain.tld，请将其设置为 'domain.tld'。"
+#~ msgid "Optionally set this to your parent domain, if you want authentication and authorization to happen on a domain level. If you're running applications as app1.domain.tld, app2.domain.tld, set this to 'domain.tld'."
+#~ msgstr "如果您希望在域名级别进行身份验证和授权，可以选择将其设置为您的父域名。如果您运行应用 app1.domain.tld、app2.domain.tld，请将其设置为 'domain.tld'。"
 
 #: src/flow/stages/identification/IdentificationStage.ts
 msgid "Or"
@@ -4646,7 +4557,8 @@ msgstr "或者"
 msgid "Or manually import"
 msgstr "或者手动导入"
 
-#: src/admin/flows/BoundStagesList.ts src/admin/flows/StageBindingForm.ts
+#: src/admin/flows/BoundStagesList.ts
+#: src/admin/flows/StageBindingForm.ts
 #: src/admin/policies/BoundPoliciesList.ts
 #: src/admin/policies/BoundPoliciesList.ts
 #: src/admin/policies/PolicyBindingForm.ts
@@ -4696,17 +4608,17 @@ msgstr "前哨状态"
 msgid "Outpost(s)"
 msgstr "前哨"
 
-#: src/admin/AdminInterface.ts src/admin/outposts/OutpostListPage.ts
+#: src/admin/AdminInterface.ts
+#: src/admin/outposts/OutpostListPage.ts
 msgid "Outposts"
 msgstr "前哨"
 
 #: src/admin/outposts/OutpostListPage.ts
-msgid ""
-"Outposts are deployments of authentik components to support different "
-"environments and protocols, like reverse proxies."
+msgid "Outposts are deployments of authentik components to support different environments and protocols, like reverse proxies."
 msgstr "前哨是对 authentik 组件的部署，用于支持不同的环境和协议，例如反向代理。"
 
-#: src/admin/AdminInterface.ts src/admin/applications/ApplicationViewPage.ts
+#: src/admin/AdminInterface.ts
+#: src/admin/applications/ApplicationViewPage.ts
 #: src/admin/groups/GroupViewPage.ts
 #: src/admin/providers/ldap/LDAPProviderViewPage.ts
 #: src/admin/providers/oauth2/OAuth2ProviderViewPage.ts
@@ -4722,7 +4634,8 @@ msgstr "前哨是对 authentik 组件的部署，用于支持不同的环境和�
 msgid "Overview"
 msgstr "总览"
 
-#: src/admin/groups/GroupForm.ts src/admin/groups/GroupListPage.ts
+#: src/admin/groups/GroupForm.ts
+#: src/admin/groups/GroupListPage.ts
 #: src/admin/groups/RelatedGroupList.ts
 msgid "Parent"
 msgstr "父级"
@@ -4739,11 +4652,13 @@ msgstr "通过策略？"
 #~ msgstr "当事件匹配选定的条件时通过。"
 
 #: src/admin/applications/ApplicationCheckAccessForm.ts
-#: src/admin/events/EventInfo.ts src/admin/policies/PolicyTestForm.ts
+#: src/admin/events/EventInfo.ts
+#: src/admin/policies/PolicyTestForm.ts
 msgid "Passing"
 msgstr "通过"
 
-#: src/admin/users/ServiceAccountForm.ts src/admin/users/UserPasswordForm.ts
+#: src/admin/users/ServiceAccountForm.ts
+#: src/admin/users/UserPasswordForm.ts
 #: src/flow/stages/identification/IdentificationStage.ts
 #: src/flow/stages/identification/IdentificationStage.ts
 #: src/flow/stages/password/PasswordStage.ts
@@ -4779,15 +4694,10 @@ msgstr "Dropbox 制作的密码强度估算器，详见："
 #~ msgstr "密码、2FA 等"
 
 #: src/admin/stages/prompt/PromptForm.ts
-msgid ""
-"Password: Masked input, multiple inputs of this type on the same prompt need"
-" to be identical."
+msgid "Password: Masked input, multiple inputs of this type on the same prompt need to be identical."
 msgstr "密码：屏蔽显示输入内容，多个此类型的输入如果在同一个输入项下，则内容需要相同。"
 
-#~ msgid ""
-#~ "Password: Masked input, password is validated against sources. Policies "
-#~ "still have to be applied to this Stage. If two of these are used in the same"
-#~ " stage, they are ensured to be identical."
+#~ msgid "Password: Masked input, password is validated against sources. Policies still have to be applied to this Stage. If two of these are used in the same stage, they are ensured to be identical."
 #~ msgstr "密码：屏蔽输入内容，密码根据来源进行验证。策略仍需应用于此阶段。如果在同一阶段使用其中的两个，则确保它们是相同的。"
 
 #: src/admin/stages/identification/IdentificationStageForm.ts
@@ -4795,28 +4705,23 @@ msgid "Passwordless flow"
 msgstr "无密码流程"
 
 #: src/admin/blueprints/BlueprintForm.ts
-#: src/admin/blueprints/BlueprintListPage.ts src/admin/users/UserForm.ts
+#: src/admin/blueprints/BlueprintListPage.ts
+#: src/admin/users/UserForm.ts
 msgid "Path"
 msgstr "路径"
 
 #: src/admin/stages/user_write/UserWriteStageForm.ts
-msgid ""
-"Path new users will be created under. If left blank, the default path will "
-"be used."
+msgid "Path new users will be created under. If left blank, the default path will be used."
 msgstr "新用户将会在此路径下创建。如果留空，则使用默认路径。"
 
-#~ msgid ""
-#~ "Path new users will be created under. If left blank, the default path will "
-#~ "be used.fo"
+#~ msgid "Path new users will be created under. If left blank, the default path will be used.fo"
 #~ msgstr "新用户将会在此路径下创建。如果留空，则使用默认路径。"
 
 #: src/admin/sources/ldap/LDAPSourceForm.ts
 #: src/admin/sources/oauth/OAuthSourceForm.ts
 #: src/admin/sources/plex/PlexSourceForm.ts
 #: src/admin/sources/saml/SAMLSourceForm.ts
-msgid ""
-"Path template for users created. Use placeholders like `%(slug)s` to insert "
-"the source slug."
+msgid "Path template for users created. Use placeholders like `%(slug)s` to insert the source slug."
 msgstr "创建用户的路径模板。使用占位符如 `%(slug)s` 插入源 Slug。"
 
 #: src/admin/crypto/CertificateKeyPairForm.ts
@@ -4864,7 +4769,8 @@ msgstr "请输入您的电话号码。"
 msgid "Please enter your TOTP Code"
 msgstr "请输入您的 TOTP 代码"
 
-#: src/admin/AdminInterface.ts src/admin/flows/FlowListPage.ts
+#: src/admin/AdminInterface.ts
+#: src/admin/flows/FlowListPage.ts
 #: src/admin/policies/PolicyListPage.ts
 msgid "Policies"
 msgstr "策略"
@@ -4906,7 +4812,8 @@ msgid "Policy Bindings"
 msgstr "策略绑定"
 
 #: src/admin/applications/ApplicationForm.ts
-#: src/admin/applications/ApplicationViewPage.ts src/admin/flows/FlowForm.ts
+#: src/admin/applications/ApplicationViewPage.ts
+#: src/admin/flows/FlowForm.ts
 #: src/admin/flows/StageBindingForm.ts
 msgid "Policy engine mode"
 msgstr "策略引擎模式"
@@ -4951,9 +4858,7 @@ msgstr "Post 绑定"
 #~ msgstr "Post 绑定（自动提交）"
 
 #: src/admin/sources/saml/SAMLSourceForm.ts
-msgid ""
-"Post binding but the request is automatically sent and the user doesn't have"
-" to confirm."
+msgid "Post binding but the request is automatically sent and the user doesn't have to confirm."
 msgstr "Post 绑定，但请求会被自动发送，不需要用户确认。"
 
 #: src/admin/sources/saml/SAMLSourceForm.ts
@@ -4988,8 +4893,7 @@ msgid "Private key available?"
 msgstr "私钥可用吗？"
 
 #: src/admin/stages/captcha/CaptchaStageForm.ts
-msgid ""
-"Private key, acquired from https://www.google.com/recaptcha/intro/v3.html."
+msgid "Private key, acquired from https://www.google.com/recaptcha/intro/v3.html."
 msgstr "私钥，从 https://www.google.com/recaptcha/intro/v3.html 获取。"
 
 #: src/admin/sources/oauth/OAuthSourceForm.ts
@@ -5000,16 +4904,15 @@ msgstr "个人资料 URL"
 #~ msgstr "输入"
 
 #: src/admin/stages/consent/ConsentStageForm.ts
-msgid ""
-"Prompt for the user's consent. The consent can either be permanent or expire"
-" in a defined amount of time."
+msgid "Prompt for the user's consent. The consent can either be permanent or expire in a defined amount of time."
 msgstr "请求用户同意授权。同意授权可以是永久性的，也可以在规定的时间后过期。"
 
 #: src/admin/stages/prompt/PromptListPage.ts
 msgid "Prompt(s)"
 msgstr "输入"
 
-#: src/admin/AdminInterface.ts src/admin/stages/prompt/PromptListPage.ts
+#: src/admin/AdminInterface.ts
+#: src/admin/stages/prompt/PromptListPage.ts
 msgid "Prompts"
 msgstr "输入"
 
@@ -5063,14 +4966,11 @@ msgstr "协议设置"
 
 #: src/admin/applications/wizard/TypeApplicationWizardPage.ts
 #: src/admin/applications/wizard/TypeApplicationWizardPage.ts
-msgid ""
-"Provide an LDAP interface for applications and users to authenticate "
-"against."
+msgid "Provide an LDAP interface for applications and users to authenticate against."
 msgstr "为应用程序和用户提供 LDAP 接口以进行身份​​验证。"
 
 #: src/admin/providers/ProviderListPage.ts
-msgid ""
-"Provide support for protocols like SAML and OAuth to assigned applications."
+msgid "Provide support for protocols like SAML and OAuth to assigned applications."
 msgstr "为分配的应用程序提供对 SAML 和 OAuth 等协议的支持。"
 
 #: src/admin/applications/ApplicationForm.ts
@@ -5093,13 +4993,15 @@ msgstr "提供程序类型"
 msgid "Provider(s)"
 msgstr "提供程序"
 
-#: src/admin/AdminInterface.ts src/admin/outposts/OutpostListPage.ts
+#: src/admin/AdminInterface.ts
+#: src/admin/outposts/OutpostListPage.ts
 #: src/admin/providers/ProviderListPage.ts
 msgid "Providers"
 msgstr "提供程序"
 
 #: src/admin/applications/wizard/TypeApplicationWizardPage.ts
-#: src/admin/outposts/OutpostForm.ts src/admin/outposts/OutpostListPage.ts
+#: src/admin/outposts/OutpostForm.ts
+#: src/admin/outposts/OutpostListPage.ts
 #: src/admin/providers/proxy/ProxyProviderForm.ts
 #: src/admin/providers/proxy/ProxyProviderViewPage.ts
 msgid "Proxy"
@@ -5114,9 +5016,7 @@ msgid "Public"
 msgstr "公开"
 
 #: src/admin/providers/oauth2/OAuth2ProviderForm.ts
-msgid ""
-"Public clients are incapable of maintaining the confidentiality and should "
-"use methods like PKCE."
+msgid "Public clients are incapable of maintaining the confidentiality and should use methods like PKCE."
 msgstr "公开客户端没有能力维护其凭据的机密性，应该使用 PKCE 等方法。"
 
 #: src/admin/stages/captcha/CaptchaStageForm.ts
@@ -5124,8 +5024,7 @@ msgid "Public Key"
 msgstr "公钥"
 
 #: src/admin/stages/captcha/CaptchaStageForm.ts
-msgid ""
-"Public key, acquired from https://www.google.com/recaptcha/intro/v3.html."
+msgid "Public key, acquired from https://www.google.com/recaptcha/intro/v3.html."
 msgstr "公钥，从 https://www.google.com/recaptcha/intro/v3.html 获取。"
 
 #: src/admin/applications/ApplicationForm.ts
@@ -5141,7 +5040,8 @@ msgstr "快速操作"
 msgid "Radio Button Group (fixed choice)"
 msgstr "单选按钮组（固定选项）"
 
-#: src/admin/outposts/OutpostForm.ts src/admin/outposts/OutpostListPage.ts
+#: src/admin/outposts/OutpostForm.ts
+#: src/admin/outposts/OutpostListPage.ts
 msgid "Radius"
 msgstr "Radius"
 
@@ -5164,8 +5064,10 @@ msgstr "在您的设备上接收推送通知。"
 msgid "Recent events"
 msgstr "近期事件"
 
-#: src/admin/flows/utils.ts src/admin/tokens/TokenListPage.ts
-#: src/admin/users/RelatedUserList.ts src/admin/users/UserListPage.ts
+#: src/admin/flows/utils.ts
+#: src/admin/tokens/TokenListPage.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
 msgid "Recovery"
 msgstr "恢复"
 
@@ -5175,16 +5077,15 @@ msgid "Recovery flow"
 msgstr "恢复流程"
 
 #: src/admin/tenants/TenantForm.ts
-msgid ""
-"Recovery flow. If left empty, the first applicable flow sorted by the slug "
-"is used."
+msgid "Recovery flow. If left empty, the first applicable flow sorted by the slug is used."
 msgstr "恢复流程。如果留空，则使用按 Slug 排序的第一个适用流程。"
 
 #: src/flow/stages/authenticator_validate/AuthenticatorValidateStage.ts
 msgid "Recovery keys"
 msgstr "恢复密钥"
 
-#: src/admin/users/RelatedUserList.ts src/admin/users/UserListPage.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
 msgid "Recovery link cannot be emailed, user has no email address saved."
 msgstr "无法通过电子邮件发送恢复链接，用户没有保存电子邮件地址。"
 
@@ -5208,15 +5109,18 @@ msgstr "重定向 URI"
 msgid "Redirect URIs/Origins (RegEx)"
 msgstr "重定向 URI/Origin（正则）"
 
-#: src/elements/forms/DeleteBulkForm.ts src/elements/forms/DeleteForm.ts
+#: src/elements/forms/DeleteBulkForm.ts
+#: src/elements/forms/DeleteForm.ts
 msgid "reference will be reset to default value"
 msgstr "引用将被重置为默认值"
 
-#: src/elements/forms/DeleteBulkForm.ts src/elements/forms/DeleteForm.ts
+#: src/elements/forms/DeleteBulkForm.ts
+#: src/elements/forms/DeleteForm.ts
 msgid "reference will be set to an empty value"
 msgstr "引用将被设置为空值"
 
-#: src/elements/table/Table.ts src/elements/user/UserDevicesList.ts
+#: src/elements/table/Table.ts
+#: src/elements/user/UserDevicesList.ts
 msgid "Refresh"
 msgstr "刷新"
 
@@ -5239,17 +5143,14 @@ msgid "Register device"
 msgstr "注册设备"
 
 #: src/admin/providers/proxy/ProxyProviderForm.ts
-msgid ""
-"Regular expressions for which authentication is not required. Each new line "
-"is interpreted as a new expression."
+msgid "Regular expressions for which authentication is not required. Each new line is interpreted as a new expression."
 msgstr "用于描述何处不需要身份验证的正则表达式。每个新行都被解释为一个新的表达式。"
 
-#~ msgid ""
-#~ "Regular expressions for which authentication is not required. Each new line "
-#~ "is interpreted as a new Regular Expression."
+#~ msgid "Regular expressions for which authentication is not required. Each new line is interpreted as a new Regular Expression."
 #~ msgstr "用于描述何处不需要身份验证的正则表达式。每个新行都被解释为一个新的正则表达式。"
 
-#: src/admin/users/RelatedUserList.ts src/admin/users/UserListPage.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
 msgid "Regular user"
 msgstr "普通用户"
 
@@ -5265,7 +5166,8 @@ msgstr "相关操作"
 msgid "Related objects"
 msgstr "相关对象"
 
-#: src/admin/groups/RelatedGroupList.ts src/admin/users/RelatedUserList.ts
+#: src/admin/groups/RelatedGroupList.ts
+#: src/admin/users/RelatedUserList.ts
 msgid "Remove"
 msgstr "删除"
 
@@ -5286,19 +5188,13 @@ msgid "Reputation"
 msgstr "信誉"
 
 #: src/admin/policies/reputation/ReputationListPage.ts
-msgid ""
-"Reputation for IP and user identifiers. Scores are decreased for each failed"
-" login and increased for each successful login."
+msgid "Reputation for IP and user identifiers. Scores are decreased for each failed login and increased for each successful login."
 msgstr "IP 和用户标识符的信誉。每次登录失败分数都会降低，每次登录成功分数都会增加。"
 
-#~ msgid ""
-#~ "Reputation for IPs. Scores are decreased for each failed login and increased"
-#~ " for each successful login."
+#~ msgid "Reputation for IPs. Scores are decreased for each failed login and increased for each successful login."
 #~ msgstr "IP 的信誉。每次登录失败分数都会降低，每次登录成功分数都会增加。"
 
-#~ msgid ""
-#~ "Reputation for usernames. Scores are decreased for each failed login and "
-#~ "increased for each successful login."
+#~ msgid "Reputation for usernames. Scores are decreased for each failed login and increased for each successful login."
 #~ msgstr "用户名的声誉。每次登录失败分数都会降低，每次登录成功分数都会增加。"
 
 #~ msgid "Reputation policy"
@@ -5315,7 +5211,8 @@ msgstr "IP 和用户标识符的信誉。每次登录失败分数都会降低，
 msgid "Reputation scores"
 msgstr "信誉分数"
 
-#: src/admin/events/EventInfo.ts src/admin/events/EventInfo.ts
+#: src/admin/events/EventInfo.ts
+#: src/admin/events/EventInfo.ts
 msgid "Request"
 msgstr "请求"
 
@@ -5359,9 +5256,7 @@ msgstr "必需。"
 #~ msgstr "必填。不超过 150 个字符。仅限字母、数字和 @/./+/-/_ 。"
 
 #: src/admin/providers/oauth2/OAuth2ProviderForm.ts
-msgid ""
-"Requires the user to have a 'upn' attribute set, and falls back to hashed "
-"user ID. Use this mode only if you have different UPN and Mail domains."
+msgid "Requires the user to have a 'upn' attribute set, and falls back to hashed user ID. Use this mode only if you have different UPN and Mail domains."
 msgstr "需要用户设置过“upn”属性，否则回退到哈希过的用户 ID。仅应在您拥有不同 UPN 和邮件域时使用此模式。"
 
 #: src/admin/users/UserViewPage.ts
@@ -5375,17 +5270,13 @@ msgstr "常驻钥匙要求"
 #~ msgid "Resources"
 #~ msgstr "资源"
 
-#~ msgid ""
-#~ "RESTART restarts the flow from the beginning, while keeping the flow "
-#~ "context."
+#~ msgid "RESTART restarts the flow from the beginning, while keeping the flow context."
 #~ msgstr "RESTART 从头开始重新启动流程，同时保留流程上下文。"
 
 #~ msgid "RESTART restarts the flow from the beginning."
 #~ msgstr "RESTART 从头开始重新启动流程。"
 
-#~ msgid ""
-#~ "RESTART_WITH_CONTEXT restarts the flow from the beginning, while keeping the"
-#~ " flow context."
+#~ msgid "RESTART_WITH_CONTEXT restarts the flow from the beginning, while keeping the flow context."
 #~ msgstr "RESTART_WITH_CONTEXT 从头开始重新启动流程，同时保留流程上下文。"
 
 #: src/admin/flows/StageBindingForm.ts
@@ -5409,8 +5300,7 @@ msgstr "重试"
 msgid "Retry authentication"
 msgstr "重试身份验证"
 
-#~ msgid ""
-#~ "RETRY returns the error message and a similar challenge to the executor."
+#~ msgid "RETRY returns the error message and a similar challenge to the executor."
 #~ msgstr "RETRY 向执行器返回错误消息和类似的质询。"
 
 #~ msgid "Retry Task"
@@ -5429,9 +5319,7 @@ msgstr "返回主页"
 msgid "Return to device picker"
 msgstr "返回设备选择器"
 
-#~ msgid ""
-#~ "Return true if request IP/target username's score is below a certain "
-#~ "threshold."
+#~ msgid "Return true if request IP/target username's score is below a certain threshold."
 #~ msgstr "如果请求 IP/目标用户名的分数低于特定阈值则返回真。 "
 
 #: src/admin/flows/StageBindingForm.ts
@@ -5549,7 +5437,8 @@ msgstr "搜索组"
 msgid "Search mode"
 msgstr "搜索模式"
 
-#: src/elements/table/TableSearch.ts src/user/LibraryPage.ts
+#: src/elements/table/TableSearch.ts
+#: src/user/LibraryPage.ts
 msgid "Search..."
 msgstr "搜索..."
 
@@ -5601,9 +5490,7 @@ msgstr "了解更多："
 msgid "Select a provider that this application should use."
 msgstr "选择此应用应该使用的提供程序。"
 
-#~ msgid ""
-#~ "Select a provider that this application should use. Alternatively, create a "
-#~ "new provider."
+#~ msgid "Select a provider that this application should use. Alternatively, create a new provider."
 #~ msgstr "选择此应用程序应使用的提供程序。或者创建一个新的提供程序。"
 
 #: src/elements/table/Table.ts
@@ -5626,9 +5513,7 @@ msgid "Select an object."
 msgstr "选择一个对象。"
 
 #: src/admin/applications/ApplicationForm.ts
-msgid ""
-"Select backchannel providers which augment the functionality of the main "
-"provider."
+msgid "Select backchannel providers which augment the functionality of the main provider."
 msgstr "选择可为主要提供程序增强功能的反向通道提供程序。"
 
 #: src/admin/users/GroupSelectModal.ts
@@ -5644,15 +5529,14 @@ msgid "Select providers to add to application"
 msgstr "选择要添加到应用的提供程序"
 
 #: src/admin/stages/identification/IdentificationStageForm.ts
-msgid ""
-"Select sources should be shown for users to authenticate with. This only "
-"affects web-based sources, not LDAP."
+msgid "Select sources should be shown for users to authenticate with. This only affects web-based sources, not LDAP."
 msgstr "选择的源应显示给用户进行身份验证。这只会影响基于 Web 的源，而不影响 LDAP。"
 
 #: src/admin/outposts/ServiceConnectionWizard.ts
 #: src/admin/policies/PolicyWizard.ts
 #: src/admin/property-mappings/PropertyMappingWizard.ts
-#: src/admin/providers/ProviderWizard.ts src/admin/sources/SourceWizard.ts
+#: src/admin/providers/ProviderWizard.ts
+#: src/admin/sources/SourceWizard.ts
 #: src/admin/stages/StageWizard.ts
 msgid "Select type"
 msgstr "选择类型"
@@ -5662,21 +5546,15 @@ msgid "Select users to add"
 msgstr "选择要添加的用户"
 
 #: src/admin/providers/oauth2/OAuth2ProviderForm.ts
-msgid ""
-"Select which scopes can be used by the client. The client still has to "
-"specify the scope to access the data."
+msgid "Select which scopes can be used by the client. The client still has to specify the scope to access the data."
 msgstr "选择客户端可以使用哪些作用域。客户端仍然需要指定访问数据的范围。"
 
 #: src/admin/sources/plex/PlexSourceForm.ts
-msgid ""
-"Select which server a user has to be a member of to be allowed to "
-"authenticate."
+msgid "Select which server a user has to be a member of to be allowed to authenticate."
 msgstr "选择用户必须是哪个服务器的成员才能进行身份验证。"
 
 #: src/admin/events/RuleForm.ts
-msgid ""
-"Select which transports should be used to notify the user. If none are "
-"selected, the notification will only be shown in the authentik UI."
+msgid "Select which transports should be used to notify the user. If none are selected, the notification will only be shown in the authentik UI."
 msgstr "选择应使用哪些传输方式来通知用户。如果未选择任何内容，则通知将仅显示在 authentik UI 中。"
 
 #: src/flow/stages/user_login/UserLoginStage.ts
@@ -5684,19 +5562,14 @@ msgid "Select Yes to reduce the number of times you're asked to sign in."
 msgstr "选择“是”以减少您被要求登录的次数。"
 
 #: src/admin/stages/prompt/PromptStageForm.ts
-msgid ""
-"Selected policies are executed when the stage is submitted to validate the "
-"data."
+msgid "Selected policies are executed when the stage is submitted to validate the data."
 msgstr "当阶段被提交以验证数据时，执行选定的策略。"
 
-#~ msgid ""
-#~ "Selecting a service-connection enables the management of the outpost by "
-#~ "authentik."
+#~ msgid "Selecting a service-connection enables the management of the outpost by authentik."
 #~ msgstr "选择服务连接使 authentik 能够管理前哨。"
 
 #: src/admin/outposts/OutpostForm.ts
-msgid ""
-"Selecting an integration enables the management of the outpost by authentik."
+msgid "Selecting an integration enables the management of the outpost by authentik."
 msgstr "选择集成使 authentik 能够管理前哨。"
 
 #: src/admin/stages/password/PasswordStageForm.ts
@@ -5704,9 +5577,7 @@ msgid "Selection of backends to test the password against."
 msgstr "选择用于测试密码的后端。"
 
 #: src/admin/providers/proxy/ProxyProviderForm.ts
-msgid ""
-"Send a custom HTTP-Basic Authentication header based on values from "
-"authentik."
+msgid "Send a custom HTTP-Basic Authentication header based on values from authentik."
 msgstr "根据来自 authentik 的值发送自定义 HTTP-Basic 身份验证标头。"
 
 #: src/flow/stages/email/EmailStage.ts
@@ -5717,21 +5588,21 @@ msgstr "再次发送电子邮件。"
 msgid "Send HTTP-Basic Authentication"
 msgstr "发送 HTTP-Basic 身份验证"
 
-#: src/admin/users/RelatedUserList.ts src/admin/users/UserListPage.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
 msgid "Send link"
 msgstr "发送链接"
 
 #: src/admin/events/RuleListPage.ts
-msgid ""
-"Send notifications whenever a specific Event is created and matched by "
-"policies."
+msgid "Send notifications whenever a specific Event is created and matched by policies."
 msgstr "每当特定事件被创建并匹配策略时，都会发送通知。"
 
 #: src/admin/events/TransportForm.ts
 msgid "Send once"
 msgstr "发送一次"
 
-#: src/admin/users/RelatedUserList.ts src/admin/users/UserListPage.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
 msgid "Send recovery link to user"
 msgstr "向用户发送恢复链接"
 
@@ -5784,9 +5655,7 @@ msgstr "会话持续时间"
 msgid "Session ID"
 msgstr "会话 ID"
 
-#~ msgid ""
-#~ "Session not valid on or after current time + this value (Format: "
-#~ "hours=1;minutes=2;seconds=3)."
+#~ msgid "Session not valid on or after current time + this value (Format: hours=1;minutes=2;seconds=3)."
 #~ msgstr "从当前时间经过多久时或之后，会话无效（格式：hours=1;minutes=2;seconds=3）。"
 
 #: src/admin/providers/saml/SAMLProviderForm.ts
@@ -5801,49 +5670,45 @@ msgstr "不在此刻或之后，会话有效"
 msgid "Session(s)"
 msgstr "会话"
 
-#: src/admin/users/UserViewPage.ts src/user/user-settings/UserSettingsPage.ts
+#: src/admin/users/UserViewPage.ts
+#: src/user/user-settings/UserSettingsPage.ts
 msgid "Sessions"
 msgstr "会话"
 
-#~ msgid ""
-#~ "Set a custom HTTP-Basic Authentication header based on values from "
-#~ "authentik."
+#~ msgid "Set a custom HTTP-Basic Authentication header based on values from authentik."
 #~ msgstr "根据来自 authentik 的值设置自定义 HTTP-Basic 身份验证标头。"
 
-#: src/admin/groups/GroupForm.ts src/admin/outposts/OutpostForm.ts
+#: src/admin/groups/GroupForm.ts
+#: src/admin/outposts/OutpostForm.ts
 #: src/admin/outposts/ServiceConnectionKubernetesForm.ts
-#: src/admin/policies/PolicyTestForm.ts src/admin/users/UserForm.ts
+#: src/admin/policies/PolicyTestForm.ts
+#: src/admin/users/UserForm.ts
 msgid "Set custom attributes using YAML or JSON."
 msgstr "使用 YAML 或 JSON 设置自定义属性。"
 
 #: src/admin/tenants/TenantForm.ts
-msgid ""
-"Set custom attributes using YAML or JSON. Any attributes set here will be "
-"inherited by users, if the request is handled by this tenant."
+msgid "Set custom attributes using YAML or JSON. Any attributes set here will be inherited by users, if the request is handled by this tenant."
 msgstr "使用 YAML 或 JSON 格式设置自定义属性。如果请求由此租户处理，则用户会继承此处设置的任何自定义属性。  "
 
 #~ msgid "Set HTTP-Basic Authentication"
 #~ msgstr "设置 HTTP-Basic 身份验证"
 
-#: src/admin/users/RelatedUserList.ts src/admin/users/UserListPage.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
 #: src/admin/users/UserViewPage.ts
 msgid "Set password"
 msgstr "设置密码"
 
 #: src/admin/providers/proxy/ProxyProviderForm.ts
-msgid ""
-"Set this to the domain you wish the authentication to be valid for. Must be "
-"a parent domain of the URL above. If you're running applications as "
-"app1.domain.tld, app2.domain.tld, set this to 'domain.tld'."
-msgstr ""
-"将此设置为您希望身份验证有效的域名。必须是上述 URL 的父域名。如果您的应用部署在 "
-"app1.domain.tld、app2.domain.tld，请将其设置为 'domain.tld'。"
+msgid "Set this to the domain you wish the authentication to be valid for. Must be a parent domain of the URL above. If you're running applications as app1.domain.tld, app2.domain.tld, set this to 'domain.tld'."
+msgstr "将此设置为您希望身份验证有效的域名。必须是上述 URL 的父域名。如果您的应用部署在 app1.domain.tld、app2.domain.tld，请将其设置为 'domain.tld'。"
 
 #: src/admin/providers/proxy/ProxyProviderViewPage.ts
 msgid "Setup"
 msgstr "设置"
 
-#: src/admin/events/RuleForm.ts src/admin/events/RuleListPage.ts
+#: src/admin/events/RuleForm.ts
+#: src/admin/events/RuleListPage.ts
 msgid "Severity"
 msgstr "严重程度"
 
@@ -5864,9 +5729,7 @@ msgid "Shared secret"
 msgstr "共享密钥"
 
 #: src/admin/stages/prompt/PromptStageForm.ts
-msgid ""
-"Show arbitrary input fields to the user, for example during enrollment. Data"
-" is saved in the flow context under the 'prompt_data' variable."
+msgid "Show arbitrary input fields to the user, for example during enrollment. Data is saved in the flow context under the 'prompt_data' variable."
 msgstr "向用户显示任意输入字段，例如在注册期间。数据保存在流程上下文中的 'prompt_data' 变量下。"
 
 #: src/elements/Expand.ts
@@ -5931,9 +5794,7 @@ msgid "Single-page applications"
 msgstr "单页应用程序"
 
 #: src/admin/applications/wizard/oauth/TypeOAuthApplicationWizardPage.ts
-msgid ""
-"Single-page applications which handle authentication in the browser (for "
-"example, Javascript, Angular, React, Vue)"
+msgid "Single-page applications which handle authentication in the browser (for example, Javascript, Angular, React, Vue)"
 msgstr "在浏览器内处理身份验证的单页应用程序（例如 Javascript、Angular、React、Vue）"
 
 #~ msgid "Skip path regex"
@@ -5952,7 +5813,8 @@ msgstr "SLO URL（Post）"
 msgid "SLO URL (Redirect)"
 msgstr "SLO URL（重定向）"
 
-#: src/admin/applications/ApplicationForm.ts src/admin/flows/FlowForm.ts
+#: src/admin/applications/ApplicationForm.ts
+#: src/admin/flows/FlowForm.ts
 #: src/admin/sources/ldap/LDAPSourceForm.ts
 #: src/admin/sources/oauth/OAuthSourceForm.ts
 #: src/admin/sources/plex/PlexSourceForm.ts
@@ -6016,16 +5878,11 @@ msgstr "源"
 msgid "Sources"
 msgstr "源"
 
-#~ msgid ""
-#~ "Sources of identities, which can either be synced into authentik's database,"
-#~ " like LDAP, or can be used by users to authenticate and enroll themselves, "
-#~ "like OAuth and social logins"
+#~ msgid "Sources of identities, which can either be synced into authentik's database, like LDAP, or can be used by users to authenticate and enroll themselves, like OAuth and social logins"
 #~ msgstr "身份来源，既可以同步到 authentik 的数据库中，例如 LDAP，也可以被用户用来进行身份验证和注册，例如 OAuth 和社交登录"
 
 #: src/admin/sources/SourceListPage.ts
-msgid ""
-"Sources of identities, which can either be synced into authentik's database,"
-" or can be used by users to authenticate and enroll themselves."
+msgid "Sources of identities, which can either be synced into authentik's database, or can be used by users to authenticate and enroll themselves."
 msgstr "身份来源，既可以同步到 authentik 的数据库中，也可以被用户用来进行身份验证和注册。"
 
 #: src/common/ui/locale.ts
@@ -6057,7 +5914,8 @@ msgstr "SSO URL（重定向）"
 msgid "Stacked"
 msgstr "叠放"
 
-#: src/admin/flows/BoundStagesList.ts src/admin/flows/StageBindingForm.ts
+#: src/admin/flows/BoundStagesList.ts
+#: src/admin/flows/StageBindingForm.ts
 msgid "Stage"
 msgstr "阶段"
 
@@ -6093,43 +5951,30 @@ msgid "Stage type"
 msgstr "阶段类型"
 
 #: src/admin/stages/authenticator_duo/AuthenticatorDuoStageForm.ts
-msgid ""
-"Stage used to configure a duo-based authenticator. This stage should be used"
-" for configuration flows."
+msgid "Stage used to configure a duo-based authenticator. This stage should be used for configuration flows."
 msgstr "用来配置基于 Duo 的身份验证器的阶段。此阶段应该用于配置流程。"
 
 #: src/admin/stages/authenticator_static/AuthenticatorStaticStageForm.ts
-msgid ""
-"Stage used to configure a static authenticator (i.e. static tokens). This "
-"stage should be used for configuration flows."
+msgid "Stage used to configure a static authenticator (i.e. static tokens). This stage should be used for configuration flows."
 msgstr "用来配置静态身份验证器（即静态令牌）的阶段。此阶段应该用于配置流程。"
 
 #: src/admin/stages/authenticator_totp/AuthenticatorTOTPStageForm.ts
-msgid ""
-"Stage used to configure a TOTP authenticator (i.e. Authy/Google "
-"Authenticator)."
+msgid "Stage used to configure a TOTP authenticator (i.e. Authy/Google Authenticator)."
 msgstr "用来配置 TOTP 身份验证器（即 Authy/Google 身份验证器）的阶段。"
 
 #: src/admin/stages/authenticator_webauthn/AuthenticateWebAuthnStageForm.ts
-msgid ""
-"Stage used to configure a WebAutnn authenticator (i.e. Yubikey, "
-"FaceID/Windows Hello)."
+msgid "Stage used to configure a WebAutnn authenticator (i.e. Yubikey, FaceID/Windows Hello)."
 msgstr "用来配置 WebAuthn 身份验证器（即 Yubikey、FaceID/Windows Hello）的阶段。"
 
 #: src/admin/stages/authenticator_sms/AuthenticatorSMSStageForm.ts
 msgid "Stage used to configure an SMS-based TOTP authenticator."
 msgstr "用来配置基于短信的 TOTP 身份验证器的阶段。"
 
-#~ msgid ""
-#~ "Stage used to configure Authenticator when user doesn't have any compatible "
-#~ "devices. After this configuration Stage passes, the user is not prompted "
-#~ "again."
+#~ msgid "Stage used to configure Authenticator when user doesn't have any compatible devices. After this configuration Stage passes, the user is not prompted again."
 #~ msgstr "在用户没有任何兼容设备时用来配置身份验证器的阶段。此配置阶段通过后，不会再次提示用户。"
 
 #: src/admin/stages/authenticator_validate/AuthenticatorValidateStageForm.ts
-msgid ""
-"Stage used to validate any authenticator. This stage should be used during "
-"authentication or authorization flows."
+msgid "Stage used to validate any authenticator. This stage should be used during authentication or authorization flows."
 msgstr "用来验证任何身份验证器的阶段。此阶段应在身份验证或授权流程中使用。"
 
 #: src/admin/stages/authenticator_duo/AuthenticatorDuoStageForm.ts
@@ -6154,22 +5999,19 @@ msgstr "阶段特定设置"
 msgid "Stage(s)"
 msgstr "阶段"
 
-#: src/admin/AdminInterface.ts src/admin/flows/FlowListPage.ts
-#: src/admin/stages/prompt/PromptListPage.ts src/admin/stages/StageListPage.ts
+#: src/admin/AdminInterface.ts
+#: src/admin/flows/FlowListPage.ts
+#: src/admin/stages/prompt/PromptListPage.ts
+#: src/admin/stages/StageListPage.ts
 msgid "Stages"
 msgstr "阶段"
 
 #: src/admin/stages/StageListPage.ts
-msgid ""
-"Stages are single steps of a Flow that a user is guided through. A stage can"
-" only be executed from within a flow."
+msgid "Stages are single steps of a Flow that a user is guided through. A stage can only be executed from within a flow."
 msgstr "阶段是引导用户完成流程的单个步骤。阶段只能在流程内部执行。"
 
 #: src/admin/stages/authenticator_validate/AuthenticatorValidateStageForm.ts
-msgid ""
-"Stages used to configure Authenticator when user doesn't have any compatible"
-" devices. After this configuration Stage passes, the user is not prompted "
-"again."
+msgid "Stages used to configure Authenticator when user doesn't have any compatible devices. After this configuration Stage passes, the user is not prompted again."
 msgstr "当用户没有任何兼容的设备时，用来配置身份验证器的阶段。此阶段通过后，将不再请求此用户。"
 
 #: src/admin/stages/authenticator_duo/DuoDeviceImportForm.ts
@@ -6204,9 +6046,7 @@ msgid "Static: Static value, displayed as-is."
 msgstr "静态：静态值，按原样显示。"
 
 #: src/admin/stages/deny/DenyStageForm.ts
-msgid ""
-"Statically deny the flow. To use this stage effectively, disable *Evaluate "
-"on plan* on the respective binding."
+msgid "Statically deny the flow. To use this stage effectively, disable *Evaluate on plan* on the respective binding."
 msgstr "静态拒绝流。要有效地使用此阶段，请在相应的绑定上禁用*规划时进行评估*。"
 
 #: src/admin/blueprints/BlueprintListPage.ts
@@ -6232,7 +6072,8 @@ msgstr "保持登录？"
 msgid "Stop impersonation"
 msgstr "停止模拟身份"
 
-#: src/admin/events/EventInfo.ts src/admin/stages/email/EmailStageForm.ts
+#: src/admin/events/EventInfo.ts
+#: src/admin/stages/email/EmailStageForm.ts
 msgid "Subject"
 msgstr "主题"
 
@@ -6244,7 +6085,8 @@ msgstr "Subject 模式"
 msgid "Subject-alt name"
 msgstr "替代名称"
 
-#: src/admin/blueprints/BlueprintListPage.ts src/admin/flows/FlowImportForm.ts
+#: src/admin/blueprints/BlueprintListPage.ts
+#: src/admin/flows/FlowImportForm.ts
 #: src/admin/system-tasks/SystemTaskListPage.ts
 msgid "Successful"
 msgstr "成功"
@@ -6282,7 +6124,8 @@ msgstr "已成功复制 TOTP 配置。"
 msgid "Successfully created application."
 msgstr "已成功创建应用程序。"
 
-#: src/admin/flows/StageBindingForm.ts src/admin/policies/PolicyBindingForm.ts
+#: src/admin/flows/StageBindingForm.ts
+#: src/admin/policies/PolicyBindingForm.ts
 msgid "Successfully created binding."
 msgstr "已成功创建绑定。"
 
@@ -6394,11 +6237,13 @@ msgstr "已成功创建令牌。"
 msgid "Successfully created transport."
 msgstr "已成功创建传输。"
 
-#: src/admin/users/ServiceAccountForm.ts src/admin/users/UserForm.ts
+#: src/admin/users/ServiceAccountForm.ts
+#: src/admin/users/UserForm.ts
 msgid "Successfully created user."
 msgstr "已成功创建用户。"
 
-#: src/elements/forms/DeleteBulkForm.ts src/elements/forms/DeleteForm.ts
+#: src/elements/forms/DeleteBulkForm.ts
+#: src/elements/forms/DeleteForm.ts
 msgid "Successfully deleted {0} {1}"
 msgstr "已成功删除 {0} {1}"
 
@@ -6412,7 +6257,8 @@ msgstr "解绑成功"
 msgid "Successfully generated certificate-key pair."
 msgstr "已成功生成证书密钥对。"
 
-#: src/admin/users/RelatedUserList.ts src/admin/users/UserListPage.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
 #: src/admin/users/UserViewPage.ts
 msgid "Successfully generated recovery link"
 msgstr "已成功生成恢复链接"
@@ -6451,7 +6297,8 @@ msgstr "已成功更新 {0} {1}"
 msgid "Successfully updated application."
 msgstr "已成功更新应用程序。"
 
-#: src/admin/flows/StageBindingForm.ts src/admin/policies/PolicyBindingForm.ts
+#: src/admin/flows/StageBindingForm.ts
+#: src/admin/policies/PolicyBindingForm.ts
 msgid "Successfully updated binding."
 msgstr "已成功更新绑定。"
 
@@ -6582,13 +6429,16 @@ msgstr "已成功更新传输。"
 msgid "Successfully updated user."
 msgstr "已成功更新用户。"
 
-#: src/admin/groups/GroupViewPage.ts src/admin/users/GroupSelectModal.ts
-#: src/admin/users/RelatedUserList.ts src/admin/users/UserListPage.ts
+#: src/admin/groups/GroupViewPage.ts
+#: src/admin/users/GroupSelectModal.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
 #: src/admin/users/UserViewPage.ts
 msgid "Superuser"
 msgstr "超级用户"
 
-#: src/admin/groups/GroupListPage.ts src/admin/groups/RelatedGroupList.ts
+#: src/admin/groups/GroupListPage.ts
+#: src/admin/groups/RelatedGroupList.ts
 msgid "Superuser privileges?"
 msgstr "超级用户权限？"
 
@@ -6649,7 +6499,8 @@ msgstr "系统任务异常"
 msgid "System task execution"
 msgstr "系统任务执行"
 
-#: src/admin/AdminInterface.ts src/admin/system-tasks/SystemTaskListPage.ts
+#: src/admin/AdminInterface.ts
+#: src/admin/system-tasks/SystemTaskListPage.ts
 msgid "System Tasks"
 msgstr "系统任务"
 
@@ -6674,7 +6525,8 @@ msgid "Template"
 msgstr "模板"
 
 #: src/admin/admin-overview/cards/RecentEventsCard.ts
-#: src/admin/events/EventListPage.ts src/admin/events/EventViewPage.ts
+#: src/admin/events/EventListPage.ts
+#: src/admin/events/EventViewPage.ts
 msgid "Tenant"
 msgstr "租户"
 
@@ -6682,7 +6534,8 @@ msgstr "租户"
 msgid "Tenant(s)"
 msgstr "租户"
 
-#: src/admin/AdminInterface.ts src/admin/tenants/TenantListPage.ts
+#: src/admin/AdminInterface.ts
+#: src/admin/tenants/TenantListPage.ts
 msgid "Tenants"
 msgstr "租户"
 
@@ -6721,15 +6574,11 @@ msgid "Text: Simple Text input"
 msgstr "文本：简单文本输入"
 
 #: src/admin/stages/authenticator_webauthn/AuthenticateWebAuthnStageForm.ts
-msgid ""
-"The authenticator can create and store a dedicated credential, but if it "
-"doesn't that's alright too"
+msgid "The authenticator can create and store a dedicated credential, but if it doesn't that's alright too"
 msgstr "身份验证器可以创建和存储专用凭据，但不创建也可以"
 
 #: src/admin/stages/authenticator_webauthn/AuthenticateWebAuthnStageForm.ts
-msgid ""
-"The authenticator MUST create a dedicated credential. If it cannot, the RP "
-"is prepared for an error to occur"
+msgid "The authenticator MUST create a dedicated credential. If it cannot, the RP is prepared for an error to occur"
 msgstr "身份验证器必须创建专用凭据。如果不能，RP 预期会发生错误"
 
 #: src/admin/stages/authenticator_webauthn/AuthenticateWebAuthnStageForm.ts
@@ -6738,20 +6587,14 @@ msgstr "身份验证器不应该创建专用凭据"
 
 #: src/admin/providers/proxy/ProxyProviderForm.ts
 #: src/admin/providers/proxy/ProxyProviderForm.ts
-msgid ""
-"The external URL you'll access the application at. Include any non-standard "
-"port."
+msgid "The external URL you'll access the application at. Include any non-standard port."
 msgstr "您将通过此外部 URL 访问应用程序。请包括任何非标准端口。"
 
-#~ msgid ""
-#~ "The external URL you'll authenticate at. Can be the same domain as "
-#~ "authentik."
+#~ msgid "The external URL you'll authenticate at. Can be the same domain as authentik."
 #~ msgstr "您将在此外部 URL 进行身份验证。可以使用与 authentik 相同的域名。"
 
 #: src/admin/providers/proxy/ProxyProviderForm.ts
-msgid ""
-"The external URL you'll authenticate at. The authentik core server should be"
-" reachable under this URL."
+msgid "The external URL you'll authenticate at. The authentik core server should be reachable under this URL."
 msgstr "您将在此外部 URL 进行身份验证。通过此 URL 应该可以访问到 authentik 核心服务器。"
 
 #: src/elements/utils/TimeDeltaHelp.ts
@@ -6770,15 +6613,11 @@ msgid "The Host IP of the docker host"
 msgstr "Docker 宿主机的主机 IP"
 
 #: src/admin/providers/ProviderWizard.ts
-msgid ""
-"The new application wizard greatly simplifies the steps required to create "
-"applications and providers."
+msgid "The new application wizard greatly simplifies the steps required to create applications and providers."
 msgstr "新应用程序向导大幅度简化了创建应用程序和提供程序所需的操作步骤。"
 
 #: src/admin/providers/ldap/LDAPProviderForm.ts
-msgid ""
-"The outpost holds all users and groups in-memory and will refresh every 5 "
-"Minutes"
+msgid "The outpost holds all users and groups in-memory and will refresh every 5 Minutes"
 msgstr "前哨将所有用户和组保存在内存中，并每 5 分钟刷新一次"
 
 #~ msgid ""
@@ -6801,29 +6640,16 @@ msgstr ""
 "策略不通过。"
 
 #: src/admin/policies/dummy/DummyPolicyForm.ts
-msgid ""
-"The policy takes a random time to execute. This controls the minimum time it"
-" will take."
+msgid "The policy takes a random time to execute. This controls the minimum time it will take."
 msgstr "策略需要一段随机时间来执行。这将控制所需的最短时间。"
 
 #: src/admin/providers/ldap/LDAPProviderForm.ts
-msgid ""
-"The start for gidNumbers, this number is added to a number generated from "
-"the group.Pk to make sure that the numbers aren't too low for POSIX groups. "
-"Default is 4000 to ensure that we don't collide with local groups or users "
-"primary groups gidNumber"
-msgstr ""
-"起始 gidNumbers，这个数字会被添加到从 group.Pk 生成的数字中，以确保对于 POSIX 用户来说，这个数字不会太低。默认值为 "
-"4000，以确保我们不会与本地群组或用户主组的 gidNumber 发生冲突"
+msgid "The start for gidNumbers, this number is added to a number generated from the group.Pk to make sure that the numbers aren't too low for POSIX groups. Default is 4000 to ensure that we don't collide with local groups or users primary groups gidNumber"
+msgstr "起始 gidNumbers，这个数字会被添加到从 group.Pk 生成的数字中，以确保对于 POSIX 用户来说，这个数字不会太低。默认值为 4000，以确保我们不会与本地群组或用户主组的 gidNumber 发生冲突"
 
 #: src/admin/providers/ldap/LDAPProviderForm.ts
-msgid ""
-"The start for uidNumbers, this number is added to the user.Pk to make sure "
-"that the numbers aren't too low for POSIX users. Default is 2000 to ensure "
-"that we don't collide with local users uidNumber"
-msgstr ""
-"起始 uidNumbers，这个数字会被添加到 user.Pk 中，以确保对于 POSIX 用户来说，这个数字不会太低。默认值为 "
-"2000，以确保我们不会与本地用户的 uidNumber 发生冲突"
+msgid "The start for uidNumbers, this number is added to the user.Pk to make sure that the numbers aren't too low for POSIX users. Default is 2000 to ensure that we don't collide with local users uidNumber"
+msgstr "起始 uidNumbers，这个数字会被添加到 user.Pk 中，以确保对于 POSIX 用户来说，这个数字不会太低。默认值为 2000，以确保我们不会与本地用户的 uidNumber 发生冲突"
 
 #: src/elements/router/Router404.ts
 msgid "The URL \"{0}\" was not found."
@@ -6871,9 +6697,7 @@ msgid "These policies control which users can access this application."
 msgstr "这些策略控制哪些用户可以访问此应用程序。"
 
 #: src/admin/applications/wizard/oauth/TypeOAuthAPIApplicationWizardPage.ts
-msgid ""
-"This configuration can be used to authenticate to authentik with other APIs "
-"other otherwise programmatically."
+msgid "This configuration can be used to authenticate to authentik with other APIs other otherwise programmatically."
 msgstr "此配置可用于通过其他 API 或以编程方式处理 authentik 身份验证。"
 
 #: src/flow/FlowInspector.ts
@@ -6893,22 +6717,15 @@ msgid "This is the password to be used with basic auth"
 msgstr "这是用于 Basic 身份验证的密码"
 
 #: src/admin/stages/authenticator_sms/AuthenticatorSMSStageForm.ts
-msgid ""
-"This is the username to be used with basic auth or the token when used with "
-"bearer token"
+msgid "This is the username to be used with basic auth or the token when used with bearer token"
 msgstr "这是用于 Basic 身份验证的用户名，或是使用 Bearer 令牌时的令牌"
 
 #: src/admin/providers/proxy/ProxyProviderForm.ts
-msgid ""
-"This provider will behave like a transparent reverse-proxy, except requests "
-"must be authenticated. If your upstream application uses HTTPS, make sure to"
-" connect to the outpost using HTTPS as well."
-msgstr ""
-"除了请求必须经过身份验证外，此提供程序的行为类似于透明反向代理。如果您的上游应用程序使用 HTTPS，请确保连接到前哨时也使用 HTTPS。"
+msgid "This provider will behave like a transparent reverse-proxy, except requests must be authenticated. If your upstream application uses HTTPS, make sure to connect to the outpost using HTTPS as well."
+msgstr "除了请求必须经过身份验证外，此提供程序的行为类似于透明反向代理。如果您的上游应用程序使用 HTTPS，请确保连接到前哨时也使用 HTTPS。"
 
 #: src/admin/tenants/TenantForm.ts
-msgid ""
-"This setting only affects new Events, as the expiration is saved per-event."
+msgid "This setting only affects new Events, as the expiration is saved per-event."
 msgstr "此设置仅影响新事件，因为过期时间是分事件保存的。"
 
 #: src/admin/stages/invitation/InvitationStageForm.ts
@@ -6916,14 +6733,10 @@ msgid "This stage can be included in enrollment flows to accept invitations."
 msgstr "此阶段可以包含在注册流程中以接受邀请。"
 
 #: src/admin/stages/captcha/CaptchaStageForm.ts
-msgid ""
-"This stage checks the user's current session against the Google reCaptcha "
-"(or compatible) service."
+msgid "This stage checks the user's current session against the Google reCaptcha (or compatible) service."
 msgstr "此阶段会根据 Google reCaptcha（或兼容的）服务检查用户的当前会话。"
 
-#~ msgid ""
-#~ "This stage checks the user's current session against the Google reCaptcha "
-#~ "service."
+#~ msgid "This stage checks the user's current session against the Google reCaptcha service."
 #~ msgstr "此阶段会根据 Google reCAPTCHA 服务检查用户的当前会话。"
 
 #: src/admin/policies/reputation/ReputationPolicyForm.ts
@@ -6939,19 +6752,11 @@ msgid "Time in minutes the token sent is valid."
 msgstr "发出令牌的有效时间（单位为分钟）。"
 
 #: src/admin/sources/saml/SAMLSourceForm.ts
-msgid ""
-"Time offset when temporary users should be deleted. This only applies if "
-"your IDP uses the NameID Format 'transient', and the user doesn't log out "
-"manually."
+msgid "Time offset when temporary users should be deleted. This only applies if your IDP uses the NameID Format 'transient', and the user doesn't log out manually."
 msgstr "删除临时用户的时间偏移。这仅适用于您的 IDP 使用 NameID 格式 'transient' 且用户未手动登出的情况。"
 
-#~ msgid ""
-#~ "Time offset when temporary users should be deleted. This only applies if "
-#~ "your IDP uses the NameID Format 'transient', and the user doesn't log out "
-#~ "manually. (Format: hours=1;minutes=2;seconds=3)."
-#~ msgstr ""
-#~ "删除临时用户的时间偏移。这仅适用于您的 IDP 使用 NameID 格式 'transient' "
-#~ "且用户未手动登出的情况。（格式：hours=1;minutes=2;seconds=3）。"
+#~ msgid "Time offset when temporary users should be deleted. This only applies if your IDP uses the NameID Format 'transient', and the user doesn't log out manually. (Format: hours=1;minutes=2;seconds=3)."
+#~ msgstr "删除临时用户的时间偏移。这仅适用于您的 IDP 使用 NameID 格式 'transient' 且用户未手动登出的情况。（格式：hours=1;minutes=2;seconds=3）。"
 
 #~ msgid "Time-based One-Time Passwords"
 #~ msgstr "基于时间的一次性密码"
@@ -6962,7 +6767,8 @@ msgstr "删除临时用户的时间偏移。这仅适用于您的 IDP 使用 Nam
 msgid "Timeout"
 msgstr "超时"
 
-#: src/admin/flows/FlowForm.ts src/admin/tenants/TenantForm.ts
+#: src/admin/flows/FlowForm.ts
+#: src/admin/tenants/TenantForm.ts
 msgid "Title"
 msgstr "标题"
 
@@ -6986,31 +6792,22 @@ msgid "To"
 msgstr "至"
 
 #: src/admin/providers/oauth2/OAuth2ProviderForm.ts
-msgid ""
-"To allow any redirect URI, set this value to \".*\". Be aware of the "
-"possible security implications this can have."
+msgid "To allow any redirect URI, set this value to \".*\". Be aware of the possible security implications this can have."
 msgstr "要允许任何重定向 URI，请将此值设置为 \".*\"。请注意这可能带来的安全影响。"
 
-#~ msgid ""
-#~ "To allow any redirect URI, set this value to \"*\". Be aware of the possible"
-#~ " security implications this can have."
+#~ msgid "To allow any redirect URI, set this value to \"*\". Be aware of the possible security implications this can have."
 #~ msgstr "要允许任何重定向 URI，请将此值设置为 \"*\"。请注意这可能带来的安全影响。"
 
 #: src/admin/users/UserViewPage.ts
-msgid ""
-"To create a recovery link, the current tenant needs to have a recovery flow "
-"configured."
+msgid "To create a recovery link, the current tenant needs to have a recovery flow configured."
 msgstr "要创建恢复链接，当前租户需要配置恢复流程。"
 
-#~ msgid ""
-#~ "To directly reset a user's password, configure a recovery flow on the "
-#~ "currently active tenant."
+#~ msgid "To directly reset a user's password, configure a recovery flow on the currently active tenant."
 #~ msgstr "要直接重置用户的密码，请在当前活动的租户上配置恢复流程。"
 
-#: src/admin/users/RelatedUserList.ts src/admin/users/UserListPage.ts
-msgid ""
-"To let a user directly reset a their password, configure a recovery flow on "
-"the currently active tenant."
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
+msgid "To let a user directly reset a their password, configure a recovery flow on the currently active tenant."
 msgstr "要让用户直接重置密码，请在当前活动的租户上配置恢复流程。"
 
 #: src/admin/sources/ldap/LDAPSourceForm.ts
@@ -7034,9 +6831,7 @@ msgid "Token is managed by authentik."
 msgstr "令牌由 authentik 管理。"
 
 #: src/admin/providers/scim/SCIMProviderForm.ts
-msgid ""
-"Token to authenticate with. Currently only bearer authentication is "
-"supported."
+msgid "Token to authenticate with. Currently only bearer authentication is supported."
 msgstr "用于验证身份的令牌。当前仅支持 Bearer 身份验证。"
 
 #: src/admin/providers/oauth2/OAuth2ProviderViewPage.ts
@@ -7066,9 +6861,7 @@ msgid "Tokens and App passwords"
 msgstr "令牌和应用程序密码"
 
 #: src/admin/tokens/TokenListPage.ts
-msgid ""
-"Tokens are used throughout authentik for Email validation stages, Recovery "
-"keys and API access."
+msgid "Tokens are used throughout authentik for Email validation stages, Recovery keys and API access."
 msgstr "令牌在整个 authentik 中用于电子邮件验证阶段、恢复密钥和 API 访问。"
 
 #: src/flow/stages/authenticator_validate/AuthenticatorValidateStage.ts
@@ -7152,12 +6945,14 @@ msgid "Twilio Auth Token"
 msgstr "Twilio 身份验证令牌"
 
 #: src/admin/applications/ProviderSelectModal.ts
-#: src/admin/flows/BoundStagesList.ts src/admin/outposts/OutpostForm.ts
+#: src/admin/flows/BoundStagesList.ts
+#: src/admin/outposts/OutpostForm.ts
 #: src/admin/outposts/OutpostListPage.ts
 #: src/admin/outposts/ServiceConnectionListPage.ts
 #: src/admin/policies/PolicyListPage.ts
 #: src/admin/property-mappings/PropertyMappingListPage.ts
-#: src/admin/providers/ProviderListPage.ts src/admin/sources/SourceListPage.ts
+#: src/admin/providers/ProviderListPage.ts
+#: src/admin/sources/SourceListPage.ts
 #: src/admin/stages/prompt/PromptForm.ts
 #: src/admin/stages/prompt/PromptListPage.ts
 #: src/elements/user/UserDevicesList.ts
@@ -7169,7 +6964,8 @@ msgstr "类型"
 msgid "UI settings"
 msgstr "用户界面设置"
 
-#: src/admin/events/EventInfo.ts src/admin/users/RelatedUserList.ts
+#: src/admin/events/EventInfo.ts
+#: src/admin/users/RelatedUserList.ts
 #: src/admin/users/UserListPage.ts
 msgid "UID"
 msgstr "UID"
@@ -7242,7 +7038,8 @@ msgstr "未知提供程序类型"
 msgid "Unknown proxy mode"
 msgstr "未知代理模式"
 
-#: src/admin/events/RuleListPage.ts src/admin/events/RuleListPage.ts
+#: src/admin/events/RuleListPage.ts
+#: src/admin/events/RuleListPage.ts
 msgid "Unknown severity"
 msgstr "未知严重程度"
 
@@ -7276,11 +7073,16 @@ msgstr "最新！"
 #: src/admin/applications/ApplicationViewPage.ts
 #: src/admin/blueprints/BlueprintListPage.ts
 #: src/admin/crypto/CertificateKeyPairListPage.ts
-#: src/admin/events/RuleListPage.ts src/admin/events/TransportListPage.ts
-#: src/admin/flows/BoundStagesList.ts src/admin/flows/BoundStagesList.ts
-#: src/admin/flows/FlowListPage.ts src/admin/flows/FlowViewPage.ts
-#: src/admin/groups/GroupListPage.ts src/admin/groups/GroupViewPage.ts
-#: src/admin/groups/RelatedGroupList.ts src/admin/outposts/OutpostListPage.ts
+#: src/admin/events/RuleListPage.ts
+#: src/admin/events/TransportListPage.ts
+#: src/admin/flows/BoundStagesList.ts
+#: src/admin/flows/BoundStagesList.ts
+#: src/admin/flows/FlowListPage.ts
+#: src/admin/flows/FlowViewPage.ts
+#: src/admin/groups/GroupListPage.ts
+#: src/admin/groups/GroupViewPage.ts
+#: src/admin/groups/RelatedGroupList.ts
+#: src/admin/outposts/OutpostListPage.ts
 #: src/admin/outposts/ServiceConnectionListPage.ts
 #: src/admin/policies/BoundPoliciesList.ts
 #: src/admin/policies/BoundPoliciesList.ts
@@ -7301,10 +7103,14 @@ msgstr "最新！"
 #: src/admin/sources/saml/SAMLSourceViewPage.ts
 #: src/admin/sources/SourceListPage.ts
 #: src/admin/stages/invitation/InvitationListPage.ts
-#: src/admin/stages/prompt/PromptListPage.ts src/admin/stages/StageListPage.ts
-#: src/admin/tenants/TenantListPage.ts src/admin/tokens/TokenListPage.ts
-#: src/admin/users/RelatedUserList.ts src/admin/users/UserActiveForm.ts
-#: src/admin/users/UserListPage.ts src/admin/users/UserViewPage.ts
+#: src/admin/stages/prompt/PromptListPage.ts
+#: src/admin/stages/StageListPage.ts
+#: src/admin/tenants/TenantListPage.ts
+#: src/admin/tokens/TokenListPage.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserActiveForm.ts
+#: src/admin/users/UserListPage.ts
+#: src/admin/users/UserViewPage.ts
 #: src/user/user-settings/mfa/MFADevicesPage.ts
 #: src/user/user-settings/tokens/UserTokenList.ts
 msgid "Update"
@@ -7315,8 +7121,10 @@ msgstr "更新"
 #: src/admin/policies/BoundPoliciesList.ts
 #: src/admin/policies/PolicyListPage.ts
 #: src/admin/property-mappings/PropertyMappingListPage.ts
-#: src/admin/providers/ProviderListPage.ts src/admin/sources/SourceListPage.ts
-#: src/admin/stages/StageListPage.ts src/admin/users/UserActiveForm.ts
+#: src/admin/providers/ProviderListPage.ts
+#: src/admin/sources/SourceListPage.ts
+#: src/admin/stages/StageListPage.ts
+#: src/admin/users/UserActiveForm.ts
 msgid "Update {0}"
 msgstr "更新 {0}"
 
@@ -7349,11 +7157,13 @@ msgstr "更新详情"
 msgid "Update Device"
 msgstr "更新设备"
 
-#: src/admin/flows/FlowListPage.ts src/admin/flows/FlowViewPage.ts
+#: src/admin/flows/FlowListPage.ts
+#: src/admin/flows/FlowViewPage.ts
 msgid "Update Flow"
 msgstr "更新流程"
 
-#: src/admin/groups/GroupListPage.ts src/admin/groups/GroupViewPage.ts
+#: src/admin/groups/GroupListPage.ts
+#: src/admin/groups/GroupViewPage.ts
 #: src/admin/groups/RelatedGroupList.ts
 #: src/admin/policies/BoundPoliciesList.ts
 msgid "Update Group"
@@ -7391,9 +7201,12 @@ msgstr "更新 OAuth2 提供程序"
 msgid "Update Outpost"
 msgstr "更新前哨"
 
-#: src/admin/users/RelatedUserList.ts src/admin/users/RelatedUserList.ts
-#: src/admin/users/UserListPage.ts src/admin/users/UserListPage.ts
-#: src/admin/users/UserViewPage.ts src/admin/users/UserViewPage.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
+#: src/admin/users/UserListPage.ts
+#: src/admin/users/UserViewPage.ts
+#: src/admin/users/UserViewPage.ts
 msgid "Update password"
 msgstr "更新密码"
 
@@ -7438,8 +7251,10 @@ msgstr "更新租户"
 msgid "Update Token"
 msgstr "更新令牌"
 
-#: src/admin/policies/BoundPoliciesList.ts src/admin/users/RelatedUserList.ts
-#: src/admin/users/UserListPage.ts src/admin/users/UserViewPage.ts
+#: src/admin/policies/BoundPoliciesList.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
+#: src/admin/users/UserViewPage.ts
 msgid "Update User"
 msgstr "更新用户"
 
@@ -7467,8 +7282,7 @@ msgid "URL settings"
 msgstr "URL 设置"
 
 #: src/admin/applications/wizard/saml/TypeSAMLConfigApplicationWizardPage.ts
-msgid ""
-"URL that authentik will redirect back to after successful authentication."
+msgid "URL that authentik will redirect back to after successful authentication."
 msgstr "身份验证成功后，authentik 将重定向回的 URL。"
 
 #: src/admin/sources/saml/SAMLSourceForm.ts
@@ -7480,9 +7294,7 @@ msgid "URL the user is redirect to to consent the authorization."
 msgstr "用户被重定向到以同意授权的 URL。"
 
 #: src/admin/stages/captcha/CaptchaStageForm.ts
-msgid ""
-"URL to fetch JavaScript from, defaults to recaptcha. Can be replaced with "
-"any compatible alternative."
+msgid "URL to fetch JavaScript from, defaults to recaptcha. Can be replaced with any compatible alternative."
 msgstr "拉取 JavaScript 的 URL，默认为 recaptcha。可以替换为任何兼容替代。"
 
 #: src/admin/sources/oauth/OAuthSourceForm.ts
@@ -7494,15 +7306,11 @@ msgid "URL used by authentik to retrieve tokens."
 msgstr "authentik 用来获取令牌的 URL。"
 
 #: src/admin/sources/oauth/OAuthSourceForm.ts
-msgid ""
-"URL used to request the initial token. This URL is only required for OAuth "
-"1."
+msgid "URL used to request the initial token. This URL is only required for OAuth 1."
 msgstr "用于请求初始令牌的 URL。只有 OAuth 1 才需要此网址。"
 
 #: src/admin/stages/captcha/CaptchaStageForm.ts
-msgid ""
-"URL used to validate captcha response, defaults to recaptcha. Can be "
-"replaced with any compatible alternative."
+msgid "URL used to validate captcha response, defaults to recaptcha. Can be replaced with any compatible alternative."
 msgstr "用于校验验证码响应的 URL，默认为 recaptcha。可以替换为任何兼容替代。"
 
 #: src/admin/applications/wizard/link/TypeLinkApplicationWizardPage.ts
@@ -7530,52 +7338,30 @@ msgid "Use SSL"
 msgstr "使用 SSL"
 
 #: src/admin/sources/oauth/utils.ts
-msgid ""
-"Use the user's email address, but deny enrollment when the email address "
-"already exists"
+msgid "Use the user's email address, but deny enrollment when the email address already exists"
 msgstr "使用用户的电子邮件地址，但在电子邮件地址已存在时拒绝注册"
 
-#~ msgid ""
-#~ "Use the user's email address, but deny enrollment when the email address "
-#~ "already exists."
+#~ msgid "Use the user's email address, but deny enrollment when the email address already exists."
 #~ msgstr "使用用户的电子邮件地址，但在电子邮件地址已存在时拒绝注册。"
 
 #: src/admin/sources/oauth/utils.ts
-msgid ""
-"Use the user's username, but deny enrollment when the username already "
-"exists"
+msgid "Use the user's username, but deny enrollment when the username already exists"
 msgstr "使用用户的用户名，但在用户名已存在时拒绝注册"
 
-#~ msgid ""
-#~ "Use the user's username, but deny enrollment when the username already "
-#~ "exists."
+#~ msgid "Use the user's username, but deny enrollment when the username already exists."
 #~ msgstr "使用用户的用户名，但在用户名已存在时拒绝注册。"
 
 #: src/admin/users/ServiceAccountForm.ts
-msgid ""
-"Use the username and password below to authenticate. The password can be "
-"retrieved later on the Tokens page."
+msgid "Use the username and password below to authenticate. The password can be retrieved later on the Tokens page."
 msgstr "使用下面的用户名和密码进行身份验证。密码可以稍后在令牌页面上获取。"
 
 #: src/admin/providers/proxy/ProxyProviderForm.ts
-msgid ""
-"Use this provider with nginx's auth_request or traefik's forwardAuth. Each "
-"application/domain needs its own provider. Additionally, on each domain, "
-"/outpost.goauthentik.io must be routed to the outpost (when using a manged "
-"outpost, this is done for you)."
-msgstr ""
-"与 nginx 的 auth_request 或 traefik 的 ForwardAuth "
-"一起使用此提供程序。每个应用程序/域名都需要自己的提供程序。此外，在每个域名上，/outpost.goauthentik.io "
-"必须路由到前哨（在使用托管的 Outpost 时，这已经为您处理好了）。"
+msgid "Use this provider with nginx's auth_request or traefik's forwardAuth. Each application/domain needs its own provider. Additionally, on each domain, /outpost.goauthentik.io must be routed to the outpost (when using a manged outpost, this is done for you)."
+msgstr "与 nginx 的 auth_request 或 traefik 的 ForwardAuth 一起使用此提供程序。每个应用程序/域名都需要自己的提供程序。此外，在每个域名上，/outpost.goauthentik.io 必须路由到前哨（在使用托管的 Outpost 时，这已经为您处理好了）。"
 
 #: src/admin/providers/proxy/ProxyProviderForm.ts
-msgid ""
-"Use this provider with nginx's auth_request or traefik's forwardAuth. Only a"
-" single provider is required per root domain. You can't do per-application "
-"authorization, but you don't have to create a provider for each application."
-msgstr ""
-"与 nginx 的 auth_request 或 traefik 的 ForwardAuth "
-"一起使用此提供程序。每个根域名只需要一个提供程序。您无法管理每个应用程序的授权，但不必为每个应用程序分别创建提供程序。"
+msgid "Use this provider with nginx's auth_request or traefik's forwardAuth. Only a single provider is required per root domain. You can't do per-application authorization, but you don't have to create a provider for each application."
+msgstr "与 nginx 的 auth_request 或 traefik 的 ForwardAuth 一起使用此提供程序。每个根域名只需要一个提供程序。您无法管理每个应用程序的授权，但不必为每个应用程序分别创建提供程序。"
 
 #: src/admin/tenants/TenantForm.ts
 msgid "Use this tenant for each domain that doesn't have a dedicated tenant."
@@ -7595,21 +7381,27 @@ msgstr "使用流程执行器登录"
 
 #: src/admin/admin-overview/cards/RecentEventsCard.ts
 #: src/admin/applications/ApplicationCheckAccessForm.ts
-#: src/admin/events/EventInfo.ts src/admin/events/EventListPage.ts
-#: src/admin/events/EventViewPage.ts src/admin/policies/PolicyBindingForm.ts
+#: src/admin/events/EventInfo.ts
+#: src/admin/events/EventListPage.ts
+#: src/admin/events/EventViewPage.ts
+#: src/admin/policies/PolicyBindingForm.ts
 #: src/admin/policies/PolicyBindingForm.ts
 #: src/admin/policies/PolicyTestForm.ts
 #: src/admin/property-mappings/PropertyMappingTestForm.ts
 #: src/admin/stages/authenticator_duo/DuoDeviceImportForm.ts
-#: src/admin/tokens/TokenForm.ts src/admin/tokens/TokenListPage.ts
-#: src/admin/users/RelatedUserList.ts src/admin/users/UserListPage.ts
-#: src/admin/users/UserViewPage.ts src/elements/events/ObjectChangelog.ts
+#: src/admin/tokens/TokenForm.ts
+#: src/admin/tokens/TokenListPage.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
+#: src/admin/users/UserViewPage.ts
+#: src/elements/events/ObjectChangelog.ts
 #: src/elements/events/UserEvents.ts
 #: src/user/user-settings/tokens/UserTokenList.ts
 msgid "User"
 msgstr "用户"
 
-#: src/admin/policies/BoundPoliciesList.ts src/admin/users/UserViewPage.ts
+#: src/admin/policies/BoundPoliciesList.ts
+#: src/admin/users/UserViewPage.ts
 msgid "User {0}"
 msgstr "用户 {0}"
 
@@ -7654,9 +7446,7 @@ msgid "User interface"
 msgstr "用户界面"
 
 #: src/admin/policies/PolicyBindingForm.ts
-msgid ""
-"User mappings can only be checked if a user is already logged in when trying"
-" to access this source."
+msgid "User mappings can only be checked if a user is already logged in when trying to access this source."
 msgstr "用户绑定仅会在已登录用户访问此源时检查。"
 
 #: src/admin/sources/oauth/OAuthSourceForm.ts
@@ -7706,7 +7496,8 @@ msgstr "用户设置流程"
 msgid "User statistics"
 msgstr "用户统计"
 
-#: src/admin/users/RelatedUserList.ts src/admin/users/UserListPage.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
 msgid "User status"
 msgstr "用户状态"
 
@@ -7741,23 +7532,22 @@ msgstr "用户的头像"
 msgid "User's display name."
 msgstr "用户的显示名称"
 
-#: src/admin/users/ServiceAccountForm.ts src/admin/users/UserForm.ts
+#: src/admin/users/ServiceAccountForm.ts
+#: src/admin/users/UserForm.ts
 msgid "User's primary identifier. 150 characters or fewer."
 msgstr "用户主标识符。不超过 150 个字符。"
 
-#: src/admin/users/RelatedUserList.ts src/admin/users/UserListPage.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
 msgid "User(s)"
 msgstr "用户"
 
 #: src/admin/providers/proxy/ProxyProviderForm.ts
-msgid ""
-"User/Group Attribute used for the password part of the HTTP-Basic Header."
+msgid "User/Group Attribute used for the password part of the HTTP-Basic Header."
 msgstr "用于 HTTP-Basic 标头的密码部分的用户/组属性。"
 
 #: src/admin/providers/proxy/ProxyProviderForm.ts
-msgid ""
-"User/Group Attribute used for the user part of the HTTP-Basic Header. If not"
-" set, the user's Email address is used."
+msgid "User/Group Attribute used for the user part of the HTTP-Basic Header. If not set, the user's Email address is used."
 msgstr "用于 HTTP-Basic 标头用户名部分的用户/组属性。如果未设置，则使用用户的电子邮件地址。"
 
 #: src/admin/providers/oauth2/OAuth2ProviderViewPage.ts
@@ -7765,21 +7555,24 @@ msgid "Userinfo URL"
 msgstr "用户信息 URL"
 
 #: src/admin/stages/identification/IdentificationStageForm.ts
-#: src/admin/users/RelatedUserList.ts src/admin/users/ServiceAccountForm.ts
-#: src/admin/users/ServiceAccountForm.ts src/admin/users/UserForm.ts
-#: src/admin/users/UserListPage.ts src/admin/users/UserViewPage.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/ServiceAccountForm.ts
+#: src/admin/users/ServiceAccountForm.ts
+#: src/admin/users/UserForm.ts
+#: src/admin/users/UserListPage.ts
+#: src/admin/users/UserViewPage.ts
 #: src/flow/stages/identification/IdentificationStage.ts
 msgid "Username"
 msgstr "用户名"
 
 #: src/admin/stages/prompt/PromptForm.ts
-msgid ""
-"Username: Same as Text input, but checks for and prevents duplicate "
-"usernames."
+msgid "Username: Same as Text input, but checks for and prevents duplicate usernames."
 msgstr "用户名：与文本输入相同，但检查并防止用户名重复。"
 
-#: src/admin/AdminInterface.ts src/admin/AdminInterface.ts
-#: src/admin/groups/GroupViewPage.ts src/admin/users/UserListPage.ts
+#: src/admin/AdminInterface.ts
+#: src/admin/AdminInterface.ts
+#: src/admin/groups/GroupViewPage.ts
+#: src/admin/users/UserListPage.ts
 msgid "Users"
 msgstr "用户"
 
@@ -7792,9 +7585,7 @@ msgid "Users created per day in the last month"
 msgstr "上个月中每天创建的用户"
 
 #: src/admin/providers/ldap/LDAPProviderForm.ts
-msgid ""
-"Users in the selected group can do search queries. If no group is selected, "
-"no LDAP Searches are allowed."
+msgid "Users in the selected group can do search queries. If no group is selected, no LDAP Searches are allowed."
 msgstr "所选组中的用户可以执行搜索查询。如果未选择任何组，则不允许 LDAP 搜索。"
 
 #: src/admin/users/RelatedUserList.ts
@@ -7810,15 +7601,11 @@ msgid "Using source"
 msgstr "使用源"
 
 #: src/admin/users/ServiceAccountForm.ts
-msgid ""
-"Valid for 360 days, after which the password will automatically rotate. You "
-"can copy the password from the Token List."
+msgid "Valid for 360 days, after which the password will automatically rotate. You can copy the password from the Token List."
 msgstr "有效期为 360 天，之后密码将自动轮换。您可以从令牌列表中复制密码。"
 
 #: src/admin/providers/oauth2/OAuth2ProviderForm.ts
-msgid ""
-"Valid redirect URLs after a successful authorization flow. Also specify any "
-"origins here for Implicit flows."
+msgid "Valid redirect URLs after a successful authorization flow. Also specify any origins here for Implicit flows."
 msgstr "授权流程成功后有效的重定向 URL。还可以在此处为隐式流程指定任何来源。"
 
 #: src/admin/providers/proxy/ProxyProviderForm.ts
@@ -7856,9 +7643,7 @@ msgstr "验证 Kubernetes API SSL 证书"
 #~ msgstr "仅验证"
 
 #: src/admin/stages/email/EmailStageForm.ts
-msgid ""
-"Verify the user's email address by sending them a one-time-link. Can also be"
-" used for recovery to verify the user's authenticity."
+msgid "Verify the user's email address by sending them a one-time-link. Can also be used for recovery to verify the user's authenticity."
 msgstr "通过向用户发送一次性链接来验证用户的电子邮件地址。也可用于在恢复时验证用户的真实性。"
 
 #: src/admin/admin-overview/cards/VersionStatusCard.ts
@@ -7899,16 +7684,15 @@ msgstr "正在等待身份验证…"
 #: src/admin/admin-overview/cards/SystemStatusCard.ts
 #: src/admin/admin-overview/cards/SystemStatusCard.ts
 #: src/admin/admin-overview/cards/SystemStatusCard.ts
-#: src/admin/blueprints/BlueprintListPage.ts src/admin/events/RuleForm.ts
+#: src/admin/blueprints/BlueprintListPage.ts
+#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 #: src/admin/system-tasks/SystemTaskListPage.ts
 msgid "Warning"
 msgstr "警告"
 
 #: src/admin/users/GroupSelectModal.ts
-msgid ""
-"Warning: Adding the user to the selected group(s) will give them superuser "
-"permissions."
+msgid "Warning: Adding the user to the selected group(s) will give them superuser permissions."
 msgstr "警告：将用户添加到所选的组会使其获得超级用户权限。"
 
 #: src/admin/applications/ApplicationViewPage.ts
@@ -7916,14 +7700,11 @@ msgid "Warning: Application is not used by any Outpost."
 msgstr "警告：应用程序未被任何前哨使用。"
 
 #: src/admin/outposts/OutpostListPage.ts
-msgid ""
-"Warning: authentik Domain is not configured, authentication will not work."
+msgid "Warning: authentik Domain is not configured, authentication will not work."
 msgstr "警告：未配置 authentik 域名，身份验证将不起作用。"
 
 #: src/admin/stages/invitation/InvitationListPage.ts
-msgid ""
-"Warning: No invitation stage is bound to any flow. Invitations will not work"
-" as expected."
+msgid "Warning: No invitation stage is bound to any flow. Invitations will not work as expected."
 msgstr "警告：没有邀请阶段绑定到任何流程。邀请将无法按预期工作。"
 
 #: src/admin/policies/PolicyListPage.ts
@@ -7946,15 +7727,11 @@ msgid "Warning: Provider not assigned to any application."
 msgstr "警告：提供程序未分配给任何应用程序。"
 
 #: src/admin/users/RelatedUserList.ts
-msgid ""
-"Warning: This group is configured with superuser access. Added users will "
-"have superuser access."
+msgid "Warning: This group is configured with superuser access. Added users will have superuser access."
 msgstr "警告：此组已配置为超级用户权限。加入的用户将会拥有超级用户权限。"
 
 #: src/admin/users/UserListPage.ts
-msgid ""
-"Warning: You're about to delete the user you're logged in as ({0}). Proceed "
-"at your own risk."
+msgid "Warning: You're about to delete the user you're logged in as ({0}). Proceed at your own risk."
 msgstr "警告：您即将删除当前登录的用户（{0}）。如果继续，请自担风险。"
 
 #: src/admin/applications/wizard/oauth/TypeOAuthApplicationWizardPage.ts
@@ -7997,16 +7774,11 @@ msgid "Welcome, {name}."
 msgstr "欢迎，{name}。"
 
 #: src/admin/stages/email/EmailStageForm.ts
-msgid ""
-"When a user returns from the email successfully, their account will be "
-"activated."
+msgid "When a user returns from the email successfully, their account will be activated."
 msgstr "当用户成功自电子邮件中返回时，其账户将被激活。"
 
 #: src/admin/stages/identification/IdentificationStageForm.ts
-msgid ""
-"When a valid username/email has been entered, and this option is enabled, "
-"the user's username and avatar will be shown. Otherwise, the text that the "
-"user entered will be shown."
+msgid "When a valid username/email has been entered, and this option is enabled, the user's username and avatar will be shown. Otherwise, the text that the user entered will be shown."
 msgstr "如果输入了有效的用户名/电子邮箱，并且启用了此选项，则会显示用户的用户名和头像。否则，将显示用户输入的文本。"
 
 #: src/admin/stages/prompt/PromptForm.ts
@@ -8033,9 +7805,7 @@ msgstr ""
 #~ "如果评估失败，则返回占位符本身。"
 
 #: src/admin/sources/ldap/LDAPSourceForm.ts
-msgid ""
-"When connecting to an LDAP Server with TLS, certificates are not checked by "
-"default. Specify a keypair to validate the remote certificate."
+msgid "When connecting to an LDAP Server with TLS, certificates are not checked by default. Specify a keypair to validate the remote certificate."
 msgstr "使用 TLS 连接到 LDAP 服务器时，默认情况下不检查证书。指定密钥对以验证远程证书。"
 
 #: src/admin/outposts/ServiceConnectionDockerForm.ts
@@ -8047,24 +7817,18 @@ msgid "When enabled, all previous sessions of the user will be terminated."
 msgstr "启用时，此用户的所有过往会话将会被终止。"
 
 #: src/admin/providers/proxy/ProxyProviderForm.ts
-msgid ""
-"When enabled, authentik will intercept the Authorization header to "
-"authenticate the request."
+msgid "When enabled, authentik will intercept the Authorization header to authenticate the request."
 msgstr "启用时，authentik 将会拦截 Authorization 标头以认证请求。"
 
 #: src/admin/stages/email/EmailStageForm.ts
-msgid ""
-"When enabled, global Email connection settings will be used and connection "
-"settings below will be ignored."
+msgid "When enabled, global Email connection settings will be used and connection settings below will be ignored."
 msgstr "启用后，将使用全局电子邮件连接设置，下面的连接设置将被忽略。"
 
 #: src/admin/stages/invitation/InvitationForm.ts
 msgid "When enabled, the invitation will be deleted after usage."
 msgstr "启用后，邀请将在使用后被删除。"
 
-#~ msgid ""
-#~ "When enabled, this stage has the ability to create new users. If no user is "
-#~ "available in the flow with this disabled, the stage will fail."
+#~ msgid "When enabled, this stage has the ability to create new users. If no user is available in the flow with this disabled, the stage will fail."
 #~ msgstr "启用时，此阶段将能够创建新用户。如果禁用此选项，并且流程中没有可用的用户，则此阶段失败。"
 
 #: src/admin/stages/identification/IdentificationStageForm.ts
@@ -8072,9 +7836,7 @@ msgid "When enabled, user fields are matched regardless of their casing."
 msgstr "启用后，无论大小写如何，都将匹配用户字段。"
 
 #: src/admin/stages/authenticator_validate/AuthenticatorValidateStageForm.ts
-msgid ""
-"When multiple stages are selected, the user can choose which one they want "
-"to enroll."
+msgid "When multiple stages are selected, the user can choose which one they want to enroll."
 msgstr "选中多个阶段时，用户可以选择要注册哪个。"
 
 #: src/admin/stages/user_write/UserWriteStageForm.ts
@@ -8082,26 +7844,19 @@ msgid "When no user is present in the flow context, the stage will fail."
 msgstr "如果流程上下文中没有出现用户，此阶段失败。"
 
 #: src/admin/stages/user_write/UserWriteStageForm.ts
-msgid ""
-"When no user is present in the the flow context, a new user is created."
+msgid "When no user is present in the the flow context, a new user is created."
 msgstr "如果流程上下文中没有出现用户，则创建新用户。"
 
 #: src/admin/stages/identification/IdentificationStageForm.ts
-msgid ""
-"When selected, a password field is shown on the same page instead of a "
-"separate page. This prevents username enumeration attacks."
+msgid "When selected, a password field is shown on the same page instead of a separate page. This prevents username enumeration attacks."
 msgstr "选中后，密码字段将显示在同一页面，而不是单独的页面上。这样可以防止用户名枚举攻击。"
 
 #: src/admin/providers/saml/SAMLProviderForm.ts
-msgid ""
-"When selected, incoming assertion's Signatures will be validated against "
-"this certificate. To allow unsigned Requests, leave on default."
+msgid "When selected, incoming assertion's Signatures will be validated against this certificate. To allow unsigned Requests, leave on default."
 msgstr "选中后，传入断言的签名将根据此证书进行验证。要允许未签名的请求，请保留默认值。"
 
 #: src/admin/stages/invitation/InvitationForm.ts
-msgid ""
-"When selected, the invite will only be usable with the flow. By default the "
-"invite is accepted on all flows with invitation stages."
+msgid "When selected, the invite will only be usable with the flow. By default the invite is accepted on all flows with invitation stages."
 msgstr "选中时，此邀请仅可在对应流程中使用。默认情况下，此邀请接受所有流程的邀请阶段。"
 
 #: src/admin/policies/dummy/DummyPolicyForm.ts
@@ -8110,15 +7865,11 @@ msgstr "选中时，此邀请仅可在对应流程中使用。默认情况下，
 #: src/admin/policies/expression/ExpressionPolicyForm.ts
 #: src/admin/policies/password/PasswordPolicyForm.ts
 #: src/admin/policies/reputation/ReputationPolicyForm.ts
-msgid ""
-"When this option is enabled, all executions of this policy will be logged. "
-"By default, only execution errors are logged."
+msgid "When this option is enabled, all executions of this policy will be logged. By default, only execution errors are logged."
 msgstr "启用此选项后，将记录此策略的所有执行日志。默认情况下，只记录执行错误。"
 
 #: src/admin/stages/prompt/PromptForm.ts
-msgid ""
-"When used in conjunction with a User Write stage, use attributes.foo to "
-"write attributes."
+msgid "When used in conjunction with a User Write stage, use attributes.foo to write attributes."
 msgstr "当与用户写入阶段结合使用时，请使用 attributes.foo 来编写属性。"
 
 #: src/admin/stages/authenticator_duo/AuthenticatorDuoStageForm.ts
@@ -8130,27 +7881,18 @@ msgstr ""
 "这允许 authentik 自动导入设备。"
 
 #: src/admin/tenants/TenantForm.ts
-msgid ""
-"When using an external logging solution for archiving, this can be set to "
-"\"minutes=5\"."
+msgid "When using an external logging solution for archiving, this can be set to \"minutes=5\"."
 msgstr "使用外部日志记录解决方案进行存档时，可以将其设置为 \"minutes=5\"。"
 
 #: src/admin/providers/proxy/ProxyProviderForm.ts
-msgid ""
-"When using proxy or forward auth (single application) mode, the requested "
-"URL Path is checked against the regular expressions. When using forward auth"
-" (domain mode), the full requested URL including scheme and host is matched "
-"against the regular expressions."
-msgstr ""
-"使用代理或 Forward Auth（单应用）模式时，将根据正则表达式检查请求的 URL 路径。使用 Forward "
-"Auth（域名模式）时，将根据正则表达式检查请求的完整 URL（包括协议和主机名）。"
+msgid "When using proxy or forward auth (single application) mode, the requested URL Path is checked against the regular expressions. When using forward auth (domain mode), the full requested URL including scheme and host is matched against the regular expressions."
+msgstr "使用代理或 Forward Auth（单应用）模式时，将根据正则表达式检查请求的 URL 路径。使用 Forward Auth（域名模式）时，将根据正则表达式检查请求的完整 URL（包括协议和主机名）。"
 
 #~ msgid "Whoops!"
 #~ msgstr "哎呦！"
 
 #: src/admin/flows/FlowForm.ts
-msgid ""
-"Will either follow the ?next parameter or redirect to the default interface"
+msgid "Will either follow the ?next parameter or redirect to the default interface"
 msgstr "将会遵循 ?next 参数或者重定向到默认接口"
 
 #: src/admin/flows/FlowForm.ts
@@ -8190,21 +7932,25 @@ msgid "X509 Subject"
 msgstr "X509 主题"
 
 #: src/admin/applications/wizard/TypeApplicationWizardPage.ts
-msgid ""
-"XML-based SSO standard. Use this if your application only supports SAML."
+msgid "XML-based SSO standard. Use this if your application only supports SAML."
 msgstr "基于 XML 的 SSO 标准。如果您的应用程序仅支持 SAML 则应使用。"
 
 #: src/admin/applications/ApplicationCheckAccessForm.ts
-#: src/admin/blueprints/BlueprintListPage.ts src/admin/flows/FlowImportForm.ts
-#: src/admin/groups/GroupListPage.ts src/admin/groups/MemberSelectModal.ts
+#: src/admin/blueprints/BlueprintListPage.ts
+#: src/admin/flows/FlowImportForm.ts
+#: src/admin/groups/GroupListPage.ts
+#: src/admin/groups/MemberSelectModal.ts
 #: src/admin/groups/RelatedGroupList.ts
 #: src/admin/outposts/ServiceConnectionListPage.ts
 #: src/admin/policies/BoundPoliciesList.ts
 #: src/admin/policies/PolicyTestForm.ts
 #: src/admin/providers/proxy/ProxyProviderViewPage.ts
-#: src/admin/tenants/TenantListPage.ts src/admin/tokens/TokenListPage.ts
-#: src/admin/users/GroupSelectModal.ts src/admin/users/RelatedUserList.ts
-#: src/admin/users/UserListPage.ts src/elements/oauth/UserRefreshList.ts
+#: src/admin/tenants/TenantListPage.ts
+#: src/admin/tokens/TokenListPage.ts
+#: src/admin/users/GroupSelectModal.ts
+#: src/admin/users/RelatedUserList.ts
+#: src/admin/users/UserListPage.ts
+#: src/elements/oauth/UserRefreshList.ts
 #: src/elements/user/UserDevicesList.ts
 #: src/flow/stages/user_login/UserLoginStage.ts
 #: src/user/user-settings/tokens/UserTokenList.ts

--- a/web/src/locales/zh-Hant.po
+++ b/web/src/locales/zh-Hant.po
@@ -973,6 +973,10 @@ msgid "Based on the User's username"
 msgstr ""
 
 #: src/admin/providers/oauth2/OAuth2ProviderForm.ts
+msgid "Based on the User's UUID"
+msgstr ""
+
+#: src/admin/providers/oauth2/OAuth2ProviderForm.ts
 #~ msgid "Based on the username"
 #~ msgstr "基于用户名"
 

--- a/web/src/locales/zh_TW.po
+++ b/web/src/locales/zh_TW.po
@@ -973,6 +973,10 @@ msgid "Based on the User's username"
 msgstr ""
 
 #: src/admin/providers/oauth2/OAuth2ProviderForm.ts
+msgid "Based on the User's UUID"
+msgstr ""
+
+#: src/admin/providers/oauth2/OAuth2ProviderForm.ts
 #~ msgid "Based on the username"
 #~ msgstr "基于用户名"
 


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details

-   **Does this resolve an issue?**
    Resolves https://github.com/goauthentik/authentik/issues/5541

## Changes

### New Features

-   Adds user.uuid as an OAuth2 subject option

### Breaking Changes

-   None

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [x] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)
-   [x] The translation files have been updated (`make i18n-extract`)

**Note:** Frontend compilation throw a warning on typescript types, but I believe that's because package.json is pulling @goauthentik/api with static definitions from npm, rather than the newly updated local schema... Or perhaps I'm missing a step :)

## Documentation

**Note:** I think not applicable - thought I remembered something about this in docs, but it was only the SCIM bit saying if you **do** change the subject mode, you'll need to change externalId there as well (which is fully configurable via python snippet).

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
