### PR TITLE
providers/SCIM: patch group name

### DIFF
--- a/authentik/providers/scim/clients/group.py
+++ b/authentik/providers/scim/clients/group.py
@@ -120,17 +120,19 @@ class SCIMGroupClient(SCIMClient[Group, SCIMGroupSchema]):
         except SCIMRequestException:
             # Some providers don't support PUT on groups, so this is mainly a fix for the initial
             # sync, send patch add requests for all the users the group currently has
-            # TODO: send patch request for group name
             users = list(group.users.order_by("id").values_list("id", flat=True))
-            return self._patch_add_users(group, users)
-
-    def _patch(
-        self,
-        group_id: str,
-        *ops: PatchOperation,
-    ):
-        req = PatchRequest(Operations=ops)
-        self._request("PATCH", f"/Groups/{group_id}", data=req.json())
+            self._patch_add_users(group, users)
+            # Also update the group name
+            self._patch(
+                scim_group.id,
+                PatchOperation(
+                    op=PatchOp.replace,
+                    value={
+                        "id": connection.id,
+                        "displayName": group.name,
+                    }
+                ),
+            )
 
     def update_group(self, group: Group, action: PatchOp, users_set: set[int]):
         """Update a group, either using PUT to replace it or PATCH if supported"""
@@ -150,6 +152,14 @@ class SCIMGroupClient(SCIMClient[Group, SCIMGroupSchema]):
                 if action == PatchOp.remove:
                     return self._patch_remove_users(group, users_set)
             raise exc
+
+    def _patch(
+        self,
+        group_id: str,
+        *ops: PatchOperation,
+    ):
+        req = PatchRequest(Operations=ops)
+        self._request("PATCH", f"/Groups/{group_id}", data=req.json())
 
     def _patch_add_users(self, group: Group, users_set: set[int]):
         """Add users in users_set to group"""

--- a/authentik/providers/scim/clients/group.py
+++ b/authentik/providers/scim/clients/group.py
@@ -117,20 +117,23 @@ class SCIMGroupClient(SCIMClient[Group, SCIMGroupSchema]):
                     exclude_unset=True,
                 ),
             )
+        except ResourceMissing:
+            # Resource missing is handled by self.write, which will re-create the group
+            raise
         except SCIMRequestException:
             # Some providers don't support PUT on groups, so this is mainly a fix for the initial
             # sync, send patch add requests for all the users the group currently has
             users = list(group.users.order_by("id").values_list("id", flat=True))
             self._patch_add_users(group, users)
             # Also update the group name
-            self._patch(
+            return self._patch(
                 scim_group.id,
                 PatchOperation(
                     op=PatchOp.replace,
                     value={
                         "id": connection.id,
                         "displayName": group.name,
-                    }
+                    },
                 ),
             )
 


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details

#5396

Add patch support for group names when group PUT fails, also fixes ResourceMissing being caught too early and not triggering a re-create

## Changes

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
