### PR TITLE
web/admin: add description to notification rule group field

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-09 18:53+0000\n"
+"POT-Creation-Date: 2023-05-10 17:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -46,10 +46,10 @@ msgstr ""
 
 #: authentik/blueprints/models.py:32
 msgid ""
-"Objects which are managed by authentik. These objects are created and "
-"updated automatically. This is flag only indicates that an object can be "
-"overwritten by migrations. You can still modify the objects via the API, but "
-"expect changes to be overwritten in a later update."
+"Objects that are managed by authentik. These objects are created and updated "
+"automatically. This flag only indicates that an object can be overwritten by "
+"migrations. You can still modify the objects via the API, but expect changes "
+"to be overwritten in a later update."
 msgstr ""
 
 #: authentik/blueprints/models.py:109
@@ -1647,11 +1647,19 @@ msgstr ""
 msgid "Okta OAuth Sources"
 msgstr ""
 
-#: authentik/sources/oauth/models.py:239
+#: authentik/sources/oauth/models.py:225
+msgid "Reddit OAuth Source"
+msgstr ""
+
+#: authentik/sources/oauth/models.py:226
+msgid "Reddit OAuth Sources"
+msgstr ""
+
+#: authentik/sources/oauth/models.py:248
 msgid "User OAuth Source Connection"
 msgstr ""
 
-#: authentik/sources/oauth/models.py:240
+#: authentik/sources/oauth/models.py:249
 msgid "User OAuth Source Connections"
 msgstr ""
 

--- a/web/src/admin/events/RuleForm.ts
+++ b/web/src/admin/events/RuleForm.ts
@@ -1,3 +1,4 @@
+import { SeverityToLabel } from "@goauthentik/admin/events/RuleListPage";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
 import "@goauthentik/elements/forms/HorizontalFormElement";
 import { ModelForm } from "@goauthentik/elements/forms/ModelForm";
@@ -91,6 +92,9 @@ export class RuleForm extends ModelForm<NotificationRule, string> {
                     ?blankable=${true}
                 >
                 </ak-search-select>
+                <p class="pf-c-form__helper-text">
+                    ${t`Select the group of users which the alerts are sent to. If no group is selected the rule is disabled.`}
+                </p>
             </ak-form-element-horizontal>
             <ak-form-element-horizontal label=${t`Transports`} ?required=${true} name="transports">
                 <select class="pf-c-form-control" multiple>
@@ -114,16 +118,16 @@ export class RuleForm extends ModelForm<NotificationRule, string> {
                 <ak-radio
                     .options=${[
                         {
-                            label: t`Alert`,
+                            label: SeverityToLabel(SeverityEnum.Alert),
                             value: SeverityEnum.Alert,
                             default: true,
                         },
                         {
-                            label: t`Warning`,
+                            label: SeverityToLabel(SeverityEnum.Warning),
                             value: SeverityEnum.Warning,
                         },
                         {
-                            label: t`Notice`,
+                            label: SeverityToLabel(SeverityEnum.Notice),
                             value: SeverityEnum.Notice,
                         },
                     ]}

--- a/web/src/locales/de.po
+++ b/web/src/locales/de.po
@@ -420,7 +420,6 @@ msgstr "Erweiterte Einstellungen"
 msgid "Affected model:"
 msgstr "Betroffenes Modell:"
 
-#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 msgid "Alert"
 msgstr "Alarm"
@@ -4383,7 +4382,6 @@ msgstr "Nicht Sie?"
 msgid "Notes"
 msgstr ""
 
-#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 msgid "Notice"
 msgstr "Hinweis"
@@ -5628,6 +5626,10 @@ msgstr ""
 #: src/admin/stages/identification/IdentificationStageForm.ts
 msgid "Select sources should be shown for users to authenticate with. This only affects web-based sources, not LDAP."
 msgstr "Es sollten ausgewählte Quellen angezeigt werden, mit denen sich Benutzer authentifizieren können. Dies betrifft nur webbasierte Quellen, nicht LDAP."
+
+#: src/admin/events/RuleForm.ts
+msgid "Select the group of users which the alerts are sent to. If no group is selected the rule is disabled."
+msgstr ""
 
 #: src/admin/outposts/ServiceConnectionWizard.ts
 #: src/admin/policies/PolicyWizard.ts
@@ -7812,7 +7814,6 @@ msgstr ""
 #: src/admin/admin-overview/cards/SystemStatusCard.ts
 #: src/admin/admin-overview/cards/SystemStatusCard.ts
 #: src/admin/blueprints/BlueprintListPage.ts
-#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 #: src/admin/system-tasks/SystemTaskListPage.ts
 msgid "Warning"

--- a/web/src/locales/en.po
+++ b/web/src/locales/en.po
@@ -401,7 +401,6 @@ msgstr "Advanced settings"
 msgid "Affected model:"
 msgstr "Affected model:"
 
-#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 msgid "Alert"
 msgstr "Alert"
@@ -4445,7 +4444,6 @@ msgstr "Not you?"
 msgid "Notes"
 msgstr "Notes"
 
-#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 msgid "Notice"
 msgstr "Notice"
@@ -5746,6 +5744,10 @@ msgstr "Select providers to add to application"
 #: src/admin/stages/identification/IdentificationStageForm.ts
 msgid "Select sources should be shown for users to authenticate with. This only affects web-based sources, not LDAP."
 msgstr "Select sources should be shown for users to authenticate with. This only affects web-based sources, not LDAP."
+
+#: src/admin/events/RuleForm.ts
+msgid "Select the group of users which the alerts are sent to. If no group is selected the rule is disabled."
+msgstr "Select the group of users which the alerts are sent to. If no group is selected the rule is disabled."
 
 #: src/admin/outposts/ServiceConnectionWizard.ts
 #: src/admin/policies/PolicyWizard.ts
@@ -7978,7 +7980,6 @@ msgstr "Waiting for authentication..."
 #: src/admin/admin-overview/cards/SystemStatusCard.ts
 #: src/admin/admin-overview/cards/SystemStatusCard.ts
 #: src/admin/blueprints/BlueprintListPage.ts
-#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 #: src/admin/system-tasks/SystemTaskListPage.ts
 msgid "Warning"

--- a/web/src/locales/es.po
+++ b/web/src/locales/es.po
@@ -398,7 +398,6 @@ msgstr "Configuraciones avanzadas"
 msgid "Affected model:"
 msgstr "Modelo afectado:"
 
-#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 msgid "Alert"
 msgstr "Alerta"
@@ -4359,7 +4358,6 @@ msgstr "¿No eres tú?"
 msgid "Notes"
 msgstr ""
 
-#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 msgid "Notice"
 msgstr "Notificación"
@@ -5604,6 +5602,10 @@ msgstr ""
 #: src/admin/stages/identification/IdentificationStageForm.ts
 msgid "Select sources should be shown for users to authenticate with. This only affects web-based sources, not LDAP."
 msgstr "Se deben mostrar las fuentes seleccionadas para que los usuarios se autentiquen con ellas. Esto solo afecta a las fuentes basadas en web, no a LDAP."
+
+#: src/admin/events/RuleForm.ts
+msgid "Select the group of users which the alerts are sent to. If no group is selected the rule is disabled."
+msgstr ""
 
 #: src/admin/outposts/ServiceConnectionWizard.ts
 #: src/admin/policies/PolicyWizard.ts
@@ -7788,7 +7790,6 @@ msgstr ""
 #: src/admin/admin-overview/cards/SystemStatusCard.ts
 #: src/admin/admin-overview/cards/SystemStatusCard.ts
 #: src/admin/blueprints/BlueprintListPage.ts
-#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 #: src/admin/system-tasks/SystemTaskListPage.ts
 msgid "Warning"

--- a/web/src/locales/fr_FR.po
+++ b/web/src/locales/fr_FR.po
@@ -403,7 +403,6 @@ msgstr "Paramètres avancés"
 msgid "Affected model:"
 msgstr "Modèle affecté :"
 
-#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 msgid "Alert"
 msgstr "Alerte"
@@ -4360,7 +4359,6 @@ msgstr "Pas vous ?"
 msgid "Notes"
 msgstr ""
 
-#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 msgid "Notice"
 msgstr "Note"
@@ -5605,6 +5603,10 @@ msgstr ""
 #: src/admin/stages/identification/IdentificationStageForm.ts
 msgid "Select sources should be shown for users to authenticate with. This only affects web-based sources, not LDAP."
 msgstr "Sélectionnez les sources à afficher aux utilisateurs pour s'authentifier. Cela affecte uniquement les sources web, pas LDAP."
+
+#: src/admin/events/RuleForm.ts
+msgid "Select the group of users which the alerts are sent to. If no group is selected the rule is disabled."
+msgstr ""
 
 #: src/admin/outposts/ServiceConnectionWizard.ts
 #: src/admin/policies/PolicyWizard.ts
@@ -7779,7 +7781,6 @@ msgstr ""
 #: src/admin/admin-overview/cards/SystemStatusCard.ts
 #: src/admin/admin-overview/cards/SystemStatusCard.ts
 #: src/admin/blueprints/BlueprintListPage.ts
-#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 #: src/admin/system-tasks/SystemTaskListPage.ts
 msgid "Warning"

--- a/web/src/locales/pl.po
+++ b/web/src/locales/pl.po
@@ -402,7 +402,6 @@ msgstr "Zaawansowane ustawienia"
 msgid "Affected model:"
 msgstr "Model, którego dotyczy problem:"
 
-#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 msgid "Alert"
 msgstr "Alert"
@@ -4367,7 +4366,6 @@ msgstr "Nie ty?"
 msgid "Notes"
 msgstr ""
 
-#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 msgid "Notice"
 msgstr "Uwaga"
@@ -5614,6 +5612,10 @@ msgstr ""
 #: src/admin/stages/identification/IdentificationStageForm.ts
 msgid "Select sources should be shown for users to authenticate with. This only affects web-based sources, not LDAP."
 msgstr "Powinny być wyświetlane wybrane źródła, za pomocą których użytkownicy mogą się uwierzytelniać. Dotyczy to tylko źródeł internetowych, a nie LDAP."
+
+#: src/admin/events/RuleForm.ts
+msgid "Select the group of users which the alerts are sent to. If no group is selected the rule is disabled."
+msgstr ""
 
 #: src/admin/outposts/ServiceConnectionWizard.ts
 #: src/admin/policies/PolicyWizard.ts
@@ -7798,7 +7800,6 @@ msgstr ""
 #: src/admin/admin-overview/cards/SystemStatusCard.ts
 #: src/admin/admin-overview/cards/SystemStatusCard.ts
 #: src/admin/blueprints/BlueprintListPage.ts
-#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 #: src/admin/system-tasks/SystemTaskListPage.ts
 msgid "Warning"

--- a/web/src/locales/pseudo-LOCALE.po
+++ b/web/src/locales/pseudo-LOCALE.po
@@ -397,7 +397,6 @@ msgstr ""
 msgid "Affected model:"
 msgstr ""
 
-#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 msgid "Alert"
 msgstr ""
@@ -4424,7 +4423,6 @@ msgstr ""
 msgid "Notes"
 msgstr ""
 
-#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 msgid "Notice"
 msgstr ""
@@ -5713,6 +5711,10 @@ msgstr ""
 
 #: src/admin/stages/identification/IdentificationStageForm.ts
 msgid "Select sources should be shown for users to authenticate with. This only affects web-based sources, not LDAP."
+msgstr ""
+
+#: src/admin/events/RuleForm.ts
+msgid "Select the group of users which the alerts are sent to. If no group is selected the rule is disabled."
 msgstr ""
 
 #: src/admin/outposts/ServiceConnectionWizard.ts
@@ -7936,7 +7938,6 @@ msgstr ""
 #: src/admin/admin-overview/cards/SystemStatusCard.ts
 #: src/admin/admin-overview/cards/SystemStatusCard.ts
 #: src/admin/blueprints/BlueprintListPage.ts
-#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 #: src/admin/system-tasks/SystemTaskListPage.ts
 msgid "Warning"

--- a/web/src/locales/tr.po
+++ b/web/src/locales/tr.po
@@ -398,7 +398,6 @@ msgstr "Gelişmiş ayarlar"
 msgid "Affected model:"
 msgstr "Etkilenen model:"
 
-#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 msgid "Alert"
 msgstr "Alarm"
@@ -4359,7 +4358,6 @@ msgstr "Sen değil mi?"
 msgid "Notes"
 msgstr ""
 
-#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 msgid "Notice"
 msgstr "Uyarı"
@@ -5604,6 +5602,10 @@ msgstr ""
 #: src/admin/stages/identification/IdentificationStageForm.ts
 msgid "Select sources should be shown for users to authenticate with. This only affects web-based sources, not LDAP."
 msgstr "Kullanıcıların kimlik doğrulaması için belirli kaynaklar gösterilmelidir. Bu, LDAP'yi değil, yalnızca web tabanlı kaynakları etkiler."
+
+#: src/admin/events/RuleForm.ts
+msgid "Select the group of users which the alerts are sent to. If no group is selected the rule is disabled."
+msgstr ""
 
 #: src/admin/outposts/ServiceConnectionWizard.ts
 #: src/admin/policies/PolicyWizard.ts
@@ -7788,7 +7790,6 @@ msgstr ""
 #: src/admin/admin-overview/cards/SystemStatusCard.ts
 #: src/admin/admin-overview/cards/SystemStatusCard.ts
 #: src/admin/blueprints/BlueprintListPage.ts
-#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 #: src/admin/system-tasks/SystemTaskListPage.ts
 msgid "Warning"

--- a/web/src/locales/zh-Hans.po
+++ b/web/src/locales/zh-Hans.po
@@ -393,7 +393,6 @@ msgstr "高级设置"
 msgid "Affected model:"
 msgstr "受影响的模型："
 
-#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 msgid "Alert"
 msgstr "注意"
@@ -4299,7 +4298,6 @@ msgstr "不是您？"
 msgid "Notes"
 msgstr "备注"
 
-#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 msgid "Notice"
 msgstr "通知"
@@ -5531,6 +5529,10 @@ msgstr "选择要添加到应用的提供程序"
 #: src/admin/stages/identification/IdentificationStageForm.ts
 msgid "Select sources should be shown for users to authenticate with. This only affects web-based sources, not LDAP."
 msgstr "选择的源应显示给用户进行身份验证。这只会影响基于 Web 的源，而不影响 LDAP。"
+
+#: src/admin/events/RuleForm.ts
+msgid "Select the group of users which the alerts are sent to. If no group is selected the rule is disabled."
+msgstr ""
 
 #: src/admin/outposts/ServiceConnectionWizard.ts
 #: src/admin/policies/PolicyWizard.ts
@@ -7685,7 +7687,6 @@ msgstr "正在等待身份验证…"
 #: src/admin/admin-overview/cards/SystemStatusCard.ts
 #: src/admin/admin-overview/cards/SystemStatusCard.ts
 #: src/admin/blueprints/BlueprintListPage.ts
-#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 #: src/admin/system-tasks/SystemTaskListPage.ts
 msgid "Warning"

--- a/web/src/locales/zh-Hant.po
+++ b/web/src/locales/zh-Hant.po
@@ -404,7 +404,6 @@ msgstr "高级设置"
 msgid "Affected model:"
 msgstr "受影响的模型："
 
-#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 msgid "Alert"
 msgstr "注意"
@@ -4367,7 +4366,6 @@ msgstr "不是你？"
 msgid "Notes"
 msgstr ""
 
-#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 msgid "Notice"
 msgstr "注意"
@@ -5612,6 +5610,10 @@ msgstr ""
 #: src/admin/stages/identification/IdentificationStageForm.ts
 msgid "Select sources should be shown for users to authenticate with. This only affects web-based sources, not LDAP."
 msgstr "应显示选择的源以供用户进行身份验证。这只会影响基于 Web 的源，而不影响 LDAP。"
+
+#: src/admin/events/RuleForm.ts
+msgid "Select the group of users which the alerts are sent to. If no group is selected the rule is disabled."
+msgstr ""
 
 #: src/admin/outposts/ServiceConnectionWizard.ts
 #: src/admin/policies/PolicyWizard.ts
@@ -7796,7 +7798,6 @@ msgstr ""
 #: src/admin/admin-overview/cards/SystemStatusCard.ts
 #: src/admin/admin-overview/cards/SystemStatusCard.ts
 #: src/admin/blueprints/BlueprintListPage.ts
-#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 #: src/admin/system-tasks/SystemTaskListPage.ts
 msgid "Warning"

--- a/web/src/locales/zh_TW.po
+++ b/web/src/locales/zh_TW.po
@@ -404,7 +404,6 @@ msgstr "高级设置"
 msgid "Affected model:"
 msgstr "受影响的模型："
 
-#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 msgid "Alert"
 msgstr "注意"
@@ -4367,7 +4366,6 @@ msgstr "不是你？"
 msgid "Notes"
 msgstr ""
 
-#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 msgid "Notice"
 msgstr "注意"
@@ -5612,6 +5610,10 @@ msgstr ""
 #: src/admin/stages/identification/IdentificationStageForm.ts
 msgid "Select sources should be shown for users to authenticate with. This only affects web-based sources, not LDAP."
 msgstr "应显示选择的源以供用户进行身份验证。这只会影响基于 Web 的源，而不影响 LDAP。"
+
+#: src/admin/events/RuleForm.ts
+msgid "Select the group of users which the alerts are sent to. If no group is selected the rule is disabled."
+msgstr ""
 
 #: src/admin/outposts/ServiceConnectionWizard.ts
 #: src/admin/policies/PolicyWizard.ts
@@ -7796,7 +7798,6 @@ msgstr ""
 #: src/admin/admin-overview/cards/SystemStatusCard.ts
 #: src/admin/admin-overview/cards/SystemStatusCard.ts
 #: src/admin/blueprints/BlueprintListPage.ts
-#: src/admin/events/RuleForm.ts
 #: src/admin/events/RuleListPage.ts
 #: src/admin/system-tasks/SystemTaskListPage.ts
 msgid "Warning"


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details

The rule list page already shows a rule as disabled if no group is selected, but there's no notice when editing a rule

## Changes

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)
-   [x] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
