### PR TITLE
providers/proxy: fix panic when claims in session were nil

### DIFF
--- a/authentik/providers/oauth2/migrations/0016_alter_refreshtoken_token.py
+++ b/authentik/providers/oauth2/migrations/0016_alter_refreshtoken_token.py
@@ -21,4 +21,26 @@ class Migration(migrations.Migration):
                 default=authentik.providers.oauth2.models.generate_client_secret
             ),
         ),
+        migrations.AlterField(
+            model_name="oauth2provider",
+            name="sub_mode",
+            field=models.TextField(
+                choices=[
+                    ("hashed_user_id", "Based on the Hashed User ID"),
+                    ("user_id", "Based on user ID"),
+                    ("user_uuid", "Based on user UUID"),
+                    ("user_username", "Based on the username"),
+                    (
+                        "user_email",
+                        "Based on the User's Email. This is recommended over the UPN method.",
+                    ),
+                    (
+                        "user_upn",
+                        "Based on the User's UPN, only works if user has a 'upn' attribute set. Use this method only if you have different UPN and Mail domains.",
+                    ),
+                ],
+                default="hashed_user_id",
+                help_text="Configure what data should be used as unique User Identifier. For most cases, the default should be fine.",
+            ),
+        ),
     ]

--- a/internal/outpost/proxyv2/application/session.go
+++ b/internal/outpost/proxyv2/application/session.go
@@ -94,6 +94,10 @@ func (a *Application) Logout(sub string) error {
 				a.log.WithError(err).Trace("failed to decode session")
 				continue
 			}
+			rc, ok := s.Values[constants.SessionClaims]
+			if !ok || rc == nil {
+				continue
+			}
 			claims := s.Values[constants.SessionClaims].(Claims)
 			if claims.Sub == sub {
 				a.log.WithField("path", fullPath).Trace("deleting session")


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details

closes #5478

The previous code assumed that all sessions had claims which isn't correct as there can be a session where the login process was started but never finished

## Changes

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
