### PR TITLE
web/admin: only show prompt creation when editing prompt stage

### DIFF
--- a/web/src/admin/stages/prompt/PromptStageForm.ts
+++ b/web/src/admin/stages/prompt/PromptStageForm.ts
@@ -95,14 +95,20 @@ export class PromptStageForm extends ModelForm<PromptStage, string> {
                         <p class="pf-c-form__helper-text">
                             ${t`Hold control/command to select multiple items.`}
                         </p>
-                        <ak-forms-modal>
-                            <span slot="submit"> ${t`Create`} </span>
-                            <span slot="header"> ${t`Create Prompt`} </span>
-                            <ak-prompt-form slot="form"> </ak-prompt-form>
-                            <button type="button" slot="trigger" class="pf-c-button pf-m-primary">
-                                ${t`Create`}
-                            </button>
-                        </ak-forms-modal>
+                        ${this.instance
+                            ? html`<ak-forms-modal>
+                                  <span slot="submit"> ${t`Create`} </span>
+                                  <span slot="header"> ${t`Create Prompt`} </span>
+                                  <ak-prompt-form slot="form"> </ak-prompt-form>
+                                  <button
+                                      type="button"
+                                      slot="trigger"
+                                      class="pf-c-button pf-m-primary"
+                                  >
+                                      ${t`Create`}
+                                  </button>
+                              </ak-forms-modal>`
+                            : html``}
                     </ak-form-element-horizontal>
                     <ak-form-element-horizontal
                         label=${t`Validation Policies`}


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://github.com/goauthentik/authentik/blob/main/CONTRIBUTING.md#how-can-i-contribute).
-->

# Details

closes #5206

## Changes

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)
-   [x] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
