### PR TITLE
root: migrate from os.path to Pathlib

### DIFF
--- a/authentik/api/v3/config.py
+++ b/authentik/api/v3/config.py
@@ -1,5 +1,5 @@
 """core Configs API"""
-from os import path
+from pathlib import Path
 
 from django.conf import settings
 from django.db import models
@@ -63,7 +63,7 @@ class ConfigView(APIView):
         """Get all capabilities this server instance supports"""
         caps = []
         deb_test = settings.DEBUG or settings.TEST
-        if path.ismount(settings.MEDIA_ROOT) or deb_test:
+        if Path(settings.MEDIA_ROOT).is_mount() or deb_test:
             caps.append(Capabilities.CAN_SAVE_MEDIA)
         if GEOIP_READER.enabled:
             caps.append(Capabilities.CAN_GEO_IP)

--- a/authentik/root/settings.py
+++ b/authentik/root/settings.py
@@ -4,6 +4,7 @@ import importlib
 import logging
 import os
 from hashlib import sha512
+from pathlib import Path
 from urllib.parse import quote_plus
 
 import structlog
@@ -19,11 +20,9 @@ from authentik.stages.password import BACKEND_APP_PASSWORD, BACKEND_INBUILT, BAC
 
 LOGGER = structlog.get_logger()
 
-# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-STATIC_ROOT = BASE_DIR + "/static"
-STATICFILES_DIRS = [BASE_DIR + "/web"]
-MEDIA_ROOT = BASE_DIR + "/media"
+BASE_DIR = Path(__file__).absolute().parent.parent.parent
+STATICFILES_DIRS = [BASE_DIR / Path("web")]
+MEDIA_ROOT = BASE_DIR / Path("media")
 
 DEBUG = CONFIG.y_bool("debug")
 SECRET_KEY = CONFIG.y("secret_key")


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://goauthentik.io/developer-docs/#how-can-i-contribute).
-->

## Details

Some preventative cleanup to use pathlib instead of os.path

## Changes

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
