### PR TITLE
events: don't include task uid in task metric

### DIFF
--- a/authentik/events/monitored_tasks.py
+++ b/authentik/events/monitored_tasks.py
@@ -87,9 +87,9 @@ class TaskInfo:
         except TypeError:
             duration = 0
         GAUGE_TASKS.labels(
-            task_name=self.task_name,
+            task_name=self.task_name.split(":")[0],
             task_uid=self.result.uid or "",
-            status=self.result.status,
+            status=self.result.status.value,
         ).set(duration)
 
     def save(self, timeout_hours=6):


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://goauthentik.io/developer-docs/#how-can-i-contribute).
-->

## Details

Currently tasks have a uid label but also include the uid in the task_name, making it harder to query and alert:
![image](https://github.com/goauthentik/authentik/assets/1932513/9e969b98-2bb3-46a5-8cec-b158d4109cab)

## Changes

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
