### PR TITLE
web/elements: don't send value from writeOnly field that hasn't been modified

### DIFF
--- a/web/src/elements/forms/Form.ts
+++ b/web/src/elements/forms/Form.ts
@@ -142,6 +142,10 @@ export abstract class Form<T> extends AKElement {
             if (element.hidden || !inputElement) {
                 return;
             }
+            // Skip elements that are writeOnly where the user hasn't clicked on the value
+            if (element.writeOnly && !element.writeOnlyActivated) {
+                return;
+            }
             if (
                 inputElement.tagName.toLowerCase() === "select" &&
                 "multiple" in inputElement.attributes


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://goauthentik.io/developer-docs/#how-can-i-contribute).
-->

## Details

Without this, writeOnly fields are sent as "" in the API which causes errors as the field isn't change and shouldn't be sent

## Changes

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
