### PR TITLE
stages/authenticator_sms: Fix json serialization in send_generic

### DIFF
--- a/authentik/stages/authenticator_sms/models.py
+++ b/authentik/stages/authenticator_sms/models.py
@@ -99,7 +99,7 @@ class AuthenticatorSMSStage(ConfigurableStage, FriendlyNamedStage, Stage):
             "From": self.from_number,
             "To": device.phone_number,
             "Body": token,
-            "Message": self.get_message(token),
+            "Message": str(self.get_message(token)),
         }
 
         if self.mapping:


### PR DESCRIPTION
##Details
Resolves #5629. Problem is/was that self.get_message(token) in send_generic returned a type django.utils.functional.lazy.<locals>.__proxy__ which is not json serializable.

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

