### PR TITLE
lifecycle: Add depends_on for worker and server container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,9 @@ services:
     ports:
       - "${COMPOSE_PORT_HTTP:-9000}:9000"
       - "${COMPOSE_PORT_HTTPS:-9443}:9443"
+    depends_on:
+      - postgresql
+      - redis
   worker:
     image: ${AUTHENTIK_IMAGE:-ghcr.io/goauthentik/server}:${AUTHENTIK_TAG:-2023.5.0}
     restart: unless-stopped
@@ -73,6 +76,9 @@ services:
       - ./custom-templates:/templates
     env_file:
       - .env
+    depends_on:
+      - postgresql
+      - redis
 
 volumes:
   database:


### PR DESCRIPTION
## Details

It is possible that the server or worker container start prior to redis or postgresql, rendering their health status as unhealthy. It makes sense to define an explicit start-up sequence.

-   **Does this resolve an issue?**
    No

## Changes

- Declaration of the stack start-up sequence:
  1.  postgresql and redis container start in parallel, after both containers run:
  2.  the server and worker start in parallel

### New Features

### Breaking Changes

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
