### PR TITLE
web/flows: fix authenticator_validate device select not sent to backend

### DIFF
--- a/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStage.ts
+++ b/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStage.ts
@@ -53,10 +53,10 @@ export class AuthenticatorValidateStage
     _selectedDeviceChallenge?: DeviceChallenge;
 
     set selectedDeviceChallenge(value: DeviceChallenge | undefined) {
-        //Do nothing if value is undefined or is casted to boolean false
-        if (typeof value === "undefined") return;
-        if (!value) return;
+        const previousChallenge = this._selectedDeviceChallenge;
         this._selectedDeviceChallenge = value;
+        if (!value) return;
+        if (value === previousChallenge) return;
         // We don't use this.submit here, as we don't want to advance the flow.
         // We just want to notify the backend which challenge has been selected.
         new FlowsApi(DEFAULT_CONFIG).flowsExecutorSolve({

--- a/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStage.ts
+++ b/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStage.ts
@@ -54,7 +54,7 @@ export class AuthenticatorValidateStage
 
     set selectedDeviceChallenge(value: DeviceChallenge | undefined) {
         //Do nothing if value is undefined or is casted to boolean false
-        if (typeof value === 'undefined') return;
+        if (typeof value === "undefined") return;
         if (!value) return;
         this._selectedDeviceChallenge = value;
         // We don't use this.submit here, as we don't want to advance the flow.

--- a/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStage.ts
+++ b/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStage.ts
@@ -53,9 +53,10 @@ export class AuthenticatorValidateStage
     _selectedDeviceChallenge?: DeviceChallenge;
 
     set selectedDeviceChallenge(value: DeviceChallenge | undefined) {
-        this._selectedDeviceChallenge = value;
+        //Do nothing if value is undefined or is casted to boolean false
+        if (typeof value === 'undefined') return;
         if (!value) return;
-        if (value === this._selectedDeviceChallenge) return;
+        this._selectedDeviceChallenge = value;
         // We don't use this.submit here, as we don't want to advance the flow.
         // We just want to notify the backend which challenge has been selected.
         new FlowsApi(DEFAULT_CONFIG).flowsExecutorSolve({


### PR DESCRIPTION
## Details
Resolves #5020    
The old code version always returned without doing anything. I assume the intention was to ensure "value" is not undefined and is not false.

I tried the new version with sms and totp device. Having both active at the same time or only one. I did however not test a Yubikey /Webauthn. 

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)
If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`) <- This creates a lot of changes not caused by my fix so I did  not commit this . 