### PR TITLE
Dont print entire stacktrace

### DIFF
--- a/authentik/outposts/api/outposts.py
+++ b/authentik/outposts/api/outposts.py
@@ -72,7 +72,7 @@ class OutpostSerializer(ModelSerializer):
         try:
             from_dict(OutpostConfig, config)
         except DaciteError as exc:
-            raise ValidationError(f"Failed to validate config: {str(exc)}") from exc
+            raise ValidationError(f"Failed to validate config: {str(exc.args[0])}") from exc
         return config
 
     class Meta:

--- a/authentik/sources/oauth/api/source.py
+++ b/authentik/sources/oauth/api/source.py
@@ -70,7 +70,7 @@ class OAuthSourceSerializer(SourceSerializer):
                 attrs["profile_url"] = config["userinfo_endpoint"]
                 attrs["oidc_jwks_url"] = config["jwks_uri"]
             except (IndexError, KeyError) as exc:
-                raise ValidationError(f"Invalid well-known configuration: {exc}")
+                raise ValidationError(f"Invalid well-known configuration: {exc.args[0]} not found")
 
         jwks_url = attrs.get("oidc_jwks_url")
         if jwks_url and jwks_url != "":

--- a/authentik/stages/authenticator_webauthn/stage.py
+++ b/authentik/stages/authenticator_webauthn/stage.py
@@ -62,7 +62,7 @@ class AuthenticatorWebAuthnChallengeResponse(ChallengeResponse):
             )
         except InvalidRegistrationResponse as exc:
             self.stage.logger.warning("registration failed", exc=exc)
-            raise ValidationError(f"Registration failed. Error: {exc}")
+            raise ValidationError(f"Registration failed. Error: {exc.args[0]}")
 
         credential_id_exists = WebAuthnDevice.objects.filter(
             credential_id=bytes_to_base64url(registration.credential_id)

--- a/authentik/stages/identification/stage.py
+++ b/authentik/stages/identification/stage.py
@@ -145,7 +145,7 @@ class IdentificationChallengeResponse(ChallengeResponse):
                 raise ValidationError("Failed to authenticate.")
             self.pre_user = user
         except PermissionDenied as exc:
-            raise ValidationError(str(exc)) from exc
+            raise ValidationError(str(exc.args[0])) from exc
         return attrs
 
 


### PR DESCRIPTION


## Details

Only print first arg of the exception stack trace, as to not expose the entire stack trace.

-   **Does this resolve an issue?**
    Resolves 
- CodeQL Scanning 

## Changes

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
