### PR TITLE
website/integrations: Updated AWS docs for the new IAM Center and SCIM

### DIFF
--- a/website/integrations/services/aws/index.md
+++ b/website/integrations/services/aws/index.md
@@ -87,30 +87,30 @@ return user.username
 
 ## Preparation
 
-The following placeholders will be used:
+The following placeholders are used:
 
 -   `authentik.company` is the FQDN of the authentik install.
 
 Additional Preparation:
 
 -   A certificate to sign SAML assertions is required. You can use authentik's default certificate, or provide/generate one yourself.
--   You may pre-create an AWS application
+-   You may pre-create an AWS application.
 
-## Procedure
+## How to integrate with AWS
 
 In AWS:
 
--   In AWS Navigate to: `IAM Identity Center -> Settings -> Identity Source (tab)`
--   On the right hand side click `Actions -> Change identity source`
+-   In AWS navigate to: `IAM Identity Center -> Settings -> Identity Source (tab)`
+-   On the right side click `Actions -> Change identity source`
 -   Select `External Identity Provider`
--   Under `Service Provider metadata` it'll allow you to download a metadata file. Download this file.
+-   Under `Service Provider metadata` download the metadata file. 
 
 Now go to your authentik instance, and perform the following steps.
 
 -   Under _Providers_ create a new _SAML Provider from metadata_. Give it a name, and upload the metadata file AWS gave you.
--   Click _Next_. Give it a name, and close.
--   If you haven't done so yet, create an application for AWS and connect the Provider to it.
--   Navigate to the provider you've just created, select _Edit_
+-   Click _Next_. Give it a name, and close the file.
+-   If you haven't done so yet, create an application for AWS and connect the provider to it.
+-   Navigate to the provider you've just created, and then select _Edit_
 -   Copy the _Issuer URL_ to the _Audience_ field.
 -   Under _Advanced Protocol Settings_ set a _Signing Certificate_
 -   Save and Close.
@@ -118,38 +118,38 @@ Now go to your authentik instance, and perform the following steps.
 
 Now go back to your AWS instance
 
--   Under `Identity provider metadata` upload both the the `Metadata file` and `Signing Certificate` authentik gave you.
--   Choose `Next`.
--   In your settings pane, under the tab `Identity Source` click `Actions -> Manage Authentication`
--   Take note of the `AWS access portal sign-in URL` (this is especially important if you've changed it from the default)
+-   Under `Identity provider metadata` upload both the the `Metadata` file and `Signing Certificate` that authentik gave you.
+-   Click `Next`.
+-   In your settings pane, under the tab `Identity Source`, click `Actions -> Manage Authentication`.
+-   Take note of the `AWS access portal sign-in URL` (this is especially important if you changed it from the default).
 
 Now go back to your authentik instance.
 
--   Navigate to the Application you've created for AWS and click _Edit_.
+-   Navigate to the Application that you created for AWS and click _Edit_.
 -   Under _UI Settings_ make sure the _Start URL_ matches the _AWS access portal sign-in URL_
 
 ## Caveats and Troubleshooting
 
--   Users need to exist in AWS in order to use them through authentik. AWS will throw an error if it doesn't recognise the user.
+-   Users need to already exist in AWS in order to use them through authentik. AWS will throw an error if it doesn't recognise the user.
 -   In case you're stuck, you can see the SSO logs in Amazon CloudTrail -> Event History. Look for `ExtenalIdPDirectoryLogin`
 
 Note:
 
-## Optional: Auto provisioning with SCIM
+## Optional: Automated provisioning with SCIM
 
-Some people may opt for the automatic provisioning feature called SCIM.
-SCIM allows you to synchronise (part of) your directory to AWS's IAM. Saving you the hassle of having to create users by hand.
-In order to do so, go to your AWS Identity Center
+Some people may opt TO USE the automatic provisioning feature called SCIM (System for Cross-domain Identity Management).
+SCIM allows you to synchronize (part of) your directory to AWS's IAM, saving you the hassle of having to create users by hand.
+In order to do so, take the following steps in your AWS Identity Center:
 
--   In your `Settings` pane, locate the `Automatic Provisioning` Info box. Click `Enable`
--   AWS will give you an `SCIM Endpoint` and a `Access Token`. Take note of these
+-   In your `Settings` pane, locate the `Automatic Provisioning` Info box. Click `Enable`.
+-   AWS will give you an `SCIM Endpoint` and a `Access Token`. Take note of these values.
 
 Go back to your authentik instance
 
 -   Navigate to _Providers_ -> _Create_
 -   Select _SCIM Provider_
--   Give it a name, under _URL_ enter the _SCIM Endpoint_ and under _Token_ enter the _Access Token_ AWS provided you with.
--   In case you wish, change the user filtering settings to your liking. Click _Finish_
+-   Give it a name, under _URL_ enter the _SCIM Endpoint_, and then under _Token_ enter the _Access Token_ AWS provided you with.
+-   Optionally, change the user filtering settings to your liking. Click _Finish_
 
 -   Go to _Customization -> Property Mappings_
 -   Click _Create -> SCIM Mapping_
@@ -157,7 +157,7 @@ Go back to your authentik instance
 -   As the expression, enter:
 
 ```python
-# The only thing this does, is strip the default mapping from it's 'photos' attribute,
+# This expression strips the default mapping from its 'photos' attribute,
 # which is a forbidden property in AWS IAM.
 return {
     "photos": None,
@@ -165,11 +165,11 @@ return {
 ```
 
 -   Click _Save_. Navigate back to your SCIM provider, click _Edit_
--   Under _User Property Mappings_ select the default mapping and the mapping you've just created.
+-   Under _User Property Mappings_ select the default mapping and the mapping that you just created.
 -   Click _Update_
 
 -   Navigate to your application, click _Edit_.
--   Under _Backchannel providers_ add the SCIM provider you've created.
+-   Under _Backchannel providers_ add the SCIM provider that you created.
 -   Click _Update_
 
-The SCIM provider should sync automatically whenever you create/alter/remove anything. You can manually sync by going to your SCIM provider and click the _Run sync again_ button. Once it synced, you should see the users and groups in your AWS IAM center.
+The SCIM provider should sync automatically whenever you create/alter/remove anything. You can manually sync by going to your SCIM provider and click the _Run sync again_ button. Once the SCIM provider has synced, you should see the users and groups in your AWS IAM center.

--- a/website/integrations/services/aws/index.md
+++ b/website/integrations/services/aws/index.md
@@ -11,12 +11,14 @@ Amazon Web Services (AWS) is the world’s most comprehensive and broadly adopte
 :::
 
 ## Select your method
+
 There are two ways to perform the integration. The classic IAM SAML way, or the 'newer' IAM Identity Center way.
 This all depends on your preference and needs.
 
 # Method 1: Classic IAM
 
 ## Preparation
+
 The following placeholders will be used:
 
 -   `authentik.company` is the FQDN of the authentik install.
@@ -81,8 +83,6 @@ To use the user's username, use this snippet
 return user.username
 ```
 
-
-
 # Method 2: IAM Identity Center
 
 ## Preparation
@@ -92,46 +92,51 @@ The following placeholders will be used:
 -   `authentik.company` is the FQDN of the authentik install.
 
 Additional Preparation:
--   A certificate to sign SAML assertions is required. You can use Authentik's default certificate, or provide/generate one yourself.
+
+-   A certificate to sign SAML assertions is required. You can use authentik's default certificate, or provide/generate one yourself.
 -   You may pre-create an AWS application
 
 ## Procedure
 
 In AWS:
+
 -   In AWS Navigate to: `IAM Identity Center -> Settings -> Identity Source (tab)`
 -   On the right hand side click `Actions -> Change identity source`
 -   Select `External Identity Provider`
 -   Under `Service Provider metadata` it'll allow you to download a metadata file. Download this file.
 
 Now go to your authentik instance, and perform the following steps.
--   Under `Providers` create a new `SAML Provider from metadata`. Give it a name, and upload the metadata file AWS gave you.
--   Click `Next`. Give it a name, and close.
+
+-   Under _Providers_ create a new _SAML Provider from metadata_. Give it a name, and upload the metadata file AWS gave you.
+-   Click _Next_. Give it a name, and close.
 -   If you haven't done so yet, create an application for AWS and connect the Provider to it.
--   Navigate to the provider you've just created, select `Edit`
--   Copy the `Issuer` URL to the `Audience` field.
--   Under `Advanced Protocol Settings` set a `Signing Certificate`
+-   Navigate to the provider you've just created, select _Edit_
+-   Copy the _Issuer URL_ to the _Audience_ field.
+-   Under _Advanced Protocol Settings_ set a _Signing Certificate_
 -   Save and Close.
--   Under `Related Objects` download the `Metadata file`, and the `Signing Certificate`
+-   Under _Related Objects_ download the _Metadata file_, and the _Signing Certificate_
 
 Now go back to your AWS instance
+
 -   Under `Identity provider metadata` upload both the the `Metadata file` and `Signing Certificate` authentik gave you.
 -   Choose `Next`.
 -   In your settings pane, under the tab `Identity Source` click `Actions -> Manage Authentication`
 -   Take note of the `AWS access portal sign-in URL` (this is especially important if you've changed it from the default)
 
 Now go back to your authentik instance.
--   Navigate to the Application you've created for AWS and click `Edit`.
--   Under `UI Settings` make sure the `Start URL` matches the `AWS access portal sign-in URL` 
 
+-   Navigate to the Application you've created for AWS and click _Edit_.
+-   Under _UI Settings_ make sure the _Start URL_ matches the _AWS access portal sign-in URL_
 
 ## Caveats and Troubleshooting
+
 -   Users need to exist in AWS in order to use them through authentik. AWS will throw an error if it doesn't recognise the user.
 -   In case you're stuck, you can see the SSO logs in Amazon CloudTrail -> Event History. Look for `ExtenalIdPDirectoryLogin`
-
 
 Note:
 
 ## Optional: Auto provisioning with SCIM
+
 Some people may opt for the automatic provisioning feature called SCIM.
 SCIM allows you to synchronise (part of) your directory to AWS's IAM. Saving you the hassle of having to create users by hand.
 In order to do so, go to your AWS Identity Center
@@ -139,55 +144,32 @@ In order to do so, go to your AWS Identity Center
 -   In your `Settings` pane, locate the `Automatic Provisioning` Info box. Click `Enable`
 -   AWS will give you an `SCIM Endpoint` and a `Access Token`. Take note of these
 
-Go back to your Authentik instance
--   Navigate to `Providers -> Create`
--   Select `SCIM Provider`
--   Give it a name, under `URL` enter the `SCIM Endpoint` and under `Token` enter the `Access Token` AWS provided you with.
--   In case you wish, change the user filtering settings to your liking. Click `Finish`
->   The next steps (regarding the Attribute Mapping) will become unneeded in a next release. At the time of writing `2023.5.0` it's a work-around for issue [#5640](https://github.com/goauthentik/authentik/issues/5640)
--   Go to `Customization -> Property Mappings`
--   Click `Create -> SCIM Mapping`
--   As the expression, enter: 
+Go back to your authentik instance
+
+-   Navigate to _Providers_ -> _Create_
+-   Select _SCIM Provider_
+-   Give it a name, under _URL_ enter the _SCIM Endpoint_ and under _Token_ enter the _Access Token_ AWS provided you with.
+-   In case you wish, change the user filtering settings to your liking. Click _Finish_
+
+-   Go to _Customization -> Property Mappings_
+-   Click _Create -> SCIM Mapping_
+-   Make sure to give the mapping a name that's lexically lower than `authentik default`, for example `AWS SCIM User mapping`
+-   As the expression, enter:
+
 ```python
-        if " " in request.user.name:
-            givenName, _, familyName = request.user.name.partition(" ")
-
-        # photos supports URLs to images, however authentik might return data URIs
-        avatar = request.user.avatar
-
-        locale = request.user.locale()
-        if locale == "":
-            locale = None
-
-        emails = []
-        if request.user.email != "":
-            emails.append({
-                "value": request.user.email,
-                "type": "other",
-                "primary": True,
-            })
-        return {
-            "userName": request.user.username,
-            "name": {
-                "formatted": request.user.name,
-                "givenName": givenName,
-                "familyName": familyName,
-            },
-            "displayName": request.user.name,
-            "locale": locale,
-            "active": request.user.is_active,
-            "emails": emails,
-        }
+# The only thing this does, is strip the default mapping from it's 'photos' attribute,
+# which is a forbidden property in AWS IAM.
+return {
+    "photos": None,
+}
 ```
 
->    Note: The only thing this does, is strip the default mapping from it's 'photos' attribute, which is a forbidden property in AWS IAM.
--   Click `Save`. Navigate back to your SCIM provider, click `Edit`
--   Under `User Property Mappings` select _only_ the mapping you've just created.
--   Click `Update`
--   Navigate to your application, click `Edit`.
--   Under `Backchannel providers` add the SCIM provider you've created.
--   Click `Update`
+-   Click _Save_. Navigate back to your SCIM provider, click _Edit_
+-   Under _User Property Mappings_ select the default mapping and the mapping you've just created.
+-   Click _Update_
 
-The SCIM provider should sync automatically whenever you create/alter/remove anything.
-You can manually sync by going to your SCIM provider and click the `Run sync again` button.
-Once it synced, you should see the users and groups in your AWS IAM center.
+-   Navigate to your application, click _Edit_.
+-   Under _Backchannel providers_ add the SCIM provider you've created.
+-   Click _Update_
+
+The SCIM provider should sync automatically whenever you create/alter/remove anything. You can manually sync by going to your SCIM provider and click the _Run sync again_ button. Once it synced, you should see the users and groups in your AWS IAM center.

--- a/website/integrations/services/aws/index.md
+++ b/website/integrations/services/aws/index.md
@@ -23,35 +23,35 @@ Additional Preparation:
 ## Procedure
 
 In AWS:
-1.   In AWS Navigate to: `IAM Identity Center -> Settings -> Identity Source (tab)`
-2.   On the right hand side click `Actions -> Change identity source`
-3.   Select `External Identity Provider`
-4.   Under `Service Provider metadata` it'll allow you to download a metadata file. Download this file.
+-   In AWS Navigate to: `IAM Identity Center -> Settings -> Identity Source (tab)`
+-   On the right hand side click `Actions -> Change identity source`
+-   Select `External Identity Provider`
+-   Under `Service Provider metadata` it'll allow you to download a metadata file. Download this file.
 
 Now go to your authentik instance, and perform the following steps.
-5.   Under `Providers` create a new `SAML Provider from metadata`. Give it a name, and upload the metadata file AWS gave you.
-6.   Click `Next`. Give it a name, and close.
-7.   If you haven't done so yet, create an application for AWS and connect the Provider to it.
-8.   Navigate to the provider you've just created, select `Edit`
-9.   Copy the `Issuer` URL to the `Audience` field.
-10.   Under `Advanced Protocol Settings` set a `Signing Certificate`
-11.   Save and Close.
-12.   Under `Related Objects` download the `Metadata file`, and the `Signing Certificate`
+-   Under `Providers` create a new `SAML Provider from metadata`. Give it a name, and upload the metadata file AWS gave you.
+-   Click `Next`. Give it a name, and close.
+-   If you haven't done so yet, create an application for AWS and connect the Provider to it.
+-   Navigate to the provider you've just created, select `Edit`
+-   Copy the `Issuer` URL to the `Audience` field.
+-   Under `Advanced Protocol Settings` set a `Signing Certificate`
+-   Save and Close.
+-   Under `Related Objects` download the `Metadata file`, and the `Signing Certificate`
 
 Now go back to your AWS instance
-13.   Under `Identity provider metadata` upload both the the `Metadata file` and `Signing Certificate` authentik gave you.
-14.   Choose `Next`.
-15.   In your settings pane, under the tab `Identity Source` click `Actions -> Manage Authentication`
-16.   Take note of the `AWS access portal sign-in URL` (this is especially important if you've changed it from the default)
+-   Under `Identity provider metadata` upload both the the `Metadata file` and `Signing Certificate` authentik gave you.
+-   Choose `Next`.
+-   In your settings pane, under the tab `Identity Source` click `Actions -> Manage Authentication`
+-   Take note of the `AWS access portal sign-in URL` (this is especially important if you've changed it from the default)
 
 Now go back to your authentik instance.
-17.   Navigate to the Application you've created for AWS and click `Edit`.
-18.   Under `UI Settings` make sure the `Start URL` matches the `AWS access portal sign-in URL` 
+-   Navigate to the Application you've created for AWS and click `Edit`.
+-   Under `UI Settings` make sure the `Start URL` matches the `AWS access portal sign-in URL` 
 
 
 ## Caveats and Troubleshooting
-1.   Users need to exist in AWS in order to use them through authentik. AWS will throw an error if it doesn't recognise the user.
-2.   In case you're stuck, you can see the SSO logs in Amazon CloudTrail -> Event History. Look for `ExtenalIdPDirectoryLogin`
+-   Users need to exist in AWS in order to use them through authentik. AWS will throw an error if it doesn't recognise the user.
+-   In case you're stuck, you can see the SSO logs in Amazon CloudTrail -> Event History. Look for `ExtenalIdPDirectoryLogin`
 
 
 Note:
@@ -61,18 +61,18 @@ Some people may opt for the automatic provisioning feature called SCIM.
 SCIM allows you to synchronise (part of) your directory to AWS's IAM. Saving you the hassle of having to create users by hand.
 In order to do so, go to your AWS Identity Center
 
-1.   In your `Settings` pane, locate the `Automatic Provisioning` Info box. Click `Enable`
-2.   AWS will give you an `SCIM Endpoint` and a `Access Token`. Take note of these
+-   In your `Settings` pane, locate the `Automatic Provisioning` Info box. Click `Enable`
+-   AWS will give you an `SCIM Endpoint` and a `Access Token`. Take note of these
 
 Go back to your Authentik instance
-3.   Navigate to `Providers -> Create`
-4.   Select `SCIM Provider`
-5.   Give it a name, under `URL` enter the `SCIM Endpoint` and under `Token` enter the `Access Token` AWS provided you with.
-6.   In case you wish, change the user filtering settings to your liking. Click `Finish`
+-   Navigate to `Providers -> Create`
+-   Select `SCIM Provider`
+-   Give it a name, under `URL` enter the `SCIM Endpoint` and under `Token` enter the `Access Token` AWS provided you with.
+-   In case you wish, change the user filtering settings to your liking. Click `Finish`
 >   The next steps (regarding the Attribute Mapping) will become unneeded in a next release. At the time of writing `2023.5.0` it's a work-around for issue [#5640](https://github.com/goauthentik/authentik/issues/5640)
-7.   Go to `Customization -> Property Mappings`
-8.   Click `Create -> SCIM Mapping`
-9.   As the expression, enter: 
+-   Go to `Customization -> Property Mappings`
+-   Click `Create -> SCIM Mapping`
+-   As the expression, enter: 
 ```python
         if " " in request.user.name:
             givenName, _, familyName = request.user.name.partition(" ")
@@ -106,12 +106,12 @@ Go back to your Authentik instance
 ```
 
 >    Note: The only thing this does, is strip the default mapping from it's 'photos' attribute, which is a forbidden property in AWS IAM.
-10.   Click `Save`. Navigate back to your SCIM provider, click `Edit`
-11.   Under `User Property Mappings` select _only_ the mapping you've just created.
-12.   Click `Update`
-13.   Navigate to your application, click `Edit`.
-14.   Under `Backchannel providers` add the SCIM provider you've created.
-15.   Click `Update`
+-   Click `Save`. Navigate back to your SCIM provider, click `Edit`
+-   Under `User Property Mappings` select _only_ the mapping you've just created.
+-   Click `Update`
+-   Navigate to your application, click `Edit`.
+-   Under `Backchannel providers` add the SCIM provider you've created.
+-   Click `Update`
 
 The SCIM provider should sync automatically whenever you create/alter/remove anything.
 You can manually sync by going to your SCIM provider and click the `Run sync again` button.

--- a/website/integrations/services/aws/index.md
+++ b/website/integrations/services/aws/index.md
@@ -16,62 +16,103 @@ The following placeholders will be used:
 
 -   `authentik.company` is the FQDN of the authentik install.
 
-Create an application in authentik and note the slug, as this will be used later. Create a SAML provider with the following parameters:
+Additional Preparation:
+-   A certificate to sign SAML assertions is required. You can use Authentik's default certificate, or provide/generate one yourself.
+-   You may pre-create an AWS application
 
--   ACS URL: `https://signin.aws.amazon.com/saml`
--   Audience: `urn:amazon:webservices`
--   Issuer: `authentik`
--   Binding: `Post`
+## Procedure
 
-You can of course use a custom signing certificate, and adjust durations.
+In AWS:
+1.   In AWS Navigate to: `IAM Identity Center -> Settings -> Identity Source (tab)`
+2.   On the right hand side click `Actions -> Change identity source`
+3.   Select `External Identity Provider`
+4.   Under `Service Provider metadata` it'll allow you to download a metadata file. Download this file.
 
-## AWS
+Now go to your authentik instance, and perform the following steps.
+5.   Under `Providers` create a new `SAML Provider from metadata`. Give it a name, and upload the metadata file AWS gave you.
+6.   Click `Next`. Give it a name, and close.
+7.   If you haven't done so yet, create an application for AWS and connect the Provider to it.
+8.   Navigate to the provider you've just created, select `Edit`
+9.   Copy the `Issuer` URL to the `Audience` field.
+10.   Under `Advanced Protocol Settings` set a `Signing Certificate`
+11.   Save and Close.
+12.   Under `Related Objects` download the `Metadata file`, and the `Signing Certificate`
 
-Create a role with the permissions you desire, and note the ARN.
+Now go back to your AWS instance
+13.   Under `Identity provider metadata` upload both the the `Metadata file` and `Signing Certificate` authentik gave you.
+14.   Choose `Next`.
+15.   In your settings pane, under the tab `Identity Source` click `Actions -> Manage Authentication`
+16.   Take note of the `AWS access portal sign-in URL` (this is especially important if you've changed it from the default)
 
-After you've created the Property Mappings below, add them to the Provider.
+Now go back to your authentik instance.
+17.   Navigate to the Application you've created for AWS and click `Edit`.
+18.   Under `UI Settings` make sure the `Start URL` matches the `AWS access portal sign-in URL` 
 
-Create an application, assign policies, and assign this provider.
 
-Export the metadata from authentik, and create an Identity Provider [here](https://console.aws.amazon.com/iam/home#/providers).
+## Caveats and Troubleshooting
+1.   Users need to exist in AWS in order to use them through authentik. AWS will throw an error if it doesn't recognise the user.
+2.   In case you're stuck, you can see the SSO logs in Amazon CloudTrail -> Event History. Look for `ExtenalIdPDirectoryLogin`
 
-#### Role Mapping
 
-The Role mapping specifies the AWS ARN(s) of the identity provider, and the role the user should assume ([see](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_saml_assertions.html#saml_role-attribute)).
+Note:
 
-This Mapping needs to have the SAML Name field set to "https://aws.amazon.com/SAML/Attributes/Role"
+## Optional: Auto provisioning with SCIM
+Some people may opt for the automatic provisioning feature called SCIM.
+SCIM allows you to synchronise (part of) your directory to AWS's IAM. Saving you the hassle of having to create users by hand.
+In order to do so, go to your AWS Identity Center
 
-As expression, you can return a static ARN like so
+1.   In your `Settings` pane, locate the `Automatic Provisioning` Info box. Click `Enable`
+2.   AWS will give you an `SCIM Endpoint` and a `Access Token`. Take note of these
 
+Go back to your Authentik instance
+3.   Navigate to `Providers -> Create`
+4.   Select `SCIM Provider`
+5.   Give it a name, under `URL` enter the `SCIM Endpoint` and under `Token` enter the `Access Token` AWS provided you with.
+6.   In case you wish, change the user filtering settings to your liking. Click `Finish`
+>   The next steps (regarding the Attribute Mapping) will become unneeded in a next release. At the time of writing `2023.5.0` it's a work-around for issue [#5640](https://github.com/goauthentik/authentik/issues/5640)
+7.   Go to `Customization -> Property Mappings`
+8.   Click `Create -> SCIM Mapping`
+9.   As the expression, enter: 
 ```python
-return "arn:aws:iam::123412341234:role/saml_role,arn:aws:iam::123412341234:saml-provider/authentik"
+        if " " in request.user.name:
+            givenName, _, familyName = request.user.name.partition(" ")
+
+        # photos supports URLs to images, however authentik might return data URIs
+        avatar = request.user.avatar
+
+        locale = request.user.locale()
+        if locale == "":
+            locale = None
+
+        emails = []
+        if request.user.email != "":
+            emails.append({
+                "value": request.user.email,
+                "type": "other",
+                "primary": True,
+            })
+        return {
+            "userName": request.user.username,
+            "name": {
+                "formatted": request.user.name,
+                "givenName": givenName,
+                "familyName": familyName,
+            },
+            "displayName": request.user.name,
+            "locale": locale,
+            "active": request.user.is_active,
+            "emails": emails,
+        }
 ```
 
-Or, if you want to assign AWS Roles based on Group membership, you can add a custom attribute to the Groups, for example "aws_role", and use this snippet below. Groups are sorted by name and later groups overwrite earlier groups' attributes.
+>    Note: The only thing this does, is strip the default mapping from it's 'photos' attribute, which is a forbidden property in AWS IAM.
+10.   Click `Save`. Navigate back to your SCIM provider, click `Edit`
+11.   Under `User Property Mappings` select _only_ the mapping you've just created.
+12.   Click `Update`
+13.   Navigate to your application, click `Edit`.
+14.   Under `Backchannel providers` add the SCIM provider you've created.
+15.   Click `Update`
 
-```python
-role_name = user.group_attributes().get("aws_role", "")
-return f"arn:aws:iam::123412341234:role/{role_name},arn:aws:iam::123412341234:saml-provider/authentik"
-```
-
-If you want to allow a user to choose from multiple roles, use this snippet
-
-```python
-return [
-    "arn:aws:iam::123412341234:role/role_a,arn:aws:iam::123412341234:saml-provider/authentik",
-    "arn:aws:iam::123412341234:role/role_b,arn:aws:iam::123412341234:saml-provider/authentik",
-    "arn:aws:iam::123412341234:role/role_c,arn:aws:iam::123412341234:saml-provider/authentik",
-]
-```
-
-### RoleSessionName Mapping
-
-The RoleSessionMapping specifies what identifier will be shown at the top of the Management Console ([see](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_saml_assertions.html#saml_role-session-attribute)).
-
-This mapping needs to have the SAML Name field set to "https://aws.amazon.com/SAML/Attributes/RoleSessionName".
-
-To use the user's username, use this snippet
-
-```python
-return user.username
-```
+The SCIM provider should sync automatically whenever you create/alter/remove anything.
+You can manually sync by going to your SCIM provider and click the `Run sync again` button.
+Once it synced, you should see the users and groups in your AWS IAM center.

--- a/website/integrations/services/aws/index.md
+++ b/website/integrations/services/aws/index.md
@@ -10,6 +10,81 @@ title: Amazon Web Services
 Amazon Web Services (AWS) is the world’s most comprehensive and broadly adopted cloud platform, offering over 175 fully featured services from data centers globally. Millions of customers—including the fastest-growing startups, largest enterprises, and leading government agencies—are using AWS to lower costs, become more agile, and innovate faster.
 :::
 
+## Select your method
+There are two ways to perform the integration. The classic IAM SAML way, or the 'newer' IAM Identity Center way.
+This all depends on your preference and needs.
+
+# Method 1: Classic IAM
+
+## Preparation
+The following placeholders will be used:
+
+-   `authentik.company` is the FQDN of the authentik install.
+
+Create an application in authentik and note the slug, as this will be used later. Create a SAML provider with the following parameters:
+
+-   ACS URL: `https://signin.aws.amazon.com/saml`
+-   Audience: `urn:amazon:webservices`
+-   Issuer: `authentik`
+-   Binding: `Post`
+
+You can of course use a custom signing certificate, and adjust durations.
+
+## AWS
+
+Create a role with the permissions you desire, and note the ARN.
+
+After you've created the Property Mappings below, add them to the Provider.
+
+Create an application, assign policies, and assign this provider.
+
+Export the metadata from authentik, and create an Identity Provider [here](https://console.aws.amazon.com/iam/home#/providers).
+
+#### Role Mapping
+
+The Role mapping specifies the AWS ARN(s) of the identity provider, and the role the user should assume ([see](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_saml_assertions.html#saml_role-attribute)).
+
+This Mapping needs to have the SAML Name field set to "https://aws.amazon.com/SAML/Attributes/Role"
+
+As expression, you can return a static ARN like so
+
+```python
+return "arn:aws:iam::123412341234:role/saml_role,arn:aws:iam::123412341234:saml-provider/authentik"
+```
+
+Or, if you want to assign AWS Roles based on Group membership, you can add a custom attribute to the Groups, for example "aws_role", and use this snippet below. Groups are sorted by name and later groups overwrite earlier groups' attributes.
+
+```python
+role_name = user.group_attributes().get("aws_role", "")
+return f"arn:aws:iam::123412341234:role/{role_name},arn:aws:iam::123412341234:saml-provider/authentik"
+```
+
+If you want to allow a user to choose from multiple roles, use this snippet
+
+```python
+return [
+    "arn:aws:iam::123412341234:role/role_a,arn:aws:iam::123412341234:saml-provider/authentik",
+    "arn:aws:iam::123412341234:role/role_b,arn:aws:iam::123412341234:saml-provider/authentik",
+    "arn:aws:iam::123412341234:role/role_c,arn:aws:iam::123412341234:saml-provider/authentik",
+]
+```
+
+### RoleSessionName Mapping
+
+The RoleSessionMapping specifies what identifier will be shown at the top of the Management Console ([see](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_saml_assertions.html#saml_role-session-attribute)).
+
+This mapping needs to have the SAML Name field set to "https://aws.amazon.com/SAML/Attributes/RoleSessionName".
+
+To use the user's username, use this snippet
+
+```python
+return user.username
+```
+
+
+
+# Method 2: IAM Identity Center
+
 ## Preparation
 
 The following placeholders will be used:

--- a/website/integrations/services/aws/index.md
+++ b/website/integrations/services/aws/index.md
@@ -103,7 +103,7 @@ In AWS:
 -   In AWS navigate to: `IAM Identity Center -> Settings -> Identity Source (tab)`
 -   On the right side click `Actions -> Change identity source`
 -   Select `External Identity Provider`
--   Under `Service Provider metadata` download the metadata file. 
+-   Under `Service Provider metadata` download the metadata file.
 
 Now go to your authentik instance, and perform the following steps.
 


### PR DESCRIPTION
Updated the AWS Integration docs to match the new IAM Centre's method. This includes SCIM.

<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://goauthentik.io/developer-docs/#how-can-i-contribute).
-->

## Changes

The AWS integration docs have been updated to reflect the new IAM Identity Center.
This also adds configuration guidance for SCIM.

-   [X] The documentation has been updated
-   [X] The documentation has been formatted (`make website`) 
     (I believe the CI takes care of this itself, right?)
