### PR TITLE
providers/radius: add warning message when radius provider is not used with outpost

### DIFF
--- a/authentik/core/templates/if/user.html
+++ b/authentik/core/templates/if/user.html
@@ -4,8 +4,8 @@
 
 {% block head %}
 <script src="{% static 'dist/user/UserInterface.js' %}?version={{ version }}" type="module"></script>
-<meta name="theme-color" content="#151515" media="(prefers-color-scheme: light)">
-<meta name="theme-color" content="#151515" media="(prefers-color-scheme: dark)">
+<meta name="theme-color" content="#1c1e21" media="(prefers-color-scheme: light)">
+<meta name="theme-color" content="#1c1e21" media="(prefers-color-scheme: dark)">
 <link rel="icon" href="{{ tenant.branding_favicon }}">
 <link rel="shortcut icon" href="{{ tenant.branding_favicon }}">
 {% include "base/header_js.html" %}

--- a/authentik/providers/radius/api.py
+++ b/authentik/providers/radius/api.py
@@ -1,5 +1,5 @@
 """RadiusProvider API Views"""
-from rest_framework.fields import CharField
+from rest_framework.fields import CharField, ListField
 from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
 
@@ -11,6 +11,8 @@ from authentik.providers.radius.models import RadiusProvider
 class RadiusProviderSerializer(ProviderSerializer):
     """RadiusProvider Serializer"""
 
+    outpost_set = ListField(child=CharField(), read_only=True, source="outpost_set.all")
+
     class Meta:
         model = RadiusProvider
         fields = ProviderSerializer.Meta.fields + [
@@ -18,6 +20,7 @@ class RadiusProviderSerializer(ProviderSerializer):
             # Shared secret is not a write-only field, as
             # an admin might have to view it
             "shared_secret",
+            "outpost_set",
         ]
         extra_kwargs = ProviderSerializer.Meta.extra_kwargs
 

--- a/schema.yml
+++ b/schema.yml
@@ -38956,6 +38956,11 @@ components:
         shared_secret:
           type: string
           description: Shared secret between clients and server to hash packets.
+        outpost_set:
+          type: array
+          items:
+            type: string
+          readOnly: true
       required:
       - assigned_application_name
       - assigned_application_slug
@@ -38965,6 +38970,7 @@ components:
       - component
       - meta_model_name
       - name
+      - outpost_set
       - pk
       - verbose_name
       - verbose_name_plural

--- a/web/src/admin/providers/radius/RadiusProviderViewPage.ts
+++ b/web/src/admin/providers/radius/RadiusProviderViewPage.ts
@@ -79,6 +79,11 @@ export class RadiusProviderViewPage extends AKElement {
                 data-tab-title="${t`Overview`}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
+            ${this.provider?.outpostSet.length < 1
+                ? html`<div slot="header" class="pf-c-banner pf-m-warning">
+                      ${t`Warning: Provider is not used by any Outpost.`}
+                  </div>`
+                : html``}
                 <div class="pf-u-display-flex pf-u-justify-content-center">
                     <div class="pf-u-w-75">
                         <div class="pf-c-card">
@@ -152,7 +157,7 @@ export class RadiusProviderViewPage extends AKElement {
                         <ak-object-changelog
                             targetModelPk=${this.provider.pk || ""}
                             targetModelApp="authentik_providers_radius"
-                            targetModelName="RadiusProvider"
+                            targetModelName="radiusprovider"
                         >
                         </ak-object-changelog>
                     </div>

--- a/web/src/admin/providers/radius/RadiusProviderViewPage.ts
+++ b/web/src/admin/providers/radius/RadiusProviderViewPage.ts
@@ -79,11 +79,11 @@ export class RadiusProviderViewPage extends AKElement {
                 data-tab-title="${t`Overview`}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
-            ${this.provider?.outpostSet.length < 1
-                ? html`<div slot="header" class="pf-c-banner pf-m-warning">
-                      ${t`Warning: Provider is not used by any Outpost.`}
-                  </div>`
-                : html``}
+                ${this.provider?.outpostSet.length < 1
+                    ? html`<div slot="header" class="pf-c-banner pf-m-warning">
+                          ${t`Warning: Provider is not used by any Outpost.`}
+                      </div>`
+                    : html``}
                 <div class="pf-u-display-flex pf-u-justify-content-center">
                     <div class="pf-u-w-75">
                         <div class="pf-c-card">


### PR DESCRIPTION
same message as Proxy and LDAP provider have

<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://goauthentik.io/developer-docs/#how-can-i-contribute).
-->

## Details

Add a warning when a radius provider is not used by an outpost

## Changes

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
