### PR TITLE
root: add devcontainers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM ghcr.io/goauthentik/server:latest
+
+USER root
+
+RUN pip install --no-cache-dir -r /requirements-dev.txt

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,4 +2,6 @@ FROM ghcr.io/goauthentik/server:latest
 
 USER root
 
-RUN pip install --no-cache-dir -r /requirements-dev.txt
+HEALTHCHECK --interval=10s CMD exit 0
+
+RUN pip install --no-cache-dir -r /app-root/requirements-dev.txt

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+{
+    "name": "authentik",
+    "dockerComposeFile": "docker-compose.yml",
+    "service": "app",
+    "workspaceFolder": "/authentik",
+    "features": {
+        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+        "ghcr.io/devcontainers/features/go:1": {},
+        "ghcr.io/devcontainers/features/node:1": {}
+    },
+    "forwardPorts": [9000],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "EditorConfig.EditorConfig",
+                "bashmish.es6-string-css",
+                "bpruitt-goddard.mermaid-markdown-syntax-highlighting",
+                "dbaeumer.vscode-eslint",
+                "esbenp.prettier-vscode",
+                "golang.go",
+                "Gruntfuggly.todo-tree",
+                "mechatroner.rainbow-csv",
+                "ms-python.black-formatter",
+                "ms-python.isort",
+                "ms-python.pylint",
+                "ms-python.python",
+                "ms-python.vscode-pylance",
+                "redhat.vscode-yaml",
+                "Tobermory.es6-string-html",
+                "unifiedjs.vscode-mdx"
+            ]
+        }
+    }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
     "name": "authentik",
     "dockerComposeFile": "docker-compose.yml",
     "service": "app",
-    "workspaceFolder": "/authentik",
+    "workspaceFolder": "/app-root",
     "features": {
         "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
         "ghcr.io/devcontainers/features/go:1": {},

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.8'
+
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - ../:/authentik:cached
+    command: debug
+  db:
+    image: docker.io/library/postgres:15
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    network_mode: service:app
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_DB: postgres
+      POSTGRES_PASSWORD: postgres
+  redis:
+    image: docker.io/redis/redis-stack-server
+    restart: unless-stopped
+    network_mode: service:app
+
+volumes:
+  postgres-data:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,8 +6,13 @@ services:
       context: ..
       dockerfile: .devcontainer/Dockerfile
     volumes:
-      - ../:/authentik:cached
+      - ../:/app-root:cached
     command: debug
+    environment:
+      AUTHENTIK_POSTGRESQL__USER: postgres
+      AUTHENTIK_POSTGRESQL__PASSWORD: postgres
+      AUTHENTIK_BOOTSTRAP_PASSWORD: akadmin
+      AUTHENTIK_BOOTSTRAP_TOKEN: akadmin
   db:
     image: docker.io/library/postgres:15
     restart: unless-stopped
@@ -16,7 +21,7 @@ services:
     network_mode: service:app
     environment:
       POSTGRES_USER: postgres
-      POSTGRES_DB: postgres
+      POSTGRES_DB: authentik
       POSTGRES_PASSWORD: postgres
   redis:
     image: docker.io/redis/redis-stack-server

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,26 +3,23 @@
     "tasks": [
         {
             "label": "authentik[core]: format & test",
-            "command": "poetry",
-            "args": [
-                "run",
-                "make"
-            ],
+            "command": "make",
             "group": "build",
         },
         {
             "label": "authentik[core]: run",
-            "command": "poetry",
+            "command": "ak",
             "args": [
-                "run",
-                "make",
-                "run",
+                "server",
             ],
             "group": "build",
             "presentation": {
                 "panel": "dedicated",
                 "group": "running"
             },
+            "runOptions": {
+                "runOn": "folderOpen"
+            }
         },
         {
             "label": "authentik[web]: format",
@@ -39,6 +36,9 @@
                 "panel": "dedicated",
                 "group": "running"
             },
+            "runOptions": {
+                "runOn": "folderOpen"
+            }
         },
         {
             "label": "authentik: install",

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends libxmlsec1-openssl libmaxminddb0 && \
     # Required for bootstrap & healtcheck
     apt-get install -y --no-install-recommends runit && \
-    pip install --no-cache-dir -r /requirements.txt && \
+    pip install --no-cache-dir -r /app-root/requirements.txt && \
     apt-get remove --purge -y build-essential pkg-config libxmlsec1-dev && \
     apt-get autoremove --purge -y && \
     apt-get clean && \
@@ -111,7 +111,7 @@ USER 1000
 
 ENV TMPDIR /dev/shm/
 ENV PYTHONUNBUFFERED 1
-ENV PATH "/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/lifecycle"
+ENV PATH "/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/app-root/lifecycle"
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=60s --retries=3 CMD [ "ak", "healthcheck" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,14 +68,14 @@ LABEL org.opencontainers.image.url https://goauthentik.io
 LABEL org.opencontainers.image.description goauthentik.io Main server image, see https://goauthentik.io for more info.
 LABEL org.opencontainers.image.source https://github.com/goauthentik/authentik
 
-WORKDIR /
+WORKDIR /app-root
 
 ARG GIT_BUILD_HASH
 ENV GIT_BUILD_HASH=$GIT_BUILD_HASH
 
-COPY --from=poetry-locker /work/requirements.txt /
-COPY --from=poetry-locker /work/requirements-dev.txt /
-COPY --from=geoip /usr/share/GeoIP /geoip
+COPY --from=poetry-locker /work/requirements.txt /app-root
+COPY --from=poetry-locker /work/requirements-dev.txt /app-root
+COPY --from=geoip /usr/share/GeoIP /app-root/geoip
 
 RUN apt-get update && \
     # Required for installing pip packages
@@ -89,23 +89,23 @@ RUN apt-get update && \
     apt-get autoremove --purge -y && \
     apt-get clean && \
     rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/ && \
-    adduser --system --no-create-home --uid 1000 --group --home /authentik authentik && \
+    adduser --system --no-create-home --uid 1000 --group --home /app-root authentik && \
+    mkdir -p /app-root /app-root/.ssh && \
     mkdir -p /certs /media /blueprints && \
-    mkdir -p /authentik/.ssh && \
-    chown authentik:authentik /certs /media /authentik/.ssh
+    chown -R authentik:authentik /certs /media /app-root/
 
-COPY ./authentik/ /authentik
-COPY ./pyproject.toml /
-COPY ./schemas /schemas
-COPY ./locale /locale
-COPY ./tests /tests
-COPY ./manage.py /
+COPY ./authentik/ /app-root/authentik
+COPY ./pyproject.toml /app-root/
+COPY ./schemas /app-root/schemas
+COPY ./locale /app-root/locale
+COPY ./tests /app-root/tests
+COPY ./manage.py /app-root/
 COPY ./blueprints /blueprints
-COPY ./lifecycle/ /lifecycle
+COPY ./lifecycle/ /app-root/lifecycle
 COPY --from=go-builder /work/authentik /bin/authentik
-COPY --from=web-builder /work/web/dist/ /web/dist/
-COPY --from=web-builder /work/web/authentik/ /web/authentik/
-COPY --from=website-builder /work/website/help/ /website/help/
+COPY --from=web-builder /work/web/dist/ /app-root/web/dist/
+COPY --from=web-builder /work/web/authentik/ /app-root/web/authentik/
+COPY --from=website-builder /work/website/help/ /app-root/website/help/
 
 USER 1000
 
@@ -113,6 +113,6 @@ ENV TMPDIR /dev/shm/
 ENV PYTHONUNBUFFERED 1
 ENV PATH "/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/lifecycle"
 
-HEALTHCHECK --interval=30s --timeout=30s --start-period=60s --retries=3 CMD [ "/lifecycle/ak", "healthcheck" ]
+HEALTHCHECK --interval=30s --timeout=30s --start-period=60s --retries=3 CMD [ "ak", "healthcheck" ]
 
-ENTRYPOINT [ "/usr/local/bin/dumb-init", "--", "/lifecycle/ak" ]
+ENTRYPOINT [ "/usr/local/bin/dumb-init", "--", "ak" ]

--- a/authentik/lib/default.yml
+++ b/authentik/lib/default.yml
@@ -72,7 +72,7 @@ cookie_domain: null
 disable_update_check: false
 disable_startup_analytics: false
 avatars: env://AUTHENTIK_AUTHENTIK__AVATARS?gravatar,initials
-geoip: "/geoip/GeoLite2-City.mmdb"
+geoip: "/app-root/geoip/GeoLite2-City.mmdb"
 
 footer_links: []
 


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://goauthentik.io/developer-docs/#how-can-i-contribute).
-->

## Details

Improvement developer experience by having the option to use devcontainers for development

Includes all the development dependencies, a postgres and redis database, and doesn't require installing any dependencies on the host

For the actual container there's actually some pretty big changes, as currently we run a lot of things in the root folder of the container, which makes mapping them to the host harder. This PR also moves the root of authentik to `/app-root` (maybe it should be `/app`?)

This might (will?) be a breaking change for all the external mounts, which we could at the same time also move to all be subfolders under `/data` to keep things easier

somewhat relies on https://github.com/goauthentik/authentik/pull/13172

## Changes

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
