### PR TITLE
root: add install ID

### DIFF
--- a/authentik/core/models.py
+++ b/authentik/core/models.py
@@ -5,7 +5,6 @@ from typing import Any, Optional
 from uuid import uuid4
 
 from deepmerge import always_merger
-from django.conf import settings
 from django.contrib.auth.hashers import check_password
 from django.contrib.auth.models import AbstractUser
 from django.contrib.auth.models import UserManager as DjangoUserManager
@@ -33,6 +32,7 @@ from authentik.lib.models import (
 )
 from authentik.lib.utils.http import get_client_ip
 from authentik.policies.models import PolicyBindingModel
+from authentik.root.install_id import get_install_id
 
 LOGGER = get_logger()
 USER_ATTRIBUTE_DEBUG = "goauthentik.io/user/debug"
@@ -217,7 +217,7 @@ class User(SerializerModel, GuardianUserMixin, AbstractUser):
     @property
     def uid(self) -> str:
         """Generate a globally unique UID, based on the user ID and the hashed secret key"""
-        return sha256(f"{self.id}-{settings.SECRET_KEY}".encode("ascii")).hexdigest()
+        return sha256(f"{self.id}-{get_install_id()}".encode("ascii")).hexdigest()
 
     def locale(self, request: Optional[HttpRequest] = None) -> str:
         """Get the locale the user has configured"""

--- a/authentik/flows/views/inspector.py
+++ b/authentik/flows/views/inspector.py
@@ -23,6 +23,7 @@ from authentik.flows.api.bindings import FlowStageBindingSerializer
 from authentik.flows.models import Flow
 from authentik.flows.planner import FlowPlan
 from authentik.flows.views.executor import SESSION_KEY_HISTORY, SESSION_KEY_PLAN
+from authentik.root.install_id import get_install_id
 
 
 class FlowInspectorPlanSerializer(PassiveSerializer):
@@ -51,7 +52,7 @@ class FlowInspectorPlanSerializer(PassiveSerializer):
         """Get a unique session ID"""
         request: Request = self.context["request"]
         return sha256(
-            f"{request._request.session.session_key}-{settings.SECRET_KEY}".encode("ascii")
+            f"{request._request.session.session_key}-{get_install_id()}".encode("ascii")
         ).hexdigest()
 
 

--- a/authentik/root/install_id.py
+++ b/authentik/root/install_id.py
@@ -1,0 +1,13 @@
+"""install ID"""
+from functools import lru_cache
+
+from django.db import connection
+
+
+@lru_cache
+def get_install_id() -> str:
+    """Get install ID of this instance. The method is cached as the install ID is
+    not expected to change"""
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT id FROM authentik_install_id LIMIT 1;")
+        return cursor.fetchone()[0]

--- a/authentik/root/install_id.py
+++ b/authentik/root/install_id.py
@@ -1,8 +1,8 @@
 """install ID"""
-from uuid import uuid4
-from django.conf import settings
 from functools import lru_cache
+from uuid import uuid4
 
+from django.conf import settings
 from django.db import connection
 
 

--- a/authentik/root/install_id.py
+++ b/authentik/root/install_id.py
@@ -1,4 +1,6 @@
 """install ID"""
+from uuid import uuid4
+from django.conf import settings
 from functools import lru_cache
 
 from django.db import connection
@@ -8,6 +10,8 @@ from django.db import connection
 def get_install_id() -> str:
     """Get install ID of this instance. The method is cached as the install ID is
     not expected to change"""
+    if settings.TEST:
+        return str(uuid4())
     with connection.cursor() as cursor:
         cursor.execute("SELECT id FROM authentik_install_id LIMIT 1;")
         return cursor.fetchone()[0]

--- a/authentik/root/middleware.py
+++ b/authentik/root/middleware.py
@@ -22,6 +22,7 @@ from authentik.root.install_id import get_install_id
 LOGGER = get_logger("authentik.asgi")
 ACR_AUTHENTIK_SESSION = "goauthentik.io/core/default"
 
+
 @lru_cache
 def get_signing_hash():
     """Get cookie JWT signing hash"""

--- a/authentik/root/middleware.py
+++ b/authentik/root/middleware.py
@@ -1,4 +1,5 @@
 """Dynamically set SameSite depending if the upstream connection is TLS or not"""
+from functools import lru_cache
 from hashlib import sha512
 from time import time
 from timeit import default_timer
@@ -20,7 +21,11 @@ from authentik.root.install_id import get_install_id
 
 LOGGER = get_logger("authentik.asgi")
 ACR_AUTHENTIK_SESSION = "goauthentik.io/core/default"
-SIGNING_HASH = sha512(get_install_id().encode()).hexdigest()
+
+@lru_cache
+def get_signing_hash():
+    """Get cookie JWT signing hash"""
+    return sha512(get_install_id().encode()).hexdigest()
 
 
 class SessionMiddleware(UpstreamSessionMiddleware):
@@ -48,7 +53,7 @@ class SessionMiddleware(UpstreamSessionMiddleware):
         # for testing setups, where the session is directly set
         session_key = key if settings.TEST else None
         try:
-            session_payload = decode(key, SIGNING_HASH, algorithms=["HS256"])
+            session_payload = decode(key, get_signing_hash(), algorithms=["HS256"])
             session_key = session_payload["sid"]
         except (KeyError, PyJWTError):
             pass
@@ -115,7 +120,7 @@ class SessionMiddleware(UpstreamSessionMiddleware):
                     }
                     if request.user.is_authenticated:
                         payload["sub"] = request.user.uid
-                    value = encode(payload=payload, key=SIGNING_HASH)
+                    value = encode(payload=payload, key=get_signing_hash())
                     if settings.TEST:
                         value = request.session.session_key
                     response.set_cookie(

--- a/authentik/root/middleware.py
+++ b/authentik/root/middleware.py
@@ -16,10 +16,11 @@ from jwt import PyJWTError, decode, encode
 from structlog.stdlib import get_logger
 
 from authentik.lib.utils.http import get_client_ip
+from authentik.root.install_id import get_install_id
 
 LOGGER = get_logger("authentik.asgi")
 ACR_AUTHENTIK_SESSION = "goauthentik.io/core/default"
-SIGNING_HASH = sha512(settings.SECRET_KEY.encode()).hexdigest()
+SIGNING_HASH = sha512(get_install_id().encode()).hexdigest()
 
 
 class SessionMiddleware(UpstreamSessionMiddleware):

--- a/authentik/stages/authenticator_validate/stage.py
+++ b/authentik/stages/authenticator_validate/stage.py
@@ -20,6 +20,7 @@ from authentik.flows.models import FlowDesignation, NotConfiguredAction, Stage
 from authentik.flows.planner import PLAN_CONTEXT_PENDING_USER
 from authentik.flows.stage import ChallengeStageView
 from authentik.lib.utils.time import timedelta_from_string
+from authentik.root.install_id import get_install_id
 from authentik.stages.authenticator_sms.models import SMSDevice
 from authentik.stages.authenticator_validate.challenge import (
     DeviceChallenge,
@@ -316,7 +317,7 @@ class AuthenticatorValidateStageView(ChallengeStageView):
     def cookie_jwt_key(self) -> str:
         """Signing key for MFA Cookie for this stage"""
         return sha256(
-            f"{settings.SECRET_KEY}:{self.executor.current_stage.pk.hex}".encode("ascii")
+            f"{get_install_id()}:{self.executor.current_stage.pk.hex}".encode("ascii")
         ).hexdigest()
 
     def check_mfa_cookie(self, allowed_devices: list[Device]):

--- a/authentik/stages/authenticator_validate/tests/test_totp.py
+++ b/authentik/stages/authenticator_validate/tests/test_totp.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 from hashlib import sha256
 from time import sleep
 
-from django.conf import settings
 from django.test.client import RequestFactory
 from django.urls.base import reverse
 from django_otp.oath import TOTP
@@ -17,6 +16,7 @@ from authentik.flows.stage import StageView
 from authentik.flows.tests import FlowTestCase
 from authentik.flows.views.executor import FlowExecutorView
 from authentik.lib.generators import generate_id
+from authentik.root.install_id import get_install_id
 from authentik.stages.authenticator_validate.challenge import (
     get_challenge_for_device,
     validate_challenge_code,
@@ -194,7 +194,7 @@ class AuthenticatorValidateStageTOTPTests(FlowTestCase):
                 "stage": stage.pk.hex + generate_id(),
                 "exp": (datetime.now() + timedelta(days=3)).timestamp(),
             },
-            key=sha256(f"{settings.SECRET_KEY}:{stage.pk.hex}".encode("ascii")).hexdigest(),
+            key=sha256(f"{get_install_id()}:{stage.pk.hex}".encode("ascii")).hexdigest(),
         )
         response = self.client.post(
             reverse("authentik_api:flow-executor", kwargs={"flow_slug": self.flow.slug}),
@@ -233,7 +233,7 @@ class AuthenticatorValidateStageTOTPTests(FlowTestCase):
                 "stage": stage.pk.hex,
                 "exp": (datetime.now() + timedelta(days=3)).timestamp(),
             },
-            key=sha256(f"{settings.SECRET_KEY}:{stage.pk.hex}".encode("ascii")).hexdigest(),
+            key=sha256(f"{get_install_id()}:{stage.pk.hex}".encode("ascii")).hexdigest(),
         )
         response = self.client.post(
             reverse("authentik_api:flow-executor", kwargs={"flow_slug": self.flow.slug}),
@@ -272,7 +272,7 @@ class AuthenticatorValidateStageTOTPTests(FlowTestCase):
                 "stage": stage.pk.hex,
                 "exp": (datetime.now() - timedelta(days=3)).timestamp(),
             },
-            key=sha256(f"{settings.SECRET_KEY}:{stage.pk.hex}".encode("ascii")).hexdigest(),
+            key=sha256(f"{get_install_id()}:{stage.pk.hex}".encode("ascii")).hexdigest(),
         )
         response = self.client.post(
             reverse("authentik_api:flow-executor", kwargs={"flow_slug": self.flow.slug}),

--- a/lifecycle/gunicorn.conf.py
+++ b/lifecycle/gunicorn.conf.py
@@ -15,6 +15,7 @@ from authentik import get_full_version
 from authentik.lib.config import CONFIG
 from authentik.lib.utils.http import get_http_session
 from authentik.lib.utils.reflection import get_env
+from authentik.root.install_id import get_install_id
 from lifecycle.worker import DjangoUvicornWorker
 
 if TYPE_CHECKING:
@@ -148,9 +149,7 @@ if not CONFIG.y_bool("disable_startup_analytics", False):
                     ),
                 },
                 headers={
-                    "User-Agent": sha512(str(CONFIG.y("secret_key")).encode("ascii")).hexdigest()[
-                        :16
-                    ],
+                    "User-Agent": sha512(get_install_id().encode("ascii")).hexdigest()[:16],
                     "Content-Type": "application/json",
                 },
                 timeout=5,

--- a/lifecycle/system_migrations/install_id.py
+++ b/lifecycle/system_migrations/install_id.py
@@ -18,12 +18,10 @@ class Migration(BaseMigration):
         )
         return not bool(self.cur.rowcount)
 
-    def run(self):
-        self.cur.execute("select count(*) from django_migrations;")
-        migrations = self.cur.fetchone()[0]
+    def upgrade(self, migrate=False):
         self.cur.execute(SQL_STATEMENT)
         self.con.commit()
-        if migrations > 0:
+        if migrate:
             # If we already have migrations in the database, assume we're upgrading an existing install
             # and set the install id to the secret key
             self.cur.execute(
@@ -34,3 +32,14 @@ class Migration(BaseMigration):
             install_id = str(uuid4())
             self.cur.execute("INSERT INTO authentik_install_id (id) VALUES (%s)", (install_id,))
         self.con.commit()
+
+    def run(self):
+        self.cur.execute(
+            "select * from information_schema.tables where table_name = 'django_migrations';"
+        )
+        if not bool(self.cur.rowcount):
+            # No django_migrations table, so generate a new id
+            return self.upgrade(migrate=False)
+        self.cur.execute("select count(*) from django_migrations;")
+        migrations = self.cur.fetchone()[0]
+        return self.upgrade(migrate=migrations > 0)

--- a/lifecycle/system_migrations/install_id.py
+++ b/lifecycle/system_migrations/install_id.py
@@ -1,0 +1,36 @@
+# flake8: noqa
+from uuid import uuid4
+
+from authentik.lib.config import CONFIG
+from lifecycle.migrate import BaseMigration
+
+SQL_STATEMENT = """BEGIN TRANSACTION;
+CREATE TABLE IF NOT EXISTS authentik_install_id (
+    id TEXT NOT NULL
+);
+COMMIT;"""
+
+
+class Migration(BaseMigration):
+    def needs_migration(self) -> bool:
+        self.cur.execute(
+            "select * from information_schema.tables where table_name = 'authentik_install_id';"
+        )
+        return not bool(self.cur.rowcount)
+
+    def run(self):
+        self.cur.execute("select count(*) from django_migrations;")
+        migrations = self.cur.fetchone()[0]
+        self.cur.execute(SQL_STATEMENT)
+        self.con.commit()
+        if migrations > 0:
+            # If we already have migrations in the database, assume we're upgrading an existing install
+            # and set the install id to the secret key
+            self.cur.execute(
+                "INSERT INTO authentik_install_id (id) VALUES (%s)", (CONFIG.y("secret_key"),)
+            )
+        else:
+            # Otherwise assume a new install, generate an install ID based on a UUID
+            install_id = str(uuid4())
+            self.cur.execute("INSERT INTO authentik_install_id (id) VALUES (%s)", (install_id,))
+        self.con.commit()


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://goauthentik.io/developer-docs/#how-can-i-contribute).
-->

## Details

Instead of using the secret key in various places as a unique identifier for hashes, use a separate identifier. This allows us to rotate the secret key in the future (using https://docs.djangoproject.com/en/4.2/ref/settings/#std-setting-SECRET_KEY_FALLBACKS)

Also this will be used in the future for enterprise licenses

By default when upgrading an existing instance (i.e. there are entries in the django_migrations table) we use the current secret_key as install ID to keep backwards compatibility with user IDs etc, if there are no migrations then we generate a new install ID

## Changes

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
