### PR TITLE
web/user: fix broken search on application library

### DIFF
--- a/web/src/user/LibraryPage/ApplicationSearch.ts
+++ b/web/src/user/LibraryPage/ApplicationSearch.ts
@@ -16,10 +16,6 @@ import type { Application } from "@goauthentik/api";
 import { SEARCH_ITEM_SELECTED, SEARCH_UPDATED } from "./constants";
 import { customEvent } from "./helpers";
 
-function fuseToApps(apps: Fuse.FuseResult<Application>[]): Application[] {
-    return apps.map((item) => item.item);
-}
-
 @customElement("ak-library-list-search")
 export class LibraryPageApplicationList extends AKElement {
     static styles = [PFBase, PFDisplay];
@@ -55,16 +51,15 @@ export class LibraryPageApplicationList extends AKElement {
     }
 
     onSelected(apps: Fuse.FuseResult<Application>[]) {
-        const items = fuseToApps(apps);
         this.dispatchEvent(
             customEvent(SEARCH_UPDATED, {
-                selectedApp: items[0],
-                filteredApps: items,
+                apps: apps.map((app) => app.item),
             }),
         );
     }
 
     connectedCallback() {
+        super.connectedCallback();
         this.fuse.setCollection(this.apps);
         if (!this.query) {
             return;

--- a/web/src/user/LibraryPage/LibraryPageImpl.ts
+++ b/web/src/user/LibraryPage/LibraryPageImpl.ts
@@ -85,8 +85,13 @@ export class LibraryPage extends AKElement {
             throw new Error("ak-library-search-updated must send a custom event.");
         }
         event.stopPropagation();
-        this.selectedApp = event.detail.apps[0];
-        this.filteredApps = event.detail.apps;
+        const apps = event.detail.apps;
+        this.selectedApp = undefined;
+        this.filteredApps = this.apps.results;
+        if (apps.length > 0) {
+            this.selectedApp = apps[0];
+            this.filteredApps = event.detail.apps;
+        }
     }
 
     launchRequest(event: Event) {
@@ -125,7 +130,7 @@ export class LibraryPage extends AKElement {
     }
 
     renderSearch() {
-        return html`<ak-library-list-search .apps="{this.apps.results}"></ak-library-list-search>`;
+        return html`<ak-library-list-search .apps=${this.apps.results}></ak-library-list-search>`;
     }
 
     render() {


### PR DESCRIPTION
This is *mortifying*.  I didn't test this well enough, and apparently broke it again once I'd tested it.  This patch restores the original behavior ("no match" means "just show everything"), and fixes a small bit of semantic lint -- the "search" feature should not be assigning meaning to what it finds; it's enough to pass back the prioritized list to whatever client wanted it, and let the client decide what to do with it.

<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://goauthentik.io/developer-docs/#how-can-i-contribute).
-->

## Details

-   **Does this resolve an issue?**
    
Resolves #5171

## Changes

Fixes the search feature so that the data being passed back and forth correspond to the design.

-   [X] Local tests pass (`ak test authentik/`)
-   [X] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [X] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [X] The code has been formatted (`make web`)
-   [X] The translation files have been updated (`make i18n-extract`)
