### PR TITLE
web/user: fix MFA enroll dropdown broken when password stage has no configuration flow

### DIFF
--- a/web/src/user/user-settings/UserSettingsPage.ts
+++ b/web/src/user/user-settings/UserSettingsPage.ts
@@ -75,9 +75,9 @@ export class UserSettingsPage extends AKElement {
     }
 
     render(): TemplateResult {
-        const pwStage = this.userSettings?.filter(
-            (stage) => stage.component === "ak-user-settings-password",
-        );
+        const pwStage =
+            this.userSettings?.filter((stage) => stage.component === "ak-user-settings-password") ||
+            [];
         return html`<div class="pf-c-page">
             <main role="main" class="pf-c-page__main" tabindex="-1">
                 <ak-tabs ?vertical="${true}">
@@ -91,7 +91,7 @@ export class UserSettingsPage extends AKElement {
                                 <ak-user-settings-flow-executor></ak-user-settings-flow-executor>
                             </div>
                             <div class="pf-l-stack__item">
-                                ${pwStage
+                                ${pwStage.length > 0
                                     ? html`<ak-user-settings-password
                                           configureUrl=${ifDefined(pwStage[0].configureUrl)}
                                       ></ak-user-settings-password>`


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://goauthentik.io/developer-docs/#how-can-i-contribute).
-->

## Details

Without a configuration flow in the password stage, the MFA enroll dropdown is broken

## Changes

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
