### PR TITLE
website/docs: add Note about wget command

### DIFF
--- a/website/docs/releases/2023/v2023.5.md
+++ b/website/docs/releases/2023/v2023.5.md
@@ -41,11 +41,9 @@ This release does not introduce any new requirements.
 
 Download the docker-compose file for 2023.5 from [here](https://goauthentik.io/version/2023.5/docker-compose.yml). Afterwards, run `docker-compose up -d`.
 
-:::info
-To download the latest `docker-compose.yml` file you can use the `wget` command followed by the file's location URL.
+To download the latest `docker-compose.yml` file you can use the `wget` command followed by the file's location URL. The `-O` flag retains the downloaded file's name, overwriting any existing local file with the same name.
 
 Example: `wget -O docker-compose.yml https://goauthentik.io/docker-compose.yml`
-:::
 
 ### Kubernetes
 

--- a/website/docs/releases/2023/v2023.5.md
+++ b/website/docs/releases/2023/v2023.5.md
@@ -39,11 +39,14 @@ This release does not introduce any new requirements.
 
 ### docker-compose
 
-Download the docker-compose file for 2023.5 from [here](https://goauthentik.io/version/2023.5/docker-compose.yml). Afterwards, run `docker-compose up -d`.
+To upgrade, download the new docker-compose file and update the Docker stack with the new version, using these commands:
 
-To download the latest `docker-compose.yml` file you can use the `wget` command followed by the file's location URL. The `-O` flag retains the downloaded file's name, overwriting any existing local file with the same name.
+```
+wget -O docker-compose.yml https://goauthentik.io/version/2023.5/docker-compose.yml
+docker-compose up -d
+```
 
-Example: `wget -O docker-compose.yml https://goauthentik.io/docker-compose.yml`
+The `-O` flag retains the downloaded file's name, overwriting any existing local file with the same name.
 
 ### Kubernetes
 

--- a/website/docs/releases/2023/v2023.5.md
+++ b/website/docs/releases/2023/v2023.5.md
@@ -39,7 +39,13 @@ This release does not introduce any new requirements.
 
 ### docker-compose
 
-Download the docker-compose file for 2023.5 from [here](https://goauthentik.io/version/2023.5/docker-compose.yml). Afterwards, simply run `docker-compose up -d`.
+Download the docker-compose file for 2023.5 from [here](https://goauthentik.io/version/2023.5/docker-compose.yml). Afterwards, run `docker-compose up -d`.
+
+:::info
+To download the latest `docker-compose.yml` file you can use the `wget` command followed by the file's location URL.
+
+Example: `wget -O docker-compose.yml https://goauthentik.io/docker-compose.yml`
+:::
 
 ### Kubernetes
 

--- a/website/docs/releases/_template.md
+++ b/website/docs/releases/_template.md
@@ -13,7 +13,13 @@ This release does not introduce any new requirements.
 
 ### docker-compose
 
-Download the docker-compose file for xxxx.x from [here](https://goauthentik.io/version/xxxx.x/docker-compose.yml). Afterwards, simply run `docker-compose up -d`.
+Download the docker-compose file for xxxx.x from [here](https://goauthentik.io/version/xxxx.x/docker-compose.yml). Afterwards, run `docker-compose up -d`.
+
+:::info
+To download the latest `docker-compose.yml` file you can use the `wget` command followed by the file's location URL.
+
+Example: `wget -O docker-compose.yml https://goauthentik.io/docker-compose.yml`
+:::
 
 ### Kubernetes
 

--- a/website/docs/releases/_template.md
+++ b/website/docs/releases/_template.md
@@ -15,11 +15,9 @@ This release does not introduce any new requirements.
 
 Download the docker-compose file for xxxx.x from [here](https://goauthentik.io/version/xxxx.x/docker-compose.yml). Afterwards, run `docker-compose up -d`.
 
-:::info
-To download the latest `docker-compose.yml` file you can use the `wget` command followed by the file's location URL.
+To download the latest `docker-compose.yml` file you can use the `wget` command followed by the file's location URL. The `-O` flag retains the downloaded file's name, overwriting any existing local file with the same name.
 
 Example: `wget -O docker-compose.yml https://goauthentik.io/docker-compose.yml`
-:::
 
 ### Kubernetes
 

--- a/website/docs/releases/_template.md
+++ b/website/docs/releases/_template.md
@@ -13,11 +13,14 @@ This release does not introduce any new requirements.
 
 ### docker-compose
 
-Download the docker-compose file for xxxx.x from [here](https://goauthentik.io/version/xxxx.x/docker-compose.yml). Afterwards, run `docker-compose up -d`.
+To upgrade, download the new docker-compose file and update the Docker stack with the new version, using these commands:
 
-To download the latest `docker-compose.yml` file you can use the `wget` command followed by the file's location URL. The `-O` flag retains the downloaded file's name, overwriting any existing local file with the same name.
+```
+wget -O docker-compose.yml https://goauthentik.io/version/xxxx.x/docker-compose.yml
+docker-compose up -d
+```
 
-Example: `wget -O docker-compose.yml https://goauthentik.io/docker-compose.yml`
+The `-O` flag retains the downloaded file's name, overwriting any existing local file with the same name.
 
 ### Kubernetes
 


### PR DESCRIPTION


## Changes
Added a Note to the latest Release Notes and to the template, to suggest using the `wget` command to download the latest docker-compose file.

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
