### PR TITLE
web/flows: fix RedirectStage not detecting absolute URLs correctly

### DIFF
--- a/web/src/flow/stages/RedirectStage.ts
+++ b/web/src/flow/stages/RedirectStage.ts
@@ -39,13 +39,7 @@ export class RedirectStage extends BaseStage<RedirectChallenge, FlowChallengeRes
     }
 
     getURL(): string {
-        var urlPattern = /^((http|https):\/\/)/;
-
-        if(!urlPattern.test(this.challenge.to)) {
-            return window.location.origin + this.challenge.to;
-        }
-
-        return this.challenge.to;
+        return new URL(this.challenge.to, document.baseURI).toString();
     }
 
     firstUpdated(): void {

--- a/web/src/flow/stages/RedirectStage.ts
+++ b/web/src/flow/stages/RedirectStage.ts
@@ -39,9 +39,12 @@ export class RedirectStage extends BaseStage<RedirectChallenge, FlowChallengeRes
     }
 
     getURL(): string {
-        if (!this.challenge.to.includes("://")) {
+        var urlPattern = /^((http|https):\/\/)/;
+
+        if(!urlPattern.test(this.challenge.to)) {
             return window.location.origin + this.challenge.to;
         }
+
         return this.challenge.to;
     }
 


### PR DESCRIPTION
## Details

-   **Does this resolve an issue?**
    Resolves #5732

## Changes

### New Features

-   `getURL()` method in `RedirectStage.ts` now actually detects URLs

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
