### PR TITLE
blueprints: allow setting user's passwords from blueprints

### DIFF
--- a/authentik/blueprints/tests/fixtures/conditional_fields.yaml
+++ b/authentik/blueprints/tests/fixtures/conditional_fields.yaml
@@ -11,31 +11,37 @@ metadata:
 entries:
   - model: authentik_core.token
     identifiers:
-      identifier: %(uid)s-token
+      identifier: "%(uid)s-token"
     attrs:
-      key: %(uid)s
-      user: %(user)s
+      key: "%(uid)s"
+      user: "%(user)s"
       intent: api
   - model: authentik_core.application
     identifiers:
-      slug: %(uid)s-app
+      slug: "%(uid)s-app"
     attrs:
-      name: %(uid)s-app
+      name: "%(uid)s-app"
       icon: https://goauthentik.io/img/icon.png
   - model: authentik_sources_oauth.oauthsource
     identifiers:
-      slug: %(uid)s-source
+      slug: "%(uid)s-source"
     attrs:
-      name: %(uid)s-source
+      name: "%(uid)s-source"
       provider_type: azuread
-      consumer_key: %(uid)s
-      consumer_secret: %(uid)s
+      consumer_key: "%(uid)s"
+      consumer_secret: "%(uid)s"
       icon: https://goauthentik.io/img/icon.png
   - model: authentik_flows.flow
     identifiers:
-      slug: %(uid)s-flow
+      slug: "%(uid)s-flow"
     attrs:
-      name: %(uid)s-flow
-      title: %(uid)s-flow
+      name: "%(uid)s-flow"
+      title: "%(uid)s-flow"
       designation: authentication
       background: https://goauthentik.io/img/icon.png
+  - model: authentik_core.user
+    identifiers:
+      username: "%(uid)s"
+    attrs:
+      name: "%(uid)s"
+      password: "%(uid)s"

--- a/authentik/blueprints/tests/test_v1_conditional_fields.py
+++ b/authentik/blueprints/tests/test_v1_conditional_fields.py
@@ -2,7 +2,7 @@
 from django.test import TransactionTestCase
 
 from authentik.blueprints.v1.importer import Importer
-from authentik.core.models import Application, Token
+from authentik.core.models import Application, Token, User
 from authentik.core.tests.utils import create_test_admin_user
 from authentik.flows.models import Flow
 from authentik.lib.generators import generate_id
@@ -45,3 +45,9 @@ class TestBlueprintsV1ConditionalFields(TransactionTestCase):
         flow = Flow.objects.filter(slug=f"{self.uid}-flow").first()
         self.assertIsNotNone(flow)
         self.assertEqual(flow.background, "https://goauthentik.io/img/icon.png")
+
+    def test_user(self):
+        """Test user"""
+        user: User = User.objects.filter(username=self.uid).first()
+        self.assertIsNotNone(user)
+        self.assertTrue(user.check_password(self.uid))

--- a/authentik/blueprints/v1/tasks.py
+++ b/authentik/blueprints/v1/tasks.py
@@ -184,9 +184,9 @@ def apply_blueprint(self: MonitoredTask, instance_pk: str):
     instance: Optional[BlueprintInstance] = None
     try:
         instance: BlueprintInstance = BlueprintInstance.objects.filter(pk=instance_pk).first()
-        self.set_uid(slugify(instance.name))
         if not instance or not instance.enabled:
             return
+        self.set_uid(slugify(instance.name))
         blueprint_content = instance.retrieve()
         file_hash = sha512(blueprint_content.encode()).hexdigest()
         importer = Importer(blueprint_content, instance.context)

--- a/authentik/core/api/tokens.py
+++ b/authentik/core/api/tokens.py
@@ -33,7 +33,7 @@ class TokenSerializer(ManagedSerializer, ModelSerializer):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         if SERIALIZER_CONTEXT_BLUEPRINT in self.context:
-            self.fields["key"] = CharField()
+            self.fields["key"] = CharField(required=False)
 
     def validate(self, attrs: dict[Any, str]) -> dict[Any, str]:
         """Ensure only API or App password tokens are created."""

--- a/blueprints/schema.json
+++ b/blueprints/schema.json
@@ -8228,6 +8228,11 @@
                     "type": "string",
                     "minLength": 1,
                     "title": "Path"
+                },
+                "password": {
+                    "type": "string",
+                    "minLength": 1,
+                    "title": "Password"
                 }
             },
             "required": []

--- a/website/developer-docs/blueprints/v1/models.md
+++ b/website/developer-docs/blueprints/v1/models.md
@@ -26,6 +26,29 @@ For example:
       intent: api
 ```
 
+### `authentik_core.user`
+
+:::info
+Requires authentik 2023.6
+:::
+
+Via the standard API, a user's password can only be set via the separate `/api/v3/core/users/<id>/set_password/` endpoint. In blueprints, the password of a user can be set using the `password` field.
+
+Keep in mind that if an LDAP Source is configured and the user maps to an LDAP user, this password change will be propagated to the LDAP server.
+
+For example:
+
+```yaml
+# [...]
+- model: authentik_core.user
+  state: present
+  identifiers:
+      username: test-user
+  attrs:
+      name: test user
+      password: this-should-be-a-long-value
+```
+
 ### `authentik_core.application`
 
 :::info


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://goauthentik.io/developer-docs/#how-can-i-contribute).
-->

## Details

closes #5700

### New Features

- Allow changing the users password from blueprints

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [x] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
