### PR TITLE
outposts/ldap: fix race condition when refreshing the provider

### DIFF
--- a/.github/workflows/ci-outpost.yml
+++ b/.github/workflows/ci-outpost.yml
@@ -29,7 +29,8 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          args: --timeout 5000s
+          version: v1.52.2
+          args: --timeout 5000s --verbose
           skip-pkg-cache: true
   test-unittest:
     runs-on: ubuntu-latest

--- a/internal/outpost/ldap/instance.go
+++ b/internal/outpost/ldap/instance.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/nmcclain/ldap"
 	log "github.com/sirupsen/logrus"
+
 	"goauthentik.io/api/v3"
 	"goauthentik.io/internal/constants"
 	"goauthentik.io/internal/outpost/ldap/bind"
@@ -39,7 +40,7 @@ type ProviderInstance struct {
 	outpostName         string
 	outpostPk           int32
 	searchAllowedGroups []*strfmt.UUID
-	boundUsersMutex     sync.RWMutex
+	boundUsersMutex     *sync.RWMutex
 	boundUsers          map[string]*flags.UserFlags
 
 	uidStartNumber int32

--- a/internal/outpost/ldap/refresh.go
+++ b/internal/outpost/ldap/refresh.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	log "github.com/sirupsen/logrus"
+
 	"goauthentik.io/api/v3"
 	"goauthentik.io/internal/outpost/ldap/bind"
 	directbind "goauthentik.io/internal/outpost/ldap/bind/direct"
@@ -56,11 +57,12 @@ func (ls *LDAPServer) Refresh() error {
 
 		// Get existing instance so we can transfer boundUsers
 		existing := ls.getCurrentProvider(provider.Pk)
+		usersMutex := &sync.RWMutex{}
 		users := make(map[string]*flags.UserFlags)
 		if existing != nil {
-			existing.boundUsersMutex.RLock()
+			usersMutex = existing.boundUsersMutex
+			// Shallow copy, no need to lock
 			users = existing.boundUsers
-			existing.boundUsersMutex.RUnlock()
 		}
 
 		providers[idx] = &ProviderInstance{
@@ -72,7 +74,7 @@ func (ls *LDAPServer) Refresh() error {
 			authenticationFlowSlug: provider.BindFlowSlug,
 			invalidationFlowSlug:   invalidationFlow,
 			searchAllowedGroups:    []*strfmt.UUID{(*strfmt.UUID)(provider.SearchGroup.Get())},
-			boundUsersMutex:        sync.RWMutex{},
+			boundUsersMutex:        usersMutex,
 			boundUsers:             users,
 			s:                      ls,
 			log:                    logger,


### PR DESCRIPTION
## Details

Fixes the race condition causing the crash found in #4138, which doesn't actually have anything to do with the issue itself

As far as I can work out, when the outpost refreshes its list of providers, it copies over its `boundUsers`, probably to avoid having to fetch them all again, and does so by making a shallow copy of that `map`, but not the mutex associated with it. It now has multiple references to the same map, each protected by a different mutex, which under certain conditions can cause a `concurrent map read and map write` error.

The fix replaces the duo map + mutex with a reference to a `sync.Map` which does basically the same thing, but internally. We now don't need to worry about properly copying the mutex and such, as it is handled by `sync.Map`.

## Changes

### New Features

None

### Breaking Changes

None

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [x] N/A The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] N/A The code has been formatted (`make web`)
-   [x] N/A The translation files have been updated (`make i18n-extract`)

If applicable

-   [x] N/A The documentation has been updated
-   [x] N/A The documentation has been formatted (`make website`)
