### PR TITLE
providers/oauth2: launch url: if URL parsing fails, return no launch URL

### DIFF
--- a/authentik/core/models.py
+++ b/authentik/core/models.py
@@ -376,10 +376,10 @@ class Application(SerializerModel, PolicyBindingModel):
     def get_launch_url(self, user: Optional["User"] = None) -> Optional[str]:
         """Get launch URL if set, otherwise attempt to get launch URL based on provider."""
         url = None
-        if provider := self.get_provider():
-            url = provider.launch_url
         if self.meta_launch_url:
             url = self.meta_launch_url
+        elif provider := self.get_provider():
+            url = provider.launch_url
         if user and url:
             if isinstance(user, SimpleLazyObject):
                 user._setup()

--- a/authentik/providers/oauth2/models.py
+++ b/authentik/providers/oauth2/models.py
@@ -17,6 +17,7 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from jwt import encode
 from rest_framework.serializers import Serializer
+from structlog.stdlib import get_logger
 
 from authentik.core.models import ExpiringModel, PropertyMapping, Provider, User
 from authentik.crypto.models import CertificateKeyPair
@@ -25,6 +26,8 @@ from authentik.lib.models import SerializerModel
 from authentik.lib.utils.time import timedelta_string_validator
 from authentik.providers.oauth2.id_token import IDToken, SubModes
 from authentik.sources.oauth.models import OAuthSource
+
+LOGGER = get_logger()
 
 
 def generate_client_secret() -> str:
@@ -254,7 +257,9 @@ class OAuth2Provider(Provider):
         try:
             launch_url = urlparse(main_url)._replace(path="")
             return urlunparse(launch_url)
-        except ValueError:
+        # pylint: disable=broad-except
+        except Exception as exc:
+            LOGGER.warning("Failed to format launch url", exc=exc)
             return None
 
     @property

--- a/authentik/providers/oauth2/models.py
+++ b/authentik/providers/oauth2/models.py
@@ -257,8 +257,7 @@ class OAuth2Provider(Provider):
         try:
             launch_url = urlparse(main_url)._replace(path="")
             return urlunparse(launch_url)
-        # pylint: disable=broad-except
-        except Exception as exc:
+        except ValueError as exc:
             LOGGER.warning("Failed to format launch url", exc=exc)
             return None
 

--- a/authentik/providers/oauth2/models.py
+++ b/authentik/providers/oauth2/models.py
@@ -251,8 +251,11 @@ class OAuth2Provider(Provider):
         if self.redirect_uris == "":
             return None
         main_url = self.redirect_uris.split("\n", maxsplit=1)[0]
-        launch_url = urlparse(main_url)._replace(path="")
-        return urlunparse(launch_url)
+        try:
+            launch_url = urlparse(main_url)._replace(path="")
+            return urlunparse(launch_url)
+        except ValueError:
+            return None
 
     @property
     def component(self) -> str:

--- a/authentik/providers/oauth2/tests/test_api.py
+++ b/authentik/providers/oauth2/tests/test_api.py
@@ -46,7 +46,7 @@ class TestAPI(APITestCase):
         self.assertEqual(body["issuer"], "http://testserver/application/o/test/")
 
     # https://github.com/goauthentik/authentik/pull/5918
-    @skipUnless(version_info >= (3, 11,4), "This behaviour is only Python 3.11.4 and up")
+    @skipUnless(version_info >= (3, 11, 4), "This behaviour is only Python 3.11.4 and up")
     def test_launch_url(self):
         """Test launch_url"""
         self.provider.redirect_uris = (

--- a/authentik/providers/oauth2/tests/test_api.py
+++ b/authentik/providers/oauth2/tests/test_api.py
@@ -1,5 +1,7 @@
 """Test OAuth2 API"""
 from json import loads
+from sys import version_info
+from unittest import skipUnless
 
 from django.urls import reverse
 from rest_framework.test import APITestCase
@@ -42,3 +44,14 @@ class TestAPI(APITestCase):
         self.assertEqual(response.status_code, 200)
         body = loads(response.content.decode())
         self.assertEqual(body["issuer"], "http://testserver/application/o/test/")
+
+    # https://github.com/goauthentik/authentik/pull/5918
+    @skipUnless(version_info >= (3, 11,4), "This behaviour is only Python 3.11.4 and up")
+    def test_launch_url(self):
+        """Test launch_url"""
+        self.provider.redirect_uris = (
+            "https://[\\d\\w]+.pr.test.goauthentik.io/source/oauth/callback/authentik/\n"
+        )
+        self.provider.save()
+        self.provider.refresh_from_db()
+        self.assertIsNone(self.provider.launch_url)


### PR DESCRIPTION
## Details

With a redirect URI such as `https://[\d\w]+.pr.test.goauthentik.io/source/oauth/callback/authentik/`, parsing fails with:

<details>
<summary>Stacktrace</summary>

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/asgiref/sync.py", line 472, in thread_handler
    raise exc_info[1]
  File "/usr/local/lib/python3.11/site-packages/django/core/handlers/base.py", line 253, in _get_response_async
    response = await wrapped_callback(
               ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/asgiref/sync.py", line 435, in __call__
    ret = await asyncio.wait_for(future, timeout=None)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/asyncio/tasks.py", line 442, in wait_for
    return await fut
           ^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/asgiref/current_thread_executor.py", line 22, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/asgiref/sync.py", line 476, in thread_handler
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/sentry_sdk/integrations/django/views.py", line 84, in sentry_wrapped_callback
    return callback(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/views/decorators/csrf.py", line 55, in wrapped_view
    return view_func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/rest_framework/viewsets.py", line 125, in view
    return self.dispatch(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/usr/local/lib/python3.11/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/usr/local/lib/python3.11/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/authentik/core/api/applications.py", line 217, in list
    return self.get_paginated_response(serializer.data)
                                       ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/rest_framework/serializers.py", line 768, in data
    ret = super().data
          ^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/rest_framework/serializers.py", line 253, in data
    self._data = self.to_representation(self.instance)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/rest_framework/serializers.py", line 686, in to_representation
    return [
           ^
  File "/usr/local/lib/python3.11/site-packages/rest_framework/serializers.py", line 687, in <listcomp>
    self.child.to_representation(item) for item in iterable
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/rest_framework/serializers.py", line 522, in to_representation
    ret[field.field_name] = field.to_representation(attribute)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/rest_framework/fields.py", line 1838, in to_representation
    return method(value)
           ^^^^^^^^^^^^^
  File "/authentik/core/api/applications.py", line 66, in get_launch_url
    return app.get_launch_url(user)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/authentik/core/models.py", line 380, in get_launch_url
    url = provider.launch_url
          ^^^^^^^^^^^^^^^^^^^
  File "/authentik/providers/oauth2/models.py", line 254, in launch_url
    launch_url = urlparse(main_url)._replace(path="")
                 ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/urllib/parse.py", line 395, in urlparse
    splitresult = urlsplit(url, scheme, allow_fragments)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/urllib/parse.py", line 500, in urlsplit
    _check_bracketed_host(bracketed_host)
  File "/usr/local/lib/python3.11/urllib/parse.py", line 446, in _check_bracketed_host
    ip = ipaddress.ip_address(hostname) # Throws Value Error if not IPv6 or IPv4
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/ipaddress.py", line 54, in ip_address
    raise ValueError(f'{address!r} does not appear to be an IPv4 or IPv6 address')
builtins.ValueError: '\\d\\w' does not appear to be an IPv4 or IPv6 address
```

</details>

This is a dirty hack to simply return None (i.e. no launch URL found) if said parsing fails. Feel free to do it a different way

## Changes

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
