### PR TITLE
ci: add workflow to automatically update next branch

### DIFF
--- a/.github/workflows/next-branch.yml
+++ b/.github/workflows/next-branch.yml
@@ -1,0 +1,20 @@
+name: next-branch
+
+on:
+  schedule:
+    - cron: "0 12 * * *" # every day at noon
+  workflow_dispatch:
+
+jobs:
+  update-next:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: main
+      - id: main-status
+        run: |
+          echo "::set-output name=status::$(curl -fsSL -o head_status.json -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ github.token}}" "https://api.github.com/repos/${{ github.repository }}/commits/HEAD/status" | jq -r '.state')"
+      - if: ${{ steps.main-status.outputs.status == 'success' }}
+        run: |
+          git push origin next --force

--- a/.github/workflows/release-next-branch.yml
+++ b/.github/workflows/release-next-branch.yml
@@ -1,4 +1,4 @@
-name: next-branch
+name: release-next-branch
 
 on:
   schedule:
@@ -8,13 +8,15 @@ on:
 jobs:
   update-next:
     runs-on: ubuntu-latest
+    environment: internal-production
     steps:
       - uses: actions/checkout@v3
         with:
           ref: main
       - id: main-status
         run: |
-          echo "::set-output name=status::$(curl -fsSL -o head_status.json -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ github.token}}" "https://api.github.com/repos/${{ github.repository }}/commits/HEAD/status" | jq -r '.state')"
+          status=$(curl -fsSL -o head_status.json -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ github.token}}" "https://api.github.com/repos/${{ github.repository }}/commits/HEAD/status" | jq -r '.status')
+          echo "status=${status}" >> $GITHUB_OUTPUT
       - if: ${{ steps.main-status.outputs.status == 'success' }}
         run: |
           git push origin next --force

--- a/.github/workflows/release-next-branch.yml
+++ b/.github/workflows/release-next-branch.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 12 * * *" # every day at noon
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   update-next:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Details

-  Resolves https://github.com/goauthentik/meta/issues/29

## Changes

Add workflow to automatically update the `next` branch, every day at noon UTC, and only if the CI passes on `main`.

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
