### PR TITLE
sources/ldap: fix duplicate bind when authenticating user directly to…

### DIFF
--- a/authentik/sources/ldap/auth.py
+++ b/authentik/sources/ldap/auth.py
@@ -57,13 +57,13 @@ class LDAPBackend(InbuiltBackend):
         # Try to bind as new user
         LOGGER.debug("Attempting to bind as user", user=user)
         try:
-            temp_connection = source.connection(
+            # source.connection also attempts to bind
+            source.connection(
                 connection_kwargs={
                     "user": user.attributes.get(LDAP_DISTINGUISHED_NAME),
                     "password": password,
                 }
             )
-            temp_connection.bind()
             return user
         except LDAPInvalidCredentialsResult as exc:
             LOGGER.debug("invalid LDAP credentials", user=user, exc=exc)

--- a/authentik/sources/ldap/models.py
+++ b/authentik/sources/ldap/models.py
@@ -145,7 +145,9 @@ class LDAPSource(Source):
         if self.start_tls:
             connection.start_tls(read_server_info=False)
         try:
-            connection.bind()
+            successful = connection.bind()
+            if successful:
+                return connection
         except LDAPSchemaError as exc:
             # Schema error, so try connecting without schema info
             # See https://github.com/goauthentik/authentik/issues/4590
@@ -153,7 +155,7 @@ class LDAPSource(Source):
                 raise exc
             server_kwargs["get_info"] = NONE
             return self.connection(server_kwargs, connection_kwargs)
-        return connection
+        return RuntimeError("Failed to bind")
 
     class Meta:
         verbose_name = _("LDAP Source")


### PR DESCRIPTION
… LDAP source

<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://goauthentik.io/developer-docs/#how-can-i-contribute).
-->

## Details

closes #5920

Ensure we don't double bind to LDAP when authenticating user, add test to prevent regression

## Changes

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
