### PR TITLE
outposts: configurable k8s affinity, tolerations, resources

### DIFF
--- a/authentik/outposts/models.py
+++ b/authentik/outposts/models.py
@@ -76,6 +76,9 @@ class OutpostConfig:
     kubernetes_service_type: str = field(default="ClusterIP")
     kubernetes_disabled_components: list[str] = field(default_factory=list)
     kubernetes_image_pull_secrets: list[str] = field(default_factory=list)
+    kubernetes_affinity: Optional[str] = field(default=None)
+    kubernetes_tolerations: Optional[str] = field(default=None)
+    kubernetes_resources: Optional[str] = field(default=None)
 
 
 class OutpostModel(Model):

--- a/tests/integration/test_outpost_kubernetes.py
+++ b/tests/integration/test_outpost_kubernetes.py
@@ -46,6 +46,10 @@ class OutpostKubernetesTests(TestCase):
 
         config = self.outpost.config
         config.kubernetes_replicas = 3
+        # pylint: disable=line-too-long
+        config.kubernetes_affinity = """{"nodeAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"preference":{"matchExpressions":[{"key":"node-label-key","operator":"In","values":["node-label-value"]}]},"weight":1}],"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"topology.kubernetes.io/region","operator":"In","values":["east1"]},{"key":"topology.kubernetes.io/zone","operator":"In","values":["us-east-1c"]}]}]}}}"""  # noqa: E501
+        config.kubernetes_toleration = """{"tolerations":[{"key":"is_cpu_compute","operator":"Exists"},{"key":"is_gpu_compute","operator":"Exists"}]}"""  # noqa: E501
+        config.kubernetes_resources = """{"resources":{"requests":{"cpu":"2","memory":"4Gi"},"limits":{"cpu":"4","memory":"8Gi"}}}"""  # noqa: E501
         self.outpost.config = config
 
         with self.assertRaises(NeedsUpdate):

--- a/website/docs/outposts/_config.md
+++ b/website/docs/outposts/_config.md
@@ -64,4 +64,16 @@ kubernetes_image_pull_secrets: []
 # (Available with 2022.11.0+)
 # Applies to: proxy outposts
 kubernetes_ingress_class_name: null
+# Optionally configure a Kubernetes affinity for outpost deployment
+# Takes a single json string as input, E.G:
+# '{"nodeAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"preference":{"matchExpressions":[{"key":"node-label-key","operator":"In","values":["node-label-value"]}]},"weight":1}],"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"topology.kubernetes.io/region","operator":"In","values":["east1"]},{"key":"topology.kubernetes.io/zone","operator":"In","values":["us-east-1c"]}]}]}}}'
+kubernetes_affinity: null
+# Optionally configure Kubernetes tolerations for outpost deployment
+# Takes a single json string as input, E.G:
+# '{"tolerations":[{"key":"is_cpu_compute","operator":"Exists"},{"key":"is_gpu_compute","operator":"Exists"}]}'
+kubernetes_tolerations: null
+# Optionally configure Kubernetes resources for outpost deployment
+# Takes a single json string as input, E.G:
+# '{"resources":{"requests":{"cpu":"2","memory":"4Gi"},"limits":{"cpu":"4","memory":"8Gi"}}}'
+kubernetes_resources: null
 ```

--- a/website/docs/outposts/integrations/kubernetes.md
+++ b/website/docs/outposts/integrations/kubernetes.md
@@ -32,6 +32,9 @@ The following outpost settings are used:
     -   'prometheus servicemonitor'
     -   'ingress'
     -   'traefik middleware'
+-   `kubernetes_affinity`: Allows configuration of Kubernetes nodeAffinity for outpost deployment, from a single JSON string
+-   `kubernetes_tolerations`: Allows configuration of Kubernetes tolerations for outpost deployment, from a single JSON string
+-   `kubernetes_resources`: Allows configuration of Kubernetes resources for outpost deployment, from a single JSON string
 -   `kubernetes_image_pull_secrets`: If the above docker image is in a private repository, use these secrets to pull.
 
     NOTE: The secret must be created manually in the namespace first.


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://goauthentik.io/developer-docs/#how-can-i-contribute).
-->

## Details

-   **Does this resolve an issue?**
    Resolves #5908

## Changes

### New Features

-   Adds the ability to configure k8s affinity, tolerations, resources in outpost deployments; passing e.g `kubernetes_affinity` as a single compressed JSON string

### Breaking Changes

-  None known

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
