### PR TITLE
web/admin: fix codemirror not working on safari

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -34,6 +34,7 @@
                 "lit": "^2.7.5",
                 "mermaid": "^10.2.3",
                 "rapidoc": "^9.3.4",
+                "style-mod": "^4.0.3",
                 "webcomponent-qr-code": "^1.1.1",
                 "yaml": "^2.3.1"
             },
@@ -20825,8 +20826,9 @@
             }
         },
         "node_modules/style-mod": {
-            "version": "4.0.0",
-            "license": "MIT"
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.3.tgz",
+            "integrity": "sha512-78Jv8kYJdjbvRwwijtCevYADfsI0lGzYJe4mMFdceO8l75DFFDoqBhR1jVDicDRRaX4//g1u9wKeo+ztc2h1Rw=="
         },
         "node_modules/stylis": {
             "version": "4.2.0",

--- a/web/package.json
+++ b/web/package.json
@@ -50,6 +50,7 @@
         "lit": "^2.7.5",
         "mermaid": "^10.2.3",
         "rapidoc": "^9.3.4",
+        "style-mod": "^4.0.3",
         "webcomponent-qr-code": "^1.1.1",
         "yaml": "^2.3.1"
     },

--- a/web/rollup.config.js
+++ b/web/rollup.config.js
@@ -9,7 +9,7 @@ import cssimport from "rollup-plugin-cssimport";
 import { terser } from "rollup-plugin-terser";
 
 // https://github.com/d3/d3-interpolate/issues/58
-const D3_WARNING = /Circular dependency.*d3-[interpolate|selection]/;
+const IGNORED_WARNINGS = /Circular dependency(.*d3-[interpolate|selection])|(.*@lit\/localize.*)/;
 
 const extensions = [".js", ".jsx", ".ts", ".tsx"];
 
@@ -81,7 +81,7 @@ export const defaultOptions = {
     cache: true,
     context: "window",
     onwarn: function (warning, warn) {
-        if (D3_WARNING.test(warning)) {
+        if (IGNORED_WARNINGS.test(warning)) {
             return;
         }
         if (warning.code === "UNRESOLVED_IMPORT") {


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://goauthentik.io/developer-docs/#how-can-i-contribute).
-->

## Details

closes #4155

Fixes codemirror not (always) rendering on Safari. Was indirectly caused by a supporting library of CodeMirror not being the newest version, since this is fixed upstream (https://github.com/marijnh/style-mod/pull/6)

## Changes

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)
-   [x] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
