### PR TITLE
web: Storybook css import fix

### DIFF
--- a/web/src/common/utils.ts
+++ b/web/src/common/utils.ts
@@ -1,4 +1,5 @@
 import { SentryIgnoredError } from "@goauthentik/common/errors";
+import { CSSResult, css } from "lit";
 
 export function getCookie(name: string): string {
     let cookieValue = "";
@@ -115,3 +116,19 @@ export function dateTimeLocal(date: Date): string {
     const parts = localISOTime.split(":");
     return `${parts[0]}:${parts[1]}`;
 }
+
+// Lit is extremely well-typed with regard to CSS, and Storybook's `build` does not currently have a
+// coherent way of importing CSS-as-text into CSSStyleSheet. It works well when Storybook is running
+// in `dev,` but in `build` it fails. Storied components will have to map their textual CSS imports
+// using the function below.
+type AdaptableStylesheet = Readonly<string | CSSResult | CSSStyleSheet>;
+type AdaptedStylesheets = CSSStyleSheet | CSSStyleSheet[];
+
+// prettier-ignore
+export const _adaptCSS = (sheet: AdaptableStylesheet) =>
+    typeof sheet === "string" ? css([sheet] as unknown as TemplateStringsArray, ...[]).styleSheet
+    : "styleSheet" in sheet ? sheet.styleSheet
+    : sheet;
+
+export const adaptCSS = (sheet: AdaptableStylesheet | AdaptableStylesheet[]): AdaptedStylesheets =>
+    Array.isArray(sheet) ? sheet.map(_adaptCSS) : _adaptCSS(sheet);

--- a/web/src/common/utils.ts
+++ b/web/src/common/utils.ts
@@ -1,4 +1,5 @@
 import { SentryIgnoredError } from "@goauthentik/common/errors";
+
 import { CSSResult, css } from "lit";
 
 export function getCookie(name: string): string {
@@ -124,11 +125,20 @@ export function dateTimeLocal(date: Date): string {
 type AdaptableStylesheet = Readonly<string | CSSResult | CSSStyleSheet>;
 type AdaptedStylesheets = CSSStyleSheet | CSSStyleSheet[];
 
-// prettier-ignore
-export const _adaptCSS = (sheet: AdaptableStylesheet) =>
-    typeof sheet === "string" ? css([sheet] as unknown as TemplateStringsArray, ...[]).styleSheet
-    : "styleSheet" in sheet ? sheet.styleSheet
-    : sheet;
+const isCSSResult = (v: any): v is CSSResult =>
+    v instanceof CSSResult && v.styleSheet !== undefined;
 
-export const adaptCSS = (sheet: AdaptableStylesheet | AdaptableStylesheet[]): AdaptedStylesheets =>
-    Array.isArray(sheet) ? sheet.map(_adaptCSS) : _adaptCSS(sheet);
+// prettier-ignore
+export const _adaptCSS = (sheet: AdaptableStylesheet): CSSStyleSheet =>
+    (typeof sheet === "string" ? css([sheet] as unknown as TemplateStringsArray, ...[]).styleSheet
+        : isCSSResult(sheet) ? sheet.styleSheet
+        : sheet) as CSSStyleSheet;
+
+// Overloaded function definitions inform consumers that if you pass it an array, expect an array in
+// return; if you pass it a scaler, expect a scalar in return.
+
+export function adaptCSS(sheet: AdaptableStylesheet): CSSStyleSheet;
+export function adaptCSS(sheet: AdaptableStylesheet[]): CSSStyleSheet[];
+export function adaptCSS(sheet: AdaptableStylesheet | AdaptableStylesheet[]): AdaptedStylesheets {
+    return Array.isArray(sheet) ? sheet.map(_adaptCSS) : _adaptCSS(sheet);
+}

--- a/web/src/common/utils.ts
+++ b/web/src/common/utils.ts
@@ -125,7 +125,7 @@ export function dateTimeLocal(date: Date): string {
 type AdaptableStylesheet = Readonly<string | CSSResult | CSSStyleSheet>;
 type AdaptedStylesheets = CSSStyleSheet | CSSStyleSheet[];
 
-const isCSSResult = (v: any): v is CSSResult =>
+const isCSSResult = (v: unknown): v is CSSResult =>
     v instanceof CSSResult && v.styleSheet !== undefined;
 
 // prettier-ignore

--- a/web/src/elements/Base.ts
+++ b/web/src/elements/Base.ts
@@ -1,8 +1,8 @@
 import { config, tenant } from "@goauthentik/common/api/config";
 import { EVENT_LOCALE_CHANGE, EVENT_THEME_CHANGE } from "@goauthentik/common/constants";
 import { UIConfig, uiConfig } from "@goauthentik/common/ui/config";
-
-import { CSSResult, LitElement } from "lit";
+import { adaptCSS } from "@goauthentik/common/utils";
+import { LitElement } from "lit";
 import { state } from "lit/decorators.js";
 
 import AKGlobal from "@goauthentik/common/styles/authentik.css";
@@ -13,7 +13,7 @@ import { Config, CurrentTenant, UiThemeEnum } from "@goauthentik/api";
 
 export function rootInterface<T extends Interface>(): T | undefined {
     const el = Array.from(document.body.querySelectorAll("*")).filter(
-        (el) => el instanceof Interface,
+        (el) => el instanceof Interface
     );
     return el[0] as T;
 }
@@ -31,8 +31,8 @@ function fetchCustomCSS(): Promise<string[]> {
                         .finally(() => {
                             return "";
                         });
-                },
-            ),
+                }
+            )
         );
     }
     return css;
@@ -68,8 +68,7 @@ export class AKElement extends LitElement {
         if ("ShadyDOM" in window) {
             styleRoot = document;
         }
-        const globalStyleSheet = AKGlobal instanceof CSSResult ? AKGlobal.styleSheet : AKGlobal;
-        styleRoot.adoptedStyleSheets = [...styleRoot.adoptedStyleSheets, globalStyleSheet];
+        styleRoot.adoptedStyleSheets = adaptCSS([...styleRoot.adoptedStyleSheets, AKGlobal]);
         this._initTheme(styleRoot);
         this._initCustomCSS(styleRoot);
         return root;
@@ -86,7 +85,7 @@ export class AKElement extends LitElement {
             root,
             window.matchMedia(QUERY_MEDIA_COLOR_LIGHT).matches
                 ? UiThemeEnum.Light
-                : UiThemeEnum.Dark,
+                : UiThemeEnum.Dark
         );
         this._applyTheme(root, await this.getTheme());
     }
@@ -148,7 +147,7 @@ export class AKElement extends LitElement {
                 bubbles: true,
                 composed: true,
                 detail: theme,
-            }),
+            })
         );
         this.setAttribute("theme", theme);
         const stylesheet = AKElement.themeToStylesheet(theme);

--- a/web/src/elements/Base.ts
+++ b/web/src/elements/Base.ts
@@ -2,6 +2,7 @@ import { config, tenant } from "@goauthentik/common/api/config";
 import { EVENT_LOCALE_CHANGE, EVENT_THEME_CHANGE } from "@goauthentik/common/constants";
 import { UIConfig, uiConfig } from "@goauthentik/common/ui/config";
 import { adaptCSS } from "@goauthentik/common/utils";
+
 import { LitElement } from "lit";
 import { state } from "lit/decorators.js";
 
@@ -13,7 +14,7 @@ import { Config, CurrentTenant, UiThemeEnum } from "@goauthentik/api";
 
 export function rootInterface<T extends Interface>(): T | undefined {
     const el = Array.from(document.body.querySelectorAll("*")).filter(
-        (el) => el instanceof Interface
+        (el) => el instanceof Interface,
     );
     return el[0] as T;
 }
@@ -31,8 +32,8 @@ function fetchCustomCSS(): Promise<string[]> {
                         .finally(() => {
                             return "";
                         });
-                }
-            )
+                },
+            ),
         );
     }
     return css;
@@ -85,7 +86,7 @@ export class AKElement extends LitElement {
             root,
             window.matchMedia(QUERY_MEDIA_COLOR_LIGHT).matches
                 ? UiThemeEnum.Light
-                : UiThemeEnum.Dark
+                : UiThemeEnum.Dark,
         );
         this._applyTheme(root, await this.getTheme());
     }
@@ -147,7 +148,7 @@ export class AKElement extends LitElement {
                 bubbles: true,
                 composed: true,
                 detail: theme,
-            })
+            }),
         );
         this.setAttribute("theme", theme);
         const stylesheet = AKElement.themeToStylesheet(theme);

--- a/web/src/user/LibraryPage/ApplicationEmptyState.ts
+++ b/web/src/user/LibraryPage/ApplicationEmptyState.ts
@@ -1,7 +1,7 @@
 import { docLink } from "@goauthentik/common/global";
+import { adaptCSS } from "@goauthentik/common/utils";
 import { AKElement } from "@goauthentik/elements/Base";
 import { paramURL } from "@goauthentik/elements/router/RouterOutlet";
-import { adaptCSS } from "@goauthentik/common/utils";
 
 import { msg } from "@lit/localize";
 import { css, html } from "lit";

--- a/web/src/user/LibraryPage/ApplicationEmptyState.ts
+++ b/web/src/user/LibraryPage/ApplicationEmptyState.ts
@@ -1,6 +1,7 @@
 import { docLink } from "@goauthentik/common/global";
 import { AKElement } from "@goauthentik/elements/Base";
 import { paramURL } from "@goauthentik/elements/router/RouterOutlet";
+import { adaptCSS } from "@goauthentik/common/utils";
 
 import { msg } from "@lit/localize";
 import { css, html } from "lit";
@@ -19,7 +20,7 @@ import PFSpacing from "@patternfly/patternfly/utilities/Spacing/spacing.css";
  * administrator, provide a link to the "Create a new application" page.
  */
 
-const styles = [
+const styles = adaptCSS([
     PFBase,
     PFEmptyState,
     PFButton,
@@ -31,7 +32,7 @@ const styles = [
             font-weight: bold;
         }
     `,
-];
+]);
 
 @customElement("ak-library-application-empty-list")
 export class LibraryPageApplicationEmptyList extends AKElement {


### PR DESCRIPTION
This is an incredibly frustrating issue, because Storybook works in `dev` mode but not in `build` mode, and that's not at all what you'd expecte from a mature piece of software.  Lit uses the native CSS adoptedStylesheets field, which takes only a constructedStylesheet. Lit provides a way of generating those, but the imports from Patternfly (or any `.css` file) are text, and converting those to stylesheets required a bit of magic.

What this means going forward is that any Storied components will have to have their CSS wrapped in a way that ensures it is managed correctly by Lit (well, to be pedantic, by the
shadowDOM.adoptedStylesheets).  That wrapper is provided and the components that need it have been wrapped.

This problem deserves further investigation, but for the time being this actually does solve it with a minimum amount of surgical pain.


## Details

-   **Does this resolve an issue?**
    Resolves storybook not resolving in `build` mode.

## Changes

-   [X] Local tests pass (`ak test authentik/`)
-   [X] The code has been formatted (`make lint-fix`)

