### PR TITLE
*: use dataclass slots wherever applicable

### DIFF
--- a/authentik/core/types.py
+++ b/authentik/core/types.py
@@ -8,7 +8,7 @@ from authentik.core.api.utils import PassiveSerializer
 from authentik.flows.challenge import Challenge
 
 
-@dataclass
+@dataclass(slots=True)
 class UILoginButton:
     """Dataclass for Source's ui_login_button"""
 

--- a/authentik/flows/markers.py
+++ b/authentik/flows/markers.py
@@ -30,7 +30,7 @@ class StageMarker:
         return binding
 
 
-@dataclass
+@dataclass(slots=True)
 class ReevaluateMarker(StageMarker):
     """Reevaluate Marker, forces stage's policies to be evaluated again."""
 

--- a/authentik/flows/planner.py
+++ b/authentik/flows/planner.py
@@ -45,7 +45,7 @@ def cache_key(flow: Flow, user: Optional[User] = None) -> str:
     return prefix
 
 
-@dataclass
+@dataclass(slots=True)
 class FlowPlan:
     """This data-class is the output of a FlowPlanner. It holds a flat list
     of all Stages that should be run."""

--- a/authentik/outposts/channels.py
+++ b/authentik/outposts/channels.py
@@ -28,7 +28,7 @@ class WebsocketMessageInstruction(IntEnum):
     TRIGGER_UPDATE = 2
 
 
-@dataclass
+@dataclass(slots=True)
 class WebsocketMessage:
     """Complete Websocket Message that is being sent"""
 

--- a/authentik/policies/types.py
+++ b/authentik/policies/types.py
@@ -19,7 +19,7 @@ LOGGER = get_logger()
 CACHE_PREFIX = "goauthentik.io/policies/"
 
 
-@dataclass
+@dataclass(slots=True)
 class PolicyRequest:
     """Data-class to hold policy request data"""
 
@@ -27,14 +27,14 @@ class PolicyRequest:
     http_request: Optional[HttpRequest]
     obj: Optional[Model]
     context: dict[str, Any]
-    debug: bool = False
+    debug: bool
 
     def __init__(self, user: User):
-        super().__init__()
         self.user = user
         self.http_request = None
         self.obj = None
         self.context = {}
+        self.debug = False
 
     def set_http_request(self, request: HttpRequest):  # pragma: no cover
         """Load data from HTTP request, including geoip when enabled"""
@@ -67,7 +67,7 @@ class PolicyRequest:
         return text + ">"
 
 
-@dataclass
+@dataclass(slots=True)
 class PolicyResult:
     """Result from evaluating a policy."""
 
@@ -81,7 +81,6 @@ class PolicyResult:
     log_messages: Optional[list[dict]]
 
     def __init__(self, passing: bool, *messages: str):
-        super().__init__()
         self.passing = passing
         self.messages = messages
         self.raw_result = None

--- a/authentik/providers/oauth2/id_token.py
+++ b/authentik/providers/oauth2/id_token.py
@@ -41,7 +41,7 @@ class SubModes(models.TextChoices):
     )
 
 
-@dataclass
+@dataclass(slots=True)
 # pylint: disable=too-many-instance-attributes
 class IDToken:
     """The primary extension that OpenID Connect makes to OAuth 2.0 to enable End-Users to be

--- a/authentik/providers/oauth2/views/authorize.py
+++ b/authentik/providers/oauth2/views/authorize.py
@@ -74,7 +74,7 @@ SESSION_KEY_LAST_LOGIN_UID = "authentik/providers/oauth2/last_login_uid"
 ALLOWED_PROMPT_PARAMS = {PROMPT_NONE, PROMPT_CONSENT, PROMPT_LOGIN}
 
 
-@dataclass
+@dataclass(slots=True)
 # pylint: disable=too-many-instance-attributes
 class OAuthAuthorizationParams:
     """Parameters required to authorize an OAuth Client"""

--- a/authentik/providers/oauth2/views/introspection.py
+++ b/authentik/providers/oauth2/views/introspection.py
@@ -14,7 +14,7 @@ from authentik.providers.oauth2.utils import TokenResponse, authenticate_provide
 LOGGER = get_logger()
 
 
-@dataclass
+@dataclass(slots=True)
 class TokenIntrospectionParams:
     """Parameters for Token Introspection"""
 

--- a/authentik/providers/oauth2/views/token.py
+++ b/authentik/providers/oauth2/views/token.py
@@ -58,7 +58,7 @@ from authentik.stages.password.stage import PLAN_CONTEXT_METHOD, PLAN_CONTEXT_ME
 LOGGER = get_logger()
 
 
-@dataclass
+@dataclass(slots=True)
 # pylint: disable=too-many-instance-attributes
 class TokenParams:
     """Token params"""

--- a/authentik/providers/oauth2/views/token_revoke.py
+++ b/authentik/providers/oauth2/views/token_revoke.py
@@ -14,7 +14,7 @@ from authentik.providers.oauth2.utils import TokenResponse, authenticate_provide
 LOGGER = get_logger()
 
 
-@dataclass
+@dataclass(slots=True)
 class TokenRevocationParams:
     """Parameters for Token Revocation"""
 

--- a/authentik/providers/saml/processors/authn_request_parser.py
+++ b/authentik/providers/saml/processors/authn_request_parser.py
@@ -31,7 +31,7 @@ ERROR_SIGNATURE_REQUIRED_BUT_ABSENT = (
 ERROR_FAILED_TO_VERIFY = "Failed to verify signature"
 
 
-@dataclass
+@dataclass(slots=True)
 class AuthNRequest:
     """AuthNRequest Dataclass"""
 

--- a/authentik/providers/saml/processors/logout_request_parser.py
+++ b/authentik/providers/saml/processors/logout_request_parser.py
@@ -12,7 +12,7 @@ from authentik.providers.saml.utils.encoding import decode_base64_and_inflate
 from authentik.sources.saml.processors.constants import NS_SAML_PROTOCOL
 
 
-@dataclass
+@dataclass(slots=True)
 class LogoutRequest:
     """Logout Request"""
 

--- a/authentik/providers/saml/processors/metadata_parser.py
+++ b/authentik/providers/saml/processors/metadata_parser.py
@@ -35,7 +35,7 @@ def format_pem_certificate(unformatted_cert: str) -> str:
     return "\n".join(lines)
 
 
-@dataclass
+@dataclass(slots=True)
 class ServiceProviderMetadata:
     """SP Metadata Dataclass"""
 


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://goauthentik.io/developer-docs/#how-can-i-contribute).
-->

## Details

closes #744

## Changes

### New Features

Adds `slots=True` to the `@dataclass` calls where applicable. 

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
