### PR TITLE
providers/oauth2: correctly advertise code_challenge_methods_supported

### DIFF
--- a/authentik/providers/oauth2/constants.py
+++ b/authentik/providers/oauth2/constants.py
@@ -19,6 +19,11 @@ SCOPE_OPENID = "openid"
 SCOPE_OPENID_PROFILE = "profile"
 SCOPE_OPENID_EMAIL = "email"
 
+# https://www.iana.org/assignments/oauth-parameters/\
+#   oauth-parameters.xhtml#pkce-code-challenge-method
+PKCE_METHOD_PLAIN = "plain"
+PKCE_METHOD_S256 = "S256"
+
 TOKEN_TYPE = "Bearer"  # nosec
 
 SCOPE_AUTHENTIK_API = "goauthentik.io/api"

--- a/authentik/providers/oauth2/views/authorize.py
+++ b/authentik/providers/oauth2/views/authorize.py
@@ -35,6 +35,8 @@ from authentik.lib.views import bad_request_message
 from authentik.policies.types import PolicyRequest
 from authentik.policies.views import PolicyAccessView, RequestValidationError
 from authentik.providers.oauth2.constants import (
+    PKCE_METHOD_PLAIN,
+    PKCE_METHOD_S256,
     PROMPT_CONSENT,
     PROMPT_LOGIN,
     PROMPT_NONE,
@@ -254,7 +256,10 @@ class OAuthAuthorizationParams:
 
     def check_code_challenge(self):
         """PKCE validation of the transformation method."""
-        if self.code_challenge and self.code_challenge_method not in ["plain", "S256"]:
+        if self.code_challenge and self.code_challenge_method not in [
+            PKCE_METHOD_PLAIN,
+            PKCE_METHOD_S256,
+        ]:
             raise AuthorizeError(
                 self.redirect_uri,
                 "invalid_request",

--- a/authentik/providers/oauth2/views/provider.py
+++ b/authentik/providers/oauth2/views/provider.py
@@ -17,6 +17,8 @@ from authentik.providers.oauth2.constants import (
     GRANT_TYPE_IMPLICIT,
     GRANT_TYPE_PASSWORD,
     GRANT_TYPE_REFRESH_TOKEN,
+    PKCE_METHOD_PLAIN,
+    PKCE_METHOD_S256,
     SCOPE_OPENID,
 )
 from authentik.providers.oauth2.models import (
@@ -109,6 +111,7 @@ class ProviderInfoView(View):
             "request_parameter_supported": False,
             "claims_supported": self.get_claims(provider),
             "claims_parameter_supported": False,
+            "code_challenge_methods_supported": [PKCE_METHOD_PLAIN, PKCE_METHOD_S256],
         }
 
     def get_claims(self, provider: OAuth2Provider) -> list[str]:

--- a/authentik/providers/oauth2/views/token.py
+++ b/authentik/providers/oauth2/views/token.py
@@ -39,6 +39,7 @@ from authentik.providers.oauth2.constants import (
     GRANT_TYPE_DEVICE_CODE,
     GRANT_TYPE_PASSWORD,
     GRANT_TYPE_REFRESH_TOKEN,
+    PKCE_METHOD_S256,
     TOKEN_TYPE,
 )
 from authentik.providers.oauth2.errors import DeviceCodeError, TokenError, UserAuthError
@@ -221,7 +222,7 @@ class TokenParams:
 
         # Validate PKCE parameters.
         if self.code_verifier:
-            if self.authorization_code.code_challenge_method == "S256":
+            if self.authorization_code.code_challenge_method == PKCE_METHOD_S256:
                 new_code_challenge = (
                     urlsafe_b64encode(sha256(self.code_verifier.encode("ascii")).digest())
                     .decode("utf-8")


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://goauthentik.io/developer-docs/#how-can-i-contribute).
-->

## Details

closes #5991

## Changes

### New Features

add `code_challenge_methods_supported` to openid provider endpoint

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
