### PR TITLE
core: prevent selecting a group as a parent of itself

### DIFF
--- a/authentik/core/api/groups.py
+++ b/authentik/core/api/groups.py
@@ -1,5 +1,6 @@
 """Groups API Viewset"""
 from json import loads
+from typing import Optional
 
 from django.db.models.query import QuerySet
 from django.http import Http404
@@ -51,6 +52,13 @@ class GroupSerializer(ModelSerializer):
     parent_name = CharField(source="parent.name", read_only=True)
 
     num_pk = IntegerField(read_only=True)
+
+    def validate_parent(self, parent: Optional[Group]):
+        if not self.instance:
+            return parent
+        if str(parent.group_uuid) == str(self.instance.group_uuid):
+            raise ValidationError("Cannot set group as parent of itself.")
+        return parent
 
     class Meta:
         model = Group

--- a/authentik/core/api/groups.py
+++ b/authentik/core/api/groups.py
@@ -54,7 +54,8 @@ class GroupSerializer(ModelSerializer):
     num_pk = IntegerField(read_only=True)
 
     def validate_parent(self, parent: Optional[Group]):
-        if not self.instance:
+        """Validate group parent (if set), ensuring the parent isn't itself"""
+        if not self.instance or not parent:
             return parent
         if str(parent.group_uuid) == str(self.instance.group_uuid):
             raise ValidationError("Cannot set group as parent of itself.")

--- a/authentik/core/tests/test_groups_api.py
+++ b/authentik/core/tests/test_groups_api.py
@@ -67,3 +67,16 @@ class TestGroupsAPI(APITestCase):
             },
         )
         self.assertEqual(res.status_code, 404)
+
+    def test_parent_self(self):
+        """Test parent"""
+        group = Group.objects.create(name=generate_id())
+        self.client.force_login(self.admin)
+        res = self.client.patch(
+            reverse("authentik_api:group-detail", kwargs={"pk": group.pk}),
+            data={
+                "pk": self.user.pk + 3,
+                "parent": group.pk,
+            },
+        )
+        self.assertEqual(res.status_code, 400)

--- a/web/src/admin/groups/GroupForm.ts
+++ b/web/src/admin/groups/GroupForm.ts
@@ -95,6 +95,9 @@ export class GroupForm extends ModelForm<Group, string> {
                             args.search = query;
                         }
                         const groups = await new CoreApi(DEFAULT_CONFIG).coreGroupsList(args);
+                        if (this.instance) {
+                            return groups.results.filter((g) => g.pk !== this.instance?.pk);
+                        }
                         return groups.results;
                     }}
                     .renderElement=${(group: Group): string => {


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://goauthentik.io/developer-docs/#how-can-i-contribute).
-->

## Details

Prevent (both at the API level and UI level) from selecting a group as a parent of itself

#5338

## Changes

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)
-   [x] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
