### PR TITLE
website/integrations: remove placeholders from AWS setup

### DIFF
--- a/website/integrations/services/aws/index.md
+++ b/website/integrations/services/aws/index.md
@@ -21,8 +21,6 @@ This all depends on your preference and needs.
 
 The following placeholders will be used:
 
--   `authentik.company` is the FQDN of the authentik install.
-
 Create an application in authentik and note the slug, as this will be used later. Create a SAML provider with the following parameters:
 
 -   ACS URL: `https://signin.aws.amazon.com/saml`

--- a/website/integrations/services/aws/index.md
+++ b/website/integrations/services/aws/index.md
@@ -19,8 +19,6 @@ This all depends on your preference and needs.
 
 ## Preparation
 
-The following placeholders will be used:
-
 Create an application in authentik and note the slug, as this will be used later. Create a SAML provider with the following parameters:
 
 -   ACS URL: `https://signin.aws.amazon.com/saml`
@@ -84,12 +82,6 @@ return user.username
 # Method 2: IAM Identity Center
 
 ## Preparation
-
-The following placeholders are used:
-
--   `authentik.company` is the FQDN of the authentik install.
-
-Additional Preparation:
 
 -   A certificate to sign SAML assertions is required. You can use authentik's default certificate, or provide/generate one yourself.
 -   You may pre-create an AWS application.


### PR DESCRIPTION
removing irrelevant line for this type of AWS setup


## Changes

If applicable

-   [ x] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
