### PR TITLE
sources/ldap: improve scalability

### DIFF
--- a/authentik/events/monitored_tasks.py
+++ b/authentik/events/monitored_tasks.py
@@ -69,8 +69,10 @@ class TaskInfo:
         return cache.get_many(cache.keys(CACHE_KEY_PREFIX + "*"))
 
     @staticmethod
-    def by_name(name: str) -> Optional["TaskInfo"]:
+    def by_name(name: str) -> Optional["TaskInfo"] | Optional[list["TaskInfo"]]:
         """Get TaskInfo Object by name"""
+        if "*" in name:
+            return cache.get_many(cache.keys(CACHE_KEY_PREFIX + name)).values()
         return cache.get(CACHE_KEY_PREFIX + name, None)
 
     def delete(self):

--- a/authentik/sources/ldap/api.py
+++ b/authentik/sources/ldap/api.py
@@ -118,11 +118,8 @@ class LDAPSourceViewSet(UsedByMixin, ModelViewSet):
         """Get source's sync status"""
         source = self.get_object()
         results = []
-        for sync_class in SYNC_CLASSES:
-            sync_name = sync_class.__name__.replace("LDAPSynchronizer", "").lower()
-            task = TaskInfo.by_name(f"ldap_sync:{source.slug}:{sync_name}")
-            if task:
-                results.append(task)
+        for task in TaskInfo.by_name(f"ldap_sync:{source.slug}:*"):
+            results.append(task)
         return Response(TaskSerializer(results, many=True).data)
 
     @extend_schema(
@@ -143,7 +140,7 @@ class LDAPSourceViewSet(UsedByMixin, ModelViewSet):
         source = self.get_object()
         all_objects = {}
         for sync_class in SYNC_CLASSES:
-            class_name = sync_class.__name__.replace("LDAPSynchronizer", "").lower()
+            class_name = sync_class.name()
             all_objects.setdefault(class_name, [])
             for obj in sync_class(source).get_objects(size_limit=10):
                 obj: dict

--- a/authentik/sources/ldap/api.py
+++ b/authentik/sources/ldap/api.py
@@ -118,8 +118,10 @@ class LDAPSourceViewSet(UsedByMixin, ModelViewSet):
         """Get source's sync status"""
         source = self.get_object()
         results = []
-        for task in TaskInfo.by_name(f"ldap_sync:{source.slug}:*"):
-            results.append(task)
+        tasks = TaskInfo.by_name(f"ldap_sync:{source.slug}:*")
+        if tasks:
+            for task in tasks:
+                results.append(task)
         return Response(TaskSerializer(results, many=True).data)
 
     @extend_schema(

--- a/authentik/sources/ldap/management/commands/ldap_sync.py
+++ b/authentik/sources/ldap/management/commands/ldap_sync.py
@@ -2,9 +2,8 @@
 from django.core.management.base import BaseCommand
 from structlog.stdlib import get_logger
 
-from authentik.lib.utils.reflection import class_to_path
 from authentik.sources.ldap.models import LDAPSource
-from authentik.sources.ldap.tasks import SYNC_CLASSES, ldap_sync
+from authentik.sources.ldap.tasks import ldap_sync_single
 
 LOGGER = get_logger()
 
@@ -21,7 +20,4 @@ class Command(BaseCommand):
             if not source:
                 LOGGER.warning("Source does not exist", slug=source_slug)
                 continue
-            for sync_class in SYNC_CLASSES:
-                LOGGER.info("Starting sync", cls=sync_class)
-                # pylint: disable=no-value-for-parameter
-                ldap_sync(source.pk, class_to_path(sync_class))
+            ldap_sync_single(source)

--- a/authentik/sources/ldap/signals.py
+++ b/authentik/sources/ldap/signals.py
@@ -12,13 +12,9 @@ from authentik.core.models import User
 from authentik.core.signals import password_changed
 from authentik.events.models import Event, EventAction
 from authentik.flows.planner import PLAN_CONTEXT_PENDING_USER
-from authentik.lib.utils.reflection import class_to_path
 from authentik.sources.ldap.models import LDAPSource
 from authentik.sources.ldap.password import LDAPPasswordChanger
-from authentik.sources.ldap.sync.groups import GroupLDAPSynchronizer
-from authentik.sources.ldap.sync.membership import MembershipLDAPSynchronizer
-from authentik.sources.ldap.sync.users import UserLDAPSynchronizer
-from authentik.sources.ldap.tasks import ldap_sync
+from authentik.sources.ldap.tasks import ldap_sync_single
 from authentik.stages.prompt.signals import password_validate
 
 LOGGER = get_logger()
@@ -35,12 +31,7 @@ def sync_ldap_source_on_save(sender, instance: LDAPSource, **_):
     #   and the mappings are created with an m2m event
     if not instance.property_mappings.exists() or not instance.property_mappings_group.exists():
         return
-    for sync_class in [
-        UserLDAPSynchronizer,
-        GroupLDAPSynchronizer,
-        MembershipLDAPSynchronizer,
-    ]:
-        ldap_sync.delay(instance.pk, class_to_path(sync_class))
+    ldap_sync_single.delay(instance.pk)
 
 
 @receiver(password_validate)

--- a/authentik/sources/ldap/sync/base.py
+++ b/authentik/sources/ldap/sync/base.py
@@ -1,9 +1,9 @@
 """Sync LDAP Users and groups into authentik"""
-from typing import Any, Generator
+from typing import Any, Generator, Optional
 
 from django.db.models.base import Model
 from django.db.models.query import QuerySet
-from ldap3 import Connection
+from ldap3 import DEREF_ALWAYS, SUBTREE, Connection
 from structlog.stdlib import BoundLogger, get_logger
 
 from authentik.core.exceptions import PropertyMappingExpressionException
@@ -28,6 +28,10 @@ class BaseLDAPSynchronizer:
         self._connection = source.connection()
         self._messages = []
         self._logger = get_logger().bind(source=source, syncer=self.__class__.__name__)
+
+    @staticmethod
+    def name() -> str:
+        raise NotImplementedError
 
     @property
     def messages(self) -> list[str]:
@@ -60,7 +64,48 @@ class BaseLDAPSynchronizer:
         """Get objects from LDAP, implemented in subclass"""
         raise NotImplementedError()
 
-    def sync(self) -> int:
+    def search_paginator(
+        self,
+        search_base,
+        search_filter,
+        search_scope=SUBTREE,
+        dereference_aliases=DEREF_ALWAYS,
+        attributes=None,
+        size_limit=0,
+        time_limit=0,
+        types_only=False,
+        get_operational_attributes=False,
+        controls=None,
+        paged_size=5,
+        paged_criticality=False,
+    ):
+        """Search in pages, returns each page"""
+        cookie = True
+        while cookie:
+            self._connection.search(
+                search_base,
+                search_filter,
+                search_scope,
+                dereference_aliases,
+                attributes,
+                size_limit,
+                time_limit,
+                types_only,
+                get_operational_attributes,
+                controls,
+                paged_size,
+                paged_criticality,
+                None if cookie is True else cookie,
+            )
+            try:
+                cookie = self._connection.result["controls"]["1.2.840.113556.1.4.319"]["value"][
+                    "cookie"
+                ]
+            except KeyError:
+                cookie = None
+            yield self._connection.response
+
+    def sync(self, page: Optional[list]) -> int:
         """Sync function, implemented in subclass"""
         raise NotImplementedError()
 

--- a/authentik/sources/ldap/sync/base.py
+++ b/authentik/sources/ldap/sync/base.py
@@ -1,5 +1,5 @@
 """Sync LDAP Users and groups into authentik"""
-from typing import Any, Generator, Optional
+from typing import Any, Generator
 
 from django.conf import settings
 from django.db.models.base import Model
@@ -44,7 +44,7 @@ class BaseLDAPSynchronizer:
         for page in self.get_objects():
             self.sync(page)
 
-    def sync(self, page: Optional[list]) -> int:
+    def sync(self, page_data: list) -> int:
         """Sync function, implemented in subclass"""
         raise NotImplementedError()
 

--- a/authentik/sources/ldap/sync/groups.py
+++ b/authentik/sources/ldap/sync/groups.py
@@ -1,5 +1,5 @@
 """Sync LDAP Users and groups into authentik"""
-from typing import Generator, Optional
+from typing import Generator
 
 from django.core.exceptions import FieldError
 from django.db.utils import IntegrityError
@@ -26,13 +26,13 @@ class GroupLDAPSynchronizer(BaseLDAPSynchronizer):
             **kwargs,
         )
 
-    def sync(self, page: Optional[list]) -> int:
+    def sync(self, page_data: list) -> int:
         """Iterate over all LDAP Groups and create authentik_core.Group instances"""
         if not self._source.sync_groups:
             self.message("Group syncing is disabled for this Source")
             return -1
         group_count = 0
-        for group in page:
+        for group in page_data:
             if "attributes" not in group:
                 continue
             attributes = group.get("attributes", {})

--- a/authentik/sources/ldap/sync/groups.py
+++ b/authentik/sources/ldap/sync/groups.py
@@ -1,5 +1,5 @@
 """Sync LDAP Users and groups into authentik"""
-from typing import Generator
+from typing import Generator, Optional
 
 from django.core.exceptions import FieldError
 from django.db.utils import IntegrityError
@@ -13,8 +13,12 @@ from authentik.sources.ldap.sync.base import LDAP_UNIQUENESS, BaseLDAPSynchroniz
 class GroupLDAPSynchronizer(BaseLDAPSynchronizer):
     """Sync LDAP Users and groups into authentik"""
 
+    @staticmethod
+    def name() -> str:
+        return "groups"
+
     def get_objects(self, **kwargs) -> Generator:
-        return self._connection.extend.standard.paged_search(
+        return self.search_paginator(
             search_base=self.base_dn_groups,
             search_filter=self._source.group_object_filter,
             search_scope=SUBTREE,
@@ -22,13 +26,13 @@ class GroupLDAPSynchronizer(BaseLDAPSynchronizer):
             **kwargs,
         )
 
-    def sync(self) -> int:
+    def sync(self, page: Optional[list]) -> int:
         """Iterate over all LDAP Groups and create authentik_core.Group instances"""
         if not self._source.sync_groups:
             self.message("Group syncing is disabled for this Source")
             return -1
         group_count = 0
-        for group in self.get_objects():
+        for group in page:
             if "attributes" not in group:
                 continue
             attributes = group.get("attributes", {})

--- a/authentik/sources/ldap/sync/membership.py
+++ b/authentik/sources/ldap/sync/membership.py
@@ -36,13 +36,13 @@ class MembershipLDAPSynchronizer(BaseLDAPSynchronizer):
             **kwargs,
         )
 
-    def sync(self, page: Optional[list]) -> int:
+    def sync(self, page_data: list) -> int:
         """Iterate over all Users and assign Groups using memberOf Field"""
         if not self._source.sync_groups:
             self.message("Group syncing is disabled for this Source")
             return -1
         membership_count = 0
-        for group in page:
+        for group in page_data:
             if "attributes" not in group:
                 continue
             members = group.get("attributes", {}).get(self._source.group_membership_field, [])

--- a/authentik/sources/ldap/sync/membership.py
+++ b/authentik/sources/ldap/sync/membership.py
@@ -19,8 +19,12 @@ class MembershipLDAPSynchronizer(BaseLDAPSynchronizer):
         super().__init__(source)
         self.group_cache: dict[str, Group] = {}
 
+    @staticmethod
+    def name() -> str:
+        return "membership"
+
     def get_objects(self, **kwargs) -> Generator:
-        return self._connection.extend.standard.paged_search(
+        return self.search_paginator(
             search_base=self.base_dn_groups,
             search_filter=self._source.group_object_filter,
             search_scope=SUBTREE,
@@ -32,13 +36,13 @@ class MembershipLDAPSynchronizer(BaseLDAPSynchronizer):
             **kwargs,
         )
 
-    def sync(self) -> int:
+    def sync(self, page: Optional[list]) -> int:
         """Iterate over all Users and assign Groups using memberOf Field"""
         if not self._source.sync_groups:
             self.message("Group syncing is disabled for this Source")
             return -1
         membership_count = 0
-        for group in self.get_objects():
+        for group in page:
             if "attributes" not in group:
                 continue
             members = group.get("attributes", {}).get(self._source.group_membership_field, [])

--- a/authentik/sources/ldap/sync/users.py
+++ b/authentik/sources/ldap/sync/users.py
@@ -1,5 +1,5 @@
 """Sync LDAP Users into authentik"""
-from typing import Generator, Optional
+from typing import Generator
 
 from django.core.exceptions import FieldError
 from django.db.utils import IntegrityError
@@ -28,13 +28,13 @@ class UserLDAPSynchronizer(BaseLDAPSynchronizer):
             **kwargs,
         )
 
-    def sync(self, page: Optional[list]) -> int:
+    def sync(self, page_data: list) -> int:
         """Iterate over all LDAP Users and create authentik_core.User instances"""
         if not self._source.sync_users:
             self.message("User syncing is disabled for this Source")
             return -1
         user_count = 0
-        for user in page:
+        for user in page_data:
             if "attributes" not in user:
                 continue
             attributes = user.get("attributes", {})

--- a/authentik/sources/ldap/sync/vendor/freeipa.py
+++ b/authentik/sources/ldap/sync/vendor/freeipa.py
@@ -11,6 +11,10 @@ from authentik.sources.ldap.sync.base import BaseLDAPSynchronizer
 class FreeIPA(BaseLDAPSynchronizer):
     """FreeIPA-specific LDAP"""
 
+    @staticmethod
+    def name() -> str:
+        return "freeipa"
+
     def get_objects(self, **kwargs) -> Generator:
         yield None
 

--- a/authentik/sources/ldap/sync/vendor/ms_ad.py
+++ b/authentik/sources/ldap/sync/vendor/ms_ad.py
@@ -42,6 +42,10 @@ class UserAccountControl(IntFlag):
 class MicrosoftActiveDirectory(BaseLDAPSynchronizer):
     """Microsoft-specific LDAP"""
 
+    @staticmethod
+    def name() -> str:
+        return "microsoft_ad"
+
     def get_objects(self, **kwargs) -> Generator:
         yield None
 

--- a/authentik/sources/ldap/tests/test_auth.py
+++ b/authentik/sources/ldap/tests/test_auth.py
@@ -43,7 +43,7 @@ class LDAPSyncTests(TestCase):
         connection = MagicMock(return_value=raw_conn)
         with patch("authentik.sources.ldap.models.LDAPSource.connection", connection):
             user_sync = UserLDAPSynchronizer(self.source)
-            user_sync.sync()
+            user_sync.sync_full()
 
             user = User.objects.get(username="user0_sn")
             # auth_user_by_bind = Mock(return_value=user)
@@ -71,7 +71,7 @@ class LDAPSyncTests(TestCase):
         connection = MagicMock(return_value=mock_ad_connection(LDAP_PASSWORD))
         with patch("authentik.sources.ldap.models.LDAPSource.connection", connection):
             user_sync = UserLDAPSynchronizer(self.source)
-            user_sync.sync()
+            user_sync.sync_full()
 
             user = User.objects.get(username="user0_sn")
             auth_user_by_bind = Mock(return_value=user)
@@ -98,7 +98,7 @@ class LDAPSyncTests(TestCase):
         connection = MagicMock(return_value=mock_slapd_connection(LDAP_PASSWORD))
         with patch("authentik.sources.ldap.models.LDAPSource.connection", connection):
             user_sync = UserLDAPSynchronizer(self.source)
-            user_sync.sync()
+            user_sync.sync_full()
 
             user = User.objects.get(username="user0_sn")
             auth_user_by_bind = Mock(return_value=user)

--- a/authentik/sources/ldap/tests/test_sync.py
+++ b/authentik/sources/ldap/tests/test_sync.py
@@ -51,7 +51,7 @@ class LDAPSyncTests(TestCase):
         connection = MagicMock(return_value=mock_ad_connection(LDAP_PASSWORD))
         with patch("authentik.sources.ldap.models.LDAPSource.connection", connection):
             user_sync = UserLDAPSynchronizer(self.source)
-            user_sync.sync()
+            user_sync.sync_full()
             self.assertFalse(User.objects.filter(username="user0_sn").exists())
             self.assertFalse(User.objects.filter(username="user1_sn").exists())
         events = Event.objects.filter(
@@ -87,7 +87,7 @@ class LDAPSyncTests(TestCase):
 
         with patch("authentik.sources.ldap.models.LDAPSource.connection", connection):
             user_sync = UserLDAPSynchronizer(self.source)
-            user_sync.sync()
+            user_sync.sync_full()
             user = User.objects.filter(username="user0_sn").first()
             self.assertEqual(user.attributes["foo"], "bar")
             self.assertFalse(user.is_active)
@@ -106,7 +106,7 @@ class LDAPSyncTests(TestCase):
         connection = MagicMock(return_value=mock_slapd_connection(LDAP_PASSWORD))
         with patch("authentik.sources.ldap.models.LDAPSource.connection", connection):
             user_sync = UserLDAPSynchronizer(self.source)
-            user_sync.sync()
+            user_sync.sync_full()
             self.assertTrue(User.objects.filter(username="user0_sn").exists())
             self.assertFalse(User.objects.filter(username="user1_sn").exists())
 
@@ -128,9 +128,9 @@ class LDAPSyncTests(TestCase):
             self.source.sync_parent_group = parent_group
             self.source.save()
             group_sync = GroupLDAPSynchronizer(self.source)
-            group_sync.sync()
+            group_sync.sync_full()
             membership_sync = MembershipLDAPSynchronizer(self.source)
-            membership_sync.sync()
+            membership_sync.sync_full()
             group: Group = Group.objects.filter(name="test-group").first()
             self.assertIsNotNone(group)
             self.assertEqual(group.parent, parent_group)
@@ -152,9 +152,9 @@ class LDAPSyncTests(TestCase):
         with patch("authentik.sources.ldap.models.LDAPSource.connection", connection):
             self.source.save()
             group_sync = GroupLDAPSynchronizer(self.source)
-            group_sync.sync()
+            group_sync.sync_full()
             membership_sync = MembershipLDAPSynchronizer(self.source)
-            membership_sync.sync()
+            membership_sync.sync_full()
             group = Group.objects.filter(name="group1")
             self.assertTrue(group.exists())
 
@@ -177,11 +177,11 @@ class LDAPSyncTests(TestCase):
         with patch("authentik.sources.ldap.models.LDAPSource.connection", connection):
             self.source.save()
             user_sync = UserLDAPSynchronizer(self.source)
-            user_sync.sync()
+            user_sync.sync_full()
             group_sync = GroupLDAPSynchronizer(self.source)
-            group_sync.sync()
+            group_sync.sync_full()
             membership_sync = MembershipLDAPSynchronizer(self.source)
-            membership_sync.sync()
+            membership_sync.sync_full()
             # Test if membership mapping based on memberUid works.
             posix_group = Group.objects.filter(name="group-posix").first()
             self.assertTrue(posix_group.users.filter(name="user-posix").exists())

--- a/schema.yml
+++ b/schema.yml
@@ -4041,11 +4041,6 @@ paths:
           * `api` - Intent Api
           * `recovery` - Intent Recovery
           * `app_password` - Intent App Password
-
-          * `verification` - Intent Verification
-          * `api` - Intent Api
-          * `recovery` - Intent Recovery
-          * `app_password` - Intent App Password
       - in: query
         name: managed
         schema:
@@ -5962,10 +5957,6 @@ paths:
           * `notice` - Notice
           * `warning` - Warning
           * `alert` - Alert
-
-          * `notice` - Notice
-          * `warning` - Warning
-          * `alert` - Alert
       - in: query
         name: user
         schema:
@@ -6502,11 +6493,6 @@ paths:
           * `webhook` - Generic Webhook
           * `webhook_slack` - Slack Webhook (Slack/Discord)
           * `email` - Email
-
-          * `local` - authentik inbuilt notifications
-          * `webhook` - Generic Webhook
-          * `webhook_slack` - Slack Webhook (Slack/Discord)
-          * `email` - Email
       - in: query
         name: name
         schema:
@@ -6890,9 +6876,6 @@ paths:
           - all
           - any
         description: |-
-          * `all` - all, all policies must pass
-          * `any` - any, any policy must pass
-
           * `all` - all, all policies must pass
           * `any` - any, any policy must pass
       - in: query
@@ -15945,11 +15928,6 @@ paths:
           * `http://www.w3.org/2001/04/xmlenc#sha256` - SHA256
           * `http://www.w3.org/2001/04/xmldsig-more#sha384` - SHA384
           * `http://www.w3.org/2001/04/xmlenc#sha512` - SHA512
-
-          * `http://www.w3.org/2000/09/xmldsig#sha1` - SHA1
-          * `http://www.w3.org/2001/04/xmlenc#sha256` - SHA256
-          * `http://www.w3.org/2001/04/xmldsig-more#sha384` - SHA384
-          * `http://www.w3.org/2001/04/xmlenc#sha512` - SHA512
       - in: query
         name: is_backchannel
         schema:
@@ -16015,12 +15993,6 @@ paths:
           - http://www.w3.org/2001/04/xmldsig-more#rsa-sha384
           - http://www.w3.org/2001/04/xmldsig-more#rsa-sha512
         description: |-
-          * `http://www.w3.org/2000/09/xmldsig#rsa-sha1` - RSA-SHA1
-          * `http://www.w3.org/2001/04/xmldsig-more#rsa-sha256` - RSA-SHA256
-          * `http://www.w3.org/2001/04/xmldsig-more#rsa-sha384` - RSA-SHA384
-          * `http://www.w3.org/2001/04/xmldsig-more#rsa-sha512` - RSA-SHA512
-          * `http://www.w3.org/2000/09/xmldsig#dsa-sha1` - DSA-SHA1
-
           * `http://www.w3.org/2000/09/xmldsig#rsa-sha1` - RSA-SHA1
           * `http://www.w3.org/2001/04/xmldsig-more#rsa-sha256` - RSA-SHA256
           * `http://www.w3.org/2001/04/xmldsig-more#rsa-sha384` - RSA-SHA384
@@ -17667,9 +17639,6 @@ paths:
         description: |-
           * `all` - all, all policies must pass
           * `any` - any, any policy must pass
-
-          * `all` - all, all policies must pass
-          * `any` - any, any policy must pass
       - in: query
         name: profile_url
         schema:
@@ -18036,9 +18005,6 @@ paths:
         description: |-
           * `all` - all, all policies must pass
           * `any` - any, any policy must pass
-
-          * `all` - all, all policies must pass
-          * `any` - any, any policy must pass
       - name: search
         required: false
         in: query
@@ -18383,10 +18349,6 @@ paths:
           * `REDIRECT` - Redirect Binding
           * `POST` - POST Binding
           * `POST_AUTO` - POST Binding with auto-confirmation
-
-          * `REDIRECT` - Redirect Binding
-          * `POST` - POST Binding
-          * `POST_AUTO` - POST Binding with auto-confirmation
       - in: query
         name: digest_algorithm
         schema:
@@ -18397,11 +18359,6 @@ paths:
           - http://www.w3.org/2001/04/xmlenc#sha256
           - http://www.w3.org/2001/04/xmlenc#sha512
         description: |-
-          * `http://www.w3.org/2000/09/xmldsig#sha1` - SHA1
-          * `http://www.w3.org/2001/04/xmlenc#sha256` - SHA256
-          * `http://www.w3.org/2001/04/xmldsig-more#sha384` - SHA384
-          * `http://www.w3.org/2001/04/xmlenc#sha512` - SHA512
-
           * `http://www.w3.org/2000/09/xmldsig#sha1` - SHA1
           * `http://www.w3.org/2001/04/xmlenc#sha256` - SHA256
           * `http://www.w3.org/2001/04/xmldsig-more#sha384` - SHA384
@@ -18473,9 +18430,6 @@ paths:
         description: |-
           * `all` - all, all policies must pass
           * `any` - any, any policy must pass
-
-          * `all` - all, all policies must pass
-          * `any` - any, any policy must pass
       - in: query
         name: pre_authentication_flow
         schema:
@@ -18498,12 +18452,6 @@ paths:
           - http://www.w3.org/2001/04/xmldsig-more#rsa-sha384
           - http://www.w3.org/2001/04/xmldsig-more#rsa-sha512
         description: |-
-          * `http://www.w3.org/2000/09/xmldsig#rsa-sha1` - RSA-SHA1
-          * `http://www.w3.org/2001/04/xmldsig-more#rsa-sha256` - RSA-SHA256
-          * `http://www.w3.org/2001/04/xmldsig-more#rsa-sha384` - RSA-SHA384
-          * `http://www.w3.org/2001/04/xmldsig-more#rsa-sha512` - RSA-SHA512
-          * `http://www.w3.org/2000/09/xmldsig#dsa-sha1` - DSA-SHA1
-
           * `http://www.w3.org/2000/09/xmldsig#rsa-sha1` - RSA-SHA1
           * `http://www.w3.org/2001/04/xmldsig-more#rsa-sha256` - RSA-SHA256
           * `http://www.w3.org/2001/04/xmldsig-more#rsa-sha384` - RSA-SHA384
@@ -20455,9 +20403,6 @@ paths:
         description: |-
           * `basic` - Basic
           * `bearer` - Bearer
-
-          * `basic` - Basic
-          * `bearer` - Bearer
       - in: query
         name: configure_flow
         schema:
@@ -20506,9 +20451,6 @@ paths:
           - generic
           - twilio
         description: |-
-          * `twilio` - Twilio
-          * `generic` - Generic
-
           * `twilio` - Twilio
           * `generic` - Generic
       - name: search
@@ -21069,9 +21011,6 @@ paths:
         description: |-
           * `6` - 6 digits, widely compatible
           * `8` - 8 digits, not compatible with apps like Google Authenticator
-
-          * `6` - 6 digits, widely compatible
-          * `8` - 8 digits, not compatible with apps like Google Authenticator
       - in: query
         name: friendly_name
         schema:
@@ -21375,10 +21314,6 @@ paths:
           * `skip` - Skip
           * `deny` - Deny
           * `configure` - Configure
-
-          * `skip` - Skip
-          * `deny` - Deny
-          * `configure` - Configure
       - name: ordering
         required: false
         in: query
@@ -21655,9 +21590,6 @@ paths:
         description: |-
           * `platform` - Platform
           * `cross-platform` - Cross Platform
-
-          * `platform` - Platform
-          * `cross-platform` - Cross Platform
       - in: query
         name: configure_flow
         schema:
@@ -21701,10 +21633,6 @@ paths:
           * `discouraged` - Discouraged
           * `preferred` - Preferred
           * `required` - Required
-
-          * `discouraged` - Discouraged
-          * `preferred` - Preferred
-          * `required` - Required
       - name: search
         required: false
         in: query
@@ -21725,10 +21653,6 @@ paths:
           - preferred
           - required
         description: |-
-          * `required` - Required
-          * `preferred` - Preferred
-          * `discouraged` - Discouraged
-
           * `required` - Required
           * `preferred` - Preferred
           * `discouraged` - Discouraged
@@ -22259,10 +22183,6 @@ paths:
           - expiring
           - permanent
         description: |-
-          * `always_require` - Always Require
-          * `permanent` - Permanent
-          * `expiring` - Expiring
-
           * `always_require` - Always Require
           * `permanent` - Permanent
           * `expiring` - Expiring
@@ -24663,25 +24583,6 @@ paths:
           * `hidden` - Hidden: Hidden field, can be used to insert data into form.
           * `static` - Static: Static value, displayed as-is.
           * `ak-locale` - authentik: Selection of locales authentik supports
-
-          * `text` - Text: Simple Text input
-          * `text_area` - Text area: Multiline Text Input.
-          * `text_read_only` - Text (read-only): Simple Text input, but cannot be edited.
-          * `text_area_read_only` - Text area (read-only): Multiline Text input, but cannot be edited.
-          * `username` - Username: Same as Text input, but checks for and prevents duplicate usernames.
-          * `email` - Email: Text field with Email type.
-          * `password` - Password: Masked input, multiple inputs of this type on the same prompt need to be identical.
-          * `number` - Number
-          * `checkbox` - Checkbox
-          * `radio-button-group` - Fixed choice field rendered as a group of radio buttons.
-          * `dropdown` - Fixed choice field rendered as a dropdown.
-          * `date` - Date
-          * `date-time` - Date Time
-          * `file` - File: File upload for arbitrary files. File content will be available in flow context as data-URI
-          * `separator` - Separator: Static Separator Line
-          * `hidden` - Hidden: Hidden field, can be used to insert data into form.
-          * `static` - Static: Static value, displayed as-is.
-          * `ak-locale` - authentik: Selection of locales authentik supports
       tags:
       - stages
       security:
@@ -26133,10 +26034,6 @@ paths:
           - create_when_required
           - never_create
         description: |-
-          * `never_create` - Never Create
-          * `create_when_required` - Create When Required
-          * `always_create` - Always Create
-
           * `never_create` - Never Create
           * `create_when_required` - Create When Required
           * `always_create` - Always Create

--- a/tests/e2e/test_source_ldap_samba.py
+++ b/tests/e2e/test_source_ldap_samba.py
@@ -63,7 +63,7 @@ class TestSourceLDAPSamba(SeleniumTestCase):
         source.property_mappings_group.set(
             LDAPPropertyMapping.objects.filter(name="goauthentik.io/sources/ldap/default-name")
         )
-        UserLDAPSynchronizer(source).sync()
+        UserLDAPSynchronizer(source).sync_full()
         self.assertTrue(User.objects.filter(username="bob").exists())
         self.assertTrue(User.objects.filter(username="james").exists())
         self.assertTrue(User.objects.filter(username="john").exists())
@@ -94,9 +94,9 @@ class TestSourceLDAPSamba(SeleniumTestCase):
         source.property_mappings_group.set(
             LDAPPropertyMapping.objects.filter(managed="goauthentik.io/sources/ldap/default-name")
         )
-        GroupLDAPSynchronizer(source).sync()
-        UserLDAPSynchronizer(source).sync()
-        MembershipLDAPSynchronizer(source).sync()
+        GroupLDAPSynchronizer(source).sync_full()
+        UserLDAPSynchronizer(source).sync_full()
+        MembershipLDAPSynchronizer(source).sync_full()
         self.assertIsNotNone(User.objects.get(username="bob"))
         self.assertIsNotNone(User.objects.get(username="james"))
         self.assertIsNotNone(User.objects.get(username="john"))
@@ -137,7 +137,7 @@ class TestSourceLDAPSamba(SeleniumTestCase):
         source.property_mappings_group.set(
             LDAPPropertyMapping.objects.filter(name="goauthentik.io/sources/ldap/default-name")
         )
-        UserLDAPSynchronizer(source).sync()
+        UserLDAPSynchronizer(source).sync_full()
         username = "bob"
         password = generate_id()
         result = self.container.exec_run(
@@ -160,7 +160,7 @@ class TestSourceLDAPSamba(SeleniumTestCase):
         )
         self.assertEqual(result.exit_code, 0)
         # Sync again
-        UserLDAPSynchronizer(source).sync()
+        UserLDAPSynchronizer(source).sync_full()
         user.refresh_from_db()
         # Since password in samba was checked, it should be invalidated here too
         self.assertFalse(user.has_usable_password())


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://goauthentik.io/developer-docs/#how-can-i-contribute).
-->

## Details

Refactor LDAP Sync to run more parallelised, currently user, group and membership sync run as a single task each, which causes issues with large directories (both with the timeout and the general speed as the sync only runs on a single thread)

This PR changes this sync to pre-fetch all the LDAP data in a single task, then create a task for each page of data it gets (default size of 50 objects per page), then launches all of those pages as tasks which can run on separate workers

closes #6052

## Changes

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
