### PR TITLE
stages/authenticator_validate: fix regression

### DIFF
--- a/authentik/stages/authenticator_validate/stage.py
+++ b/authentik/stages/authenticator_validate/stage.py
@@ -282,7 +282,7 @@ class AuthenticatorValidateStageView(ChallengeStageView):
             and self.executor.current_stage.not_configured_action == NotConfiguredAction.CONFIGURE
         ):
             self.logger.debug("Got selected stage in context, running that")
-            stage_pk = self.executor.plan.context(PLAN_CONTEXT_SELECTED_STAGE)
+            stage_pk = self.executor.plan.context.get(PLAN_CONTEXT_SELECTED_STAGE)
             # Because the foreign key to stage.configuration_stage points to
             # a base stage class, we need to do another lookup
             stage = Stage.objects.get_subclass(pk=stage_pk)


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://goauthentik.io/developer-docs/#how-can-i-contribute).
-->

## Details

resolves #6061

Regression added in 2023.4.2 and 2023.5.4, adds tests to prevent this regression in the future

## Changes

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
