### PR TITLE
sources/ldap: fix 100% cpu usage when LDAP Server is unavailable

### DIFF
--- a/authentik/sources/ldap/models.py
+++ b/authentik/sources/ldap/models.py
@@ -151,7 +151,7 @@ class LDAPSource(Source):
                 servers.append(Server(server, **server_kwargs))
         else:
             servers = [Server(self.server_uri, **server_kwargs)]
-        return ServerPool(servers, RANDOM, active=True, exhaust=True)
+        return ServerPool(servers, RANDOM, active=5, exhaust=True)
 
     def connection(
         self, server_kwargs: Optional[dict] = None, connection_kwargs: Optional[dict] = None


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://goauthentik.io/developer-docs/#how-can-i-contribute).
-->

## Details

closes #6092

This was quite annoying to debug, turns out when using an ldap3 ServerPool with the settings we currently have, ldap3 will continue trying to connect to unavailable servers, which for some reason causes 100% cpu usage

## Changes

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
