### PR TITLE
providers/ldap: fix inconsistent saving of user flags on failed cached binds

### DIFF
--- a/internal/outpost/ldap/bind/direct/bind.go
+++ b/internal/outpost/ldap/bind/direct/bind.go
@@ -28,9 +28,12 @@ func (db *DirectBinder) Bind(username string, req *bind.Request) (ldap.LDAPResul
 	passed, err := fe.Execute()
 	flags := flags.UserFlags{
 		Session: fe.GetSession(),
-		UserPk:  -1,
+		UserPk:  flags.InvalidUserPK,
 	}
-	//only set, if empty
+	// only set flags if we don't have flags for this DN yet
+	// as flags are only checked during the bind, we can remember whether a certain DN
+	// can search or not, as if they bind correctly first and then use incorrect credentials
+	// later, they won't get past this step anyways
 	if db.si.GetFlags(req.BindDN) == nil {
 		db.si.SetFlags(req.BindDN, &flags)
 	}

--- a/internal/outpost/ldap/bind/direct/bind.go
+++ b/internal/outpost/ldap/bind/direct/bind.go
@@ -28,6 +28,7 @@ func (db *DirectBinder) Bind(username string, req *bind.Request) (ldap.LDAPResul
 	passed, err := fe.Execute()
 	flags := flags.UserFlags{
 		Session: fe.GetSession(),
+		UserPk:  -1,
 	}
 	db.si.SetFlags(req.BindDN, &flags)
 	if err != nil {

--- a/internal/outpost/ldap/bind/direct/bind.go
+++ b/internal/outpost/ldap/bind/direct/bind.go
@@ -30,7 +30,10 @@ func (db *DirectBinder) Bind(username string, req *bind.Request) (ldap.LDAPResul
 		Session: fe.GetSession(),
 		UserPk:  -1,
 	}
-	db.si.SetFlags(req.BindDN, &flags)
+	//only set, if empty
+	if db.si.GetFlags(req.BindDN) == nil {
+		db.si.SetFlags(req.BindDN, &flags)
+	}
 	if err != nil {
 		metrics.RequestsRejected.With(prometheus.Labels{
 			"outpost_name": db.si.GetOutpostName(),

--- a/internal/outpost/ldap/flags/flags.go
+++ b/internal/outpost/ldap/flags/flags.go
@@ -6,6 +6,8 @@ import (
 	"goauthentik.io/api/v3"
 )
 
+const InvalidUserPK = -1
+
 type UserFlags struct {
 	UserInfo  *api.User
 	UserPk    int32

--- a/internal/outpost/ldap/search/memory/memory.go
+++ b/internal/outpost/ldap/search/memory/memory.go
@@ -112,12 +112,13 @@ func (ms *MemorySearcher) Search(req *search.Request) (ldap.ServerSearchResult, 
 						flags.UserInfo = &ms.users[i]
 					}
 				}
-
 				if flags.UserInfo == nil {
 					req.Log().WithField("pk", flags.UserPk).Warning("User with pk is not in local cache")
 					err = fmt.Errorf("failed to get userinfo")
 				}
-			} else {
+			}
+			if flags.UserInfo != nil {
+				req.Log().WithField("baseDN", req.BaseDN).WithField("userinfo", flags.UserInfo).Debug("Assign userinfo")
 				u[0] = *flags.UserInfo
 			}
 			users = &u

--- a/internal/outpost/ldap/search/memory/memory.go
+++ b/internal/outpost/ldap/search/memory/memory.go
@@ -12,6 +12,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"goauthentik.io/api/v3"
 	"goauthentik.io/internal/outpost/ldap/constants"
+	"goauthentik.io/internal/outpost/ldap/flags"
 	"goauthentik.io/internal/outpost/ldap/group"
 	"goauthentik.io/internal/outpost/ldap/metrics"
 	"goauthentik.io/internal/outpost/ldap/search"
@@ -72,8 +73,8 @@ func (ms *MemorySearcher) Search(req *search.Request) (ldap.ServerSearchResult, 
 		return ldap.ServerSearchResult{ResultCode: ldap.LDAPResultInsufficientAccessRights}, fmt.Errorf("Search Error: BindDN %s not in our BaseDN %s", req.BindDN, ms.si.GetBaseDN())
 	}
 
-	flags := ms.si.GetFlags(req.BindDN)
-	if flags == nil || (flags.UserInfo == nil && flags.UserPk == -1) {
+	flag := ms.si.GetFlags(req.BindDN)
+	if flag == nil || (flag.UserInfo == nil && flag.UserPk == flags.InvalidUserPK) {
 		req.Log().Debug("User info not cached")
 		metrics.RequestsRejected.With(prometheus.Labels{
 			"outpost_name": ms.si.GetOutpostName(),
@@ -102,24 +103,23 @@ func (ms *MemorySearcher) Search(req *search.Request) (ldap.ServerSearchResult, 
 	var groups []*group.LDAPGroup
 
 	if needUsers {
-		if flags.CanSearch {
+		if flag.CanSearch {
 			users = &ms.users
 		} else {
 			u := make([]api.User, 1)
-			if flags.UserInfo == nil {
+			if flag.UserInfo == nil {
 				for i, u := range ms.users {
-					if u.Pk == flags.UserPk {
-						flags.UserInfo = &ms.users[i]
+					if u.Pk == flag.UserPk {
+						flag.UserInfo = &ms.users[i]
 					}
 				}
-				if flags.UserInfo == nil {
-					req.Log().WithField("pk", flags.UserPk).Warning("User with pk is not in local cache")
+				if flag.UserInfo == nil {
+					req.Log().WithField("pk", flag.UserPk).Warning("User with pk is not in local cache")
 					err = fmt.Errorf("failed to get userinfo")
 				}
 			}
-			if flags.UserInfo != nil {
-				req.Log().WithField("baseDN", req.BaseDN).WithField("userinfo", flags.UserInfo).Debug("Assign userinfo")
-				u[0] = *flags.UserInfo
+			if flag.UserInfo != nil {
+				u[0] = *flag.UserInfo
 			}
 			users = &u
 		}
@@ -129,17 +129,17 @@ func (ms *MemorySearcher) Search(req *search.Request) (ldap.ServerSearchResult, 
 		groups = make([]*group.LDAPGroup, 0)
 
 		for _, g := range ms.groups {
-			if flags.CanSearch {
+			if flag.CanSearch {
 				groups = append(groups, group.FromAPIGroup(g, ms.si))
 			} else {
 				// If the user cannot search, we're going to only return
 				// the groups they're in _and_ only return themselves
 				// as a member.
 				for _, u := range g.UsersObj {
-					if flags.UserPk == u.Pk {
+					if flag.UserPk == u.Pk {
 						//TODO: Is there a better way to clone this object?
 						fg := api.NewGroup(g.Pk, g.NumPk, g.Name, g.ParentName, []api.GroupMember{u})
-						fg.SetUsers([]int32{flags.UserPk})
+						fg.SetUsers([]int32{flag.UserPk})
 						if g.Parent.IsSet() {
 							fg.SetParent(*g.Parent.Get())
 						}

--- a/internal/outpost/ldap/search/memory/memory.go
+++ b/internal/outpost/ldap/search/memory/memory.go
@@ -73,7 +73,7 @@ func (ms *MemorySearcher) Search(req *search.Request) (ldap.ServerSearchResult, 
 	}
 
 	flags := ms.si.GetFlags(req.BindDN)
-	if flags == nil {
+	if flags == nil || (flags.UserInfo == nil && flags.UserPk == -1) {
 		req.Log().Debug("User info not cached")
 		metrics.RequestsRejected.With(prometheus.Labels{
 			"outpost_name": ms.si.GetOutpostName(),


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://goauthentik.io/developer-docs/#how-can-i-contribute).
-->

This has been a very nasty bug I was trying to fix for a long time now. By pure accident I stumbled across a simple `ldapsearch` that would corrupt the state of a user.



## Details
This happens if you use both cached bind and cached search.

In the current version, if you bind a user, the SetFlags will be set according to the BindDN. If the user later logs in again but uses different credentials, i.e. a wrong password, the SetFlags will be reset (in the direct binder), login however will fail (as expected). If the user then correctly signs in again, the session will not be refreshed (as it is still valid), and `SetFlags` will not be updated, resulting in "User with PK not in local cache" messages with Pk being `0`, as the binder did not receive a Pk from the server.

This also fixes a bug that only provides data for a "newly" logged-in user, if you ask twice.

-   **Does this resolve an issue?**
    Yes, but I did not file one, sorry.

## Changes

I changed the logic to only call `SetFlags`, if none are available, to avoid overwriting the existing information of a user that logs in. I added the Pk of -1, because I was not sure, if 0 is a valid Pk or not.

In the search/memory, I updated the logic as well:
-  clients would report as being there, because GetFlags would return non-nil, but they haven't authenticated -> this should bail   in my opinion (line 76)
-  The if-else logic is broken. In the `true` case, the `u[0]` is never set, resulting in the second bug, as the `users` object is empty and does not contain the `userinfo` that has just been identified by the logic

### New Features

none

### Breaking Changes

none

## Checklist

-   [X] Local tests pass (`ak test authentik/`)
-   [X] The code has been formatted (`make lint-fix`)
