### PR TITLE
sources/ldap: fix ldap_sync cli command not running in foreground

### DIFF
--- a/authentik/sources/ldap/sync/users.py
+++ b/authentik/sources/ldap/sync/users.py
@@ -49,7 +49,7 @@ class UserLDAPSynchronizer(BaseLDAPSynchronizer):
             uniq = self._flatten(attributes[self._source.object_uniqueness_field])
             try:
                 defaults = self.build_user_properties(user_dn, **attributes)
-                self._logger.debug("Creating user with attributes", **defaults)
+                self._logger.debug("Writing user with attributes", **defaults)
                 if "username" not in defaults:
                     raise IntegrityError("Username was not set by propertymappings")
                 ak_user, created = self.update_or_create_attributes(

--- a/website/docs/troubleshooting/ldap_source.md
+++ b/website/docs/troubleshooting/ldap_source.md
@@ -5,7 +5,7 @@ title: Troubleshooting LDAP Synchronization
 To troubleshoot LDAP sources, you can run the command below to run a synchronization in the foreground and see any errors or warnings that might happen directly
 
 ```
-docker-compose run --rm server ldap_sync *slug of the source*
+docker-compose run --rm worker ldap_sync *slug of the source*
 ```
 
 or, for Kubernetes, run


### PR DESCRIPTION
closes #6317

<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://goauthentik.io/developer-docs/#how-can-i-contribute).
-->

## Details

-   **Does this resolve an issue?**
    Resolves #

## Changes

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
