### PR TITLE
providers/oauth2: fix grant_type password raising an exception

### DIFF
--- a/authentik/core/migrations/0031_alter_user_type.py
+++ b/authentik/core/migrations/0031_alter_user_type.py
@@ -17,6 +17,7 @@ def migrate_user_type_v2(apps: Apps, schema_editor: BaseDatabaseSchemaEditor):
         user.type = UserTypes.INTERNAL
         user.save()
 
+
 class Migration(migrations.Migration):
     dependencies = [
         ("authentik_core", "0030_user_type"),

--- a/authentik/providers/oauth2/views/token.py
+++ b/authentik/providers/oauth2/views/token.py
@@ -459,13 +459,13 @@ class TokenView(View):
                 if self.params.grant_type == GRANT_TYPE_REFRESH_TOKEN:
                     LOGGER.debug("Refreshing refresh token")
                     return TokenResponse(self.create_refresh_response())
-                if self.params.grant_type == GRANT_TYPE_CLIENT_CREDENTIALS:
-                    LOGGER.debug("Client credentials grant")
+                if self.params.grant_type in [GRANT_TYPE_CLIENT_CREDENTIALS, GRANT_TYPE_PASSWORD]:
+                    LOGGER.debug("Client credentials/password grant")
                     return TokenResponse(self.create_client_credentials_response())
                 if self.params.grant_type == GRANT_TYPE_DEVICE_CODE:
                     LOGGER.debug("Device code grant")
                     return TokenResponse(self.create_device_code_response())
-                raise ValueError(f"Invalid grant_type: {self.params.grant_type}")
+                raise TokenError("unsupported_grant_type")
         except (TokenError, DeviceCodeError) as error:
             return TokenResponse(error.create_dict(), status=400)
         except UserAuthError as error:


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://goauthentik.io/developer-docs/#how-can-i-contribute).
-->

## Details

#6139

doesn't fully solve the issue as we're still technically not complaint with our client_credentials grant implementation

## Changes

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
