### PR TITLE
Fix: Add Support for non-default Redis username

### DIFF
--- a/internal/config/struct.go
+++ b/internal/config/struct.go
@@ -27,6 +27,7 @@ type Config struct {
 type RedisConfig struct {
 	Host                   string `yaml:"host" env:"AUTHENTIK_REDIS__HOST"`
 	Port                   int    `yaml:"port" env:"AUTHENTIK_REDIS__PORT"`
+	User                   string `yaml:"user" env:"AUTHENTIK_REDIS__USER"`
 	Password               string `yaml:"password" env:"AUTHENTIK_REDIS__PASSWORD"`
 	TLS                    bool   `yaml:"tls" env:"AUTHENTIK_REDIS__TLS"`
 	TLSReqs                string `yaml:"tls_reqs" env:"AUTHENTIK_REDIS__TLS_REQS"`

--- a/internal/outpost/proxyv2/application/session.go
+++ b/internal/outpost/proxyv2/application/session.go
@@ -29,7 +29,7 @@ func (a *Application) getStore(p api.ProxyOutpostConfig, externalHost *url.URL) 
 		maxAge = int(*t) + 1
 	}
 	if config.Get().Redis.Host != "" {
-		rs, err := redistore.NewRediStoreWithDB(10, "tcp", fmt.Sprintf("%s:%d", config.Get().Redis.Host, config.Get().Redis.Port), config.Get().Redis.Password, strconv.Itoa(config.Get().Redis.DB))
+		rs, err := redistore.NewRediStoreWithDB(10, "tcp", fmt.Sprintf("%s:%d", config.Get().Redis.Host, config.Get().Redis.Port), config.Get().Redis.User, config.Get().Redis.Password, strconv.Itoa(config.Get().Redis.DB))
 		if err != nil {
 			panic(err)
 		}

--- a/lifecycle/system_migrations/to_0_13_authentik.py
+++ b/lifecycle/system_migrations/to_0_13_authentik.py
@@ -116,6 +116,7 @@ class Migration(BaseMigration):
                 host=CONFIG.get("redis.host"),
                 port=6379,
                 db=db,
+                username=CONFIG.get("redis.user"),
                 password=CONFIG.get("redis.password"),
             )
             redis.flushall()

--- a/lifecycle/wait_for_db.py
+++ b/lifecycle/wait_for_db.py
@@ -45,9 +45,10 @@ REDIS_PROTOCOL_PREFIX = "redis://"
 if CONFIG.get_bool("redis.tls", False):
     REDIS_PROTOCOL_PREFIX = "rediss://"
 REDIS_URL = (
-    f"{REDIS_PROTOCOL_PREFIX}:"
-    f"{quote_plus(CONFIG.get('redis.password'))}@{quote_plus(CONFIG.get('redis.host'))}:"
-    f"{int(CONFIG.get('redis.port'))}/{CONFIG.get('redis.db')}"
+    f"{REDIS_PROTOCOL_PREFIX}"
+    f"{quote_plus(CONFIG.get('redis.user'))}:{quote_plus(CONFIG.get('redis.password'))}"
+    f"@{quote_plus(CONFIG.get('redis.host'))}:{int(CONFIG.get('redis.port'))}"
+    f"/{CONFIG.get('redis.db')}"
 )
 while True:
     try:

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-21 13:04+0000\n"
+"POT-Creation-Date: 2023-07-22 17:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -585,65 +585,65 @@ msgstr ""
 msgid "Invalid kubeconfig"
 msgstr ""
 
-#: authentik/outposts/models.py:121
+#: authentik/outposts/models.py:122
 msgid ""
 "If enabled, use the local connection. Required Docker socket/Kubernetes "
 "Integration"
 msgstr ""
 
-#: authentik/outposts/models.py:151
+#: authentik/outposts/models.py:152
 msgid "Outpost Service-Connection"
 msgstr ""
 
-#: authentik/outposts/models.py:152
+#: authentik/outposts/models.py:153
 msgid "Outpost Service-Connections"
 msgstr ""
 
-#: authentik/outposts/models.py:160
+#: authentik/outposts/models.py:161
 msgid ""
 "Can be in the format of 'unix://<path>' when connecting to a local docker "
 "daemon, or 'https://<hostname>:2376' when connecting to a remote system."
 msgstr ""
 
-#: authentik/outposts/models.py:172
+#: authentik/outposts/models.py:173
 msgid ""
 "CA which the endpoint's Certificate is verified against. Can be left empty "
 "for no validation."
 msgstr ""
 
-#: authentik/outposts/models.py:184
+#: authentik/outposts/models.py:185
 msgid ""
 "Certificate/Key used for authentication. Can be left empty for no "
 "authentication."
 msgstr ""
 
-#: authentik/outposts/models.py:202
+#: authentik/outposts/models.py:203
 msgid "Docker Service-Connection"
 msgstr ""
 
-#: authentik/outposts/models.py:203
+#: authentik/outposts/models.py:204
 msgid "Docker Service-Connections"
 msgstr ""
 
-#: authentik/outposts/models.py:211
+#: authentik/outposts/models.py:212
 msgid ""
 "Paste your kubeconfig here. authentik will automatically use the currently "
 "selected context."
 msgstr ""
 
-#: authentik/outposts/models.py:217
+#: authentik/outposts/models.py:218
 msgid "Verify SSL Certificates of the Kubernetes API endpoint"
 msgstr ""
 
-#: authentik/outposts/models.py:234
+#: authentik/outposts/models.py:235
 msgid "Kubernetes Service-Connection"
 msgstr ""
 
-#: authentik/outposts/models.py:235
+#: authentik/outposts/models.py:236
 msgid "Kubernetes Service-Connections"
 msgstr ""
 
-#: authentik/outposts/models.py:251
+#: authentik/outposts/models.py:252
 msgid ""
 "Select Service-Connection authentik should use to manage this outpost. Leave "
 "empty if authentik should not handle the deployment."

--- a/web/xliff/de.xlf
+++ b/web/xliff/de.xlf
@@ -5751,15 +5751,6 @@ Bindings to groups/users are checked against the user of the event.</source>
 <trans-unit id="s9f9492d30a96b9c6">
   <source>User type</source>
 </trans-unit>
-<trans-unit id="s0b9a40b7b2853c7d">
-  <source>Default user</source>
-</trans-unit>
-<trans-unit id="s35b9fa270f45b391">
-  <source>External user</source>
-</trans-unit>
-<trans-unit id="s1a635369edaf4dc3">
-  <source>Service account</source>
-</trans-unit>
 <trans-unit id="s0e427111d750cc02">
   <source>Successfully updated license.</source>
 </trans-unit>
@@ -5828,6 +5819,15 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s0285b4bd69130fa3">
   <source>Install License</source>
+</trans-unit>
+<trans-unit id="scef2eb6a2bfe3110">
+  <source>Internal users might be users such as company employees, which will get access to the full Enterprise feature set.</source>
+</trans-unit>
+<trans-unit id="sf66389b04fcc219c">
+  <source>External users might be external consultants or B2C customers. These users don't get access to enterprise features.</source>
+</trans-unit>
+<trans-unit id="s77e8668a27dbc402">
+  <source>Service accounts should be used for machine-to-machine authentication or other automations.</source>
 </trans-unit>
     </body>
   </file>

--- a/web/xliff/en.xlf
+++ b/web/xliff/en.xlf
@@ -6067,15 +6067,6 @@ Bindings to groups/users are checked against the user of the event.</source>
 <trans-unit id="s9f9492d30a96b9c6">
   <source>User type</source>
 </trans-unit>
-<trans-unit id="s0b9a40b7b2853c7d">
-  <source>Default user</source>
-</trans-unit>
-<trans-unit id="s35b9fa270f45b391">
-  <source>External user</source>
-</trans-unit>
-<trans-unit id="s1a635369edaf4dc3">
-  <source>Service account</source>
-</trans-unit>
 <trans-unit id="s0e427111d750cc02">
   <source>Successfully updated license.</source>
 </trans-unit>
@@ -6144,6 +6135,15 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s0285b4bd69130fa3">
   <source>Install License</source>
+</trans-unit>
+<trans-unit id="scef2eb6a2bfe3110">
+  <source>Internal users might be users such as company employees, which will get access to the full Enterprise feature set.</source>
+</trans-unit>
+<trans-unit id="sf66389b04fcc219c">
+  <source>External users might be external consultants or B2C customers. These users don't get access to enterprise features.</source>
+</trans-unit>
+<trans-unit id="s77e8668a27dbc402">
+  <source>Service accounts should be used for machine-to-machine authentication or other automations.</source>
 </trans-unit>
     </body>
   </file>

--- a/web/xliff/es.xlf
+++ b/web/xliff/es.xlf
@@ -5659,15 +5659,6 @@ Bindings to groups/users are checked against the user of the event.</source>
 <trans-unit id="s9f9492d30a96b9c6">
   <source>User type</source>
 </trans-unit>
-<trans-unit id="s0b9a40b7b2853c7d">
-  <source>Default user</source>
-</trans-unit>
-<trans-unit id="s35b9fa270f45b391">
-  <source>External user</source>
-</trans-unit>
-<trans-unit id="s1a635369edaf4dc3">
-  <source>Service account</source>
-</trans-unit>
 <trans-unit id="s0e427111d750cc02">
   <source>Successfully updated license.</source>
 </trans-unit>
@@ -5736,6 +5727,15 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s0285b4bd69130fa3">
   <source>Install License</source>
+</trans-unit>
+<trans-unit id="scef2eb6a2bfe3110">
+  <source>Internal users might be users such as company employees, which will get access to the full Enterprise feature set.</source>
+</trans-unit>
+<trans-unit id="sf66389b04fcc219c">
+  <source>External users might be external consultants or B2C customers. These users don't get access to enterprise features.</source>
+</trans-unit>
+<trans-unit id="s77e8668a27dbc402">
+  <source>Service accounts should be used for machine-to-machine authentication or other automations.</source>
 </trans-unit>
     </body>
   </file>

--- a/web/xliff/fr_FR.xlf
+++ b/web/xliff/fr_FR.xlf
@@ -5766,15 +5766,6 @@ Bindings to groups/users are checked against the user of the event.</source>
 <trans-unit id="s9f9492d30a96b9c6">
   <source>User type</source>
 </trans-unit>
-<trans-unit id="s0b9a40b7b2853c7d">
-  <source>Default user</source>
-</trans-unit>
-<trans-unit id="s35b9fa270f45b391">
-  <source>External user</source>
-</trans-unit>
-<trans-unit id="s1a635369edaf4dc3">
-  <source>Service account</source>
-</trans-unit>
 <trans-unit id="s0e427111d750cc02">
   <source>Successfully updated license.</source>
 </trans-unit>
@@ -5843,6 +5834,15 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s0285b4bd69130fa3">
   <source>Install License</source>
+</trans-unit>
+<trans-unit id="scef2eb6a2bfe3110">
+  <source>Internal users might be users such as company employees, which will get access to the full Enterprise feature set.</source>
+</trans-unit>
+<trans-unit id="sf66389b04fcc219c">
+  <source>External users might be external consultants or B2C customers. These users don't get access to enterprise features.</source>
+</trans-unit>
+<trans-unit id="s77e8668a27dbc402">
+  <source>Service accounts should be used for machine-to-machine authentication or other automations.</source>
 </trans-unit>
     </body>
   </file>

--- a/web/xliff/pl.xlf
+++ b/web/xliff/pl.xlf
@@ -5898,15 +5898,6 @@ Bindings to groups/users are checked against the user of the event.</source>
 <trans-unit id="s9f9492d30a96b9c6">
   <source>User type</source>
 </trans-unit>
-<trans-unit id="s0b9a40b7b2853c7d">
-  <source>Default user</source>
-</trans-unit>
-<trans-unit id="s35b9fa270f45b391">
-  <source>External user</source>
-</trans-unit>
-<trans-unit id="s1a635369edaf4dc3">
-  <source>Service account</source>
-</trans-unit>
 <trans-unit id="s0e427111d750cc02">
   <source>Successfully updated license.</source>
 </trans-unit>
@@ -5975,6 +5966,15 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s0285b4bd69130fa3">
   <source>Install License</source>
+</trans-unit>
+<trans-unit id="scef2eb6a2bfe3110">
+  <source>Internal users might be users such as company employees, which will get access to the full Enterprise feature set.</source>
+</trans-unit>
+<trans-unit id="sf66389b04fcc219c">
+  <source>External users might be external consultants or B2C customers. These users don't get access to enterprise features.</source>
+</trans-unit>
+<trans-unit id="s77e8668a27dbc402">
+  <source>Service accounts should be used for machine-to-machine authentication or other automations.</source>
 </trans-unit>
     </body>
   </file>

--- a/web/xliff/pseudo-LOCALE.xlf
+++ b/web/xliff/pseudo-LOCALE.xlf
@@ -6002,15 +6002,6 @@ Bindings to groups/users are checked against the user of the event.</source>
 <trans-unit id="s9f9492d30a96b9c6">
   <source>User type</source>
 </trans-unit>
-<trans-unit id="s0b9a40b7b2853c7d">
-  <source>Default user</source>
-</trans-unit>
-<trans-unit id="s35b9fa270f45b391">
-  <source>External user</source>
-</trans-unit>
-<trans-unit id="s1a635369edaf4dc3">
-  <source>Service account</source>
-</trans-unit>
 <trans-unit id="s0e427111d750cc02">
   <source>Successfully updated license.</source>
 </trans-unit>
@@ -6079,6 +6070,15 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s0285b4bd69130fa3">
   <source>Install License</source>
+</trans-unit>
+<trans-unit id="scef2eb6a2bfe3110">
+  <source>Internal users might be users such as company employees, which will get access to the full Enterprise feature set.</source>
+</trans-unit>
+<trans-unit id="sf66389b04fcc219c">
+  <source>External users might be external consultants or B2C customers. These users don't get access to enterprise features.</source>
+</trans-unit>
+<trans-unit id="s77e8668a27dbc402">
+  <source>Service accounts should be used for machine-to-machine authentication or other automations.</source>
 </trans-unit>
     </body>
   </file>

--- a/web/xliff/tr.xlf
+++ b/web/xliff/tr.xlf
@@ -5649,15 +5649,6 @@ Bindings to groups/users are checked against the user of the event.</source>
 <trans-unit id="s9f9492d30a96b9c6">
   <source>User type</source>
 </trans-unit>
-<trans-unit id="s0b9a40b7b2853c7d">
-  <source>Default user</source>
-</trans-unit>
-<trans-unit id="s35b9fa270f45b391">
-  <source>External user</source>
-</trans-unit>
-<trans-unit id="s1a635369edaf4dc3">
-  <source>Service account</source>
-</trans-unit>
 <trans-unit id="s0e427111d750cc02">
   <source>Successfully updated license.</source>
 </trans-unit>
@@ -5726,6 +5717,15 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s0285b4bd69130fa3">
   <source>Install License</source>
+</trans-unit>
+<trans-unit id="scef2eb6a2bfe3110">
+  <source>Internal users might be users such as company employees, which will get access to the full Enterprise feature set.</source>
+</trans-unit>
+<trans-unit id="sf66389b04fcc219c">
+  <source>External users might be external consultants or B2C customers. These users don't get access to enterprise features.</source>
+</trans-unit>
+<trans-unit id="s77e8668a27dbc402">
+  <source>Service accounts should be used for machine-to-machine authentication or other automations.</source>
 </trans-unit>
     </body>
   </file>

--- a/web/xliff/zh-Hans.xlf
+++ b/web/xliff/zh-Hans.xlf
@@ -7585,18 +7585,6 @@ Bindings to groups/users are checked against the user of the event.</source>
   <source>User type</source>
   <target>用户类型</target>
 </trans-unit>
-<trans-unit id="s0b9a40b7b2853c7d">
-  <source>Default user</source>
-  <target>默认用户</target>
-</trans-unit>
-<trans-unit id="s35b9fa270f45b391">
-  <source>External user</source>
-  <target>外部用户</target>
-</trans-unit>
-<trans-unit id="s1a635369edaf4dc3">
-  <source>Service account</source>
-  <target>服务账户</target>
-</trans-unit>
 <trans-unit id="s0e427111d750cc02">
   <source>Successfully updated license.</source>
   <target>已成功更新许可证。</target>
@@ -7678,6 +7666,15 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s0285b4bd69130fa3">
   <source>Install License</source>
+</trans-unit>
+<trans-unit id="scef2eb6a2bfe3110">
+  <source>Internal users might be users such as company employees, which will get access to the full Enterprise feature set.</source>
+</trans-unit>
+<trans-unit id="sf66389b04fcc219c">
+  <source>External users might be external consultants or B2C customers. These users don't get access to enterprise features.</source>
+</trans-unit>
+<trans-unit id="s77e8668a27dbc402">
+  <source>Service accounts should be used for machine-to-machine authentication or other automations.</source>
 </trans-unit>
     </body>
   </file>

--- a/web/xliff/zh-Hant.xlf
+++ b/web/xliff/zh-Hant.xlf
@@ -5704,15 +5704,6 @@ Bindings to groups/users are checked against the user of the event.</source>
 <trans-unit id="s9f9492d30a96b9c6">
   <source>User type</source>
 </trans-unit>
-<trans-unit id="s0b9a40b7b2853c7d">
-  <source>Default user</source>
-</trans-unit>
-<trans-unit id="s35b9fa270f45b391">
-  <source>External user</source>
-</trans-unit>
-<trans-unit id="s1a635369edaf4dc3">
-  <source>Service account</source>
-</trans-unit>
 <trans-unit id="s0e427111d750cc02">
   <source>Successfully updated license.</source>
 </trans-unit>
@@ -5781,6 +5772,15 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s0285b4bd69130fa3">
   <source>Install License</source>
+</trans-unit>
+<trans-unit id="scef2eb6a2bfe3110">
+  <source>Internal users might be users such as company employees, which will get access to the full Enterprise feature set.</source>
+</trans-unit>
+<trans-unit id="sf66389b04fcc219c">
+  <source>External users might be external consultants or B2C customers. These users don't get access to enterprise features.</source>
+</trans-unit>
+<trans-unit id="s77e8668a27dbc402">
+  <source>Service accounts should be used for machine-to-machine authentication or other automations.</source>
 </trans-unit>
     </body>
   </file>

--- a/web/xliff/zh_TW.xlf
+++ b/web/xliff/zh_TW.xlf
@@ -5703,15 +5703,6 @@ Bindings to groups/users are checked against the user of the event.</source>
 <trans-unit id="s9f9492d30a96b9c6">
   <source>User type</source>
 </trans-unit>
-<trans-unit id="s0b9a40b7b2853c7d">
-  <source>Default user</source>
-</trans-unit>
-<trans-unit id="s35b9fa270f45b391">
-  <source>External user</source>
-</trans-unit>
-<trans-unit id="s1a635369edaf4dc3">
-  <source>Service account</source>
-</trans-unit>
 <trans-unit id="s0e427111d750cc02">
   <source>Successfully updated license.</source>
 </trans-unit>
@@ -5780,6 +5771,15 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s0285b4bd69130fa3">
   <source>Install License</source>
+</trans-unit>
+<trans-unit id="scef2eb6a2bfe3110">
+  <source>Internal users might be users such as company employees, which will get access to the full Enterprise feature set.</source>
+</trans-unit>
+<trans-unit id="sf66389b04fcc219c">
+  <source>External users might be external consultants or B2C customers. These users don't get access to enterprise features.</source>
+</trans-unit>
+<trans-unit id="s77e8668a27dbc402">
+  <source>Service accounts should be used for machine-to-machine authentication or other automations.</source>
 </trans-unit>
     </body>
   </file>

--- a/website/docs/installation/configuration.md
+++ b/website/docs/installation/configuration.md
@@ -42,6 +42,7 @@ kubectl exec -it deployment/authentik-worker -c authentik -- ak dump_config
 
 -   `AUTHENTIK_REDIS__HOST`: Hostname of your Redis Server
 -   `AUTHENTIK_REDIS__PORT`: Redis port, defaults to 6379
+-   `AUTHENTIK_REDIS__USER`: Username for your Redis Server
 -   `AUTHENTIK_REDIS__PASSWORD`: Password for your Redis Server
 -   `AUTHENTIK_REDIS__TLS`: Use TLS to connect to Redis, defaults to false
 -   `AUTHENTIK_REDIS__TLS_REQS`: Redis TLS requirements, defaults to "none"


### PR DESCRIPTION
## Details

- This closes the Issue #5348, it's blocked until [redistore#65](https://github.com/boj/redistore/pull/65) is merged.

## Changes

### New Features

-   Adding the environment `AUTHENTIK_REDIS__USER` which allows to set the redis username.

### Breaking Changes

-   None. Not setting the environment will not cause any trouble.

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [x] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)
-   [x] The translation files have been updated (`make i18n-extract`)

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
