### PR TITLE
outposts: Fix infinite self-recursion in traefik reconciler.

### DIFF
--- a/authentik/providers/proxy/controllers/k8s/traefik.py
+++ b/authentik/providers/proxy/controllers/k8s/traefik.py
@@ -26,19 +26,19 @@ class TraefikMiddlewareReconciler(KubernetesObjectReconciler):
         return self.reconciler.noop
 
     def reconcile(self, current: TraefikMiddleware, reference: TraefikMiddleware):
-        return self.reconcile(current, reference)
+        return self.reconciler.reconcile(current, reference)
 
     def get_reference_object(self) -> TraefikMiddleware:
-        return self.get_reference_object()
+        return self.reconciler.get_reference_object()
 
     def create(self, reference: TraefikMiddleware):
-        return self.create(reference)
+        return self.reconciler.create(reference)
 
     def delete(self, reference: TraefikMiddleware):
-        return self.delete(reference)
+        return self.reconciler.delete(reference)
 
     def retrieve(self) -> TraefikMiddleware:
-        return self.retrieve()
+        return self.reconciler.retrieve()
 
     def update(self, current: TraefikMiddleware, reference: TraefikMiddleware):
-        return self.update(current, reference)
+        return self.reconciler.update(current, reference)


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://goauthentik.io/developer-docs/#how-can-i-contribute).
-->

## Details

- Fixes an infinite self recursion in the traefik middleware reconciler due to the facade class forwarding method calls to itself.
- Due to this issue, at present, it fails to create traefik middleware resources.
- This appears to have been introduced with #5801 
```
Task outpost_controller encountered an error: Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/celery/app/trace.py", line 477, in trace_task
    R = retval = fun(*args, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/celery/app/trace.py", line 760, in __protected_call__
    return self.run(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/authentik/outposts/tasks.py", line 151, in outpost_controller
    logs = getattr(controller, f"{action}_with_logs")()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/authentik/outposts/controllers/kubernetes.py", line 92, in up_with_logs
    reconciler.up()
  File "/authentik/outposts/controllers/k8s/base.py", line 65, in up
    reference = self.get_reference_object()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/authentik/providers/proxy/controllers/k8s/traefik.py", line 28, in get_reference_object
    return self.get_reference_object()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/authentik/providers/proxy/controllers/k8s/traefik.py", line 28, in get_reference_object
    return self.get_reference_object()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/authentik/providers/proxy/controllers/k8s/traefik.py", line 28, in get_reference_object
    return self.get_reference_object()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  [Previous line repeated 956 more times]
builtins.RecursionError: maximum recursion depth exceeded
```

## Changes

Change the TraefikMiddlewareReconciler to properly forward all method calls to the wrapped reconciler instance.

### New Features

N/A

### Breaking Changes

N/A

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
