### PR TITLE
outposts: fix patch processing

### DIFF
--- a/authentik/outposts/controllers/k8s/base.py
+++ b/authentik/outposts/controllers/k8s/base.py
@@ -1,7 +1,9 @@
 """Base Kubernetes Reconciler"""
+from dataclasses import asdict
 from json import dumps
 from typing import TYPE_CHECKING, Generic, Optional, TypeVar
 
+from dacite.core import from_dict
 from django.utils.text import slugify
 from jsonpatch import JsonPatchConflict, JsonPatchException, JsonPatchTestFailed, apply_patch
 from kubernetes.client import ApiClient, V1ObjectMeta
@@ -75,18 +77,28 @@ class KubernetesObjectReconciler(Generic[T]):
         """Get patched reference object"""
         reference = self.get_reference_object()
         patch = self.get_patch()
-        v1deploy_json = ApiClient().sanitize_for_serialization(reference)
+        try:
+            json = ApiClient().sanitize_for_serialization(reference)
+        # Custom objects will not be known to the clients openapi types
+        except AttributeError:
+            json = asdict(reference)
         try:
             if patch is not None:
-                ref_v1deploy = apply_patch(v1deploy_json, patch)
+                ref = apply_patch(json, patch)
             else:
-                ref_v1deploy = v1deploy_json
+                ref = json
         except (JsonPatchException, JsonPatchConflict, JsonPatchTestFailed) as exc:
             raise ControllerException(f"JSON Patch failed: {exc}") from exc
         mock_response = Response()
-        mock_response.data = dumps(ref_v1deploy)
+        mock_response.data = dumps(ref)
 
-        return ApiClient().deserialize(mock_response, reference.__class__.__name__)
+        try:
+            result = ApiClient().deserialize(mock_response, reference.__class__.__name__)
+        # Custom objects will not be known to the clients openapi types
+        except AttributeError:
+            result = from_dict(reference.__class__, data=ref)
+
+        return result
 
     # pylint: disable=invalid-name
     def up(self):

--- a/authentik/outposts/controllers/k8s/base.py
+++ b/authentik/outposts/controllers/k8s/base.py
@@ -45,7 +45,7 @@ class KubernetesObjectReconciler(Generic[T]):
         patches = self.controller.outpost.config.kubernetes_json_patches
         if not patches:
             return None
-        return patches.get(self.name, None)
+        return patches.get(self.reconciler_name(), None)
 
     @property
     def is_embedded(self) -> bool:

--- a/authentik/outposts/controllers/k8s/base.py
+++ b/authentik/outposts/controllers/k8s/base.py
@@ -83,10 +83,9 @@ class KubernetesObjectReconciler(Generic[T]):
         except AttributeError:
             json = asdict(reference)
         try:
+            ref = json
             if patch is not None:
                 ref = apply_patch(json, patch)
-            else:
-                ref = json
         except (JsonPatchException, JsonPatchConflict, JsonPatchTestFailed) as exc:
             raise ControllerException(f"JSON Patch failed: {exc}") from exc
         mock_response = Response()


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://goauthentik.io/developer-docs/#how-can-i-contribute).
-->

## Details

-   Follow-up fixes from regressions introduced in #6319

## Changes

### New Features

-   Fixes reconcile error `'PrometheusServiceMonitor' object has no attribute 'openapi_types'` 
-   Fixes `patches.get()` always returning `None`

### Breaking Changes

-   N/A

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
