### PR TITLE
Fix documentation on setting up nginx

### DIFF
--- a/website/docs/providers/proxy/_nginx_proxy_manager.md
+++ b/website/docs/providers/proxy/_nginx_proxy_manager.md
@@ -44,7 +44,7 @@ location /outpost.goauthentik.io {
     proxy_pass              http://outpost.company:9000/outpost.goauthentik.io;
     # ensure the host of this vserver matches your external URL you've configured
     # in authentik
-    proxy_set_header        Host $host;
+    proxy_set_header        X-Forwarded-Host $host;
     proxy_set_header        X-Original-URL $scheme://$http_host$request_uri;
     add_header              Set-Cookie $auth_cookie;
     auth_request_set        $auth_cookie $upstream_http_set_cookie;

--- a/website/docs/providers/proxy/_nginx_standalone.md
+++ b/website/docs/providers/proxy/_nginx_standalone.md
@@ -46,7 +46,7 @@ server {
         proxy_pass              http://outpost.company:9000/outpost.goauthentik.io;
         # ensure the host of this vserver matches your external URL you've configured
         # in authentik
-        proxy_set_header        Host $host;
+        proxy_set_header        X-Forwarded-Host $host;
         proxy_set_header        X-Original-URL $scheme://$http_host$request_uri;
         add_header              Set-Cookie $auth_cookie;
         auth_request_set        $auth_cookie $upstream_http_set_cookie;


### PR DESCRIPTION
Resolves #2594
(Yes, it's already closed, but there wasn't a fix listed until I commented there just a few minutes ago)

The scenario here is using multiple providers on the single embedded outpost, where both use Forwarded auth.

In the case where only one provider is used per outpost, you hit this snipped of go code:

```internal/outpost/proxyv2/handlers.go
func (ps *ProxyServer) Handle(...) {
  ...
  a, host := ps.lookupApp(r)
  if a == nil {
    // If we only have one handler, host name switching doesn't matter
    if len(ps.apps) == 1 {
      ...
      for k := range ps.apps {
        ps.apps[k].ServeHTTP(rw, r)
        return
      }
    }
    ...
```

where ps.lookupApp is defined here:
github.com/goauthentik/authentik/blob/main/internal/utils/web/host.go
```
package web

import (
  "net/http"
)

var xForwardedHost = http.CanonicalHeaderKey("X-Forwarded-Host")

func GetHost(req *http.Request) string {
  host := req.Host
  if req.Header.Get(xForwardedHost) != "" {
    host = req.Header.Get(xForwardedHost)
  }
  return host
}
```

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
