### PR TITLE
website/developer-docs: add new template for procedures

### DIFF
--- a/website/developer-docs/docs/templates/index.md
+++ b/website/developer-docs/docs/templates/index.md
@@ -1,0 +1,15 @@
+---
+title: "Templates"
+---
+
+In technical docuemntation, there are document "types" (similar to how there are data types). 
+
+The most common types are:
+
+* [Procedural](./procedural.md): these are How To docs, the HOW infomratin, with step-by-step instructions for accomplishing a task. This is what most people are looking for when they open the docs... and best practice is to separate the procedural docs from long, lengthy conceptual or reference docs.
+
+* Conceptual: these docs provide the WHY information, and explain when to use a feature (or when not to!), and general concepts behind the fature or functioanlity.
+
+* Reference: this is typically tables or lists of reference information, such as configuration values, or most commmonly APIs.
+
+We have templates for the different types, to make it super-easy for whomever wants to contribute some documentation! 

--- a/website/developer-docs/docs/templates/index.md
+++ b/website/developer-docs/docs/templates/index.md
@@ -2,14 +2,14 @@
 title: "Templates"
 ---
 
-In technical docuemntation, there are document "types" (similar to how there are data types). 
+In technical docuemntation, there are document "types" (similar to how there are data types).
 
 The most common types are:
 
-* [Procedural](./procedural.md): these are How To docs, the HOW infomratin, with step-by-step instructions for accomplishing a task. This is what most people are looking for when they open the docs... and best practice is to separate the procedural docs from long, lengthy conceptual or reference docs.
+-   [**Procedural**](./procedural.md): these are How To docs, the HOW information, with step-by-step instructions for accomplishing a task. This is what most people are looking for when they open the docs... and best practice is to separate the procedural docs from long, lengthy conceptual or reference docs.
 
-* Conceptual: these docs provide the WHY information, and explain when to use a feature (or when not to!), and general concepts behind the fature or functioanlity.
+-   **Conceptual**: these docs provide the WHY information, and explain when to use a feature (or when not to!), and general concepts behind the fature or functioanlity.
 
-* Reference: this is typically tables or lists of reference information, such as configuration values, or most commmonly APIs.
+-   **Reference**: this is typically tables or lists of reference information, such as configuration values, or most commmonly APIs.
 
-We have templates for the different types, to make it super-easy for whomever wants to contribute some documentation! 
+We have templates for the different types, to make it super-easy for whomever wants to contribute some documentation!

--- a/website/developer-docs/docs/templates/procedural.md
+++ b/website/developer-docs/docs/templates/procedural.md
@@ -1,16 +1,16 @@
 ---
-title: "Writing template (Procedural topic)"
-metaTitle: "Writing template (Procedural topic)"
-metaDescription: "A template for writing procedural documentation topics."
+title: "Procedural topic"
 ---
 
-Use a title that focuses on the task you are writing about... for example, "Add a new Group" or "Edit user profiles". For procedural docs, there should be a verb in the tilte, and usually the noun (the th8ing you are working on).
+Use a title that focuses on the task you are writing about... for example, "Add a new Group" or "Edit user profiles". For procedural docs, there should be a verb in the tilte, and usually the noun (the thing you are working on).
 
-In this first section write one or two sentences about the task. Keep it brief; if it goes on too long, then create a separate conceptual topic, in a separate `.md` file. We don;t want readers to have to scroll through paragraphs of conceptual info before they get to Step 1.
+Use the infinitive form of the verb (i.e. "add") not the gerund form (i.e. "adding").
+
+In this first section write one or two sentences about the task. Keep it brief; if it goes on too long, then create a separate conceptual topic, in a separate `.md` file. We don't want readers to have to scroll through paragraphs of conceptual info before they get to Step 1.
 
 ## Prerequisites (optional section)
 
-In this section, inform the reader of anythng they need to do, or have configured or installed, before they start following the procedural instructions below.
+In this section, inform the reader of anything they need to do, or have configured or installed, before they start following the procedural instructions below.
 
 ## Overview of steps/workflow (optional section)
 

--- a/website/developer-docs/docs/templates/procedural.md
+++ b/website/developer-docs/docs/templates/procedural.md
@@ -2,9 +2,7 @@
 title: "Procedural topic"
 ---
 
-Use a title that focuses on the task you are writing about... for example, "Add a new Group" or "Edit user profiles". For procedural docs, there should be a verb in the tilte, and usually the noun (the thing you are working on).
-
-Use the infinitive form of the verb (i.e. "add") not the gerund form (i.e. "adding").
+Use a title that focuses on the task you are writing about... for example, "Add a new Group" or "Edit user profiles". For procedural docs, there should be a verb in the tilte, and usually the noun (the thing you are working on). For the title (and all headings) use the infinitive form of the verb (i.e. "add") not the gerund form (i.e. "adding").
 
 In this first section write one or two sentences about the task. Keep it brief; if it goes on too long, then create a separate conceptual topic, in a separate `.md` file. We don't want readers to have to scroll through paragraphs of conceptual info before they get to Step 1.
 

--- a/website/developer-docs/docs/templates_docs/procedural.md
+++ b/website/developer-docs/docs/templates_docs/procedural.md
@@ -1,0 +1,39 @@
+---
+title: 'Writing template (Procedural topic)'
+metaTitle: 'Writing template (Procedural topic)'
+metaDescription: 'A template for writing procedural documentation topics.'
+---
+
+Use a title that focuses on the task you are writing about... for example, "Add a new Group" or "Edit user profiles". For procedural docs, there should be a verb in the tilte, and usually the noun (the th8ing you are working on).
+
+In this first section write one or two sentences about the task. Keep it brief; if it goes on too long, then create a separate conceptual topic, in a separate `.md` file. We don;t want readers to have to scroll through paragraphs of conceptual info before they get to Step 1.
+
+## Prerequisites (optional section)
+
+In this section, inform the reader of anythng they need to do, or have configured or installed, before they start following the procedural instructions below.
+
+## Overview of steps/workflow (optional section)
+
+If the task is quite long or complex, it might be good to add a bullet list of the main steps, or even a diagram of the workflow, just so that the reader can first familairize themselves with the 50,000 meter view before they dive into the detailed steps.
+
+## first several group steps
+
+If the task involves a lot of steps, try to group them into simalr steps and have a Head3 or Hedad4 title for each group.
+
+In this section, help the reader get oriented... where do they need to be (i.e. in the GUI, on a CLI, etc).
+
+Have a separate paragraph for each step.
+
+Start instructions with the desired outcome, followed by the instructions.
+
+EXAMPLE: To define a new port number, navigate to the Admin interface, and then to the **Settings** tab.
+
+## next step of grouped steps
+
+Continue with the steps... 
+
+Use screenshots sparingly, only for complex UIs where it is difficult to describe a UI element with words.
+
+## verify the steps
+
+Whenever possible, it is useful to add verification steps at the end of a procedural topic. For example, if the procedural was about installing a product, use this section to tell them how they can verify that the install was successful

--- a/website/developer-docs/docs/templates_docs/procedural.md
+++ b/website/developer-docs/docs/templates_docs/procedural.md
@@ -1,7 +1,7 @@
 ---
-title: 'Writing template (Procedural topic)'
-metaTitle: 'Writing template (Procedural topic)'
-metaDescription: 'A template for writing procedural documentation topics.'
+title: "Writing template (Procedural topic)"
+metaTitle: "Writing template (Procedural topic)"
+metaDescription: "A template for writing procedural documentation topics."
 ---
 
 Use a title that focuses on the task you are writing about... for example, "Add a new Group" or "Edit user profiles". For procedural docs, there should be a verb in the tilte, and usually the noun (the th8ing you are working on).
@@ -30,7 +30,7 @@ EXAMPLE: To define a new port number, navigate to the Admin interface, and then 
 
 ## next step of grouped steps
 
-Continue with the steps... 
+Continue with the steps...
 
 Use screenshots sparingly, only for complex UIs where it is difficult to describe a UI element with words.
 

--- a/website/sidebarsDev.js
+++ b/website/sidebarsDev.js
@@ -55,8 +55,17 @@ module.exports = {
             id: "translation",
         },
         {
-            type: "doc",
-            id: "docs/writing-documentation",
+            type: "category",
+            label: "Writing documentation",
+            collapsed: false,
+            link: {
+                type: "doc",
+                id: "docs/templates_docs",
+            },
+            items: [
+                "/template_docs/procedural",
+              
+            ],
         },
         {
             type: "doc",

--- a/website/sidebarsDev.js
+++ b/website/sidebarsDev.js
@@ -63,7 +63,7 @@ module.exports = {
                 id: "docs/templates_docs",
             },
             items: [
-                "/template_docs/procedural",
+                "template_docs/procedural",
               
             ],
         },

--- a/website/sidebarsDev.js
+++ b/website/sidebarsDev.js
@@ -57,12 +57,21 @@ module.exports = {
         {
             type: "category",
             label: "Writing documentation",
-            collapsed: false,
             link: {
                 type: "doc",
                 id: "docs/writing-documentation",
             },
-            items: ["docs/templates/index"],
+            items: [
+                {
+                    type: "category",
+                    label: "Templates",
+                    link: {
+                        type: "doc",
+                        id: "docs/templates/index",
+                    },
+                    items: ["docs/templates/procedural"],
+                },
+            ],
         },
         {
             type: "doc",

--- a/website/sidebarsDev.js
+++ b/website/sidebarsDev.js
@@ -60,10 +60,10 @@ module.exports = {
             collapsed: false,
             link: {
                 type: "doc",
-                id: "docs/templates_docs",
+                id: "docs/writing-documentation",
             },
             items: [
-                "template_docs/procedural",
+                "docs/templates/index",
               
             ],
         },

--- a/website/sidebarsDev.js
+++ b/website/sidebarsDev.js
@@ -62,10 +62,7 @@ module.exports = {
                 type: "doc",
                 id: "docs/writing-documentation",
             },
-            items: [
-                "docs/templates/index",
-              
-            ],
+            items: ["docs/templates/index"],
         },
         {
             type: "doc",


### PR DESCRIPTION
Draft for a new section in Dev Docs, for documentation templates. The `sidebarDev.js` file still needs something; the new topic `procedural.md` displays without the left-side nav pane. :-(

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
