### PR TITLE
api: log errors if app URLs import fail

### DIFF
--- a/authentik/api/v3/urls.py
+++ b/authentik/api/v3/urls.py
@@ -22,11 +22,11 @@ for _authentik_app in get_apps():
     try:
         api_urls = import_module(f"{_authentik_app.name}.urls")
     except (ModuleNotFoundError, ImportError) as exc:
-        LOGGER.debug("Could not import app", app_name=_authentik_app.name, exception=exc)
+        LOGGER.warning("Could not import app's URLs", app_name=_authentik_app.name, exception=exc)
         continue
     if not hasattr(api_urls, "api_urlpatterns"):
         LOGGER.debug(
-            "Could not import app API URL patterns",
+            "App does not define API URLs",
             app_name=_authentik_app.name,
         )
         continue

--- a/authentik/api/v3/urls.py
+++ b/authentik/api/v3/urls.py
@@ -21,9 +21,14 @@ _other_urls = []
 for _authentik_app in get_apps():
     try:
         api_urls = import_module(f"{_authentik_app.name}.urls")
-    except (ModuleNotFoundError, ImportError):
+    except (ModuleNotFoundError, ImportError) as exc:
+        LOGGER.debug("Could not import app", app_name=_authentik_app.name, exception=exc)
         continue
     if not hasattr(api_urls, "api_urlpatterns"):
+        LOGGER.debug(
+            "Could not import app API URL patterns",
+            app_name=_authentik_app.name,
+        )
         continue
     urls: list = getattr(api_urls, "api_urlpatterns")
     for url in urls:


### PR DESCRIPTION
## Details

If an app has an error like a typo in an import, it's catched by `except ImportError` and thus relatively impossible to debug when developing.

The way I give the exception to the logger probably isn't the way to do this though.

## Changes

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
