### PR TITLE
outposts: make metrics compliant with Prometheus best-practices

### DIFF
--- a/internal/outpost/ldap/bind.go
+++ b/internal/outpost/ldap/bind.go
@@ -2,6 +2,7 @@ package ldap
 
 import (
 	"net"
+	"time"
 
 	"beryju.io/ldap"
 	"github.com/getsentry/sentry-go"
@@ -17,6 +18,11 @@ func (ls *LDAPServer) Bind(bindDN string, bindPW string, conn net.Conn) (ldap.LD
 	defer func() {
 		span.Finish()
 		metrics.Requests.With(prometheus.Labels{
+			"outpost_name": ls.ac.Outpost.Name,
+			"type":         "bind",
+			"app":          selectedApp,
+		}).Observe(float64(span.EndTime.Sub(span.StartTime)) / float64(time.Second))
+		metrics.RequestsLegacy.With(prometheus.Labels{
 			"outpost_name": ls.ac.Outpost.Name,
 			"type":         "bind",
 			"app":          selectedApp,
@@ -44,6 +50,12 @@ func (ls *LDAPServer) Bind(bindDN string, bindPW string, conn net.Conn) (ldap.LD
 	}
 	req.Log().WithField("request", "bind").Warning("No provider found for request")
 	metrics.RequestsRejected.With(prometheus.Labels{
+		"outpost_name": ls.ac.Outpost.Name,
+		"type":         "bind",
+		"reason":       "no_provider",
+		"app":          "",
+	}).Inc()
+	metrics.RequestsRejectedLegacy.With(prometheus.Labels{
 		"outpost_name": ls.ac.Outpost.Name,
 		"type":         "bind",
 		"reason":       "no_provider",

--- a/internal/outpost/ldap/bind/direct/bind.go
+++ b/internal/outpost/ldap/bind/direct/bind.go
@@ -52,11 +52,23 @@ func (db *DirectBinder) Bind(username string, req *bind.Request) (ldap.LDAPResul
 			"reason":       "flow_error",
 			"app":          db.si.GetAppSlug(),
 		}).Inc()
+		metrics.RequestsRejectedLegacy.With(prometheus.Labels{
+			"outpost_name": db.si.GetOutpostName(),
+			"type":         "bind",
+			"reason":       "flow_error",
+			"app":          db.si.GetAppSlug(),
+		}).Inc()
 		req.Log().WithError(err).Warning("failed to execute flow")
 		return ldap.LDAPResultInvalidCredentials, nil
 	}
 	if !passed {
 		metrics.RequestsRejected.With(prometheus.Labels{
+			"outpost_name": db.si.GetOutpostName(),
+			"type":         "bind",
+			"reason":       "invalid_credentials",
+			"app":          db.si.GetAppSlug(),
+		}).Inc()
+		metrics.RequestsRejectedLegacy.With(prometheus.Labels{
 			"outpost_name": db.si.GetOutpostName(),
 			"type":         "bind",
 			"reason":       "invalid_credentials",
@@ -75,10 +87,22 @@ func (db *DirectBinder) Bind(username string, req *bind.Request) (ldap.LDAPResul
 			"reason":       "access_denied",
 			"app":          db.si.GetAppSlug(),
 		}).Inc()
+		metrics.RequestsRejectedLegacy.With(prometheus.Labels{
+			"outpost_name": db.si.GetOutpostName(),
+			"type":         "bind",
+			"reason":       "access_denied",
+			"app":          db.si.GetAppSlug(),
+		}).Inc()
 		return ldap.LDAPResultInsufficientAccessRights, nil
 	}
 	if err != nil {
 		metrics.RequestsRejected.With(prometheus.Labels{
+			"outpost_name": db.si.GetOutpostName(),
+			"type":         "bind",
+			"reason":       "access_check_fail",
+			"app":          db.si.GetAppSlug(),
+		}).Inc()
+		metrics.RequestsRejectedLegacy.With(prometheus.Labels{
 			"outpost_name": db.si.GetOutpostName(),
 			"type":         "bind",
 			"reason":       "access_check_fail",
@@ -93,6 +117,12 @@ func (db *DirectBinder) Bind(username string, req *bind.Request) (ldap.LDAPResul
 	userInfo, _, err := fe.ApiClient().CoreApi.CoreUsersMeRetrieve(context.Background()).Execute()
 	if err != nil {
 		metrics.RequestsRejected.With(prometheus.Labels{
+			"outpost_name": db.si.GetOutpostName(),
+			"type":         "bind",
+			"reason":       "user_info_fail",
+			"app":          db.si.GetAppSlug(),
+		}).Inc()
+		metrics.RequestsRejectedLegacy.With(prometheus.Labels{
 			"outpost_name": db.si.GetOutpostName(),
 			"type":         "bind",
 			"reason":       "user_info_fail",

--- a/internal/outpost/ldap/metrics/metrics.go
+++ b/internal/outpost/ldap/metrics/metrics.go
@@ -15,10 +15,20 @@ import (
 
 var (
 	Requests = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "authentik_outpost_ldap_request_duration_seconds",
+		Help: "LDAP request latencies in seconds",
+	}, []string{"outpost_name", "type", "app"})
+	RequestsRejected = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "authentik_outpost_ldap_requests_rejected_total",
+		Help: "Total number of rejected requests",
+	}, []string{"outpost_name", "type", "reason", "app"})
+
+	// NOTE: the following metrics are kept for compatibility purpose
+	RequestsLegacy = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "authentik_outpost_ldap_requests",
 		Help: "The total number of configured providers",
 	}, []string{"outpost_name", "type", "app"})
-	RequestsRejected = promauto.NewCounterVec(prometheus.CounterOpts{
+	RequestsRejectedLegacy = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "authentik_outpost_ldap_requests_rejected",
 		Help: "Total number of rejected requests",
 	}, []string{"outpost_name", "type", "reason", "app"})

--- a/internal/outpost/ldap/search.go
+++ b/internal/outpost/ldap/search.go
@@ -2,6 +2,7 @@ package ldap
 
 import (
 	"net"
+	"time"
 
 	"beryju.io/ldap"
 	"github.com/getsentry/sentry-go"
@@ -18,6 +19,11 @@ func (ls *LDAPServer) Search(bindDN string, searchReq ldap.SearchRequest, conn n
 	defer func() {
 		span.Finish()
 		metrics.Requests.With(prometheus.Labels{
+			"outpost_name": ls.ac.Outpost.Name,
+			"type":         "search",
+			"app":          selectedApp,
+		}).Observe(float64(span.EndTime.Sub(span.StartTime)) / float64(time.Second))
+		metrics.RequestsLegacy.With(prometheus.Labels{
 			"outpost_name": ls.ac.Outpost.Name,
 			"type":         "search",
 			"app":          selectedApp,

--- a/internal/outpost/ldap/search/direct/direct.go
+++ b/internal/outpost/ldap/search/direct/direct.go
@@ -45,10 +45,22 @@ func (ds *DirectSearcher) Search(req *search.Request) (ldap.ServerSearchResult, 
 			"reason":       "empty_bind_dn",
 			"app":          ds.si.GetAppSlug(),
 		}).Inc()
+		metrics.RequestsRejectedLegacy.With(prometheus.Labels{
+			"outpost_name": ds.si.GetOutpostName(),
+			"type":         "search",
+			"reason":       "empty_bind_dn",
+			"app":          ds.si.GetAppSlug(),
+		}).Inc()
 		return ldap.ServerSearchResult{ResultCode: ldap.LDAPResultInsufficientAccessRights}, fmt.Errorf("Search Error: Anonymous BindDN not allowed %s", req.BindDN)
 	}
 	if !utils.HasSuffixNoCase(req.BindDN, ","+baseDN) {
 		metrics.RequestsRejected.With(prometheus.Labels{
+			"outpost_name": ds.si.GetOutpostName(),
+			"type":         "search",
+			"reason":       "invalid_bind_dn",
+			"app":          ds.si.GetAppSlug(),
+		}).Inc()
+		metrics.RequestsRejectedLegacy.With(prometheus.Labels{
 			"outpost_name": ds.si.GetOutpostName(),
 			"type":         "search",
 			"reason":       "invalid_bind_dn",
@@ -66,6 +78,12 @@ func (ds *DirectSearcher) Search(req *search.Request) (ldap.ServerSearchResult, 
 			"reason":       "user_info_not_cached",
 			"app":          ds.si.GetAppSlug(),
 		}).Inc()
+		metrics.RequestsRejectedLegacy.With(prometheus.Labels{
+			"outpost_name": ds.si.GetOutpostName(),
+			"type":         "search",
+			"reason":       "user_info_not_cached",
+			"app":          ds.si.GetAppSlug(),
+		}).Inc()
 		return ldap.ServerSearchResult{ResultCode: ldap.LDAPResultInsufficientAccessRights}, errors.New("access denied")
 	}
 	accsp.Finish()
@@ -73,6 +91,12 @@ func (ds *DirectSearcher) Search(req *search.Request) (ldap.ServerSearchResult, 
 	parsedFilter, err := ldap.CompileFilter(req.Filter)
 	if err != nil {
 		metrics.RequestsRejected.With(prometheus.Labels{
+			"outpost_name": ds.si.GetOutpostName(),
+			"type":         "search",
+			"reason":       "filter_parse_fail",
+			"app":          ds.si.GetAppSlug(),
+		}).Inc()
+		metrics.RequestsRejectedLegacy.With(prometheus.Labels{
 			"outpost_name": ds.si.GetOutpostName(),
 			"type":         "search",
 			"reason":       "filter_parse_fail",

--- a/internal/outpost/ldap/search/memory/memory.go
+++ b/internal/outpost/ldap/search/memory/memory.go
@@ -62,10 +62,22 @@ func (ms *MemorySearcher) Search(req *search.Request) (ldap.ServerSearchResult, 
 			"reason":       "empty_bind_dn",
 			"app":          ms.si.GetAppSlug(),
 		}).Inc()
+		metrics.RequestsRejectedLegacy.With(prometheus.Labels{
+			"outpost_name": ms.si.GetOutpostName(),
+			"type":         "search",
+			"reason":       "empty_bind_dn",
+			"app":          ms.si.GetAppSlug(),
+		}).Inc()
 		return ldap.ServerSearchResult{ResultCode: ldap.LDAPResultInsufficientAccessRights}, fmt.Errorf("Search Error: Anonymous BindDN not allowed %s", req.BindDN)
 	}
 	if !utils.HasSuffixNoCase(req.BindDN, ","+baseDN) {
 		metrics.RequestsRejected.With(prometheus.Labels{
+			"outpost_name": ms.si.GetOutpostName(),
+			"type":         "search",
+			"reason":       "invalid_bind_dn",
+			"app":          ms.si.GetAppSlug(),
+		}).Inc()
+		metrics.RequestsRejectedLegacy.With(prometheus.Labels{
 			"outpost_name": ms.si.GetOutpostName(),
 			"type":         "search",
 			"reason":       "invalid_bind_dn",
@@ -78,6 +90,12 @@ func (ms *MemorySearcher) Search(req *search.Request) (ldap.ServerSearchResult, 
 	if flag == nil || (flag.UserInfo == nil && flag.UserPk == flags.InvalidUserPK) {
 		req.Log().Debug("User info not cached")
 		metrics.RequestsRejected.With(prometheus.Labels{
+			"outpost_name": ms.si.GetOutpostName(),
+			"type":         "search",
+			"reason":       "user_info_not_cached",
+			"app":          ms.si.GetAppSlug(),
+		}).Inc()
+		metrics.RequestsRejectedLegacy.With(prometheus.Labels{
 			"outpost_name": ms.si.GetOutpostName(),
 			"type":         "search",
 			"reason":       "user_info_not_cached",

--- a/internal/outpost/proxyv2/application/application.go
+++ b/internal/outpost/proxyv2/application/application.go
@@ -163,13 +163,19 @@ func NewApplication(p api.ProxyOutpostConfig, c *http.Client, server Server) (*A
 			}
 			before := time.Now()
 			inner.ServeHTTP(rw, r)
-			after := time.Since(before)
+			elapsed := time.Since(before)
 			metrics.Requests.With(prometheus.Labels{
 				"outpost_name": a.outpostName,
 				"type":         "app",
 				"method":       r.Method,
 				"host":         web.GetHost(r),
-			}).Observe(float64(after))
+			}).Observe(float64(elapsed) / float64(time.Second))
+			metrics.RequestsLegacy.With(prometheus.Labels{
+				"outpost_name": a.outpostName,
+				"type":         "app",
+				"method":       r.Method,
+				"host":         web.GetHost(r),
+			}).Observe(float64(elapsed))
 		})
 	})
 	if server.API().GlobalConfig.ErrorReporting.Enabled {

--- a/internal/outpost/proxyv2/application/mode_proxy.go
+++ b/internal/outpost/proxyv2/application/mode_proxy.go
@@ -55,7 +55,7 @@ func (a *Application) configureProxy() error {
 		}
 		before := time.Now()
 		rp.ServeHTTP(rw, r)
-		after := time.Since(before)
+		elapsed := time.Since(before)
 
 		metrics.UpstreamTiming.With(prometheus.Labels{
 			"outpost_name":  a.outpostName,
@@ -63,7 +63,14 @@ func (a *Application) configureProxy() error {
 			"method":        r.Method,
 			"scheme":        r.URL.Scheme,
 			"host":          web.GetHost(r),
-		}).Observe(float64(after))
+		}).Observe(float64(elapsed) / float64(time.Second))
+		metrics.UpstreamTimingLegacy.With(prometheus.Labels{
+			"outpost_name":  a.outpostName,
+			"upstream_host": r.URL.Host,
+			"method":        r.Method,
+			"scheme":        r.URL.Scheme,
+			"host":          web.GetHost(r),
+		}).Observe(float64(elapsed))
 	})
 	return nil
 }

--- a/internal/outpost/proxyv2/handlers.go
+++ b/internal/outpost/proxyv2/handlers.go
@@ -19,25 +19,37 @@ import (
 func (ps *ProxyServer) HandlePing(rw http.ResponseWriter, r *http.Request) {
 	before := time.Now()
 	rw.WriteHeader(204)
-	after := time.Since(before)
+	elapsed := time.Since(before)
 	metrics.Requests.With(prometheus.Labels{
 		"outpost_name": ps.akAPI.Outpost.Name,
 		"method":       r.Method,
 		"host":         web.GetHost(r),
 		"type":         "ping",
-	}).Observe(float64(after))
+	}).Observe(float64(elapsed) / float64(time.Second))
+	metrics.RequestsLegacy.With(prometheus.Labels{
+		"outpost_name": ps.akAPI.Outpost.Name,
+		"method":       r.Method,
+		"host":         web.GetHost(r),
+		"type":         "ping",
+	}).Observe(float64(elapsed))
 }
 
 func (ps *ProxyServer) HandleStatic(rw http.ResponseWriter, r *http.Request) {
 	before := time.Now()
 	web.DisableIndex(http.StripPrefix("/outpost.goauthentik.io/static/dist", staticWeb.StaticHandler)).ServeHTTP(rw, r)
-	after := time.Since(before)
+	elapsed := time.Since(before)
 	metrics.Requests.With(prometheus.Labels{
 		"outpost_name": ps.akAPI.Outpost.Name,
 		"method":       r.Method,
 		"host":         web.GetHost(r),
 		"type":         "static",
-	}).Observe(float64(after))
+	}).Observe(float64(elapsed) / float64(time.Second))
+	metrics.RequestsLegacy.With(prometheus.Labels{
+		"outpost_name": ps.akAPI.Outpost.Name,
+		"method":       r.Method,
+		"host":         web.GetHost(r),
+		"type":         "static",
+	}).Observe(float64(elapsed))
 }
 
 func (ps *ProxyServer) lookupApp(r *http.Request) (*application.Application, string) {

--- a/internal/outpost/proxyv2/metrics/metrics.go
+++ b/internal/outpost/proxyv2/metrics/metrics.go
@@ -15,10 +15,20 @@ import (
 
 var (
 	Requests = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "authentik_outpost_proxy_request_duration_seconds",
+		Help: "Proxy request latencies in seconds",
+	}, []string{"outpost_name", "method", "host", "type"})
+	UpstreamTiming = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "authentik_outpost_proxy_upstream_response_duration_seconds",
+		Help: "Proxy upstream response latencies in seconds",
+	}, []string{"outpost_name", "method", "scheme", "host", "upstream_host"})
+
+	// NOTE: the following metric is kept for compatibility purpose
+	RequestsLegacy = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "authentik_outpost_proxy_requests",
 		Help: "The total number of configured providers",
 	}, []string{"outpost_name", "method", "host", "type"})
-	UpstreamTiming = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	UpstreamTimingLegacy = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "authentik_outpost_proxy_upstream_time",
 		Help: "A summary of the duration we wait for the upstream reply",
 	}, []string{"outpost_name", "method", "scheme", "host", "upstream_host"})

--- a/internal/outpost/radius/handle_access_request.go
+++ b/internal/outpost/radius/handle_access_request.go
@@ -32,11 +32,21 @@ func (rs *RadiusServer) Handle_AccessRequest(w radius.ResponseWriter, r *RadiusR
 			"reason":       "flow_error",
 			"app":          r.pi.appSlug,
 		}).Inc()
+		metrics.RequestsRejectedLegacy.With(prometheus.Labels{
+			"outpost_name": rs.ac.Outpost.Name,
+			"reason":       "flow_error",
+			"app":          r.pi.appSlug,
+		}).Inc()
 		_ = w.Write(r.Response(radius.CodeAccessReject))
 		return
 	}
 	if !passed {
 		metrics.RequestsRejected.With(prometheus.Labels{
+			"outpost_name": rs.ac.Outpost.Name,
+			"reason":       "invalid_credentials",
+			"app":          r.pi.appSlug,
+		}).Inc()
+		metrics.RequestsRejectedLegacy.With(prometheus.Labels{
 			"outpost_name": rs.ac.Outpost.Name,
 			"reason":       "invalid_credentials",
 			"app":          r.pi.appSlug,
@@ -53,12 +63,22 @@ func (rs *RadiusServer) Handle_AccessRequest(w radius.ResponseWriter, r *RadiusR
 			"reason":       "access_check_fail",
 			"app":          r.pi.appSlug,
 		}).Inc()
+		metrics.RequestsRejectedLegacy.With(prometheus.Labels{
+			"outpost_name": rs.ac.Outpost.Name,
+			"reason":       "access_check_fail",
+			"app":          r.pi.appSlug,
+		}).Inc()
 		return
 	}
 	if !access {
 		r.Log().WithField("username", username).Info("Access denied for user")
 		_ = w.Write(r.Response(radius.CodeAccessReject))
 		metrics.RequestsRejected.With(prometheus.Labels{
+			"outpost_name": rs.ac.Outpost.Name,
+			"reason":       "access_denied",
+			"app":          r.pi.appSlug,
+		}).Inc()
+		metrics.RequestsRejectedLegacy.With(prometheus.Labels{
 			"outpost_name": rs.ac.Outpost.Name,
 			"reason":       "access_denied",
 			"app":          r.pi.appSlug,

--- a/internal/outpost/radius/handler.go
+++ b/internal/outpost/radius/handler.go
@@ -2,6 +2,7 @@ package radius
 
 import (
 	"crypto/sha512"
+	"time"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/google/uuid"
@@ -43,6 +44,10 @@ func (rs *RadiusServer) ServeRADIUS(w radius.ResponseWriter, r *radius.Request) 
 	defer func() {
 		span.Finish()
 		metrics.Requests.With(prometheus.Labels{
+			"outpost_name": rs.ac.Outpost.Name,
+			"app":          selectedApp,
+		}).Observe(float64(span.EndTime.Sub(span.StartTime)) / float64(time.Second))
+		metrics.RequestsLegacy.With(prometheus.Labels{
 			"outpost_name": rs.ac.Outpost.Name,
 			"app":          selectedApp,
 		}).Observe(float64(span.EndTime.Sub(span.StartTime)))

--- a/internal/outpost/radius/metrics/metrics.go
+++ b/internal/outpost/radius/metrics/metrics.go
@@ -15,10 +15,20 @@ import (
 
 var (
 	Requests = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "authentik_outpost_radius_request_duration_seconds",
+		Help: "RADIUS request latencies in seconds",
+	}, []string{"outpost_name", "app"})
+	RequestsRejected = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "authentik_outpost_radius_requests_rejected_total",
+		Help: "Total number of rejected requests",
+	}, []string{"outpost_name", "reason", "app"})
+
+	// NOTE: the following metric is kept for compatibility purpose
+	RequestsLegacy = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "authentik_outpost_radius_requests",
 		Help: "The total number of successful requests",
 	}, []string{"outpost_name", "app"})
-	RequestsRejected = promauto.NewCounterVec(prometheus.CounterOpts{
+	RequestsRejectedLegacy = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "authentik_outpost_radius_requests_rejected",
 		Help: "Total number of rejected requests",
 	}, []string{"outpost_name", "reason", "app"})

--- a/internal/web/metrics.go
+++ b/internal/web/metrics.go
@@ -15,6 +15,12 @@ import (
 
 var (
 	Requests = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "authentik_main_request_duration_seconds",
+		Help: "API request latencies in seconds",
+	}, []string{"dest"})
+
+	// NOTE: the following metric is kept for compatibility purpose
+	RequestsLegacy = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "authentik_main_requests",
 		Help: "The total number of configured providers",
 	}, []string{"dest"})


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://goauthentik.io/developer-docs/#how-can-i-contribute).
-->

## Details

This PR don't fix a specific issue but follows this discussion: https://github.com/goauthentik/authentik/discussions/6315.

All histograms created with `promauto` are populated with nanosecond durations, whereas the default buckets are designed for [second durations](https://pkg.go.dev/github.com/prometheus/client_golang/prometheus#pkg-variables), making them useless (everything will be stored in the "infinite" bucket).

I've also found that some metric helpers aren't "useful"; for example `The total number of providers configured` for `authentik_outpost_ldap_requests`, which isn't the case.

So this PR attempts to fix both these issues and renames the metrics with something that follows [Prometheus best practice](https://prometheus.io/docs/practices/naming/#metric-names). I haven't removed the old metrics to avoid breaking existing alerts and dashboards.

## Changes

### New Features

- Add new metrics for outposts metrics 

### Breaking Changes

Nothing

## Checklist

- [X] Local tests pass (`ak test authentik/`)
- [X] The code has been formatted (`make lint-fix`)
