### PR TITLE
web/user: fix alignment between image icons and fallback text icons

### DIFF
--- a/web/src/user/LibraryApplication/AppIcon.ts
+++ b/web/src/user/LibraryApplication/AppIcon.ts
@@ -24,6 +24,9 @@ export class AppIcon extends AKElement {
             PFFAIcons,
             PFAvatar,
             css`
+                :host {
+                    max-height: calc(var(--icon-height) + var(--icon-border) + var(--icon-border));
+                }
                 :host([size="pf-m-lg"]) {
                     --icon-height: 4rem;
                     --icon-border: 0.25rem;


### PR DESCRIPTION
<!--
👋 Hello there! Welcome.

Please check the [Contributing guidelines](https://goauthentik.io/developer-docs/#how-can-i-contribute).
-->

## Details

-   **Does this resolve an issue?**
    Resolves #

## Changes

### New Features

-   Adds feature which does x, y, and z.

### Breaking Changes

-   Adds breaking change which causes \<issue\>.

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
