### PR TITLE
web/admin: set required flag to false for user attributes

### DIFF
--- a/web/src/admin/users/UserForm.ts
+++ b/web/src/admin/users/UserForm.ts
@@ -145,7 +145,7 @@ export class UserForm extends ModelForm<User, number> {
             </ak-form-element-horizontal>
             <ak-form-element-horizontal
                 label=${msg("Attributes")}
-                ?required=${true}
+                ?required=${false}
                 name="attributes"
             >
                 <ak-codemirror

--- a/web/src/admin/users/UserForm.ts
+++ b/web/src/admin/users/UserForm.ts
@@ -17,6 +17,10 @@ import { CoreApi, User } from "@goauthentik/api";
 
 @customElement("ak-user-form")
 export class UserForm extends ModelForm<User, number> {
+    static get defaultUserAttributes(): { [key: string]: unknown } {
+        return {};
+    }
+
     static get styles(): CSSResult[] {
         return super.styles.concat(css`
             .pf-c-button.pf-m-control {
@@ -43,6 +47,9 @@ export class UserForm extends ModelForm<User, number> {
     }
 
     async send(data: User): Promise<User> {
+        if (data.attributes === null) {
+            data.attributes = UserForm.defaultUserAttributes;
+        }
         if (this.instance?.pk) {
             return new CoreApi(DEFAULT_CONFIG).coreUsersPartialUpdate({
                 id: this.instance.pk,
@@ -150,7 +157,9 @@ export class UserForm extends ModelForm<User, number> {
             >
                 <ak-codemirror
                     mode="yaml"
-                    value="${YAML.stringify(first(this.instance?.attributes, {}))}"
+                    value="${YAML.stringify(
+                        first(this.instance?.attributes, UserForm.defaultUserAttributes),
+                    )}"
                 >
                 </ak-codemirror>
                 <p class="pf-c-form__helper-text">


### PR DESCRIPTION

## Details
 On the Create user form, the field for Attributes is not required, so I removed the asterisk by editing `web/src/admin/users/UserForm.ts` to set required flag to `false`. 

## Changes

Attributes field on Create User no longer shown as Required (which it is not).

### New Features

n/a

### Breaking Changes

n/a

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
