### PR TITLE
blueprints: prevent duplicate password stage in default flow when using combined identification stage

### DIFF
--- a/blueprints/default/flow-default-authentication-flow.yaml
+++ b/blueprints/default/flow-default-authentication-flow.yaml
@@ -51,6 +51,7 @@ entries:
     order: 20
     stage: !KeyOf default-authentication-password
     target: !KeyOf flow
+  id: default-authentication-flow-password-binding
   model: authentik_flows.flowstagebinding
 - identifiers:
     order: 30
@@ -62,3 +63,18 @@ entries:
     stage: !KeyOf default-authentication-login
     target: !KeyOf flow
   model: authentik_flows.flowstagebinding
+- model: authentik_policies_expression.expressionpolicy
+  id: default-authentication-flow-password-optional
+  identifiers:
+    name: default-authentication-flow-password-stage
+  attrs:
+    expression: |
+      flow_plan = request.context["flow_plan"]
+      # If the user does not have a backend attached to it, they haven't
+      # been authenticated yet and we need the password stage
+      return not hasattr(flow_plan.context["pending_user"], "backend")
+- model: authentik_policies.policybinding
+  identifiers:
+    order: 10
+    target: !KeyOf default-authentication-flow-password-binding
+    policy: !KeyOf default-authentication-flow-password-optional


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

closes #5407

Adds a policy that checks if the user has already been authenticated (explicitly only checks password authentication) and skips the password stage that is bound by default

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
