### PR TITLE
provider/oauth2: fix aud (Audience) field type which can be a list of…

### DIFF
--- a/authentik/providers/oauth2/id_token.py
+++ b/authentik/providers/oauth2/id_token.py
@@ -1,6 +1,6 @@
 """id_token utils"""
 from dataclasses import asdict, dataclass, field
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from django.db import models
 from django.http import HttpRequest
@@ -57,7 +57,7 @@ class IDToken:
     # Subject, https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.2
     sub: Optional[str] = None
     # Audience, https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.3
-    aud: Optional[str] = None
+    aud: Optional[Union[str, list[str]]] = None
     # Expiration time, https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.4
     exp: Optional[int] = None
     # Issued at, https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.6


### PR DESCRIPTION
## Details

As defined in RFC 7519, aud (audience) field may be a list of strings but as for now, Authentik only accepts a single string.
This is useful in may scenario so that an access token can be emitted with several client IDs via custom mappings. For example, in #4021.

Note, in Python 3.11, type could be str | list[str] | None but I kept the old format to keep the consistent but I could change all the types in the object if needed.

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
