### PR TITLE
providers/proxy: set outpost session cookie to httponly and secure wh…

### DIFF
--- a/internal/outpost/proxyv2/application/session.go
+++ b/internal/outpost/proxyv2/application/session.go
@@ -37,6 +37,10 @@ func (a *Application) getStore(p api.ProxyOutpostConfig, externalHost *url.URL) 
 		rs.SetMaxLength(math.MaxInt)
 		rs.SetKeyPrefix(RedisKeyPrefix)
 
+		rs.Options.HttpOnly = true
+		if strings.ToLower(externalHost.Scheme) == "https" {
+			rs.Options.Secure = true
+		}
 		rs.Options.Domain = *p.CookieDomain
 		a.log.Trace("using redis session backend")
 		return rs
@@ -51,6 +55,10 @@ func (a *Application) getStore(p api.ProxyOutpostConfig, externalHost *url.URL) 
 
 	// Note, when using the FilesystemStore only the session.ID is written to a browser cookie, so this is explicit for the storage on disk
 	cs.MaxLength(math.MaxInt)
+	cs.Options.HttpOnly = true
+	if strings.ToLower(externalHost.Scheme) == "https" {
+		cs.Options.Secure = true
+	}
 	cs.Options.Domain = *p.CookieDomain
 	a.log.WithField("dir", dir).Trace("using filesystem session backend")
 	return cs

--- a/internal/outpost/proxyv2/application/session.go
+++ b/internal/outpost/proxyv2/application/session.go
@@ -3,6 +3,7 @@ package application
 import (
 	"fmt"
 	"math"
+	"net/http"
 	"net/url"
 	"os"
 	"path"
@@ -42,6 +43,7 @@ func (a *Application) getStore(p api.ProxyOutpostConfig, externalHost *url.URL) 
 			rs.Options.Secure = true
 		}
 		rs.Options.Domain = *p.CookieDomain
+		rs.Options.SameSite = http.SameSiteLaxMode
 		a.log.Trace("using redis session backend")
 		return rs
 	}
@@ -60,6 +62,7 @@ func (a *Application) getStore(p api.ProxyOutpostConfig, externalHost *url.URL) 
 		cs.Options.Secure = true
 	}
 	cs.Options.Domain = *p.CookieDomain
+	cs.Options.SameSite = http.SameSiteLaxMode
 	a.log.WithField("dir", dir).Trace("using filesystem session backend")
 	return cs
 }


### PR DESCRIPTION
…en possible

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

security improvement, possible issues when a provider has an external URL configured with HTTPS but is being accessed via HTTP, but that's not supported anyways 

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
