### PR TITLE
root: always use persistent database connections

### DIFF
--- a/authentik/root/settings.py
+++ b/authentik/root/settings.py
@@ -279,14 +279,14 @@ DATABASES = {
         "SSLROOTCERT": CONFIG.get("postgresql.sslrootcert"),
         "SSLCERT": CONFIG.get("postgresql.sslcert"),
         "SSLKEY": CONFIG.get("postgresql.sslkey"),
+        # https://docs.djangoproject.com/en/4.0/ref/databases/#persistent-connections
+        "CONN_MAX_AGE": None,
     }
 }
 
 if CONFIG.get_bool("postgresql.use_pgbouncer", False):
     # https://docs.djangoproject.com/en/4.0/ref/databases/#transaction-pooling-server-side-cursors
     DATABASES["default"]["DISABLE_SERVER_SIDE_CURSORS"] = True
-    # https://docs.djangoproject.com/en/4.0/ref/databases/#persistent-connections
-    DATABASES["default"]["CONN_MAX_AGE"] = None  # persistent
 
 # Email
 # These values should never actually be used, emails are only sent from email stages, which

--- a/authentik/root/settings.py
+++ b/authentik/root/settings.py
@@ -281,6 +281,7 @@ DATABASES = {
         "SSLKEY": CONFIG.get("postgresql.sslkey"),
         # https://docs.djangoproject.com/en/4.0/ref/databases/#persistent-connections
         "CONN_MAX_AGE": None,
+        "CONN_HEALTH_CHECKS": True,
     }
 }
 


### PR DESCRIPTION
## Details

Ideally this would avoid re-opening a database connection for every database query, even when not using pg_bouncer.

Upside: we're avoiding creating connections for every database query.

Downside: we would always have, at most, N connections open, N being the number of workers, once every worker has been hit with a web request. Also, if something breaks, the connection is not re-created automatically, if I understand correctly.

We could also set [CONN_HEALTH_CHECKS](https://docs.djangoproject.com/en/4.1/ref/settings/#std-setting-CONN_HEALTH_CHECKS) to true to mitigate that last bit, which will check the connection health once per web request.

Finally, this may help with auto-rotating secrets, in which case the connection would stay opened and healthy from when the password has been changed on postgres' side, until it reaches authentik.

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
