### PR TITLE
website/docs: add link to Postgres12 info

### DIFF
--- a/website/docs/installation/kubernetes.md
+++ b/website/docs/installation/kubernetes.md
@@ -64,6 +64,10 @@ helm upgrade --install authentik authentik/authentik -f values.yaml
 
 During the installation process, the database migrations will be applied automatically on startup.
 
+:::info
+The authentik release 2023.05.x deprecated support for Postgres v11. If you are running 2023.05.x or 2023.06.x, refer to the [Release Notes](https://goauthentik.io/docs/releases/2023.5#breaking-changes) for more information. If you are running authentik on Kubernetes, also refer to the documentation for how to [upgrade to Postgres v12](https://goauthentik.io/docs/troubleshooting/postgres/upgrade_kubernetes).
+:::
+
 ### Accessing authentik
 
 Once the installation is complete, access authentik at `https://<ingress-host-name>/if/flow/initial-setup/`. Here, you can set a password for the default akadmin user.


### PR DESCRIPTION
Added an Info note about needing to upgrade to Postgres v12. I'll take this note back out after we release the next version, in which the Helm Charts point to Postgres 15.

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
