### PR TITLE
root: upgrade debian base images to debian 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /work/web
 RUN npm ci --include=dev && npm run build
 
 # Stage 3: Poetry to requirements.txt export
-FROM docker.io/python:3.11.4-slim-bullseye AS poetry-locker
+FROM docker.io/python:3.11.4-slim-bookworm AS poetry-locker
 
 WORKDIR /work
 COPY ./pyproject.toml /work
@@ -31,7 +31,7 @@ RUN pip install --no-cache-dir poetry && \
     poetry export -f requirements.txt --dev --output requirements-dev.txt
 
 # Stage 4: Build go proxy
-FROM docker.io/golang:1.21.0-bullseye AS go-builder
+FROM docker.io/golang:1.21.0-bookworm AS go-builder
 
 WORKDIR /work
 
@@ -61,7 +61,7 @@ RUN --mount=type=secret,id=GEOIPUPDATE_ACCOUNT_ID \
     /bin/sh -c "/usr/bin/entry.sh || echo 'Failed to get GeoIP database, disabling'; exit 0"
 
 # Stage 6: Run
-FROM docker.io/python:3.11.4-slim-bullseye AS final-image
+FROM docker.io/python:3.11.4-slim-bookworm AS final-image
 
 ARG GIT_BUILD_HASH
 ARG VERSION

--- a/ldap.Dockerfile
+++ b/ldap.Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM docker.io/golang:1.21.0-bullseye AS builder
+FROM docker.io/golang:1.21.0-bookworm AS builder
 
 WORKDIR /go/src/goauthentik.io
 

--- a/proxy.Dockerfile
+++ b/proxy.Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /static
 RUN npm ci --include=dev && npm run build-proxy
 
 # Stage 2: Build
-FROM docker.io/golang:1.21.0-bullseye AS builder
+FROM docker.io/golang:1.21.0-bookworm AS builder
 
 WORKDIR /go/src/goauthentik.io
 

--- a/radius.Dockerfile
+++ b/radius.Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM docker.io/golang:1.21.0-bullseye AS builder
+FROM docker.io/golang:1.21.0-bookworm AS builder
 
 WORKDIR /go/src/goauthentik.io
 


### PR DESCRIPTION
## Details

Upgrades base images to debian 12. Distroless image has not been upgraded as debian 12 [is not supported yet](https://github.com/GoogleContainerTools/distroless/issues/1337)

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
