### PR TITLE
web/user: fix user settings elements not being in cards

### DIFF
--- a/web/src/user/user-settings/UserSettingsPage.ts
+++ b/web/src/user/user-settings/UserSettingsPage.ts
@@ -116,43 +116,63 @@ export class UserSettingsPage extends AKElement {
                         data-tab-title="${msg("Sessions")}"
                         class="pf-c-page__main-section pf-m-no-padding-mobile"
                     >
-                        <ak-user-session-list
-                            targetUser=${ifDefined(
-                                rootInterface<UserInterface>()?.me?.user.username,
-                            )}
-                        ></ak-user-session-list>
+                        <div class="pf-c-card">
+                            <div class="pf-c-card__body">
+                                <ak-user-session-list
+                                    targetUser=${ifDefined(
+                                        rootInterface<UserInterface>()?.me?.user.username,
+                                    )}
+                                ></ak-user-session-list>
+                            </div>
+                        </div>
                     </section>
                     <section
                         slot="page-consents"
                         data-tab-title="${msg("Consent")}"
                         class="pf-c-page__main-section pf-m-no-padding-mobile"
                     >
-                        <ak-user-consent-list
-                            userId=${ifDefined(rootInterface<UserInterface>()?.me?.user.pk)}
-                        ></ak-user-consent-list>
+                        <div class="pf-c-card">
+                            <div class="pf-c-card__body">
+                                <ak-user-consent-list
+                                    userId=${ifDefined(rootInterface<UserInterface>()?.me?.user.pk)}
+                                ></ak-user-consent-list>
+                            </div>
+                        </div>
                     </section>
                     <section
                         slot="page-mfa"
                         data-tab-title="${msg("MFA Devices")}"
                         class="pf-c-page__main-section pf-m-no-padding-mobile"
                     >
-                        <ak-user-settings-mfa
-                            .userSettings=${this.userSettings}
-                        ></ak-user-settings-mfa>
+                        <div class="pf-c-card">
+                            <div class="pf-c-card__body">
+                                <ak-user-settings-mfa
+                                    .userSettings=${this.userSettings}
+                                ></ak-user-settings-mfa>
+                            </div>
+                        </div>
                     </section>
                     <section
                         slot="page-sources"
                         data-tab-title="${msg("Connected services")}"
                         class="pf-c-page__main-section pf-m-no-padding-mobile"
                     >
-                        <ak-user-settings-source></ak-user-settings-source>
+                        <div class="pf-c-card">
+                            <div class="pf-c-card__body">
+                                <ak-user-settings-source></ak-user-settings-source>
+                            </div>
+                        </div>
                     </section>
                     <section
                         slot="page-tokens"
                         data-tab-title="${msg("Tokens and App passwords")}"
                         class="pf-c-page__main-section pf-m-no-padding-mobile"
                     >
-                        <ak-user-token-list></ak-user-token-list>
+                        <div class="pf-c-card">
+                            <div class="pf-c-card__body">
+                                <ak-user-token-list></ak-user-token-list>
+                            </div>
+                        </div>
                     </section>
                 </ak-tabs>
             </main>


### PR DESCRIPTION
this broke some theming on the light theme

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
