### PR TITLE
core: fix filtering users by type attribute

### DIFF
--- a/authentik/core/api/users.py
+++ b/authentik/core/api/users.py
@@ -309,7 +309,7 @@ class UsersFilter(FilterSet):
     path = CharFilter(field_name="path")
     path_startswith = CharFilter(field_name="path", lookup_expr="startswith")
 
-    type = MultipleChoiceFilter(field_name="type")
+    type = MultipleChoiceFilter(choices=UserTypes.choices, field_name="type")
 
     groups_by_name = ModelMultipleChoiceFilter(
         field_name="ak_groups__name",

--- a/authentik/core/tests/test_users_api.py
+++ b/authentik/core/tests/test_users_api.py
@@ -28,6 +28,19 @@ class TestUsersAPI(APITestCase):
         self.admin = create_test_admin_user()
         self.user = User.objects.create(username="test-user")
 
+    def test_filter_type(self):
+        """Test API filtering by type"""
+        self.client.force_login(self.admin)
+        user = create_test_admin_user(type=UserTypes.EXTERNAL)
+        response = self.client.get(
+            reverse("authentik_api:user-list"),
+            data={
+                "type": UserTypes.EXTERNAL,
+                "username": user.username,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+
     def test_metrics(self):
         """Test user's metrics"""
         self.client.force_login(self.admin)

--- a/authentik/core/tests/utils.py
+++ b/authentik/core/tests/utils.py
@@ -21,7 +21,7 @@ def create_test_flow(
     )
 
 
-def create_test_admin_user(name: Optional[str] = None) -> User:
+def create_test_admin_user(name: Optional[str] = None, **kwargs) -> User:
     """Generate a test-admin user"""
     uid = generate_id(20) if not name else name
     group = Group.objects.create(name=uid, is_superuser=True)
@@ -29,6 +29,7 @@ def create_test_admin_user(name: Optional[str] = None) -> User:
         username=uid,
         name=uid,
         email=f"{uid}@goauthentik.io",
+        **kwargs,
     )
     user.set_password(uid)
     user.save()
@@ -36,12 +37,12 @@ def create_test_admin_user(name: Optional[str] = None) -> User:
     return user
 
 
-def create_test_tenant() -> Tenant:
+def create_test_tenant(**kwargs) -> Tenant:
     """Generate a test tenant, removing all other tenants to make sure this one
     matches."""
     uid = generate_id(20)
     Tenant.objects.all().delete()
-    return Tenant.objects.create(domain=uid, default=True)
+    return Tenant.objects.create(domain=uid, default=True, **kwargs)
 
 
 def create_test_cert(use_ec_private_key=False) -> CertificateKeyPair:


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

Due to a missing argument, filtering users by type attribute wasn't possible, which broke the RelatedUserList

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
