### PR TITLE
root: fix config loading for outposts

### DIFF
--- a/authentik/lib/config.go
+++ b/authentik/lib/config.go
@@ -1,0 +1,10 @@
+package lib
+
+import _ "embed"
+
+//go:embed default.yml
+var defaultConfig []byte
+
+func DefaultConfig() []byte {
+	return defaultConfig
+}

--- a/authentik/sources/oauth/api/source.py
+++ b/authentik/sources/oauth/api/source.py
@@ -62,7 +62,8 @@ class OAuthSourceSerializer(SourceSerializer):
                 well_known_config = session.get(well_known)
                 well_known_config.raise_for_status()
             except RequestException as exc:
-                raise ValidationError(exc.response.text)
+                text = exc.response.text if exc.response else str(exc)
+                raise ValidationError(text)
             config = well_known_config.json()
             try:
                 attrs["authorization_url"] = config["authorization_endpoint"]
@@ -78,7 +79,8 @@ class OAuthSourceSerializer(SourceSerializer):
                 jwks_config = session.get(jwks_url)
                 jwks_config.raise_for_status()
             except RequestException as exc:
-                raise ValidationError(exc.response.text)
+                text = exc.response.text if exc.response else str(exc)
+                raise ValidationError(text)
             config = jwks_config.json()
             attrs["oidc_jwks"] = config
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,7 +67,12 @@ func Get() *Config {
 }
 
 func (c *Config) Setup(paths ...string) {
-	c.LoadConfig(lib.DefaultConfig())
+	// initially try to load the default config which is compiled in
+	err := c.LoadConfig(lib.DefaultConfig())
+	// this should never fail
+	if err != nil {
+		panic(fmt.Errorf("failed to load inbuilt config: %v", err))
+	}
 	log.WithField("path", "inbuilt-default").Debug("Loaded config")
 	for _, path := range paths {
 		err := c.LoadConfigFromFile(path)
@@ -75,7 +80,7 @@ func (c *Config) Setup(paths ...string) {
 			log.WithError(err).Info("failed to load config, skipping")
 		}
 	}
-	err := c.fromEnv()
+	err = c.fromEnv()
 	if err != nil {
 		log.WithError(err).Info("failed to load env vars")
 	}

--- a/internal/outpost/proxyv2/application/application.go
+++ b/internal/outpost/proxyv2/application/application.go
@@ -55,6 +55,8 @@ type Application struct {
 
 	errorTemplates  *template.Template
 	authHeaderCache *ttlcache.Cache[string, Claims]
+
+	isEmbedded bool
 }
 
 type Server interface {
@@ -86,15 +88,15 @@ func NewApplication(p api.ProxyOutpostConfig, c *http.Client, server Server) (*A
 		CallbackSignature: []string{"true"},
 	}.Encode()
 
-	managed := false
+	isEmbedded := false
 	if m := server.API().Outpost.Managed.Get(); m != nil {
-		managed = *m == "goauthentik.io/outposts/embedded"
+		isEmbedded = *m == "goauthentik.io/outposts/embedded"
 	}
 	// Configure an OpenID Connect aware OAuth2 client.
 	endpoint := GetOIDCEndpoint(
 		p,
 		server.API().Outpost.Config["authentik_host"].(string),
-		managed,
+		isEmbedded,
 	)
 
 	verifier := oidc.NewVerifier(endpoint.Issuer, ks, &oidc.Config{
@@ -132,6 +134,7 @@ func NewApplication(p api.ProxyOutpostConfig, c *http.Client, server Server) (*A
 		ak:                   server.API(),
 		authHeaderCache:      ttlcache.New(ttlcache.WithDisableTouchOnHit[string, Claims]()),
 		srv:                  server,
+		isEmbedded:           isEmbedded,
 	}
 	go a.authHeaderCache.Start()
 	a.sessions = a.getStore(p, externalHost)

--- a/internal/outpost/proxyv2/application/session.go
+++ b/internal/outpost/proxyv2/application/session.go
@@ -29,7 +29,7 @@ func (a *Application) getStore(p api.ProxyOutpostConfig, externalHost *url.URL) 
 		// Add one to the validity to ensure we don't have a session with indefinite length
 		maxAge = int(*t) + 1
 	}
-	if config.Get().Redis.Host != "" {
+	if a.isEmbedded {
 		rs, err := redistore.NewRediStoreWithDB(10, "tcp", fmt.Sprintf("%s:%d", config.Get().Redis.Host, config.Get().Redis.Port), config.Get().Redis.Password, strconv.Itoa(config.Get().Redis.DB))
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

Follow up to https://github.com/goauthentik/authentik/pull/6629

Since all the default config is in the yaml file now, when running an outpost we get some invalid-ish defaults since the yaml file isn't (and shouldn't have to be, especially for binary builds) included.

This includes the default yaml file in the binary and always loads it

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
