### PR TITLE
web/user: only render expand element when required

### DIFF
--- a/web/src/admin/admin-overview/cards/VersionStatusCard.ts
+++ b/web/src/admin/admin-overview/cards/VersionStatusCard.ts
@@ -43,11 +43,11 @@ export class VersionStatusCard extends AdminStatusCard<Version> {
 
     renderValue(): TemplateResult {
         let text = this.value?.versionCurrent;
-        let link = "https://goauthentik.io/docs/releases/${this.value?.versionCurrent}";
+        let link = `https://goauthentik.io/docs/releases/${this.value?.versionCurrent}`;
         if (this.value?.buildHash) {
             text = this.value.buildHash?.substring(0, 7);
-            link = "https://github.com/goauthentik/authentik/commit/${this.value.buildHash}";
+            link = `https://github.com/goauthentik/authentik/commit/${this.value.buildHash}`;
         }
-        return html`<a href=${link} target="_blank"> ${text} </a>`;
+        return html`<a href=${link} target="_blank">${text}</a>`;
     }
 }

--- a/web/src/user/LibraryApplication/index.ts
+++ b/web/src/user/LibraryApplication/index.ts
@@ -67,6 +67,13 @@ export class LibraryApplication extends AKElement {
             return html`<ak-spinner></ak-spinner>`;
         }
         const me = rootInterface<UserInterface>()?.me;
+        let expandable = false;
+        if (rootInterface()?.uiConfig?.enabledFeatures.applicationEdit && me?.user.isSuperuser) {
+            expandable = true;
+        }
+        if (this.application.metaPublisher !== "" || this.application.metaDescription !== "") {
+            expandable = true;
+        }
         return html` <div
             class="pf-c-card pf-m-hoverable pf-m-compact ${this.selected
                 ? "pf-m-selectable pf-m-selected"
@@ -89,22 +96,25 @@ export class LibraryApplication extends AKElement {
                 >
             </div>
             <div class="expander"></div>
-            <ak-expand textOpen=${msg("Less details")} textClosed=${msg("More details")}>
-                <div class="pf-c-content">
-                    <small>${this.application.metaPublisher}</small>
-                </div>
-                ${truncateWords(this.application.metaDescription || "", 10)}
-                ${rootInterface()?.uiConfig?.enabledFeatures.applicationEdit && me?.user.isSuperuser
-                    ? html`
-                          <a
-                              class="pf-c-button pf-m-control pf-m-small pf-m-block"
-                              href="/if/admin/#/core/applications/${this.application?.slug}"
-                          >
-                              <i class="fas fa-edit"></i>&nbsp;${msg("Edit")}
-                          </a>
-                      `
-                    : html``}
-            </ak-expand>
+            ${expandable
+                ? html`<ak-expand textOpen=${msg("Less details")} textClosed=${msg("More details")}>
+                      <div class="pf-c-content">
+                          <small>${this.application.metaPublisher}</small>
+                      </div>
+                      ${truncateWords(this.application.metaDescription || "", 10)}
+                      ${rootInterface()?.uiConfig?.enabledFeatures.applicationEdit &&
+                      me?.user.isSuperuser
+                          ? html`
+                                <a
+                                    class="pf-c-button pf-m-control pf-m-small pf-m-block"
+                                    href="/if/admin/#/core/applications/${this.application?.slug}"
+                                >
+                                    <i class="fas fa-edit"></i>&nbsp;${msg("Edit")}
+                                </a>
+                            `
+                          : html``}
+                  </ak-expand>`
+                : html``}
         </div>`;
     }
 }


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

The expandable element is only supposed to be rendered when there's actual information to show

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)
-   [x] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
