### PR TITLE
providers/proxy: fix JWKS url in embedded outpost

### DIFF
--- a/internal/outpost/proxyv2/application/endpoint_test.go
+++ b/internal/outpost/proxyv2/application/endpoint_test.go
@@ -82,7 +82,7 @@ func TestEndpointEmbedded(t *testing.T) {
 	assert.Equal(t, "https://authentik-host.test.goauthentik.io/application/o/authorize/", ep.AuthURL)
 	assert.Equal(t, "https://authentik-host.test.goauthentik.io/application/o/test-app/", ep.Issuer)
 	assert.Equal(t, "https://test.goauthentik.io/application/o/token/", ep.TokenURL)
-	assert.Equal(t, "https://test.goauthentik.io/application/o/test-app/jwks/", ep.JwksUri)
+	assert.Equal(t, "https://authentik-host.test.goauthentik.io/application/o/test-app/jwks/", ep.JwksUri)
 	assert.Equal(t, "https://authentik-host.test.goauthentik.io/application/o/test-app/end-session/", ep.EndSessionEndpoint)
 	assert.Equal(t, "https://test.goauthentik.io/application/o/introspect/", ep.TokenIntrospection)
 }


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

(Currently we don't use JWKS in the proxy provider but still)

The embedded outpost sets the JWKS url to localhost:8000 which is what we get from the API, where it should be replaced by the value of `authentik_host`. This change also makes it a bit clearer which values are updated with `authentik_host` and which are updated with `AUTHENTIK_HOST_BROWSER`

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
