### PR TITLE
providers/oauth2: fix id_token being saved incorrectly leading to lost claims

### DIFF
--- a/authentik/providers/oauth2/models.py
+++ b/authentik/providers/oauth2/models.py
@@ -2,6 +2,7 @@
 import base64
 import binascii
 import json
+from dataclasses import asdict
 from functools import cached_property
 from hashlib import sha256
 from typing import Any, Optional
@@ -358,7 +359,7 @@ class AccessToken(SerializerModel, ExpiringModel, BaseGrantModel):
     @id_token.setter
     def id_token(self, value: IDToken):
         self.token = value.to_access_token(self.provider)
-        self._id_token = json.dumps(value.to_dict())
+        self._id_token = json.dumps(asdict(value))
 
     @property
     def at_hash(self):
@@ -400,7 +401,7 @@ class RefreshToken(SerializerModel, ExpiringModel, BaseGrantModel):
 
     @id_token.setter
     def id_token(self, value: IDToken):
-        self._id_token = json.dumps(value.to_dict())
+        self._id_token = json.dumps(asdict(value))
 
     @property
     def serializer(self) -> Serializer:

--- a/authentik/providers/oauth2/tests/test_token_cc.py
+++ b/authentik/providers/oauth2/tests/test_token_cc.py
@@ -151,6 +151,14 @@ class TestTokenClientCredentials(OAuthTestCase):
         )
         self.assertEqual(jwt["given_name"], self.user.name)
         self.assertEqual(jwt["preferred_username"], self.user.username)
+        jwt = decode(
+            body["id_token"],
+            key=self.provider.signing_key.public_key,
+            algorithms=[alg],
+            audience=self.provider.client_id,
+        )
+        self.assertEqual(jwt["given_name"], self.user.name)
+        self.assertEqual(jwt["preferred_username"], self.user.username)
 
     def test_successful_password(self):
         """test successful (password grant)"""

--- a/scripts/generate_config.py
+++ b/scripts/generate_config.py
@@ -16,9 +16,6 @@ with open("local.env.yml", "w", encoding="utf-8") as _config:
                 "container_image_base": "ghcr.io/goauthentik/dev-%(type)s:gh-%(build_hash)s",
             },
             "blueprints_dir": "./blueprints",
-            "web": {
-                "outpost_port_offset": 100,
-            },
             "cert_discovery_dir": "./certs",
             "geoip": "tests/GeoLite2-City-Test.mmdb",
         },


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

closes #6642

IDToken.to_dict() is "lossy" as in it moves some data around, which we need for general usage, but for the database we need to save them as-is so `from_dict` can restore them correctly

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
