### PR TITLE
blueprints: fix tag values not resolved correctly

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ build/**
 build_docs/**
 Dockerfile
 authentik/enterprise
+blueprints/local

--- a/authentik/blueprints/tests/fixtures/conditional_fields.yaml
+++ b/authentik/blueprints/tests/fixtures/conditional_fields.yaml
@@ -45,3 +45,8 @@ entries:
     attrs:
       name: "%(uid)s"
       password: "%(uid)s"
+  - model: authentik_core.user
+    identifiers:
+      username: "%(uid)s-no-password"
+    attrs:
+      name: "%(uid)s"

--- a/authentik/blueprints/tests/fixtures/tags.yaml
+++ b/authentik/blueprints/tests/fixtures/tags.yaml
@@ -36,6 +36,7 @@ entries:
       model: authentik_policies_expression.expressionpolicy
     - attrs:
           attributes:
+              env_null: !Env [bar-baz, null]
               policy_pk1:
                   !Format [
                       "%s-%s",

--- a/authentik/blueprints/tests/test_v1.py
+++ b/authentik/blueprints/tests/test_v1.py
@@ -213,8 +213,9 @@ class TestBlueprintsV1(TransactionTestCase):
                         },
                     },
                     "nested_context": "context-nested-value",
+                    "env_null": None,
                 }
-            )
+            ).exists()
         )
         self.assertTrue(
             OAuthSource.objects.filter(

--- a/authentik/blueprints/tests/test_v1_conditional_fields.py
+++ b/authentik/blueprints/tests/test_v1_conditional_fields.py
@@ -51,3 +51,9 @@ class TestBlueprintsV1ConditionalFields(TransactionTestCase):
         user: User = User.objects.filter(username=self.uid).first()
         self.assertIsNotNone(user)
         self.assertTrue(user.check_password(self.uid))
+
+    def test_user_null(self):
+        """Test user"""
+        user: User = User.objects.filter(username=f"{self.uid}-no-password").first()
+        self.assertIsNotNone(user)
+        self.assertFalse(user.has_usable_password())

--- a/authentik/blueprints/v1/common.py
+++ b/authentik/blueprints/v1/common.py
@@ -223,11 +223,11 @@ class Env(YAMLTag):
         if isinstance(node, ScalarNode):
             self.key = node.value
         if isinstance(node, SequenceNode):
-            self.key = node.value[0].value
-            self.default = node.value[1].value
+            self.key = loader.construct_object(node.value[0])
+            self.default = loader.construct_object(node.value[1])
 
     def resolve(self, entry: BlueprintEntry, blueprint: Blueprint) -> Any:
-        return getenv(self.key, self.default)
+        return getenv(self.key) or self.default
 
 
 class Context(YAMLTag):
@@ -242,8 +242,8 @@ class Context(YAMLTag):
         if isinstance(node, ScalarNode):
             self.key = node.value
         if isinstance(node, SequenceNode):
-            self.key = node.value[0].value
-            self.default = node.value[1].value
+            self.key = loader.construct_object(node.value[0])
+            self.default = loader.construct_object(node.value[1])
 
     def resolve(self, entry: BlueprintEntry, blueprint: Blueprint) -> Any:
         value = self.default
@@ -262,7 +262,7 @@ class Format(YAMLTag):
 
     def __init__(self, loader: "BlueprintLoader", node: SequenceNode) -> None:
         super().__init__()
-        self.format_string = node.value[0].value
+        self.format_string = loader.construct_object(node.value[0])
         self.args = []
         for raw_node in node.value[1:]:
             self.args.append(loader.construct_object(raw_node))
@@ -341,7 +341,7 @@ class Condition(YAMLTag):
 
     def __init__(self, loader: "BlueprintLoader", node: SequenceNode) -> None:
         super().__init__()
-        self.mode = node.value[0].value
+        self.mode = loader.construct_object(node.value[0])
         self.args = []
         for raw_node in node.value[1:]:
             self.args.append(loader.construct_object(raw_node))
@@ -416,7 +416,7 @@ class Enumerate(YAMLTag, YAMLTagContext):
     def __init__(self, loader: "BlueprintLoader", node: SequenceNode) -> None:
         super().__init__()
         self.iterable = loader.construct_object(node.value[0])
-        self.output_body = node.value[1].value
+        self.output_body = loader.construct_object(node.value[1])
         self.item_body = loader.construct_object(node.value[2])
         self.__current_context: tuple[Any, Any] = tuple()
 

--- a/authentik/core/api/users.py
+++ b/authentik/core/api/users.py
@@ -123,24 +123,26 @@ class UserSerializer(ModelSerializer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if SERIALIZER_CONTEXT_BLUEPRINT in self.context:
-            self.fields["password"] = CharField(required=False)
+            self.fields["password"] = CharField(required=False, allow_null=True)
 
     def create(self, validated_data: dict) -> User:
         """If this serializer is used in the blueprint context, we allow for
         directly setting a password. However should be done via the `set_password`
         method instead of directly setting it like rest_framework."""
+        password = validated_data.pop("password", None)
         instance: User = super().create(validated_data)
-        if SERIALIZER_CONTEXT_BLUEPRINT in self.context and "password" in validated_data:
-            instance.set_password(validated_data["password"])
+        if SERIALIZER_CONTEXT_BLUEPRINT in self.context and password:
+            instance.set_password(password)
             instance.save()
         return instance
 
     def update(self, instance: User, validated_data: dict) -> User:
         """Same as `create` above, set the password directly if we're in a blueprint
         context"""
+        password = validated_data.pop("password", None)
         instance = super().update(instance, validated_data)
-        if SERIALIZER_CONTEXT_BLUEPRINT in self.context and "password" in validated_data:
-            instance.set_password(validated_data["password"])
+        if SERIALIZER_CONTEXT_BLUEPRINT in self.context and password:
+            instance.set_password(password)
             instance.save()
         return instance
 

--- a/blueprints/schema.json
+++ b/blueprints/schema.json
@@ -8400,7 +8400,10 @@
                     "title": "Type"
                 },
                 "password": {
-                    "type": "string",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
                     "minLength": 1,
                     "title": "Password"
                 }


### PR DESCRIPTION
this lead to `null` in an `!Env` tag being returned as `"null"`

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

This actually broke the bootstrap process when not using automated installs, as it would always set the password to `"null"` and break the initial setup flow

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
