### PR TITLE
*: fix api errors raised in general validate() to specify a field

### DIFF
--- a/authentik/api/schema.py
+++ b/authentik/api/schema.py
@@ -9,6 +9,7 @@ from drf_spectacular.plumbing import (
 )
 from drf_spectacular.settings import spectacular_settings
 from drf_spectacular.types import OpenApiTypes
+from rest_framework.settings import api_settings
 
 from authentik.api.pagination import PAGINATION_COMPONENT_NAME, PAGINATION_SCHEMA
 
@@ -31,7 +32,7 @@ GENERIC_ERROR = build_object_type(
 VALIDATION_ERROR = build_object_type(
     description=_("Validation Error"),
     properties={
-        "non_field_errors": build_array_type(build_standard_type(OpenApiTypes.STR)),
+        api_settings.NON_FIELD_ERRORS_KEY: build_array_type(build_standard_type(OpenApiTypes.STR)),
         "code": build_standard_type(OpenApiTypes.STR),
     },
     required=[],

--- a/authentik/blueprints/v1/meta/apply_blueprint.py
+++ b/authentik/blueprints/v1/meta/apply_blueprint.py
@@ -31,7 +31,7 @@ class ApplyBlueprintMetaSerializer(PassiveSerializer):
         required = attrs["required"]
         instance = BlueprintInstance.objects.filter(**identifiers).first()
         if not instance and required:
-            raise ValidationError("Required blueprint does not exist")
+            raise ValidationError({"identifiers": "Required blueprint does not exist"})
         self.blueprint_instance = instance
         return super().validate(attrs)
 

--- a/authentik/core/api/tokens.py
+++ b/authentik/core/api/tokens.py
@@ -47,7 +47,7 @@ class TokenSerializer(ManagedSerializer, ModelSerializer):
             attrs.setdefault("user", request.user)
         attrs.setdefault("intent", TokenIntents.INTENT_API)
         if attrs.get("intent") not in [TokenIntents.INTENT_API, TokenIntents.INTENT_APP_PASSWORD]:
-            raise ValidationError(f"Invalid intent {attrs.get('intent')}")
+            raise ValidationError({"intent": f"Invalid intent {attrs.get('intent')}"})
         return attrs
 
     class Meta:

--- a/authentik/events/api/notification_transports.py
+++ b/authentik/events/api/notification_transports.py
@@ -39,7 +39,7 @@ class NotificationTransportSerializer(ModelSerializer):
         mode = attrs.get("mode")
         if mode in [TransportMode.WEBHOOK, TransportMode.WEBHOOK_SLACK]:
             if "webhook_url" not in attrs or attrs.get("webhook_url", "") == "":
-                raise ValidationError("Webhook URL may not be empty.")
+                raise ValidationError({"webhook_url": "Webhook URL may not be empty."})
         return attrs
 
     class Meta:

--- a/authentik/providers/proxy/api.py
+++ b/authentik/providers/proxy/api.py
@@ -59,7 +59,9 @@ class ProxyProviderSerializer(ProviderSerializer):
             attrs.get("mode", ProxyMode.PROXY) == ProxyMode.PROXY
             and attrs.get("internal_host", "") == ""
         ):
-            raise ValidationError(_("Internal host cannot be empty when forward auth is disabled."))
+            raise ValidationError(
+                {"internal_host": _("Internal host cannot be empty when forward auth is disabled.")}
+            )
         return attrs
 
     def create(self, validated_data: dict):

--- a/authentik/providers/proxy/tests.py
+++ b/authentik/providers/proxy/tests.py
@@ -69,7 +69,7 @@ class ProxyProviderTests(APITestCase):
         self.assertEqual(response.status_code, 400)
         self.assertJSONEqual(
             response.content.decode(),
-            {"non_field_errors": ["Internal host cannot be empty when forward auth is disabled."]},
+            {"internal_host": ["Internal host cannot be empty when forward auth is disabled."]},
         )
 
     def test_create_defaults(self):

--- a/authentik/sources/ldap/api.py
+++ b/authentik/sources/ldap/api.py
@@ -44,7 +44,11 @@ class LDAPSourceSerializer(SourceSerializer):
                 sources = sources.exclude(pk=self.instance.pk)
             if sources.exists():
                 raise ValidationError(
-                    "Only a single LDAP Source with password synchronization is allowed"
+                    {
+                        "sync_users_password": (
+                            "Only a single LDAP Source with password synchronization is allowed"
+                        )
+                    }
                 )
         return super().validate(attrs)
 

--- a/authentik/sources/oauth/api/source.py
+++ b/authentik/sources/oauth/api/source.py
@@ -63,7 +63,7 @@ class OAuthSourceSerializer(SourceSerializer):
                 well_known_config.raise_for_status()
             except RequestException as exc:
                 text = exc.response.text if exc.response else str(exc)
-                raise ValidationError(text)
+                raise ValidationError({"oidc_well_known_url": text})
             config = well_known_config.json()
             try:
                 attrs["authorization_url"] = config["authorization_endpoint"]
@@ -71,7 +71,9 @@ class OAuthSourceSerializer(SourceSerializer):
                 attrs["profile_url"] = config["userinfo_endpoint"]
                 attrs["oidc_jwks_url"] = config["jwks_uri"]
             except (IndexError, KeyError) as exc:
-                raise ValidationError(f"Invalid well-known configuration: {exc}")
+                raise ValidationError(
+                    {"oidc_well_known_url": f"Invalid well-known configuration: {exc}"}
+                )
 
         jwks_url = attrs.get("oidc_jwks_url")
         if jwks_url and jwks_url != "":
@@ -80,7 +82,7 @@ class OAuthSourceSerializer(SourceSerializer):
                 jwks_config.raise_for_status()
             except RequestException as exc:
                 text = exc.response.text if exc.response else str(exc)
-                raise ValidationError(text)
+                raise ValidationError({"jwks_url": text})
             config = jwks_config.json()
             attrs["oidc_jwks"] = config
 

--- a/authentik/stages/user_login/tests.py
+++ b/authentik/stages/user_login/tests.py
@@ -99,6 +99,7 @@ class TestUserLoginStage(FlowTestCase):
         session[SESSION_KEY_PLAN] = plan
         session.save()
 
+        before_request = now()
         response = self.client.get(
             reverse("authentik_api:flow-executor", kwargs={"flow_slug": self.flow.slug})
         )
@@ -108,7 +109,7 @@ class TestUserLoginStage(FlowTestCase):
         session_key = self.client.session.session_key
         session = AuthenticatedSession.objects.filter(session_key=session_key).first()
         self.assertAlmostEqual(
-            session.expires.timestamp() - now().timestamp(),
+            session.expires.timestamp() - before_request.timestamp(),
             timedelta_from_string(self.stage.session_duration).total_seconds(),
             delta=1,
         )

--- a/authentik/tenants/api.py
+++ b/authentik/tenants/api.py
@@ -36,7 +36,7 @@ class TenantSerializer(ModelSerializer):
             if self.instance:
                 tenants = tenants.exclude(pk=self.instance.pk)
             if tenants.exists():
-                raise ValidationError("Only a single Tenant can be set as default.")
+                raise ValidationError({"default": "Only a single Tenant can be set as default."})
         return super().validate(attrs)
 
     class Meta:

--- a/web/src/admin/providers/ldap/LDAPProviderForm.ts
+++ b/web/src/admin/providers/ldap/LDAPProviderForm.ts
@@ -217,7 +217,6 @@ export class LDAPProviderFormPage extends ModelForm<LDAPProvider, number> {
                     </ak-form-element-horizontal>
                     <ak-form-element-horizontal
                         label=${msg("TLS Server name")}
-                        ?required=${true}
                         name="tlsServerName"
                     >
                         <input


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

currently when for example creating a proxy provider in proxy mode and not setting an internal host, there's an error about the field being required, but its a general `non_field_error` instead of an error attributed to the field. This change fixes that for most cases where non-field validation is done

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
