### PR TITLE
website/docs: fix typos

### DIFF
--- a/website/docs/enterprise/index.md
+++ b/website/docs/enterprise/index.md
@@ -7,7 +7,7 @@ The Enterprise release of authentik provides all of the functionality that we ha
 Refer to our Enterprise documentation for information about creating and managing your organization, purchasing and activating a license, support, and managing billing and organization members.
 
 -   [Get started with Enterprise](./get-started.md)
--   [Manage you Enterprise account](./manage-enterprise.md)
+-   [Manage your Enterprise account](./manage-enterprise.md)
 -   [Support for Enterprise accounts](./entsupport.md)
 
 Our standard technical documentation covers how to configure, customize, and use authentik, whether the open source version that we have built our reputation on, or our Enterprise version with dedicated support.

--- a/website/docs/enterprise/manage-enterprise.md
+++ b/website/docs/enterprise/manage-enterprise.md
@@ -4,7 +4,7 @@ title: Manage your Enterprise account
 
 ## Organization management
 
-Your organization defines the members, their roles, the license associated with the organization, and account management for billing, payment methods, and invoice history.
+Your organization defines the members, their roles, the licenses associated with the organization, and account management for billing, payment methods, and invoice history.
 
 ### Create an Organization
 


### PR DESCRIPTION
Fixed two typos.

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
