### PR TITLE
blueprints: fix policy exception causing password stage to be skipped after upgrade

### DIFF
--- a/blueprints/default/flow-default-authentication-flow.yaml
+++ b/blueprints/default/flow-default-authentication-flow.yaml
@@ -71,10 +71,12 @@ entries:
     name: default-authentication-flow-password-stage
   attrs:
     expression: |
-      flow_plan = request.context["flow_plan"]
+      flow_plan = request.context.get("flow_plan")
+      if not flow_plan:
+          return True
       # If the user does not have a backend attached to it, they haven't
       # been authenticated yet and we need the password stage
-      return not hasattr(flow_plan.context["pending_user"], "backend")
+      return not hasattr(flow_plan.context.get("pending_user"), "backend")
 - model: authentik_policies.policybinding
   identifiers:
     order: 10

--- a/blueprints/default/flow-default-authentication-flow.yaml
+++ b/blueprints/default/flow-default-authentication-flow.yaml
@@ -51,6 +51,8 @@ entries:
     order: 20
     stage: !KeyOf default-authentication-password
     target: !KeyOf flow
+  attrs:
+    re_evaluate_policies: true
   id: default-authentication-flow-password-binding
   model: authentik_flows.flowstagebinding
 - identifiers:


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

closes #6673

due to changing defaults, after upgrading from some versions, a new default policy would be run at the wrong time causing it to fail, which would cause the password stage to get skipped

this fixes both the missing default value and also makes the policy more resilient to errors

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
