### PR TITLE
root/revert persistent connections

### DIFF
--- a/authentik/root/settings.py
+++ b/authentik/root/settings.py
@@ -279,15 +279,14 @@ DATABASES = {
         "SSLROOTCERT": CONFIG.get("postgresql.sslrootcert"),
         "SSLCERT": CONFIG.get("postgresql.sslcert"),
         "SSLKEY": CONFIG.get("postgresql.sslkey"),
-        # https://docs.djangoproject.com/en/4.0/ref/databases/#persistent-connections
-        "CONN_MAX_AGE": None,
-        "CONN_HEALTH_CHECKS": True,
     }
 }
 
 if CONFIG.get_bool("postgresql.use_pgbouncer", False):
     # https://docs.djangoproject.com/en/4.0/ref/databases/#transaction-pooling-server-side-cursors
     DATABASES["default"]["DISABLE_SERVER_SIDE_CURSORS"] = True
+    # https://docs.djangoproject.com/en/4.0/ref/databases/#persistent-connections
+    DATABASES["default"]["CONN_MAX_AGE"] = None  # persistent
 
 # Email
 # These values should never actually be used, emails are only sent from email stages, which


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

revert #6560

causes postgres connection count to skyrocket 
![image](https://github.com/goauthentik/authentik/assets/1932513/c6c8732d-1108-45a3-9296-91b29f9b2d31)

it looks like there's some issue with persistent connection with max_age `None` and gunicorn?

after reverting the connections are way down

![image](https://github.com/goauthentik/authentik/assets/1932513/6871de72-dba5-44de-a832-2fdb72a093c7)

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
