### PR TITLE
web: fix application name not showing on admin dashboard

### DIFF
--- a/authentik/events/api/events.py
+++ b/authentik/events/api/events.py
@@ -10,7 +10,7 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from guardian.shortcuts import get_objects_for_user
 from rest_framework.decorators import action
-from rest_framework.fields import DictField, IntegerField
+from rest_framework.fields import CharField, IntegerField
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import ModelSerializer
@@ -42,7 +42,7 @@ class EventSerializer(ModelSerializer):
 class EventTopPerUserSerializer(PassiveSerializer):
     """Response object of Event's top_per_user"""
 
-    application = DictField()
+    application_name = CharField()
     counted_events = IntegerField()
     unique_users = IntegerField()
 
@@ -141,9 +141,10 @@ class EventViewSet(ModelViewSet):
             .annotate(application=KeyTextTransform("authorized_application", "context"))
             .annotate(user_pk=KeyTextTransform("pk", "user"))
             .values("application")
+            .annotate(application_name=KeyTextTransform("name", "application"))
             .annotate(counted_events=Count("application"))
             .annotate(unique_users=Count("user_pk", distinct=True))
-            .values("unique_users", "application", "counted_events")
+            .values("unique_users", "application_name", "counted_events")
             .order_by("-counted_events")[:top_n]
         )
 

--- a/lifecycle/ak
+++ b/lifecycle/ak
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 MODE_FILE="${TMPDIR}/authentik-mode"
 
 function log {

--- a/schema.yml
+++ b/schema.yml
@@ -29800,15 +29800,14 @@ components:
       type: object
       description: Response object of Event's top_per_user
       properties:
-        application:
-          type: object
-          additionalProperties: {}
+        application_name:
+          type: string
         counted_events:
           type: integer
         unique_users:
           type: integer
       required:
-      - application
+      - application_name
       - counted_events
       - unique_users
     ExpiringBaseGrantModel:

--- a/web/src/admin/admin-overview/TopApplicationsTable.ts
+++ b/web/src/admin/admin-overview/TopApplicationsTable.ts
@@ -32,7 +32,7 @@ export class TopApplicationsTable extends AKElement {
 
     renderRow(event: EventTopPerUser): TemplateResult {
         return html`<tr role="row">
-            <td role="cell">${event.application.name}</td>
+            <td role="cell">${event.applicationName}</td>
             <td role="cell">${event.countedEvents}</td>
             <td role="cell">
                 <progress


### PR DESCRIPTION
## Details

Since 2023.8, the application name is not showing on the admin dashboard anymore

![image](https://github.com/goauthentik/authentik/assets/18313093/bad3e35e-3c80-402d-b5de-53fce1953b07)

This is due to the fact that the API endpoint used returns nested JSON:

```json
[
  {
    "application": "{\"pk\": \"87b69f323fc64435b181d1fc966cb939\", \"app\": \"authentik_core\", \"name\": \"Nextcloud\", \"model_name\": \"application\"}",
    "counted_events": 56,
    "unique_users": 3
  }
]
```

whereas it previously returned that `application` key expanded.

This PR gets rid of the `application` data altogether and simply gives back the application name.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [x] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
