### PR TITLE
web/admin: fix ak-toggle-group for policy and blueprint uses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,8 +148,7 @@ web-lint-fix:
 
 web-lint:
 	cd web && npm run lint
-	# TODO: The analyzer hasn't run correctly in awhile.
-	# cd web && npm run lit-analyse
+	cd web && npm run lit-analyse
 
 web-check-compile:
 	cd web && npm run tsc

--- a/web/src/admin/blueprints/BlueprintForm.ts
+++ b/web/src/admin/blueprints/BlueprintForm.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
 import { docLink } from "@goauthentik/common/global";
 import { first } from "@goauthentik/common/utils";
+import "@goauthentik/components/ak-toggle-group";
 import "@goauthentik/elements/CodeMirror";
 import "@goauthentik/elements/forms/FormGroup";
 import "@goauthentik/elements/forms/HorizontalFormElement";
@@ -18,9 +19,9 @@ import PFContent from "@patternfly/patternfly/components/Content/content.css";
 import { BlueprintFile, BlueprintInstance, ManagedApi } from "@goauthentik/api";
 
 enum blueprintSource {
-    file,
-    oci,
-    internal,
+    file = "file",
+    oci = "oci",
+    internal = "internal",
 }
 
 @customElement("ak-blueprint-form")

--- a/web/src/admin/policies/PolicyBindingForm.ts
+++ b/web/src/admin/policies/PolicyBindingForm.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
 import { first, groupBy } from "@goauthentik/common/utils";
+import "@goauthentik/components/ak-toggle-group";
 import "@goauthentik/elements/forms/HorizontalFormElement";
 import { ModelForm } from "@goauthentik/elements/forms/ModelForm";
 import "@goauthentik/elements/forms/SearchSelect";
@@ -24,9 +25,9 @@ import {
 } from "@goauthentik/api";
 
 enum target {
-    policy,
-    group,
-    user,
+    policy = "policy",
+    group = "group",
+    user = "user",
 }
 
 @customElement("ak-policy-binding-form")

--- a/web/src/admin/policies/PolicyBindingForm.ts
+++ b/web/src/admin/policies/PolicyBindingForm.ts
@@ -52,7 +52,7 @@ export class PolicyBindingForm extends ModelForm<PolicyBinding, string> {
     @property()
     targetPk?: string;
 
-    @property({ type: Number })
+    @state()
     policyGroupUser: target = target.policy;
 
     @property({ type: Boolean })

--- a/web/src/components/ak-toggle-group.ts
+++ b/web/src/components/ak-toggle-group.ts
@@ -6,6 +6,7 @@ import { customElement, property } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 
 import PFToggleGroup from "@patternfly/patternfly/components/ToggleGroup/toggle-group.css";
+import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 type Pair = [string, string];
 
@@ -26,6 +27,7 @@ type Pair = [string, string];
 export class AkToggleGroup extends CustomEmitterElement(AKElement) {
     static get styles() {
         return [
+            PFBase,
             PFToggleGroup,
             css`
                 .pf-c-toggle-group {


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

ak-toggle-group expects to have the `value` be a string, but for the policy binding form and the blueprint instance form we were using numbers as types, which got cast to string and so never matched any of the checks

Additionally there were some imports missing and the PFBase css was missing so the font wasn't correct

cc @kensternberg-authentik 

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)
-   [x] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
