### PR TITLE
core: make groups' parent_name nullable as it might not be set

### DIFF
--- a/authentik/core/api/groups.py
+++ b/authentik/core/api/groups.py
@@ -49,7 +49,7 @@ class GroupSerializer(ModelSerializer):
     users_obj = ListSerializer(
         child=GroupMemberSerializer(), read_only=True, source="users", required=False
     )
-    parent_name = CharField(source="parent.name", read_only=True)
+    parent_name = CharField(source="parent.name", read_only=True, allow_null=True)
 
     num_pk = IntegerField(read_only=True)
 

--- a/schema.yml
+++ b/schema.yml
@@ -30498,6 +30498,7 @@ components:
         parent_name:
           type: string
           readOnly: true
+          nullable: true
         users:
           type: array
           items:


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

See https://github.com/goauthentik/authentik/discussions/6652

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
