### PR TITLE
website: fix reference to flow stage binding option

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-23 10:04+0000\n"
+"POT-Creation-Date: 2023-08-30 17:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -23,11 +23,11 @@ msgstr ""
 msgid "Successfully re-scheduled Task %(name)s!"
 msgstr ""
 
-#: authentik/api/schema.py:24
+#: authentik/api/schema.py:25
 msgid "Generic API Error"
 msgstr ""
 
-#: authentik/api/schema.py:32
+#: authentik/api/schema.py:33
 msgid "Validation Error"
 msgstr ""
 
@@ -82,11 +82,11 @@ msgstr ""
 msgid "Create a SAML Provider by importing its Metadata."
 msgstr ""
 
-#: authentik/core/api/users.py:150
+#: authentik/core/api/users.py:158
 msgid "No leading or trailing slashes allowed."
 msgstr ""
 
-#: authentik/core/api/users.py:153
+#: authentik/core/api/users.py:161
 msgid "No empty segments in user path allowed."
 msgstr ""
 
@@ -102,7 +102,7 @@ msgstr ""
 msgid "User's display name."
 msgstr ""
 
-#: authentik/core/models.py:268 authentik/providers/oauth2/models.py:294
+#: authentik/core/models.py:268 authentik/providers/oauth2/models.py:295
 msgid "User"
 msgstr ""
 
@@ -291,12 +291,12 @@ msgstr ""
 msgid "Go home"
 msgstr ""
 
-#: authentik/core/templates/login/base_full.html:90
+#: authentik/core/templates/login/base_full.html:89
 msgid "Powered by authentik"
 msgstr ""
 
 #: authentik/core/views/apps.py:53
-#: authentik/providers/oauth2/views/authorize.py:391
+#: authentik/providers/oauth2/views/authorize.py:393
 #: authentik/providers/oauth2/views/device_init.py:70
 #: authentik/providers/saml/views/sso.py:70
 #, python-format
@@ -917,216 +917,216 @@ msgid ""
 "this method only if you have different UPN and Mail domains."
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:42
+#: authentik/providers/oauth2/models.py:43
 msgid "Confidential"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:43
+#: authentik/providers/oauth2/models.py:44
 msgid "Public"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:65
+#: authentik/providers/oauth2/models.py:66
 msgid "Same identifier is used for all providers"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:67
+#: authentik/providers/oauth2/models.py:68
 msgid "Each provider has a different issuer, based on the application slug."
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:74
+#: authentik/providers/oauth2/models.py:75
 msgid "code (Authorization Code Flow)"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:75
+#: authentik/providers/oauth2/models.py:76
 msgid "id_token (Implicit Flow)"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:76
+#: authentik/providers/oauth2/models.py:77
 msgid "id_token token (Implicit Flow)"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:77
+#: authentik/providers/oauth2/models.py:78
 msgid "code token (Hybrid Flow)"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:78
+#: authentik/providers/oauth2/models.py:79
 msgid "code id_token (Hybrid Flow)"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:79
+#: authentik/providers/oauth2/models.py:80
 msgid "code id_token token (Hybrid Flow)"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:85
+#: authentik/providers/oauth2/models.py:86
 msgid "HS256 (Symmetric Encryption)"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:86
+#: authentik/providers/oauth2/models.py:87
 msgid "RS256 (Asymmetric Encryption)"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:87
+#: authentik/providers/oauth2/models.py:88
 msgid "ES256 (Asymmetric Encryption)"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:93
+#: authentik/providers/oauth2/models.py:94
 msgid "Scope used by the client"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:97
+#: authentik/providers/oauth2/models.py:98
 msgid ""
 "Description shown to the user when consenting. If left empty, the user won't "
 "be informed."
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:116
+#: authentik/providers/oauth2/models.py:117
 msgid "Scope Mapping"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:117
+#: authentik/providers/oauth2/models.py:118
 msgid "Scope Mappings"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:127
+#: authentik/providers/oauth2/models.py:128
 msgid "Client Type"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:129
+#: authentik/providers/oauth2/models.py:130
 msgid ""
 "Confidential clients are capable of maintaining the confidentiality of their "
 "credentials. Public clients are incapable"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:136
+#: authentik/providers/oauth2/models.py:137
 msgid "Client ID"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:142
+#: authentik/providers/oauth2/models.py:143
 msgid "Client Secret"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:148
+#: authentik/providers/oauth2/models.py:149
 msgid "Redirect URIs"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:149
+#: authentik/providers/oauth2/models.py:150
 msgid "Enter each URI on a new line."
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:154
+#: authentik/providers/oauth2/models.py:155
 msgid "Include claims in id_token"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:156
+#: authentik/providers/oauth2/models.py:157
 msgid ""
 "Include User claims from scopes in the id_token, for applications that don't "
 "access the userinfo endpoint."
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:165
+#: authentik/providers/oauth2/models.py:166
 msgid ""
 "Access codes not valid on or after current time + this value (Format: "
 "hours=1;minutes=2;seconds=3)."
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:173
-#: authentik/providers/oauth2/models.py:181
+#: authentik/providers/oauth2/models.py:174
+#: authentik/providers/oauth2/models.py:182
 msgid ""
 "Tokens not valid on or after current time + this value (Format: hours=1;"
 "minutes=2;seconds=3)."
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:190
+#: authentik/providers/oauth2/models.py:191
 msgid ""
 "Configure what data should be used as unique User Identifier. For most "
 "cases, the default should be fine."
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:197
+#: authentik/providers/oauth2/models.py:198
 msgid "Configure how the issuer field of the ID Token should be filled."
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:202
+#: authentik/providers/oauth2/models.py:203
 msgid "Signing Key"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:206
+#: authentik/providers/oauth2/models.py:207
 msgid ""
 "Key used to sign the tokens. Only required when JWT Algorithm is set to "
 "RS256."
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:213
+#: authentik/providers/oauth2/models.py:214
 msgid ""
 "Any JWT signed by the JWK of the selected source can be used to authenticate."
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:286
+#: authentik/providers/oauth2/models.py:287
 msgid "OAuth2/OpenID Provider"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:287
+#: authentik/providers/oauth2/models.py:288
 msgid "OAuth2/OpenID Providers"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:296
-#: authentik/providers/oauth2/models.py:428
+#: authentik/providers/oauth2/models.py:297
+#: authentik/providers/oauth2/models.py:429
 msgid "Scopes"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:315
+#: authentik/providers/oauth2/models.py:316
 msgid "Code"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:316
+#: authentik/providers/oauth2/models.py:317
 msgid "Nonce"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:317
+#: authentik/providers/oauth2/models.py:318
 msgid "Code Challenge"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:319
+#: authentik/providers/oauth2/models.py:320
 msgid "Code Challenge Method"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:339
+#: authentik/providers/oauth2/models.py:340
 msgid "Authorization Code"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:340
+#: authentik/providers/oauth2/models.py:341
 msgid "Authorization Codes"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:382
+#: authentik/providers/oauth2/models.py:383
 msgid "OAuth2 Access Token"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:383
+#: authentik/providers/oauth2/models.py:384
 msgid "OAuth2 Access Tokens"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:393
+#: authentik/providers/oauth2/models.py:394
 msgid "ID Token"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:412
+#: authentik/providers/oauth2/models.py:413
 msgid "OAuth2 Refresh Token"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:413
+#: authentik/providers/oauth2/models.py:414
 msgid "OAuth2 Refresh Tokens"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:440
+#: authentik/providers/oauth2/models.py:441
 msgid "Device Token"
 msgstr ""
 
-#: authentik/providers/oauth2/models.py:441
+#: authentik/providers/oauth2/models.py:442
 msgid "Device Tokens"
 msgstr ""
 
-#: authentik/providers/oauth2/views/authorize.py:446
+#: authentik/providers/oauth2/views/authorize.py:448
 #: authentik/providers/saml/views/flows.py:87
 #, python-format
 msgid "Redirecting to %(app)s..."
@@ -1136,20 +1136,20 @@ msgstr ""
 msgid "Invalid code"
 msgstr ""
 
-#: authentik/providers/oauth2/views/userinfo.py:51
-#: authentik/providers/oauth2/views/userinfo.py:52
+#: authentik/providers/oauth2/views/userinfo.py:55
+#: authentik/providers/oauth2/views/userinfo.py:56
 msgid "GitHub Compatibility: Access your User Information"
 msgstr ""
 
-#: authentik/providers/oauth2/views/userinfo.py:53
+#: authentik/providers/oauth2/views/userinfo.py:57
 msgid "GitHub Compatibility: Access you Email addresses"
 msgstr ""
 
-#: authentik/providers/oauth2/views/userinfo.py:54
+#: authentik/providers/oauth2/views/userinfo.py:58
 msgid "GitHub Compatibility: Access your Groups"
 msgstr ""
 
-#: authentik/providers/oauth2/views/userinfo.py:55
+#: authentik/providers/oauth2/views/userinfo.py:59
 msgid "authentik API Access on behalf of your user"
 msgstr ""
 
@@ -1157,7 +1157,7 @@ msgstr ""
 msgid "User and password attributes must be set when basic auth is enabled."
 msgstr ""
 
-#: authentik/providers/proxy/api.py:62
+#: authentik/providers/proxy/api.py:63
 msgid "Internal host cannot be empty when forward auth is disabled."
 msgstr ""
 
@@ -1895,7 +1895,7 @@ msgstr ""
 msgid "TOTP Authenticator Setup Stages"
 msgstr ""
 
-#: authentik/stages/authenticator_validate/challenge.py:123
+#: authentik/stages/authenticator_validate/challenge.py:131
 msgid "Invalid Token"
 msgstr ""
 
@@ -2047,15 +2047,15 @@ msgstr ""
 msgid "Email Stages"
 msgstr ""
 
-#: authentik/stages/email/stage.py:112
+#: authentik/stages/email/stage.py:117
 msgid "Successfully verified Email."
 msgstr ""
 
-#: authentik/stages/email/stage.py:119 authentik/stages/email/stage.py:141
+#: authentik/stages/email/stage.py:124 authentik/stages/email/stage.py:146
 msgid "No pending user."
 msgstr ""
 
-#: authentik/stages/email/stage.py:131
+#: authentik/stages/email/stage.py:136
 msgid "Email sent."
 msgstr ""
 
@@ -2178,11 +2178,11 @@ msgstr ""
 msgid "Identification Stages"
 msgstr ""
 
-#: authentik/stages/identification/stage.py:184
+#: authentik/stages/identification/stage.py:188
 msgid "Log in"
 msgstr ""
 
-#: authentik/stages/identification/stage.py:185
+#: authentik/stages/identification/stage.py:189
 msgid "Continue"
 msgstr ""
 

--- a/web/src/admin/stages/deny/DenyStageForm.ts
+++ b/web/src/admin/stages/deny/DenyStageForm.ts
@@ -42,7 +42,7 @@ export class DenyStageForm extends ModelForm<DenyStage, string> {
         return html`<form class="pf-c-form pf-m-horizontal">
             <span>
                 ${msg(
-                    "Statically deny the flow. To use this stage effectively, disable *Evaluate on plan* on the respective binding.",
+                    "Statically deny the flow. To use this stage effectively, disable *Evaluate when flow is planned* on the respective binding.",
                 )}
             </span>
             <ak-form-element-horizontal label=${msg("Name")} ?required=${true} name="name">

--- a/web/xliff/de.xlf
+++ b/web/xliff/de.xlf
@@ -4135,10 +4135,6 @@ doesn't pass when either or both of the selected options are equal or above the 
       <trans-unit id="se0c660020d9cf5b7">
         <source>Offset after which consent expires.</source>
       </trans-unit>
-      <trans-unit id="s5e9527b6481a94ce">
-        <source>Statically deny the flow. To use this stage effectively, disable *Evaluate on plan* on the respective binding.</source>
-        <target>Den Fluss statisch verweigern. Um diese Phase effektiv zu nutzen, deaktivieren Sie *Evaluate on plan* für die entsprechende Bindung</target>
-      </trans-unit>
       <trans-unit id="s22b10ed263b96194">
         <source>Dummy stage used for testing. Shows a simple continue button and always passes.</source>
         <target>Dummy-Stage zum Testen verwendet. Zeigt eine einfache Schaltfläche zum Fortfahren und besteht immer.</target>
@@ -5894,6 +5890,9 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s57b07e524f8f5c2a">
   <source>External: <x id="0" equiv-text="${item.externalUsers}"/></source>
+</trans-unit>
+<trans-unit id="s7f68101a50f526ee">
+  <source>Statically deny the flow. To use this stage effectively, disable *Evaluate when flow is planned* on the respective binding.</source>
 </trans-unit>
     </body>
   </file>

--- a/web/xliff/en.xlf
+++ b/web/xliff/en.xlf
@@ -4365,10 +4365,6 @@ doesn't pass when either or both of the selected options are equal or above the 
         <source>Offset after which consent expires.</source>
         <target>Offset after which consent expires.</target>
       </trans-unit>
-      <trans-unit id="s5e9527b6481a94ce">
-        <source>Statically deny the flow. To use this stage effectively, disable *Evaluate on plan* on the respective binding.</source>
-        <target>Statically deny the flow. To use this stage effectively, disable *Evaluate on plan* on the respective binding.</target>
-      </trans-unit>
       <trans-unit id="s22b10ed263b96194">
         <source>Dummy stage used for testing. Shows a simple continue button and always passes.</source>
         <target>Dummy stage used for testing. Shows a simple continue button and always passes.</target>
@@ -6210,6 +6206,9 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s57b07e524f8f5c2a">
   <source>External: <x id="0" equiv-text="${item.externalUsers}"/></source>
+</trans-unit>
+<trans-unit id="s7f68101a50f526ee">
+  <source>Statically deny the flow. To use this stage effectively, disable *Evaluate when flow is planned* on the respective binding.</source>
 </trans-unit>
     </body>
   </file>

--- a/web/xliff/es.xlf
+++ b/web/xliff/es.xlf
@@ -4061,10 +4061,6 @@ doesn't pass when either or both of the selected options are equal or above the 
       <trans-unit id="se0c660020d9cf5b7">
         <source>Offset after which consent expires.</source>
       </trans-unit>
-      <trans-unit id="s5e9527b6481a94ce">
-        <source>Statically deny the flow. To use this stage effectively, disable *Evaluate on plan* on the respective binding.</source>
-        <target>Niega el flujo estáticamente. Para usar esta etapa de manera efectiva, desactive *Evaluar en plan* en el encuadernado respectivo.</target>
-      </trans-unit>
       <trans-unit id="s22b10ed263b96194">
         <source>Dummy stage used for testing. Shows a simple continue button and always passes.</source>
         <target>Escenario ficticio utilizado para las pruebas. Muestra un botón de continuar simple y siempre pasa.</target>
@@ -5802,6 +5798,9 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s57b07e524f8f5c2a">
   <source>External: <x id="0" equiv-text="${item.externalUsers}"/></source>
+</trans-unit>
+<trans-unit id="s7f68101a50f526ee">
+  <source>Statically deny the flow. To use this stage effectively, disable *Evaluate when flow is planned* on the respective binding.</source>
 </trans-unit>
     </body>
   </file>

--- a/web/xliff/fr_FR.xlf
+++ b/web/xliff/fr_FR.xlf
@@ -4137,10 +4137,6 @@ doesn't pass when either or both of the selected options are equal or above the 
       <trans-unit id="se0c660020d9cf5b7">
         <source>Offset after which consent expires.</source>
       </trans-unit>
-      <trans-unit id="s5e9527b6481a94ce">
-        <source>Statically deny the flow. To use this stage effectively, disable *Evaluate on plan* on the respective binding.</source>
-        <target>Refuser statiquement le flux. Pour utiliser cette étape efficacement, désactivez *Évaluer en planification* dans la liaison applicable.</target>
-      </trans-unit>
       <trans-unit id="s22b10ed263b96194">
         <source>Dummy stage used for testing. Shows a simple continue button and always passes.</source>
         <target>Étape factice utilisée pour les tests. Montre un simple bouton continuer et réussit toujours.</target>
@@ -5909,6 +5905,9 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s57b07e524f8f5c2a">
   <source>External: <x id="0" equiv-text="${item.externalUsers}"/></source>
+</trans-unit>
+<trans-unit id="s7f68101a50f526ee">
+  <source>Statically deny the flow. To use this stage effectively, disable *Evaluate when flow is planned* on the respective binding.</source>
 </trans-unit>
     </body>
   </file>

--- a/web/xliff/pl.xlf
+++ b/web/xliff/pl.xlf
@@ -4234,10 +4234,6 @@ doesn't pass when either or both of the selected options are equal or above the 
         <source>Offset after which consent expires.</source>
         <target>Przesunięcie, po którym zgoda wygasa.</target>
       </trans-unit>
-      <trans-unit id="s5e9527b6481a94ce">
-        <source>Statically deny the flow. To use this stage effectively, disable *Evaluate on plan* on the respective binding.</source>
-        <target>Statycznie zaprzeczaj przepływowi. Aby efektywnie korzystać z tego etapu, wyłącz opcję *Oceń zgodnie z planem* w odpowiednim powiązaniu.</target>
-      </trans-unit>
       <trans-unit id="s22b10ed263b96194">
         <source>Dummy stage used for testing. Shows a simple continue button and always passes.</source>
         <target>Atrapa etapu używana do testowania. Pokazuje prosty przycisk kontynuuj i zawsze przechodzi.</target>
@@ -6041,6 +6037,9 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s57b07e524f8f5c2a">
   <source>External: <x id="0" equiv-text="${item.externalUsers}"/></source>
+</trans-unit>
+<trans-unit id="s7f68101a50f526ee">
+  <source>Statically deny the flow. To use this stage effectively, disable *Evaluate when flow is planned* on the respective binding.</source>
 </trans-unit>
     </body>
   </file>

--- a/web/xliff/pseudo-LOCALE.xlf
+++ b/web/xliff/pseudo-LOCALE.xlf
@@ -4329,10 +4329,6 @@ doesn't pass when either or both of the selected options are equal or above the 
         <source>Offset after which consent expires.</source>
         
       </trans-unit>
-      <trans-unit id="s5e9527b6481a94ce">
-        <source>Statically deny the flow. To use this stage effectively, disable *Evaluate on plan* on the respective binding.</source>
-        
-      </trans-unit>
       <trans-unit id="s22b10ed263b96194">
         <source>Dummy stage used for testing. Shows a simple continue button and always passes.</source>
         
@@ -6145,6 +6141,9 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s57b07e524f8f5c2a">
   <source>External: <x id="0" equiv-text="${item.externalUsers}"/></source>
+</trans-unit>
+<trans-unit id="s7f68101a50f526ee">
+  <source>Statically deny the flow. To use this stage effectively, disable *Evaluate when flow is planned* on the respective binding.</source>
 </trans-unit>
     </body>
   </file>

--- a/web/xliff/tr.xlf
+++ b/web/xliff/tr.xlf
@@ -4052,10 +4052,6 @@ doesn't pass when either or both of the selected options are equal or above the 
       <trans-unit id="se0c660020d9cf5b7">
         <source>Offset after which consent expires.</source>
       </trans-unit>
-      <trans-unit id="s5e9527b6481a94ce">
-        <source>Statically deny the flow. To use this stage effectively, disable *Evaluate on plan* on the respective binding.</source>
-        <target>Akışı statik olarak reddet. Bu aşamayı etkili bir şekilde kullanmak için ilgili bağlama üzerinde *Planda değerlendirme* devre dışı bırakın.</target>
-      </trans-unit>
       <trans-unit id="s22b10ed263b96194">
         <source>Dummy stage used for testing. Shows a simple continue button and always passes.</source>
         <target>Test için kullanılan kukla aşama. Basit bir devam düğmesi gösterir ve her zaman geçer.</target>
@@ -5792,6 +5788,9 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s57b07e524f8f5c2a">
   <source>External: <x id="0" equiv-text="${item.externalUsers}"/></source>
+</trans-unit>
+<trans-unit id="s7f68101a50f526ee">
+  <source>Statically deny the flow. To use this stage effectively, disable *Evaluate when flow is planned* on the respective binding.</source>
 </trans-unit>
     </body>
   </file>

--- a/web/xliff/zh-Hans.xlf
+++ b/web/xliff/zh-Hans.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" ?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+<?xml version="1.0"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file target-language="zh-Hans" source-language="en" original="lit-localize-inputs" datatype="plaintext">
     <body>
       <trans-unit id="s4caed5b7a7e5d89b">
@@ -618,9 +618,9 @@
         
       </trans-unit>
       <trans-unit id="saa0e2675da69651b">
-        <source>The URL &quot;<x id="0" equiv-text="${this.url}"/>&quot; was not found.</source>
-        <target>未找到 URL &quot; 
-        <x id="0" equiv-text="${this.url}"/>&quot;。</target>
+        <source>The URL "<x id="0" equiv-text="${this.url}"/>" was not found.</source>
+        <target>未找到 URL " 
+        <x id="0" equiv-text="${this.url}"/>"。</target>
         
       </trans-unit>
       <trans-unit id="s58cd9c2fe836d9c6">
@@ -1072,8 +1072,8 @@
         
       </trans-unit>
       <trans-unit id="sa8384c9c26731f83">
-        <source>To allow any redirect URI, set this value to &quot;.*&quot;. Be aware of the possible security implications this can have.</source>
-        <target>要允许任何重定向 URI，请将此值设置为 &quot;.*&quot;。请注意这可能带来的安全影响。</target>
+        <source>To allow any redirect URI, set this value to ".*". Be aware of the possible security implications this can have.</source>
+        <target>要允许任何重定向 URI，请将此值设置为 ".*"。请注意这可能带来的安全影响。</target>
         
       </trans-unit>
       <trans-unit id="s55787f4dfcdce52b">
@@ -1819,8 +1819,8 @@
         
       </trans-unit>
       <trans-unit id="sa90b7809586c35ce">
-        <source>Either input a full URL, a relative path, or use 'fa://fa-test' to use the Font Awesome icon &quot;fa-test&quot;.</source>
-        <target>输入完整 URL、相对路径，或者使用 'fa://fa-test' 来使用 Font Awesome 图标 &quot;fa-test&quot;。</target>
+        <source>Either input a full URL, a relative path, or use 'fa://fa-test' to use the Font Awesome icon "fa-test".</source>
+        <target>输入完整 URL、相对路径，或者使用 'fa://fa-test' 来使用 Font Awesome 图标 "fa-test"。</target>
         
       </trans-unit>
       <trans-unit id="s0410779cb47de312">
@@ -3248,8 +3248,8 @@ doesn't pass when either or both of the selected options are equal or above the 
         
       </trans-unit>
       <trans-unit id="s76768bebabb7d543">
-        <source>Field which contains members of a group. Note that if using the &quot;memberUid&quot; field, the value is assumed to contain a relative distinguished name. e.g. 'memberUid=some-user' instead of 'memberUid=cn=some-user,ou=groups,...'</source>
-        <target>包含组成员的字段。请注意，如果使用 &quot;memberUid&quot; 字段，则假定该值包含相对可分辨名称。例如，'memberUid=some-user' 而不是 'memberUid=cn=some-user,ou=groups,...'</target>
+        <source>Field which contains members of a group. Note that if using the "memberUid" field, the value is assumed to contain a relative distinguished name. e.g. 'memberUid=some-user' instead of 'memberUid=cn=some-user,ou=groups,...'</source>
+        <target>包含组成员的字段。请注意，如果使用 "memberUid" 字段，则假定该值包含相对可分辨名称。例如，'memberUid=some-user' 而不是 'memberUid=cn=some-user,ou=groups,...'</target>
         
       </trans-unit>
       <trans-unit id="s026555347e589f0e">
@@ -4046,8 +4046,8 @@ doesn't pass when either or both of the selected options are equal or above the 
         
       </trans-unit>
       <trans-unit id="s7b1fba26d245cb1c">
-        <source>When using an external logging solution for archiving, this can be set to &quot;minutes=5&quot;.</source>
-        <target>使用外部日志记录解决方案进行存档时，可以将其设置为 &quot;minutes=5&quot;。</target>
+        <source>When using an external logging solution for archiving, this can be set to "minutes=5".</source>
+        <target>使用外部日志记录解决方案进行存档时，可以将其设置为 "minutes=5"。</target>
         
       </trans-unit>
       <trans-unit id="s44536d20bb5c8257">
@@ -4056,8 +4056,8 @@ doesn't pass when either or both of the selected options are equal or above the 
         
       </trans-unit>
       <trans-unit id="s3bb51cabb02b997e">
-        <source>Format: &quot;weeks=3;days=2;hours=3,seconds=2&quot;.</source>
-        <target>格式：&quot;weeks=3;days=2;hours=3,seconds=2&quot;。</target>
+        <source>Format: "weeks=3;days=2;hours=3,seconds=2".</source>
+        <target>格式："weeks=3;days=2;hours=3,seconds=2"。</target>
         
       </trans-unit>
       <trans-unit id="s04bfd02201db5ab8">
@@ -4253,10 +4253,10 @@ doesn't pass when either or both of the selected options are equal or above the 
         
       </trans-unit>
       <trans-unit id="sa95a538bfbb86111">
-        <source>Are you sure you want to update <x id="0" equiv-text="${this.objectLabel}"/> &quot;<x id="1" equiv-text="${this.obj?.name}"/>&quot;?</source>
+        <source>Are you sure you want to update <x id="0" equiv-text="${this.objectLabel}"/> "<x id="1" equiv-text="${this.obj?.name}"/>"?</source>
         <target>您确定要更新 
-        <x id="0" equiv-text="${this.objectLabel}"/>&quot; 
-        <x id="1" equiv-text="${this.obj?.name}"/>&quot; 吗？</target>
+        <x id="0" equiv-text="${this.objectLabel}"/>" 
+        <x id="1" equiv-text="${this.obj?.name}"/>" 吗？</target>
         
       </trans-unit>
       <trans-unit id="sc92d7cfb6ee1fec6">
@@ -5372,7 +5372,7 @@ doesn't pass when either or both of the selected options are equal or above the 
         
       </trans-unit>
       <trans-unit id="sdf1d8edef27236f0">
-        <source>A &quot;roaming&quot; authenticator, like a YubiKey</source>
+        <source>A "roaming" authenticator, like a YubiKey</source>
         <target>像 YubiKey 这样的“漫游”身份验证器</target>
         
       </trans-unit>
@@ -5454,11 +5454,6 @@ doesn't pass when either or both of the selected options are equal or above the 
       <trans-unit id="se0c660020d9cf5b7">
         <source>Offset after which consent expires.</source>
         <target>同意过期后的偏移。</target>
-        
-      </trans-unit>
-      <trans-unit id="s5e9527b6481a94ce">
-        <source>Statically deny the flow. To use this stage effectively, disable *Evaluate on plan* on the respective binding.</source>
-        <target>静态拒绝流。要有效地使用此阶段，请在相应的绑定上禁用*规划时进行评估*。</target>
         
       </trans-unit>
       <trans-unit id="s22b10ed263b96194">
@@ -5712,10 +5707,10 @@ doesn't pass when either or both of the selected options are equal or above the 
         
       </trans-unit>
       <trans-unit id="s2d5f69929bb7221d">
-        <source><x id="0" equiv-text="${prompt.name}"/> (&quot;<x id="1" equiv-text="${prompt.fieldKey}"/>&quot;, of type <x id="2" equiv-text="${prompt.type}"/>)</source>
+        <source><x id="0" equiv-text="${prompt.name}"/> ("<x id="1" equiv-text="${prompt.fieldKey}"/>", of type <x id="2" equiv-text="${prompt.type}"/>)</source>
         <target>
-        <x id="0" equiv-text="${prompt.name}"/>（&quot; 
-        <x id="1" equiv-text="${prompt.fieldKey}"/>&quot;，类型为 
+        <x id="0" equiv-text="${prompt.name}"/>（" 
+        <x id="1" equiv-text="${prompt.fieldKey}"/>"，类型为 
         <x id="2" equiv-text="${prompt.type}"/>）</target>
         
       </trans-unit>
@@ -5764,7 +5759,7 @@ doesn't pass when either or both of the selected options are equal or above the 
         
       </trans-unit>
       <trans-unit id="s1608b2f94fa0dbd4">
-        <source>If set to a duration above 0, the user will have the option to choose to &quot;stay signed in&quot;, which will extend their session by the time specified here.</source>
+        <source>If set to a duration above 0, the user will have the option to choose to "stay signed in", which will extend their session by the time specified here.</source>
         <target>如果设置时长大于 0，用户可以选择“保持登录”选项，这将使用户的会话延长此处设置的时间。</target>
         
       </trans-unit>
@@ -7776,6 +7771,9 @@ Bindings to groups/users are checked against the user of the event.</source>
 <trans-unit id="s57b07e524f8f5c2a">
   <source>External: <x id="0" equiv-text="${item.externalUsers}"/></source>
   <target>外部：<x id="0" equiv-text="${item.externalUsers}"/></target>
+</trans-unit>
+<trans-unit id="s7f68101a50f526ee">
+  <source>Statically deny the flow. To use this stage effectively, disable *Evaluate when flow is planned* on the respective binding.</source>
 </trans-unit>
     </body>
   </file>

--- a/web/xliff/zh-Hant.xlf
+++ b/web/xliff/zh-Hant.xlf
@@ -4097,10 +4097,6 @@ doesn't pass when either or both of the selected options are equal or above the 
       <trans-unit id="se0c660020d9cf5b7">
         <source>Offset after which consent expires.</source>
       </trans-unit>
-      <trans-unit id="s5e9527b6481a94ce">
-        <source>Statically deny the flow. To use this stage effectively, disable *Evaluate on plan* on the respective binding.</source>
-        <target>静态拒绝流。要有效地使用此阶段，请在相应的绑定上禁用*按计划评估*。</target>
-      </trans-unit>
       <trans-unit id="s22b10ed263b96194">
         <source>Dummy stage used for testing. Shows a simple continue button and always passes.</source>
         <target>用于测试的虚拟阶段。显示一个简单的 “继续” 按钮，并且始终通过。</target>
@@ -5847,6 +5843,9 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s57b07e524f8f5c2a">
   <source>External: <x id="0" equiv-text="${item.externalUsers}"/></source>
+</trans-unit>
+<trans-unit id="s7f68101a50f526ee">
+  <source>Statically deny the flow. To use this stage effectively, disable *Evaluate when flow is planned* on the respective binding.</source>
 </trans-unit>
     </body>
   </file>

--- a/web/xliff/zh_TW.xlf
+++ b/web/xliff/zh_TW.xlf
@@ -4097,10 +4097,6 @@ doesn't pass when either or both of the selected options are equal or above the 
       <trans-unit id="se0c660020d9cf5b7">
         <source>Offset after which consent expires.</source>
       </trans-unit>
-      <trans-unit id="s5e9527b6481a94ce">
-        <source>Statically deny the flow. To use this stage effectively, disable *Evaluate on plan* on the respective binding.</source>
-        <target>静态拒绝流。要有效地使用此阶段，请在相应的绑定上禁用*按计划评估*。</target>
-      </trans-unit>
       <trans-unit id="s22b10ed263b96194">
         <source>Dummy stage used for testing. Shows a simple continue button and always passes.</source>
         <target>用于测试的虚拟阶段。显示一个简单的 “继续” 按钮，并且始终通过。</target>
@@ -5846,6 +5842,9 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s57b07e524f8f5c2a">
   <source>External: <x id="0" equiv-text="${item.externalUsers}"/></source>
+</trans-unit>
+<trans-unit id="s7f68101a50f526ee">
+  <source>Statically deny the flow. To use this stage effectively, disable *Evaluate when flow is planned* on the respective binding.</source>
 </trans-unit>
     </body>
   </file>

--- a/website/docs/flow/examples/snippets.md
+++ b/website/docs/flow/examples/snippets.md
@@ -16,7 +16,7 @@ plan.redirect("https://foo.bar")
 return False
 ```
 
-This policy should be bound to the stage after your redirect should happen. For example, if you have an identification and a password stage, and you want to redirect after identification, bind the policy to the password stage. Make sure the policy binding is set to re-evaluate policies.
+This policy should be bound to the stage after your redirect should happen. For example, if you have an identification and a password stage, and you want to redirect after identification, bind the policy to the password stage. Make sure the stage binding's option _Evaluate when stage is run_ is enabled.
 
 ### Deny flow when user is authenticated
 

--- a/website/docs/flow/index.md
+++ b/website/docs/flow/index.md
@@ -10,7 +10,7 @@ For example, a standard login flow would consist of the following stages:
 -   Password, the user's password is checked against the hash in the database
 -   Log the user in
 
-Upon flow execution, a plan containing all stages is generated. This means that all attached policies are evaluated upon execution. This behaviour can be altered by enabling the **Re-evaluate Policies** option on the binding.
+Upon flow execution, a plan containing all stages is generated. This means that all attached policies are evaluated upon execution. This behaviour can be altered by enabling the **Evaluate when stage is run** option on the binding.
 
 To determine which flow is linked, authentik searches all flows with the required designation and chooses the first instance the current user has access to.
 

--- a/website/docs/flow/inspector.md
+++ b/website/docs/flow/inspector.md
@@ -14,7 +14,7 @@ The following infos are shown in the inspector
 
 ## Next stage
 
-This is the currently planned next stage. If you have stage bindings configured to evaluate on plan (default), then you will see the result here. If you however have them configured to re-evaluate, then this will not show up here, since the results will vary based on your input.
+This is the currently planned next stage. If you have stage bindings configured to _Evaluate when flow is planned_, then you will see the result here. If you however have them configured to re-evaluate (_Evaluate when stage is run_), then this will not show up here, since the results will vary based on your input.
 
 Shown is the name and kind of the stage, as well as the unique ID.
 

--- a/website/docs/flow/stages/deny.md
+++ b/website/docs/flow/stages/deny.md
@@ -6,5 +6,5 @@ This stage stops the execution of a flow. This can be used to conditionally deny
 even if they are not signed in (and permissions can't be checked via groups).
 
 :::caution
-To effectively use this stage, make sure to **disable** _Evaluate on plan_ on the Stage binding.
+To effectively use this stage, make sure _Evaluate when flow is planned_ is **disable** on the Stage binding.
 :::

--- a/website/docs/flow/stages/password/index.md
+++ b/website/docs/flow/stages/password/index.md
@@ -26,4 +26,4 @@ return DuoDevice.objects.filter(user=request.context['pending_user'], confirmed=
 
 Afterwards, bind the policy you've created to the stage binding of the password stage.
 
-Make sure to uncheck _Evaluate on plan_ and check _Re-evaluate policies_, otherwise an invalid result will be cached.
+Make sure to uncheck _Evaluate when flow is planned_ and check _Evaluate when stage is run_, otherwise an invalid result will be cached.

--- a/website/docs/policies/index.md
+++ b/website/docs/policies/index.md
@@ -43,4 +43,4 @@ authentik keeps track of failed login attempts by source IP and attempted userna
 
 This policy can be used, for example, to prompt clients with a low score to pass a captcha before they can continue.
 
-To make sure this policy is executed correctly, set `Re-evaluate policies` when using it with a flow.
+To make sure this policy is executed correctly, set _Evaluate when stage is run_ when using it with a flow.


### PR DESCRIPTION
the option name was changed a while back but the docs still used the old name

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

Found by @authentik-db-cooper, we used the old names for some options in the docs

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
