### PR TITLE
root: connect to backend via socket

### DIFF
--- a/authentik/core/management/commands/dev_server.py
+++ b/authentik/core/management/commands/dev_server.py
@@ -1,0 +1,9 @@
+"""custom runserver command"""
+from django.core.management.commands.runserver import Command as RunServer
+
+
+class Command(RunServer):
+    """custom runserver command, which doesn't show the misleading django startup message"""
+
+    def on_bind(self, server_port):
+        pass

--- a/authentik/core/management/commands/dev_server.py
+++ b/authentik/core/management/commands/dev_server.py
@@ -1,5 +1,5 @@
 """custom runserver command"""
-from django.core.management.commands.runserver import Command as RunServer
+from daphne.management.commands.runserver import Command as RunServer
 
 
 class Command(RunServer):

--- a/authentik/lib/logging.py
+++ b/authentik/lib/logging.py
@@ -1,6 +1,111 @@
 """logging helpers"""
+import logging
 from logging import Logger
 from os import getpid
+
+import structlog
+
+from authentik.lib.config import CONFIG
+
+LOG_PRE_CHAIN = [
+    # Add the log level and a timestamp to the event_dict if the log entry
+    # is not from structlog.
+    structlog.stdlib.add_log_level,
+    structlog.stdlib.add_logger_name,
+    structlog.processors.TimeStamper(),
+    structlog.processors.StackInfoRenderer(),
+]
+
+
+def get_log_level():
+    """Get log level, clamp trace to debug"""
+    level = CONFIG.get("log_level").upper()
+    # We could add a custom level to stdlib logging and structlog, but it's not easy or clean
+    # https://stackoverflow.com/questions/54505487/custom-log-level-not-working-with-structlog
+    # Additionally, the entire code uses debug as highest level
+    # so that would have to be re-written too
+    if level == "TRACE":
+        level = "DEBUG"
+    return level
+
+
+def structlog_configure():
+    """Configure structlog itself"""
+    structlog.configure_once(
+        processors=[
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.add_logger_name,
+            structlog.contextvars.merge_contextvars,
+            add_process_id,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.TimeStamper(fmt="iso", utc=False),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.dict_tracebacks,
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.make_filtering_bound_logger(
+            getattr(logging, get_log_level(), logging.WARNING)
+        ),
+        cache_logger_on_first_use=True,
+    )
+
+
+def get_logger_config():
+    """Configure python stdlib's logging"""
+    debug = CONFIG.get_bool("debug")
+    global_level = get_log_level()
+    base_config = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "json": {
+                "()": structlog.stdlib.ProcessorFormatter,
+                "processor": structlog.processors.JSONRenderer(sort_keys=True),
+                "foreign_pre_chain": LOG_PRE_CHAIN + [structlog.processors.dict_tracebacks],
+            },
+            "console": {
+                "()": structlog.stdlib.ProcessorFormatter,
+                "processor": structlog.dev.ConsoleRenderer(colors=debug),
+                "foreign_pre_chain": LOG_PRE_CHAIN,
+            },
+        },
+        "handlers": {
+            "console": {
+                "level": "DEBUG",
+                "class": "logging.StreamHandler",
+                "formatter": "console" if debug else "json",
+            },
+        },
+        "loggers": {},
+    }
+
+    handler_level_map = {
+        "": global_level,
+        "authentik": global_level,
+        "django": "WARNING",
+        "django.request": "ERROR",
+        "celery": "WARNING",
+        "selenium": "WARNING",
+        "docker": "WARNING",
+        "urllib3": "WARNING",
+        "websockets": "WARNING",
+        "daphne": "WARNING",
+        "kubernetes": "INFO",
+        "asyncio": "WARNING",
+        "redis": "WARNING",
+        "silk": "INFO",
+        "fsevents": "WARNING",
+        "uvicorn": "WARNING",
+        "gunicorn": "INFO",
+    }
+    for handler_name, level in handler_level_map.items():
+        base_config["loggers"][handler_name] = {
+            "handlers": ["console"],
+            "level": level,
+            "propagate": False,
+        }
+    return base_config
 
 
 def add_process_id(logger: Logger, method_name: str, event_dict):

--- a/authentik/root/middleware.py
+++ b/authentik/root/middleware.py
@@ -172,7 +172,7 @@ class ChannelsLoggingMiddleware:
         LOGGER.info(
             scope["path"],
             scheme="ws",
-            remote=scope.get("client", [""])[0],
+            remote=headers.get(b"x-forwarded-for", b"").decode(),
             user_agent=headers.get(b"user-agent", b"").decode(),
             **kwargs,
         )

--- a/authentik/root/settings.py
+++ b/authentik/root/settings.py
@@ -1,24 +1,20 @@
 """root settings for authentik"""
 
 import importlib
-import logging
 import os
 from hashlib import sha512
 from pathlib import Path
 from urllib.parse import quote_plus
 
-import structlog
 from celery.schedules import crontab
 from sentry_sdk import set_tag
 
 from authentik import ENV_GIT_HASH_KEY, __version__
 from authentik.lib.config import CONFIG
-from authentik.lib.logging import add_process_id
+from authentik.lib.logging import get_logger_config, structlog_configure
 from authentik.lib.sentry import sentry_init
 from authentik.lib.utils.reflection import get_env
 from authentik.stages.password import BACKEND_APP_PASSWORD, BACKEND_INBUILT, BACKEND_LDAP
-
-LOGGER = structlog.get_logger()
 
 BASE_DIR = Path(__file__).absolute().parent.parent.parent
 STATICFILES_DIRS = [BASE_DIR / Path("web")]
@@ -368,90 +364,9 @@ MEDIA_URL = "/media/"
 
 TEST = False
 TEST_RUNNER = "authentik.root.test_runner.PytestTestRunner"
-# We can't check TEST here as its set later by the test runner
-LOG_LEVEL = CONFIG.get("log_level").upper() if "TF_BUILD" not in os.environ else "DEBUG"
-# We could add a custom level to stdlib logging and structlog, but it's not easy or clean
-# https://stackoverflow.com/questions/54505487/custom-log-level-not-working-with-structlog
-# Additionally, the entire code uses debug as highest level so that would have to be re-written too
-if LOG_LEVEL == "TRACE":
-    LOG_LEVEL = "DEBUG"
 
-structlog.configure_once(
-    processors=[
-        structlog.stdlib.add_log_level,
-        structlog.stdlib.add_logger_name,
-        structlog.contextvars.merge_contextvars,
-        add_process_id,
-        structlog.stdlib.PositionalArgumentsFormatter(),
-        structlog.processors.TimeStamper(fmt="iso", utc=False),
-        structlog.processors.StackInfoRenderer(),
-        structlog.processors.dict_tracebacks,
-        structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
-    ],
-    logger_factory=structlog.stdlib.LoggerFactory(),
-    wrapper_class=structlog.make_filtering_bound_logger(
-        getattr(logging, LOG_LEVEL, logging.WARNING)
-    ),
-    cache_logger_on_first_use=True,
-)
-
-LOG_PRE_CHAIN = [
-    # Add the log level and a timestamp to the event_dict if the log entry
-    # is not from structlog.
-    structlog.stdlib.add_log_level,
-    structlog.stdlib.add_logger_name,
-    structlog.processors.TimeStamper(),
-    structlog.processors.StackInfoRenderer(),
-]
-
-LOGGING = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "formatters": {
-        "json": {
-            "()": structlog.stdlib.ProcessorFormatter,
-            "processor": structlog.processors.JSONRenderer(sort_keys=True),
-            "foreign_pre_chain": LOG_PRE_CHAIN + [structlog.processors.dict_tracebacks],
-        },
-        "console": {
-            "()": structlog.stdlib.ProcessorFormatter,
-            "processor": structlog.dev.ConsoleRenderer(colors=DEBUG),
-            "foreign_pre_chain": LOG_PRE_CHAIN,
-        },
-    },
-    "handlers": {
-        "console": {
-            "level": "DEBUG",
-            "class": "logging.StreamHandler",
-            "formatter": "console" if DEBUG else "json",
-        },
-    },
-    "loggers": {},
-}
-
-_LOGGING_HANDLER_MAP = {
-    "": LOG_LEVEL,
-    "authentik": LOG_LEVEL,
-    "django": "WARNING",
-    "django.request": "ERROR",
-    "celery": "WARNING",
-    "selenium": "WARNING",
-    "docker": "WARNING",
-    "urllib3": "WARNING",
-    "websockets": "WARNING",
-    "daphne": "WARNING",
-    "kubernetes": "INFO",
-    "asyncio": "WARNING",
-    "redis": "WARNING",
-    "silk": "INFO",
-    "fsevents": "WARNING",
-}
-for handler_name, level in _LOGGING_HANDLER_MAP.items():
-    LOGGING["loggers"][handler_name] = {
-        "handlers": ["console"],
-        "level": level,
-        "propagate": False,
-    }
+structlog_configure()
+LOGGING = get_logger_config()
 
 
 _DISALLOWED_ITEMS = [

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -60,7 +60,10 @@ var rootCmd = &cobra.Command{
 		ex := common.Init()
 		defer common.Defer()
 
-		u, _ := url.Parse("http://localhost:9000")
+		u, err := url.Parse(fmt.Sprintf("http://%s", config.Get().Listen.HTTP))
+		if err != nil {
+			panic(err)
+		}
 
 		ws := web.NewWebServer()
 		ws.Core().HealthyCallback = func() {

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -13,7 +13,6 @@ import (
 	"goauthentik.io/internal/config"
 	"goauthentik.io/internal/constants"
 	"goauthentik.io/internal/debug"
-	"goauthentik.io/internal/gounicorn"
 	"goauthentik.io/internal/outpost/ak"
 	"goauthentik.io/internal/outpost/proxyv2"
 	sentryutils "goauthentik.io/internal/utils/sentry"
@@ -21,8 +20,6 @@ import (
 	"goauthentik.io/internal/web"
 	"goauthentik.io/internal/web/tenant_tls"
 )
-
-var running = true
 
 var rootCmd = &cobra.Command{
 	Use:     "authentik",
@@ -63,38 +60,20 @@ var rootCmd = &cobra.Command{
 		ex := common.Init()
 		defer common.Defer()
 
-		u, _ := url.Parse("http://localhost:8000")
+		u, _ := url.Parse("http://localhost:9000")
 
-		g := gounicorn.New()
-		defer func() {
-			l.Info("shutting down gunicorn")
-			g.Kill()
-		}()
-		ws := web.NewWebServer(g)
-		g.HealthyCallback = func() {
-			if !config.Get().Outposts.DisableEmbeddedOutpost {
-				go attemptProxyStart(ws, u)
+		ws := web.NewWebServer()
+		ws.Core().HealthyCallback = func() {
+			if config.Get().Outposts.DisableEmbeddedOutpost {
+				return
 			}
+			go attemptProxyStart(ws, u)
 		}
-		go web.RunMetricsServer()
-		go attemptStartBackend(g)
 		ws.Start()
 		<-ex
-		running = false
 		l.Info("shutting down webserver")
 		go ws.Shutdown()
-
 	},
-}
-
-func attemptStartBackend(g *gounicorn.GoUnicorn) {
-	for {
-		if !running {
-			return
-		}
-		err := g.Start()
-		log.WithField("logger", "authentik.router").WithError(err).Warning("gunicorn process died, restarting")
-	}
 }
 
 func attemptProxyStart(ws *web.WebServer, u *url.URL) {

--- a/internal/gounicorn/gounicorn.go
+++ b/internal/gounicorn/gounicorn.go
@@ -41,7 +41,7 @@ func (g *GoUnicorn) initCmd() {
 	args := []string{"-c", "./lifecycle/gunicorn.conf.py", "authentik.root.asgi:application"}
 	if config.Get().Debug {
 		command = "./manage.py"
-		args = []string{"runserver"}
+		args = []string{"dev_server"}
 	}
 	g.log.WithField("args", args).WithField("cmd", command).Debug("Starting gunicorn")
 	g.p = exec.Command(command, args...)

--- a/internal/gounicorn/gounicorn.go
+++ b/internal/gounicorn/gounicorn.go
@@ -1,7 +1,6 @@
 package gounicorn
 
 import (
-	"net/http"
 	"os"
 	"os/exec"
 	"runtime"
@@ -10,10 +9,10 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"goauthentik.io/internal/config"
-	"goauthentik.io/internal/utils/web"
 )
 
 type GoUnicorn struct {
+	Healthcheck     func() bool
 	HealthyCallback func()
 
 	log     *log.Entry
@@ -23,9 +22,10 @@ type GoUnicorn struct {
 	alive   bool
 }
 
-func New() *GoUnicorn {
+func New(healthcheck func() bool) *GoUnicorn {
 	logger := log.WithField("logger", "authentik.router.unicorn")
 	g := &GoUnicorn{
+		Healthcheck:     healthcheck,
 		log:             logger,
 		started:         false,
 		killed:          false,
@@ -69,22 +69,11 @@ func (g *GoUnicorn) Start() error {
 
 func (g *GoUnicorn) healthcheck() {
 	g.log.Debug("starting healthcheck")
-	h := &http.Client{
-		Transport: web.NewUserAgentTransport("goauthentik.io/proxy/healthcheck", http.DefaultTransport),
-	}
-	check := func() bool {
-		res, err := h.Get("http://localhost:8000/-/health/live/")
-		if err == nil && res.StatusCode == 204 {
-			g.alive = true
-			return true
-		}
-		return false
-	}
-
 	// Default healthcheck is every 1 second on startup
 	// once we've been healthy once, increase to 30 seconds
 	for range time.Tick(time.Second) {
-		if check() {
+		if g.Healthcheck() {
+			g.alive = true
 			g.log.Info("backend is alive, backing off with healthchecks")
 			g.HealthyCallback()
 			break
@@ -92,7 +81,7 @@ func (g *GoUnicorn) healthcheck() {
 		g.log.Debug("backend not alive yet")
 	}
 	for range time.Tick(30 * time.Second) {
-		check()
+		g.Healthcheck()
 	}
 }
 

--- a/internal/web/metrics.go
+++ b/internal/web/metrics.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 
@@ -26,7 +27,7 @@ var (
 	}, []string{"dest"})
 )
 
-func (ws *WebServer) RunMetricsServer() {
+func (ws *WebServer) runMetricsServer() {
 	m := mux.NewRouter()
 	l := log.WithField("logger", "authentik.router.metrics")
 	m.Use(sentry.SentryNoSampleMiddleware)
@@ -38,7 +39,7 @@ func (ws *WebServer) RunMetricsServer() {
 		).ServeHTTP(rw, r)
 
 		// Get upstream metrics
-		re, err := http.NewRequest("GET", "http://socket/-/metrics/", nil)
+		re, err := http.NewRequest("GET", fmt.Sprintf("%s/-/metrics/", ws.ul.String()), nil)
 		if err != nil {
 			l.WithError(err).Warning("failed to get upstream metrics")
 			return

--- a/internal/web/metrics.go
+++ b/internal/web/metrics.go
@@ -26,7 +26,7 @@ var (
 	}, []string{"dest"})
 )
 
-func RunMetricsServer() {
+func (ws *WebServer) RunMetricsServer() {
 	m := mux.NewRouter()
 	l := log.WithField("logger", "authentik.router.metrics")
 	m.Use(sentry.SentryNoSampleMiddleware)
@@ -38,13 +38,13 @@ func RunMetricsServer() {
 		).ServeHTTP(rw, r)
 
 		// Get upstream metrics
-		re, err := http.NewRequest("GET", "http://localhost:8000/-/metrics/", nil)
+		re, err := http.NewRequest("GET", "http://socket/-/metrics/", nil)
 		if err != nil {
 			l.WithError(err).Warning("failed to get upstream metrics")
 			return
 		}
 		re.SetBasicAuth("monitor", config.Get().SecretKey)
-		res, err := http.DefaultClient.Do(re)
+		res, err := ws.upstreamHttpClient().Do(re)
 		if err != nil {
 			l.WithError(err).Warning("failed to get upstream metrics")
 			return

--- a/internal/web/proxy.go
+++ b/internal/web/proxy.go
@@ -14,8 +14,8 @@ import (
 func (ws *WebServer) configureProxy() {
 	// Reverse proxy to the application server
 	director := func(req *http.Request) {
-		req.URL.Scheme = "http"
-		req.URL.Host = "socket"
+		req.URL.Scheme = ws.ul.Scheme
+		req.URL.Host = ws.ul.Host
 		if _, ok := req.Header["User-Agent"]; !ok {
 			// explicitly disable User-Agent so it's not set to default value
 			req.Header.Set("User-Agent", "")

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -96,7 +96,7 @@ func NewWebServer() *WebServer {
 }
 
 func (ws *WebServer) Start() {
-	go ws.RunMetricsServer()
+	go ws.runMetricsServer()
 	go ws.attemptStartBackend()
 	go ws.listenPlain()
 	go ws.listenTLS()

--- a/lifecycle/gunicorn.conf.py
+++ b/lifecycle/gunicorn.conf.py
@@ -21,7 +21,7 @@ from lifecycle.worker import DjangoUvicornWorker
 if TYPE_CHECKING:
     from gunicorn.arbiter import Arbiter
 
-bind = "127.0.0.1:8000"
+bind = "unix://./authentik-core.sock"
 
 _tmp = Path(gettempdir())
 worker_class = "lifecycle.worker.DjangoUvicornWorker"

--- a/lifecycle/gunicorn.conf.py
+++ b/lifecycle/gunicorn.conf.py
@@ -21,12 +21,12 @@ from lifecycle.worker import DjangoUvicornWorker
 if TYPE_CHECKING:
     from gunicorn.arbiter import Arbiter
 
-bind = "unix://./authentik-core.sock"
-
 _tmp = Path(gettempdir())
 worker_class = "lifecycle.worker.DjangoUvicornWorker"
 worker_tmp_dir = str(_tmp.joinpath("authentik_worker_tmp"))
 prometheus_tmp_dir = str(_tmp.joinpath("authentik_prometheus_tmp"))
+
+bind = f"unix://{str(_tmp.joinpath('authentik-core.sock'))}"
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "authentik.root.settings")
 os.environ.setdefault("PROMETHEUS_MULTIPROC_DIR", prometheus_tmp_dir)

--- a/lifecycle/gunicorn.conf.py
+++ b/lifecycle/gunicorn.conf.py
@@ -7,12 +7,12 @@ from pathlib import Path
 from tempfile import gettempdir
 from typing import TYPE_CHECKING
 
-import structlog
 from kubernetes.config.incluster_config import SERVICE_HOST_ENV_NAME
 from prometheus_client.values import MultiProcessValue
 
 from authentik import get_full_version
 from authentik.lib.config import CONFIG
+from authentik.lib.logging import get_logger_config
 from authentik.lib.utils.http import get_http_session
 from authentik.lib.utils.reflection import get_env
 from authentik.root.install_id import get_install_id_raw
@@ -26,52 +26,18 @@ worker_class = "lifecycle.worker.DjangoUvicornWorker"
 worker_tmp_dir = str(_tmp.joinpath("authentik_worker_tmp"))
 prometheus_tmp_dir = str(_tmp.joinpath("authentik_prometheus_tmp"))
 
+makedirs(worker_tmp_dir, exist_ok=True)
+makedirs(prometheus_tmp_dir, exist_ok=True)
+
 bind = f"unix://{str(_tmp.joinpath('authentik-core.sock'))}"
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "authentik.root.settings")
 os.environ.setdefault("PROMETHEUS_MULTIPROC_DIR", prometheus_tmp_dir)
 
-makedirs(worker_tmp_dir, exist_ok=True)
-makedirs(prometheus_tmp_dir, exist_ok=True)
-
 max_requests = 1000
 max_requests_jitter = 50
 
-_debug = CONFIG.get_bool("DEBUG", False)
-
-logconfig_dict = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "formatters": {
-        "json": {
-            "()": structlog.stdlib.ProcessorFormatter,
-            "processor": structlog.processors.JSONRenderer(),
-            "foreign_pre_chain": [
-                structlog.stdlib.add_log_level,
-                structlog.stdlib.add_logger_name,
-                structlog.processors.TimeStamper(),
-                structlog.processors.StackInfoRenderer(),
-            ],
-        },
-        "console": {
-            "()": structlog.stdlib.ProcessorFormatter,
-            "processor": structlog.dev.ConsoleRenderer(colors=True),
-            "foreign_pre_chain": [
-                structlog.stdlib.add_log_level,
-                structlog.stdlib.add_logger_name,
-                structlog.processors.TimeStamper(),
-                structlog.processors.StackInfoRenderer(),
-            ],
-        },
-    },
-    "handlers": {
-        "console": {"class": "logging.StreamHandler", "formatter": "json" if _debug else "console"},
-    },
-    "loggers": {
-        "uvicorn": {"handlers": ["console"], "level": "WARNING", "propagate": False},
-        "gunicorn": {"handlers": ["console"], "level": "INFO", "propagate": False},
-    },
-}
+logconfig_dict = get_logger_config()
 
 # if we're running in kubernetes, use fixed workers because we can scale with more pods
 # otherwise (assume docker-compose), use as much as we can


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

I don't know why we haven't been doing this all along tbh

Instead of having the go wrapper connect to gunicorn via localhost:8000, we can just have gunicorn listen on a socket and go forward to that

This also finally fixes the issue where gunicorn logs on startup were not json format, by taking out the logging config from django's settings and making them re-usable

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
