### PR TITLE
crypto: fix has_key filter

### DIFF
--- a/authentik/crypto/api.py
+++ b/authentik/crypto/api.py
@@ -189,6 +189,8 @@ class CertificateKeyPairFilter(FilterSet):
 
     def filter_has_key(self, queryset, name, value):  # pragma: no cover
         """Only return certificate-key pairs with keys"""
+        if not value:
+            return queryset
         return queryset.exclude(key_data__exact="")
 
     class Meta:


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

closes #6722

we used to use the has_key API incorrectly (only setting it to true when required, and when not required not sending the parameter at all), so this was never noticed

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
