### PR TITLE
providers/saml: fix SAML metadata import API requiring flow slug inst…

### DIFF
--- a/authentik/providers/saml/api/providers.py
+++ b/authentik/providers/saml/api/providers.py
@@ -13,10 +13,9 @@ from rest_framework.decorators import action
 from rest_framework.fields import CharField, FileField, SerializerMethodField
 from rest_framework.parsers import MultiPartParser
 from rest_framework.permissions import AllowAny
-from rest_framework.relations import SlugRelatedField
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.serializers import ValidationError
+from rest_framework.serializers import PrimaryKeyRelatedField, ValidationError
 from rest_framework.viewsets import ModelViewSet
 from structlog.stdlib import get_logger
 
@@ -168,10 +167,8 @@ class SAMLProviderImportSerializer(PassiveSerializer):
     """Import saml provider from XML Metadata"""
 
     name = CharField(required=True)
-    # Using SlugField because https://github.com/OpenAPITools/openapi-generator/issues/3278
-    authorization_flow = SlugRelatedField(
+    authorization_flow = PrimaryKeyRelatedField(
         queryset=Flow.objects.filter(designation=FlowDesignation.AUTHORIZATION),
-        slug_field="slug",
     )
     file = FileField()
 

--- a/authentik/providers/saml/tests/test_api.py
+++ b/authentik/providers/saml/tests/test_api.py
@@ -89,7 +89,7 @@ class TestSAMLProviderAPI(APITestCase):
                 {
                     "file": metadata,
                     "name": generate_id(),
-                    "authorization_flow": create_test_flow(FlowDesignation.AUTHORIZATION).slug,
+                    "authorization_flow": create_test_flow(FlowDesignation.AUTHORIZATION).pk,
                 },
                 format="multipart",
             )
@@ -106,7 +106,7 @@ class TestSAMLProviderAPI(APITestCase):
                 {
                     "file": metadata,
                     "name": generate_id(),
-                    "authorization_flow": create_test_flow().slug,
+                    "authorization_flow": create_test_flow().pk,
                 },
                 format="multipart",
             )

--- a/authentik/root/settings.py
+++ b/authentik/root/settings.py
@@ -402,7 +402,6 @@ LOG_PRE_CHAIN = [
     structlog.stdlib.add_logger_name,
     structlog.processors.TimeStamper(),
     structlog.processors.StackInfoRenderer(),
-    structlog.processors.format_exc_info,
 ]
 
 LOGGING = {
@@ -412,7 +411,7 @@ LOGGING = {
         "json": {
             "()": structlog.stdlib.ProcessorFormatter,
             "processor": structlog.processors.JSONRenderer(sort_keys=True),
-            "foreign_pre_chain": LOG_PRE_CHAIN,
+            "foreign_pre_chain": LOG_PRE_CHAIN + [structlog.processors.dict_tracebacks],
         },
         "console": {
             "()": structlog.stdlib.ProcessorFormatter,

--- a/schema.yml
+++ b/schema.yml
@@ -38459,8 +38459,7 @@ components:
           minLength: 1
         authorization_flow:
           type: string
-          minLength: 1
-          description: Visible in the URL.
+          format: uuid
         file:
           type: string
           format: binary


### PR DESCRIPTION
…ead of pk

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

closes #948

this API endpoint was always an outlier in requiring the flow slug instead of uuid, and we used to work around this in the frontend, but we really should fix the API to behave the same

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
