### PR TITLE
web: replace ampersand

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-30 17:44+0000\n"
+"POT-Creation-Date: 2023-09-02 15:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -323,6 +323,14 @@ msgstr ""
 
 #: authentik/crypto/models.py:102
 msgid "Certificate-Key Pairs"
+msgstr ""
+
+#: authentik/enterprise/models.py:193
+msgid "License Usage"
+msgstr ""
+
+#: authentik/enterprise/models.py:194
+msgid "License Usage Records"
 msgstr ""
 
 #: authentik/events/models.py:290
@@ -804,12 +812,20 @@ msgstr ""
 msgid "Password Policies"
 msgstr ""
 
-#: authentik/policies/reputation/models.py:58
+#: authentik/policies/reputation/models.py:67
 msgid "Reputation Policy"
 msgstr ""
 
-#: authentik/policies/reputation/models.py:59
+#: authentik/policies/reputation/models.py:68
 msgid "Reputation Policies"
+msgstr ""
+
+#: authentik/policies/reputation/models.py:95
+msgid "Reputation Score"
+msgstr ""
+
+#: authentik/policies/reputation/models.py:96
+msgid "Reputation Scores"
 msgstr ""
 
 #: authentik/policies/templates/policies/denied.html:7
@@ -1242,11 +1258,11 @@ msgstr ""
 msgid "Radius Providers"
 msgstr ""
 
-#: authentik/providers/saml/api/providers.py:260
+#: authentik/providers/saml/api/providers.py:257
 msgid "Invalid XML Syntax"
 msgstr ""
 
-#: authentik/providers/saml/api/providers.py:270
+#: authentik/providers/saml/api/providers.py:267
 #, python-format
 msgid "Failed to import Metadata: %(message)s"
 msgstr ""

--- a/web/src/admin/AdminInterface.ts
+++ b/web/src/admin/AdminInterface.ts
@@ -263,7 +263,7 @@ export class AdminInterface extends Interface {
                 </ak-sidebar-item>
             </ak-sidebar-item>
             <ak-sidebar-item>
-                <span slot="label">${msg("Flows & Stages")}</span>
+                <span slot="label">${msg("Flows and Stages")}</span>
                 <ak-sidebar-item
                     path="/flow/flows"
                     .activeWhen=${[`^/flow/flows/(?<slug>${SLUG_REGEX})$`]}
@@ -295,10 +295,10 @@ export class AdminInterface extends Interface {
                     path="/core/sources"
                     .activeWhen=${[`^/core/sources/(?<slug>${SLUG_REGEX})$`]}
                 >
-                    <span slot="label">${msg("Federation & Social login")}</span>
+                    <span slot="label">${msg("Federation and Social login")}</span>
                 </ak-sidebar-item>
                 <ak-sidebar-item path="/core/tokens">
-                    <span slot="label">${msg("Tokens & App passwords")}</span>
+                    <span slot="label">${msg("Tokens and App passwords")}</span>
                 </ak-sidebar-item>
                 <ak-sidebar-item path="/flow/stages/invitations">
                     <span slot="label">${msg("Invitations")}</span>

--- a/web/src/admin/flows/BoundStagesList.ts
+++ b/web/src/admin/flows/BoundStagesList.ts
@@ -142,7 +142,7 @@ export class BoundStagesList extends Table<FlowStageBinding> {
     renderToolbar(): TemplateResult {
         return html`
             <ak-stage-wizard
-                createText=${msg("Create & bind Stage")}
+                createText=${msg("Create and bind Stage")}
                 ?showBindingPage=${true}
                 bindingTarget=${ifDefined(this.target)}
             ></ak-stage-wizard>

--- a/web/src/admin/policies/BoundPoliciesList.ts
+++ b/web/src/admin/policies/BoundPoliciesList.ts
@@ -194,7 +194,7 @@ export class BoundPoliciesList extends Table<PolicyBinding> {
 
     renderToolbar(): TemplateResult {
         return html`<ak-policy-wizard
-                createText=${msg("Create & bind Policy")}
+                createText=${msg("Create and bind Policy")}
                 ?showBindingPage=${true}
                 bindingTarget=${ifDefined(this.target)}
             ></ak-policy-wizard>

--- a/web/src/admin/sources/SourceListPage.ts
+++ b/web/src/admin/sources/SourceListPage.ts
@@ -24,7 +24,7 @@ import { Source, SourcesApi } from "@goauthentik/api";
 @customElement("ak-source-list")
 export class SourceListPage extends TablePage<Source> {
     pageTitle(): string {
-        return msg("Federation & Social login");
+        return msg("Federation and Social login");
     }
     pageDescription(): string | undefined {
         return msg(

--- a/web/xliff/de.xlf
+++ b/web/xliff/de.xlf
@@ -2292,9 +2292,6 @@ doesn't pass when either or both of the selected options are equal or above the 
         <source>No policies are currently bound to this object.</source>
         <target>Aktuell sind keine Richtlinien mit diesem Objekt verknüpft.</target>
       </trans-unit>
-      <trans-unit id="s6b66ad92d4c1a0a8">
-        <source>Create &amp; bind Policy</source>
-      </trans-unit>
       <trans-unit id="sddb040c47daae56b">
         <source>Bind existing policy</source>
       </trans-unit>
@@ -2696,10 +2693,6 @@ doesn't pass when either or both of the selected options are equal or above the 
       <trans-unit id="s19b09f4fc72175d1">
         <source>Create a new source.</source>
         <target>Neue Quelle erstellen.</target>
-      </trans-unit>
-      <trans-unit id="sf96b3cc66d2e25f8">
-        <source>Federation &amp; Social login</source>
-        <target>Föderierter &amp; Social Login</target>
       </trans-unit>
       <trans-unit id="s6152026c364ad974">
         <source>Sources of identities, which can either be synced into authentik's database, or can be used by users to authenticate and enroll themselves.</source>
@@ -4644,9 +4637,6 @@ doesn't pass when either or both of the selected options are equal or above the 
         <source>Bind stage</source>
         <target>Phasen-Verknüpfung</target>
       </trans-unit>
-      <trans-unit id="se8eb190d8f084f80">
-        <source>Create &amp; bind Stage</source>
-      </trans-unit>
       <trans-unit id="scc2e420c54dc8089">
         <source>Bind existing stage</source>
       </trans-unit>
@@ -5214,17 +5204,9 @@ Bindings to groups/users are checked against the user of the event.</source>
         <source>Customisation</source>
         <target>Anpassung</target>
       </trans-unit>
-      <trans-unit id="s58398dbcff942947">
-        <source>Flows &amp; Stages</source>
-        <target>Abläufe &amp; Phasen</target>
-      </trans-unit>
       <trans-unit id="sc0829ee663ced008">
         <source>Directory</source>
         <target>Verzeichnis</target>
-      </trans-unit>
-      <trans-unit id="sdf4e926513e26458">
-        <source>Tokens &amp; App passwords</source>
-        <target>Tokens &amp; App Passwörter</target>
       </trans-unit>
       <trans-unit id="sa81e2cdaf6921adc">
         <source>System</source>
@@ -5893,6 +5875,18 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s7f68101a50f526ee">
   <source>Statically deny the flow. To use this stage effectively, disable *Evaluate when flow is planned* on the respective binding.</source>
+</trans-unit>
+<trans-unit id="s911a27022aba349f">
+  <source>Create and bind Policy</source>
+</trans-unit>
+<trans-unit id="sb1a4e9b288e2f005">
+  <source>Federation and Social login</source>
+</trans-unit>
+<trans-unit id="s6f367f5604d5056d">
+  <source>Create and bind Stage</source>
+</trans-unit>
+<trans-unit id="s1a65ee08832fbfe2">
+  <source>Flows and Stages</source>
 </trans-unit>
     </body>
   </file>

--- a/web/xliff/en.xlf
+++ b/web/xliff/en.xlf
@@ -2438,10 +2438,6 @@ doesn't pass when either or both of the selected options are equal or above the 
         <source>No policies are currently bound to this object.</source>
         <target>No policies are currently bound to this object.</target>
       </trans-unit>
-      <trans-unit id="s6b66ad92d4c1a0a8">
-        <source>Create &amp; bind Policy</source>
-        <target>Create &amp; bind Policy</target>
-      </trans-unit>
       <trans-unit id="sddb040c47daae56b">
         <source>Bind existing policy</source>
         <target>Bind existing policy</target>
@@ -2857,10 +2853,6 @@ doesn't pass when either or both of the selected options are equal or above the 
       <trans-unit id="s19b09f4fc72175d1">
         <source>Create a new source.</source>
         <target>Create a new source.</target>
-      </trans-unit>
-      <trans-unit id="sf96b3cc66d2e25f8">
-        <source>Federation &amp; Social login</source>
-        <target>Federation &amp; Social login</target>
       </trans-unit>
       <trans-unit id="s6152026c364ad974">
         <source>Sources of identities, which can either be synced into authentik's database, or can be used by users to authenticate and enroll themselves.</source>
@@ -4912,10 +4904,6 @@ doesn't pass when either or both of the selected options are equal or above the 
         <source>Bind stage</source>
         <target>Bind stage</target>
       </trans-unit>
-      <trans-unit id="se8eb190d8f084f80">
-        <source>Create &amp; bind Stage</source>
-        <target>Create &amp; bind Stage</target>
-      </trans-unit>
       <trans-unit id="scc2e420c54dc8089">
         <source>Bind existing stage</source>
         <target>Bind existing stage</target>
@@ -5512,17 +5500,9 @@ Bindings to groups/users are checked against the user of the event.</source>
         <source>Customisation</source>
         <target>Customisation</target>
       </trans-unit>
-      <trans-unit id="s58398dbcff942947">
-        <source>Flows &amp; Stages</source>
-        <target>Flows &amp; Stages</target>
-      </trans-unit>
       <trans-unit id="sc0829ee663ced008">
         <source>Directory</source>
         <target>Directory</target>
-      </trans-unit>
-      <trans-unit id="sdf4e926513e26458">
-        <source>Tokens &amp; App passwords</source>
-        <target>Tokens &amp; App passwords</target>
       </trans-unit>
       <trans-unit id="sa81e2cdaf6921adc">
         <source>System</source>
@@ -6209,6 +6189,18 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s7f68101a50f526ee">
   <source>Statically deny the flow. To use this stage effectively, disable *Evaluate when flow is planned* on the respective binding.</source>
+</trans-unit>
+<trans-unit id="s911a27022aba349f">
+  <source>Create and bind Policy</source>
+</trans-unit>
+<trans-unit id="sb1a4e9b288e2f005">
+  <source>Federation and Social login</source>
+</trans-unit>
+<trans-unit id="s6f367f5604d5056d">
+  <source>Create and bind Stage</source>
+</trans-unit>
+<trans-unit id="s1a65ee08832fbfe2">
+  <source>Flows and Stages</source>
 </trans-unit>
     </body>
   </file>

--- a/web/xliff/es.xlf
+++ b/web/xliff/es.xlf
@@ -2250,9 +2250,6 @@ doesn't pass when either or both of the selected options are equal or above the 
         <source>No policies are currently bound to this object.</source>
         <target>Actualmente, no hay políticas vinculadas a este objeto.</target>
       </trans-unit>
-      <trans-unit id="s6b66ad92d4c1a0a8">
-        <source>Create &amp; bind Policy</source>
-      </trans-unit>
       <trans-unit id="sddb040c47daae56b">
         <source>Bind existing policy</source>
       </trans-unit>
@@ -2648,10 +2645,6 @@ doesn't pass when either or both of the selected options are equal or above the 
       </trans-unit>
       <trans-unit id="s19b09f4fc72175d1">
         <source>Create a new source.</source>
-      </trans-unit>
-      <trans-unit id="sf96b3cc66d2e25f8">
-        <source>Federation &amp; Social login</source>
-        <target>Inicio de sesión de federación y redes</target>
       </trans-unit>
       <trans-unit id="s6152026c364ad974">
         <source>Sources of identities, which can either be synced into authentik's database, or can be used by users to authenticate and enroll themselves.</source>
@@ -4565,9 +4558,6 @@ doesn't pass when either or both of the selected options are equal or above the 
         <source>Bind stage</source>
         <target>Etapa Bind</target>
       </trans-unit>
-      <trans-unit id="se8eb190d8f084f80">
-        <source>Create &amp; bind Stage</source>
-      </trans-unit>
       <trans-unit id="scc2e420c54dc8089">
         <source>Bind existing stage</source>
       </trans-unit>
@@ -5131,17 +5121,9 @@ Bindings to groups/users are checked against the user of the event.</source>
         <source>Customisation</source>
         <target>Personalización</target>
       </trans-unit>
-      <trans-unit id="s58398dbcff942947">
-        <source>Flows &amp; Stages</source>
-        <target>Flujos y etapas</target>
-      </trans-unit>
       <trans-unit id="sc0829ee663ced008">
         <source>Directory</source>
         <target>Directorio</target>
-      </trans-unit>
-      <trans-unit id="sdf4e926513e26458">
-        <source>Tokens &amp; App passwords</source>
-        <target>Tokens y contraseñas de aplicaciones</target>
       </trans-unit>
       <trans-unit id="sa81e2cdaf6921adc">
         <source>System</source>
@@ -5801,6 +5783,18 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s7f68101a50f526ee">
   <source>Statically deny the flow. To use this stage effectively, disable *Evaluate when flow is planned* on the respective binding.</source>
+</trans-unit>
+<trans-unit id="s911a27022aba349f">
+  <source>Create and bind Policy</source>
+</trans-unit>
+<trans-unit id="sb1a4e9b288e2f005">
+  <source>Federation and Social login</source>
+</trans-unit>
+<trans-unit id="s6f367f5604d5056d">
+  <source>Create and bind Stage</source>
+</trans-unit>
+<trans-unit id="s1a65ee08832fbfe2">
+  <source>Flows and Stages</source>
 </trans-unit>
     </body>
   </file>

--- a/web/xliff/fr_FR.xlf
+++ b/web/xliff/fr_FR.xlf
@@ -2308,10 +2308,6 @@ doesn't pass when either or both of the selected options are equal or above the 
         <source>No policies are currently bound to this object.</source>
         <target>Aucune politique n'est actuellement lié à cet objet.</target>
       </trans-unit>
-      <trans-unit id="s6b66ad92d4c1a0a8">
-        <source>Create &amp; bind Policy</source>
-        <target>Créer &amp; Lier une politique</target>
-      </trans-unit>
       <trans-unit id="sddb040c47daae56b">
         <source>Bind existing policy</source>
         <target>Lier une politique existante</target>
@@ -2715,10 +2711,6 @@ doesn't pass when either or both of the selected options are equal or above the 
       <trans-unit id="s19b09f4fc72175d1">
         <source>Create a new source.</source>
         <target>Créer une nouvelle source.</target>
-      </trans-unit>
-      <trans-unit id="sf96b3cc66d2e25f8">
-        <source>Federation &amp; Social login</source>
-        <target>Fédération &amp; Connection Sociale</target>
       </trans-unit>
       <trans-unit id="s6152026c364ad974">
         <source>Sources of identities, which can either be synced into authentik's database, or can be used by users to authenticate and enroll themselves.</source>
@@ -4655,10 +4647,6 @@ doesn't pass when either or both of the selected options are equal or above the 
         <source>Bind stage</source>
         <target>Lier une étape</target>
       </trans-unit>
-      <trans-unit id="se8eb190d8f084f80">
-        <source>Create &amp; bind Stage</source>
-        <target>Créer &amp; Lier une étape</target>
-      </trans-unit>
       <trans-unit id="scc2e420c54dc8089">
         <source>Bind existing stage</source>
         <target>Lier une étape existante</target>
@@ -5228,17 +5216,9 @@ Bindings to groups/users are checked against the user of the event.</source>
         <source>Customisation</source>
         <target>Personalisation</target>
       </trans-unit>
-      <trans-unit id="s58398dbcff942947">
-        <source>Flows &amp; Stages</source>
-        <target>Flux &amp; Étapes</target>
-      </trans-unit>
       <trans-unit id="sc0829ee663ced008">
         <source>Directory</source>
         <target>Répertoire</target>
-      </trans-unit>
-      <trans-unit id="sdf4e926513e26458">
-        <source>Tokens &amp; App passwords</source>
-        <target>Jetons &amp; mots de passe d'application</target>
       </trans-unit>
       <trans-unit id="sa81e2cdaf6921adc">
         <source>System</source>
@@ -5908,6 +5888,18 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s7f68101a50f526ee">
   <source>Statically deny the flow. To use this stage effectively, disable *Evaluate when flow is planned* on the respective binding.</source>
+</trans-unit>
+<trans-unit id="s911a27022aba349f">
+  <source>Create and bind Policy</source>
+</trans-unit>
+<trans-unit id="sb1a4e9b288e2f005">
+  <source>Federation and Social login</source>
+</trans-unit>
+<trans-unit id="s6f367f5604d5056d">
+  <source>Create and bind Stage</source>
+</trans-unit>
+<trans-unit id="s1a65ee08832fbfe2">
+  <source>Flows and Stages</source>
 </trans-unit>
     </body>
   </file>

--- a/web/xliff/pl.xlf
+++ b/web/xliff/pl.xlf
@@ -2353,9 +2353,6 @@ doesn't pass when either or both of the selected options are equal or above the 
         <source>No policies are currently bound to this object.</source>
         <target>Żadne zasady nie są obecnie powiązane z tym obiektem.</target>
       </trans-unit>
-      <trans-unit id="s6b66ad92d4c1a0a8">
-        <source>Create &amp; bind Policy</source>
-      </trans-unit>
       <trans-unit id="sddb040c47daae56b">
         <source>Bind existing policy</source>
       </trans-unit>
@@ -2763,10 +2760,6 @@ doesn't pass when either or both of the selected options are equal or above the 
       <trans-unit id="s19b09f4fc72175d1">
         <source>Create a new source.</source>
         <target>Utwórz nowe źródło.</target>
-      </trans-unit>
-      <trans-unit id="sf96b3cc66d2e25f8">
-        <source>Federation &amp; Social login</source>
-        <target>Logowanie federacyjne i społecznościowe</target>
       </trans-unit>
       <trans-unit id="s6152026c364ad974">
         <source>Sources of identities, which can either be synced into authentik's database, or can be used by users to authenticate and enroll themselves.</source>
@@ -4764,9 +4757,6 @@ doesn't pass when either or both of the selected options are equal or above the 
         <source>Bind stage</source>
         <target>Powiąż etap</target>
       </trans-unit>
-      <trans-unit id="se8eb190d8f084f80">
-        <source>Create &amp; bind Stage</source>
-      </trans-unit>
       <trans-unit id="scc2e420c54dc8089">
         <source>Bind existing stage</source>
       </trans-unit>
@@ -5352,17 +5342,9 @@ Bindings to groups/users are checked against the user of the event.</source>
         <source>Customisation</source>
         <target>Dostosowywanie</target>
       </trans-unit>
-      <trans-unit id="s58398dbcff942947">
-        <source>Flows &amp; Stages</source>
-        <target>Przepływy i etapy</target>
-      </trans-unit>
       <trans-unit id="sc0829ee663ced008">
         <source>Directory</source>
         <target>Katalog</target>
-      </trans-unit>
-      <trans-unit id="sdf4e926513e26458">
-        <source>Tokens &amp; App passwords</source>
-        <target>Tokeny i hasła aplikacji</target>
       </trans-unit>
       <trans-unit id="sa81e2cdaf6921adc">
         <source>System</source>
@@ -6040,6 +6022,18 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s7f68101a50f526ee">
   <source>Statically deny the flow. To use this stage effectively, disable *Evaluate when flow is planned* on the respective binding.</source>
+</trans-unit>
+<trans-unit id="s911a27022aba349f">
+  <source>Create and bind Policy</source>
+</trans-unit>
+<trans-unit id="sb1a4e9b288e2f005">
+  <source>Federation and Social login</source>
+</trans-unit>
+<trans-unit id="s6f367f5604d5056d">
+  <source>Create and bind Stage</source>
+</trans-unit>
+<trans-unit id="s1a65ee08832fbfe2">
+  <source>Flows and Stages</source>
 </trans-unit>
     </body>
   </file>

--- a/web/xliff/pseudo-LOCALE.xlf
+++ b/web/xliff/pseudo-LOCALE.xlf
@@ -2413,10 +2413,6 @@ doesn't pass when either or both of the selected options are equal or above the 
         <source>No policies are currently bound to this object.</source>
         
       </trans-unit>
-      <trans-unit id="s6b66ad92d4c1a0a8">
-        <source>Create &amp; bind Policy</source>
-        
-      </trans-unit>
       <trans-unit id="sddb040c47daae56b">
         <source>Bind existing policy</source>
         
@@ -2831,10 +2827,6 @@ doesn't pass when either or both of the selected options are equal or above the 
       </trans-unit>
       <trans-unit id="s19b09f4fc72175d1">
         <source>Create a new source.</source>
-        
-      </trans-unit>
-      <trans-unit id="sf96b3cc66d2e25f8">
-        <source>Federation &amp; Social login</source>
         
       </trans-unit>
       <trans-unit id="s6152026c364ad974">
@@ -4872,10 +4864,6 @@ doesn't pass when either or both of the selected options are equal or above the 
         <source>Bind stage</source>
         
       </trans-unit>
-      <trans-unit id="se8eb190d8f084f80">
-        <source>Create &amp; bind Stage</source>
-        
-      </trans-unit>
       <trans-unit id="scc2e420c54dc8089">
         <source>Bind existing stage</source>
         
@@ -5464,16 +5452,8 @@ Bindings to groups/users are checked against the user of the event.</source>
         <source>Customisation</source>
         
       </trans-unit>
-      <trans-unit id="s58398dbcff942947">
-        <source>Flows &amp; Stages</source>
-        
-      </trans-unit>
       <trans-unit id="sc0829ee663ced008">
         <source>Directory</source>
-        
-      </trans-unit>
-      <trans-unit id="sdf4e926513e26458">
-        <source>Tokens &amp; App passwords</source>
         
       </trans-unit>
       <trans-unit id="sa81e2cdaf6921adc">
@@ -6144,6 +6124,18 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s7f68101a50f526ee">
   <source>Statically deny the flow. To use this stage effectively, disable *Evaluate when flow is planned* on the respective binding.</source>
+</trans-unit>
+<trans-unit id="s911a27022aba349f">
+  <source>Create and bind Policy</source>
+</trans-unit>
+<trans-unit id="sb1a4e9b288e2f005">
+  <source>Federation and Social login</source>
+</trans-unit>
+<trans-unit id="s6f367f5604d5056d">
+  <source>Create and bind Stage</source>
+</trans-unit>
+<trans-unit id="s1a65ee08832fbfe2">
+  <source>Flows and Stages</source>
 </trans-unit>
     </body>
   </file>

--- a/web/xliff/tr.xlf
+++ b/web/xliff/tr.xlf
@@ -2249,9 +2249,6 @@ doesn't pass when either or both of the selected options are equal or above the 
         <source>No policies are currently bound to this object.</source>
         <target>Hiçbir ilke şu anda bu nesneye bağlı değildir.</target>
       </trans-unit>
-      <trans-unit id="s6b66ad92d4c1a0a8">
-        <source>Create &amp; bind Policy</source>
-      </trans-unit>
       <trans-unit id="sddb040c47daae56b">
         <source>Bind existing policy</source>
       </trans-unit>
@@ -2647,10 +2644,6 @@ doesn't pass when either or both of the selected options are equal or above the 
       </trans-unit>
       <trans-unit id="s19b09f4fc72175d1">
         <source>Create a new source.</source>
-      </trans-unit>
-      <trans-unit id="sf96b3cc66d2e25f8">
-        <source>Federation &amp; Social login</source>
-        <target>Federasyon ve Sosyal Giriş</target>
       </trans-unit>
       <trans-unit id="s6152026c364ad974">
         <source>Sources of identities, which can either be synced into authentik's database, or can be used by users to authenticate and enroll themselves.</source>
@@ -4556,9 +4549,6 @@ doesn't pass when either or both of the selected options are equal or above the 
         <source>Bind stage</source>
         <target>Bağlama aşaması</target>
       </trans-unit>
-      <trans-unit id="se8eb190d8f084f80">
-        <source>Create &amp; bind Stage</source>
-      </trans-unit>
       <trans-unit id="scc2e420c54dc8089">
         <source>Bind existing stage</source>
       </trans-unit>
@@ -5121,17 +5111,9 @@ Bindings to groups/users are checked against the user of the event.</source>
         <source>Customisation</source>
         <target>Özelleştirme</target>
       </trans-unit>
-      <trans-unit id="s58398dbcff942947">
-        <source>Flows &amp; Stages</source>
-        <target>Akışlar ve Aşamalar</target>
-      </trans-unit>
       <trans-unit id="sc0829ee663ced008">
         <source>Directory</source>
         <target>Rehber</target>
-      </trans-unit>
-      <trans-unit id="sdf4e926513e26458">
-        <source>Tokens &amp; App passwords</source>
-        <target>Belirteçler ve Uygulama parolaları</target>
       </trans-unit>
       <trans-unit id="sa81e2cdaf6921adc">
         <source>System</source>
@@ -5791,6 +5773,18 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s7f68101a50f526ee">
   <source>Statically deny the flow. To use this stage effectively, disable *Evaluate when flow is planned* on the respective binding.</source>
+</trans-unit>
+<trans-unit id="s911a27022aba349f">
+  <source>Create and bind Policy</source>
+</trans-unit>
+<trans-unit id="sb1a4e9b288e2f005">
+  <source>Federation and Social login</source>
+</trans-unit>
+<trans-unit id="s6f367f5604d5056d">
+  <source>Create and bind Stage</source>
+</trans-unit>
+<trans-unit id="s1a65ee08832fbfe2">
+  <source>Flows and Stages</source>
 </trans-unit>
     </body>
   </file>

--- a/web/xliff/zh-Hans.xlf
+++ b/web/xliff/zh-Hans.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" ?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+<?xml version="1.0"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file target-language="zh-Hans" source-language="en" original="lit-localize-inputs" datatype="plaintext">
     <body>
       <trans-unit id="s4caed5b7a7e5d89b">
@@ -618,9 +618,9 @@
         
       </trans-unit>
       <trans-unit id="saa0e2675da69651b">
-        <source>The URL &quot;<x id="0" equiv-text="${this.url}"/>&quot; was not found.</source>
-        <target>未找到 URL &quot; 
-        <x id="0" equiv-text="${this.url}"/>&quot;。</target>
+        <source>The URL "<x id="0" equiv-text="${this.url}"/>" was not found.</source>
+        <target>未找到 URL " 
+        <x id="0" equiv-text="${this.url}"/>"。</target>
         
       </trans-unit>
       <trans-unit id="s58cd9c2fe836d9c6">
@@ -1072,8 +1072,8 @@
         
       </trans-unit>
       <trans-unit id="sa8384c9c26731f83">
-        <source>To allow any redirect URI, set this value to &quot;.*&quot;. Be aware of the possible security implications this can have.</source>
-        <target>要允许任何重定向 URI，请将此值设置为 &quot;.*&quot;。请注意这可能带来的安全影响。</target>
+        <source>To allow any redirect URI, set this value to ".*". Be aware of the possible security implications this can have.</source>
+        <target>要允许任何重定向 URI，请将此值设置为 ".*"。请注意这可能带来的安全影响。</target>
         
       </trans-unit>
       <trans-unit id="s55787f4dfcdce52b">
@@ -1819,8 +1819,8 @@
         
       </trans-unit>
       <trans-unit id="sa90b7809586c35ce">
-        <source>Either input a full URL, a relative path, or use 'fa://fa-test' to use the Font Awesome icon &quot;fa-test&quot;.</source>
-        <target>输入完整 URL、相对路径，或者使用 'fa://fa-test' 来使用 Font Awesome 图标 &quot;fa-test&quot;。</target>
+        <source>Either input a full URL, a relative path, or use 'fa://fa-test' to use the Font Awesome icon "fa-test".</source>
+        <target>输入完整 URL、相对路径，或者使用 'fa://fa-test' 来使用 Font Awesome 图标 "fa-test"。</target>
         
       </trans-unit>
       <trans-unit id="s0410779cb47de312">
@@ -3042,11 +3042,6 @@ doesn't pass when either or both of the selected options are equal or above the 
         <target>当前没有策略绑定到此对象。</target>
         
       </trans-unit>
-      <trans-unit id="s6b66ad92d4c1a0a8">
-        <source>Create &amp; bind Policy</source>
-        <target>创建 &amp; 绑定策略</target>
-        
-      </trans-unit>
       <trans-unit id="sddb040c47daae56b">
         <source>Bind existing policy</source>
         <target>绑定已有策略</target>
@@ -3248,8 +3243,8 @@ doesn't pass when either or both of the selected options are equal or above the 
         
       </trans-unit>
       <trans-unit id="s76768bebabb7d543">
-        <source>Field which contains members of a group. Note that if using the &quot;memberUid&quot; field, the value is assumed to contain a relative distinguished name. e.g. 'memberUid=some-user' instead of 'memberUid=cn=some-user,ou=groups,...'</source>
-        <target>包含组成员的字段。请注意，如果使用 &quot;memberUid&quot; 字段，则假定该值包含相对可分辨名称。例如，'memberUid=some-user' 而不是 'memberUid=cn=some-user,ou=groups,...'</target>
+        <source>Field which contains members of a group. Note that if using the "memberUid" field, the value is assumed to contain a relative distinguished name. e.g. 'memberUid=some-user' instead of 'memberUid=cn=some-user,ou=groups,...'</source>
+        <target>包含组成员的字段。请注意，如果使用 "memberUid" 字段，则假定该值包含相对可分辨名称。例如，'memberUid=some-user' 而不是 'memberUid=cn=some-user,ou=groups,...'</target>
         
       </trans-unit>
       <trans-unit id="s026555347e589f0e">
@@ -3565,11 +3560,6 @@ doesn't pass when either or both of the selected options are equal or above the 
       <trans-unit id="s19b09f4fc72175d1">
         <source>Create a new source.</source>
         <target>创建一个新身份来源。</target>
-        
-      </trans-unit>
-      <trans-unit id="sf96b3cc66d2e25f8">
-        <source>Federation &amp; Social login</source>
-        <target>联结与社交登录</target>
         
       </trans-unit>
       <trans-unit id="s6152026c364ad974">
@@ -4046,8 +4036,8 @@ doesn't pass when either or both of the selected options are equal or above the 
         
       </trans-unit>
       <trans-unit id="s7b1fba26d245cb1c">
-        <source>When using an external logging solution for archiving, this can be set to &quot;minutes=5&quot;.</source>
-        <target>使用外部日志记录解决方案进行存档时，可以将其设置为 &quot;minutes=5&quot;。</target>
+        <source>When using an external logging solution for archiving, this can be set to "minutes=5".</source>
+        <target>使用外部日志记录解决方案进行存档时，可以将其设置为 "minutes=5"。</target>
         
       </trans-unit>
       <trans-unit id="s44536d20bb5c8257">
@@ -4056,8 +4046,8 @@ doesn't pass when either or both of the selected options are equal or above the 
         
       </trans-unit>
       <trans-unit id="s3bb51cabb02b997e">
-        <source>Format: &quot;weeks=3;days=2;hours=3,seconds=2&quot;.</source>
-        <target>格式：&quot;weeks=3;days=2;hours=3,seconds=2&quot;。</target>
+        <source>Format: "weeks=3;days=2;hours=3,seconds=2".</source>
+        <target>格式："weeks=3;days=2;hours=3,seconds=2"。</target>
         
       </trans-unit>
       <trans-unit id="s04bfd02201db5ab8">
@@ -4253,10 +4243,10 @@ doesn't pass when either or both of the selected options are equal or above the 
         
       </trans-unit>
       <trans-unit id="sa95a538bfbb86111">
-        <source>Are you sure you want to update <x id="0" equiv-text="${this.objectLabel}"/> &quot;<x id="1" equiv-text="${this.obj?.name}"/>&quot;?</source>
+        <source>Are you sure you want to update <x id="0" equiv-text="${this.objectLabel}"/> "<x id="1" equiv-text="${this.obj?.name}"/>"?</source>
         <target>您确定要更新 
-        <x id="0" equiv-text="${this.objectLabel}"/>&quot; 
-        <x id="1" equiv-text="${this.obj?.name}"/>&quot; 吗？</target>
+        <x id="0" equiv-text="${this.objectLabel}"/>" 
+        <x id="1" equiv-text="${this.obj?.name}"/>" 吗？</target>
         
       </trans-unit>
       <trans-unit id="sc92d7cfb6ee1fec6">
@@ -5372,7 +5362,7 @@ doesn't pass when either or both of the selected options are equal or above the 
         
       </trans-unit>
       <trans-unit id="sdf1d8edef27236f0">
-        <source>A &quot;roaming&quot; authenticator, like a YubiKey</source>
+        <source>A "roaming" authenticator, like a YubiKey</source>
         <target>像 YubiKey 这样的“漫游”身份验证器</target>
         
       </trans-unit>
@@ -5707,10 +5697,10 @@ doesn't pass when either or both of the selected options are equal or above the 
         
       </trans-unit>
       <trans-unit id="s2d5f69929bb7221d">
-        <source><x id="0" equiv-text="${prompt.name}"/> (&quot;<x id="1" equiv-text="${prompt.fieldKey}"/>&quot;, of type <x id="2" equiv-text="${prompt.type}"/>)</source>
+        <source><x id="0" equiv-text="${prompt.name}"/> ("<x id="1" equiv-text="${prompt.fieldKey}"/>", of type <x id="2" equiv-text="${prompt.type}"/>)</source>
         <target>
-        <x id="0" equiv-text="${prompt.name}"/>（&quot; 
-        <x id="1" equiv-text="${prompt.fieldKey}"/>&quot;，类型为 
+        <x id="0" equiv-text="${prompt.name}"/>（" 
+        <x id="1" equiv-text="${prompt.fieldKey}"/>"，类型为 
         <x id="2" equiv-text="${prompt.type}"/>）</target>
         
       </trans-unit>
@@ -5759,7 +5749,7 @@ doesn't pass when either or both of the selected options are equal or above the 
         
       </trans-unit>
       <trans-unit id="s1608b2f94fa0dbd4">
-        <source>If set to a duration above 0, the user will have the option to choose to &quot;stay signed in&quot;, which will extend their session by the time specified here.</source>
+        <source>If set to a duration above 0, the user will have the option to choose to "stay signed in", which will extend their session by the time specified here.</source>
         <target>如果设置时长大于 0，用户可以选择“保持登录”选项，这将使用户的会话延长此处设置的时间。</target>
         
       </trans-unit>
@@ -6139,11 +6129,6 @@ doesn't pass when either or both of the selected options are equal or above the 
       <trans-unit id="s207e8b106806d7e4">
         <source>Bind stage</source>
         <target>绑定阶段</target>
-        
-      </trans-unit>
-      <trans-unit id="se8eb190d8f084f80">
-        <source>Create &amp; bind Stage</source>
-        <target>创建 &amp; 绑定阶段</target>
         
       </trans-unit>
       <trans-unit id="scc2e420c54dc8089">
@@ -6890,19 +6875,9 @@ Bindings to groups/users are checked against the user of the event.</source>
         <target>自定义</target>
         
       </trans-unit>
-      <trans-unit id="s58398dbcff942947">
-        <source>Flows &amp; Stages</source>
-        <target>流程与阶段</target>
-        
-      </trans-unit>
       <trans-unit id="sc0829ee663ced008">
         <source>Directory</source>
         <target>目录</target>
-        
-      </trans-unit>
-      <trans-unit id="sdf4e926513e26458">
-        <source>Tokens &amp; App passwords</source>
-        <target>令牌和应用程序密码</target>
         
       </trans-unit>
       <trans-unit id="sa81e2cdaf6921adc">
@@ -7775,6 +7750,18 @@ Bindings to groups/users are checked against the user of the event.</source>
 <trans-unit id="s7f68101a50f526ee">
   <source>Statically deny the flow. To use this stage effectively, disable *Evaluate when flow is planned* on the respective binding.</source>
   <target>静态拒绝流。要有效地使用此阶段，请在相应的绑定上禁用*规划时进行评估*。</target>
+</trans-unit>
+<trans-unit id="s911a27022aba349f">
+  <source>Create and bind Policy</source>
+</trans-unit>
+<trans-unit id="sb1a4e9b288e2f005">
+  <source>Federation and Social login</source>
+</trans-unit>
+<trans-unit id="s6f367f5604d5056d">
+  <source>Create and bind Stage</source>
+</trans-unit>
+<trans-unit id="s1a65ee08832fbfe2">
+  <source>Flows and Stages</source>
 </trans-unit>
     </body>
   </file>

--- a/web/xliff/zh-Hant.xlf
+++ b/web/xliff/zh-Hant.xlf
@@ -2273,9 +2273,6 @@ doesn't pass when either or both of the selected options are equal or above the 
         <source>No policies are currently bound to this object.</source>
         <target>当前没有策略绑定到此对象。</target>
       </trans-unit>
-      <trans-unit id="s6b66ad92d4c1a0a8">
-        <source>Create &amp; bind Policy</source>
-      </trans-unit>
       <trans-unit id="sddb040c47daae56b">
         <source>Bind existing policy</source>
       </trans-unit>
@@ -2673,10 +2670,6 @@ doesn't pass when either or both of the selected options are equal or above the 
       <trans-unit id="s19b09f4fc72175d1">
         <source>Create a new source.</source>
         <target>创建一个新身份来源。</target>
-      </trans-unit>
-      <trans-unit id="sf96b3cc66d2e25f8">
-        <source>Federation &amp; Social login</source>
-        <target>联盟和社交登录</target>
       </trans-unit>
       <trans-unit id="s6152026c364ad974">
         <source>Sources of identities, which can either be synced into authentik's database, or can be used by users to authenticate and enroll themselves.</source>
@@ -4603,9 +4596,6 @@ doesn't pass when either or both of the selected options are equal or above the 
         <source>Bind stage</source>
         <target>Bind 阶段</target>
       </trans-unit>
-      <trans-unit id="se8eb190d8f084f80">
-        <source>Create &amp; bind Stage</source>
-      </trans-unit>
       <trans-unit id="scc2e420c54dc8089">
         <source>Bind existing stage</source>
       </trans-unit>
@@ -5172,17 +5162,9 @@ Bindings to groups/users are checked against the user of the event.</source>
         <source>Customisation</source>
         <target>定制</target>
       </trans-unit>
-      <trans-unit id="s58398dbcff942947">
-        <source>Flows &amp; Stages</source>
-        <target>流程和阶段</target>
-      </trans-unit>
       <trans-unit id="sc0829ee663ced008">
         <source>Directory</source>
         <target>目录</target>
-      </trans-unit>
-      <trans-unit id="sdf4e926513e26458">
-        <source>Tokens &amp; App passwords</source>
-        <target>令牌和应用程序密码</target>
       </trans-unit>
       <trans-unit id="sa81e2cdaf6921adc">
         <source>System</source>
@@ -5846,6 +5828,18 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s7f68101a50f526ee">
   <source>Statically deny the flow. To use this stage effectively, disable *Evaluate when flow is planned* on the respective binding.</source>
+</trans-unit>
+<trans-unit id="s911a27022aba349f">
+  <source>Create and bind Policy</source>
+</trans-unit>
+<trans-unit id="sb1a4e9b288e2f005">
+  <source>Federation and Social login</source>
+</trans-unit>
+<trans-unit id="s6f367f5604d5056d">
+  <source>Create and bind Stage</source>
+</trans-unit>
+<trans-unit id="s1a65ee08832fbfe2">
+  <source>Flows and Stages</source>
 </trans-unit>
     </body>
   </file>

--- a/web/xliff/zh_TW.xlf
+++ b/web/xliff/zh_TW.xlf
@@ -2273,9 +2273,6 @@ doesn't pass when either or both of the selected options are equal or above the 
         <source>No policies are currently bound to this object.</source>
         <target>当前没有策略绑定到此对象。</target>
       </trans-unit>
-      <trans-unit id="s6b66ad92d4c1a0a8">
-        <source>Create &amp; bind Policy</source>
-      </trans-unit>
       <trans-unit id="sddb040c47daae56b">
         <source>Bind existing policy</source>
       </trans-unit>
@@ -2673,10 +2670,6 @@ doesn't pass when either or both of the selected options are equal or above the 
       <trans-unit id="s19b09f4fc72175d1">
         <source>Create a new source.</source>
         <target>创建一个新身份来源。</target>
-      </trans-unit>
-      <trans-unit id="sf96b3cc66d2e25f8">
-        <source>Federation &amp; Social login</source>
-        <target>联盟和社交登录</target>
       </trans-unit>
       <trans-unit id="s6152026c364ad974">
         <source>Sources of identities, which can either be synced into authentik's database, or can be used by users to authenticate and enroll themselves.</source>
@@ -4602,9 +4595,6 @@ doesn't pass when either or both of the selected options are equal or above the 
         <source>Bind stage</source>
         <target>Bind 阶段</target>
       </trans-unit>
-      <trans-unit id="se8eb190d8f084f80">
-        <source>Create &amp; bind Stage</source>
-      </trans-unit>
       <trans-unit id="scc2e420c54dc8089">
         <source>Bind existing stage</source>
       </trans-unit>
@@ -5171,17 +5161,9 @@ Bindings to groups/users are checked against the user of the event.</source>
         <source>Customisation</source>
         <target>定制</target>
       </trans-unit>
-      <trans-unit id="s58398dbcff942947">
-        <source>Flows &amp; Stages</source>
-        <target>流程和阶段</target>
-      </trans-unit>
       <trans-unit id="sc0829ee663ced008">
         <source>Directory</source>
         <target>目录</target>
-      </trans-unit>
-      <trans-unit id="sdf4e926513e26458">
-        <source>Tokens &amp; App passwords</source>
-        <target>令牌和应用程序密码</target>
       </trans-unit>
       <trans-unit id="sa81e2cdaf6921adc">
         <source>System</source>
@@ -5845,6 +5827,18 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s7f68101a50f526ee">
   <source>Statically deny the flow. To use this stage effectively, disable *Evaluate when flow is planned* on the respective binding.</source>
+</trans-unit>
+<trans-unit id="s911a27022aba349f">
+  <source>Create and bind Policy</source>
+</trans-unit>
+<trans-unit id="sb1a4e9b288e2f005">
+  <source>Federation and Social login</source>
+</trans-unit>
+<trans-unit id="s6f367f5604d5056d">
+  <source>Create and bind Stage</source>
+</trans-unit>
+<trans-unit id="s1a65ee08832fbfe2">
+  <source>Flows and Stages</source>
 </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

closes #6736

due to the way html escaping is handled in lit-localize, using a `&` in a string gets escaped into the xlf file to `&amp;` which is correct, but doesn't get unescaped when loading back in again

As a workaround we'll just replace the `&` with `and`

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
