### PR TITLE
sources/ldap: fix FreeIPA nsaccountlock sync

### DIFF
--- a/authentik/sources/ldap/sync/vendor/freeipa.py
+++ b/authentik/sources/ldap/sync/vendor/freeipa.py
@@ -45,7 +45,11 @@ class FreeIPA(BaseLDAPSynchronizer):
         # 389-ds and this will trigger regardless
         if "nsaccountlock" not in attributes:
             return
-        is_active = attributes.get("nsaccountlock", False)
+        # For some reason, nsaccountlock is not defined properly in the schema as bool
+        # hence we get it as a list of strings
+        _is_active = str(self._flatten(attributes.get("nsaccountlock", ["FALSE"])))
+        # So we have to attempt to convert it to a bool
+        is_active = _is_active.lower() == "true"
         if is_active != user.is_active:
             user.is_active = is_active
             user.save()

--- a/authentik/sources/ldap/tests/mock_freeipa.py
+++ b/authentik/sources/ldap/tests/mock_freeipa.py
@@ -1,11 +1,11 @@
 """ldap testing utils"""
 
-from ldap3 import MOCK_SYNC, OFFLINE_SLAPD_2_4, Connection, Server
+from ldap3 import MOCK_SYNC, OFFLINE_DS389_1_3_3, Connection, Server
 
 
-def mock_slapd_connection(password: str) -> Connection:
-    """Create mock SLAPD connection"""
-    server = Server("my_fake_server", get_info=OFFLINE_SLAPD_2_4)
+def mock_freeipa_connection(password: str) -> Connection:
+    """Create mock FreeIPA-ish connection"""
+    server = Server("my_fake_server", get_info=OFFLINE_DS389_1_3_3)
     _pass = "foo"  # noqa # nosec
     connection = Connection(
         server,
@@ -94,6 +94,17 @@ def mock_slapd_connection(password: str) -> Connection:
             "uid": "user-posix",
             "cn": "user-posix",
             "objectClass": "posixAccount",
+        },
+    )
+    # Locked out user
+    connection.strategy.add_entry(
+        "cn=user-nsaccountlock,ou=users,dc=goauthentik,dc=io",
+        {
+            "userPassword": password,
+            "uid": "user-nsaccountlock",
+            "cn": "user-nsaccountlock",
+            "objectClass": "person",
+            "nsaccountlock": ["TRUE"],
         },
     )
     connection.bind()


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

closes #6692

nsaccountlock is not defined "correctly" in the LDAP Schema and as such we get it as `["TRUE"]`

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
