### PR TITLE
policies/reputation: require either check to be enabled

### DIFF
--- a/authentik/policies/reputation/api.py
+++ b/authentik/policies/reputation/api.py
@@ -1,5 +1,7 @@
 """Reputation policy API Views"""
+from django.utils.translation import gettext_lazy as _
 from rest_framework import mixins
+from rest_framework.exceptions import ValidationError
 from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import GenericViewSet, ModelViewSet
 
@@ -10,6 +12,11 @@ from authentik.policies.reputation.models import Reputation, ReputationPolicy
 
 class ReputationPolicySerializer(PolicySerializer):
     """Reputation Policy Serializer"""
+
+    def validate(self, attrs: dict) -> dict:
+        if not attrs.get("check_ip", False) and not attrs.get("check_username", False):
+            raise ValidationError(_("Either IP or Username must be checked"))
+        return super().validate(attrs)
 
     class Meta:
         model = ReputationPolicy

--- a/authentik/policies/reputation/tests.py
+++ b/authentik/policies/reputation/tests.py
@@ -3,6 +3,8 @@ from django.core.cache import cache
 from django.test import RequestFactory, TestCase
 
 from authentik.core.models import User
+from authentik.lib.generators import generate_id
+from authentik.policies.reputation.api import ReputationPolicySerializer
 from authentik.policies.reputation.models import CACHE_KEY_PREFIX, Reputation, ReputationPolicy
 from authentik.policies.reputation.tasks import save_reputation
 from authentik.policies.types import PolicyRequest
@@ -61,3 +63,8 @@ class TestReputationPolicy(TestCase):
             name="reputation-test", threshold=0
         )
         self.assertTrue(policy.passes(request).passing)
+
+    def test_api(self):
+        """Test API Validation"""
+        no_toggle = ReputationPolicySerializer(data={"name": generate_id(), "threshold": -5})
+        self.assertFalse(no_toggle.is_valid())

--- a/web/src/admin/policies/reputation/ReputationPolicyForm.ts
+++ b/web/src/admin/policies/reputation/ReputationPolicyForm.ts
@@ -93,7 +93,7 @@ doesn't pass when either or both of the selected options are equal or above the 
                             <input
                                 class="pf-c-switch__input"
                                 type="checkbox"
-                                ?checked=${first(this.instance?.checkIp, false)}
+                                ?checked=${first(this.instance?.checkIp, true)}
                             />
                             <span class="pf-c-switch__toggle">
                                 <span class="pf-c-switch__toggle-icon">


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

Currently the reputation policy can be created with both checks disable, which doesn't do anything (as expected)

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
