### PR TITLE
flows: remove need for post() wrapper by using dispatch

### DIFF
--- a/authentik/core/sources/flow_manager.py
+++ b/authentik/core/sources/flow_manager.py
@@ -48,7 +48,7 @@ class Action(Enum):
 class MessageStage(StageView):
     """Show a pre-configured message after the flow is done"""
 
-    def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+    def dispatch(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
         """Show a pre-configured message after the flow is done"""
         message = getattr(self.executor.current_stage, "message", "")
         level = getattr(self.executor.current_stage, "level", messages.SUCCESS)
@@ -58,10 +58,6 @@ class MessageStage(StageView):
             message,
         )
         return self.executor.stage_ok()
-
-    def post(self, request: HttpRequest) -> HttpResponse:
-        """Wrapper for post requests"""
-        return self.get(request)
 
 
 class SourceFlowManager:

--- a/authentik/core/sources/stage.py
+++ b/authentik/core/sources/stage.py
@@ -13,7 +13,7 @@ class PostUserEnrollmentStage(StageView):
     """Dynamically injected stage which saves the Connection after
     the user has been enrolled."""
 
-    def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+    def dispatch(self, request: HttpRequest) -> HttpResponse:
         """Stage used after the user has been enrolled"""
         connection: UserSourceConnection = self.executor.plan.context[
             PLAN_CONTEXT_SOURCES_CONNECTION
@@ -27,7 +27,3 @@ class PostUserEnrollmentStage(StageView):
             source=connection.source,
         ).from_http(self.request)
         return self.executor.stage_ok()
-
-    def post(self, request: HttpRequest) -> HttpResponse:
-        """Wrapper for post requests"""
-        return self.get(request)

--- a/authentik/flows/tests/test_stage_views.py
+++ b/authentik/flows/tests/test_stage_views.py
@@ -21,8 +21,9 @@ def view_tester_factory(view_class: type[StageView]) -> Callable:
 
     def tester(self: TestViews):
         model_class = view_class(self.exec)
-        self.assertIsNotNone(model_class.post)
-        self.assertIsNotNone(model_class.get)
+        if not hasattr(model_class, "dispatch"):
+            self.assertIsNotNone(model_class.post)
+            self.assertIsNotNone(model_class.get)
 
     return tester
 

--- a/authentik/flows/views/executor.py
+++ b/authentik/flows/views/executor.py
@@ -295,7 +295,7 @@ class FlowExecutorView(APIView):
                 span.set_data("Method", "GET")
                 span.set_data("authentik Stage", self.current_stage_view)
                 span.set_data("authentik Flow", self.flow.slug)
-                stage_response = self.current_stage_view.get(request, *args, **kwargs)
+                stage_response = self.current_stage_view.dispatch(request)
                 return to_stage_response(request, stage_response)
         except Exception as exc:  # pylint: disable=broad-except
             return self.handle_exception(exc)
@@ -339,7 +339,7 @@ class FlowExecutorView(APIView):
                 span.set_data("Method", "POST")
                 span.set_data("authentik Stage", self.current_stage_view)
                 span.set_data("authentik Flow", self.flow.slug)
-                stage_response = self.current_stage_view.post(request, *args, **kwargs)
+                stage_response = self.current_stage_view.dispatch(request)
                 return to_stage_response(request, stage_response)
         except Exception as exc:  # pylint: disable=broad-except
             return self.handle_exception(exc)

--- a/authentik/stages/deny/stage.py
+++ b/authentik/stages/deny/stage.py
@@ -7,10 +7,6 @@ from authentik.flows.stage import StageView
 class DenyStageView(StageView):
     """Cancels the current flow"""
 
-    def get(self, request: HttpRequest) -> HttpResponse:
+    def dispatch(self, request: HttpRequest) -> HttpResponse:
         """Cancels the current flow"""
         return self.executor.stage_invalid()
-
-    def post(self, request: HttpRequest) -> HttpResponse:
-        """Wrapper for post requests"""
-        return self.get(request)

--- a/authentik/stages/invitation/stage.py
+++ b/authentik/stages/invitation/stage.py
@@ -21,10 +21,6 @@ INVITATION = "invitation"
 class InvitationStageView(StageView):
     """Finalise Authentication flow by logging the user in"""
 
-    def post(self, request: HttpRequest) -> HttpResponse:
-        """Wrapper for post requests"""
-        return self.get(request)
-
     def get_token(self) -> Optional[str]:
         """Get token from saved get-arguments or prompt_data"""
         # Check for ?token= and ?itoken=
@@ -55,7 +51,7 @@ class InvitationStageView(StageView):
             return None
         return invite
 
-    def get(self, request: HttpRequest) -> HttpResponse:
+    def dispatch(self, request: HttpRequest) -> HttpResponse:
         """Apply data to the current flow based on a URL"""
         stage: InvitationStage = self.executor.current_stage
 

--- a/authentik/stages/user_delete/stage.py
+++ b/authentik/stages/user_delete/stage.py
@@ -11,11 +11,7 @@ from authentik.flows.stage import StageView
 class UserDeleteStageView(StageView):
     """Finalise unenrollment flow by deleting the user object."""
 
-    def post(self, request: HttpRequest) -> HttpResponse:
-        """Wrapper for post requests"""
-        return self.get(request)
-
-    def get(self, request: HttpRequest) -> HttpResponse:
+    def dispatch(self, request: HttpRequest) -> HttpResponse:
         """Delete currently pending user"""
         user = self.get_pending_user()
         if not user.is_authenticated:

--- a/authentik/stages/user_login/stage.py
+++ b/authentik/stages/user_login/stage.py
@@ -41,17 +41,11 @@ class UserLoginStageView(ChallengeStageView):
             }
         )
 
-    def post(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
-        """Wrapper for post requests"""
+    def dispatch(self, request: HttpRequest) -> HttpResponse:
+        """Check for remember_me, and do login"""
         stage: UserLoginStage = self.executor.current_stage
         if timedelta_from_string(stage.remember_me_offset).total_seconds() > 0:
-            return super().post(request, *args, **kwargs)
-        return self.do_login(request)
-
-    def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
-        stage: UserLoginStage = self.executor.current_stage
-        if timedelta_from_string(stage.remember_me_offset).total_seconds() > 0:
-            return super().get(request, *args, **kwargs)
+            return super().dispatch(request)
         return self.do_login(request)
 
     def challenge_valid(self, response: UserLoginChallengeResponse) -> HttpResponse:

--- a/authentik/stages/user_logout/stage.py
+++ b/authentik/stages/user_logout/stage.py
@@ -8,7 +8,7 @@ from authentik.flows.stage import StageView
 class UserLogoutStageView(StageView):
     """Finalise Authentication flow by logging the user in"""
 
-    def get(self, request: HttpRequest) -> HttpResponse:
+    def dispatch(self, request: HttpRequest) -> HttpResponse:
         """Remove the user from the current session"""
         self.logger.debug(
             "Logged out",
@@ -17,7 +17,3 @@ class UserLogoutStageView(StageView):
         )
         logout(self.request)
         return self.executor.stage_ok()
-
-    def post(self, request: HttpRequest) -> HttpResponse:
-        """Wrapper for post requests"""
-        return self.get(request)

--- a/authentik/stages/user_write/stage.py
+++ b/authentik/stages/user_write/stage.py
@@ -51,10 +51,6 @@ class UserWriteStageView(StageView):
             attrs = attrs.get(comp)
         attrs[parts[-1]] = value
 
-    def post(self, request: HttpRequest) -> HttpResponse:
-        """Wrapper for post requests"""
-        return self.get(request)
-
     def ensure_user(self) -> tuple[Optional[User], bool]:
         """Ensure a user exists"""
         user_created = False
@@ -127,7 +123,7 @@ class UserWriteStageView(StageView):
             if connection.source.name not in user.attributes[USER_ATTRIBUTE_SOURCES]:
                 user.attributes[USER_ATTRIBUTE_SOURCES].append(connection.source.name)
 
-    def get(self, request: HttpRequest) -> HttpResponse:
+    def dispatch(self, request: HttpRequest) -> HttpResponse:
         """Save data in the current flow to the currently pending user. If no user is pending,
         a new user is created."""
         if PLAN_CONTEXT_PROMPT not in self.executor.plan.context:


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

This is just some cleanup; removes the need for a wrapper for `post()` calls when the stage does the same for both methods, by using django's dispatch

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
