### PR TITLE
stages/password: move password validation to serializer

### DIFF
--- a/authentik/flows/exceptions.py
+++ b/authentik/flows/exceptions.py
@@ -26,3 +26,8 @@ class EmptyFlowException(SentryIgnoredException):
 
 class FlowSkipStageException(SentryIgnoredException):
     """Exception to skip a stage"""
+
+
+class StageInvalidException(SentryIgnoredException):
+    """Exception can be thrown in a `Challenge` or `ChallengeResponse` serializer's
+    validation to trigger a `executor.stage_invalid()` response"""

--- a/authentik/stages/password/stage.py
+++ b/authentik/stages/password/stage.py
@@ -7,7 +7,7 @@ from django.core.exceptions import PermissionDenied
 from django.http import HttpRequest, HttpResponse
 from django.urls import reverse
 from django.utils.translation import gettext as _
-from rest_framework.exceptions import ErrorDetail, ValidationError
+from rest_framework.exceptions import ValidationError
 from rest_framework.fields import CharField
 from sentry_sdk.hub import Hub
 from structlog.stdlib import get_logger
@@ -20,6 +20,7 @@ from authentik.flows.challenge import (
     ChallengeTypes,
     WithUserInfoChallenge,
 )
+from authentik.flows.exceptions import StageInvalidException
 from authentik.flows.models import Flow, FlowDesignation, Stage
 from authentik.flows.planner import PLAN_CONTEXT_PENDING_USER
 from authentik.flows.stage import ChallengeStageView
@@ -79,9 +80,52 @@ class PasswordChallenge(WithUserInfoChallenge):
 class PasswordChallengeResponse(ChallengeResponse):
     """Password challenge response"""
 
+    component = CharField(default="ak-stage-password")
+
     password = CharField(trim_whitespace=False)
 
-    component = CharField(default="ak-stage-password")
+    def validate_password(self, password: str) -> str | None:
+        """Validate password and authenticate user"""
+        executor = self.stage.executor
+        if PLAN_CONTEXT_PENDING_USER not in executor.plan.context:
+            raise StageInvalidException("No pending user")
+        # Get the pending user's username, which is used as
+        # an Identifier by most authentication backends
+        pending_user: User = executor.plan.context[PLAN_CONTEXT_PENDING_USER]
+        auth_kwargs = {
+            "password": password,
+            "username": pending_user.username,
+        }
+        try:
+            with Hub.current.start_span(
+                op="authentik.stages.password.authenticate",
+                description="User authenticate call",
+            ):
+                user = authenticate(
+                    self.stage.request,
+                    executor.current_stage.backends,
+                    executor.current_stage,
+                    **auth_kwargs,
+                )
+        except PermissionDenied as exc:
+            del auth_kwargs["password"]
+            # User was found, but permission was denied (i.e. user is not active)
+            self.stage.logger.debug("Denied access", **auth_kwargs)
+            raise StageInvalidException("Denied access") from exc
+        except ValidationError as exc:
+            del auth_kwargs["password"]
+            # User was found, authentication succeeded, but another signal raised an error
+            # (most likely LDAP)
+            self.stage.logger.debug("Validation error from signal", exc=exc, **auth_kwargs)
+            raise StageInvalidException("Validation error") from exc
+        if not user:
+            # No user was found -> invalid credentials
+            self.stage.logger.info("Invalid credentials")
+            raise ValidationError(_("Invalid password"), "invalid")
+        # User instance returned from authenticate() has .backend property set
+        executor.plan.context[PLAN_CONTEXT_PENDING_USER] = user
+        executor.plan.context[PLAN_CONTEXT_AUTHENTICATION_BACKEND] = user.backend
+        return password
 
 
 class PasswordStageView(ChallengeStageView):
@@ -122,43 +166,4 @@ class PasswordStageView(ChallengeStageView):
         """Authenticate against django's authentication backend"""
         if PLAN_CONTEXT_PENDING_USER not in self.executor.plan.context:
             return self.executor.stage_invalid()
-        # Get the pending user's username, which is used as
-        # an Identifier by most authentication backends
-        pending_user: User = self.executor.plan.context[PLAN_CONTEXT_PENDING_USER]
-        auth_kwargs = {
-            "password": response.validated_data.get("password", None),
-            "username": pending_user.username,
-        }
-        try:
-            with Hub.current.start_span(
-                op="authentik.stages.password.authenticate",
-                description="User authenticate call",
-            ):
-                user = authenticate(
-                    self.request,
-                    self.executor.current_stage.backends,
-                    self.executor.current_stage,
-                    **auth_kwargs,
-                )
-        except PermissionDenied:
-            del auth_kwargs["password"]
-            # User was found, but permission was denied (i.e. user is not active)
-            self.logger.debug("Denied access", **auth_kwargs)
-            return self.executor.stage_invalid()
-        except ValidationError as exc:
-            del auth_kwargs["password"]
-            # User was found, authentication succeeded, but another signal raised an error
-            # (most likely LDAP)
-            self.logger.debug("Validation error from signal", exc=exc, **auth_kwargs)
-            return self.executor.stage_invalid()
-        if not user:
-            # No user was found -> invalid credentials
-            self.logger.info("Invalid credentials")
-            # Manually inject error into form
-            response._errors.setdefault("password", [])
-            response._errors["password"].append(ErrorDetail(_("Invalid password"), "invalid"))
-            return self.challenge_invalid(response)
-        # User instance returned from authenticate() has .backend property set
-        self.executor.plan.context[PLAN_CONTEXT_PENDING_USER] = user
-        self.executor.plan.context[PLAN_CONTEXT_AUTHENTICATION_BACKEND] = user.backend
         return self.executor.stage_ok()


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

fix password stage not supporting stage binding's `restart` and `restart_with_context` modes

the restart is only triggered in the `ChallengeStageView`'s `post` handler, which is not reached when calling `stage_invalid()`. The idea is also that no validation should happen in the `challenge_valid` function of a ChallengeStageView, the validation should happen in the serializer

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
