### PR TITLE
web/admin: fix not being able to unset certificates

### DIFF
--- a/web/src/admin/common/ak-crypto-certificate-search.ts
+++ b/web/src/admin/common/ak-crypto-certificate-search.ts
@@ -69,7 +69,7 @@ export class AkCryptoCertificateSearch extends CustomListenerElement(AKElement) 
     }
 
     get value() {
-        return this.selectedKeypair ? renderValue(this.selectedKeypair) : undefined;
+        return this.selectedKeypair ? renderValue(this.selectedKeypair) : null;
     }
 
     connectedCallback() {

--- a/web/src/admin/providers/oauth2/OAuth2ProviderForm.ts
+++ b/web/src/admin/providers/oauth2/OAuth2ProviderForm.ts
@@ -205,8 +205,8 @@ ${this.instance?.redirectUris}</textarea
                     </ak-form-element-horizontal>
                     <ak-form-element-horizontal label=${msg("Signing Key")} name="signingKey">
                         <ak-crypto-certificate-search
-                            certificate=${this.instance?.signingKey}
-                            singleton
+                            certificate=${ifDefined(this.instance?.signingKey || "")}
+                            ?singleton=${!this.instance}
                         ></ak-crypto-certificate-search>
                         <p class="pf-c-form__helper-text">${msg("Key used to sign the tokens.")}</p>
                     </ak-form-element-horizontal>


### PR DESCRIPTION
This replaces the `undefined` setting of the certificate search wrapper to `null` when the admin requests no certificate.  The `undefined` setting was being elided by the `fetch` function, and the back-end ignored any changes to the field because it was not named and therefore did not, by the back-end's logic, need updating.

This fix closes [Github Issue 6742](https://github.com/goauthentik/authentik/issues/6742)

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [✓] Local tests pass (`ak test authentik/`)
-   [✓] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [✓] The code has been formatted (`make web`)
-   [✓] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
