### PR TITLE
root: lock node to 20.5

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -23,7 +23,7 @@ runs:
     - name: Setup node
       uses: actions/setup-node@v3
       with:
-        node-version: "20"
+        node-version: "20.5"
         cache: "npm"
         cache-dependency-path: web/package-lock.json
     - name: Setup dependencies

--- a/.github/workflows/ci-outpost.yml
+++ b/.github/workflows/ci-outpost.yml
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: "go.mod"
-      - uses: actions/setup-node@v3.8.1
+      - uses: actions/setup-node@v3
         with:
           node-version: "20.5"
           cache: "npm"

--- a/.github/workflows/ci-outpost.yml
+++ b/.github/workflows/ci-outpost.yml
@@ -122,7 +122,7 @@ jobs:
           go-version-file: "go.mod"
       - uses: actions/setup-node@v3.8.1
         with:
-          node-version: "20"
+          node-version: "20.5"
           cache: "npm"
           cache-dependency-path: web/package-lock.json
       - name: Generate API

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3.8.1
+      - uses: actions/setup-node@v3
         with:
           node-version: "20.5"
           cache: "npm"
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3.8.1
+      - uses: actions/setup-node@v3
         with:
           node-version: "20.5"
           cache: "npm"
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3.8.1
+      - uses: actions/setup-node@v3
         with:
           node-version: "20.5"
           cache: "npm"
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3.8.1
+      - uses: actions/setup-node@v3
         with:
           node-version: "20.5"
           cache: "npm"
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3.8.1
+      - uses: actions/setup-node@v3
         with:
           node-version: "20.5"
           cache: "npm"

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3.8.1
         with:
-          node-version: "20"
+          node-version: "20.5"
           cache: "npm"
           cache-dependency-path: web/package-lock.json
       - working-directory: web/
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3.8.1
         with:
-          node-version: "20"
+          node-version: "20.5"
           cache: "npm"
           cache-dependency-path: web/package-lock.json
       - working-directory: web/
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3.8.1
         with:
-          node-version: "20"
+          node-version: "20.5"
           cache: "npm"
           cache-dependency-path: web/package-lock.json
       - working-directory: web/
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3.8.1
         with:
-          node-version: "20"
+          node-version: "20.5"
           cache: "npm"
           cache-dependency-path: web/package-lock.json
       - working-directory: web/
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3.8.1
         with:
-          node-version: "20"
+          node-version: "20.5"
           cache: "npm"
           cache-dependency-path: web/package-lock.json
       - working-directory: web/

--- a/.github/workflows/ci-website.yml
+++ b/.github/workflows/ci-website.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3.8.1
+      - uses: actions/setup-node@v3
         with:
           node-version: "20.5"
           cache: "npm"
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3.8.1
+      - uses: actions/setup-node@v3
         with:
           node-version: "20.5"
           cache: "npm"
@@ -50,7 +50,7 @@ jobs:
           - build-docs-only
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3.8.1
+      - uses: actions/setup-node@v3
         with:
           node-version: "20.5"
           cache: "npm"

--- a/.github/workflows/ci-website.yml
+++ b/.github/workflows/ci-website.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3.8.1
         with:
-          node-version: "20"
+          node-version: "20.5"
           cache: "npm"
           cache-dependency-path: website/package-lock.json
       - working-directory: website/
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3.8.1
         with:
-          node-version: "20"
+          node-version: "20.5"
           cache: "npm"
           cache-dependency-path: website/package-lock.json
       - working-directory: website/
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3.8.1
         with:
-          node-version: "20"
+          node-version: "20.5"
           cache: "npm"
           cache-dependency-path: website/package-lock.json
       - working-directory: website/

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -112,7 +112,7 @@ jobs:
           go-version-file: "go.mod"
       - uses: actions/setup-node@v3.8.1
         with:
-          node-version: "20"
+          node-version: "20.5"
           cache: "npm"
           cache-dependency-path: web/package-lock.json
       - name: Build web

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -110,7 +110,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: "go.mod"
-      - uses: actions/setup-node@v3.8.1
+      - uses: actions/setup-node@v3
         with:
           node-version: "20.5"
           cache: "npm"

--- a/.github/workflows/web-api-publish.yml
+++ b/.github/workflows/web-api-publish.yml
@@ -19,7 +19,7 @@ jobs:
           token: ${{ steps.generate_token.outputs.token }}
       - uses: actions/setup-node@v3.8.1
         with:
-          node-version: "20"
+          node-version: "20.5"
           registry-url: "https://registry.npmjs.org"
       - name: Generate API Client
         run: make gen-client-ts

--- a/.github/workflows/web-api-publish.yml
+++ b/.github/workflows/web-api-publish.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ steps.generate_token.outputs.token }}
-      - uses: actions/setup-node@v3.8.1
+      - uses: actions/setup-node@v3
         with:
           node-version: "20.5"
           registry-url: "https://registry.npmjs.org"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build website
-FROM --platform=${BUILDPLATFORM} docker.io/node:20 as website-builder
+FROM --platform=${BUILDPLATFORM} docker.io/node:20.5 as website-builder
 
 COPY ./website /work/website/
 COPY ./blueprints /work/blueprints/
@@ -10,7 +10,7 @@ WORKDIR /work/website
 RUN npm ci --include=dev && npm run build-docs-only
 
 # Stage 2: Build webui
-FROM --platform=${BUILDPLATFORM} docker.io/node:20 as web-builder
+FROM --platform=${BUILDPLATFORM} docker.io/node:20.5 as web-builder
 
 COPY ./web /work/web/
 COPY ./website /work/website/

--- a/proxy.Dockerfile
+++ b/proxy.Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build website
-FROM --platform=${BUILDPLATFORM} docker.io/node:20 as web-builder
+FROM --platform=${BUILDPLATFORM} docker.io/node:20.5 as web-builder
 
 COPY ./web /static/
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

Node 20.6 broke some things

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
