### PR TITLE
flows: stage_invalid() makes flow restart depending on invalid_response_action setting

### DIFF
--- a/authentik/flows/views/executor.py
+++ b/authentik/flows/views/executor.py
@@ -123,7 +123,7 @@ class FlowExecutorView(APIView):
     flow: Flow
 
     plan: Optional[FlowPlan] = None
-    current_binding: FlowStageBinding
+    current_binding: Optional[FlowStageBinding] = None
     current_stage: Stage
     current_stage_view: View
 
@@ -429,7 +429,7 @@ class FlowExecutorView(APIView):
         Optionally, an exception can be passed, which will be shown if the current user
         is a superuser."""
         self._logger.debug("f(exec): Stage invalid")
-        if self.current_binding.invalid_response_action in [
+        if self.current_binding and self.current_binding.invalid_response_action in [
             InvalidResponseAction.RESTART,
             InvalidResponseAction.RESTART_WITH_CONTEXT,
         ]:
@@ -437,7 +437,7 @@ class FlowExecutorView(APIView):
                 self.current_binding.invalid_response_action
                 == InvalidResponseAction.RESTART_WITH_CONTEXT
             )
-            self.logger.debug(
+            self._logger.debug(
                 "f(exec): Invalid response, restarting flow",
                 keep_context=keep_context,
             )


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

Instead of always stopping the flow as-is when calling `executor.stage_invalid()`, honour the `invalid_response_action` setting and restart the flow

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
