### PR TITLE
sources/ldap: dont prefetch useless items

### DIFF
--- a/authentik/sources/ldap/sync/groups.py
+++ b/authentik/sources/ldap/sync/groups.py
@@ -18,6 +18,9 @@ class GroupLDAPSynchronizer(BaseLDAPSynchronizer):
         return "groups"
 
     def get_objects(self, **kwargs) -> Generator:
+        if not self._source.sync_groups:
+            self.message("Group syncing is disabled for this Source")
+            return iter(())
         return self.search_paginator(
             search_base=self.base_dn_groups,
             search_filter=self._source.group_object_filter,

--- a/authentik/sources/ldap/sync/membership.py
+++ b/authentik/sources/ldap/sync/membership.py
@@ -24,6 +24,9 @@ class MembershipLDAPSynchronizer(BaseLDAPSynchronizer):
         return "membership"
 
     def get_objects(self, **kwargs) -> Generator:
+        if not self._source.sync_groups:
+            self.message("Group syncing is disabled for this Source")
+            return iter(())
         return self.search_paginator(
             search_base=self.base_dn_groups,
             search_filter=self._source.group_object_filter,

--- a/authentik/sources/ldap/sync/users.py
+++ b/authentik/sources/ldap/sync/users.py
@@ -20,6 +20,9 @@ class UserLDAPSynchronizer(BaseLDAPSynchronizer):
         return "users"
 
     def get_objects(self, **kwargs) -> Generator:
+        if not self._source.sync_users:
+            self.message("User syncing is disabled for this Source")
+            return iter(())
         return self.search_paginator(
             search_base=self.base_dn_users,
             search_filter=self._source.user_object_filter,


### PR DESCRIPTION
While looking into LDAP synchronization, I realized that it is actually fetching all the groups and memberships from the LDAP server, even if group synchronization is disabled for a source. I fixed this.
