### PR TITLE
root: move root-dir in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -145,8 +145,6 @@ LABEL org.opencontainers.image.authors="Authentik Security Inc." \
     org.opencontainers.image.vendor="Authentik Security Inc." \
     org.opencontainers.image.version=${VERSION}
 
-WORKDIR /
-
 # We cannot cache this layer otherwise we'll end up with a bigger image
 RUN apt-get update && \
     apt-get upgrade -y && \
@@ -157,28 +155,26 @@ RUN apt-get update && \
     pip3 install --no-cache-dir --upgrade pip && \
     apt-get clean && \
     rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/ && \
-    adduser --system --no-create-home --uid 1000 --group --home /authentik authentik && \
+    adduser --system --no-create-home --uid 1000 --group --home /ak-root authentik && \
     mkdir -p /certs /media /blueprints && \
-    mkdir -p /authentik/.ssh && \
-    mkdir -p /ak-root && \
-    chown authentik:authentik /certs /media /authentik/.ssh /ak-root
+    mkdir -p /ak-root/authentik/.ssh && \
+    chown authentik:authentik /certs /media /ak-root/authentik/.ssh /ak-root
 
-COPY ./authentik/ /authentik
-COPY ./pyproject.toml /
-COPY ./uv.lock /
-COPY ./schemas /schemas
-COPY ./locale /locale
-COPY ./tests /tests
-COPY ./manage.py /
+COPY ./authentik/ /ak-root/authentik
+COPY ./pyproject.toml /ak-root/
+COPY ./uv.lock /ak-root/
+COPY ./schemas /ak-root/schemas
+COPY ./locale /ak-root/locale
+COPY ./tests /ak-root/tests
+COPY ./manage.py /ak-root/
 COPY ./blueprints /blueprints
-COPY ./lifecycle/ /lifecycle
+COPY ./lifecycle/ /ak-root/lifecycle
 COPY ./authentik/sources/kerberos/krb5.conf /etc/krb5.conf
 COPY --from=go-builder /go/authentik /bin/authentik
 COPY ./packages/ /ak-root/packages
-RUN  ln -s /ak-root/packages /packages
 COPY --from=python-deps /ak-root/.venv /ak-root/.venv
-COPY --from=node-builder /work/web/dist/ /web/dist/
-COPY --from=node-builder /work/web/authentik/ /web/authentik/
+COPY --from=node-builder /work/web/dist/ /ak-root/web/dist/
+COPY --from=node-builder /work/web/authentik/ /ak-root/web/authentik/
 COPY --from=geoip /usr/share/GeoIP /geoip
 
 USER 1000
@@ -189,5 +185,7 @@ ENV TMPDIR=/dev/shm/ \
     GOFIPS=1
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=60s --retries=3 CMD [ "ak", "healthcheck" ]
+
+WORKDIR /ak-root
 
 ENTRYPOINT [ "dumb-init", "--", "ak" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ FROM ghcr.io/astral-sh/uv:0.8.11 AS uv
 FROM ghcr.io/goauthentik/fips-python:3.13.6-slim-bookworm-fips AS python-base
 
 ENV VENV_PATH="/ak-root/.venv" \
-    PATH="/lifecycle:/ak-root/.venv/bin:$PATH" \
+    PATH="/ak-root/lifecycle:/ak-root/venv/bin:$PATH" \
     UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
     UV_NATIVE_TLS=1 \

--- a/lifecycle/ak
+++ b/lifecycle/ak
@@ -68,9 +68,28 @@ function prepare_debug {
     chown authentik:authentik /unittest.xml
 }
 
+function migrate_container_change_root_dir {
+    # With authentik 2025.2 we're moving the root directory of the authentik app
+    # into /ak-root, mainly to not clutter the root filesystem of the container
+    # and to make it possible to use devcontainers in the future.
+    # In most installs this migration isn't required as no files are mounted into
+    # these directories, however it is used if scripts are overwritten from the outside
+    # or more commonly the flow background image is overwritten in `/web`
+    if [ -d /authentik ]; then
+        log "Legacy /authentik folder exist, migrating files"
+        cp -rp /authentik/* /ak-root/authentik
+    fi
+    if [ ! -d /web ]; then
+        log "Legacy /web folder exist, migrating files"
+        cp -rp /web/* /ak-root/web
+    fi
+}
+
 if [[ "$(python -m authentik.lib.config debugger 2>/dev/null)" == "True" ]]; then
     prepare_debug
 fi
+
+migrate_container_change_root_dir
 
 if [[ "$1" == "server" ]]; then
     set_mode "server"

--- a/lifecycle/ak
+++ b/lifecycle/ak
@@ -75,6 +75,10 @@ function migrate_container_change_root_dir {
     # In most installs this migration isn't required as no files are mounted into
     # these directories, however it is used if scripts are overwritten from the outside
     # or more commonly the flow background image is overwritten in `/web`
+    # Check if we're in a container
+    if [ ! -d /ak-root ]; then
+        return
+    fi
     if [ -d /authentik ]; then
         log "Legacy /authentik folder exist, migrating files"
         cp -rp /authentik/* /ak-root/authentik

--- a/lifecycle/ak
+++ b/lifecycle/ak
@@ -69,7 +69,7 @@ function prepare_debug {
 }
 
 function migrate_container_change_root_dir {
-    # With authentik 2025.2 we're moving the root directory of the authentik app
+    # With authentik 2025.10 we're moving the root directory of the authentik app
     # into /ak-root, mainly to not clutter the root filesystem of the container
     # and to make it possible to use devcontainers in the future.
     # In most installs this migration isn't required as no files are mounted into


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

related to #5677 

move the main code into /ak-root alongside the venv, which makes it easier when using with dev-containers to map the local dir into the container

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
