### PR TITLE
root: fix dumb-init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -151,4 +151,4 @@ ENV TMPDIR=/dev/shm/ \
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=60s --retries=3 CMD [ "/lifecycle/ak", "healthcheck" ]
 
-ENTRYPOINT [ "/usr/local/bin/dumb-init", "--", "/lifecycle/ak" ]
+ENTRYPOINT [ "dumb-init", "--", "/lifecycle/ak" ]


### PR DESCRIPTION
## Details

Following #5341, dumb-init is now in /ak-root/venv/bin. Sorta related to #6848 

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
