### PR TITLE
web: remove admin-to-user component reference(s)

### DIFF
--- a/web/src/admin/applications/ApplicationListPage.ts
+++ b/web/src/admin/applications/ApplicationListPage.ts
@@ -3,6 +3,7 @@ import "@goauthentik/admin/applications/wizard/ApplicationWizard";
 import { PFSize } from "@goauthentik/app/elements/Spinner";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
 import { uiConfig } from "@goauthentik/common/ui/config";
+import "@goauthentik/components/ak-app-icon";
 import MDApplication from "@goauthentik/docs/core/applications.md";
 import "@goauthentik/elements/Markdown";
 import "@goauthentik/elements/buttons/SpinnerButton";
@@ -12,7 +13,6 @@ import { getURLParam } from "@goauthentik/elements/router/RouteMatch";
 import { PaginatedResponse } from "@goauthentik/elements/table/Table";
 import { TableColumn } from "@goauthentik/elements/table/Table";
 import { TablePage } from "@goauthentik/elements/table/TablePage";
-import "@goauthentik/user/LibraryApplication/AppIcon";
 import "@patternfly/elements/pf-tooltip/pf-tooltip.js";
 
 import { msg } from "@lit/localize";

--- a/web/src/admin/applications/ApplicationViewPage.ts
+++ b/web/src/admin/applications/ApplicationViewPage.ts
@@ -4,13 +4,13 @@ import "@goauthentik/admin/applications/ApplicationForm";
 import "@goauthentik/admin/policies/BoundPoliciesList";
 import { PFSize } from "@goauthentik/app/elements/Spinner";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
+import "@goauthentik/components/ak-app-icon";
 import { AKElement } from "@goauthentik/elements/Base";
 import "@goauthentik/elements/EmptyState";
 import "@goauthentik/elements/PageHeader";
 import "@goauthentik/elements/Tabs";
 import "@goauthentik/elements/buttons/SpinnerButton";
 import "@goauthentik/elements/events/ObjectChangelog";
-import "@goauthentik/user/LibraryApplication/AppIcon";
 
 import { msg } from "@lit/localize";
 import { CSSResult, TemplateResult, html } from "lit";

--- a/web/src/components/ak-app-icon.ts
+++ b/web/src/components/ak-app-icon.ts
@@ -81,3 +81,5 @@ export class AppIcon extends AKElement {
         return html`<span class="icon">${this.app?.name.charAt(0).toUpperCase()}</span>`;
     }
 }
+
+export default AppIcon;

--- a/web/src/user/LibraryApplication/index.ts
+++ b/web/src/user/LibraryApplication/index.ts
@@ -1,14 +1,16 @@
 import { PFSize } from "@goauthentik/app/elements/Spinner";
 import { truncateWords } from "@goauthentik/common/utils";
+import "@goauthentik/components/ak-app-icon";
 import { AKElement, rootInterface } from "@goauthentik/elements/Base";
 import "@goauthentik/elements/Expand";
-import "@goauthentik/user/LibraryApplication/AppIcon";
 import { UserInterface } from "@goauthentik/user/UserInterface";
 
 import { msg } from "@lit/localize";
-import { CSSResult, TemplateResult, css, html } from "lit";
+import { CSSResult, TemplateResult, css, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
+import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
+import { styleMap } from "lit/directives/style-map.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFCard from "@patternfly/patternfly/components/Card/card.css";
@@ -62,23 +64,44 @@ export class LibraryApplication extends AKElement {
         ];
     }
 
+    renderExpansion(application: Application) {
+        const me = rootInterface<UserInterface>()?.me;
+
+        return html`<ak-expand textOpen=${msg("Less details")} textClosed=${msg("More details")}>
+            <div class="pf-c-content">
+                <small>${application.metaPublisher}</small>
+            </div>
+            ${truncateWords(application.metaDescription || "", 10)}
+            ${rootInterface()?.uiConfig?.enabledFeatures.applicationEdit && me?.user.isSuperuser
+                ? html`
+                      <a
+                          class="pf-c-button pf-m-control pf-m-small pf-m-block"
+                          href="/if/admin/#/core/applications/${application?.slug}"
+                      >
+                          <i class="fas fa-edit"></i>&nbsp;${msg("Edit")}
+                      </a>
+                  `
+                : html``}
+        </ak-expand>`;
+    }
+
     render(): TemplateResult {
         if (!this.application) {
             return html`<ak-spinner></ak-spinner>`;
         }
+
         const me = rootInterface<UserInterface>()?.me;
-        let expandable = false;
-        if (rootInterface()?.uiConfig?.enabledFeatures.applicationEdit && me?.user.isSuperuser) {
-            expandable = true;
-        }
-        if (this.application.metaPublisher !== "" || this.application.metaDescription !== "") {
-            expandable = true;
-        }
+        const expandable =
+            (rootInterface()?.uiConfig?.enabledFeatures.applicationEdit && me?.user.isSuperuser) ||
+            this.application.metaPublisher !== "" ||
+            this.application.metaDescription !== "";
+
+        const classes = { "pf-m-selectable pf-m-selected": this.selected };
+        const styles = this.background ? { background: this.background } : {};
+
         return html` <div
-            class="pf-c-card pf-m-hoverable pf-m-compact ${this.selected
-                ? "pf-m-selectable pf-m-selected"
-                : ""}"
-            style=${this.background !== "" ? `background: ${this.background} !important` : ""}
+            class="pf-c-card pf-m-hoverable pf-m-compact ${classMap(classes)}"
+            style=${styleMap(styles)}
         >
             <div class="pf-c-card__header">
                 <a
@@ -96,25 +119,7 @@ export class LibraryApplication extends AKElement {
                 >
             </div>
             <div class="expander"></div>
-            ${expandable
-                ? html`<ak-expand textOpen=${msg("Less details")} textClosed=${msg("More details")}>
-                      <div class="pf-c-content">
-                          <small>${this.application.metaPublisher}</small>
-                      </div>
-                      ${truncateWords(this.application.metaDescription || "", 10)}
-                      ${rootInterface()?.uiConfig?.enabledFeatures.applicationEdit &&
-                      me?.user.isSuperuser
-                          ? html`
-                                <a
-                                    class="pf-c-button pf-m-control pf-m-small pf-m-block"
-                                    href="/if/admin/#/core/applications/${this.application?.slug}"
-                                >
-                                    <i class="fas fa-edit"></i>&nbsp;${msg("Edit")}
-                                </a>
-                            `
-                          : html``}
-                  </ak-expand>`
-                : html``}
+            ${expandable ? this.renderExpansion(this.application) : nothing}
         </div>`;
     }
 }


### PR DESCRIPTION
There was only one: AppIcon.  This has been moved to `components`.
    
Touching the LibraryApplications page triggered a cyclomatic complexity check.  Extracting the expansion block and streamlining the class and style declarations with lit directives helped.

## Checklist

-   [X] Local tests pass (`ak test authentik/`)
-   [X] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [N/A] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [X] The code has been formatted (`make web`)
-   [N/A] The translation files have been updated (`make i18n-extract`)

If applicable

-   [N/A] The documentation has been updated
-   [N/A] The documentation has been formatted (`make website`)
