### PR TITLE
root: fix gunicorn not starting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,11 +75,11 @@ RUN --mount=type=secret,id=GEOIPUPDATE_ACCOUNT_ID \
 # Stage 5: Python dependencies
 FROM docker.io/python:3.11.5-bookworm AS python-deps
 
-WORKDIR /work/poetry
+WORKDIR /ak-root/poetry
 
-ENV VENV_PATH="/work/venv" \
+ENV VENV_PATH="/ak-root/venv" \
     POETRY_VIRTUALENVS_CREATE=false \
-    PATH="/work/venv/bin:$PATH"
+    PATH="/ak-root/venv/bin:$PATH"
 
 RUN --mount=type=cache,target=/var/cache/apt \
     apt-get update && \
@@ -90,7 +90,7 @@ RUN --mount=type=bind,target=./pyproject.toml,src=./pyproject.toml \
     --mount=type=bind,target=./poetry.lock,src=./poetry.lock \
     --mount=type=cache,target=/root/.cache/pip \
     --mount=type=cache,target=/root/.cache/pypoetry \
-    python -m venv /work/venv/ && \
+    python -m venv /ak-root/venv/ && \
     pip3 install --upgrade pip && \
     pip3 install poetry && \
     poetry install --only=main --no-ansi --no-interaction
@@ -134,7 +134,7 @@ COPY ./manage.py /
 COPY ./blueprints /blueprints
 COPY ./lifecycle/ /lifecycle
 COPY --from=go-builder /go/authentik /bin/authentik
-COPY --from=python-deps /work/venv /ak-root/venv
+COPY --from=python-deps /ak-root/venv /ak-root/venv
 COPY --from=web-builder /work/web/dist/ /web/dist/
 COPY --from=web-builder /work/web/authentik/ /web/authentik/
 COPY --from=website-builder /work/website/help/ /website/help/


### PR DESCRIPTION
## Details

Gunicorn ended up with a shebang of `/work/venv/bin/python`. Building the venv in the same path as where it's copied fixes that. Also, I have now tested that authentik starts and I can access stuff.

Related: #5341 #6848 #6853

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
