### PR TITLE
sources/ldap: made ldap_sync_single calls from ldap_sync_all asynchronous

### DIFF
--- a/authentik/sources/ldap/tasks.py
+++ b/authentik/sources/ldap/tasks.py
@@ -30,7 +30,7 @@ CACHE_KEY_PREFIX = "goauthentik.io/sources/ldap/page/"
 def ldap_sync_all():
     """Sync all sources"""
     for source in LDAPSource.objects.filter(enabled=True):
-        ldap_sync_single(source.pk)
+        ldap_sync_single.apply_async(args=[source.pk])
 
 
 @CELERY_APP.task(


### PR DESCRIPTION
Contrary to the commit message of d36574fc1a9c2f21e3f3bb0f0652fb5f05c7f435, ldap_sync_all does not call ldap_sync_single asynchronously. This leads to timeout, if the ldap_sync_single calls take more than 10 minutes in total.

This change fixes the issue.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
