### PR TITLE
website: edited .toml file added redirect

### DIFF
--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -7,6 +7,11 @@
   from = "/docs/integrations/*"
   to = "/integrations/:splat"
 
+# Redirects for file name changes
+[[redirects]]
+  from = "/docs/installation/configuration.md"
+  to = "/docs/installation/configuration.mdx"
+
 # Docusaurus update removes index
 [[redirects]]
   from = "/docs/:firstPart/index"


### PR DESCRIPTION
This PR is to add a redirect to the `netlify.toml` page, to handle the file name change in PR #6854 

I *think this PR has to be merged first, so that 6584 can successfully build, but let me know if that's not right.

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
