### PR TITLE
sources/ldap: fix inverted interpretation of FreeIPA nsaccountlock

### DIFF
--- a/authentik/sources/ldap/sync/vendor/freeipa.py
+++ b/authentik/sources/ldap/sync/vendor/freeipa.py
@@ -47,9 +47,11 @@ class FreeIPA(BaseLDAPSynchronizer):
             return
         # For some reason, nsaccountlock is not defined properly in the schema as bool
         # hence we get it as a list of strings
-        _is_active = str(self._flatten(attributes.get("nsaccountlock", ["FALSE"])))
+        _is_locked = str(self._flatten(attributes.get("nsaccountlock", ["FALSE"])))
         # So we have to attempt to convert it to a bool
-        is_active = _is_active.lower() == "true"
+        is_locked = _is_locked.lower() == "true"
+        # And then invert it since freeipa saves locked and we save active
+        is_active = not is_locked
         if is_active != user.is_active:
             user.is_active = is_active
             user.save()

--- a/authentik/sources/ldap/tests/test_sync.py
+++ b/authentik/sources/ldap/tests/test_sync.py
@@ -137,6 +137,7 @@ class LDAPSyncTests(TestCase):
             user_sync.sync_full()
             self.assertTrue(User.objects.filter(username="user0_sn").exists())
             self.assertFalse(User.objects.filter(username="user1_sn").exists())
+            self.assertFalse(User.objects.get(username="user-nsaccountlock").is_active)
 
     def test_sync_groups_ad(self):
         """Test group sync"""


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

This should've been caught in the last PR for this, but we didn't actually check the is_active attribute in the added tests

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
