### PR TITLE
lib: add file logging to lib logging

### DIFF
--- a/authentik/lib/default.yml
+++ b/authentik/lib/default.yml
@@ -43,6 +43,7 @@ debug: false
 remote_debug: false
 
 log_level: info
+log_path: ""
 
 error_reporting:
   enabled: false

--- a/authentik/lib/logging.py
+++ b/authentik/lib/logging.py
@@ -76,6 +76,11 @@ def get_logger_config():
                 "class": "logging.StreamHandler",
                 "formatter": "console" if debug else "json",
             },
+            "file": {
+                "class": "logging.handlers.WatchedFileHandler",
+                "filename": "/var/log/authentik/authentik.log",
+                "formatter": "json"
+            }
         },
         "loggers": {},
     }
@@ -101,7 +106,7 @@ def get_logger_config():
     }
     for handler_name, level in handler_level_map.items():
         base_config["loggers"][handler_name] = {
-            "handlers": ["console"],
+            "handlers": ["console", "file"],
             "level": level,
             "propagate": False,
         }

--- a/authentik/lib/logging.py
+++ b/authentik/lib/logging.py
@@ -1,6 +1,7 @@
 """logging helpers"""
 import logging
 from logging import Logger
+import os
 from os import getpid
 
 import structlog
@@ -55,6 +56,9 @@ def get_logger_config():
     """Configure python stdlib's logging"""
     debug = CONFIG.get_bool("debug")
     log_path = CONFIG.get("log_path")
+    # If path doesn't exist create it, this allows for new dirs as well.
+    if log_path:
+        os.makedirs(os.path.dirname(log_path), exist_ok=True)
     global_level = get_log_level()
     base_config = {
         "version": 1,

--- a/authentik/lib/logging.py
+++ b/authentik/lib/logging.py
@@ -54,6 +54,7 @@ def structlog_configure():
 def get_logger_config():
     """Configure python stdlib's logging"""
     debug = CONFIG.get_bool("debug")
+    log_path = CONFIG.get("log_path")
     global_level = get_log_level()
     base_config = {
         "version": 1,
@@ -78,7 +79,7 @@ def get_logger_config():
             },
             "file": {
                 "class": "logging.handlers.WatchedFileHandler",
-                "filename": "/var/log/authentik/authentik.log",
+                "filename": log_path,
                 "formatter": "json"
             }
         },

--- a/internal/config/struct.go
+++ b/internal/config/struct.go
@@ -4,6 +4,7 @@ type Config struct {
 	// Core specific config
 	Paths          PathsConfig          `yaml:"paths"`
 	LogLevel       string               `yaml:"log_level" env:"AUTHENTIK_LOG_LEVEL"`
+	LogPath        string               `yaml:"log_path" env:"AUTHENTIK_LOG_PATH"`
 	ErrorReporting ErrorReportingConfig `yaml:"error_reporting"`
 	Redis          RedisConfig          `yaml:"redis"`
 	Outposts       OutpostConfig        `yaml:"outposts"`


### PR DESCRIPTION
## Details
This add an optional file logging to the logger, this will allow us to choose where we want to log the current console stream into a file.

By default, this is set as empty string and I've added checks so if this isn't set, it won't include it into the logger

This will help with allowing us to create a parse for crowdsec so we can look for the actions  login_failed and invalid_identifier

https://github.com/goauthentik/authentik/issues/3715

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)