### PR TITLE
sources/ldap: add lock to sync

### DIFF
--- a/authentik/sources/ldap/tasks.py
+++ b/authentik/sources/ldap/tasks.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 from celery import chain, group
 from django.core.cache import cache
 from ldap3.core.exceptions import LDAPException
+from redis.lock import Lock, LockError
 from structlog.stdlib import get_logger
 
 from authentik.events.monitored_tasks import MonitoredTask, TaskResult, TaskResultStatus
@@ -45,18 +46,28 @@ def ldap_sync_single(source_pk: str):
     source: LDAPSource = LDAPSource.objects.filter(pk=source_pk).first()
     if not source:
         return
-    task = chain(
-        # User and group sync can happen at once, they have no dependencies on each other
-        group(
-            ldap_sync_paginator(source, UserLDAPSynchronizer)
-            + ldap_sync_paginator(source, GroupLDAPSynchronizer),
-        ),
-        # Membership sync needs to run afterwards
-        group(
-            ldap_sync_paginator(source, MembershipLDAPSynchronizer),
-        ),
-    )
-    task()
+    lock = Lock(cache.client.get_client(), name=f"goauthentik.io/sources/ldap/sync-{source.slug}")
+    if lock.locked():
+        LOGGER.debug("LDAP sync locked, skipping task", source=source.slug)
+        return
+    try:
+        with lock:
+            task = chain(
+                # User and group sync can happen at once, they have no dependencies on each other
+                group(
+                    ldap_sync_paginator(source, UserLDAPSynchronizer)
+                    + ldap_sync_paginator(source, GroupLDAPSynchronizer),
+                ),
+                # Membership sync needs to run afterwards
+                group(
+                    ldap_sync_paginator(source, MembershipLDAPSynchronizer),
+                ),
+            )
+            task()
+    except LockError:
+        # This should never happen, we check if the lock is locked above so this
+        # would only happen if there was some other timeout
+        LOGGER.debug("Failed to acquire lock for LDAP sync", source=source.slug)
 
 
 def ldap_sync_paginator(source: LDAPSource, sync: type[BaseLDAPSynchronizer]) -> list:

--- a/authentik/sources/ldap/tasks.py
+++ b/authentik/sources/ldap/tasks.py
@@ -4,7 +4,8 @@ from uuid import uuid4
 from celery import chain, group
 from django.core.cache import cache
 from ldap3.core.exceptions import LDAPException
-from redis.lock import Lock, LockError
+from redis.exceptions import LockError
+from redis.lock import Lock
 from structlog.stdlib import get_logger
 
 from authentik.events.monitored_tasks import MonitoredTask, TaskResult, TaskResultStatus


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

#6929 #6815

Scheduled tasks are still scheduled by all workers, however for most scheduled tasks this isn't really all that bad (and with #6849 that can be circumvented as well if a lot of workers are deployed), mainly for the LDAP sync task with a large directory, where a sync can take longer than the scheduled interval for it is. This adds a redis-based lock per source that prevents duplicate sync tasks. If a lock is already held or cannot be acquired, the task is skipped

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
