### PR TITLE
website/docs: add info about our docs

### DIFF
--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -3,6 +3,14 @@ title: Welcome to authentik
 slug: /
 ---
 
+## About authentik technical documentation
+
+Our tech docs cover the typical topics, from installation to configuration, adding providers, defining policies and creating login flows, event monitoring, security, and attributes. [Enterprise](./enterprise) version documentation is included here, within our standard tech docs.
+
+-   For information about integrating a specific application or software into authentik, refer to our [Integrations](../integrations) section, accessible from the top menu-bar.
+
+-   For developer-focused documentation, such as using our APIs and blueprints, setting up your development environment, translations, or how to contribute, refer to the [Developer](../developer-docs) area, accessible from the top menu-bar.
+
 ## What is authentik?
 
 authentik is an open-source Identity Provider, focused on flexibility and versatility. With authentik, site administrators, application developers, and security engineers have a dependable and secure solution for authentication in almost any type of environment. There are robust recovery actions available for the users and applications, including user profile and password management. You can quickly edit, deactivate, or even impersonate a user profile, and set a new password for new users or reset an existing password.


### PR DESCRIPTION
I wanted to add some info (to our Welcome page) about where our docs for Integration, APIs, etc. I worry people won't find API and Blueprint etc info, since they are in a diff menu.

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
