### PR TITLE
root: Add setting to adjust database config for pgpool

### DIFF
--- a/authentik/lib/default.yml
+++ b/authentik/lib/default.yml
@@ -7,6 +7,7 @@ postgresql:
   port: 5432
   password: "env://POSTGRES_PASSWORD"
   use_pgbouncer: false
+  use_pgpool: false
 
 listen:
   listen_http: 0.0.0.0:9000

--- a/authentik/root/settings.py
+++ b/authentik/root/settings.py
@@ -279,6 +279,9 @@ DATABASES = {
     }
 }
 
+if CONFIG.get_bool("postgresql.use_pgpool", False):
+    DATABASES["default"]["DISABLE_SERVER_SIDE_CURSORS"] = True
+
 if CONFIG.get_bool("postgresql.use_pgbouncer", False):
     # https://docs.djangoproject.com/en/4.0/ref/databases/#transaction-pooling-server-side-cursors
     DATABASES["default"]["DISABLE_SERVER_SIDE_CURSORS"] = True

--- a/website/docs/installation/configuration.mdx
+++ b/website/docs/installation/configuration.mdx
@@ -63,6 +63,7 @@ To check if your config has been applied correctly, you can run the following co
 -   `AUTHENTIK_POSTGRESQL__PORT`: Database port, defaults to 5432
 -   `AUTHENTIK_POSTGRESQL__PASSWORD`: Database password, defaults to the environment variable `POSTGRES_PASSWORD`
 -   `AUTHENTIK_POSTGRESQL__USE_PGBOUNCER`: Adjust configuration to support connection to PgBouncer
+-   `AUTHENTIK_POSTGRESQL__USE_PGPOOL`: Adjust configuration to support connection to Pgpool
 -   `AUTHENTIK_POSTGRESQL__SSLMODE`: Strictness of ssl verification. Defaults to `verify-ca`
 -   `AUTHENTIK_POSTGRESQL__SSLROOTCERT`: CA root for server ssl verification
 -   `AUTHENTIK_POSTGRESQL__SSLCERT`: Path to x509 client certificate to authenticate to server


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
This PR resolves the connection issues of 2023.8.3 with Pgpool. It adds a parameter `AUTHENTIK_POSTGRESQL__USE_PGPOOL` to disable server side cursors without setting `CONN_MAX_AGE` to `none` (the pgbouncer configuration).

It solves #6896  

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
