### PR TITLE
root: don't exclude enterprise from container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-env
 htmlcov
 *.env.yml
 **/node_modules
@@ -6,7 +5,6 @@ dist/**
 build/**
 build_docs/**
 *Dockerfile
-authentik/enterprise
 blueprints/local
 .git
 !gen-ts-api/node_modules


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

This was excluded in the initial enterprise PR but has somehow been included in previous releases, but now it's excluded again...?

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
