### PR TITLE
root: make postgres connection in makefile customizable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: gen dev-reset all clean test web website
+
 .SHELLFLAGS += -x -e
 PWD = $(shell pwd)
 UID = $(shell id -u)
@@ -219,7 +221,6 @@ install: web-install website-install
 	poetry install
 
 
-.PHONY: dev-drop-db dev-create-db dev-reset
 
 dev-drop-db:
 	dropdb -U $${PG_USER:-postgres} -h $${PG_HOST:-localhost} $${PG_DB:-authentik}
@@ -227,9 +228,7 @@ dev-drop-db:
 	dropdb -U $${PG_USER:-postgres} -h $${PG_HOST:-localhost} test_authentik || true
 	redis-cli -n 0 flushall
 
-
 dev-create-db:
 	createdb -U $${PG_USER:-postgres} -h $${PG_HOST:-localhost} $${PG_DB:-authentik}
-
 
 dev-reset: dev-drop-db dev-create-db migrate  ## Drop and restore the Authentik PostgreSQL instance to a "fresh install" state.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: gen dev-reset all clean test web website
 
-.SHELLFLAGS += -x -e
+.SHELLFLAGS += ${SHELLFLAGS} -e
 PWD = $(shell pwd)
 UID = $(shell id -u)
 GID = $(shell id -g)

--- a/Makefile
+++ b/Makefile
@@ -219,9 +219,9 @@ install: web-install website-install
 	poetry install
 
 dev-reset:
-	dropdb -U postgres -h localhost authentik
+	dropdb -U $${PG_USER:-postgres} -h $${PG_HOST:-localhost} $${PG_DB:-authentik}
 	# Also remove the test-db if it exists
-	dropdb -U postgres -h localhost test_authentik || true
-	createdb -U postgres -h localhost authentik
+	dropdb -U $${PG_USER:-postgres} -h $${PG_HOST:-localhost} test_authentik || true
+	createdb -U $${PG_USER:-postgres} -h $${PG_HOST:-localhost} $${PG_DB:-authentik}
 	redis-cli -n 0 flushall
 	make migrate

--- a/Makefile
+++ b/Makefile
@@ -218,10 +218,18 @@ ci-pending-migrations: ci--meta-debug
 install: web-install website-install
 	poetry install
 
-dev-reset:
+
+.PHONY: dev-drop-db dev-create-db dev-reset
+
+dev-drop-db:
 	dropdb -U $${PG_USER:-postgres} -h $${PG_HOST:-localhost} $${PG_DB:-authentik}
 	# Also remove the test-db if it exists
 	dropdb -U $${PG_USER:-postgres} -h $${PG_HOST:-localhost} test_authentik || true
-	createdb -U $${PG_USER:-postgres} -h $${PG_HOST:-localhost} $${PG_DB:-authentik}
 	redis-cli -n 0 flushall
-	make migrate
+
+
+dev-create-db:
+	createdb -U $${PG_USER:-postgres} -h $${PG_HOST:-localhost} $${PG_DB:-authentik}
+
+
+dev-reset: dev-drop-db dev-create-db migrate  ## Drop and restore the Authentik PostgreSQL instance to a "fresh install" state.

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,8 @@ all: lint-fix lint test gen web  ## Lint, build, and test everything
 help:  ## Show this help
 	@echo "\nSpecify a command. The choices are:\n"
 	@grep -E '^[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
-		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[0;36m%-24s\033[m %s\n", $$1, $$2}'
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[0;36m%-24s\033[m %s\n", $$1, $$2}' | \
+		sort
 	@echo ""
 
 test-go:

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ GID = $(shell id -g)
 NPM_VERSION = $(shell python -m scripts.npm_version)
 PY_SOURCES = authentik tests scripts lifecycle
 
+pg_user := $(shell python -m authentik.lib.config postgresql.user 2>/dev/null)
+pg_host := $(shell python -m authentik.lib.config postgresql.host 2>/dev/null)
+pg_name := $(shell python -m authentik.lib.config postgresql.name 2>/dev/null)
+
 CODESPELL_ARGS = -D - -D .github/codespell-dictionary.txt \
 		-I .github/codespell-words.txt \
 		-S 'web/src/locales/**' \
@@ -26,7 +30,7 @@ all: lint-fix lint test gen web  ## Lint, build, and test everything
 help:  ## Show this help
 	@echo "\nSpecify a command. The choices are:\n"
 	@grep -E '^[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
-	    awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[0;36m%-24s\033[m %s\n", $$1, $$2}'
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[0;36m%-24s\033[m %s\n", $$1, $$2}'
 	@echo ""
 
 test-go:
@@ -229,12 +233,12 @@ install: web-install website-install
 
 
 dev-drop-db:
-	dropdb -U $${PG_USER:-postgres} -h $${PG_HOST:-localhost} $${PG_DB:-authentik}
+	echo dropdb -U ${pg_user} -h ${pg_host} ${pg_name}
 	# Also remove the test-db if it exists
-	dropdb -U $${PG_USER:-postgres} -h $${PG_HOST:-localhost} test_authentik || true
-	redis-cli -n 0 flushall
+	dropdb -U ${pg_user} -h ${pg_host} test_${pg_name} || true
+	echo redis-cli -n 0 flushall
 
 dev-create-db:
-	createdb -U $${PG_USER:-postgres} -h $${PG_HOST:-localhost} $${PG_DB:-authentik}
+	createdb -U ${pg_user} -h ${pg_host} ${pg_name}
 
 dev-reset: dev-drop-db dev-create-db migrate  ## Drop and restore the Authentik PostgreSQL instance to a "fresh install" state.


### PR DESCRIPTION
This commit allows the `dev-reset` command in the Makefile to pick up and use credentials from the `.env` file if they are present, or fallback to the defaults provided if they are not. This is the only place in the Makefile where the database credentials are used directly against postgresql binaries. The syntax was tested with bash, zsh, and csh, and did not fail under those.

The `$${:-}` syntax is a combination of a Makefile idiom for "Pass a single `$` to the environment where this command will be executed," and the shell expresion `${VARIABLE:-default}` means "dereference the environment variable; if it is undefined, used the default value provided."

I've added `help` to the Makefile:

```
$ make help
Specify a command. The choices are:

  all                      Lint, build, and test everything
  help                     Show this help
  test                     Run the server tests and produce a coverage report
  lint-fix                 Lint and automatically fix errors in the python source code. Reports spelling errors.
  lint                     Lint the python and golang sources
  migrate                  Run the Authentik Django server's migrations
  i18n-extract             Extract strings that require translation into files to send to a translation service
  gen-build                Extract the schema from the database
  gen-client-ts            Build and install the Authentik API for Typescript into the Authentik UI Application
  web-build                Build the Authentik UI
  web-install              Install the necessary libraries to build the Authentik UI
  web-watch                Build and watch the Authentik UI for changes, updating automatically
  web-storybook-watch      Build and run the storybook documentation server
  web-lint-fix             Automatically fix formatting issues in the Authentik UI source code
  website                  Build the documentation website
  website-watch            Build and watch the documentation website, updating automatically
  dev-reset                Drop and restore the Authentik PostgreSQL instance to a "fresh install" state.
```

The help feature uses BSD `awk`, which is available on MacOS and Linux.  The syntax is simply `## your help message here` as a comment on a Makefile target line.


## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [x] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)
-   [x] The translation files have been updated (`make i18n-extract`)

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
