### PR TITLE
stages/invitation: fix mis-matched serializer class for invitation

### DIFF
--- a/authentik/blueprints/tests/test_serializer_models.py
+++ b/authentik/blueprints/tests/test_serializer_models.py
@@ -6,6 +6,7 @@ from django.test import TestCase
 
 from authentik.blueprints.v1.importer import is_model_allowed
 from authentik.lib.models import SerializerModel
+from authentik.providers.oauth2.models import RefreshToken
 
 
 class TestModels(TestCase):
@@ -21,6 +22,9 @@ def serializer_tester_factory(test_model: Type[SerializerModel]) -> Callable:
         model_class = test_model()
         self.assertTrue(isinstance(model_class, SerializerModel))
         self.assertIsNotNone(model_class.serializer)
+        if model_class.serializer.Meta().model == RefreshToken:
+            return
+        self.assertEqual(model_class.serializer.Meta().model, test_model)
 
     return tester
 

--- a/authentik/stages/invitation/models.py
+++ b/authentik/stages/invitation/models.py
@@ -75,7 +75,7 @@ class Invitation(SerializerModel, ExpiringModel):
     def serializer(self) -> Serializer:
         from authentik.stages.invitation.api import InvitationSerializer
 
-        return InvitationSerializer()
+        return InvitationSerializer
 
     def __str__(self):
         return f"Invitation {str(self.invite_uuid)} created by {self.created_by}"

--- a/authentik/stages/invitation/models.py
+++ b/authentik/stages/invitation/models.py
@@ -73,12 +73,12 @@ class Invitation(SerializerModel, ExpiringModel):
 
     @property
     def serializer(self) -> Serializer:
-        from authentik.stages.consent.api import UserConsentSerializer
+        from authentik.stages.invitation.api import InvitationSerializer
 
-        return UserConsentSerializer
+        return InvitationSerializer()
 
     def __str__(self):
-        return f"Invitation {self.invite_uuid.hex} created by {self.created_by}"
+        return f"Invitation {str(self.invite_uuid)} created by {self.created_by}"
 
     class Meta:
         verbose_name = _("Invitation")


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

the invitation object has an incorrect serializer which caused some issues with the flow inspector

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
