### PR TITLE
web/flows: fix plex login not opening new tab on mobile safari

### DIFF
--- a/web/src/flow/FlowExecutor.ts
+++ b/web/src/flow/FlowExecutor.ts
@@ -11,6 +11,8 @@ import { WebsocketClient } from "@goauthentik/common/ws";
 import { Interface } from "@goauthentik/elements/Base";
 import "@goauthentik/elements/LoadingOverlay";
 import "@goauthentik/elements/ak-locale-context";
+import "@goauthentik/flow/sources/apple/AppleLoginInit";
+import "@goauthentik/flow/sources/plex/PlexLoginInit";
 import "@goauthentik/flow/stages/FlowErrorStage";
 import "@goauthentik/flow/stages/RedirectStage";
 import { StageHost } from "@goauthentik/flow/stages/base";
@@ -353,13 +355,11 @@ export class FlowExecutor extends Interface implements StageHost {
                 ></ak-stage-user-login>`;
             // Sources
             case "ak-source-plex":
-                await import("@goauthentik/flow/sources/plex/PlexLoginInit");
                 return html`<ak-flow-source-plex
                     .host=${this as StageHost}
                     .challenge=${this.challenge}
                 ></ak-flow-source-plex>`;
             case "ak-source-oauth-apple":
-                await import("@goauthentik/flow/sources/apple/AppleLoginInit");
                 return html`<ak-flow-source-oauth-apple
                     .host=${this as StageHost}
                     .challenge=${this.challenge}


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

Importing the stage dynamically causes the new tab to not be opened correctly in safari mobile, hence statically import the stages

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)
-   [x] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
