### PR TITLE
sources/ldap: fix attribute path resolution

### DIFF
--- a/authentik/sources/ldap/sync/base.py
+++ b/authentik/sources/ldap/sync/base.py
@@ -9,7 +9,7 @@ from structlog.stdlib import BoundLogger, get_logger
 
 from authentik.core.exceptions import PropertyMappingExpressionException
 from authentik.events.models import Event, EventAction
-from authentik.lib.config import CONFIG
+from authentik.lib.config import CONFIG, set_path_in_dict
 from authentik.lib.merge import MERGE_LIST_UNIQUE
 from authentik.sources.ldap.auth import LDAP_DISTINGUISHED_NAME
 from authentik.sources.ldap.models import LDAPPropertyMapping, LDAPSource
@@ -164,7 +164,7 @@ class BaseLDAPSynchronizer:
                 if object_field.startswith("attributes."):
                     # Because returning a list might desired, we can't
                     # rely on self._flatten here. Instead, just save the result as-is
-                    properties["attributes"][object_field.replace("attributes.", "")] = value
+                    set_path_in_dict(properties, object_field, value)
                 else:
                     properties[object_field] = self._flatten(value)
             except PropertyMappingExpressionException as exc:

--- a/authentik/stages/user_write/stage.py
+++ b/authentik/stages/user_write/stage.py
@@ -14,6 +14,7 @@ from authentik.core.sources.stage import PLAN_CONTEXT_SOURCES_CONNECTION
 from authentik.flows.planner import PLAN_CONTEXT_PENDING_USER
 from authentik.flows.stage import StageView
 from authentik.flows.views.executor import FlowExecutorView
+from authentik.lib.config import set_path_in_dict
 from authentik.stages.password import BACKEND_INBUILT
 from authentik.stages.password.stage import PLAN_CONTEXT_AUTHENTICATION_BACKEND
 from authentik.stages.prompt.stage import PLAN_CONTEXT_PROMPT
@@ -44,12 +45,7 @@ class UserWriteStageView(StageView):
         # this is just a sanity check to ensure that is removed
         if parts[0] == "attributes":
             parts = parts[1:]
-        attrs = user.attributes
-        for comp in parts[:-1]:
-            if comp not in attrs:
-                attrs[comp] = {}
-            attrs = attrs.get(comp)
-        attrs[parts[-1]] = value
+        set_path_in_dict(user.attributes, ".".join(parts), value)
 
     def ensure_user(self) -> tuple[Optional[User], bool]:
         """Ensure a user exists"""


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

closes #7088

fix user_field values like `attributes.foo.bar` not being resolved fully into `attributes['foo']['bar']` as they should be

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
