### PR TITLE
root: Upgrade Python syntax for version 3.11 using pyupgrade

### DIFF
--- a/authentik/__init__.py
+++ b/authentik/__init__.py
@@ -6,7 +6,7 @@ __version__ = "2023.10.2"
 ENV_GIT_HASH_KEY = "GIT_BUILD_HASH"
 
 
-def get_build_hash(fallback: Optional[str] = None) -> str:
+def get_build_hash(fallback: str | None = None) -> str:
     """Get build hash"""
     build_hash = environ.get(ENV_GIT_HASH_KEY, fallback if fallback else "")
     return fallback if build_hash == "" and fallback else build_hash

--- a/authentik/__init__.py
+++ b/authentik/__init__.py
@@ -1,6 +1,5 @@
 """authentik root module"""
 from os import environ
-from typing import Optional
 
 __version__ = "2023.10.2"
 ENV_GIT_HASH_KEY = "GIT_BUILD_HASH"

--- a/authentik/admin/api/tasks.py
+++ b/authentik/admin/api/tasks.py
@@ -124,7 +124,7 @@ class TaskViewSet(ViewSet):
             task_func.delay(*task.task_call_args, **task.task_call_kwargs)
             messages.success(
                 self.request,
-                _("Successfully re-scheduled Task %(name)s!" % {"name": task.task_name}),
+                _("Successfully re-scheduled Task {name}!".format(name=task.task_name)),
             )
             return Response(status=204)
         except (ImportError, AttributeError):  # pragma: no cover

--- a/authentik/admin/api/tasks.py
+++ b/authentik/admin/api/tasks.py
@@ -124,7 +124,7 @@ class TaskViewSet(ViewSet):
             task_func.delay(*task.task_call_args, **task.task_call_kwargs)
             messages.success(
                 self.request,
-                _("Successfully re-scheduled Task {name}!".format(name=task.task_name)),
+                _(f"Successfully re-scheduled Task {task.task_name}!"),
             )
             return Response(status=204)
         except (ImportError, AttributeError):  # pragma: no cover

--- a/authentik/api/authentication.py
+++ b/authentik/api/authentication.py
@@ -16,7 +16,7 @@ from authentik.providers.oauth2.constants import SCOPE_AUTHENTIK_API
 LOGGER = get_logger()
 
 
-def validate_auth(header: bytes) -> Optional[str]:
+def validate_auth(header: bytes) -> str | None:
     """Validate that the header is in a correct format,
     returns type and credentials"""
     auth_credentials = header.decode().strip()
@@ -31,7 +31,7 @@ def validate_auth(header: bytes) -> Optional[str]:
     return auth_credentials
 
 
-def bearer_auth(raw_header: bytes) -> Optional[User]:
+def bearer_auth(raw_header: bytes) -> User | None:
     """raw_header in the Format of `Bearer ....`"""
     user = auth_user_lookup(raw_header)
     if not user:
@@ -41,7 +41,7 @@ def bearer_auth(raw_header: bytes) -> Optional[User]:
     return user
 
 
-def auth_user_lookup(raw_header: bytes) -> Optional[User]:
+def auth_user_lookup(raw_header: bytes) -> User | None:
     """raw_header in the Format of `Bearer ....`"""
     from authentik.providers.oauth2.models import AccessToken
 
@@ -74,7 +74,7 @@ def auth_user_lookup(raw_header: bytes) -> Optional[User]:
     raise AuthenticationFailed("Token invalid/expired")
 
 
-def token_secret_key(value: str) -> Optional[User]:
+def token_secret_key(value: str) -> User | None:
     """Check if the token is the secret key
     and return the service account for the managed outpost"""
     from authentik.outposts.apps import MANAGED_OUTPOST

--- a/authentik/api/authentication.py
+++ b/authentik/api/authentication.py
@@ -1,6 +1,6 @@
 """API Authentication"""
 from hmac import compare_digest
-from typing import Any, Optional
+from typing import Any
 
 from django.conf import settings
 from rest_framework.authentication import BaseAuthentication, get_authorization_header

--- a/authentik/api/decorators.py
+++ b/authentik/api/decorators.py
@@ -1,6 +1,7 @@
 """API Decorators"""
 from functools import wraps
-from typing import Callable, Optional
+from typing import Optional
+from collections.abc import Callable
 
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -10,7 +11,7 @@ from structlog.stdlib import get_logger
 LOGGER = get_logger()
 
 
-def permission_required(obj_perm: Optional[str] = None, global_perms: Optional[list[str]] = None):
+def permission_required(obj_perm: str | None = None, global_perms: list[str] | None = None):
     """Check permissions for a single custom action"""
 
     def wrapper_outter(func: Callable):

--- a/authentik/api/decorators.py
+++ b/authentik/api/decorators.py
@@ -1,7 +1,6 @@
 """API Decorators"""
-from functools import wraps
-from typing import Optional
 from collections.abc import Callable
+from functools import wraps
 
 from rest_framework.request import Request
 from rest_framework.response import Response

--- a/authentik/api/tests/test_auth.py
+++ b/authentik/api/tests/test_auth.py
@@ -22,17 +22,17 @@ class TestAPIAuth(TestCase):
     def test_invalid_type(self):
         """Test invalid type"""
         with self.assertRaises(AuthenticationFailed):
-            bearer_auth("foo bar".encode())
+            bearer_auth(b"foo bar")
 
     def test_invalid_empty(self):
         """Test invalid type"""
-        self.assertIsNone(bearer_auth("Bearer ".encode()))
-        self.assertIsNone(bearer_auth("".encode()))
+        self.assertIsNone(bearer_auth(b"Bearer "))
+        self.assertIsNone(bearer_auth(b""))
 
     def test_invalid_no_token(self):
         """Test invalid with no token"""
         with self.assertRaises(AuthenticationFailed):
-            auth = b64encode(":abc".encode()).decode()
+            auth = b64encode(b":abc").decode()
             self.assertIsNone(bearer_auth(f"Basic :{auth}".encode()))
 
     def test_bearer_valid(self):

--- a/authentik/api/tests/test_viewsets.py
+++ b/authentik/api/tests/test_viewsets.py
@@ -1,5 +1,5 @@
 """authentik API Modelviewset tests"""
-from typing import Callable
+from collections.abc import Callable
 
 from django.test import TestCase
 from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet

--- a/authentik/blueprints/api.py
+++ b/authentik/blueprints/api.py
@@ -51,7 +51,7 @@ class BlueprintInstanceSerializer(ModelSerializer):
         valid, logs = Importer.from_string(content, context).validate()
         if not valid:
             text_logs = "\n".join([x["event"] for x in logs])
-            raise ValidationError(_("Failed to validate blueprint: %(logs)s" % {"logs": text_logs}))
+            raise ValidationError(_("Failed to validate blueprint: {logs}".format(logs=text_logs)))
         return content
 
     def validate(self, attrs: dict) -> dict:

--- a/authentik/blueprints/api.py
+++ b/authentik/blueprints/api.py
@@ -51,7 +51,7 @@ class BlueprintInstanceSerializer(ModelSerializer):
         valid, logs = Importer.from_string(content, context).validate()
         if not valid:
             text_logs = "\n".join([x["event"] for x in logs])
-            raise ValidationError(_("Failed to validate blueprint: {logs}".format(logs=text_logs)))
+            raise ValidationError(_(f"Failed to validate blueprint: {text_logs}"))
         return content
 
     def validate(self, attrs: dict) -> dict:

--- a/authentik/blueprints/migrations/0001_initial.py
+++ b/authentik/blueprints/migrations/0001_initial.py
@@ -20,7 +20,7 @@ def check_blueprint_v1_file(BlueprintInstance: type, path: Path):
     from authentik.blueprints.v1.common import BlueprintLoader, BlueprintMetadata
     from authentik.blueprints.v1.labels import LABEL_AUTHENTIK_INSTANTIATE
 
-    with open(path, "r", encoding="utf-8") as blueprint_file:
+    with open(path, encoding="utf-8") as blueprint_file:
         raw_blueprint = load(blueprint_file.read(), BlueprintLoader)
         if not raw_blueprint:
             return

--- a/authentik/blueprints/models.py
+++ b/authentik/blueprints/models.py
@@ -88,7 +88,7 @@ class BlueprintInstance(SerializerModel, ManagedModel, CreatedUpdatedModel):
                 raise BlueprintRetrievalFailed("Invalid blueprint path")
             with full_path.open("r", encoding="utf-8") as _file:
                 return _file.read()
-        except (IOError, OSError) as exc:
+        except OSError as exc:
             raise BlueprintRetrievalFailed(exc) from exc
 
     def retrieve(self) -> str:

--- a/authentik/blueprints/tests/__init__.py
+++ b/authentik/blueprints/tests/__init__.py
@@ -1,6 +1,6 @@
 """Blueprint helpers"""
 from functools import wraps
-from typing import Callable
+from collections.abc import Callable
 
 from django.apps import apps
 

--- a/authentik/blueprints/tests/__init__.py
+++ b/authentik/blueprints/tests/__init__.py
@@ -1,6 +1,6 @@
 """Blueprint helpers"""
-from functools import wraps
 from collections.abc import Callable
+from functools import wraps
 
 from django.apps import apps
 

--- a/authentik/blueprints/tests/test_packaged.py
+++ b/authentik/blueprints/tests/test_packaged.py
@@ -1,6 +1,6 @@
 """test packaged blueprints"""
-from pathlib import Path
 from collections.abc import Callable
+from pathlib import Path
 
 from django.test import TransactionTestCase
 

--- a/authentik/blueprints/tests/test_packaged.py
+++ b/authentik/blueprints/tests/test_packaged.py
@@ -1,6 +1,6 @@
 """test packaged blueprints"""
 from pathlib import Path
-from typing import Callable
+from collections.abc import Callable
 
 from django.test import TransactionTestCase
 

--- a/authentik/blueprints/tests/test_serializer_models.py
+++ b/authentik/blueprints/tests/test_serializer_models.py
@@ -1,5 +1,4 @@
 """authentik managed models tests"""
-from typing import Type
 from collections.abc import Callable
 
 from django.apps import apps

--- a/authentik/blueprints/tests/test_serializer_models.py
+++ b/authentik/blueprints/tests/test_serializer_models.py
@@ -1,5 +1,6 @@
 """authentik managed models tests"""
-from typing import Callable, Type
+from typing import Type
+from collections.abc import Callable
 
 from django.apps import apps
 from django.test import TestCase
@@ -13,7 +14,7 @@ class TestModels(TestCase):
     """Test Models"""
 
 
-def serializer_tester_factory(test_model: Type[SerializerModel]) -> Callable:
+def serializer_tester_factory(test_model: type[SerializerModel]) -> Callable:
     """Test serializer"""
 
     def tester(self: TestModels):

--- a/authentik/blueprints/v1/common.py
+++ b/authentik/blueprints/v1/common.py
@@ -6,7 +6,8 @@ from enum import Enum
 from functools import reduce
 from operator import ixor
 from os import getenv
-from typing import Any, Iterable, Literal, Mapping, Optional, Union
+from typing import Any, Literal, Optional, Union
+from collections.abc import Iterable, Mapping
 from uuid import UUID
 
 from deepmerge import always_merger
@@ -44,7 +45,7 @@ def get_attrs(obj: SerializerModel) -> dict[str, Any]:
 class BlueprintEntryState:
     """State of a single instance"""
 
-    instance: Optional[Model] = None
+    instance: Model | None = None
 
 
 class BlueprintEntryDesiredState(Enum):
@@ -66,9 +67,9 @@ class BlueprintEntry:
     )
     conditions: list[Any] = field(default_factory=list)
     identifiers: dict[str, Any] = field(default_factory=dict)
-    attrs: Optional[dict[str, Any]] = field(default_factory=dict)
+    attrs: dict[str, Any] | None = field(default_factory=dict)
 
-    id: Optional[str] = None
+    id: str | None = None
 
     _state: BlueprintEntryState = field(default_factory=BlueprintEntryState)
 
@@ -94,7 +95,7 @@ class BlueprintEntry:
     def _get_tag_context(
         self,
         depth: int = 0,
-        context_tag_type: Optional[type["YAMLTagContext"] | tuple["YAMLTagContext", ...]] = None,
+        context_tag_type: type["YAMLTagContext"] | tuple["YAMLTagContext", ...] | None = None,
     ) -> "YAMLTagContext":
         """Get a YAMLTagContext object located at a certain depth in the tag tree"""
         if depth < 0:
@@ -169,7 +170,7 @@ class Blueprint:
     entries: list[BlueprintEntry] = field(default_factory=list)
     context: dict = field(default_factory=dict)
 
-    metadata: Optional[BlueprintMetadata] = field(default=None)
+    metadata: BlueprintMetadata | None = field(default=None)
 
 
 class YAMLTag:
@@ -217,7 +218,7 @@ class Env(YAMLTag):
     """Lookup environment variable with optional default"""
 
     key: str
-    default: Optional[Any]
+    default: Any | None
 
     def __init__(self, loader: "BlueprintLoader", node: ScalarNode | SequenceNode) -> None:
         super().__init__()
@@ -236,7 +237,7 @@ class Context(YAMLTag):
     """Lookup key from instance context"""
 
     key: str
-    default: Optional[Any]
+    default: Any | None
 
     def __init__(self, loader: "BlueprintLoader", node: ScalarNode | SequenceNode) -> None:
         super().__init__()
@@ -581,13 +582,13 @@ class BlueprintLoader(SafeLoader):
 class EntryInvalidError(SentryIgnoredException):
     """Error raised when an entry is invalid"""
 
-    entry_model: Optional[str]
-    entry_id: Optional[str]
-    validation_error: Optional[ValidationError]
+    entry_model: str | None
+    entry_id: str | None
+    validation_error: ValidationError | None
     serializer: Optional[Serializer] = None
 
     def __init__(
-        self, *args: object, validation_error: Optional[ValidationError] = None, **kwargs
+        self, *args: object, validation_error: ValidationError | None = None, **kwargs
     ) -> None:
         super().__init__(*args)
         self.entry_model = None

--- a/authentik/blueprints/v1/common.py
+++ b/authentik/blueprints/v1/common.py
@@ -585,7 +585,7 @@ class EntryInvalidError(SentryIgnoredException):
     entry_model: str | None
     entry_id: str | None
     validation_error: ValidationError | None
-    serializer: Optional[Serializer] = None
+    serializer: Serializer | None = None
 
     def __init__(
         self, *args: object, validation_error: ValidationError | None = None, **kwargs

--- a/authentik/blueprints/v1/common.py
+++ b/authentik/blueprints/v1/common.py
@@ -1,13 +1,13 @@
 """transfer common classes"""
 from collections import OrderedDict
+from collections.abc import Iterable, Mapping
 from copy import copy
 from dataclasses import asdict, dataclass, field, is_dataclass
 from enum import Enum
 from functools import reduce
 from operator import ixor
 from os import getenv
-from typing import Any, Literal, Optional, Union
-from collections.abc import Iterable, Mapping
+from typing import Any, Literal, Union
 from uuid import UUID
 
 from deepmerge import always_merger

--- a/authentik/blueprints/v1/exporter.py
+++ b/authentik/blueprints/v1/exporter.py
@@ -1,5 +1,5 @@
 """Blueprint exporter"""
-from typing import Iterable
+from collections.abc import Iterable
 from uuid import UUID
 
 from django.apps import apps
@@ -59,7 +59,7 @@ class Exporter:
         blueprint = Blueprint()
         self._pre_export(blueprint)
         blueprint.metadata = BlueprintMetadata(
-            name=_("authentik Export - %(date)s" % {"date": str(now())}),
+            name=_("authentik Export - {date}".format(date=str(now()))),
             labels={
                 LABEL_AUTHENTIK_GENERATED: "true",
             },

--- a/authentik/blueprints/v1/exporter.py
+++ b/authentik/blueprints/v1/exporter.py
@@ -59,7 +59,7 @@ class Exporter:
         blueprint = Blueprint()
         self._pre_export(blueprint)
         blueprint.metadata = BlueprintMetadata(
-            name=_("authentik Export - {date}".format(date=str(now()))),
+            name=_(f"authentik Export - {str(now())}"),
             labels={
                 LABEL_AUTHENTIK_GENERATED: "true",
             },

--- a/authentik/blueprints/v1/importer.py
+++ b/authentik/blueprints/v1/importer.py
@@ -104,7 +104,7 @@ class Importer:
     logger: BoundLogger
     _import: Blueprint
 
-    def __init__(self, blueprint: Blueprint, context: Optional[dict] = None):
+    def __init__(self, blueprint: Blueprint, context: dict | None = None):
         self.__pk_map: dict[Any, Model] = {}
         self._import = blueprint
         self.logger = get_logger()
@@ -173,7 +173,7 @@ class Importer:
         return main_query | sub_query
 
     # pylint: disable-msg=too-many-locals
-    def _validate_single(self, entry: BlueprintEntry) -> Optional[BaseSerializer]:
+    def _validate_single(self, entry: BlueprintEntry) -> BaseSerializer | None:
         """Validate a single entry"""
         if not entry.check_all_conditions_match(self._import):
             self.logger.debug("One or more conditions of this entry are not fulfilled, skipping")
@@ -344,7 +344,7 @@ class Importer:
                     self.__pk_map[entry.identifiers["pk"]] = instance.pk
                 entry._state = BlueprintEntryState(instance)
             elif state == BlueprintEntryDesiredState.ABSENT:
-                instance: Optional[Model] = serializer.instance
+                instance: Model | None = serializer.instance
                 if instance.pk:
                     instance.delete()
                     self.logger.debug("deleted model", mode=instance)

--- a/authentik/blueprints/v1/importer.py
+++ b/authentik/blueprints/v1/importer.py
@@ -1,7 +1,7 @@
 """Blueprint importer"""
 from contextlib import contextmanager
 from copy import deepcopy
-from typing import Any, Optional
+from typing import Any
 
 from dacite.config import Config
 from dacite.core import from_dict

--- a/authentik/blueprints/v1/tasks.py
+++ b/authentik/blueprints/v1/tasks.py
@@ -2,7 +2,6 @@
 from dataclasses import asdict, dataclass, field
 from hashlib import sha512
 from pathlib import Path
-from typing import Optional
 
 from dacite.core import from_dict
 from django.db import DatabaseError, InternalError, ProgrammingError
@@ -209,7 +208,14 @@ def apply_blueprint(self: MonitoredTask, instance_pk: str):
         instance.last_applied_hash = file_hash
         instance.last_applied = now()
         self.set_status(TaskResult(TaskResultStatus.SUCCESSFUL))
-    except (DatabaseError, ProgrammingError, InternalError, OSError, BlueprintRetrievalFailed, EntryInvalidError) as exc:
+    except (
+        DatabaseError,
+        ProgrammingError,
+        InternalError,
+        OSError,
+        BlueprintRetrievalFailed,
+        EntryInvalidError,
+    ) as exc:
         if instance:
             instance.status = BlueprintInstanceStatus.ERROR
         self.set_status(TaskResult(TaskResultStatus.ERROR).with_error(exc))

--- a/authentik/core/api/applications.py
+++ b/authentik/core/api/applications.py
@@ -58,7 +58,7 @@ class ApplicationSerializer(ModelSerializer):
 
     meta_icon = ReadOnlyField(source="get_meta_icon")
 
-    def get_launch_url(self, app: Application) -> Optional[str]:
+    def get_launch_url(self, app: Application) -> str | None:
         """Allow formatting of launch URL"""
         user = None
         if "request" in self.context:

--- a/authentik/core/api/applications.py
+++ b/authentik/core/api/applications.py
@@ -1,6 +1,5 @@
 """Application API Views"""
 from datetime import timedelta
-from typing import Optional
 
 from django.core.cache import cache
 from django.db.models import QuerySet

--- a/authentik/core/api/authenticated_sessions.py
+++ b/authentik/core/api/authenticated_sessions.py
@@ -1,5 +1,5 @@
 """AuthenticatedSessions API Viewset"""
-from typing import Optional, TypedDict
+from typing import TypedDict
 
 from django_filters.rest_framework import DjangoFilterBackend
 from guardian.utils import get_anonymous_user

--- a/authentik/core/api/authenticated_sessions.py
+++ b/authentik/core/api/authenticated_sessions.py
@@ -69,7 +69,7 @@ class AuthenticatedSessionSerializer(ModelSerializer):
         """Get parsed user agent"""
         return user_agent_parser.Parse(instance.last_user_agent)
 
-    def get_geo_ip(self, instance: AuthenticatedSession) -> Optional[GeoIPDict]:  # pragma: no cover
+    def get_geo_ip(self, instance: AuthenticatedSession) -> GeoIPDict | None:  # pragma: no cover
         """Get parsed user agent"""
         return GEOIP_READER.city_dict(instance.last_ip)
 

--- a/authentik/core/api/groups.py
+++ b/authentik/core/api/groups.py
@@ -58,7 +58,7 @@ class GroupSerializer(ModelSerializer):
 
     num_pk = IntegerField(read_only=True)
 
-    def validate_parent(self, parent: Optional[Group]):
+    def validate_parent(self, parent: Group | None):
         """Validate group parent (if set), ensuring the parent isn't itself"""
         if not self.instance or not parent:
             return parent

--- a/authentik/core/api/groups.py
+++ b/authentik/core/api/groups.py
@@ -1,6 +1,5 @@
 """Groups API Viewset"""
 from json import loads
-from typing import Optional
 
 from django.http import Http404
 from django_filters.filters import CharFilter, ModelMultipleChoiceFilter

--- a/authentik/core/api/sources.py
+++ b/authentik/core/api/sources.py
@@ -1,5 +1,5 @@
 """Source API Views"""
-from typing import Iterable
+from collections.abc import Iterable
 
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import OpenApiResponse, extend_schema

--- a/authentik/core/api/users.py
+++ b/authentik/core/api/users.py
@@ -1,7 +1,7 @@
 """User API Views"""
 from datetime import timedelta
 from json import loads
-from typing import Any, Optional
+from typing import Any
 
 from django.contrib.auth import update_session_auth_hash
 from django.contrib.sessions.backends.cache import KEY_PREFIX

--- a/authentik/core/api/users.py
+++ b/authentik/core/api/users.py
@@ -140,7 +140,7 @@ class UserSerializer(ModelSerializer):
         self._set_password(instance, password)
         return instance
 
-    def _set_password(self, instance: User, password: Optional[str]):
+    def _set_password(self, instance: User, password: str | None):
         """Set password of user if we're in a blueprint context, and if it's an empty
         string then use an unusable password"""
         if SERIALIZER_CONTEXT_BLUEPRINT in self.context and password:
@@ -382,7 +382,7 @@ class UserViewSet(UsedByMixin, ModelViewSet):
     def get_queryset(self):  # pragma: no cover
         return User.objects.all().exclude(pk=get_anonymous_user().pk)
 
-    def _create_recovery_link(self) -> tuple[Optional[str], Optional[Token]]:
+    def _create_recovery_link(self) -> tuple[str | None, Token | None]:
         """Create a recovery link (when the current tenant has a recovery flow set),
         that can either be shown to an admin or sent to the user directly"""
         tenant: Tenant = self.request._request.tenant

--- a/authentik/core/auth.py
+++ b/authentik/core/auth.py
@@ -16,15 +16,15 @@ class InbuiltBackend(ModelBackend):
     """Inbuilt backend"""
 
     def authenticate(
-        self, request: HttpRequest, username: Optional[str], password: Optional[str], **kwargs: Any
-    ) -> Optional[User]:
+        self, request: HttpRequest, username: str | None, password: str | None, **kwargs: Any
+    ) -> User | None:
         user = super().authenticate(request, username=username, password=password, **kwargs)
         if not user:
             return None
         self.set_method("password", request)
         return user
 
-    def set_method(self, method: str, request: Optional[HttpRequest], **kwargs):
+    def set_method(self, method: str, request: HttpRequest | None, **kwargs):
         """Set method data on current flow, if possbiel"""
         if not request:
             return
@@ -40,8 +40,8 @@ class TokenBackend(InbuiltBackend):
     """Authenticate with token"""
 
     def authenticate(
-        self, request: HttpRequest, username: Optional[str], password: Optional[str], **kwargs: Any
-    ) -> Optional[User]:
+        self, request: HttpRequest, username: str | None, password: str | None, **kwargs: Any
+    ) -> User | None:
         try:
             user = User._default_manager.get_by_natural_key(username)
         except User.DoesNotExist:

--- a/authentik/core/auth.py
+++ b/authentik/core/auth.py
@@ -1,6 +1,6 @@
 """Authenticate with tokens"""
 
-from typing import Any, Optional
+from typing import Any
 
 from django.contrib.auth.backends import ModelBackend
 from django.http.request import HttpRequest

--- a/authentik/core/expression/evaluator.py
+++ b/authentik/core/expression/evaluator.py
@@ -26,9 +26,9 @@ class PropertyMappingEvaluator(BaseEvaluator):
     def __init__(
         self,
         model: Model,
-        user: Optional[User] = None,
-        request: Optional[HttpRequest] = None,
-        dry_run: Optional[bool] = False,
+        user: User | None = None,
+        request: HttpRequest | None = None,
+        dry_run: bool | None = False,
         **kwargs,
     ):
         if hasattr(model, "name"):

--- a/authentik/core/expression/evaluator.py
+++ b/authentik/core/expression/evaluator.py
@@ -1,5 +1,5 @@
 """Property Mapping Evaluator"""
-from typing import Any, Optional
+from typing import Any
 
 from django.db.models import Model
 from django.http import HttpRequest

--- a/authentik/core/middleware.py
+++ b/authentik/core/middleware.py
@@ -1,6 +1,7 @@
 """authentik admin Middleware to impersonate users"""
 from contextvars import ContextVar
-from typing import Callable, Optional
+from typing import Optional
+from collections.abc import Callable
 from uuid import uuid4
 
 from django.http import HttpRequest, HttpResponse

--- a/authentik/core/middleware.py
+++ b/authentik/core/middleware.py
@@ -1,7 +1,7 @@
 """authentik admin Middleware to impersonate users"""
+from collections.abc import Callable
 from contextvars import ContextVar
 from typing import Optional
-from collections.abc import Callable
 from uuid import uuid4
 
 from django.http import HttpRequest, HttpResponse

--- a/authentik/core/models.py
+++ b/authentik/core/models.py
@@ -35,7 +35,6 @@ from authentik.policies.models import PolicyBindingModel
 from authentik.root.install_id import get_install_id
 
 LOGGER = get_logger()
-SERIALIZER_TYPE = type[Serializer]
 USER_ATTRIBUTE_DEBUG = "goauthentik.io/user/debug"
 USER_ATTRIBUTE_GENERATED = "goauthentik.io/user/generated"
 USER_ATTRIBUTE_EXPIRES = "goauthentik.io/user/expires"
@@ -50,6 +49,8 @@ USER_PATH_SERVICE_ACCOUNT = USER_PATH_SYSTEM_PREFIX + "/service-accounts"
 
 
 options.DEFAULT_NAMES = options.DEFAULT_NAMES + ("authentik_used_by_shadows",)
+
+SerializerType = type[Serializer]
 
 
 def default_token_duration():
@@ -336,7 +337,7 @@ class Provider(SerializerModel):
         raise NotImplementedError
 
     @property
-    def serializer(self) -> SERIALIZER_TYPE:
+    def serializer(self) -> SerializerType:
         """Get serializer for this model"""
         raise NotImplementedError
 

--- a/authentik/core/models.py
+++ b/authentik/core/models.py
@@ -198,7 +198,7 @@ class User(SerializerModel, GuardianUserMixin, AbstractUser):
         there are at most 3 queries done"""
         return Group.children_recursive(self.ak_groups.all())
 
-    def group_attributes(self, request: Optional[HttpRequest] = None) -> dict[str, Any]:
+    def group_attributes(self, request: HttpRequest | None = None) -> dict[str, Any]:
         """Get a dictionary containing the attributes from all groups the user belongs to,
         including the users attributes"""
         final_attributes = {}
@@ -254,7 +254,7 @@ class User(SerializerModel, GuardianUserMixin, AbstractUser):
         """Generate a globally unique UID, based on the user ID and the hashed secret key"""
         return sha256(f"{self.id}-{get_install_id()}".encode("ascii")).hexdigest()
 
-    def locale(self, request: Optional[HttpRequest] = None) -> str:
+    def locale(self, request: HttpRequest | None = None) -> str:
         """Get the locale the user has configured"""
         try:
             return self.attributes.get("settings", {}).get("locale", "")
@@ -324,7 +324,7 @@ class Provider(SerializerModel):
     objects = InheritanceManager()
 
     @property
-    def launch_url(self) -> Optional[str]:
+    def launch_url(self) -> str | None:
         """URL to this provider and initiate authorization for the user.
         Can return None for providers that are not URL-based"""
         return None
@@ -401,7 +401,7 @@ class Application(SerializerModel, PolicyBindingModel):
         return ApplicationSerializer
 
     @property
-    def get_meta_icon(self) -> Optional[str]:
+    def get_meta_icon(self) -> str | None:
         """Get the URL to the App Icon image. If the name is /static or starts with http
         it is returned as-is"""
         if not self.meta_icon:
@@ -410,7 +410,7 @@ class Application(SerializerModel, PolicyBindingModel):
             return self.meta_icon.name
         return self.meta_icon.url
 
-    def get_launch_url(self, user: Optional["User"] = None) -> Optional[str]:
+    def get_launch_url(self, user: Optional["User"] = None) -> str | None:
         """Get launch URL if set, otherwise attempt to get launch URL based on provider."""
         url = None
         if self.meta_launch_url:
@@ -429,7 +429,7 @@ class Application(SerializerModel, PolicyBindingModel):
                 return url
         return url
 
-    def get_provider(self) -> Optional[Provider]:
+    def get_provider(self) -> Provider | None:
         """Get casted provider instance"""
         if not self.provider:
             return None
@@ -517,7 +517,7 @@ class Source(ManagedModel, SerializerModel, PolicyBindingModel):
     objects = InheritanceManager()
 
     @property
-    def get_icon(self) -> Optional[str]:
+    def get_icon(self) -> str | None:
         """Get the URL to the Icon. If the name is /static or
         starts with http it is returned as-is"""
         if not self.icon:
@@ -542,12 +542,12 @@ class Source(ManagedModel, SerializerModel, PolicyBindingModel):
         """Return component used to edit this object"""
         raise NotImplementedError
 
-    def ui_login_button(self, request: HttpRequest) -> Optional[UILoginButton]:
+    def ui_login_button(self, request: HttpRequest) -> UILoginButton | None:
         """If source uses a http-based flow, return UI Information about the login
         button. If source doesn't use http-based flow, return None."""
         return None
 
-    def ui_user_settings(self) -> Optional[UserSettingSerializer]:
+    def ui_user_settings(self) -> UserSettingSerializer | None:
         """Entrypoint to integrate with User settings. Can either return None if no
         user settings are available, or UserSettingSerializer."""
         return None
@@ -709,7 +709,7 @@ class PropertyMapping(SerializerModel, ManagedModel):
         """Get serializer for this model"""
         raise NotImplementedError
 
-    def evaluate(self, user: Optional[User], request: Optional[HttpRequest], **kwargs) -> Any:
+    def evaluate(self, user: User | None, request: HttpRequest | None, **kwargs) -> Any:
         """Evaluate `self.expression` using `**kwargs` as Context."""
         from authentik.core.expression.evaluator import PropertyMappingEvaluator
 

--- a/authentik/core/models.py
+++ b/authentik/core/models.py
@@ -50,8 +50,6 @@ USER_PATH_SERVICE_ACCOUNT = USER_PATH_SYSTEM_PREFIX + "/service-accounts"
 
 options.DEFAULT_NAMES = options.DEFAULT_NAMES + ("authentik_used_by_shadows",)
 
-SerializerType = type[Serializer]
-
 
 def default_token_duration():
     """Default duration a Token is valid"""
@@ -337,7 +335,7 @@ class Provider(SerializerModel):
         raise NotImplementedError
 
     @property
-    def serializer(self) -> SerializerType:
+    def serializer(self) -> type[Serializer]:
         """Get serializer for this model"""
         raise NotImplementedError
 

--- a/authentik/core/models.py
+++ b/authentik/core/models.py
@@ -35,6 +35,7 @@ from authentik.policies.models import PolicyBindingModel
 from authentik.root.install_id import get_install_id
 
 LOGGER = get_logger()
+SERIALIZER_TYPE = type[Serializer]
 USER_ATTRIBUTE_DEBUG = "goauthentik.io/user/debug"
 USER_ATTRIBUTE_GENERATED = "goauthentik.io/user/generated"
 USER_ATTRIBUTE_EXPIRES = "goauthentik.io/user/expires"
@@ -335,7 +336,7 @@ class Provider(SerializerModel):
         raise NotImplementedError
 
     @property
-    def serializer(self) -> type[Serializer]:
+    def serializer(self) -> SERIALIZER_TYPE:
         """Get serializer for this model"""
         raise NotImplementedError
 

--- a/authentik/core/sources/flow_manager.py
+++ b/authentik/core/sources/flow_manager.py
@@ -90,7 +90,7 @@ class SourceFlowManager:
         self.policy_context = {}
 
     # pylint: disable=too-many-return-statements
-    def get_action(self, **kwargs) -> tuple[Action, Optional[UserSourceConnection]]:
+    def get_action(self, **kwargs) -> tuple[Action, UserSourceConnection | None]:
         """decide which action should be taken"""
         new_connection = self.connection_type(source=self.source, identifier=self.identifier)
         # When request is authenticated, always link
@@ -216,7 +216,7 @@ class SourceFlowManager:
         self,
         flow: Flow,
         connection: UserSourceConnection,
-        stages: Optional[list[StageView]] = None,
+        stages: list[StageView] | None = None,
         **kwargs,
     ) -> HttpResponse:
         """Prepare Authentication Plan, redirect user FlowExecutor"""
@@ -269,7 +269,7 @@ class SourceFlowManager:
                 in_memory_stage(
                     MessageStage,
                     message=_(
-                        "Successfully authenticated with %(source)s!" % {"source": self.source.name}
+                        "Successfully authenticated with {source}!".format(source=self.source.name)
                     ),
                 )
             ],
@@ -293,7 +293,7 @@ class SourceFlowManager:
         ).from_http(self.request)
         messages.success(
             self.request,
-            _("Successfully linked %(source)s!" % {"source": self.source.name}),
+            _("Successfully linked {source}!".format(source=self.source.name)),
         )
         return redirect(
             reverse(
@@ -321,7 +321,7 @@ class SourceFlowManager:
                 in_memory_stage(
                     MessageStage,
                     message=_(
-                        "Successfully authenticated with %(source)s!" % {"source": self.source.name}
+                        "Successfully authenticated with {source}!".format(source=self.source.name)
                     ),
                 )
             ],

--- a/authentik/core/sources/flow_manager.py
+++ b/authentik/core/sources/flow_manager.py
@@ -268,9 +268,7 @@ class SourceFlowManager:
             stages=[
                 in_memory_stage(
                     MessageStage,
-                    message=_(
-                        "Successfully authenticated with {source}!".format(source=self.source.name)
-                    ),
+                    message=_(f"Successfully authenticated with {self.source.name}!"),
                 )
             ],
             **flow_kwargs,
@@ -293,7 +291,7 @@ class SourceFlowManager:
         ).from_http(self.request)
         messages.success(
             self.request,
-            _("Successfully linked {source}!".format(source=self.source.name)),
+            _(f"Successfully linked {self.source.name}!"),
         )
         return redirect(
             reverse(
@@ -320,9 +318,7 @@ class SourceFlowManager:
             stages=[
                 in_memory_stage(
                     MessageStage,
-                    message=_(
-                        "Successfully authenticated with {source}!".format(source=self.source.name)
-                    ),
+                    message=_(f"Successfully authenticated with {self.source.name}!"),
                 )
             ],
             **{

--- a/authentik/core/sources/flow_manager.py
+++ b/authentik/core/sources/flow_manager.py
@@ -1,6 +1,6 @@
 """Source decision helper"""
 from enum import Enum
-from typing import Any, Optional
+from typing import Any
 
 from django.contrib import messages
 from django.db import IntegrityError

--- a/authentik/core/tests/test_models.py
+++ b/authentik/core/tests/test_models.py
@@ -1,6 +1,6 @@
 """authentik core models tests"""
 from time import sleep
-from typing import Callable
+from collections.abc import Callable
 
 from django.test import RequestFactory, TestCase
 from django.utils.timezone import now

--- a/authentik/core/tests/test_models.py
+++ b/authentik/core/tests/test_models.py
@@ -1,6 +1,6 @@
 """authentik core models tests"""
-from time import sleep
 from collections.abc import Callable
+from time import sleep
 
 from django.test import RequestFactory, TestCase
 from django.utils.timezone import now

--- a/authentik/core/tests/utils.py
+++ b/authentik/core/tests/utils.py
@@ -1,5 +1,4 @@
 """Test Utils"""
-from typing import Optional
 
 from django.utils.text import slugify
 

--- a/authentik/core/tests/utils.py
+++ b/authentik/core/tests/utils.py
@@ -21,7 +21,7 @@ def create_test_flow(
     )
 
 
-def create_test_user(name: Optional[str] = None, **kwargs) -> User:
+def create_test_user(name: str | None = None, **kwargs) -> User:
     """Generate a test user"""
     uid = generate_id(20) if not name else name
     kwargs.setdefault("email", f"{uid}@goauthentik.io")
@@ -35,7 +35,7 @@ def create_test_user(name: Optional[str] = None, **kwargs) -> User:
     return user
 
 
-def create_test_admin_user(name: Optional[str] = None, **kwargs) -> User:
+def create_test_admin_user(name: str | None = None, **kwargs) -> User:
     """Generate a test-admin user"""
     user = create_test_user(name, **kwargs)
     group = Group.objects.create(name=user.name or name, is_superuser=True)

--- a/authentik/core/types.py
+++ b/authentik/core/types.py
@@ -1,6 +1,5 @@
 """authentik core dataclasses"""
 from dataclasses import dataclass
-from typing import Optional
 
 from rest_framework.fields import CharField
 

--- a/authentik/core/types.py
+++ b/authentik/core/types.py
@@ -19,7 +19,7 @@ class UILoginButton:
     challenge: Challenge
 
     # Icon URL, used as-is
-    icon_url: Optional[str] = None
+    icon_url: str | None = None
 
 
 class UserSettingSerializer(PassiveSerializer):

--- a/authentik/crypto/api.py
+++ b/authentik/crypto/api.py
@@ -55,25 +55,25 @@ class CertificateKeyPairSerializer(ModelSerializer):
             return True
         return str(request.query_params.get("include_details", "true")).lower() == "true"
 
-    def get_fingerprint_sha256(self, instance: CertificateKeyPair) -> Optional[str]:
+    def get_fingerprint_sha256(self, instance: CertificateKeyPair) -> str | None:
         "Get certificate Hash (SHA256)"
         if not self._should_include_details:
             return None
         return instance.fingerprint_sha256
 
-    def get_fingerprint_sha1(self, instance: CertificateKeyPair) -> Optional[str]:
+    def get_fingerprint_sha1(self, instance: CertificateKeyPair) -> str | None:
         "Get certificate Hash (SHA1)"
         if not self._should_include_details:
             return None
         return instance.fingerprint_sha1
 
-    def get_cert_expiry(self, instance: CertificateKeyPair) -> Optional[datetime]:
+    def get_cert_expiry(self, instance: CertificateKeyPair) -> datetime | None:
         "Get certificate expiry"
         if not self._should_include_details:
             return None
         return DateTimeField().to_representation(instance.certificate.not_valid_after)
 
-    def get_cert_subject(self, instance: CertificateKeyPair) -> Optional[str]:
+    def get_cert_subject(self, instance: CertificateKeyPair) -> str | None:
         """Get certificate subject as full rfc4514"""
         if not self._should_include_details:
             return None
@@ -83,7 +83,7 @@ class CertificateKeyPairSerializer(ModelSerializer):
         """Show if this keypair has a private key configured or not"""
         return instance.key_data != "" and instance.key_data is not None
 
-    def get_private_key_type(self, instance: CertificateKeyPair) -> Optional[str]:
+    def get_private_key_type(self, instance: CertificateKeyPair) -> str | None:
         """Get the private key's type, if set"""
         if not self._should_include_details:
             return None

--- a/authentik/crypto/api.py
+++ b/authentik/crypto/api.py
@@ -1,6 +1,5 @@
 """Crypto API Views"""
 from datetime import datetime
-from typing import Optional
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.serialization import load_pem_private_key

--- a/authentik/crypto/apps.py
+++ b/authentik/crypto/apps.py
@@ -43,7 +43,7 @@ class AuthentikCryptoConfig(ManagedAppConfig):
         """Ensure managed JWT certificate"""
         from authentik.crypto.models import CertificateKeyPair
 
-        cert: Optional[CertificateKeyPair] = CertificateKeyPair.objects.filter(
+        cert: CertificateKeyPair | None = CertificateKeyPair.objects.filter(
             managed=MANAGED_KEY
         ).first()
         now = datetime.now()

--- a/authentik/crypto/apps.py
+++ b/authentik/crypto/apps.py
@@ -1,6 +1,5 @@
 """authentik crypto app config"""
 from datetime import datetime
-from typing import Optional
 
 from authentik.blueprints.apps import ManagedAppConfig
 from authentik.lib.generators import generate_id

--- a/authentik/crypto/builder.py
+++ b/authentik/crypto/builder.py
@@ -1,7 +1,6 @@
 """Create self-signed certificates"""
 import datetime
 import uuid
-from typing import Optional
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend

--- a/authentik/crypto/builder.py
+++ b/authentik/crypto/builder.py
@@ -51,7 +51,7 @@ class CertificateBuilder:
     def build(
         self,
         validity_days: int = 365,
-        subject_alt_names: Optional[list[str]] = None,
+        subject_alt_names: list[str] | None = None,
     ):
         """Build self-signed certificate"""
         one_day = datetime.timedelta(1, 0, 0)

--- a/authentik/crypto/management/commands/import_certificate.py
+++ b/authentik/crypto/management/commands/import_certificate.py
@@ -22,13 +22,13 @@ class Command(BaseCommand):
         if not keypair:
             keypair = CertificateKeyPair(name=options["name"])
             dirty = True
-        with open(options["certificate"], mode="r", encoding="utf-8") as _cert:
+        with open(options["certificate"], encoding="utf-8") as _cert:
             cert_data = _cert.read()
             if keypair.certificate_data != cert_data:
                 dirty = True
             keypair.certificate_data = cert_data
         if options["private_key"]:
-            with open(options["private_key"], mode="r", encoding="utf-8") as _key:
+            with open(options["private_key"], encoding="utf-8") as _key:
                 key_data = _key.read()
                 if keypair.key_data != key_data:
                     dirty = True

--- a/authentik/crypto/models.py
+++ b/authentik/crypto/models.py
@@ -1,7 +1,6 @@
 """authentik crypto models"""
 from binascii import hexlify
 from hashlib import md5
-from typing import Optional
 from uuid import uuid4
 
 from cryptography.hazmat.backends import default_backend

--- a/authentik/crypto/models.py
+++ b/authentik/crypto/models.py
@@ -36,9 +36,9 @@ class CertificateKeyPair(SerializerModel, ManagedModel, CreatedUpdatedModel):
         default="",
     )
 
-    _cert: Optional[Certificate] = None
-    _private_key: Optional[PrivateKeyTypes] = None
-    _public_key: Optional[PublicKeyTypes] = None
+    _cert: Certificate | None = None
+    _private_key: PrivateKeyTypes | None = None
+    _public_key: PublicKeyTypes | None = None
 
     @property
     def serializer(self) -> Serializer:
@@ -56,7 +56,7 @@ class CertificateKeyPair(SerializerModel, ManagedModel, CreatedUpdatedModel):
         return self._cert
 
     @property
-    def public_key(self) -> Optional[PublicKeyTypes]:
+    def public_key(self) -> PublicKeyTypes | None:
         """Get public key of the private key"""
         if not self._public_key:
             self._public_key = self.private_key.public_key()
@@ -65,7 +65,7 @@ class CertificateKeyPair(SerializerModel, ManagedModel, CreatedUpdatedModel):
     @property
     def private_key(
         self,
-    ) -> Optional[PrivateKeyTypes]:
+    ) -> PrivateKeyTypes | None:
         """Get python cryptography PrivateKey instance"""
         if not self._private_key and self.key_data != "":
             try:

--- a/authentik/crypto/tasks.py
+++ b/authentik/crypto/tasks.py
@@ -61,7 +61,7 @@ def certificate_discovery(self: MonitoredTask):
         else:
             cert_name = path.name.replace(path.suffix, "")
         try:
-            with open(path, "r", encoding="utf-8") as _file:
+            with open(path, encoding="utf-8") as _file:
                 body = _file.read()
                 if "PRIVATE KEY" in body:
                     private_keys[cert_name] = ensure_private_key_valid(body)

--- a/authentik/enterprise/models.py
+++ b/authentik/enterprise/models.py
@@ -26,7 +26,7 @@ from authentik.lib.models import SerializerModel
 from authentik.root.install_id import get_install_id
 
 
-@lru_cache()
+@lru_cache
 def get_licensing_key() -> Certificate:
     """Get Root CA PEM"""
     with open("authentik/enterprise/public.pem", "rb") as _key:

--- a/authentik/enterprise/policy.py
+++ b/authentik/enterprise/policy.py
@@ -1,5 +1,4 @@
 """Enterprise license policies"""
-from typing import Optional
 
 from authentik.core.models import User, UserTypes
 from authentik.enterprise.models import LicenseKey

--- a/authentik/enterprise/policy.py
+++ b/authentik/enterprise/policy.py
@@ -18,7 +18,7 @@ class EnterprisePolicyAccessView(PolicyAccessView):
             return False
         return True
 
-    def user_has_access(self, user: Optional[User] = None) -> PolicyResult:
+    def user_has_access(self, user: User | None = None) -> PolicyResult:
         user = user or self.request.user
         request = PolicyRequest(user)
         request.http_request = self.request

--- a/authentik/events/geo.py
+++ b/authentik/events/geo.py
@@ -1,6 +1,6 @@
 """events GeoIP Reader"""
 from os import stat
-from typing import Optional, TypedDict
+from typing import TypedDict
 
 from geoip2.database import Reader
 from geoip2.errors import GeoIP2Error

--- a/authentik/events/geo.py
+++ b/authentik/events/geo.py
@@ -27,7 +27,7 @@ class GeoIPReader:
     """Slim wrapper around GeoIP API"""
 
     def __init__(self):
-        self.__reader: Optional[Reader] = None
+        self.__reader: Reader | None = None
         self.__last_mtime: float = 0.0
         self.__open()
 
@@ -62,7 +62,7 @@ class GeoIPReader:
         """Check if GeoIP is enabled"""
         return bool(self.__reader)
 
-    def city(self, ip_address: str) -> Optional[City]:
+    def city(self, ip_address: str) -> City | None:
         """Wrapper for Reader.city"""
         with Hub.current.start_span(
             op="authentik.events.geo.city",
@@ -89,7 +89,7 @@ class GeoIPReader:
             city_dict["city"] = city.city.name
         return city_dict
 
-    def city_dict(self, ip_address: str) -> Optional[GeoIPDict]:
+    def city_dict(self, ip_address: str) -> GeoIPDict | None:
         """Wrapper for self.city that returns a dict"""
         city = self.city(ip_address)
         if not city:

--- a/authentik/events/middleware.py
+++ b/authentik/events/middleware.py
@@ -1,8 +1,8 @@
 """Events middleware"""
+from collections.abc import Callable
 from functools import partial
 from threading import Thread
-from typing import Any, Optional
-from collections.abc import Callable
+from typing import Any
 
 from django.conf import settings
 from django.contrib.sessions.models import Session

--- a/authentik/events/middleware.py
+++ b/authentik/events/middleware.py
@@ -1,7 +1,8 @@
 """Events middleware"""
 from functools import partial
 from threading import Thread
-from typing import Any, Callable, Optional
+from typing import Any, Optional
+from collections.abc import Callable
 
 from django.conf import settings
 from django.contrib.sessions.models import Session
@@ -75,9 +76,9 @@ class EventNewThread(Thread):
     action: str
     request: HttpRequest
     kwargs: dict[str, Any]
-    user: Optional[User] = None
+    user: User | None = None
 
-    def __init__(self, action: str, request: HttpRequest, user: Optional[User] = None, **kwargs):
+    def __init__(self, action: str, request: HttpRequest, user: User | None = None, **kwargs):
         super().__init__()
         self.action = action
         self.request = request

--- a/authentik/events/models.py
+++ b/authentik/events/models.py
@@ -4,7 +4,7 @@ from collections import Counter
 from datetime import timedelta
 from inspect import currentframe
 from smtplib import SMTPException
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 from django.db import models

--- a/authentik/events/models.py
+++ b/authentik/events/models.py
@@ -186,7 +186,7 @@ class Event(SerializerModel, ExpiringModel):
     @staticmethod
     def new(
         action: str | EventAction,
-        app: Optional[str] = None,
+        app: str | None = None,
         **kwargs,
     ) -> "Event":
         """Create new Event instance from arguments. Instance is NOT saved."""
@@ -206,7 +206,7 @@ class Event(SerializerModel, ExpiringModel):
         self.user = get_user(user)
         return self
 
-    def from_http(self, request: HttpRequest, user: Optional[User] = None) -> "Event":
+    def from_http(self, request: HttpRequest, user: User | None = None) -> "Event":
         """Add data from a Django-HttpRequest, allowing the creation of
         Events independently from requests.
         `user` arguments optionally overrides user from requests."""

--- a/authentik/events/monitored_tasks.py
+++ b/authentik/events/monitored_tasks.py
@@ -37,7 +37,7 @@ class TaskResult:
     messages: list[str] = field(default_factory=list)
 
     # Optional UID used in cache for tasks that run in different instances
-    uid: Optional[str] = field(default=None)
+    uid: str | None = field(default=None)
 
     def with_error(self, exc: Exception) -> "TaskResult":
         """Since errors might not always be pickle-able, set the traceback"""
@@ -62,7 +62,7 @@ class TaskInfo:
     task_call_args: list[Any] = field(default_factory=list)
     task_call_kwargs: dict[str, Any] = field(default_factory=dict)
 
-    task_description: Optional[str] = field(default=None)
+    task_description: str | None = field(default=None)
 
     @staticmethod
     def all() -> dict[str, "TaskInfo"]:
@@ -70,7 +70,7 @@ class TaskInfo:
         return cache.get_many(cache.keys(CACHE_KEY_PREFIX + "*"))
 
     @staticmethod
-    def by_name(name: str) -> Optional["TaskInfo"] | Optional[list["TaskInfo"]]:
+    def by_name(name: str) -> Optional["TaskInfo"] | list["TaskInfo"] | None:
         """Get TaskInfo Object by name"""
         if "*" in name:
             return cache.get_many(cache.keys(CACHE_KEY_PREFIX + name)).values()
@@ -118,10 +118,10 @@ class MonitoredTask(Task):
     # For tasks that should only be listed if they failed, set this to False
     save_on_success: bool
 
-    _result: Optional[TaskResult]
+    _result: TaskResult | None
 
-    _uid: Optional[str]
-    start: Optional[float] = None
+    _uid: str | None
+    start: float | None = None
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)

--- a/authentik/events/signals.py
+++ b/authentik/events/signals.py
@@ -1,5 +1,5 @@
 """authentik events signal listener"""
-from typing import Any, Optional
+from typing import Any
 
 from django.contrib.auth.signals import user_logged_in, user_logged_out
 from django.db.models.signals import post_save, pre_delete

--- a/authentik/events/signals.py
+++ b/authentik/events/signals.py
@@ -38,7 +38,7 @@ def on_user_logged_in(sender, request: HttpRequest, user: User, **_):
     request.session[SESSION_LOGIN_EVENT] = event
 
 
-def get_login_event(request: HttpRequest) -> Optional[Event]:
+def get_login_event(request: HttpRequest) -> Event | None:
     """Wrapper to get login event that can be mocked in tests"""
     return request.session.get(SESSION_LOGIN_EVENT, None)
 
@@ -62,7 +62,7 @@ def on_login_failed(
     sender,
     credentials: dict[str, str],
     request: HttpRequest,
-    stage: Optional[Stage] = None,
+    stage: Stage | None = None,
     **kwargs,
 ):
     """Failed Login, authentik custom event"""

--- a/authentik/events/tasks.py
+++ b/authentik/events/tasks.py
@@ -1,5 +1,4 @@
 """Event notification tasks"""
-from typing import Optional
 
 from django.db.models.query_utils import Q
 from guardian.shortcuts import get_anonymous_user

--- a/authentik/events/tasks.py
+++ b/authentik/events/tasks.py
@@ -41,7 +41,7 @@ def event_trigger_handler(event_uuid: str, trigger_name: str):
     if not event:
         LOGGER.warning("event doesn't exist yet or anymore", event_uuid=event_uuid)
         return
-    trigger: Optional[NotificationRule] = NotificationRule.objects.filter(name=trigger_name).first()
+    trigger: NotificationRule | None = NotificationRule.objects.filter(name=trigger_name).first()
     if not trigger:
         return
 

--- a/authentik/events/utils.py
+++ b/authentik/events/utils.py
@@ -6,7 +6,7 @@ from datetime import date, datetime, time, timedelta
 from enum import Enum
 from pathlib import Path
 from types import GeneratorType
-from typing import Any, Optional
+from typing import Any
 from uuid import UUID
 
 from django.contrib.auth.models import AnonymousUser

--- a/authentik/events/utils.py
+++ b/authentik/events/utils.py
@@ -70,7 +70,7 @@ def model_to_dict(model: Model) -> dict[str, Any]:
     }
 
 
-def get_user(user: User, original_user: Optional[User] = None) -> dict[str, Any]:
+def get_user(user: User, original_user: User | None = None) -> dict[str, Any]:
     """Convert user object to dictionary, optionally including the original user"""
     if isinstance(user, AnonymousUser):
         user = get_anonymous_user()

--- a/authentik/flows/api/flows_diagram.py
+++ b/authentik/flows/api/flows_diagram.py
@@ -17,8 +17,8 @@ class DiagramElement:
 
     identifier: str
     description: str
-    action: Optional[str] = None
-    source: Optional[list["DiagramElement"]] = None
+    action: str | None = None
+    source: list["DiagramElement"] | None = None
 
     style: list[str] = field(default_factory=lambda: ["[", "]"])
 
@@ -65,7 +65,7 @@ class FlowDiagram:
         ):
             element = DiagramElement(
                 f"flow_policy_{p_index}",
-                _("Policy (%(type)s)" % {"type": policy_binding.policy._meta.verbose_name})
+                _("Policy ({type})".format(type=policy_binding.policy._meta.verbose_name))
                 + "\n"
                 + policy_binding.policy.name,
                 _("Binding %(order)d" % {"order": policy_binding.order}),
@@ -91,7 +91,7 @@ class FlowDiagram:
         ):
             element = DiagramElement(
                 f"stage_{stage_index}_policy_{p_index}",
-                _("Policy (%(type)s)" % {"type": policy_binding.policy._meta.verbose_name})
+                _("Policy ({type})".format(type=policy_binding.policy._meta.verbose_name))
                 + "\n"
                 + policy_binding.policy.name,
                 "",
@@ -119,7 +119,7 @@ class FlowDiagram:
 
             element = DiagramElement(
                 f"stage_{s_index}",
-                _("Stage (%(type)s)" % {"type": stage_binding.stage._meta.verbose_name})
+                _("Stage ({type})".format(type=stage_binding.stage._meta.verbose_name))
                 + "\n"
                 + stage_binding.stage.name,
                 action,

--- a/authentik/flows/api/flows_diagram.py
+++ b/authentik/flows/api/flows_diagram.py
@@ -64,7 +64,7 @@ class FlowDiagram:
         ):
             element = DiagramElement(
                 f"flow_policy_{p_index}",
-                _("Policy ({type})".format(type=policy_binding.policy._meta.verbose_name))
+                _(f"Policy ({policy_binding.policy._meta.verbose_name})")
                 + "\n"
                 + policy_binding.policy.name,
                 _("Binding %(order)d" % {"order": policy_binding.order}),
@@ -90,7 +90,7 @@ class FlowDiagram:
         ):
             element = DiagramElement(
                 f"stage_{stage_index}_policy_{p_index}",
-                _("Policy ({type})".format(type=policy_binding.policy._meta.verbose_name))
+                _(f"Policy ({policy_binding.policy._meta.verbose_name})")
                 + "\n"
                 + policy_binding.policy.name,
                 "",
@@ -118,7 +118,7 @@ class FlowDiagram:
 
             element = DiagramElement(
                 f"stage_{s_index}",
-                _("Stage ({type})".format(type=stage_binding.stage._meta.verbose_name))
+                _(f"Stage ({stage_binding.stage._meta.verbose_name})")
                 + "\n"
                 + stage_binding.stage.name,
                 action,

--- a/authentik/flows/api/flows_diagram.py
+++ b/authentik/flows/api/flows_diagram.py
@@ -1,6 +1,5 @@
 """Flows Diagram API"""
 from dataclasses import dataclass, field
-from typing import Optional
 
 from django.utils.translation import gettext as _
 from guardian.shortcuts import get_objects_for_user

--- a/authentik/flows/challenge.py
+++ b/authentik/flows/challenge.py
@@ -103,7 +103,7 @@ class FlowErrorChallenge(Challenge):
     error = CharField(required=False)
     traceback = CharField(required=False)
 
-    def __init__(self, request: Optional[Request] = None, error: Optional[Exception] = None):
+    def __init__(self, request: Request | None = None, error: Exception | None = None):
         super().__init__(data={})
         if not request or not error:
             return

--- a/authentik/flows/exceptions.py
+++ b/authentik/flows/exceptions.py
@@ -1,5 +1,4 @@
 """flow exceptions"""
-from typing import Optional
 
 from django.utils.translation import gettext_lazy as _
 

--- a/authentik/flows/exceptions.py
+++ b/authentik/flows/exceptions.py
@@ -10,7 +10,7 @@ from authentik.policies.types import PolicyResult
 class FlowNonApplicableException(SentryIgnoredException):
     """Flow does not apply to current user (denied by policy, or otherwise)."""
 
-    policy_result: Optional[PolicyResult] = None
+    policy_result: PolicyResult | None = None
 
     @property
     def messages(self) -> str:

--- a/authentik/flows/markers.py
+++ b/authentik/flows/markers.py
@@ -24,7 +24,7 @@ class StageMarker:
         plan: "FlowPlan",
         binding: FlowStageBinding,
         http_request: HttpRequest,
-    ) -> Optional[FlowStageBinding]:
+    ) -> FlowStageBinding | None:
         """Process callback for this marker. This should be overridden by sub-classes.
         If a stage should be removed, return None."""
         return binding
@@ -41,7 +41,7 @@ class ReevaluateMarker(StageMarker):
         plan: "FlowPlan",
         binding: FlowStageBinding,
         http_request: HttpRequest,
-    ) -> Optional[FlowStageBinding]:
+    ) -> FlowStageBinding | None:
         """Re-evaluate policies bound to stage, and if they fail, remove from plan"""
         from authentik.flows.planner import PLAN_CONTEXT_PENDING_USER
 

--- a/authentik/flows/markers.py
+++ b/authentik/flows/markers.py
@@ -1,6 +1,6 @@
 """Stage Markers"""
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from django.http.request import HttpRequest
 from structlog.stdlib import get_logger

--- a/authentik/flows/models.py
+++ b/authentik/flows/models.py
@@ -1,7 +1,7 @@
 """Flow models"""
 from base64 import b64decode, b64encode
 from pickle import dumps, loads  # nosec
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 from django.db import models

--- a/authentik/flows/models.py
+++ b/authentik/flows/models.py
@@ -111,7 +111,7 @@ def in_memory_stage(view: type["StageView"], **kwargs) -> Stage:
     # we set the view as a separate property and reference a generic function
     # that returns that member
     setattr(stage, "__in_memory_type", view)
-    setattr(stage, "name", _("Dynamic In-memory stage: {doc}".format(doc=view.__doc__)))
+    setattr(stage, "name", _(f"Dynamic In-memory stage: {view.__doc__}"))
     setattr(stage._meta, "verbose_name", class_to_path(view))
     for key, value in kwargs.items():
         setattr(stage, key, value)

--- a/authentik/flows/models.py
+++ b/authentik/flows/models.py
@@ -93,7 +93,7 @@ class Stage(SerializerModel):
         """Return component used to edit this object"""
         raise NotImplementedError
 
-    def ui_user_settings(self) -> Optional[UserSettingSerializer]:
+    def ui_user_settings(self) -> UserSettingSerializer | None:
         """Entrypoint to integrate with User settings. Can either return None if no
         user settings are available, or a challenge."""
         return None
@@ -111,7 +111,7 @@ def in_memory_stage(view: type["StageView"], **kwargs) -> Stage:
     # we set the view as a separate property and reference a generic function
     # that returns that member
     setattr(stage, "__in_memory_type", view)
-    setattr(stage, "name", _("Dynamic In-memory stage: %(doc)s" % {"doc": view.__doc__}))
+    setattr(stage, "name", _("Dynamic In-memory stage: {doc}".format(doc=view.__doc__)))
     setattr(stage._meta, "verbose_name", class_to_path(view))
     for key, value in kwargs.items():
         setattr(stage, key, value)

--- a/authentik/flows/planner.py
+++ b/authentik/flows/planner.py
@@ -37,7 +37,7 @@ CACHE_TIMEOUT = CONFIG.get_int("redis.cache_timeout_flows")
 CACHE_PREFIX = "goauthentik.io/flows/planner/"
 
 
-def cache_key(flow: Flow, user: Optional[User] = None) -> str:
+def cache_key(flow: Flow, user: User | None = None) -> str:
     """Generate Cache key for flow"""
     prefix = CACHE_PREFIX + str(flow.pk)
     if user:
@@ -56,16 +56,16 @@ class FlowPlan:
     context: dict[str, Any] = field(default_factory=dict)
     markers: list[StageMarker] = field(default_factory=list)
 
-    def append_stage(self, stage: Stage, marker: Optional[StageMarker] = None):
+    def append_stage(self, stage: Stage, marker: StageMarker | None = None):
         """Append `stage` to all stages, optionally with stage marker"""
         return self.append(FlowStageBinding(stage=stage), marker)
 
-    def append(self, binding: FlowStageBinding, marker: Optional[StageMarker] = None):
+    def append(self, binding: FlowStageBinding, marker: StageMarker | None = None):
         """Append `stage` to all stages, optionally with stage marker"""
         self.bindings.append(binding)
         self.markers.append(marker or StageMarker())
 
-    def insert_stage(self, stage: Stage, marker: Optional[StageMarker] = None):
+    def insert_stage(self, stage: Stage, marker: StageMarker | None = None):
         """Insert stage into plan, as immediate next stage"""
         self.bindings.insert(1, FlowStageBinding(stage=stage, order=0))
         self.markers.insert(1, marker or StageMarker())
@@ -76,7 +76,7 @@ class FlowPlan:
 
         self.insert_stage(in_memory_stage(RedirectStage, destination=destination))
 
-    def next(self, http_request: Optional[HttpRequest]) -> Optional[FlowStageBinding]:
+    def next(self, http_request: HttpRequest | None) -> FlowStageBinding | None:
         """Return next pending stage from the bottom of the list"""
         if not self.has_stages:
             return None
@@ -143,7 +143,7 @@ class FlowPlanner:
             raise FlowNonApplicableException()
 
     def plan(
-        self, request: HttpRequest, default_context: Optional[dict[str, Any]] = None
+        self, request: HttpRequest, default_context: dict[str, Any] | None = None
     ) -> FlowPlan:
         """Check each of the flows' policies, check policies for each stage with PolicyBinding
         and return ordered list"""
@@ -208,7 +208,7 @@ class FlowPlanner:
         self,
         user: User,
         request: HttpRequest,
-        default_context: Optional[dict[str, Any]],
+        default_context: dict[str, Any] | None,
     ) -> FlowPlan:
         """Build flow plan by checking each stage in their respective
         order and checking the applied policies"""

--- a/authentik/flows/planner.py
+++ b/authentik/flows/planner.py
@@ -1,6 +1,6 @@
 """Flows Planner"""
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 from django.core.cache import cache
 from django.http import HttpRequest
@@ -142,9 +142,7 @@ class FlowPlanner:
         ):
             raise FlowNonApplicableException()
 
-    def plan(
-        self, request: HttpRequest, default_context: dict[str, Any] | None = None
-    ) -> FlowPlan:
+    def plan(self, request: HttpRequest, default_context: dict[str, Any] | None = None) -> FlowPlan:
         """Check each of the flows' policies, check policies for each stage with PolicyBinding
         and return ordered list"""
         with Hub.current.start_span(

--- a/authentik/flows/stage.py
+++ b/authentik/flows/stage.py
@@ -229,9 +229,9 @@ class ChallengeStageView(StageView):
 class AccessDeniedChallengeView(ChallengeStageView):
     """Used internally by FlowExecutor's stage_invalid()"""
 
-    error_message: Optional[str]
+    error_message: str | None
 
-    def __init__(self, executor: "FlowExecutorView", error_message: Optional[str] = None, **kwargs):
+    def __init__(self, executor: "FlowExecutorView", error_message: str | None = None, **kwargs):
         super().__init__(executor, **kwargs)
         self.error_message = error_message
 

--- a/authentik/flows/stage.py
+++ b/authentik/flows/stage.py
@@ -1,5 +1,5 @@
 """authentik stage Base view"""
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpRequest

--- a/authentik/flows/tests/__init__.py
+++ b/authentik/flows/tests/__init__.py
@@ -18,8 +18,8 @@ class FlowTestCase(APITestCase):
     def assertStageResponse(
         self,
         response: HttpResponse,
-        flow: Optional[Flow] = None,
-        user: Optional[User] = None,
+        flow: Flow | None = None,
+        user: User | None = None,
         **kwargs,
     ) -> dict[str, Any]:
         """Assert various attributes of a stage response"""

--- a/authentik/flows/tests/__init__.py
+++ b/authentik/flows/tests/__init__.py
@@ -1,6 +1,6 @@
 """Test helpers"""
 from json import loads
-from typing import Any, Optional
+from typing import Any
 
 from django.http.response import HttpResponse
 from django.urls.base import reverse

--- a/authentik/flows/tests/test_stage_model.py
+++ b/authentik/flows/tests/test_stage_model.py
@@ -1,5 +1,5 @@
 """base model tests"""
-from typing import Callable
+from collections.abc import Callable
 
 from django.test import TestCase
 

--- a/authentik/flows/tests/test_stage_views.py
+++ b/authentik/flows/tests/test_stage_views.py
@@ -1,5 +1,5 @@
 """stage view tests"""
-from typing import Callable
+from collections.abc import Callable
 
 from django.test import RequestFactory, TestCase
 

--- a/authentik/flows/views/executor.py
+++ b/authentik/flows/views/executor.py
@@ -1,6 +1,5 @@
 """authentik multi-stage authentication engine"""
 from copy import deepcopy
-from typing import Optional
 
 from django.conf import settings
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -496,9 +495,7 @@ class ToDefaultFlow(View):
         if self.designation == FlowDesignation.AUTHENTICATION:
             flow = tenant.flow_authentication
             # Check if we have a default flow from application
-            application: Application | None = self.request.session.get(
-                SESSION_KEY_APPLICATION_PRE
-            )
+            application: Application | None = self.request.session.get(SESSION_KEY_APPLICATION_PRE)
             if application and application.provider and application.provider.authentication_flow:
                 flow = application.provider.authentication_flow
         elif self.designation == FlowDesignation.INVALIDATION:

--- a/authentik/flows/views/executor.py
+++ b/authentik/flows/views/executor.py
@@ -106,8 +106,8 @@ class FlowExecutorView(APIView):
 
     flow: Flow
 
-    plan: Optional[FlowPlan] = None
-    current_binding: Optional[FlowStageBinding] = None
+    plan: FlowPlan | None = None
+    current_binding: FlowStageBinding | None = None
     current_stage: Stage
     current_stage_view: View
 
@@ -135,9 +135,9 @@ class FlowExecutorView(APIView):
             )
         return to_stage_response(self.request, self.stage_invalid(error_message=exc.messages))
 
-    def _check_flow_token(self, key: str) -> Optional[FlowPlan]:
+    def _check_flow_token(self, key: str) -> FlowPlan | None:
         """Check if the user is using a flow token to restore a plan"""
-        token: Optional[FlowToken] = FlowToken.filter_not_expired(key=key).first()
+        token: FlowToken | None = FlowToken.filter_not_expired(key=key).first()
         if not token:
             return None
         plan = None
@@ -414,7 +414,7 @@ class FlowExecutorView(APIView):
         )
         return self._flow_done()
 
-    def stage_invalid(self, error_message: Optional[str] = None) -> HttpResponse:
+    def stage_invalid(self, error_message: str | None = None) -> HttpResponse:
         """Callback used stage when data is correct but a policy denies access
         or the user account is disabled.
 
@@ -472,9 +472,9 @@ class CancelView(View):
 class ToDefaultFlow(View):
     """Redirect to default flow matching by designation"""
 
-    designation: Optional[FlowDesignation] = None
+    designation: FlowDesignation | None = None
 
-    def flow_by_policy(self, request: HttpRequest, **flow_filter) -> Optional[Flow]:
+    def flow_by_policy(self, request: HttpRequest, **flow_filter) -> Flow | None:
         """Get a Flow by `**flow_filter` and check if the request from `request` can access it."""
         flows = Flow.objects.filter(**flow_filter).order_by("slug")
         for flow in flows:
@@ -496,7 +496,7 @@ class ToDefaultFlow(View):
         if self.designation == FlowDesignation.AUTHENTICATION:
             flow = tenant.flow_authentication
             # Check if we have a default flow from application
-            application: Optional[Application] = self.request.session.get(
+            application: Application | None = self.request.session.get(
                 SESSION_KEY_APPLICATION_PRE
             )
             if application and application.provider and application.provider.authentication_flow:

--- a/authentik/lib/avatars.py
+++ b/authentik/lib/avatars.py
@@ -34,18 +34,18 @@ SVG_FONTS = [
 ]
 
 
-def avatar_mode_none(user: "User", mode: str) -> Optional[str]:
+def avatar_mode_none(user: "User", mode: str) -> str | None:
     """No avatar"""
     return DEFAULT_AVATAR
 
 
-def avatar_mode_attribute(user: "User", mode: str) -> Optional[str]:
+def avatar_mode_attribute(user: "User", mode: str) -> str | None:
     """Avatars based on a user attribute"""
     avatar = get_path_from_dict(user.attributes, mode[11:], default=None)
     return avatar
 
 
-def avatar_mode_gravatar(user: "User", mode: str) -> Optional[str]:
+def avatar_mode_gravatar(user: "User", mode: str) -> str | None:
     """Gravatar avatars"""
     # gravatar uses md5 for their URLs, so md5 can't be avoided
     mail_hash = md5(user.email.lower().encode("utf-8")).hexdigest()  # nosec
@@ -152,13 +152,13 @@ def generate_avatar_from_name(
     return etree.tostring(root_element).decode()
 
 
-def avatar_mode_generated(user: "User", mode: str) -> Optional[str]:
+def avatar_mode_generated(user: "User", mode: str) -> str | None:
     """Wrapper that converts generated avatar to base64 svg"""
     svg = generate_avatar_from_name(user.name if user.name.strip() != "" else "a k")
     return f"data:image/svg+xml;base64,{b64encode(svg.encode('utf-8')).decode('utf-8')}"
 
 
-def avatar_mode_url(user: "User", mode: str) -> Optional[str]:
+def avatar_mode_url(user: "User", mode: str) -> str | None:
     """Format url"""
     mail_hash = md5(user.email.lower().encode("utf-8")).hexdigest()  # nosec
     return mode % {

--- a/authentik/lib/avatars.py
+++ b/authentik/lib/avatars.py
@@ -2,7 +2,7 @@
 from base64 import b64encode
 from functools import cache as funccache
 from hashlib import md5
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 from urllib.parse import urlencode
 
 from django.core.cache import cache

--- a/authentik/lib/config.py
+++ b/authentik/lib/config.py
@@ -65,7 +65,7 @@ class Attr:
 
     # depending on source_type, might contain the environment variable or the path
     # to the config file containing this change or the file containing this value
-    source: Optional[str] = field(default=None)
+    source: str | None = field(default=None)
 
     def __post_init__(self):
         if isinstance(self.value, Attr):
@@ -156,7 +156,7 @@ class ConfigLoader:
             parsed_value = os.getenv(url.netloc, url.query)
         if url.scheme == "file":
             try:
-                with open(url.path, "r", encoding="utf8") as _file:
+                with open(url.path, encoding="utf8") as _file:
                     parsed_value = _file.read().strip()
             except OSError as exc:
                 self.log("error", f"Failed to read config value from {url.path}: {exc}")

--- a/authentik/lib/config.py
+++ b/authentik/lib/config.py
@@ -10,7 +10,7 @@ from json.decoder import JSONDecodeError
 from pathlib import Path
 from sys import argv, stderr
 from time import time
-from typing import Any, Optional
+from typing import Any
 from urllib.parse import urlparse
 
 import yaml

--- a/authentik/lib/expression/evaluator.py
+++ b/authentik/lib/expression/evaluator.py
@@ -3,7 +3,8 @@ import re
 import socket
 from ipaddress import ip_address, ip_network
 from textwrap import indent
-from typing import Any, Iterable, Optional
+from typing import Any, Optional
+from collections.abc import Iterable
 
 from cachetools import TLRUCache, cached
 from django.core.exceptions import FieldError
@@ -35,7 +36,7 @@ class BaseEvaluator:
     # Filename used for exec
     _filename: str
 
-    def __init__(self, filename: Optional[str] = None):
+    def __init__(self, filename: str | None = None):
         self._filename = filename if filename else "BaseEvaluator"
         # update website/docs/expressions/_objects.md
         # update website/docs/expressions/_functions.md
@@ -59,7 +60,7 @@ class BaseEvaluator:
 
     @cached(cache=TLRUCache(maxsize=32, ttu=lambda key, value, now: now + 180))
     @staticmethod
-    def expr_resolve_dns(host: str, ip_version: Optional[int] = None) -> list[str]:
+    def expr_resolve_dns(host: str, ip_version: int | None = None) -> list[str]:
         """Resolve host to a list of IPv4 and/or IPv6 addresses."""
         # Although it seems to be fine (raising OSError), docs warn
         # against passing `None` for both the host and the port
@@ -91,7 +92,7 @@ class BaseEvaluator:
             return ip_addr
 
     @staticmethod
-    def expr_flatten(value: list[Any] | Any) -> Optional[Any]:
+    def expr_flatten(value: list[Any] | Any) -> Any | None:
         """Flatten `value` if its a list"""
         if isinstance(value, list):
             if len(value) < 1:
@@ -115,7 +116,7 @@ class BaseEvaluator:
         return user.all_groups().filter(**group_filters).exists()
 
     @staticmethod
-    def expr_user_by(**filters) -> Optional[User]:
+    def expr_user_by(**filters) -> User | None:
         """Get user by filters"""
         try:
             users = User.objects.filter(**filters)
@@ -126,7 +127,7 @@ class BaseEvaluator:
             return None
 
     @staticmethod
-    def expr_func_user_has_authenticator(user: User, device_type: Optional[str] = None) -> bool:
+    def expr_func_user_has_authenticator(user: User, device_type: str | None = None) -> bool:
         """Check if a user has any authenticator devices, optionally matching *device_type*"""
         user_devices = devices_for_user(user)
         if device_type:

--- a/authentik/lib/expression/evaluator.py
+++ b/authentik/lib/expression/evaluator.py
@@ -1,10 +1,10 @@
 """authentik expression policy evaluator"""
 import re
 import socket
+from collections.abc import Iterable
 from ipaddress import ip_address, ip_network
 from textwrap import indent
-from typing import Any, Optional
-from collections.abc import Iterable
+from typing import Any
 
 from cachetools import TLRUCache, cached
 from django.core.exceptions import FieldError

--- a/authentik/lib/migrations.py
+++ b/authentik/lib/migrations.py
@@ -1,5 +1,5 @@
 """Migration helpers"""
-from typing import Iterable
+from collections.abc import Iterable
 
 from django.apps.registry import Apps
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor

--- a/authentik/lib/sentry.py
+++ b/authentik/lib/sentry.py
@@ -95,7 +95,7 @@ def traces_sampler(sampling_context: dict) -> float:
     return float(CONFIG.get("error_reporting.sample_rate", 0.1))
 
 
-def before_send(event: dict, hint: dict) -> Optional[dict]:
+def before_send(event: dict, hint: dict) -> dict | None:
     """Check if error is database error, and ignore if so"""
     # pylint: disable=no-name-in-module
     from psycopg.errors import Error

--- a/authentik/lib/sentry.py
+++ b/authentik/lib/sentry.py
@@ -1,6 +1,6 @@
 """authentik sentry integration"""
 from asyncio.exceptions import CancelledError
-from typing import Any, Optional
+from typing import Any
 
 from billiard.exceptions import SoftTimeLimitExceeded, WorkerLostError
 from celery.exceptions import CeleryError

--- a/authentik/lib/tests/test_config.py
+++ b/authentik/lib/tests/test_config.py
@@ -38,7 +38,7 @@ class TestConfig(TestCase):
         """Test URI parsing (file load)"""
         config = ConfigLoader()
         file, file_name = mkstemp()
-        write(file, "foo".encode())
+        write(file, b"foo")
         _, file2_name = mkstemp()
         chmod(file2_name, 0o000)  # Remove all permissions so we can't read the file
         self.assertEqual(config.parse_uri(f"file://{file_name}").value, "foo")
@@ -49,12 +49,12 @@ class TestConfig(TestCase):
     def test_uri_file_update(self):
         """Test URI parsing (file load and update)"""
         file, file_name = mkstemp()
-        write(file, "foo".encode())
+        write(file, b"foo")
         config = ConfigLoader(file_test=f"file://{file_name}")
         self.assertEqual(config.get("file_test"), "foo")
 
         # Update config file
-        write(file, "bar".encode())
+        write(file, b"bar")
         config.refresh("file_test")
         self.assertEqual(config.get("file_test"), "foobar")
 
@@ -70,9 +70,9 @@ class TestConfig(TestCase):
         """Test update_from_file"""
         config = ConfigLoader()
         file, file_name = mkstemp()
-        write(file, "{".encode())
+        write(file, b"{")
         file2, file2_name = mkstemp()
-        write(file2, "{".encode())
+        write(file2, b"{")
         chmod(file2_name, 0o000)  # Remove all permissions so we can't read the file
         with self.assertRaises(ImproperlyConfigured):
             config.update_from_file(file_name)

--- a/authentik/lib/tests/test_serializer_model.py
+++ b/authentik/lib/tests/test_serializer_model.py
@@ -1,5 +1,5 @@
 """base model tests"""
-from typing import Callable
+from collections.abc import Callable
 
 from django.test import TestCase
 from rest_framework.serializers import BaseSerializer

--- a/authentik/lib/tests/utils.py
+++ b/authentik/lib/tests/utils.py
@@ -19,9 +19,7 @@ def load_fixture(path: str, **kwargs) -> str:
     current = currentframe()
     parent = current.f_back
     calling_file_path = parent.f_globals["__file__"]
-    with open(
-        Path(calling_file_path).resolve().parent / Path(path), encoding="utf-8"
-    ) as _fixture:
+    with open(Path(calling_file_path).resolve().parent / Path(path), encoding="utf-8") as _fixture:
         fixture = _fixture.read()
         try:
             return fixture % kwargs

--- a/authentik/lib/tests/utils.py
+++ b/authentik/lib/tests/utils.py
@@ -20,7 +20,7 @@ def load_fixture(path: str, **kwargs) -> str:
     parent = current.f_back
     calling_file_path = parent.f_globals["__file__"]
     with open(
-        Path(calling_file_path).resolve().parent / Path(path), "r", encoding="utf-8"
+        Path(calling_file_path).resolve().parent / Path(path), encoding="utf-8"
     ) as _fixture:
         fixture = _fixture.read()
         try:

--- a/authentik/lib/utils/http.py
+++ b/authentik/lib/utils/http.py
@@ -1,5 +1,5 @@
 """http helpers"""
-from typing import Any, Optional
+from typing import Any
 
 from django.http import HttpRequest
 from requests.sessions import Session

--- a/authentik/lib/utils/http.py
+++ b/authentik/lib/utils/http.py
@@ -31,7 +31,7 @@ def _get_client_ip_from_meta(meta: dict[str, Any]) -> str:
     return DEFAULT_IP
 
 
-def _get_outpost_override_ip(request: HttpRequest) -> Optional[str]:
+def _get_outpost_override_ip(request: HttpRequest) -> str | None:
     """Get the actual remote IP when set by an outpost. Only
     allowed when the request is authenticated, by an outpost internal service account"""
     from authentik.core.models import Token, TokenIntents, UserTypes
@@ -66,7 +66,7 @@ def _get_outpost_override_ip(request: HttpRequest) -> Optional[str]:
     return fake_ip
 
 
-def get_client_ip(request: Optional[HttpRequest]) -> str:
+def get_client_ip(request: HttpRequest | None) -> str:
     """Attempt to get the client's IP by checking common HTTP Headers.
     Returns none if no IP Could be found"""
     if not request:

--- a/authentik/lib/utils/urls.py
+++ b/authentik/lib/utils/urls.py
@@ -17,7 +17,7 @@ def is_url_absolute(url):
 
 
 def redirect_with_qs(
-    view: str, get_query_set: Optional[QueryDict] = None, **kwargs
+    view: str, get_query_set: QueryDict | None = None, **kwargs
 ) -> HttpResponse:
     """Wrapper to redirect whilst keeping GET Parameters"""
     try:
@@ -32,7 +32,7 @@ def redirect_with_qs(
     return redirect(target)
 
 
-def reverse_with_qs(view: str, query: Optional[QueryDict] = None, **kwargs) -> str:
+def reverse_with_qs(view: str, query: QueryDict | None = None, **kwargs) -> str:
     """Reverse a view to it's url but include get params"""
     url = reverse(view, **kwargs)
     if query:

--- a/authentik/lib/utils/urls.py
+++ b/authentik/lib/utils/urls.py
@@ -1,5 +1,4 @@
 """URL-related utils"""
-from typing import Optional
 from urllib.parse import urlparse
 
 from django.http import HttpResponse, QueryDict
@@ -16,9 +15,7 @@ def is_url_absolute(url):
     return bool(urlparse(url).netloc)
 
 
-def redirect_with_qs(
-    view: str, get_query_set: QueryDict | None = None, **kwargs
-) -> HttpResponse:
+def redirect_with_qs(view: str, get_query_set: QueryDict | None = None, **kwargs) -> HttpResponse:
     """Wrapper to redirect whilst keeping GET Parameters"""
     try:
         target = reverse(view, kwargs=kwargs)

--- a/authentik/lib/validators.py
+++ b/authentik/lib/validators.py
@@ -1,5 +1,4 @@
 """Serializer validators"""
-from typing import Optional
 
 from django.utils.translation import gettext_lazy as _
 from rest_framework.exceptions import ValidationError

--- a/authentik/lib/validators.py
+++ b/authentik/lib/validators.py
@@ -15,7 +15,7 @@ class RequiredTogetherValidator:
     requires_context = True
     message = _("The fields {field_names} must be used together.")
 
-    def __init__(self, fields: list[str], message: Optional[str] = None) -> None:
+    def __init__(self, fields: list[str], message: str | None = None) -> None:
         self.fields = fields
         self.message = message or self.message
 
@@ -29,4 +29,4 @@ class RequiredTogetherValidator:
             raise ValidationError(message, code="required")
 
     def __repr__(self):
-        return "<%s(fields=%s)>" % (self.__class__.__name__, smart_repr(self.fields))
+        return "<{}(fields={})>".format(self.__class__.__name__, smart_repr(self.fields))

--- a/authentik/lib/validators.py
+++ b/authentik/lib/validators.py
@@ -28,4 +28,4 @@ class RequiredTogetherValidator:
             raise ValidationError(message, code="required")
 
     def __repr__(self):
-        return "<{}(fields={})>".format(self.__class__.__name__, smart_repr(self.fields))
+        return f"<{self.__class__.__name__}(fields={smart_repr(self.fields)})>"

--- a/authentik/outposts/consumer.py
+++ b/authentik/outposts/consumer.py
@@ -45,10 +45,10 @@ class WebsocketMessage:
 class OutpostConsumer(AuthJsonConsumer):
     """Handler for Outposts that connect over websockets for health checks and live updates"""
 
-    outpost: Optional[Outpost] = None
+    outpost: Outpost | None = None
     logger: BoundLogger
 
-    last_uid: Optional[str] = None
+    last_uid: str | None = None
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/authentik/outposts/consumer.py
+++ b/authentik/outposts/consumer.py
@@ -2,7 +2,7 @@
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from enum import IntEnum
-from typing import Any, Optional
+from typing import Any
 
 from asgiref.sync import async_to_sync
 from channels.exceptions import DenyConnection

--- a/authentik/outposts/controllers/base.py
+++ b/authentik/outposts/controllers/base.py
@@ -1,6 +1,5 @@
 """Base Controller"""
 from dataclasses import dataclass
-from typing import Optional
 
 from structlog.stdlib import get_logger
 from structlog.testing import capture_logs

--- a/authentik/outposts/controllers/base.py
+++ b/authentik/outposts/controllers/base.py
@@ -28,7 +28,7 @@ class DeploymentPort:
     port: int
     name: str
     protocol: str
-    inner_port: Optional[int] = None
+    inner_port: int | None = None
 
 
 class BaseClient:

--- a/authentik/outposts/controllers/docker.py
+++ b/authentik/outposts/controllers/docker.py
@@ -1,6 +1,5 @@
 """Docker controller"""
 from time import sleep
-from typing import Optional
 from urllib.parse import urlparse
 
 from django.conf import settings

--- a/authentik/outposts/controllers/docker.py
+++ b/authentik/outposts/controllers/docker.py
@@ -28,8 +28,8 @@ from authentik.outposts.models import (
 class DockerClient(UpstreamDockerClient, BaseClient):
     """Custom docker client, which can handle TLS and SSH from a database."""
 
-    tls: Optional[DockerInlineTLS]
-    ssh: Optional[DockerInlineSSH]
+    tls: DockerInlineTLS | None
+    ssh: DockerInlineSSH | None
 
     def __init__(self, connection: DockerServiceConnection):
         self.tls = None

--- a/authentik/outposts/controllers/k8s/base.py
+++ b/authentik/outposts/controllers/k8s/base.py
@@ -1,7 +1,7 @@
 """Base Kubernetes Reconciler"""
 from dataclasses import asdict
 from json import dumps
-from typing import TYPE_CHECKING, Generic, Optional, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 from dacite.core import from_dict
 from django.utils.text import slugify

--- a/authentik/outposts/controllers/k8s/base.py
+++ b/authentik/outposts/controllers/k8s/base.py
@@ -135,7 +135,7 @@ class KubernetesObjectReconciler(Generic[T]):
         else:
             self.logger.debug("Object is up-to-date.")
 
-    def _recreate(self, reference: T, current: Optional[T] = None):
+    def _recreate(self, reference: T, current: T | None = None):
         """Recreate object"""
         self.logger.debug("Recreate requested")
         if current:

--- a/authentik/outposts/controllers/k8s/utils.py
+++ b/authentik/outposts/controllers/k8s/utils.py
@@ -12,7 +12,7 @@ def get_namespace() -> str:
     """Get the namespace if we're running in a pod, otherwise default to default"""
     path = Path(SERVICE_TOKEN_FILENAME.replace("token", "namespace"))
     if path.exists():
-        with open(path, "r", encoding="utf8") as _namespace_file:
+        with open(path, encoding="utf8") as _namespace_file:
             return _namespace_file.read()
     return "default"
 

--- a/authentik/outposts/docker_ssh.py
+++ b/authentik/outposts/docker_ssh.py
@@ -80,7 +80,7 @@ class DockerInlineSSH:
         """Cleanup when we're done"""
         try:
             os.unlink(self.key_path)
-            with open(self.config_path, "r", encoding="utf-8") as ssh_config:
+            with open(self.config_path, encoding="utf-8") as ssh_config:
                 start = 0
                 end = 0
                 lines = ssh_config.readlines()

--- a/authentik/outposts/docker_tls.py
+++ b/authentik/outposts/docker_tls.py
@@ -12,15 +12,15 @@ from authentik.crypto.models import CertificateKeyPair
 class DockerInlineTLS:
     """Create Docker TLSConfig from CertificateKeyPair"""
 
-    verification_kp: Optional[CertificateKeyPair]
-    authentication_kp: Optional[CertificateKeyPair]
+    verification_kp: CertificateKeyPair | None
+    authentication_kp: CertificateKeyPair | None
 
     _paths: list[str]
 
     def __init__(
         self,
-        verification_kp: Optional[CertificateKeyPair],
-        authentication_kp: Optional[CertificateKeyPair],
+        verification_kp: CertificateKeyPair | None,
+        authentication_kp: CertificateKeyPair | None,
     ) -> None:
         self.verification_kp = verification_kp
         self.authentication_kp = authentication_kp

--- a/authentik/outposts/docker_tls.py
+++ b/authentik/outposts/docker_tls.py
@@ -2,7 +2,6 @@
 from os import unlink
 from pathlib import Path
 from tempfile import gettempdir
-from typing import Optional
 
 from docker.tls import TLSConfig
 

--- a/authentik/outposts/models.py
+++ b/authentik/outposts/models.py
@@ -1,8 +1,8 @@
 """Outpost models"""
+from collections.abc import Iterable
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
-from typing import Any, Optional
-from collections.abc import Iterable
+from typing import Any
 from uuid import uuid4
 
 from dacite.core import from_dict

--- a/authentik/outposts/models.py
+++ b/authentik/outposts/models.py
@@ -1,7 +1,8 @@
 """Outpost models"""
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
-from typing import Any, Iterable, Optional
+from typing import Any, Optional
+from collections.abc import Iterable
 from uuid import uuid4
 
 from dacite.core import from_dict
@@ -61,21 +62,21 @@ class OutpostConfig:
     log_level: str = CONFIG.get("log_level")
     object_naming_template: str = field(default="ak-outpost-%(name)s")
 
-    container_image: Optional[str] = field(default=None)
+    container_image: str | None = field(default=None)
 
-    docker_network: Optional[str] = field(default=None)
+    docker_network: str | None = field(default=None)
     docker_map_ports: bool = field(default=True)
-    docker_labels: Optional[dict[str, str]] = field(default=None)
+    docker_labels: dict[str, str] | None = field(default=None)
 
     kubernetes_replicas: int = field(default=1)
     kubernetes_namespace: str = field(default_factory=get_namespace)
     kubernetes_ingress_annotations: dict[str, str] = field(default_factory=dict)
     kubernetes_ingress_secret_name: str = field(default="authentik-outpost-tls")
-    kubernetes_ingress_class_name: Optional[str] = field(default=None)
+    kubernetes_ingress_class_name: str | None = field(default=None)
     kubernetes_service_type: str = field(default="ClusterIP")
     kubernetes_disabled_components: list[str] = field(default_factory=list)
     kubernetes_image_pull_secrets: list[str] = field(default_factory=list)
-    kubernetes_json_patches: Optional[dict[str, list[dict[str, Any]]]] = field(default=None)
+    kubernetes_json_patches: dict[str, list[dict[str, Any]]] | None = field(default=None)
 
 
 class OutpostModel(Model):
@@ -97,7 +98,7 @@ class OutpostType(models.TextChoices):
     RADIUS = "radius"
 
 
-def default_outpost_config(host: Optional[str] = None):
+def default_outpost_config(host: str | None = None):
     """Get default outpost config"""
     return asdict(OutpostConfig(authentik_host=host or ""))
 
@@ -415,14 +416,14 @@ class OutpostState:
     """Outpost instance state, last_seen and version"""
 
     uid: str
-    last_seen: Optional[datetime] = field(default=None)
-    version: Optional[str] = field(default=None)
+    last_seen: datetime | None = field(default=None)
+    version: str | None = field(default=None)
     version_should: Version = field(default=OUR_VERSION)
     build_hash: str = field(default="")
     hostname: str = field(default="")
     args: dict = field(default_factory=dict)
 
-    _outpost: Optional[Outpost] = field(default=None)
+    _outpost: Outpost | None = field(default=None)
 
     @property
     def version_outdated(self) -> bool:

--- a/authentik/outposts/tasks.py
+++ b/authentik/outposts/tasks.py
@@ -2,7 +2,7 @@
 from os import R_OK, access
 from pathlib import Path
 from socket import gethostname
-from typing import Any, Optional
+from typing import Any
 from urllib.parse import urlparse
 
 from asgiref.sync import async_to_sync

--- a/authentik/outposts/tasks.py
+++ b/authentik/outposts/tasks.py
@@ -51,7 +51,7 @@ CACHE_KEY_OUTPOST_DOWN = "goauthentik.io/outposts/teardown/%s"
 
 
 # pylint: disable=too-many-return-statements
-def controller_for_outpost(outpost: Outpost) -> Optional[type[BaseController]]:
+def controller_for_outpost(outpost: Outpost) -> type[BaseController] | None:
     """Get a controller for the outpost, when a service connection is defined"""
     if not outpost.service_connection:
         return None

--- a/authentik/policies/api/bindings.py
+++ b/authentik/policies/api/bindings.py
@@ -1,5 +1,5 @@
 """policy binding API Views"""
-from typing import OrderedDict
+from collections import OrderedDict
 
 from django.core.exceptions import ObjectDoesNotExist
 from django_filters.filters import BooleanFilter, ModelMultipleChoiceFilter

--- a/authentik/policies/denied.py
+++ b/authentik/policies/denied.py
@@ -16,14 +16,14 @@ class AccessDeniedResponse(TemplateResponse):
 
     title: str
 
-    error_message: Optional[str] = None
-    policy_result: Optional[PolicyResult] = None
+    error_message: str | None = None
+    policy_result: PolicyResult | None = None
 
     def __init__(self, request: HttpRequest, template="policies/denied.html") -> None:
         super().__init__(request, template)
         self.title = _("Access denied")
 
-    def resolve_context(self, context: Optional[dict[str, Any]]) -> Optional[dict[str, Any]]:
+    def resolve_context(self, context: dict[str, Any] | None) -> dict[str, Any] | None:
         if not context:
             context = {}
         context["title"] = self.title

--- a/authentik/policies/denied.py
+++ b/authentik/policies/denied.py
@@ -1,5 +1,5 @@
 """policy http response"""
-from typing import Any, Optional
+from typing import Any
 
 from django.http.request import HttpRequest
 from django.template.response import TemplateResponse

--- a/authentik/policies/engine.py
+++ b/authentik/policies/engine.py
@@ -2,7 +2,8 @@
 from multiprocessing import Pipe, current_process
 from multiprocessing.connection import Connection
 from timeit import default_timer
-from typing import Iterator, Optional
+from typing import Optional
+from collections.abc import Iterator
 
 from django.core.cache import cache
 from django.http import HttpRequest
@@ -26,7 +27,7 @@ class PolicyProcessInfo:
 
     process: PolicyProcess
     connection: Connection
-    result: Optional[PolicyResult]
+    result: PolicyResult | None
     binding: PolicyBinding
 
     def __init__(self, process: PolicyProcess, connection: Connection, binding: PolicyBinding):

--- a/authentik/policies/engine.py
+++ b/authentik/policies/engine.py
@@ -1,9 +1,8 @@
 """authentik policy engine"""
+from collections.abc import Iterator
 from multiprocessing import Pipe, current_process
 from multiprocessing.connection import Connection
 from timeit import default_timer
-from typing import Optional
-from collections.abc import Iterator
 
 from django.core.cache import cache
 from django.http import HttpRequest

--- a/authentik/policies/exceptions.py
+++ b/authentik/policies/exceptions.py
@@ -1,5 +1,4 @@
 """policy exceptions"""
-from typing import Optional
 
 from authentik.lib.sentry import SentryIgnoredException
 

--- a/authentik/policies/exceptions.py
+++ b/authentik/policies/exceptions.py
@@ -11,8 +11,8 @@ class PolicyEngineException(SentryIgnoredException):
 class PolicyException(SentryIgnoredException):
     """Exception that should be raised during Policy Evaluation, and can be recovered from."""
 
-    src_exc: Optional[Exception] = None
+    src_exc: Exception | None = None
 
-    def __init__(self, src_exc: Optional[Exception] = None) -> None:
+    def __init__(self, src_exc: Exception | None = None) -> None:
         super().__init__()
         self.src_exc = src_exc

--- a/authentik/policies/expression/evaluator.py
+++ b/authentik/policies/expression/evaluator.py
@@ -23,7 +23,7 @@ class PolicyEvaluator(BaseEvaluator):
 
     policy: Optional["ExpressionPolicy"] = None
 
-    def __init__(self, policy_name: Optional[str] = None):
+    def __init__(self, policy_name: str | None = None):
         super().__init__(policy_name or "PolicyEvaluator")
         self._messages = []
         # update website/docs/expressions/_objects.md

--- a/authentik/policies/process.py
+++ b/authentik/policies/process.py
@@ -45,7 +45,7 @@ class PolicyProcess(PROCESS_CLASS):
         self,
         binding: PolicyBinding,
         request: PolicyRequest,
-        connection: Optional[Connection],
+        connection: Connection | None,
     ):
         super().__init__()
         self.binding = binding

--- a/authentik/policies/process.py
+++ b/authentik/policies/process.py
@@ -1,7 +1,6 @@
 """authentik policy task"""
 from multiprocessing import get_context
 from multiprocessing.connection import Connection
-from typing import Optional
 
 from django.core.cache import cache
 from sentry_sdk.hub import Hub

--- a/authentik/policies/types.py
+++ b/authentik/policies/types.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from django.db.models import Model
 from django.http import HttpRequest

--- a/authentik/policies/types.py
+++ b/authentik/policies/types.py
@@ -24,8 +24,8 @@ class PolicyRequest:
     """Data-class to hold policy request data"""
 
     user: User
-    http_request: Optional[HttpRequest]
-    obj: Optional[Model]
+    http_request: HttpRequest | None
+    obj: Model | None
     context: dict[str, Any]
     debug: bool
 
@@ -75,10 +75,10 @@ class PolicyResult:
     messages: tuple[str, ...]
     raw_result: Any
 
-    source_binding: Optional["PolicyBinding"]
-    source_results: Optional[list["PolicyResult"]]
+    source_binding: PolicyBinding | None
+    source_results: list[PolicyResult] | None
 
-    log_messages: Optional[list[dict]]
+    log_messages: list[dict] | None
 
     def __init__(self, passing: bool, *messages: str):
         self.passing = passing

--- a/authentik/policies/views.py
+++ b/authentik/policies/views.py
@@ -22,9 +22,9 @@ LOGGER = get_logger()
 class RequestValidationError(SentryIgnoredException):
     """Error raised in pre_permission_check, when a request is invalid."""
 
-    response: Optional[HttpResponse]
+    response: HttpResponse | None
 
-    def __init__(self, response: Optional[HttpResponse] = None):
+    def __init__(self, response: HttpResponse | None = None):
         super().__init__()
         if response:
             self.response = response
@@ -94,7 +94,7 @@ class PolicyAccessView(AccessMixin, View):
         )
 
     def handle_no_permission_authenticated(
-        self, result: Optional[PolicyResult] = None
+        self, result: PolicyResult | None = None
     ) -> HttpResponse:
         """Function called when user has no permissions but is authenticated"""
         response = AccessDeniedResponse(self.request)
@@ -106,7 +106,7 @@ class PolicyAccessView(AccessMixin, View):
         """optionally modify the policy request"""
         return request
 
-    def user_has_access(self, user: Optional[User] = None) -> PolicyResult:
+    def user_has_access(self, user: User | None = None) -> PolicyResult:
         """Check if user has access to application."""
         user = user or self.request.user
         policy_engine = PolicyEngine(self.application, user or self.request.user, self.request)

--- a/authentik/policies/views.py
+++ b/authentik/policies/views.py
@@ -1,5 +1,5 @@
 """authentik access helper classes"""
-from typing import Any, Optional
+from typing import Any
 
 from django.contrib import messages
 from django.contrib.auth.mixins import AccessMixin

--- a/authentik/providers/ldap/models.py
+++ b/authentik/providers/ldap/models.py
@@ -1,5 +1,4 @@
 """LDAP Provider"""
-from typing import Optional
 from collections.abc import Iterable
 
 from django.db import models

--- a/authentik/providers/ldap/models.py
+++ b/authentik/providers/ldap/models.py
@@ -1,5 +1,6 @@
 """LDAP Provider"""
-from typing import Iterable, Optional
+from typing import Optional
+from collections.abc import Iterable
 
 from django.db import models
 from django.utils.translation import gettext_lazy as _
@@ -81,7 +82,7 @@ class LDAPProvider(OutpostModel, BackchannelProvider):
     )
 
     @property
-    def launch_url(self) -> Optional[str]:
+    def launch_url(self) -> str | None:
         """LDAP never has a launch URL"""
         return None
 

--- a/authentik/providers/oauth2/errors.py
+++ b/authentik/providers/oauth2/errors.py
@@ -26,7 +26,7 @@ class OAuth2Error(SentryIgnoredException):
     def __repr__(self) -> str:
         return self.error
 
-    def to_event(self, message: Optional[str] = None, **kwargs) -> Event:
+    def to_event(self, message: str | None = None, **kwargs) -> Event:
         """Create configuration_error Event."""
         return Event.new(
             EventAction.CONFIGURATION_ERROR,
@@ -148,7 +148,7 @@ class AuthorizeError(OAuth2Error):
         error: str,
         grant_type: str,
         state: str,
-        description: Optional[str] = None,
+        description: str | None = None,
     ):
         super().__init__()
         self.error = error

--- a/authentik/providers/oauth2/errors.py
+++ b/authentik/providers/oauth2/errors.py
@@ -1,5 +1,4 @@
 """OAuth errors"""
-from typing import Optional
 from urllib.parse import quote, urlparse
 
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect

--- a/authentik/providers/oauth2/id_token.py
+++ b/authentik/providers/oauth2/id_token.py
@@ -1,6 +1,6 @@
 """id_token utils"""
 from dataclasses import asdict, dataclass, field
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 from django.db import models
 from django.http import HttpRequest

--- a/authentik/providers/oauth2/id_token.py
+++ b/authentik/providers/oauth2/id_token.py
@@ -53,31 +53,31 @@ class IDToken:
     https://openid.net/specs/openid-connect-core-1_0.html#IDToken"""
 
     # Issuer, https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.1
-    iss: Optional[str] = None
+    iss: str | None = None
     # Subject, https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.2
-    sub: Optional[str] = None
+    sub: str | None = None
     # Audience, https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.3
-    aud: Optional[Union[str, list[str]]] = None
+    aud: str | list[str] | None = None
     # Expiration time, https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.4
-    exp: Optional[int] = None
+    exp: int | None = None
     # Issued at, https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.6
-    iat: Optional[int] = None
+    iat: int | None = None
     # Time when the authentication occurred,
     # https://openid.net/specs/openid-connect-core-1_0.html#IDToken
-    auth_time: Optional[int] = None
+    auth_time: int | None = None
     # Authentication Context Class Reference,
     # https://openid.net/specs/openid-connect-core-1_0.html#IDToken
-    acr: Optional[str] = ACR_AUTHENTIK_DEFAULT
+    acr: str | None = ACR_AUTHENTIK_DEFAULT
     # Authentication Methods References,
     # https://openid.net/specs/openid-connect-core-1_0.html#IDToken
-    amr: Optional[list[str]] = None
+    amr: list[str] | None = None
     # Code hash value, http://openid.net/specs/openid-connect-core-1_0.html
-    c_hash: Optional[str] = None
+    c_hash: str | None = None
     # Value used to associate a Client session with an ID Token,
     # http://openid.net/specs/openid-connect-core-1_0.html
-    nonce: Optional[str] = None
+    nonce: str | None = None
     # Access Token hash value, http://openid.net/specs/openid-connect-core-1_0.html
-    at_hash: Optional[str] = None
+    at_hash: str | None = None
 
     claims: dict[str, Any] = field(default_factory=dict)
 

--- a/authentik/providers/oauth2/models.py
+++ b/authentik/providers/oauth2/models.py
@@ -5,7 +5,7 @@ import json
 from dataclasses import asdict
 from functools import cached_property
 from hashlib import sha256
-from typing import Any, Optional
+from typing import Any
 from urllib.parse import urlparse, urlunparse
 
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePrivateKey

--- a/authentik/providers/oauth2/models.py
+++ b/authentik/providers/oauth2/models.py
@@ -232,7 +232,7 @@ class OAuth2Provider(Provider):
             return private_key, JWTAlgorithms.ES256
         raise ValueError(f"Invalid private key type: {type(private_key)}")
 
-    def get_issuer(self, request: HttpRequest) -> Optional[str]:
+    def get_issuer(self, request: HttpRequest) -> str | None:
         """Get issuer, based on request"""
         if self.issuer_mode == IssuerMode.GLOBAL:
             return request.build_absolute_uri(reverse("authentik_core:root-redirect"))
@@ -250,7 +250,7 @@ class OAuth2Provider(Provider):
             return None
 
     @property
-    def launch_url(self) -> Optional[str]:
+    def launch_url(self) -> str | None:
         """Guess launch_url based on first redirect_uri"""
         if self.redirect_uris == "":
             return None

--- a/authentik/providers/oauth2/utils.py
+++ b/authentik/providers/oauth2/utils.py
@@ -2,7 +2,7 @@
 import re
 from base64 import b64decode
 from binascii import Error
-from typing import Any, Optional
+from typing import Any
 from urllib.parse import urlparse
 
 from django.http import HttpRequest, HttpResponse, JsonResponse

--- a/authentik/providers/oauth2/utils.py
+++ b/authentik/providers/oauth2/utils.py
@@ -72,7 +72,7 @@ def cors_allow(request: HttpRequest, response: HttpResponse, *allowed_origins: s
     return response
 
 
-def extract_access_token(request: HttpRequest) -> Optional[str]:
+def extract_access_token(request: HttpRequest) -> str | None:
     """
     Get the access token using Authorization Request Header Field method.
     Or try getting via GET.
@@ -177,12 +177,12 @@ def protected_resource_view(scopes: list[str]):
     return wrapper
 
 
-def authenticate_provider(request: HttpRequest) -> Optional[OAuth2Provider]:
+def authenticate_provider(request: HttpRequest) -> OAuth2Provider | None:
     """Attempt to authenticate via Basic auth of client_id:client_secret"""
     client_id, client_secret = extract_client_auth(request)
     if client_id == client_secret == "":
         return None
-    provider: Optional[OAuth2Provider] = OAuth2Provider.objects.filter(client_id=client_id).first()
+    provider: OAuth2Provider | None = OAuth2Provider.objects.filter(client_id=client_id).first()
     if not provider:
         return None
     if client_id != provider.client_id or client_secret != provider.client_secret:
@@ -199,7 +199,7 @@ class HttpResponseRedirectScheme(HttpResponseRedirect):
         self,
         redirect_to: str,
         *args: Any,
-        allowed_schemes: Optional[list[str]] = None,
+        allowed_schemes: list[str] | None = None,
         **kwargs: Any,
     ) -> None:
         self.allowed_schemes = allowed_schemes or ["http", "https", "ftp"]

--- a/authentik/providers/oauth2/views/authorize.py
+++ b/authentik/providers/oauth2/views/authorize.py
@@ -444,7 +444,7 @@ class OAuthFulfillmentStage(StageView):
                     "component": "ak-stage-autosubmit",
                     "title": self.executor.plan.context.get(
                         PLAN_CONTEXT_TITLE,
-                        _("Redirecting to {app}...".format(app=self.application.name)),
+                        _(f"Redirecting to {self.application.name}..."),
                     ),
                     "url": self.params.redirect_uri,
                     "attrs": query_params,

--- a/authentik/providers/oauth2/views/authorize.py
+++ b/authentik/providers/oauth2/views/authorize.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 from json import dumps
 from re import error as RegexError
 from re import fullmatch
-from typing import Optional
 from urllib.parse import parse_qs, urlencode, urlparse, urlsplit, urlunsplit
 from uuid import uuid4
 

--- a/authentik/providers/oauth2/views/authorize.py
+++ b/authentik/providers/oauth2/views/authorize.py
@@ -84,21 +84,21 @@ class OAuthAuthorizationParams:
     client_id: str
     redirect_uri: str
     response_type: str
-    response_mode: Optional[str]
+    response_mode: str | None
     scope: list[str]
     state: str
-    nonce: Optional[str]
+    nonce: str | None
     prompt: set[str]
     grant_type: str
 
     provider: OAuth2Provider = field(default_factory=OAuth2Provider)
 
-    request: Optional[str] = None
+    request: str | None = None
 
-    max_age: Optional[int] = None
+    max_age: int | None = None
 
-    code_challenge: Optional[str] = None
-    code_challenge_method: Optional[str] = None
+    code_challenge: str | None = None
+    code_challenge_method: str | None = None
 
     @staticmethod
     def from_request(request: HttpRequest) -> "OAuthAuthorizationParams":
@@ -435,9 +435,9 @@ class OAuthFulfillmentStage(StageView):
 
             # this picks the first item in the list if the value is a list,
             # otherwise just the value as-is
-            query_params = dict(
-                (k, v[0] if isinstance(v, list) else v) for k, v in parse_qs(parsed.query).items()
-            )
+            query_params = {
+                k: v[0] if isinstance(v, list) else v for k, v in parse_qs(parsed.query).items()
+            }
 
             challenge = AutosubmitChallenge(
                 data={
@@ -445,7 +445,7 @@ class OAuthFulfillmentStage(StageView):
                     "component": "ak-stage-autosubmit",
                     "title": self.executor.plan.context.get(
                         PLAN_CONTEXT_TITLE,
-                        _("Redirecting to %(app)s..." % {"app": self.application.name}),
+                        _("Redirecting to {app}...".format(app=self.application.name)),
                     ),
                     "url": self.params.redirect_uri,
                     "attrs": query_params,
@@ -556,7 +556,7 @@ class OAuthFulfillmentStage(StageView):
                 self.params.state,
             )
 
-    def create_implicit_response(self, code: Optional[AuthorizationCode]) -> dict:
+    def create_implicit_response(self, code: AuthorizationCode | None) -> dict:
         """Create implicit response's URL Fragment dictionary"""
         query_fragment = {}
         auth_event = get_login_event(self.request)

--- a/authentik/providers/oauth2/views/device_backchannel.py
+++ b/authentik/providers/oauth2/views/device_backchannel.py
@@ -27,7 +27,7 @@ class DeviceView(View):
     provider: OAuth2Provider
     scopes: list[str] = []
 
-    def parse_request(self) -> Optional[HttpResponse]:
+    def parse_request(self) -> HttpResponse | None:
         """Parse incoming request"""
         client_id = self.request.POST.get("client_id", None)
         if not client_id:

--- a/authentik/providers/oauth2/views/device_backchannel.py
+++ b/authentik/providers/oauth2/views/device_backchannel.py
@@ -1,5 +1,4 @@
 """Device flow views"""
-from typing import Optional
 from urllib.parse import urlencode
 
 from django.http import HttpRequest, HttpResponse, HttpResponseBadRequest, JsonResponse

--- a/authentik/providers/oauth2/views/device_init.py
+++ b/authentik/providers/oauth2/views/device_init.py
@@ -32,7 +32,7 @@ LOGGER = get_logger()
 QS_KEY_CODE = "code"  # nosec
 
 
-def get_application(provider: OAuth2Provider) -> Optional[Application]:
+def get_application(provider: OAuth2Provider) -> Application | None:
     """Get application from provider"""
     try:
         app = provider.application
@@ -43,7 +43,7 @@ def get_application(provider: OAuth2Provider) -> Optional[Application]:
         return None
 
 
-def validate_code(code: int, request: HttpRequest) -> Optional[HttpResponse]:
+def validate_code(code: int, request: HttpRequest) -> HttpResponse | None:
     """Validate user token"""
     token = DeviceToken.objects.filter(
         user_code=code,

--- a/authentik/providers/oauth2/views/device_init.py
+++ b/authentik/providers/oauth2/views/device_init.py
@@ -1,5 +1,4 @@
 """Device flow views"""
-from typing import Optional
 
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _

--- a/authentik/providers/oauth2/views/jwks.py
+++ b/authentik/providers/oauth2/views/jwks.py
@@ -1,6 +1,5 @@
 """authentik OAuth2 JWKS Views"""
 from base64 import b64encode, urlsafe_b64encode
-from typing import Optional
 
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric.ec import (

--- a/authentik/providers/oauth2/views/jwks.py
+++ b/authentik/providers/oauth2/views/jwks.py
@@ -64,7 +64,7 @@ def to_base64url_uint(val: int, min_length: int = 0) -> bytes:
 class JWKSView(View):
     """Show RSA Key data for Provider"""
 
-    def get_jwk_for_key(self, key: CertificateKeyPair) -> Optional[dict]:
+    def get_jwk_for_key(self, key: CertificateKeyPair) -> dict | None:
         """Convert a certificate-key pair into JWK"""
         private_key = key.private_key
         key_data = None

--- a/authentik/providers/oauth2/views/token.py
+++ b/authentik/providers/oauth2/views/token.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from hashlib import sha256
 from re import error as RegexError
 from re import fullmatch
-from typing import Any, Optional
+from typing import Any
 
 from django.http import HttpRequest, HttpResponse
 from django.utils import timezone

--- a/authentik/providers/oauth2/views/token.py
+++ b/authentik/providers/oauth2/views/token.py
@@ -74,16 +74,16 @@ class TokenParams:
 
     provider: OAuth2Provider
 
-    authorization_code: Optional[AuthorizationCode] = None
-    refresh_token: Optional[RefreshToken] = None
-    device_code: Optional[DeviceToken] = None
-    user: Optional[User] = None
+    authorization_code: AuthorizationCode | None = None
+    refresh_token: RefreshToken | None = None
+    device_code: DeviceToken | None = None
+    user: User | None = None
 
-    code_verifier: Optional[str] = None
+    code_verifier: str | None = None
 
     raw_code: InitVar[str] = ""
     raw_token: InitVar[str] = ""
-    request: InitVar[Optional[HttpRequest]] = None
+    request: InitVar[HttpRequest | None] = None
 
     @staticmethod
     def parse(
@@ -318,8 +318,8 @@ class TokenParams:
 
         token = None
 
-        source: Optional[OAuthSource] = None
-        parsed_key: Optional[PyJWK] = None
+        source: OAuthSource | None = None
+        parsed_key: PyJWK | None = None
 
         # Fully decode the JWT without verifying the signature, so we can get access to
         # the header.
@@ -424,8 +424,8 @@ class TokenParams:
 class TokenView(View):
     """Generate tokens for clients"""
 
-    provider: Optional[OAuth2Provider] = None
-    params: Optional[TokenParams] = None
+    provider: OAuth2Provider | None = None
+    params: TokenParams | None = None
 
     def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         response = super().dispatch(request, *args, **kwargs)

--- a/authentik/providers/oauth2/views/userinfo.py
+++ b/authentik/providers/oauth2/views/userinfo.py
@@ -38,7 +38,7 @@ class UserInfoView(View):
     """Create a dictionary with all the requested claims about the End-User.
     See: http://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse"""
 
-    token: Optional[RefreshToken]
+    token: RefreshToken | None
 
     def get_scope_descriptions(
         self, scopes: list[str], provider: OAuth2Provider

--- a/authentik/providers/oauth2/views/userinfo.py
+++ b/authentik/providers/oauth2/views/userinfo.py
@@ -1,5 +1,5 @@
 """authentik OAuth2 OpenID Userinfo views"""
-from typing import Any, Optional
+from typing import Any
 
 from deepmerge import always_merger
 from django.http import HttpRequest, HttpResponse

--- a/authentik/providers/proxy/api.py
+++ b/authentik/providers/proxy/api.py
@@ -1,5 +1,5 @@
 """ProxyProvider API Views"""
-from typing import Any, Optional
+from typing import Any
 
 from django.utils.translation import gettext_lazy as _
 from drf_spectacular.utils import extend_schema_field

--- a/authentik/providers/proxy/api.py
+++ b/authentik/providers/proxy/api.py
@@ -142,7 +142,7 @@ class ProxyOutpostConfigSerializer(ModelSerializer):
         """Embed OpenID Connect provider information"""
         return ProviderInfoView(request=self.context["request"]._request).get_info(obj)
 
-    def get_access_token_validity(self, obj: ProxyProvider) -> Optional[float]:
+    def get_access_token_validity(self, obj: ProxyProvider) -> float | None:
         """Get token validity as second count"""
         return timedelta_from_string(obj.access_token_validity).total_seconds()
 

--- a/authentik/providers/proxy/models.py
+++ b/authentik/providers/proxy/models.py
@@ -1,8 +1,7 @@
 """authentik proxy models"""
 import string
-from random import SystemRandom
-from typing import Optional
 from collections.abc import Iterable
+from random import SystemRandom
 from urllib.parse import urljoin
 
 from django.db import models

--- a/authentik/providers/proxy/models.py
+++ b/authentik/providers/proxy/models.py
@@ -1,7 +1,8 @@
 """authentik proxy models"""
 import string
 from random import SystemRandom
-from typing import Iterable, Optional
+from typing import Optional
+from collections.abc import Iterable
 from urllib.parse import urljoin
 
 from django.db import models
@@ -121,7 +122,7 @@ class ProxyProvider(OutpostModel, OAuth2Provider):
         return ProxyProviderSerializer
 
     @property
-    def launch_url(self) -> Optional[str]:
+    def launch_url(self) -> str | None:
         """Use external_host as launch URL"""
         return self.external_host
 

--- a/authentik/providers/radius/models.py
+++ b/authentik/providers/radius/models.py
@@ -1,5 +1,4 @@
 """Radius Provider"""
-from typing import Optional, Type
 
 from django.db import models
 from django.utils.translation import gettext_lazy as _

--- a/authentik/providers/radius/models.py
+++ b/authentik/providers/radius/models.py
@@ -39,7 +39,7 @@ class RadiusProvider(OutpostModel, Provider):
     )
 
     @property
-    def launch_url(self) -> Optional[str]:
+    def launch_url(self) -> str | None:
         """Radius never has a launch URL"""
         return None
 
@@ -48,7 +48,7 @@ class RadiusProvider(OutpostModel, Provider):
         return "ak-provider-radius-form"
 
     @property
-    def serializer(self) -> Type[Serializer]:
+    def serializer(self) -> type[Serializer]:
         from authentik.providers.radius.api import RadiusProviderSerializer
 
         return RadiusProviderSerializer

--- a/authentik/providers/saml/api/providers.py
+++ b/authentik/providers/saml/api/providers.py
@@ -265,7 +265,7 @@ class SAMLProviderViewSet(UsedByMixin, ModelViewSet):
         except ValueError as exc:  # pragma: no cover
             LOGGER.warning(str(exc))
             raise ValidationError(
-                _("Failed to import Metadata: %(message)s" % {"message": str(exc)}),
+                _("Failed to import Metadata: {message}".format(message=str(exc))),
             )
         return Response(status=204)
 

--- a/authentik/providers/saml/api/providers.py
+++ b/authentik/providers/saml/api/providers.py
@@ -265,7 +265,7 @@ class SAMLProviderViewSet(UsedByMixin, ModelViewSet):
         except ValueError as exc:  # pragma: no cover
             LOGGER.warning(str(exc))
             raise ValidationError(
-                _("Failed to import Metadata: {message}".format(message=str(exc))),
+                _(f"Failed to import Metadata: {str(exc)}"),
             )
         return Response(status=204)
 

--- a/authentik/providers/saml/models.py
+++ b/authentik/providers/saml/models.py
@@ -143,7 +143,7 @@ class SAMLProvider(Provider):
     )
 
     @property
-    def launch_url(self) -> Optional[str]:
+    def launch_url(self) -> str | None:
         """Use IDP-Initiated SAML flow as launch URL"""
         try:
             # pylint: disable=no-member

--- a/authentik/providers/saml/models.py
+++ b/authentik/providers/saml/models.py
@@ -1,5 +1,4 @@
 """authentik saml_idp Models"""
-from typing import Optional
 
 from django.db import models
 from django.urls import reverse

--- a/authentik/providers/saml/processors/authn_request_parser.py
+++ b/authentik/providers/saml/processors/authn_request_parser.py
@@ -35,9 +35,9 @@ ERROR_FAILED_TO_VERIFY = "Failed to verify signature"
 class AuthNRequest:
     """AuthNRequest Dataclass"""
 
-    id: Optional[str] = None
+    id: str | None = None
 
-    relay_state: Optional[str] = None
+    relay_state: str | None = None
 
     name_id_policy: str = SAML_NAME_ID_FORMAT_UNSPECIFIED
 
@@ -51,7 +51,7 @@ class AuthNRequestParser:
         self.provider = provider
         self.logger = get_logger().bind(provider=self.provider)
 
-    def _parse_xml(self, decoded_xml: str | bytes, relay_state: Optional[str]) -> AuthNRequest:
+    def _parse_xml(self, decoded_xml: str | bytes, relay_state: str | None) -> AuthNRequest:
         root = ElementTree.fromstring(decoded_xml)
 
         # http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf
@@ -82,7 +82,7 @@ class AuthNRequestParser:
 
         return auth_n_request
 
-    def parse(self, saml_request: str, relay_state: Optional[str] = None) -> AuthNRequest:
+    def parse(self, saml_request: str, relay_state: str | None = None) -> AuthNRequest:
         """Validate and parse raw request with enveloped signautre."""
         try:
             decoded_xml = b64decode(saml_request.encode())
@@ -120,9 +120,9 @@ class AuthNRequestParser:
     def parse_detached(
         self,
         saml_request: str,
-        relay_state: Optional[str],
-        signature: Optional[str] = None,
-        sig_alg: Optional[str] = None,
+        relay_state: str | None,
+        signature: str | None = None,
+        sig_alg: str | None = None,
     ) -> AuthNRequest:
         """Validate and parse raw request with detached signature"""
         try:

--- a/authentik/providers/saml/processors/authn_request_parser.py
+++ b/authentik/providers/saml/processors/authn_request_parser.py
@@ -1,7 +1,6 @@
 """SAML AuthNRequest Parser and dataclass"""
 from base64 import b64decode
 from dataclasses import dataclass
-from typing import Optional
 from urllib.parse import quote_plus
 from xml.etree.ElementTree import ParseError  # nosec
 

--- a/authentik/providers/saml/processors/logout_request_parser.py
+++ b/authentik/providers/saml/processors/logout_request_parser.py
@@ -1,7 +1,6 @@
 """LogoutRequest parser"""
 from base64 import b64decode
 from dataclasses import dataclass
-from typing import Optional
 
 from defusedxml import ElementTree
 
@@ -31,9 +30,7 @@ class LogoutRequestParser:
     def __init__(self, provider: SAMLProvider):
         self.provider = provider
 
-    def _parse_xml(
-        self, decoded_xml: str | bytes, relay_state: str | None = None
-    ) -> LogoutRequest:
+    def _parse_xml(self, decoded_xml: str | bytes, relay_state: str | None = None) -> LogoutRequest:
         root = ElementTree.fromstring(decoded_xml)
         request = LogoutRequest(
             id=root.attrib["ID"],

--- a/authentik/providers/saml/processors/logout_request_parser.py
+++ b/authentik/providers/saml/processors/logout_request_parser.py
@@ -16,11 +16,11 @@ from authentik.sources.saml.processors.constants import NS_SAML_PROTOCOL
 class LogoutRequest:
     """Logout Request"""
 
-    id: Optional[str] = None
+    id: str | None = None
 
-    issuer: Optional[str] = None
+    issuer: str | None = None
 
-    relay_state: Optional[str] = None
+    relay_state: str | None = None
 
 
 class LogoutRequestParser:
@@ -32,7 +32,7 @@ class LogoutRequestParser:
         self.provider = provider
 
     def _parse_xml(
-        self, decoded_xml: str | bytes, relay_state: Optional[str] = None
+        self, decoded_xml: str | bytes, relay_state: str | None = None
     ) -> LogoutRequest:
         root = ElementTree.fromstring(decoded_xml)
         request = LogoutRequest(
@@ -44,7 +44,7 @@ class LogoutRequestParser:
         request.relay_state = relay_state
         return request
 
-    def parse(self, saml_request: str, relay_state: Optional[str] = None) -> LogoutRequest:
+    def parse(self, saml_request: str, relay_state: str | None = None) -> LogoutRequest:
         """Validate and parse raw request with enveloped signautre."""
         try:
             decoded_xml = b64decode(saml_request.encode())
@@ -55,7 +55,7 @@ class LogoutRequestParser:
     def parse_detached(
         self,
         saml_request: str,
-        relay_state: Optional[str] = None,
+        relay_state: str | None = None,
     ) -> LogoutRequest:
         """Validate and parse raw request with detached signature"""
         try:

--- a/authentik/providers/saml/processors/metadata.py
+++ b/authentik/providers/saml/processors/metadata.py
@@ -25,6 +25,8 @@ from authentik.sources.saml.processors.constants import (
     SIGN_ALGORITHM_TRANSFORM_MAP,
 )
 
+ElementOrNone = Optional[Element]
+
 
 class MetadataProcessor:
     """SAML Identity Provider Metadata Processor"""
@@ -39,7 +41,7 @@ class MetadataProcessor:
         self.force_binding = None
         self.xml_id = "_" + sha256(f"{provider.name}-{provider.pk}".encode("ascii")).hexdigest()
 
-    def get_signing_key_descriptor(self) -> Optional[Element]:
+    def get_signing_key_descriptor(self) -> ElementOrNone:
         """Get Signing KeyDescriptor, if enabled for the provider"""
         if not self.provider.signing_kp:
             return None

--- a/authentik/providers/saml/processors/metadata.py
+++ b/authentik/providers/saml/processors/metadata.py
@@ -1,6 +1,7 @@
 """SAML Identity Provider Metadata Processor"""
 from hashlib import sha256
-from typing import Iterator, Optional
+from typing import Optional
+from collections.abc import Iterator
 
 import xmlsec  # nosec
 from django.http import HttpRequest
@@ -30,7 +31,7 @@ class MetadataProcessor:
 
     provider: SAMLProvider
     http_request: HttpRequest
-    force_binding: Optional[str]
+    force_binding: str | None
 
     def __init__(self, provider: SAMLProvider, request: HttpRequest):
         self.provider = provider
@@ -38,7 +39,7 @@ class MetadataProcessor:
         self.force_binding = None
         self.xml_id = "_" + sha256(f"{provider.name}-{provider.pk}".encode("ascii")).hexdigest()
 
-    def get_signing_key_descriptor(self) -> Optional[Element]:
+    def get_signing_key_descriptor(self) -> Element | None:
         """Get Signing KeyDescriptor, if enabled for the provider"""
         if not self.provider.signing_kp:
             return None

--- a/authentik/providers/saml/processors/metadata.py
+++ b/authentik/providers/saml/processors/metadata.py
@@ -1,7 +1,6 @@
 """SAML Identity Provider Metadata Processor"""
-from hashlib import sha256
-from typing import Optional
 from collections.abc import Iterator
+from hashlib import sha256
 
 import xmlsec  # nosec
 from django.http import HttpRequest

--- a/authentik/providers/saml/processors/metadata.py
+++ b/authentik/providers/saml/processors/metadata.py
@@ -1,6 +1,7 @@
 """SAML Identity Provider Metadata Processor"""
 from collections.abc import Iterator
 from hashlib import sha256
+from typing import Optional
 
 import xmlsec  # nosec
 from django.http import HttpRequest
@@ -38,7 +39,7 @@ class MetadataProcessor:
         self.force_binding = None
         self.xml_id = "_" + sha256(f"{provider.name}-{provider.pk}".encode("ascii")).hexdigest()
 
-    def get_signing_key_descriptor(self) -> Element | None:
+    def get_signing_key_descriptor(self) -> Optional[Element]:
         """Get Signing KeyDescriptor, if enabled for the provider"""
         if not self.provider.signing_kp:
             return None

--- a/authentik/providers/saml/processors/metadata_parser.py
+++ b/authentik/providers/saml/processors/metadata_parser.py
@@ -1,6 +1,5 @@
 """SAML ServiceProvider Metadata Parser and dataclass"""
 from dataclasses import dataclass
-from typing import Optional
 
 import xmlsec
 from cryptography.hazmat.backends import default_backend

--- a/authentik/providers/saml/processors/metadata_parser.py
+++ b/authentik/providers/saml/processors/metadata_parser.py
@@ -47,7 +47,7 @@ class ServiceProviderMetadata:
     auth_n_request_signed: bool
     assertion_signed: bool
 
-    signing_keypair: Optional[CertificateKeyPair] = None
+    signing_keypair: CertificateKeyPair | None = None
 
     def to_provider(self, name: str, authorization_flow: Flow) -> SAMLProvider:
         """Create a SAMLProvider instance from the details. `name` is required,
@@ -75,7 +75,7 @@ class ServiceProviderMetadata:
 class ServiceProviderMetadataParser:
     """Service-Provider Metadata Parser"""
 
-    def get_signing_cert(self, root: etree.Element) -> Optional[CertificateKeyPair]:
+    def get_signing_cert(self, root: etree.Element) -> CertificateKeyPair | None:
         """Extract X509Certificate from metadata, when given."""
         signing_certs = root.xpath(
             '//md:SPSSODescriptor/md:KeyDescriptor[@use="signing"]//ds:X509Certificate/text()',

--- a/authentik/providers/saml/utils/time.py
+++ b/authentik/providers/saml/utils/time.py
@@ -1,6 +1,5 @@
 """Time utilities"""
 import datetime
-from typing import Optional
 
 
 def get_time_string(delta: datetime.timedelta | None = None) -> str:

--- a/authentik/providers/saml/utils/time.py
+++ b/authentik/providers/saml/utils/time.py
@@ -3,7 +3,7 @@ import datetime
 from typing import Optional
 
 
-def get_time_string(delta: Optional[datetime.timedelta] = None) -> str:
+def get_time_string(delta: datetime.timedelta | None = None) -> str:
     """Get Data formatted in SAML format"""
     if delta is None:
         delta = datetime.timedelta()

--- a/authentik/providers/saml/views/flows.py
+++ b/authentik/providers/saml/views/flows.py
@@ -84,7 +84,7 @@ class SAMLFlowFinalView(ChallengeStageView):
                     "component": "ak-stage-autosubmit",
                     "title": self.executor.plan.context.get(
                         PLAN_CONTEXT_TITLE,
-                        _("Redirecting to {app}...".format(app=application.name)),
+                        _(f"Redirecting to {application.name}..."),
                     ),
                     "url": provider.acs_url,
                     "attrs": form_attrs,

--- a/authentik/providers/saml/views/flows.py
+++ b/authentik/providers/saml/views/flows.py
@@ -84,7 +84,7 @@ class SAMLFlowFinalView(ChallengeStageView):
                     "component": "ak-stage-autosubmit",
                     "title": self.executor.plan.context.get(
                         PLAN_CONTEXT_TITLE,
-                        _("Redirecting to %(app)s..." % {"app": application.name}),
+                        _("Redirecting to {app}...".format(app=application.name)),
                     ),
                     "url": provider.acs_url,
                     "attrs": form_attrs,

--- a/authentik/providers/saml/views/slo.py
+++ b/authentik/providers/saml/views/slo.py
@@ -35,7 +35,7 @@ class SAMLSLOView(PolicyAccessView):
             SAMLProvider, pk=self.application.provider_id
         )
 
-    def check_saml_request(self) -> Optional[HttpRequest]:
+    def check_saml_request(self) -> HttpRequest | None:
         """Handler to verify the SAML Request. Must be implemented by a subclass"""
         raise NotImplementedError
 
@@ -60,7 +60,7 @@ class SAMLSLOView(PolicyAccessView):
 class SAMLSLOBindingRedirectView(SAMLSLOView):
     """SAML Handler for SLO/Redirect bindings, which are sent via GET"""
 
-    def check_saml_request(self) -> Optional[HttpRequest]:
+    def check_saml_request(self) -> HttpRequest | None:
         if REQUEST_KEY_SAML_REQUEST not in self.request.GET:
             LOGGER.info("check_saml_request: SAML payload missing")
             return bad_request_message(self.request, "The SAML request payload is missing.")
@@ -87,7 +87,7 @@ class SAMLSLOBindingRedirectView(SAMLSLOView):
 class SAMLSLOBindingPOSTView(SAMLSLOView):
     """SAML Handler for SLO/POST bindings"""
 
-    def check_saml_request(self) -> Optional[HttpRequest]:
+    def check_saml_request(self) -> HttpRequest | None:
         payload = self.request.POST
         if REQUEST_KEY_SAML_REQUEST not in payload:
             LOGGER.info("check_saml_request: SAML payload missing")

--- a/authentik/providers/saml/views/slo.py
+++ b/authentik/providers/saml/views/slo.py
@@ -1,5 +1,4 @@
 """SLO Views"""
-from typing import Optional
 
 from django.http import HttpRequest
 from django.http.response import HttpResponse

--- a/authentik/providers/saml/views/sso.py
+++ b/authentik/providers/saml/views/sso.py
@@ -47,7 +47,7 @@ class SAMLSSOView(PolicyAccessView):
             SAMLProvider, pk=self.application.provider_id
         )
 
-    def check_saml_request(self) -> Optional[HttpRequest]:
+    def check_saml_request(self) -> HttpRequest | None:
         """Handler to verify the SAML Request. Must be implemented by a subclass"""
         raise NotImplementedError
 
@@ -91,7 +91,7 @@ class SAMLSSOView(PolicyAccessView):
 class SAMLSSOBindingRedirectView(SAMLSSOView):
     """SAML Handler for SSO/Redirect bindings, which are sent via GET"""
 
-    def check_saml_request(self) -> Optional[HttpRequest]:
+    def check_saml_request(self) -> HttpRequest | None:
         """Handle REDIRECT bindings"""
         if REQUEST_KEY_SAML_REQUEST not in self.request.GET:
             LOGGER.info("SAML payload missing")
@@ -121,7 +121,7 @@ class SAMLSSOBindingRedirectView(SAMLSSOView):
 class SAMLSSOBindingPOSTView(SAMLSSOView):
     """SAML Handler for SSO/POST bindings"""
 
-    def check_saml_request(self) -> Optional[HttpRequest]:
+    def check_saml_request(self) -> HttpRequest | None:
         """Handle POST bindings"""
         payload = self.request.POST
         # Restore the post body from the session
@@ -148,7 +148,7 @@ class SAMLSSOBindingPOSTView(SAMLSSOView):
 class SAMLSSOBindingInitView(SAMLSSOView):
     """SAML Handler for for IdP Initiated login flows"""
 
-    def check_saml_request(self) -> Optional[HttpRequest]:
+    def check_saml_request(self) -> HttpRequest | None:
         """Create SAML Response from scratch"""
         LOGGER.debug("No SAML Request, using IdP-initiated flow.")
         auth_n_request = AuthNRequestParser(self.provider).idp_initiated()

--- a/authentik/providers/saml/views/sso.py
+++ b/authentik/providers/saml/views/sso.py
@@ -1,5 +1,4 @@
 """authentik SAML IDP Views"""
-from typing import Optional
 
 from django.http import Http404, HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404

--- a/authentik/providers/scim/clients/exceptions.py
+++ b/authentik/providers/scim/clients/exceptions.py
@@ -11,7 +11,7 @@ from authentik.providers.scim.clients.schema import SCIMError
 class StopSync(SentryIgnoredException):
     """Exception raised when a configuration error should stop the sync process"""
 
-    def __init__(self, exc: Exception, obj: object, mapping: Optional[object] = None) -> None:
+    def __init__(self, exc: Exception, obj: object, mapping: object | None = None) -> None:
         self.exc = exc
         self.obj = obj
         self.mapping = mapping
@@ -28,10 +28,10 @@ class StopSync(SentryIgnoredException):
 class SCIMRequestException(SentryIgnoredException):
     """Exception raised when an SCIM request fails"""
 
-    _response: Optional[Response]
-    _message: Optional[str]
+    _response: Response | None
+    _message: str | None
 
-    def __init__(self, response: Optional[Response] = None, message: Optional[str] = None) -> None:
+    def __init__(self, response: Response | None = None, message: str | None = None) -> None:
         self._response = response
         self._message = message
 

--- a/authentik/providers/scim/clients/exceptions.py
+++ b/authentik/providers/scim/clients/exceptions.py
@@ -1,5 +1,4 @@
 """SCIM Client exceptions"""
-from typing import Optional
 
 from pydantic import ValidationError
 from requests import Response

--- a/authentik/providers/scim/clients/schema.py
+++ b/authentik/providers/scim/clients/schema.py
@@ -1,5 +1,4 @@
 """Custom SCIM schemas"""
-from typing import Optional
 
 from pydanticscim.group import Group as BaseGroup
 from pydanticscim.responses import PatchRequest as BasePatchRequest

--- a/authentik/providers/scim/clients/schema.py
+++ b/authentik/providers/scim/clients/schema.py
@@ -15,19 +15,19 @@ from pydanticscim.user import User as BaseUser
 class User(BaseUser):
     """Modified User schema with added externalId field"""
 
-    externalId: Optional[str] = None
+    externalId: str | None = None
 
 
 class Group(BaseGroup):
     """Modified Group schema with added externalId field"""
 
-    externalId: Optional[str] = None
+    externalId: str | None = None
 
 
 class ServiceProviderConfiguration(BaseServiceProviderConfiguration):
     """ServiceProviderConfig with fallback"""
 
-    _is_fallback: Optional[bool] = False
+    _is_fallback: bool | None = False
 
     @property
     def is_fallback(self) -> bool:
@@ -58,4 +58,4 @@ class PatchRequest(BasePatchRequest):
 class SCIMError(BaseSCIMError):
     """SCIM error with optional status code"""
 
-    status: Optional[int]
+    status: int | None

--- a/authentik/providers/scim/tasks.py
+++ b/authentik/providers/scim/tasks.py
@@ -1,5 +1,5 @@
 """SCIM Provider tasks"""
-from typing import Any, Optional
+from typing import Any
 
 from celery.result import allow_join_result
 from django.core.paginator import Paginator

--- a/authentik/providers/scim/tasks.py
+++ b/authentik/providers/scim/tasks.py
@@ -162,7 +162,7 @@ def scim_signal_direct(model: str, pk: Any, raw_op: str):
     for provider in SCIMProvider.objects.filter(backchannel_application__isnull=False):
         client = client_for_model(provider, instance)
         # Check if the object is allowed within the provider's restrictions
-        queryset: Optional[QuerySet] = None
+        queryset: QuerySet | None = None
         if isinstance(instance, User):
             queryset = provider.get_user_qs()
         if isinstance(instance, Group):

--- a/authentik/rbac/api/rbac_roles.py
+++ b/authentik/rbac/api/rbac_roles.py
@@ -1,5 +1,4 @@
 """common RBAC serializers"""
-from typing import Optional
 
 from django.apps import apps
 from django_filters.filters import UUIDFilter

--- a/authentik/rbac/api/rbac_roles.py
+++ b/authentik/rbac/api/rbac_roles.py
@@ -35,7 +35,7 @@ class ExtraRoleObjectPermissionSerializer(RoleObjectPermissionSerializer):
         except LookupError:
             return f"{instance.content_type.app_label}.{instance.content_type.model}"
 
-    def get_object_description(self, instance: GroupObjectPermission) -> Optional[str]:
+    def get_object_description(self, instance: GroupObjectPermission) -> str | None:
         """Get model description from attached model. This operation takes at least
         one additional query, and the description is only shown if the user/role has the
         view_ permission on the object"""

--- a/authentik/rbac/api/rbac_users.py
+++ b/authentik/rbac/api/rbac_users.py
@@ -1,5 +1,4 @@
 """common RBAC serializers"""
-from typing import Optional
 
 from django.apps import apps
 from django_filters.filters import NumberFilter

--- a/authentik/rbac/api/rbac_users.py
+++ b/authentik/rbac/api/rbac_users.py
@@ -35,7 +35,7 @@ class ExtraUserObjectPermissionSerializer(UserObjectPermissionSerializer):
         except LookupError:
             return f"{instance.content_type.app_label}.{instance.content_type.model}"
 
-    def get_object_description(self, instance: UserObjectPermission) -> Optional[str]:
+    def get_object_description(self, instance: UserObjectPermission) -> str | None:
         """Get model description from attached model. This operation takes at least
         one additional query, and the description is only shown if the user/role has the
         view_ permission on the object"""

--- a/authentik/rbac/models.py
+++ b/authentik/rbac/models.py
@@ -1,5 +1,4 @@
 """RBAC models"""
-from typing import Optional
 from uuid import uuid4
 
 from django.db import models

--- a/authentik/rbac/models.py
+++ b/authentik/rbac/models.py
@@ -30,7 +30,7 @@ class Role(SerializerModel):
     # name field has the same constraints as the group model
     name = models.TextField(max_length=150, unique=True)
 
-    def assign_permission(self, *perms: str, obj: Optional[models.Model] = None):
+    def assign_permission(self, *perms: str, obj: models.Model | None = None):
         """Assign permission to role, can handle multiple permissions,
         but when assigning multiple permissions to an object the permissions
         must all belong to the object given"""

--- a/authentik/root/celery.py
+++ b/authentik/root/celery.py
@@ -4,7 +4,7 @@ from contextvars import ContextVar
 from logging.config import dictConfig
 from pathlib import Path
 from tempfile import gettempdir
-from typing import Callable
+from collections.abc import Callable
 
 from celery import Celery, bootsteps
 from celery.apps.worker import Worker

--- a/authentik/root/celery.py
+++ b/authentik/root/celery.py
@@ -1,10 +1,10 @@
 """authentik core celery"""
 import os
+from collections.abc import Callable
 from contextvars import ContextVar
 from logging.config import dictConfig
 from pathlib import Path
 from tempfile import gettempdir
-from collections.abc import Callable
 
 from celery import Celery, bootsteps
 from celery.apps.worker import Worker

--- a/authentik/root/middleware.py
+++ b/authentik/root/middleware.py
@@ -2,7 +2,7 @@
 from hashlib import sha512
 from time import time
 from timeit import default_timer
-from typing import Callable
+from collections.abc import Callable
 
 from django.conf import settings
 from django.contrib.sessions.backends.base import UpdateError

--- a/authentik/root/middleware.py
+++ b/authentik/root/middleware.py
@@ -1,8 +1,8 @@
 """Dynamically set SameSite depending if the upstream connection is TLS or not"""
+from collections.abc import Callable
 from hashlib import sha512
 from time import time
 from timeit import default_timer
-from collections.abc import Callable
 
 from django.conf import settings
 from django.contrib.sessions.backends.base import UpdateError

--- a/authentik/sources/ldap/auth.py
+++ b/authentik/sources/ldap/auth.py
@@ -1,5 +1,4 @@
 """authentik LDAP Authentication Backend"""
-from typing import Optional
 
 from django.http import HttpRequest
 from ldap3.core.exceptions import LDAPException, LDAPInvalidCredentialsResult

--- a/authentik/sources/ldap/auth.py
+++ b/authentik/sources/ldap/auth.py
@@ -28,7 +28,7 @@ class LDAPBackend(InbuiltBackend):
                 return user
         return None
 
-    def auth_user(self, source: LDAPSource, password: str, **filters: str) -> Optional[User]:
+    def auth_user(self, source: LDAPSource, password: str, **filters: str) -> User | None:
         """Try to bind as either user_dn or mail with password.
         Returns True on success, otherwise False"""
         users = User.objects.filter(**filters)
@@ -51,7 +51,7 @@ class LDAPBackend(InbuiltBackend):
         LOGGER.debug("Failed to bind, password invalid")
         return None
 
-    def auth_user_by_bind(self, source: LDAPSource, user: User, password: str) -> Optional[User]:
+    def auth_user_by_bind(self, source: LDAPSource, user: User, password: str) -> User | None:
         """Attempt authentication by binding to the LDAP server as `user`. This
         method should be avoided as its slow to do the bind."""
         # Try to bind as new user

--- a/authentik/sources/ldap/models.py
+++ b/authentik/sources/ldap/models.py
@@ -2,7 +2,6 @@
 from os import chmod
 from ssl import CERT_REQUIRED
 from tempfile import NamedTemporaryFile, mkdtemp
-from typing import Optional
 
 from django.db import models
 from django.utils.translation import gettext_lazy as _

--- a/authentik/sources/ldap/models.py
+++ b/authentik/sources/ldap/models.py
@@ -154,7 +154,7 @@ class LDAPSource(Source):
         return ServerPool(servers, RANDOM, active=5, exhaust=True)
 
     def connection(
-        self, server_kwargs: Optional[dict] = None, connection_kwargs: Optional[dict] = None
+        self, server_kwargs: dict | None = None, connection_kwargs: dict | None = None
     ) -> Connection:
         """Get a fully connected and bound LDAP Connection"""
         server_kwargs = server_kwargs or {}

--- a/authentik/sources/ldap/password.py
+++ b/authentik/sources/ldap/password.py
@@ -1,7 +1,6 @@
 """Help validate and update passwords in LDAP"""
 from enum import IntFlag
 from re import split
-from typing import Optional
 
 from ldap3 import BASE
 from ldap3.core.exceptions import LDAPAttributeError, LDAPUnwillingToPerformResult

--- a/authentik/sources/ldap/password.py
+++ b/authentik/sources/ldap/password.py
@@ -130,7 +130,7 @@ class LDAPPasswordChanger:
                     return False
         return True
 
-    def ad_password_complexity(self, password: str, user: Optional[User] = None) -> bool:
+    def ad_password_complexity(self, password: str, user: User | None = None) -> bool:
         """Check if password matches Active directory password policies
 
         https://docs.microsoft.com/en-us/windows/security/threat-protection/

--- a/authentik/sources/ldap/sync/base.py
+++ b/authentik/sources/ldap/sync/base.py
@@ -1,5 +1,6 @@
 """Sync LDAP Users and groups into authentik"""
-from typing import Any, Generator
+from typing import Any
+from collections.abc import Generator
 
 from django.conf import settings
 from django.db.models.base import Model

--- a/authentik/sources/ldap/sync/base.py
+++ b/authentik/sources/ldap/sync/base.py
@@ -1,6 +1,6 @@
 """Sync LDAP Users and groups into authentik"""
-from typing import Any
 from collections.abc import Generator
+from typing import Any
 
 from django.conf import settings
 from django.db.models.base import Model

--- a/authentik/sources/ldap/sync/groups.py
+++ b/authentik/sources/ldap/sync/groups.py
@@ -1,5 +1,5 @@
 """Sync LDAP Users and groups into authentik"""
-from typing import Generator
+from collections.abc import Generator
 
 from django.core.exceptions import FieldError
 from django.db.utils import IntegrityError

--- a/authentik/sources/ldap/sync/membership.py
+++ b/authentik/sources/ldap/sync/membership.py
@@ -1,6 +1,6 @@
 """Sync LDAP Users and groups into authentik"""
-from typing import Any, Optional
 from collections.abc import Generator
+from typing import Any
 
 from django.db.models import Q
 from ldap3 import SUBTREE

--- a/authentik/sources/ldap/sync/membership.py
+++ b/authentik/sources/ldap/sync/membership.py
@@ -1,5 +1,6 @@
 """Sync LDAP Users and groups into authentik"""
-from typing import Any, Generator, Optional
+from typing import Any, Optional
+from collections.abc import Generator
 
 from django.db.models import Q
 from ldap3 import SUBTREE
@@ -75,7 +76,7 @@ class MembershipLDAPSynchronizer(BaseLDAPSynchronizer):
         self._logger.debug("Successfully updated group membership")
         return membership_count
 
-    def get_group(self, group_dict: dict[str, Any]) -> Optional[Group]:
+    def get_group(self, group_dict: dict[str, Any]) -> Group | None:
         """Check if we fetched the group already, and if not cache it for later"""
         group_dn = group_dict.get("attributes", {}).get(LDAP_DISTINGUISHED_NAME, [])
         group_uniq = group_dict.get("attributes", {}).get(self._source.object_uniqueness_field, [])

--- a/authentik/sources/ldap/sync/users.py
+++ b/authentik/sources/ldap/sync/users.py
@@ -1,5 +1,5 @@
 """Sync LDAP Users into authentik"""
-from typing import Generator
+from collections.abc import Generator
 
 from django.core.exceptions import FieldError
 from django.db.utils import IntegrityError

--- a/authentik/sources/ldap/sync/vendor/freeipa.py
+++ b/authentik/sources/ldap/sync/vendor/freeipa.py
@@ -1,6 +1,7 @@
 """FreeIPA specific"""
 from datetime import datetime
-from typing import Any, Generator
+from typing import Any
+from collections.abc import Generator
 
 from pytz import UTC
 

--- a/authentik/sources/ldap/sync/vendor/freeipa.py
+++ b/authentik/sources/ldap/sync/vendor/freeipa.py
@@ -1,7 +1,7 @@
 """FreeIPA specific"""
+from collections.abc import Generator
 from datetime import datetime
 from typing import Any
-from collections.abc import Generator
 
 from pytz import UTC
 

--- a/authentik/sources/ldap/sync/vendor/ms_ad.py
+++ b/authentik/sources/ldap/sync/vendor/ms_ad.py
@@ -1,7 +1,8 @@
 """Active Directory specific"""
 from datetime import datetime
 from enum import IntFlag
-from typing import Any, Generator
+from typing import Any
+from collections.abc import Generator
 
 from pytz import UTC
 

--- a/authentik/sources/ldap/sync/vendor/ms_ad.py
+++ b/authentik/sources/ldap/sync/vendor/ms_ad.py
@@ -1,8 +1,8 @@
 """Active Directory specific"""
+from collections.abc import Generator
 from datetime import datetime
 from enum import IntFlag
 from typing import Any
-from collections.abc import Generator
 
 from pytz import UTC
 

--- a/authentik/sources/oauth/clients/base.py
+++ b/authentik/sources/oauth/clients/base.py
@@ -21,20 +21,20 @@ class BaseOAuthClient:
     source: OAuthSource
     request: HttpRequest
 
-    callback: Optional[str]
+    callback: str | None
 
-    def __init__(self, source: OAuthSource, request: HttpRequest, callback: Optional[str] = None):
+    def __init__(self, source: OAuthSource, request: HttpRequest, callback: str | None = None):
         self.source = source
         self.session = get_http_session()
         self.request = request
         self.callback = callback
         self.logger = get_logger().bind(source=source.slug)
 
-    def get_access_token(self, **request_kwargs) -> Optional[dict[str, Any]]:
+    def get_access_token(self, **request_kwargs) -> dict[str, Any] | None:
         """Fetch access token from callback request."""
         raise NotImplementedError("Defined in a sub-class")  # pragma: no cover
 
-    def get_profile_info(self, token: dict[str, str]) -> Optional[dict[str, Any]]:
+    def get_profile_info(self, token: dict[str, str]) -> dict[str, Any] | None:
         """Fetch user profile information."""
         profile_url = self.source.source_type.profile_url or ""
         if self.source.source_type.urls_customizable and self.source.profile_url:

--- a/authentik/sources/oauth/clients/base.py
+++ b/authentik/sources/oauth/clients/base.py
@@ -1,5 +1,5 @@
 """OAuth Clients"""
-from typing import Any, Optional
+from typing import Any
 from urllib.parse import parse_qs, quote, urlencode, urlparse, urlunparse
 
 from django.http import HttpRequest

--- a/authentik/sources/oauth/clients/oauth1.py
+++ b/authentik/sources/oauth/clients/oauth1.py
@@ -1,5 +1,5 @@
 """OAuth 1 Clients"""
-from typing import Any, Optional
+from typing import Any
 from urllib.parse import parse_qsl
 
 from requests.exceptions import RequestException

--- a/authentik/sources/oauth/clients/oauth1.py
+++ b/authentik/sources/oauth/clients/oauth1.py
@@ -20,7 +20,7 @@ class OAuthClient(BaseOAuthClient):
         "Accept": "application/json",
     }
 
-    def get_access_token(self, **request_kwargs) -> Optional[dict[str, Any]]:
+    def get_access_token(self, **request_kwargs) -> dict[str, Any] | None:
         """Fetch access token from callback request."""
         raw_token = self.request.session.get(self.session_key, None)
         verifier = self.request.GET.get("oauth_verifier", None)

--- a/authentik/sources/oauth/clients/oauth2.py
+++ b/authentik/sources/oauth/clients/oauth2.py
@@ -1,6 +1,6 @@
 """OAuth 2 Clients"""
 from json import loads
-from typing import Any, Optional
+from typing import Any
 from urllib.parse import parse_qsl
 
 from django.utils.crypto import constant_time_compare, get_random_string

--- a/authentik/sources/oauth/clients/oauth2.py
+++ b/authentik/sources/oauth/clients/oauth2.py
@@ -22,7 +22,7 @@ class OAuth2Client(BaseOAuthClient):
         "Accept": "application/json",
     }
 
-    def get_request_arg(self, key: str, default: Optional[Any] = None) -> Any:
+    def get_request_arg(self, key: str, default: Any | None = None) -> Any:
         """Depending on request type, get data from post or get"""
         if self.request.method == "POST":
             return self.request.POST.get(key, default)
@@ -54,7 +54,7 @@ class OAuth2Client(BaseOAuthClient):
         """Get client secret"""
         return self.source.consumer_secret
 
-    def get_access_token(self, **request_kwargs) -> Optional[dict[str, Any]]:
+    def get_access_token(self, **request_kwargs) -> dict[str, Any] | None:
         """Fetch access token from callback request."""
         callback = self.request.build_absolute_uri(self.callback or self.request.path)
         if not self.check_application_state():
@@ -138,7 +138,7 @@ class OAuth2Client(BaseOAuthClient):
 class UserprofileHeaderAuthClient(OAuth2Client):
     """OAuth client which only sends authentication via header, not querystring"""
 
-    def get_profile_info(self, token: dict[str, str]) -> Optional[dict[str, Any]]:
+    def get_profile_info(self, token: dict[str, str]) -> dict[str, Any] | None:
         "Fetch user profile information."
         profile_url = self.source.source_type.profile_url or ""
         if self.source.source_type.urls_customizable and self.source.profile_url:

--- a/authentik/sources/oauth/models.py
+++ b/authentik/sources/oauth/models.py
@@ -1,5 +1,5 @@
 """OAuth Client models"""
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from django.db import models
 from django.http.request import HttpRequest

--- a/authentik/sources/oauth/models.py
+++ b/authentik/sources/oauth/models.py
@@ -83,7 +83,7 @@ class OAuthSource(Source):
             icon_url=icon,
         )
 
-    def ui_user_settings(self) -> Optional[UserSettingSerializer]:
+    def ui_user_settings(self) -> UserSettingSerializer | None:
         provider_type = self.source_type
         icon = self.get_icon
         if not icon:

--- a/authentik/sources/oauth/models.py
+++ b/authentik/sources/oauth/models.py
@@ -66,7 +66,7 @@ class OAuthSource(Source):
         return "ak-source-oauth-form"
 
     @property
-    def serializer(self) -> SerializerType:
+    def serializer(self) -> type[Serializer]:
         from authentik.sources.oauth.api.source import OAuthSourceSerializer
 
         return OAuthSourceSerializer

--- a/authentik/sources/oauth/models.py
+++ b/authentik/sources/oauth/models.py
@@ -10,9 +10,10 @@ from rest_framework.serializers import Serializer
 from authentik.core.models import Source, UserSourceConnection
 from authentik.core.types import UILoginButton, UserSettingSerializer
 
-SERIALIZER_TYPE = type[Serializer]
 if TYPE_CHECKING:
     from authentik.sources.oauth.types.registry import SourceType
+
+SerializerType = type[Serializer]
 
 
 class OAuthSource(Source):
@@ -67,7 +68,7 @@ class OAuthSource(Source):
         return "ak-source-oauth-form"
 
     @property
-    def serializer(self) -> SERIALIZER_TYPE:
+    def serializer(self) -> SerializerType:
         from authentik.sources.oauth.api.source import OAuthSourceSerializer
 
         return OAuthSourceSerializer

--- a/authentik/sources/oauth/models.py
+++ b/authentik/sources/oauth/models.py
@@ -1,5 +1,5 @@
 """OAuth Client models"""
-from typing import TYPE_CHECKING, Type
+from typing import TYPE_CHECKING
 
 from django.db import models
 from django.http.request import HttpRequest

--- a/authentik/sources/oauth/models.py
+++ b/authentik/sources/oauth/models.py
@@ -13,8 +13,6 @@ from authentik.core.types import UILoginButton, UserSettingSerializer
 if TYPE_CHECKING:
     from authentik.sources.oauth.types.registry import SourceType
 
-SerializerType = type[Serializer]
-
 
 class OAuthSource(Source):
     """Login using a Generic OAuth provider."""

--- a/authentik/sources/oauth/models.py
+++ b/authentik/sources/oauth/models.py
@@ -10,6 +10,7 @@ from rest_framework.serializers import Serializer
 from authentik.core.models import Source, UserSourceConnection
 from authentik.core.types import UILoginButton, UserSettingSerializer
 
+SERIALIZER_TYPE = type[Serializer]
 if TYPE_CHECKING:
     from authentik.sources.oauth.types.registry import SourceType
 
@@ -66,7 +67,7 @@ class OAuthSource(Source):
         return "ak-source-oauth-form"
 
     @property
-    def serializer(self) -> Type[Serializer]:
+    def serializer(self) -> SERIALIZER_TYPE:
         from authentik.sources.oauth.api.source import OAuthSourceSerializer
 
         return OAuthSourceSerializer

--- a/authentik/sources/oauth/models.py
+++ b/authentik/sources/oauth/models.py
@@ -1,5 +1,5 @@
 """OAuth Client models"""
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Type
 
 from django.db import models
 from django.http.request import HttpRequest
@@ -66,7 +66,7 @@ class OAuthSource(Source):
         return "ak-source-oauth-form"
 
     @property
-    def serializer(self) -> type[Serializer]:
+    def serializer(self) -> Type[Serializer]:
         from authentik.sources.oauth.api.source import OAuthSourceSerializer
 
         return OAuthSourceSerializer

--- a/authentik/sources/oauth/types/apple.py
+++ b/authentik/sources/oauth/types/apple.py
@@ -1,6 +1,6 @@
 """Apple OAuth Views"""
 from time import time
-from typing import Any, Optional
+from typing import Any
 
 from django.http.request import HttpRequest
 from django.urls.base import reverse

--- a/authentik/sources/oauth/types/apple.py
+++ b/authentik/sources/oauth/types/apple.py
@@ -63,7 +63,7 @@ class AppleOAuthClient(OAuth2Client):
         LOGGER.debug("signing payload as secret key", payload=payload, jwt=jwt)
         return jwt
 
-    def get_profile_info(self, token: dict[str, str]) -> Optional[dict[str, Any]]:
+    def get_profile_info(self, token: dict[str, str]) -> dict[str, Any] | None:
         id_token = token.get("id_token")
         return decode(id_token, options={"verify_signature": False})
 
@@ -85,7 +85,7 @@ class AppleOAuth2Callback(OAuthCallback):
 
     client_class = AppleOAuthClient
 
-    def get_user_id(self, info: dict[str, Any]) -> Optional[str]:
+    def get_user_id(self, info: dict[str, Any]) -> str | None:
         return info["sub"]
 
     def get_user_enroll_context(

--- a/authentik/sources/oauth/types/facebook.py
+++ b/authentik/sources/oauth/types/facebook.py
@@ -21,7 +21,7 @@ class FacebookOAuthRedirect(OAuthRedirect):
 class FacebookOAuth2Client(OAuth2Client):
     """Facebook OAuth2 Client"""
 
-    def get_profile_info(self, token: dict[str, str]) -> Optional[dict[str, Any]]:
+    def get_profile_info(self, token: dict[str, str]) -> dict[str, Any] | None:
         api = GraphAPI(access_token=token["access_token"])
         return api.get_object("me", fields="id,name,email")
 

--- a/authentik/sources/oauth/types/facebook.py
+++ b/authentik/sources/oauth/types/facebook.py
@@ -1,5 +1,5 @@
 """Facebook OAuth Views"""
-from typing import Any, Optional
+from typing import Any
 
 from facebook import GraphAPI
 

--- a/authentik/sources/oauth/types/mailcow.py
+++ b/authentik/sources/oauth/types/mailcow.py
@@ -1,5 +1,5 @@
 """Mailcow OAuth Views"""
-from typing import Any, Optional
+from typing import Any
 
 from requests.exceptions import RequestException
 from structlog.stdlib import get_logger

--- a/authentik/sources/oauth/types/mailcow.py
+++ b/authentik/sources/oauth/types/mailcow.py
@@ -24,7 +24,7 @@ class MailcowOAuthRedirect(OAuthRedirect):
 class MailcowOAuth2Client(OAuth2Client):
     """MailcowOAuth2Client, for some reason, mailcow does not like the default headers"""
 
-    def get_profile_info(self, token: dict[str, str]) -> Optional[dict[str, Any]]:
+    def get_profile_info(self, token: dict[str, str]) -> dict[str, Any] | None:
         "Fetch user profile information."
         profile_url = self.source.source_type.profile_url or ""
         if self.source.source_type.urls_customizable and self.source.profile_url:

--- a/authentik/sources/oauth/types/registry.py
+++ b/authentik/sources/oauth/types/registry.py
@@ -1,7 +1,6 @@
 """Source type manager"""
-from enum import Enum
-from typing import Optional, Type
 from collections.abc import Callable
+from enum import Enum
 
 from django.http.request import HttpRequest
 from django.templatetags.static import static

--- a/authentik/sources/oauth/types/registry.py
+++ b/authentik/sources/oauth/types/registry.py
@@ -1,6 +1,7 @@
 """Source type manager"""
 from enum import Enum
-from typing import Callable, Optional, Type
+from typing import Optional, Type
+from collections.abc import Callable
 
 from django.http.request import HttpRequest
 from django.templatetags.static import static
@@ -32,12 +33,12 @@ class SourceType:
 
     urls_customizable = False
 
-    request_token_url: Optional[str] = None
-    authorization_url: Optional[str] = None
-    access_token_url: Optional[str] = None
-    profile_url: Optional[str] = None
-    oidc_well_known_url: Optional[str] = None
-    oidc_jwks_url: Optional[str] = None
+    request_token_url: str | None = None
+    authorization_url: str | None = None
+    access_token_url: str | None = None
+    profile_url: str | None = None
+    oidc_well_known_url: str | None = None
+    oidc_jwks_url: str | None = None
 
     def icon_url(self) -> str:
         """Get Icon URL for login"""
@@ -79,7 +80,7 @@ class SourceTypeRegistry:
         """Get list of tuples of all registered names"""
         return [(x.slug, x.name) for x in self.__sources]
 
-    def find_type(self, type_name: str) -> Type[SourceType]:
+    def find_type(self, type_name: str) -> type[SourceType]:
         """Find type based on source"""
         found_type = None
         for src_type in self.__sources:

--- a/authentik/sources/oauth/types/twitch.py
+++ b/authentik/sources/oauth/types/twitch.py
@@ -11,7 +11,7 @@ from authentik.sources.oauth.views.redirect import OAuthRedirect
 class TwitchClient(UserprofileHeaderAuthClient):
     """Twitch needs the token_type to be capitalized for the request header."""
 
-    def get_profile_info(self, token: dict[str, str]) -> Optional[dict[str, Any]]:
+    def get_profile_info(self, token: dict[str, str]) -> dict[str, Any] | None:
         token["token_type"] = token["token_type"].capitalize()
         return super().get_profile_info(token)
 

--- a/authentik/sources/oauth/types/twitch.py
+++ b/authentik/sources/oauth/types/twitch.py
@@ -1,6 +1,6 @@
 """Twitch OAuth Views"""
 from json import dumps
-from typing import Any, Optional
+from typing import Any
 
 from authentik.sources.oauth.clients.oauth2 import UserprofileHeaderAuthClient
 from authentik.sources.oauth.types.registry import SourceType, registry

--- a/authentik/sources/oauth/types/twitter.py
+++ b/authentik/sources/oauth/types/twitter.py
@@ -1,5 +1,5 @@
 """Twitter OAuth Views"""
-from typing import Any, Optional
+from typing import Any
 
 from authentik.lib.generators import generate_id
 from authentik.sources.oauth.clients.oauth2 import (

--- a/authentik/sources/oauth/types/twitter.py
+++ b/authentik/sources/oauth/types/twitter.py
@@ -19,7 +19,7 @@ class TwitterClient(UserprofileHeaderAuthClient):
     # is set via query parameter, so we reuse the azure client
     # see https://github.com/goauthentik/authentik/issues/1910
 
-    def get_access_token(self, **request_kwargs) -> Optional[dict[str, Any]]:
+    def get_access_token(self, **request_kwargs) -> dict[str, Any] | None:
         return super().get_access_token(
             auth=(
                 self.source.consumer_key,

--- a/authentik/sources/oauth/views/base.py
+++ b/authentik/sources/oauth/views/base.py
@@ -1,5 +1,4 @@
 """OAuth Base views"""
-from typing import Optional
 
 from django.http.request import HttpRequest
 from structlog.stdlib import get_logger

--- a/authentik/sources/oauth/views/base.py
+++ b/authentik/sources/oauth/views/base.py
@@ -18,7 +18,7 @@ class OAuthClientMixin:
 
     request: HttpRequest  # Set by View class
 
-    client_class: Optional[type[BaseOAuthClient]] = None
+    client_class: type[BaseOAuthClient] | None = None
 
     def get_client(self, source: OAuthSource, **kwargs) -> BaseOAuthClient:
         "Get instance of the OAuth client for this source."

--- a/authentik/sources/oauth/views/callback.py
+++ b/authentik/sources/oauth/views/callback.py
@@ -1,6 +1,6 @@
 """OAuth Callback Views"""
 from json import JSONDecodeError
-from typing import Any, Optional
+from typing import Any
 
 from django.conf import settings
 from django.contrib import messages

--- a/authentik/sources/oauth/views/callback.py
+++ b/authentik/sources/oauth/views/callback.py
@@ -22,7 +22,7 @@ class OAuthCallback(OAuthClientMixin, View):
     "Base OAuth callback view."
 
     source: OAuthSource
-    token: Optional[dict] = None
+    token: dict | None = None
 
     # pylint: disable=too-many-return-statements
     def dispatch(self, request: HttpRequest, *_, **kwargs) -> HttpResponse:
@@ -85,7 +85,7 @@ class OAuthCallback(OAuthClientMixin, View):
         """Create a dict of User data"""
         raise NotImplementedError()
 
-    def get_user_id(self, info: dict[str, Any]) -> Optional[str]:
+    def get_user_id(self, info: dict[str, Any]) -> str | None:
         """Return unique identifier from the profile info."""
         if "id" in info:
             return info["id"]
@@ -114,7 +114,7 @@ class OAuthSourceFlowManager(SourceFlowManager):
     def update_connection(
         self,
         connection: UserOAuthSourceConnection,
-        access_token: Optional[str] = None,
+        access_token: str | None = None,
     ) -> UserOAuthSourceConnection:
         """Set the access_token on the connection"""
         connection.access_token = access_token

--- a/authentik/sources/plex/models.py
+++ b/authentik/sources/plex/models.py
@@ -78,7 +78,7 @@ class PlexSource(Source):
             name=self.name,
         )
 
-    def ui_user_settings(self) -> Optional[UserSettingSerializer]:
+    def ui_user_settings(self) -> UserSettingSerializer | None:
         icon = self.get_icon
         if not icon:
             icon = static("authentik/sources/plex.svg")

--- a/authentik/sources/plex/models.py
+++ b/authentik/sources/plex/models.py
@@ -1,5 +1,4 @@
 """Plex source"""
-from typing import Optional
 
 from django.contrib.postgres.fields import ArrayField
 from django.db import models

--- a/authentik/sources/saml/models.py
+++ b/authentik/sources/saml/models.py
@@ -1,5 +1,4 @@
 """saml sp models"""
-from typing import Optional
 
 from django.db import models
 from django.http import HttpRequest

--- a/authentik/sources/saml/models.py
+++ b/authentik/sources/saml/models.py
@@ -203,7 +203,7 @@ class SAMLSource(Source):
             icon_url=self.get_icon,
         )
 
-    def ui_user_settings(self) -> Optional[UserSettingSerializer]:
+    def ui_user_settings(self) -> UserSettingSerializer | None:
         icon = self.get_icon
         if not icon:
             icon = static(f"authentik/sources/{self.slug}.svg")

--- a/authentik/sources/saml/processors/metadata.py
+++ b/authentik/sources/saml/processors/metadata.py
@@ -1,5 +1,6 @@
 """SAML Service Provider Metadata Processor"""
-from typing import Iterator, Optional
+from typing import Optional
+from collections.abc import Iterator
 
 from django.http import HttpRequest
 from lxml.etree import Element, SubElement, tostring  # nosec
@@ -29,7 +30,7 @@ class MetadataProcessor:
         self.source = source
         self.http_request = request
 
-    def get_signing_key_descriptor(self) -> Optional[Element]:
+    def get_signing_key_descriptor(self) -> Element | None:
         """Get Signing KeyDescriptor, if enabled for the source"""
         if self.source.signing_kp:
             key_descriptor = Element(f"{{{NS_SAML_METADATA}}}KeyDescriptor")

--- a/authentik/sources/saml/processors/metadata.py
+++ b/authentik/sources/saml/processors/metadata.py
@@ -19,6 +19,8 @@ from authentik.sources.saml.processors.constants import (
     SAML_NAME_ID_FORMAT_X509,
 )
 
+ElementOrNone = Optional[Element]
+
 
 class MetadataProcessor:
     """SAML Service Provider Metadata Processor"""
@@ -30,7 +32,7 @@ class MetadataProcessor:
         self.source = source
         self.http_request = request
 
-    def get_signing_key_descriptor(self) -> Optional[Element]:
+    def get_signing_key_descriptor(self) -> ElementOrNone:
         """Get Signing KeyDescriptor, if enabled for the source"""
         if self.source.signing_kp:
             key_descriptor = Element(f"{{{NS_SAML_METADATA}}}KeyDescriptor")

--- a/authentik/sources/saml/processors/metadata.py
+++ b/authentik/sources/saml/processors/metadata.py
@@ -1,5 +1,4 @@
 """SAML Service Provider Metadata Processor"""
-from typing import Optional
 from collections.abc import Iterator
 
 from django.http import HttpRequest

--- a/authentik/sources/saml/processors/metadata.py
+++ b/authentik/sources/saml/processors/metadata.py
@@ -1,5 +1,6 @@
 """SAML Service Provider Metadata Processor"""
 from collections.abc import Iterator
+from typing import Optional
 
 from django.http import HttpRequest
 from lxml.etree import Element, SubElement, tostring  # nosec
@@ -29,7 +30,7 @@ class MetadataProcessor:
         self.source = source
         self.http_request = request
 
-    def get_signing_key_descriptor(self) -> Element | None:
+    def get_signing_key_descriptor(self) -> Optional[Element]:
         """Get Signing KeyDescriptor, if enabled for the source"""
         if self.source.signing_kp:
             key_descriptor = Element(f"{{{NS_SAML_METADATA}}}KeyDescriptor")

--- a/authentik/stages/authenticator/models.py
+++ b/authentik/stages/authenticator/models.py
@@ -95,14 +95,14 @@ class Device(models.Model):
         except ObjectDoesNotExist:
             user = None
 
-        return "{0} ({1})".format(self.name, user)
+        return f"{self.name} ({user})"
 
     @property
     def persistent_id(self):
         """
         A stable device identifier for forms and APIs.
         """
-        return "{0}/{1}".format(self.model_label(), self.id)
+        return f"{self.model_label()}/{self.id}"
 
     @classmethod
     def model_label(cls):
@@ -112,7 +112,7 @@ class Device(models.Model):
         This is just the standard "<app_label>.<model_name>" form.
 
         """
-        return "{0}.{1}".format(cls._meta.app_label, cls._meta.model_name)
+        return f"{cls._meta.app_label}.{cls._meta.model_name}"
 
     @classmethod
     def from_persistent_id(cls, persistent_id, for_verify=False):

--- a/authentik/stages/authenticator/util.py
+++ b/authentik/stages/authenticator/util.py
@@ -42,10 +42,10 @@ def hex_validator(length=0):
 
             unhexlify(value)
         except Exception:
-            raise ValidationError("{0} is not valid hex-encoded data.".format(value))
+            raise ValidationError(f"{value} is not valid hex-encoded data.")
 
         if (length > 0) and (len(value) != length * 2):
-            raise ValidationError("{0} does not represent exactly {1} bytes.".format(value, length))
+            raise ValidationError(f"{value} does not represent exactly {length} bytes.")
 
     return _validator
 

--- a/authentik/stages/authenticator_duo/models.py
+++ b/authentik/stages/authenticator_duo/models.py
@@ -1,5 +1,4 @@
 """Duo stage"""
-from typing import Optional
 
 from django.contrib.auth import get_user_model
 from django.db import models

--- a/authentik/stages/authenticator_duo/models.py
+++ b/authentik/stages/authenticator_duo/models.py
@@ -64,7 +64,7 @@ class AuthenticatorDuoStage(ConfigurableStage, FriendlyNamedStage, Stage):
     def component(self) -> str:
         return "ak-stage-authenticator-duo-form"
 
-    def ui_user_settings(self) -> Optional[UserSettingSerializer]:
+    def ui_user_settings(self) -> UserSettingSerializer | None:
         return UserSettingSerializer(
             data={
                 "title": self.friendly_name or str(self._meta.verbose_name),

--- a/authentik/stages/authenticator_sms/models.py
+++ b/authentik/stages/authenticator_sms/models.py
@@ -1,6 +1,5 @@
 """SMS Authenticator models"""
 from hashlib import sha256
-from typing import Optional
 
 from django.contrib.auth import get_user_model
 from django.db import models

--- a/authentik/stages/authenticator_sms/models.py
+++ b/authentik/stages/authenticator_sms/models.py
@@ -78,7 +78,7 @@ class AuthenticatorSMSStage(ConfigurableStage, FriendlyNamedStage, Stage):
 
     def get_message(self, token: str) -> str:
         """Get SMS message"""
-        return _("Use this code to authenticate in authentik: %(token)s" % {"token": token})
+        return _("Use this code to authenticate in authentik: {token}".format(token=token))
 
     def send_twilio(self, token: str, device: "SMSDevice"):
         """send sms via twilio provider"""
@@ -165,7 +165,7 @@ class AuthenticatorSMSStage(ConfigurableStage, FriendlyNamedStage, Stage):
     def component(self) -> str:
         return "ak-stage-authenticator-sms-form"
 
-    def ui_user_settings(self) -> Optional[UserSettingSerializer]:
+    def ui_user_settings(self) -> UserSettingSerializer | None:
         return UserSettingSerializer(
             data={
                 "title": self.friendly_name or str(self._meta.verbose_name),

--- a/authentik/stages/authenticator_sms/models.py
+++ b/authentik/stages/authenticator_sms/models.py
@@ -77,7 +77,7 @@ class AuthenticatorSMSStage(ConfigurableStage, FriendlyNamedStage, Stage):
 
     def get_message(self, token: str) -> str:
         """Get SMS message"""
-        return _("Use this code to authenticate in authentik: {token}".format(token=token))
+        return _(f"Use this code to authenticate in authentik: {token}")
 
     def send_twilio(self, token: str, device: "SMSDevice"):
         """send sms via twilio provider"""

--- a/authentik/stages/authenticator_sms/stage.py
+++ b/authentik/stages/authenticator_sms/stage.py
@@ -1,5 +1,4 @@
 """SMS Setup stage"""
-from typing import Optional
 
 from django.db.models import Q
 from django.http import HttpRequest, HttpResponse

--- a/authentik/stages/authenticator_sms/stage.py
+++ b/authentik/stages/authenticator_sms/stage.py
@@ -76,7 +76,7 @@ class AuthenticatorSMSStageView(ChallengeStageView):
         device: SMSDevice = self.request.session[SESSION_KEY_SMS_DEVICE]
         stage.send(device.token, device)
 
-    def _has_phone_number(self) -> Optional[str]:
+    def _has_phone_number(self) -> str | None:
         context = self.executor.plan.context
         if PLAN_CONTEXT_PHONE in context.get(PLAN_CONTEXT_PROMPT, {}):
             self.logger.debug("got phone number from plan context")

--- a/authentik/stages/authenticator_static/models.py
+++ b/authentik/stages/authenticator_static/models.py
@@ -1,7 +1,6 @@
 """Static Authenticator models"""
 from base64 import b32encode
 from os import urandom
-from typing import Optional
 
 from django.conf import settings
 from django.db import models

--- a/authentik/stages/authenticator_static/models.py
+++ b/authentik/stages/authenticator_static/models.py
@@ -37,7 +37,7 @@ class AuthenticatorStaticStage(ConfigurableStage, FriendlyNamedStage, Stage):
     def component(self) -> str:
         return "ak-stage-authenticator-static-form"
 
-    def ui_user_settings(self) -> Optional[UserSettingSerializer]:
+    def ui_user_settings(self) -> UserSettingSerializer | None:
         return UserSettingSerializer(
             data={
                 "title": self.friendly_name or str(self._meta.verbose_name),

--- a/authentik/stages/authenticator_totp/models.py
+++ b/authentik/stages/authenticator_totp/models.py
@@ -2,7 +2,6 @@
 import time
 from base64 import b32encode
 from binascii import unhexlify
-from typing import Optional
 from urllib.parse import quote, urlencode
 
 from django.conf import settings

--- a/authentik/stages/authenticator_totp/models.py
+++ b/authentik/stages/authenticator_totp/models.py
@@ -47,7 +47,7 @@ class AuthenticatorTOTPStage(ConfigurableStage, FriendlyNamedStage, Stage):
     def component(self) -> str:
         return "ak-stage-authenticator-totp-form"
 
-    def ui_user_settings(self) -> Optional[UserSettingSerializer]:
+    def ui_user_settings(self) -> UserSettingSerializer | None:
         return UserSettingSerializer(
             data={
                 "title": self.friendly_name or str(self._meta.verbose_name),
@@ -219,7 +219,7 @@ class TOTPDevice(SerializerModel, ThrottlingMixin, Device):
         issuer = self._read_str_from_settings("OTP_TOTP_ISSUER")
         if issuer:
             issuer = issuer.replace(":", "")
-            label = "{}:{}".format(issuer, label)
+            label = f"{issuer}:{label}"
             urlencoded_params += "&issuer={}".format(
                 quote(issuer)
             )  # encode issuer as per RFC 3986, not quote_plus
@@ -228,7 +228,7 @@ class TOTPDevice(SerializerModel, ThrottlingMixin, Device):
         if image:
             urlencoded_params += "&image={}".format(quote(image, safe=":/"))
 
-        url = "otpauth://totp/{}?{}".format(quote(label), urlencoded_params)
+        url = f"otpauth://totp/{quote(label)}?{urlencoded_params}"
 
         return url
 

--- a/authentik/stages/authenticator_validate/challenge.py
+++ b/authentik/stages/authenticator_validate/challenge.py
@@ -75,7 +75,7 @@ def get_webauthn_challenge_without_user(
 
 
 def get_webauthn_challenge(
-    request: HttpRequest, stage: AuthenticatorValidateStage, device: Optional[WebAuthnDevice] = None
+    request: HttpRequest, stage: AuthenticatorValidateStage, device: WebAuthnDevice | None = None
 ) -> dict:
     """Send the client a challenge that we'll check later"""
     request.session.pop(SESSION_KEY_WEBAUTHN_CHALLENGE, None)

--- a/authentik/stages/authenticator_validate/challenge.py
+++ b/authentik/stages/authenticator_validate/challenge.py
@@ -1,5 +1,4 @@
 """Validation stage challenge checking"""
-from typing import Optional
 from urllib.parse import urlencode
 
 from django.http import HttpRequest

--- a/authentik/stages/authenticator_validate/stage.py
+++ b/authentik/stages/authenticator_validate/stage.py
@@ -62,7 +62,7 @@ class AuthenticatorValidationChallenge(WithUserInfoChallenge):
 class AuthenticatorValidationChallengeResponse(ChallengeResponse):
     """Challenge used for Code-based and WebAuthn authenticators"""
 
-    device: Optional[Device]
+    device: Device | None
 
     selected_challenge = DeviceChallenge(required=False)
     selected_stage = CharField(required=False)

--- a/authentik/stages/authenticator_validate/stage.py
+++ b/authentik/stages/authenticator_validate/stage.py
@@ -1,7 +1,6 @@
 """Authenticator Validation"""
 from datetime import datetime
 from hashlib import sha256
-from typing import Optional
 
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse

--- a/authentik/stages/authenticator_webauthn/models.py
+++ b/authentik/stages/authenticator_webauthn/models.py
@@ -1,5 +1,4 @@
 """WebAuthn stage"""
-from typing import Optional
 
 from django.contrib.auth import get_user_model
 from django.db import models

--- a/authentik/stages/authenticator_webauthn/models.py
+++ b/authentik/stages/authenticator_webauthn/models.py
@@ -97,7 +97,7 @@ class AuthenticateWebAuthnStage(ConfigurableStage, FriendlyNamedStage, Stage):
     def component(self) -> str:
         return "ak-stage-authenticator-webauthn-form"
 
-    def ui_user_settings(self) -> Optional[UserSettingSerializer]:
+    def ui_user_settings(self) -> UserSettingSerializer | None:
         return UserSettingSerializer(
             data={
                 "title": self.friendly_name or str(self._meta.verbose_name),

--- a/authentik/stages/authenticator_webauthn/tests.py
+++ b/authentik/stages/authenticator_webauthn/tests.py
@@ -46,8 +46,8 @@ class TestAuthenticatorWebAuthnStage(FlowTestCase):
         session = self.client.session
         session[SESSION_KEY_PLAN] = plan
         session[SESSION_KEY_WEBAUTHN_CHALLENGE] = b64decode(
-                b"o90Yh1osqW3mjGift+6WclWOya5lcdff/G0mqueN3hChacMUz"
-                b"V4mxiDafuQ0x0e1d/fcPai0fx/jMBZ8/nG2qQ=="
+            b"o90Yh1osqW3mjGift+6WclWOya5lcdff/G0mqueN3hChacMUz"
+            b"V4mxiDafuQ0x0e1d/fcPai0fx/jMBZ8/nG2qQ=="
         )
         session.save()
 

--- a/authentik/stages/authenticator_webauthn/tests.py
+++ b/authentik/stages/authenticator_webauthn/tests.py
@@ -46,10 +46,8 @@ class TestAuthenticatorWebAuthnStage(FlowTestCase):
         session = self.client.session
         session[SESSION_KEY_PLAN] = plan
         session[SESSION_KEY_WEBAUTHN_CHALLENGE] = b64decode(
-            (
-                "o90Yh1osqW3mjGift+6WclWOya5lcdff/G0mqueN3hChacMUz"
-                "V4mxiDafuQ0x0e1d/fcPai0fx/jMBZ8/nG2qQ=="
-            ).encode()
+                b"o90Yh1osqW3mjGift+6WclWOya5lcdff/G0mqueN3hChacMUz"
+                b"V4mxiDafuQ0x0e1d/fcPai0fx/jMBZ8/nG2qQ=="
         )
         session.save()
 

--- a/authentik/stages/consent/stage.py
+++ b/authentik/stages/consent/stage.py
@@ -1,5 +1,4 @@
 """authentik consent stage"""
-from typing import Optional
 from uuid import uuid4
 
 from django.http import HttpRequest, HttpResponse

--- a/authentik/stages/consent/stage.py
+++ b/authentik/stages/consent/stage.py
@@ -98,7 +98,7 @@ class ConsentStageView(ChallengeStageView):
         if PLAN_CONTEXT_PENDING_USER in self.executor.plan.context:
             user = self.executor.plan.context[PLAN_CONTEXT_PENDING_USER]
 
-        consent: Optional[UserConsent] = UserConsent.filter_not_expired(
+        consent: UserConsent | None = UserConsent.filter_not_expired(
             user=user, application=application
         ).first()
         self.executor.plan.context[PLAN_CONTEXT_CONSENT] = consent
@@ -106,7 +106,7 @@ class ConsentStageView(ChallengeStageView):
         if consent:
             perms = self.executor.plan.context.get(PLAN_CONTEXT_CONSENT_PERMISSIONS, [])
             allowed_perms = set(consent.permissions.split(" ") if consent.permissions != "" else [])
-            requested_perms = set(x["id"] for x in perms)
+            requested_perms = {x["id"] for x in perms}
 
             if allowed_perms != requested_perms:
                 self.executor.plan.context[PLAN_CONTEXT_CONSENT_PERMISSIONS] = [

--- a/authentik/stages/email/models.py
+++ b/authentik/stages/email/models.py
@@ -1,6 +1,7 @@
 """email stage models"""
 from os import R_OK, access
 from pathlib import Path
+from typing import Type
 
 from django.conf import settings
 from django.core.mail.backends.base import BaseEmailBackend
@@ -96,7 +97,7 @@ class EmailStage(Stage):
         return "ak-stage-email-form"
 
     @property
-    def backend_class(self) -> type[BaseEmailBackend]:
+    def backend_class(self) -> Type[BaseEmailBackend]:
         """Get the email backend class to use"""
         return EmailBackend
 

--- a/authentik/stages/email/models.py
+++ b/authentik/stages/email/models.py
@@ -97,7 +97,7 @@ class EmailStage(Stage):
         return "ak-stage-email-form"
 
     @property
-    def backend_class(self) -> Type[BaseEmailBackend]:
+    def backend_class(self) -> type[BaseEmailBackend]:
         """Get the email backend class to use"""
         return EmailBackend
 

--- a/authentik/stages/email/models.py
+++ b/authentik/stages/email/models.py
@@ -1,7 +1,6 @@
 """email stage models"""
 from os import R_OK, access
 from pathlib import Path
-from typing import Type
 
 from django.conf import settings
 from django.core.mail.backends.base import BaseEmailBackend
@@ -15,6 +14,7 @@ from structlog.stdlib import get_logger
 from authentik.flows.models import Stage
 from authentik.lib.config import CONFIG
 
+BASE_EMAIL_BACKEND_TYPE = type[BaseEmailBackend]
 LOGGER = get_logger()
 
 
@@ -97,7 +97,7 @@ class EmailStage(Stage):
         return "ak-stage-email-form"
 
     @property
-    def backend_class(self) -> Type[BaseEmailBackend]:
+    def backend_class(self) -> BASE_EMAIL_BACKEND_TYPE:
         """Get the email backend class to use"""
         return EmailBackend
 

--- a/authentik/stages/email/models.py
+++ b/authentik/stages/email/models.py
@@ -1,7 +1,6 @@
 """email stage models"""
 from os import R_OK, access
 from pathlib import Path
-from typing import Type
 
 from django.conf import settings
 from django.core.mail.backends.base import BaseEmailBackend

--- a/authentik/stages/email/models.py
+++ b/authentik/stages/email/models.py
@@ -14,8 +14,9 @@ from structlog.stdlib import get_logger
 from authentik.flows.models import Stage
 from authentik.lib.config import CONFIG
 
-BASE_EMAIL_BACKEND_TYPE = type[BaseEmailBackend]
 LOGGER = get_logger()
+
+BaseEmailBackendType = type[BaseEmailBackend]
 
 
 class EmailTemplates(models.TextChoices):
@@ -97,7 +98,7 @@ class EmailStage(Stage):
         return "ak-stage-email-form"
 
     @property
-    def backend_class(self) -> BASE_EMAIL_BACKEND_TYPE:
+    def backend_class(self) -> BaseEmailBackendType:
         """Get the email backend class to use"""
         return EmailBackend
 

--- a/authentik/stages/email/tasks.py
+++ b/authentik/stages/email/tasks.py
@@ -1,7 +1,7 @@
 """email stage tasks"""
 from email.utils import make_msgid
 from smtplib import SMTPException
-from typing import Any, Optional
+from typing import Any
 
 from celery import group
 from django.core.mail import EmailMultiAlternatives

--- a/authentik/stages/email/tasks.py
+++ b/authentik/stages/email/tasks.py
@@ -46,7 +46,7 @@ def get_email_body(email: EmailMultiAlternatives) -> str:
     retry_backoff=True,
     base=MonitoredTask,
 )
-def send_mail(self: MonitoredTask, message: dict[Any, Any], email_stage_pk: Optional[int] = None):
+def send_mail(self: MonitoredTask, message: dict[Any, Any], email_stage_pk: int | None = None):
     """Send Email for Email Stage. Retries are scheduled automatically."""
     self.save_on_success = False
     message_id = make_msgid(domain=DNS_NAME)

--- a/authentik/stages/email/utils.py
+++ b/authentik/stages/email/utils.py
@@ -8,7 +8,7 @@ from django.template.loader import render_to_string
 from django.utils import translation
 
 
-@lru_cache()
+@lru_cache
 def logo_data() -> MIMEImage:
     """Get logo as MIME Image for emails"""
     path = Path("web/icons/icon_left_brand.png")

--- a/authentik/stages/identification/stage.py
+++ b/authentik/stages/identification/stage.py
@@ -83,7 +83,7 @@ class IdentificationChallengeResponse(ChallengeResponse):
     password = CharField(required=False, allow_blank=True, allow_null=True)
     component = CharField(default="ak-stage-identification")
 
-    pre_user: Optional[User] = None
+    pre_user: User | None = None
 
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
         """Validate that user exists, and optionally their password"""
@@ -158,7 +158,7 @@ class IdentificationStageView(ChallengeStageView):
 
     response_class = IdentificationChallengeResponse
 
-    def get_user(self, uid_value: str) -> Optional[User]:
+    def get_user(self, uid_value: str) -> User | None:
         """Find user instance. Returns None if no user was found."""
         current_stage: IdentificationStage = self.executor.current_stage
         query = Q()

--- a/authentik/stages/identification/stage.py
+++ b/authentik/stages/identification/stage.py
@@ -2,7 +2,7 @@
 from dataclasses import asdict
 from random import SystemRandom
 from time import sleep
-from typing import Any, Optional
+from typing import Any
 
 from django.core.exceptions import PermissionDenied
 from django.db.models import Q

--- a/authentik/stages/invitation/stage.py
+++ b/authentik/stages/invitation/stage.py
@@ -21,7 +21,7 @@ INVITATION = "invitation"
 class InvitationStageView(StageView):
     """Finalise Authentication flow by logging the user in"""
 
-    def get_token(self) -> Optional[str]:
+    def get_token(self) -> str | None:
         """Get token from saved get-arguments or prompt_data"""
         # Check for ?token= and ?itoken=
         if INVITATION_TOKEN_KEY in self.request.session.get(SESSION_KEY_GET, {}):
@@ -33,7 +33,7 @@ class InvitationStageView(StageView):
             return self.executor.plan.context[PLAN_CONTEXT_PROMPT][INVITATION_TOKEN_KEY_CONTEXT]
         return None
 
-    def get_invite(self) -> Optional[Invitation]:
+    def get_invite(self) -> Invitation | None:
         """Check the token, find the invite and check it's flow"""
         token = self.get_token()
         if not token:

--- a/authentik/stages/invitation/stage.py
+++ b/authentik/stages/invitation/stage.py
@@ -1,5 +1,4 @@
 """invitation stage logic"""
-from typing import Optional
 
 from deepmerge import always_merger
 from django.core.exceptions import ValidationError

--- a/authentik/stages/password/models.py
+++ b/authentik/stages/password/models.py
@@ -1,5 +1,4 @@
 """password stage models"""
-from typing import Optional
 
 from django.contrib.postgres.fields import ArrayField
 from django.db import models

--- a/authentik/stages/password/models.py
+++ b/authentik/stages/password/models.py
@@ -61,7 +61,7 @@ class PasswordStage(ConfigurableStage, Stage):
     def component(self) -> str:
         return "ak-stage-password-form"
 
-    def ui_user_settings(self) -> Optional[UserSettingSerializer]:
+    def ui_user_settings(self) -> UserSettingSerializer | None:
         if not self.configure_flow:
             return None
         return UserSettingSerializer(

--- a/authentik/stages/password/stage.py
+++ b/authentik/stages/password/stage.py
@@ -1,5 +1,5 @@
 """authentik password stage"""
-from typing import Any, Optional
+from typing import Any
 
 from django.contrib.auth import _clean_credentials
 from django.contrib.auth.backends import BaseBackend

--- a/authentik/stages/password/stage.py
+++ b/authentik/stages/password/stage.py
@@ -35,8 +35,8 @@ SESSION_KEY_INVALID_TRIES = "authentik/stages/password/user_invalid_tries"
 
 
 def authenticate(
-    request: HttpRequest, backends: list[str], stage: Optional[Stage] = None, **credentials: Any
-) -> Optional[User]:
+    request: HttpRequest, backends: list[str], stage: Stage | None = None, **credentials: Any
+) -> User | None:
     """If the given credentials are valid, return a User object.
 
     Customized version of django's authenticate, which accepts a list of backends"""

--- a/authentik/stages/prompt/models.py
+++ b/authentik/stages/prompt/models.py
@@ -1,5 +1,5 @@
 """prompt models"""
-from typing import Any
+from typing import Any, Type
 from urllib.parse import urlparse, urlunparse
 from uuid import uuid4
 
@@ -142,7 +142,7 @@ class Prompt(SerializerModel):
     initial_value_expression = models.BooleanField(default=False)
 
     @property
-    def serializer(self) -> type[BaseSerializer]:
+    def serializer(self) -> Type[BaseSerializer]:
         from authentik.stages.prompt.api import PromptSerializer
 
         return PromptSerializer

--- a/authentik/stages/prompt/models.py
+++ b/authentik/stages/prompt/models.py
@@ -1,5 +1,5 @@
 """prompt models"""
-from typing import Any, Optional, Type
+from typing import Any
 from urllib.parse import urlparse, urlunparse
 from uuid import uuid4
 

--- a/authentik/stages/prompt/models.py
+++ b/authentik/stages/prompt/models.py
@@ -29,11 +29,11 @@ from authentik.flows.models import Stage
 from authentik.lib.models import SerializerModel
 from authentik.policies.models import Policy
 
-BASE_SERIALIZER_TYPE = type[BaseSerializer]
-
 CHOICES_CONTEXT_SUFFIX = "__choices"
 
 LOGGER = get_logger()
+
+BaseSerializerType = type[BaseSerializer]
 
 
 class FieldTypes(models.TextChoices):
@@ -144,7 +144,7 @@ class Prompt(SerializerModel):
     initial_value_expression = models.BooleanField(default=False)
 
     @property
-    def serializer(self) -> BASE_SERIALIZER_TYPE:
+    def serializer(self) -> BaseSerializerType:
         from authentik.stages.prompt.api import PromptSerializer
 
         return PromptSerializer

--- a/authentik/stages/prompt/models.py
+++ b/authentik/stages/prompt/models.py
@@ -1,5 +1,5 @@
 """prompt models"""
-from typing import Any, Type
+from typing import Any
 from urllib.parse import urlparse, urlunparse
 from uuid import uuid4
 
@@ -28,6 +28,8 @@ from authentik.core.models import User
 from authentik.flows.models import Stage
 from authentik.lib.models import SerializerModel
 from authentik.policies.models import Policy
+
+BASE_SERIALIZER_TYPE = type[BaseSerializer]
 
 CHOICES_CONTEXT_SUFFIX = "__choices"
 
@@ -142,7 +144,7 @@ class Prompt(SerializerModel):
     initial_value_expression = models.BooleanField(default=False)
 
     @property
-    def serializer(self) -> Type[BaseSerializer]:
+    def serializer(self) -> BASE_SERIALIZER_TYPE:
         from authentik.stages.prompt.api import PromptSerializer
 
         return PromptSerializer

--- a/authentik/stages/prompt/models.py
+++ b/authentik/stages/prompt/models.py
@@ -142,7 +142,7 @@ class Prompt(SerializerModel):
     initial_value_expression = models.BooleanField(default=False)
 
     @property
-    def serializer(self) -> Type[BaseSerializer]:
+    def serializer(self) -> type[BaseSerializer]:
         from authentik.stages.prompt.api import PromptSerializer
 
         return PromptSerializer
@@ -152,8 +152,8 @@ class Prompt(SerializerModel):
         prompt_context: dict,
         user: User,
         request: HttpRequest,
-        dry_run: Optional[bool] = False,
-    ) -> Optional[tuple[dict[str, Any]]]:
+        dry_run: bool | None = False,
+    ) -> tuple[dict[str, Any]] | None:
         """Get fully interpolated list of choices"""
         if self.type not in CHOICE_FIELDS:
             return None
@@ -192,7 +192,7 @@ class Prompt(SerializerModel):
         prompt_context: dict,
         user: User,
         request: HttpRequest,
-        dry_run: Optional[bool] = False,
+        dry_run: bool | None = False,
     ) -> str:
         """Get fully interpolated placeholder"""
         if self.type in CHOICE_FIELDS:
@@ -221,7 +221,7 @@ class Prompt(SerializerModel):
         prompt_context: dict,
         user: User,
         request: HttpRequest,
-        dry_run: Optional[bool] = False,
+        dry_run: bool | None = False,
     ) -> str:
         """Get fully interpolated initial value"""
 
@@ -257,7 +257,7 @@ class Prompt(SerializerModel):
 
         return value
 
-    def field(self, default: Optional[Any], choices: Optional[list[Any]] = None) -> CharField:
+    def field(self, default: Any | None, choices: list[Any] | None = None) -> CharField:
         """Get field type for Challenge and response. Choices are only valid for CHOICE_FIELDS."""
         field_class = CharField
         kwargs = {

--- a/authentik/stages/prompt/stage.py
+++ b/authentik/stages/prompt/stage.py
@@ -1,8 +1,8 @@
 """Prompt Stage Logic"""
+from collections.abc import Callable, Iterator
 from email.policy import Policy
 from types import MethodType
 from typing import Any
-from collections.abc import Callable, Iterator
 
 from django.db.models.query import QuerySet
 from django.http import HttpRequest, HttpResponse

--- a/authentik/stages/prompt/stage.py
+++ b/authentik/stages/prompt/stage.py
@@ -1,7 +1,8 @@
 """Prompt Stage Logic"""
 from email.policy import Policy
 from types import MethodType
-from typing import Any, Callable, Iterator
+from typing import Any
+from collections.abc import Callable, Iterator
 
 from django.db.models.query import QuerySet
 from django.http import HttpRequest, HttpResponse

--- a/authentik/stages/user_write/stage.py
+++ b/authentik/stages/user_write/stage.py
@@ -1,5 +1,5 @@
 """Write stage logic"""
-from typing import Any, Optional
+from typing import Any
 
 from django.contrib.auth import update_session_auth_hash
 from django.db import transaction

--- a/authentik/stages/user_write/stage.py
+++ b/authentik/stages/user_write/stage.py
@@ -48,7 +48,7 @@ class UserWriteStageView(StageView):
             parts = parts[1:]
         set_path_in_dict(user.attributes, ".".join(parts), value)
 
-    def ensure_user(self) -> tuple[Optional[User], bool]:
+    def ensure_user(self) -> tuple[User | None, bool]:
         """Ensure a user exists"""
         user_created = False
         path = self.executor.plan.context.get(

--- a/authentik/tenants/middleware.py
+++ b/authentik/tenants/middleware.py
@@ -1,5 +1,5 @@
 """Inject tenant into current request"""
-from typing import Callable
+from collections.abc import Callable
 
 from django.http.request import HttpRequest
 from django.http.response import HttpResponse


### PR DESCRIPTION
Result of running ``pyupgrade --py311-plus `find ./authentik/ -name "*.py" -type f` `` as project uses Python 3.11

Also, consider adding the pyupgrade command to the GitHub actions to automatically upgrade all new code.
Be aware that the developer is [unwilling to allow ignoring certain source code lines](https://github.com/asottile/pyupgrade/issues/345) so it may break certain functionality that requires workarounds.
In this case several manual adjustments were necessary as there are `type` collisions and the new `Element | None` type hint instead of `Optional[Element]` does not work reliably.

More information can be found here: https://github.com/asottile/pyupgrade