### PR TITLE
root: Ignore the vendor folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,6 @@ data/
 .netlify
 .ruff_cache
 source_docs/
+
+### Golang ###
+/vendor/


### PR DESCRIPTION
Adds the vendor folder to `.gitignore` to avoid uploading Go dependencies to GitHub.
