### PR TITLE
core/api: add uuid field to core api user http response

### DIFF
--- a/authentik/core/api/users.py
+++ b/authentik/core/api/users.py
@@ -190,6 +190,7 @@ class UserSerializer(ModelSerializer):
             "uid",
             "path",
             "type",
+            "uuid"
         ]
         extra_kwargs = {
             "name": {"allow_blank": True},

--- a/authentik/core/api/users.py
+++ b/authentik/core/api/users.py
@@ -190,7 +190,7 @@ class UserSerializer(ModelSerializer):
             "uid",
             "path",
             "type",
-            "uuid"
+            "uuid",
         ]
         extra_kwargs = {
             "name": {"allow_blank": True},

--- a/schema.yml
+++ b/schema.yml
@@ -40155,6 +40155,10 @@ components:
           type: string
         type:
           $ref: '#/components/schemas/UserTypeEnum'
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
       required:
       - avatar
       - groups_obj
@@ -40163,6 +40167,7 @@ components:
       - pk
       - uid
       - username
+      - uuid
     UserAccountRequest:
       type: object
       description: Account adding/removing operations


### PR DESCRIPTION
#6941 

Text from the issue:
---------------------
Hey there. I have a "feature" request to Authentik. The /core/users endpoint has a couple of filtering options like name, path and for me more important the uuid.
Since we have the ability to filter the uuid there is no way to retreive it via the API. My suggestion is to add the uuid in the user response of the api.

Would you like to do that? We achived that by adding the uuid to the user Meta class of users.py file.
https://github.com/goauthentik/authentik/blob/main/authentik/core/api/users.py
```

    class Meta:
        model = User
        fields = [
            "pk",
            "username",
            "name",
            ....
            "uuid",
        ]
        extra_kwargs = {
            "name": {"allow_blank": True},
        }
```