### PR TITLE
website/docs: fix PowerDNS Docker Hub repo name

### DIFF
--- a/website/integrations/services/powerdns-admin/index.md
+++ b/website/integrations/services/powerdns-admin/index.md
@@ -63,7 +63,7 @@ You must mount the certificate selected in authentik as a file in the Docker con
 version: "3.3"
 services:
     powerdns-admin:
-        image: ngoduykhanh/powerdns-admin:latest
+        image: powerdnsadmin/pda-legacy:latest
         restart: always
         ports:
             - 80:80


### PR DESCRIPTION
Change Docker Hub repository name : https://github.com/PowerDNS-Admin/PowerDNS-Admin/issues/1317
