### PR TITLE
tests: fix potential infinite wait in tests spinning up a container

### DIFF
--- a/authentik/root/test_runner.py
+++ b/authentik/root/test_runner.py
@@ -17,8 +17,8 @@ TestCase.maxDiff = None
 class PytestTestRunner(DiscoverRunner):  # pragma: no cover
     """Runs pytest to discover and run tests."""
 
-    def __init__(self, verbosity=1, failfast=False, keepdb=False, **kwargs):
-        super().__init__(verbosity, failfast, keepdb, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
         self.args = []
         if self.failfast:
@@ -47,6 +47,7 @@ class PytestTestRunner(DiscoverRunner):  # pragma: no cover
     @classmethod
     def add_arguments(cls, parser: ArgumentParser):
         """Add more pytest-specific arguments"""
+        DiscoverRunner.add_arguments(parser)
         parser.add_argument(
             "--randomly-seed",
             type=int,
@@ -54,9 +55,6 @@ class PytestTestRunner(DiscoverRunner):  # pragma: no cover
             "to reuse the seed from the previous run."
             "Default behaviour: use random.Random().getrandbits(32), so the seed is"
             "different on each run.",
-        )
-        parser.add_argument(
-            "--keepdb", action="store_true", help="Preserves the test DB between runs."
         )
 
     def run_tests(self, test_labels, extra_tests=None, **kwargs):

--- a/tests/e2e/test_provider_oidc.py
+++ b/tests/e2e/test_provider_oidc.py
@@ -49,13 +49,8 @@ class TestProviderOAuth2OIDC(SeleniumTestCase):
                 "OIDC_PROVIDER": f"{self.live_server_url}/application/o/{self.application_slug}/",
             },
         )
-        while True:
-            container.reload()
-            status = container.attrs.get("State", {}).get("Health", {}).get("Status")
-            if status == "healthy":
-                return container
-            self.logger.info("Container failed healthcheck")
-            sleep(1)
+        self.wait_for_container(container)
+        return container
 
     @retry()
     @apply_blueprint(

--- a/tests/e2e/test_provider_oidc_implicit.py
+++ b/tests/e2e/test_provider_oidc_implicit.py
@@ -49,13 +49,8 @@ class TestProviderOAuth2OIDCImplicit(SeleniumTestCase):
                 "OIDC_PROVIDER": f"{self.live_server_url}/application/o/{self.application_slug}/",
             },
         )
-        while True:
-            container.reload()
-            status = container.attrs.get("State", {}).get("Health", {}).get("Status")
-            if status == "healthy":
-                return container
-            self.logger.info("Container failed healthcheck")
-            sleep(1)
+        self.wait_for_container(container)
+        return container
 
     @retry()
     @apply_blueprint(

--- a/tests/e2e/test_provider_saml.py
+++ b/tests/e2e/test_provider_saml.py
@@ -48,13 +48,8 @@ class TestProviderSAML(SeleniumTestCase):
                 "SP_METADATA_URL": metadata_url,
             },
         )
-        while True:
-            container.reload()
-            status = container.attrs.get("State", {}).get("Health", {}).get("Status")
-            if status == "healthy":
-                return container
-            self.logger.info("Container failed healthcheck")
-            sleep(1)
+        self.wait_for_container(container)
+        return container
 
     @retry()
     @apply_blueprint(

--- a/tests/integration/test_outpost_docker.py
+++ b/tests/integration/test_outpost_docker.py
@@ -1,7 +1,6 @@
 """outpost tests"""
 from shutil import rmtree
 from tempfile import mkdtemp
-from time import sleep
 
 import yaml
 from channels.testing import ChannelsLiveServerTestCase
@@ -20,10 +19,10 @@ from authentik.outposts.models import (
 )
 from authentik.outposts.tasks import outpost_connection_discovery
 from authentik.providers.proxy.models import ProxyProvider
-from tests.e2e.utils import get_docker_tag
+from tests.e2e.utils import DockerTestCase, get_docker_tag
 
 
-class OutpostDockerTests(ChannelsLiveServerTestCase):
+class OutpostDockerTests(DockerTestCase, ChannelsLiveServerTestCase):
     """Test Docker Controllers"""
 
     def _start_container(self, ssl_folder: str) -> Container:
@@ -45,12 +44,8 @@ class OutpostDockerTests(ChannelsLiveServerTestCase):
                 }
             },
         )
-        while True:
-            container.reload()
-            status = container.attrs.get("State", {}).get("Health", {}).get("Status")
-            if status == "healthy":
-                return container
-            sleep(1)
+        self.wait_for_container(container)
+        return container
 
     def setUp(self):
         super().setUp()

--- a/tests/integration/test_proxy_docker.py
+++ b/tests/integration/test_proxy_docker.py
@@ -1,7 +1,6 @@
 """outpost tests"""
 from shutil import rmtree
 from tempfile import mkdtemp
-from time import sleep
 
 import yaml
 from channels.testing.live import ChannelsLiveServerTestCase
@@ -20,10 +19,10 @@ from authentik.outposts.models import (
 from authentik.outposts.tasks import outpost_connection_discovery
 from authentik.providers.proxy.controllers.docker import DockerController
 from authentik.providers.proxy.models import ProxyProvider
-from tests.e2e.utils import get_docker_tag
+from tests.e2e.utils import DockerTestCase, get_docker_tag
 
 
-class TestProxyDocker(ChannelsLiveServerTestCase):
+class TestProxyDocker(DockerTestCase, ChannelsLiveServerTestCase):
     """Test Docker Controllers"""
 
     def _start_container(self, ssl_folder: str) -> Container:
@@ -45,12 +44,8 @@ class TestProxyDocker(ChannelsLiveServerTestCase):
                 }
             },
         )
-        while True:
-            container.reload()
-            status = container.attrs.get("State", {}).get("Health", {}).get("Status")
-            if status == "healthy":
-                return container
-            sleep(1)
+        self.wait_for_container(container)
+        return container
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

Integration tests have been randomly timing out after 30 mins, most likely due us infinitely waiting for containers to be healthy

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
