### PR TITLE
outposts: use channel groups instead of saving channel names

### DIFF
--- a/authentik/outposts/consumer.py
+++ b/authentik/outposts/consumer.py
@@ -103,11 +103,12 @@ class OutpostConsumer(AuthJsonConsumer):
 
         state = OutpostState.for_instance_uid(self.outpost, uid)
         state.last_seen = datetime.now()
-        state.hostname = msg.args.get("hostname", "")
+        state.hostname = msg.args.pop("hostname", "")
 
         if msg.instruction == WebsocketMessageInstruction.HELLO:
-            state.version = msg.args.get("version", None)
-            state.build_hash = msg.args.get("buildHash", "")
+            state.version = msg.args.pop("version", None)
+            state.build_hash = msg.args.pop("buildHash", "")
+            state.args = msg.args
         elif msg.instruction == WebsocketMessageInstruction.ACK:
             return
         GAUGE_OUTPOSTS_LAST_UPDATE.labels(

--- a/authentik/outposts/models.py
+++ b/authentik/outposts/models.py
@@ -411,7 +411,6 @@ class OutpostState:
     """Outpost instance state, last_seen and version"""
 
     uid: str
-    channel_ids: list[str] = field(default_factory=list)
     last_seen: Optional[datetime] = field(default=None)
     version: Optional[str] = field(default=None)
     version_should: Version = field(default=OUR_VERSION)

--- a/authentik/outposts/models.py
+++ b/authentik/outposts/models.py
@@ -416,6 +416,7 @@ class OutpostState:
     version_should: Version = field(default=OUR_VERSION)
     build_hash: str = field(default="")
     hostname: str = field(default="")
+    args: dict = field(default_factory=dict)
 
     _outpost: Optional[Outpost] = field(default=None)
 

--- a/authentik/outposts/tests/test_ws.py
+++ b/authentik/outposts/tests/test_ws.py
@@ -7,7 +7,7 @@ from django.test import TransactionTestCase
 
 from authentik import __version__
 from authentik.core.tests.utils import create_test_flow
-from authentik.outposts.channels import WebsocketMessage, WebsocketMessageInstruction
+from authentik.outposts.consumer import WebsocketMessage, WebsocketMessageInstruction
 from authentik.outposts.models import Outpost, OutpostType
 from authentik.providers.proxy.models import ProxyProvider
 from authentik.root import websocket

--- a/authentik/outposts/urls.py
+++ b/authentik/outposts/urls.py
@@ -7,7 +7,7 @@ from authentik.outposts.api.service_connections import (
     KubernetesServiceConnectionViewSet,
     ServiceConnectionViewSet,
 )
-from authentik.outposts.channels import OutpostConsumer
+from authentik.outposts.consumer import OutpostConsumer
 from authentik.root.middleware import ChannelsLoggingMiddleware
 
 websocket_urlpatterns = [

--- a/authentik/root/settings.py
+++ b/authentik/root/settings.py
@@ -256,7 +256,7 @@ CHANNEL_LAYERS = {
         "BACKEND": "channels_redis.core.RedisChannelLayer",
         "CONFIG": {
             "hosts": [f"{_redis_url}/{CONFIG.get('redis.db')}"],
-            "prefix": "authentik_channels",
+            "prefix": "authentik_channels_",
         },
     },
 }

--- a/authentik/root/settings.py
+++ b/authentik/root/settings.py
@@ -253,7 +253,7 @@ ASGI_APPLICATION = "authentik.root.asgi.application"
 
 CHANNEL_LAYERS = {
     "default": {
-        "BACKEND": "channels_redis.core.RedisChannelLayer",
+        "BACKEND": "channels_redis.pubsub.RedisPubSubChannelLayer",
         "CONFIG": {
             "hosts": [f"{_redis_url}/{CONFIG.get('redis.db')}"],
             "prefix": "authentik_channels_",


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

Instead of managing channel name ourselves use channels' group feature to join all outpost channels into a per-outpost group that we can send messages to

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
