### PR TITLE
web: isolate clipboard handling

### DIFF
--- a/web/src/elements/utils/writeToClipboard.ts
+++ b/web/src/elements/utils/writeToClipboard.ts
@@ -1,0 +1,26 @@
+import { isSafari } from "./isSafari";
+
+export async function writeToClipboard(message: string) {
+    if (!navigator.clipboard) {
+        return false;
+    }
+
+    // Safari only allows navigator.clipboard.write with native clipboard items.
+    try {
+        if (isSafari()) {
+            await navigator.clipboard.write([
+                new ClipboardItem({
+                    "text/plain": new Blob([message], {
+                        type: "text/plain",
+                    }),
+                }),
+            ]);
+        } else {
+            await navigator.clipboard.writeText(message);
+        }
+        return true;
+    } catch (_) {
+        /* no op */
+    }
+    return false;
+}


### PR DESCRIPTION
## Details

We would like to use the clipboard for more than just the token copy button.  This commit enables that by separating the "Write to Clipboard" and "Write to Notifications" routines into separate functions, putting "writeToClipboard" into the utilities collection, and clarifying what happens when a customer presses the TokenCopy button.

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [x] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)
-   [x] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
