### PR TITLE
web: fix bad comment that was confusing lit-analyze

### DIFF
--- a/web/src/components/ak-wizard-main/ak-wizard-frame.ts
+++ b/web/src/components/ak-wizard-main/ak-wizard-frame.ts
@@ -22,7 +22,7 @@ import { type WizardButton, WizardStepLabel } from "./types";
  *
  * @element ak-wizard-frame
  *
- * @slot - Where the form itself should go
+ * @slot trigger - (Inherited from ModalButton) Define the "summon modal" button here
  *
  * @fires ak-wizard-nav - Tell the orchestrator what page the user wishes to move to.
  *


### PR DESCRIPTION
## Details

The old comment was left over from a previous revision of the wizard, and blocked lit-analyze's ability to understand the Modal's `slot="trigger"` declaration.  Lit-analyze is happy again.  Hard to believe a _comment_ was blocking a higher score on Lit's quality checker.

## Checklist

-   [X] Local tests pass (`ak test authentik/`)
-   [X] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [X] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [X] The code has been formatted (`make web`)
-   [X] The translation files have been updated (`make i18n-extract`)

If applicable

-   [X] The documentation has been updated
-   [X] The documentation has been formatted (`make website`)
