### PR TITLE
web: 3 fixes for small typos, annoyances, and improvements

### DIFF
--- a/web/src/admin/AdminInterface.ts
+++ b/web/src/admin/AdminInterface.ts
@@ -193,7 +193,7 @@ export class AdminInterface extends Interface {
             ["/if/user/", msg("User interface"), { "?isAbsoluteLink": true, "?highlight": true }],
             [null, msg("Dashboards"), { "?expanded": true }, [
                 ["/administration/overview", msg("Overview")],
-                ["/administration/dashboard/users", msg("Users")],
+                ["/administration/dashboard/users", msg("User Statistics")],
                 ["/administration/system-tasks", msg("System Tasks")]]],
             [null, msg("Applications"), null, [
                 ["/core/providers", msg("Providers"), [`^/core/providers/(?<id>${ID_REGEX})$`]],

--- a/web/src/admin/admin-overview/AdminOverviewPage.ts
+++ b/web/src/admin/admin-overview/AdminOverviewPage.ts
@@ -22,6 +22,7 @@ import PFContent from "@patternfly/patternfly/components/Content/content.css";
 import PFList from "@patternfly/patternfly/components/List/list.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
+import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 import { SessionUser } from "@goauthentik/api";
 
@@ -35,6 +36,7 @@ export function versionFamily(): string {
 export class AdminOverviewPage extends AKElement {
     static get styles(): CSSResult[] {
         return [
+            PFBase,
             PFGrid,
             PFPage,
             PFContent,
@@ -52,6 +54,13 @@ export class AdminOverviewPage extends AKElement {
                 }
                 .card-container {
                     max-height: 10em;
+                }
+                .ak-external-link {
+                    display: inline-block;
+                    margin-left: 0.175rem;
+                    vertical-align: super;
+                    line-height: normal;
+                    font-size: var(--pf-global--icon--FontSize--sm);
                 }
             `,
         ];
@@ -104,8 +113,10 @@ export class AdminOverviewPage extends AKElement {
                                             class="pf-u-mb-xl"
                                             target="_blank"
                                             href="https://goauthentik.io/integrations/"
-                                            >${msg("Explore integrations")}</a
-                                        >
+                                            >${msg("Explore integrations")}<i
+                                                class="fas fa-external-link-alt ak-external-link"
+                                            ></i
+                                        ></a>
                                     </li>
                                     <li>
                                         <a class="pf-u-mb-xl" href=${paramURL("/identity/users")}
@@ -120,8 +131,10 @@ export class AdminOverviewPage extends AKElement {
                                                 ".",
                                                 "",
                                             )}"
-                                            >${msg("Check release notes")}</a
-                                        >
+                                            >${msg("Check the release notes")}<i
+                                                class="fas fa-external-link-alt ak-external-link"
+                                            ></i
+                                        ></a>
                                     </li>
                                 </ul>
                             </ak-aggregate-card>

--- a/web/src/admin/admin-overview/DashboardUserPage.ts
+++ b/web/src/admin/admin-overview/DashboardUserPage.ts
@@ -41,7 +41,7 @@ export class DashboardUserPage extends AKElement {
     }
 
     render(): TemplateResult {
-        return html`<ak-page-header icon="pf-icon pf-icon-user" header=${msg("User statistics")}>
+        return html`<ak-page-header icon="pf-icon pf-icon-user" header=${msg("User Statistics")}>
             </ak-page-header>
             <section class="pf-c-page__main-section">
                 <div class="pf-l-grid pf-m-gutter">

--- a/website/docs/flow/stages/prompt/index.md
+++ b/website/docs/flow/stages/prompt/index.md
@@ -20,7 +20,7 @@ The prompt can be any of the following types:
 | Number                | Numerical textbox.                                                                         |
 | Checkbox              | Simple checkbox.                                                                           |
 | Radio Button Group    | Similar to checkboxes, but allows selecting a value from a set of predefined values.       |
-| Dropdwon              | A simple dropdown menu filled with predefined values.                                      |
+| Dropdown              | A simple dropdown menu filled with predefined values.                                      |
 | Date                  | Same as text, except the client renders a date-picker                                      |
 | Date-time             | Same as text, except the client renders a date-time-picker                                 |
 | File                  | Allow users to upload a file, which will be available as base64-encoded data in the flow . |


### PR DESCRIPTION
## Petty Details

I’m conducting a more comprehensive survey of the UI in order to get a more holistic idea of the changes that should be implemented. Along the way, I’m finding a few small details that annoy me. Here are three.

### Admin \> Dashboard \> Users doesn’t go to “Users”

It goes to “User statistics.” I have changed both the text of the link and the page to read “User Statistics” (it’s a title, it should be capitalized).

![image](https://github.com/goauthentik/authentik/assets/133134217/d9797bc4-b495-4df6-81c9-57c50d508ea3)

### External links should be marked as such

Give people warning when you’re about to take them out of the system, especially if you’re opening a new tab along the way.

![image](https://github.com/goauthentik/authentik/assets/133134217/fb9c8776-8f07-4ee0-b835-ddfe4f60a3ff)

### Fixed highly visible misspelling in docs

Just a thing I spotted along the way.

![image](https://github.com/goauthentik/authentik/assets/133134217/959bd987-93cf-40b0-9d26-ebb946a65a41)

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [x] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)
-   [x] The translation files have been updated (`make i18n-extract`)

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
