### PR TITLE
stages/authenticator_sms: fix error when phone number from context already exists

### DIFF
--- a/authentik/stages/authenticator_sms/tests.py
+++ b/authentik/stages/authenticator_sms/tests.py
@@ -7,7 +7,9 @@ from requests_mock import Mocker
 
 from authentik.core.tests.utils import create_test_admin_user, create_test_flow
 from authentik.flows.models import FlowStageBinding
+from authentik.flows.planner import FlowPlan
 from authentik.flows.tests import FlowTestCase
+from authentik.flows.views.executor import SESSION_KEY_PLAN
 from authentik.lib.generators import generate_id
 from authentik.stages.authenticator_sms.models import (
     AuthenticatorSMSStage,
@@ -15,7 +17,8 @@ from authentik.stages.authenticator_sms.models import (
     SMSProviders,
     hash_phone_number,
 )
-from authentik.stages.authenticator_sms.stage import SESSION_KEY_SMS_DEVICE
+from authentik.stages.authenticator_sms.stage import PLAN_CONTEXT_PHONE, SESSION_KEY_SMS_DEVICE
+from authentik.stages.prompt.stage import PLAN_CONTEXT_PROMPT
 
 
 class AuthenticatorSMSStageTests(FlowTestCase):
@@ -171,6 +174,45 @@ class AuthenticatorSMSStageTests(FlowTestCase):
             component="ak-stage-authenticator-sms",
             phone_number_required=False,
         )
+
+    def test_stage_context_data_duplicate(self):
+        """test stage context data (phone number exists already)"""
+        self.client.get(
+            reverse("authentik_flows:configure", kwargs={"stage_uuid": self.stage.stage_uuid}),
+        )
+        plan: FlowPlan = self.client.session[SESSION_KEY_PLAN]
+        plan.context[PLAN_CONTEXT_PROMPT] = {
+            PLAN_CONTEXT_PHONE: "1234",
+        }
+        session = self.client.session
+        session[SESSION_KEY_PLAN] = plan
+        session.save()
+        SMSDevice.objects.create(
+            phone_number="1234",
+            user=self.user,
+            stage=self.stage,
+        )
+        sms_send_mock = MagicMock()
+        with (
+            patch(
+                "authentik.stages.authenticator_sms.models.AuthenticatorSMSStage.send",
+                sms_send_mock,
+            ),
+        ):
+            print(self.client.session[SESSION_KEY_PLAN])
+            response = self.client.get(
+                reverse("authentik_api:flow-executor", kwargs={"flow_slug": self.flow.slug}),
+            )
+        print(response.content.decode())
+        self.assertStageResponse(
+            response,
+            self.flow,
+            self.user,
+            component="ak-stage-authenticator-sms",
+            phone_number_required=True,
+        )
+        plan: FlowPlan = self.client.session[SESSION_KEY_PLAN]
+        self.assertEqual(plan.context[PLAN_CONTEXT_PROMPT], {})
 
     def test_stage_submit_full(self):
         """test stage (submit)"""


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

closes #7262 

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
