### PR TITLE
core: Use branding_title in the end session page

### DIFF
--- a/authentik/core/templates/if/end_session.html
+++ b/authentik/core/templates/if/end_session.html
@@ -16,8 +16,8 @@ You've logged out of {{ application }}.
 {% block card %}
 <form method="POST" class="pf-c-form">
     <p>
-        {% blocktrans with application=application.name %}
-            You've logged out of {{ application }}. You can go back to the overview to launch another application, or log out of your authentik account.
+        {% blocktrans with application=application.name branding_title=tenant.branding_title %}
+            You've logged out of {{ application }}. You can go back to the overview to launch another application, or log out of your {{ branding_title }} account.
         {% endblocktrans %}
     </p>
 


### PR DESCRIPTION
## Details

Use `branding_title` in the end session "You've logged out of" section.

Currently there is one place that shows "authentik" instead of tenant name:
![image](https://github.com/goauthentik/authentik/assets/81665/a9a63bc4-c9e0-4845-bf75-0779f47f29a4)



---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
