### PR TITLE
website/integrations: Update nextcloud Admin Group Expression

### DIFF
--- a/website/integrations/services/nextcloud/index.md
+++ b/website/integrations/services/nextcloud/index.md
@@ -98,13 +98,14 @@ To give authentik users admin access to your Nextcloud instance, you need to cre
 Create a custom SAML Property Mapping:
 
 -   Set the _SAML Attribute Name_ to `http://schemas.xmlsoap.org/claims/Group`.
--   Set the _Expression_ to:
+-   Set group names that you want to passthrough to start with 'NC-'
+-   Set the admin group to 'NC-Admin'
+-   Set the _Expression_ to (the 'NC-' will be removed before sending to Nextcloud):
 
 ```python
-for group in user.ak_groups.all():
-    yield group.name
-if ak_is_group_member(request.user, name="<authentik nextcloud admin group's name>"):
-    yield "admin"
+groups = [group.name for group in user.all_groups() if group.name.startswith("NC-")]
+for group in groups:
+    yield group[3:]
 ```
 
 Then, edit the Nextcloud SAML Provider, and replace the default Groups mapping with the one you've created above.

--- a/website/integrations/services/nextcloud/index.md
+++ b/website/integrations/services/nextcloud/index.md
@@ -98,14 +98,13 @@ To give authentik users admin access to your Nextcloud instance, you need to cre
 Create a custom SAML Property Mapping:
 
 -   Set the _SAML Attribute Name_ to `http://schemas.xmlsoap.org/claims/Group`.
--   Set group names that you want to passthrough to start with 'NC-'
--   Set the admin group to 'NC-Admin'
--   Set the _Expression_ to (the 'NC-' will be removed before sending to Nextcloud):
+-   Set the _Expression_ to:
 
 ```python
-groups = [group.name for group in user.all_groups() if group.name.startswith("NC-")]
-for group in groups:
-    yield group[3:]
+for group in request.user.all_groups():
+    yield group.name
+if ak_is_group_member(request.user, name="<authentik nextcloud admin group's name>"):
+    yield "admin"
 ```
 
 Then, edit the Nextcloud SAML Provider, and replace the default Groups mapping with the one you've created above.


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

Replace user.ak_groups.all() with user.all_groups per 2023.8 release notes in Admin Group

Update Expression in Admin group to only pass groups that start with 'NC-' to NextCloud.  Add verbiage around naming for admin group.

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->


---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
