### PR TITLE
root: Improve multi arch Docker image build speed

### DIFF
--- a/ldap.Dockerfile
+++ b/ldap.Dockerfile
@@ -1,5 +1,12 @@
 # Stage 1: Build
-FROM docker.io/golang:1.21.3-bookworm AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.21.3-bookworm AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+ARG GOOS=$TARGETOS
+ARG GOARCH=$TARGETARCH
 
 WORKDIR /go/src/goauthentik.io
 
@@ -13,7 +20,7 @@ ENV CGO_ENABLED=0
 COPY . .
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    go build -o /go/ldap ./cmd/ldap
+    GOARM="${TARGETVARIANT#v}" go build -o /go/ldap ./cmd/ldap
 
 # Stage 2: Run
 FROM gcr.io/distroless/static-debian11:debug

--- a/proxy.Dockerfile
+++ b/proxy.Dockerfile
@@ -15,7 +15,14 @@ COPY web .
 RUN npm run build-proxy
 
 # Stage 2: Build
-FROM docker.io/golang:1.21.3-bookworm AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.21.3-bookworm AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+ARG GOOS=$TARGETOS
+ARG GOARCH=$TARGETARCH
 
 WORKDIR /go/src/goauthentik.io
 
@@ -29,7 +36,7 @@ ENV CGO_ENABLED=0
 COPY . .
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    go build -o /go/proxy ./cmd/proxy
+    GOARM="${TARGETVARIANT#v}" go build -o /go/proxy ./cmd/proxy
 
 # Stage 3: Run
 FROM gcr.io/distroless/static-debian11:debug

--- a/radius.Dockerfile
+++ b/radius.Dockerfile
@@ -1,5 +1,12 @@
 # Stage 1: Build
-FROM docker.io/golang:1.21.3-bookworm AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.21.3-bookworm AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+ARG GOOS=$TARGETOS
+ARG GOARCH=$TARGETARCH
 
 WORKDIR /go/src/goauthentik.io
 
@@ -13,7 +20,7 @@ ENV CGO_ENABLED=0
 COPY . .
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    go build -o /go/radius ./cmd/radius
+    GOARM="${TARGETVARIANT#v}" go build -o /go/radius ./cmd/radius
 
 # Stage 2: Run
 FROM gcr.io/distroless/static-debian11:debug


### PR DESCRIPTION
## Details
Use only the host architecture for GeoIP database updates and for Go cross-compilation.

This significantly speeds up image creation as the GeoIP database is architecture independent and does not need to be downloaded twice. Also, cross-compilation is faster than architecture emulation.

Note: The changes in this PR are part of https://github.com/goauthentik/authentik/pull/7118.
