### PR TITLE
lifecycle: rework otp_merge migration

### DIFF
--- a/lifecycle/system_migrations/otp_merge.py
+++ b/lifecycle/system_migrations/otp_merge.py
@@ -3,13 +3,17 @@ from lifecycle.migrate import BaseMigration
 
 SQL_STATEMENT = """
 BEGIN TRANSACTION;
-DELETE FROM django_migrations WHERE app = 'otp_static';
-DELETE FROM django_migrations WHERE app = 'otp_totp';
+-- Update migrations (static)
+UPDATE django_migrations SET app = 'authentik_stages_authenticator_static', name = '0008_initial' WHERE app = 'otp_static' AND name = '0001_initial';
+UPDATE django_migrations SET app = 'authentik_stages_authenticator_static', name = '0009_throttling' WHERE app = 'otp_static' AND name = '0002_throttling';
 -- Rename tables (static)
 ALTER TABLE otp_static_staticdevice RENAME TO authentik_stages_authenticator_static_staticdevice;
 ALTER TABLE otp_static_statictoken RENAME TO authentik_stages_authenticator_static_statictoken;
 ALTER SEQUENCE otp_static_statictoken_id_seq RENAME TO authentik_stages_authenticator_static_statictoken_id_seq;
 ALTER SEQUENCE otp_static_staticdevice_id_seq RENAME TO authentik_stages_authenticator_static_staticdevice_id_seq;
+-- Update migrations (totp)
+UPDATE django_migrations SET app = 'authentik_stages_authenticator_totp', name = '0008_initial' WHERE app = 'otp_totp' AND name = '0001_initial';
+UPDATE django_migrations SET app = 'authentik_stages_authenticator_totp', name = '0009_auto_20190420_0723' WHERE app = 'otp_totp' AND name = '0002_auto_20190420_0723';
 -- Rename tables (totp)
 ALTER TABLE otp_totp_totpdevice RENAME TO authentik_stages_authenticator_totp_totpdevice;
 ALTER SEQUENCE otp_totp_totpdevice_id_seq RENAME TO authentik_stages_authenticator_totp_totpdevice_id_seq;
@@ -25,22 +29,9 @@ class Migration(BaseMigration):
         return bool(self.cur.rowcount)
 
     def run(self):
-        self.cur.execute(SQL_STATEMENT)
-        self.fake_migration(
-            (
-                "authentik_stages_authenticator_static",
-                "0008_initial",
-            ),
-            (
-                "authentik_stages_authenticator_static",
-                "0009_throttling",
-            ),
-            (
-                "authentik_stages_authenticator_totp",
-                "0008_initial",
-            ),
-            (
-                "authentik_stages_authenticator_totp",
-                "0009_auto_20190420_0723",
-            ),
+        self.cur.execute(
+            "SELECT * FROM django_migrations WHERE app = 'authentik_stages_authenticator_static' AND name = '0007_authenticatorstaticstage_token_length_and_more';"
         )
+        if not bool(self.cur.rowcount):
+            raise Exception("Please upgrade to 2023.8 before upgrading to 2023.10")
+        self.cur.execute(SQL_STATEMENT)


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

Rework the otp_merge migration that causes issues when upgrading from 2023.6 or earlier to 2023.10

Replace all of the django migrate calls with inline SQL, in a single transaction, meaning that if something goes wrong we don't end up in an unknown state

Migrating from 2023.6 or earlier will show an error message

#7326

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
