### PR TITLE
providers/proxy: fix closed redis client

### DIFF
--- a/internal/outpost/proxyv2/application/session.go
+++ b/internal/outpost/proxyv2/application/session.go
@@ -131,7 +131,6 @@ func (a *Application) Logout(ctx context.Context, filter func(c Claims) bool) er
 	}
 	if rs, ok := a.sessions.(*redisstore.RedisStore); ok {
 		client := rs.Client()
-		defer client.Close()
 		keys, err := client.Keys(ctx, fmt.Sprintf("%s*", RedisKeyPrefix)).Result()
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

The old redis session storage would create a new client and hence it had to be closed in the signout handler, but with this session storage we reference the same client as the session storage, so don't close it

should close #7342

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
