### PR TITLE
stages/email: fix duplicate querystring encoding

### DIFF
--- a/authentik/stages/email/stage.py
+++ b/authentik/stages/email/stage.py
@@ -52,17 +52,13 @@ class EmailStageView(ChallengeStageView):
             kwargs={"flow_slug": self.executor.flow.slug},
         )
         # Parse query string from current URL (full query string)
-        query_params = QueryDict(self.request.META.get("QUERY_STRING", ""), mutable=True)
+        # this view is only run within a flow executor, where we need to get the query string
+        # from the query= parameter (double encoded); but for the redirect
+        # we need to expand it since it'll go through the flow interface
+        query_params = QueryDict(self.request.GET.get(QS_QUERY), mutable=True)
         query_params.pop(QS_KEY_TOKEN, None)
-
-        # Check for nested query string used by flow executor, and remove any
-        # kind of flow token from that
-        if QS_QUERY in query_params:
-            inner_query_params = QueryDict(query_params.get(QS_QUERY), mutable=True)
-            inner_query_params.pop(QS_KEY_TOKEN, None)
-            query_params[QS_QUERY] = inner_query_params.urlencode()
-
         query_params.update(kwargs)
+        print(query_params)
         full_url = base_url
         if len(query_params) > 0:
             full_url = f"{full_url}?{query_params.urlencode()}"


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

the email stage is only run through the flow executor meaning it should only check the querystring within `query=`, modify that and encode it as normal querystring for the final URL, as that doesn't hit the API directly

closes #7377

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
