### PR TITLE
web/admin: fix chart label on dashboard user page

### DIFF
--- a/web/src/admin/admin-overview/DashboardUserPage.ts
+++ b/web/src/admin/admin-overview/DashboardUserPage.ts
@@ -67,7 +67,10 @@ export class DashboardUserPage extends AKElement {
                         class="pf-l-grid__item pf-m-12-col pf-m-6-col-on-xl pf-m-6-col-on-2xl big-graph-container"
                     >
                         <ak-aggregate-card header=${msg("Logins per day in the last month")}>
-                            <ak-charts-admin-model-per-day action=${EventActions.Login} label=${msg("Logins")}>
+                            <ak-charts-admin-model-per-day
+                                action=${EventActions.Login}
+                                label=${msg("Logins")}
+                            >
                             </ak-charts-admin-model-per-day>
                         </ak-aggregate-card>
                     </div>
@@ -75,7 +78,10 @@ export class DashboardUserPage extends AKElement {
                         class="pf-l-grid__item pf-m-12-col pf-m-6-col-on-xl pf-m-6-col-on-2xl big-graph-container"
                     >
                         <ak-aggregate-card header=${msg("Failed Logins per day in the last month")}>
-                            <ak-charts-admin-model-per-day action=${EventActions.LoginFailed} label=${msg("Failed logins")}>
+                            <ak-charts-admin-model-per-day
+                                action=${EventActions.LoginFailed}
+                                label=${msg("Failed logins")}
+                            >
                             </ak-charts-admin-model-per-day>
                         </ak-aggregate-card>
                     </div>

--- a/web/src/admin/admin-overview/DashboardUserPage.ts
+++ b/web/src/admin/admin-overview/DashboardUserPage.ts
@@ -54,6 +54,7 @@ export class DashboardUserPage extends AKElement {
                                     context__model__app: "authentik_core",
                                     context__model__model_name: "user",
                                 }}
+                                label=${msg("Users created")}
                             >
                             </ak-charts-admin-model-per-day>
                         </ak-aggregate-card>
@@ -66,7 +67,7 @@ export class DashboardUserPage extends AKElement {
                         class="pf-l-grid__item pf-m-12-col pf-m-6-col-on-xl pf-m-6-col-on-2xl big-graph-container"
                     >
                         <ak-aggregate-card header=${msg("Logins per day in the last month")}>
-                            <ak-charts-admin-model-per-day action=${EventActions.Login}>
+                            <ak-charts-admin-model-per-day action=${EventActions.Login} label=${msg("Logins")}>
                             </ak-charts-admin-model-per-day>
                         </ak-aggregate-card>
                     </div>
@@ -74,7 +75,7 @@ export class DashboardUserPage extends AKElement {
                         class="pf-l-grid__item pf-m-12-col pf-m-6-col-on-xl pf-m-6-col-on-2xl big-graph-container"
                     >
                         <ak-aggregate-card header=${msg("Failed Logins per day in the last month")}>
-                            <ak-charts-admin-model-per-day action=${EventActions.LoginFailed}>
+                            <ak-charts-admin-model-per-day action=${EventActions.LoginFailed} label=${msg("Failed logins")}>
                             </ak-charts-admin-model-per-day>
                         </ak-aggregate-card>
                     </div>

--- a/web/src/admin/admin-overview/charts/AdminModelPerDay.ts
+++ b/web/src/admin/admin-overview/charts/AdminModelPerDay.ts
@@ -12,6 +12,9 @@ export class AdminModelPerDay extends AKChart<Coordinate[]> {
     @property()
     action: EventActions = EventActions.ModelCreated;
 
+    @property()
+    label?: string;
+
     @property({ attribute: false })
     query?: { [key: string]: unknown } | undefined;
 
@@ -33,7 +36,7 @@ export class AdminModelPerDay extends AKChart<Coordinate[]> {
         return {
             datasets: [
                 {
-                    label: msg("Objects created"),
+                    label: this.label || msg("Objects created"),
                     backgroundColor: "rgba(189, 229, 184, .5)",
                     spanGaps: true,
                     data:

--- a/web/xliff/de.xlf
+++ b/web/xliff/de.xlf
@@ -6038,6 +6038,12 @@ Bindings to groups/users are checked against the user of the event.</source>
 <trans-unit id="s32babfed740fd3c1">
   <source>User type used for newly created users.</source>
 </trans-unit>
+<trans-unit id="s4a34a6be4c68ec87">
+  <source>Users created</source>
+</trans-unit>
+<trans-unit id="s275c956687e2e656">
+  <source>Failed logins</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web/xliff/en.xlf
+++ b/web/xliff/en.xlf
@@ -6319,6 +6319,12 @@ Bindings to groups/users are checked against the user of the event.</source>
 <trans-unit id="s32babfed740fd3c1">
   <source>User type used for newly created users.</source>
 </trans-unit>
+<trans-unit id="s4a34a6be4c68ec87">
+  <source>Users created</source>
+</trans-unit>
+<trans-unit id="s275c956687e2e656">
+  <source>Failed logins</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web/xliff/es.xlf
+++ b/web/xliff/es.xlf
@@ -5953,6 +5953,12 @@ Bindings to groups/users are checked against the user of the event.</source>
 <trans-unit id="s32babfed740fd3c1">
   <source>User type used for newly created users.</source>
 </trans-unit>
+<trans-unit id="s4a34a6be4c68ec87">
+  <source>Users created</source>
+</trans-unit>
+<trans-unit id="s275c956687e2e656">
+  <source>Failed logins</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web/xliff/fr.xlf
+++ b/web/xliff/fr.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" ?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+<?xml version="1.0"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file target-language="fr" source-language="en" original="lit-localize-inputs" datatype="plaintext">
     <body>
       <trans-unit id="s4caed5b7a7e5d89b">
@@ -613,9 +613,9 @@ Il y a <x id="0" equiv-text="${ago}"/> jour(s)</target>
         
       </trans-unit>
       <trans-unit id="saa0e2675da69651b">
-        <source>The URL &quot;<x id="0" equiv-text="${this.url}"/>&quot; was not found.</source>
-        <target>L'URL &quot; 
-        <x id="0" equiv-text="${this.url}"/>&quot; n'a pas été trouvée.</target>
+        <source>The URL "<x id="0" equiv-text="${this.url}"/>" was not found.</source>
+        <target>L'URL " 
+        <x id="0" equiv-text="${this.url}"/>" n'a pas été trouvée.</target>
         
       </trans-unit>
       <trans-unit id="s58cd9c2fe836d9c6">
@@ -1057,8 +1057,8 @@ Il y a <x id="0" equiv-text="${ago}"/> jour(s)</target>
         
       </trans-unit>
       <trans-unit id="sa8384c9c26731f83">
-        <source>To allow any redirect URI, set this value to &quot;.*&quot;. Be aware of the possible security implications this can have.</source>
-        <target>Pour permettre n'importe quelle URI de redirection, définissez cette valeur sur &quot;.*&quot;. Soyez conscient des possibles implications de sécurité que cela peut avoir.</target>
+        <source>To allow any redirect URI, set this value to ".*". Be aware of the possible security implications this can have.</source>
+        <target>Pour permettre n'importe quelle URI de redirection, définissez cette valeur sur ".*". Soyez conscient des possibles implications de sécurité que cela peut avoir.</target>
         
       </trans-unit>
       <trans-unit id="s55787f4dfcdce52b">
@@ -1630,7 +1630,7 @@ Il y a <x id="0" equiv-text="${ago}"/> jour(s)</target>
       </trans-unit>
       <trans-unit id="s33ed903c210a6209">
         <source>Token to authenticate with. Currently only bearer authentication is supported.</source>
-        <target>Jeton d'authentification à utiliser. Actuellement, seule l'authentification &quot;bearer authentication&quot; est prise en charge.</target>
+        <target>Jeton d'authentification à utiliser. Actuellement, seule l'authentification "bearer authentication" est prise en charge.</target>
         
       </trans-unit>
       <trans-unit id="sfc8bb104e2c05af8">
@@ -1798,8 +1798,8 @@ Il y a <x id="0" equiv-text="${ago}"/> jour(s)</target>
         
       </trans-unit>
       <trans-unit id="sa90b7809586c35ce">
-        <source>Either input a full URL, a relative path, or use 'fa://fa-test' to use the Font Awesome icon &quot;fa-test&quot;.</source>
-        <target>Entrez une URL complète, un chemin relatif ou utilisez 'fa://fa-test' pour utiliser l'icône Font Awesome &quot;fa-test&quot;.</target>
+        <source>Either input a full URL, a relative path, or use 'fa://fa-test' to use the Font Awesome icon "fa-test".</source>
+        <target>Entrez une URL complète, un chemin relatif ou utilisez 'fa://fa-test' pour utiliser l'icône Font Awesome "fa-test".</target>
         
       </trans-unit>
       <trans-unit id="s0410779cb47de312">
@@ -2922,7 +2922,7 @@ doesn't pass when either or both of the selected options are equal or above the 
       </trans-unit>
       <trans-unit id="s33683c3b1dbaf264">
         <source>To use SSL instead, use 'ldaps://' and disable this option.</source>
-        <target>Pour utiliser SSL à la base, utilisez &quot;ldaps://&quot; et désactviez cette option.</target>
+        <target>Pour utiliser SSL à la base, utilisez "ldaps://" et désactviez cette option.</target>
         
       </trans-unit>
       <trans-unit id="s2221fef80f4753a2">
@@ -3011,8 +3011,8 @@ doesn't pass when either or both of the selected options are equal or above the 
         
       </trans-unit>
       <trans-unit id="s76768bebabb7d543">
-        <source>Field which contains members of a group. Note that if using the &quot;memberUid&quot; field, the value is assumed to contain a relative distinguished name. e.g. 'memberUid=some-user' instead of 'memberUid=cn=some-user,ou=groups,...'</source>
-        <target>Champ qui contient les membres d'un groupe. Si vous utilisez le champ &quot;memberUid&quot;, la valeur est censée contenir un nom distinctif relatif, par exemple 'memberUid=un-utilisateur' au lieu de 'memberUid=cn=un-utilisateur,ou=groups,...'</target>
+        <source>Field which contains members of a group. Note that if using the "memberUid" field, the value is assumed to contain a relative distinguished name. e.g. 'memberUid=some-user' instead of 'memberUid=cn=some-user,ou=groups,...'</source>
+        <target>Champ qui contient les membres d'un groupe. Si vous utilisez le champ "memberUid", la valeur est censée contenir un nom distinctif relatif, par exemple 'memberUid=un-utilisateur' au lieu de 'memberUid=cn=un-utilisateur,ou=groups,...'</target>
         
       </trans-unit>
       <trans-unit id="s026555347e589f0e">
@@ -3307,7 +3307,7 @@ doesn't pass when either or both of the selected options are equal or above the 
       </trans-unit>
       <trans-unit id="s3198c384c2f68b08">
         <source>Time offset when temporary users should be deleted. This only applies if your IDP uses the NameID Format 'transient', and the user doesn't log out manually.</source>
-        <target>Moment où les utilisateurs temporaires doivent être supprimés. Cela ne s'applique que si votre IDP utilise le format NameID &quot;transient&quot; et que l'utilisateur ne se déconnecte pas manuellement.</target>
+        <target>Moment où les utilisateurs temporaires doivent être supprimés. Cela ne s'applique que si votre IDP utilise le format NameID "transient" et que l'utilisateur ne se déconnecte pas manuellement.</target>
         
       </trans-unit>
       <trans-unit id="sb32e9c1faa0b8673">
@@ -3475,7 +3475,7 @@ doesn't pass when either or both of the selected options are equal or above the 
       </trans-unit>
       <trans-unit id="s9f8aac89fe318acc">
         <source>Optionally set the 'FriendlyName' value of the Assertion attribute.</source>
-        <target>Indiquer la valeur &quot;FriendlyName&quot; de l'attribut d'assertion (optionnel)</target>
+        <target>Indiquer la valeur "FriendlyName" de l'attribut d'assertion (optionnel)</target>
         
       </trans-unit>
       <trans-unit id="s851c108679653d2a">
@@ -3804,8 +3804,8 @@ doesn't pass when either or both of the selected options are equal or above the 
         
       </trans-unit>
       <trans-unit id="s7b1fba26d245cb1c">
-        <source>When using an external logging solution for archiving, this can be set to &quot;minutes=5&quot;.</source>
-        <target>En cas d'utilisation d'une solution de journalisation externe pour l'archivage, cette valeur peut être fixée à &quot;minutes=5&quot;.</target>
+        <source>When using an external logging solution for archiving, this can be set to "minutes=5".</source>
+        <target>En cas d'utilisation d'une solution de journalisation externe pour l'archivage, cette valeur peut être fixée à "minutes=5".</target>
         
       </trans-unit>
       <trans-unit id="s44536d20bb5c8257">
@@ -3814,8 +3814,8 @@ doesn't pass when either or both of the selected options are equal or above the 
         
       </trans-unit>
       <trans-unit id="s3bb51cabb02b997e">
-        <source>Format: &quot;weeks=3;days=2;hours=3,seconds=2&quot;.</source>
-        <target>Format : &quot;weeks=3;days=2;hours=3,seconds=2&quot;.</target>
+        <source>Format: "weeks=3;days=2;hours=3,seconds=2".</source>
+        <target>Format : "weeks=3;days=2;hours=3,seconds=2".</target>
         
       </trans-unit>
       <trans-unit id="s04bfd02201db5ab8">
@@ -4011,10 +4011,10 @@ doesn't pass when either or both of the selected options are equal or above the 
         
       </trans-unit>
       <trans-unit id="sa95a538bfbb86111">
-        <source>Are you sure you want to update <x id="0" equiv-text="${this.objectLabel}"/> &quot;<x id="1" equiv-text="${this.obj?.name}"/>&quot;?</source>
+        <source>Are you sure you want to update <x id="0" equiv-text="${this.objectLabel}"/> "<x id="1" equiv-text="${this.obj?.name}"/>"?</source>
         <target>Êtes-vous sûr de vouloir mettre à jour 
-        <x id="0" equiv-text="${this.objectLabel}"/>&quot; 
-        <x id="1" equiv-text="${this.obj?.name}"/>&quot; ?</target>
+        <x id="0" equiv-text="${this.objectLabel}"/>" 
+        <x id="1" equiv-text="${this.obj?.name}"/>" ?</target>
         
       </trans-unit>
       <trans-unit id="sc92d7cfb6ee1fec6">
@@ -5100,8 +5100,8 @@ doesn't pass when either or both of the selected options are equal or above the 
         
       </trans-unit>
       <trans-unit id="sdf1d8edef27236f0">
-        <source>A &quot;roaming&quot; authenticator, like a YubiKey</source>
-        <target>Un authentificateur &quot;itinérant&quot;, comme une YubiKey</target>
+        <source>A "roaming" authenticator, like a YubiKey</source>
+        <target>Un authentificateur "itinérant", comme une YubiKey</target>
         
       </trans-unit>
       <trans-unit id="sfffba7b23d8fb40c">
@@ -5426,7 +5426,7 @@ doesn't pass when either or both of the selected options are equal or above the 
       </trans-unit>
       <trans-unit id="s5170f9ef331949c0">
         <source>Show arbitrary input fields to the user, for example during enrollment. Data is saved in the flow context under the 'prompt_data' variable.</source>
-        <target>Afficher des champs de saisie arbitraires à l'utilisateur, par exemple pendant l'inscription. Les données sont enregistrées dans le contexte du flux sous la variable &quot;prompt_data&quot;.</target>
+        <target>Afficher des champs de saisie arbitraires à l'utilisateur, par exemple pendant l'inscription. Les données sont enregistrées dans le contexte du flux sous la variable "prompt_data".</target>
         
       </trans-unit>
       <trans-unit id="s36cb242ac90353bc">
@@ -5435,10 +5435,10 @@ doesn't pass when either or both of the selected options are equal or above the 
         
       </trans-unit>
       <trans-unit id="s2d5f69929bb7221d">
-        <source><x id="0" equiv-text="${prompt.name}"/> (&quot;<x id="1" equiv-text="${prompt.fieldKey}"/>&quot;, of type <x id="2" equiv-text="${prompt.type}"/>)</source>
+        <source><x id="0" equiv-text="${prompt.name}"/> ("<x id="1" equiv-text="${prompt.fieldKey}"/>", of type <x id="2" equiv-text="${prompt.type}"/>)</source>
         <target>
-        <x id="0" equiv-text="${prompt.name}"/>(&quot; 
-        <x id="1" equiv-text="${prompt.fieldKey}"/>&quot;, de type 
+        <x id="0" equiv-text="${prompt.name}"/>(" 
+        <x id="1" equiv-text="${prompt.fieldKey}"/>", de type 
         <x id="2" equiv-text="${prompt.type}"/>)</target>
         
       </trans-unit>
@@ -5487,8 +5487,8 @@ doesn't pass when either or both of the selected options are equal or above the 
         
       </trans-unit>
       <trans-unit id="s1608b2f94fa0dbd4">
-        <source>If set to a duration above 0, the user will have the option to choose to &quot;stay signed in&quot;, which will extend their session by the time specified here.</source>
-        <target>Si défini à une durée supérieure à 0, l'utilisateur aura la possibilité de choisir de &quot;rester connecté&quot;, ce qui prolongera sa session jusqu'à la durée spécifiée ici.</target>
+        <source>If set to a duration above 0, the user will have the option to choose to "stay signed in", which will extend their session by the time specified here.</source>
+        <target>Si défini à une durée supérieure à 0, l'utilisateur aura la possibilité de choisir de "rester connecté", ce qui prolongera sa session jusqu'à la durée spécifiée ici.</target>
         
       </trans-unit>
       <trans-unit id="s542a71bb8f41e057">
@@ -6272,7 +6272,7 @@ Les liaisons avec les groupes/utilisateurs sont vérifiées par rapport à l'uti
       </trans-unit>
       <trans-unit id="sa7fcf026bd25f231">
         <source>Can be in the format of 'unix://' when connecting to a local docker daemon, using 'ssh://' to connect via SSH, or 'https://:2376' when connecting to a remote system.</source>
-        <target>Peut être au format &quot;unix://&quot; pour une connexion à un service docker local, &quot;ssh://&quot; pour une connexion via SSH, ou &quot;https://:2376&quot; pour une connexion à un système distant.</target>
+        <target>Peut être au format "unix://" pour une connexion à un service docker local, "ssh://" pour une connexion via SSH, ou "https://:2376" pour une connexion à un système distant.</target>
         
       </trans-unit>
       <trans-unit id="saf1d289e3137c2ea">
@@ -7579,7 +7579,7 @@ Les liaisons avec les groupes/utilisateurs sont vérifiées par rapport à l'uti
 </trans-unit>
 <trans-unit id="sff0ac1ace2d90709">
   <source>Use this provider with nginx's auth_request or traefik's forwardAuth. Each application/domain needs its own provider. Additionally, on each domain, /outpost.goauthentik.io must be routed to the outpost (when using a managed outpost, this is done for you).</source>
-  <target>Utilisez ce fournisseur avec l'option &quot;auth_request&quot; de Nginx ou &quot;forwardAuth&quot; de Traefik. Chaque application/domaine a besoin de son propre fournisseur. De plus, sur chaque domaine, &quot;/outpost.goauthentik.io&quot; doit être routé vers le poste avancé (lorsque vous utilisez un poste avancé géré, cela est fait pour vous).</target>
+  <target>Utilisez ce fournisseur avec l'option "auth_request" de Nginx ou "forwardAuth" de Traefik. Chaque application/domaine a besoin de son propre fournisseur. De plus, sur chaque domaine, "/outpost.goauthentik.io" doit être routé vers le poste avancé (lorsque vous utilisez un poste avancé géré, cela est fait pour vous).</target>
 </trans-unit>
 <trans-unit id="scb58b8a60cad8762">
   <source>Default relay state</source>
@@ -7939,6 +7939,12 @@ Les liaisons avec les groupes/utilisateurs sont vérifiées par rapport à l'uti
 <trans-unit id="s32babfed740fd3c1">
   <source>User type used for newly created users.</source>
   <target>Type d'utilisateur pour les utilisateurs nouvellement créés.</target>
+</trans-unit>
+<trans-unit id="s4a34a6be4c68ec87">
+  <source>Users created</source>
+</trans-unit>
+<trans-unit id="s275c956687e2e656">
+  <source>Failed logins</source>
 </trans-unit>
     </body>
   </file>

--- a/web/xliff/pl.xlf
+++ b/web/xliff/pl.xlf
@@ -6161,6 +6161,12 @@ Bindings to groups/users are checked against the user of the event.</source>
 <trans-unit id="s32babfed740fd3c1">
   <source>User type used for newly created users.</source>
 </trans-unit>
+<trans-unit id="s4a34a6be4c68ec87">
+  <source>Users created</source>
+</trans-unit>
+<trans-unit id="s275c956687e2e656">
+  <source>Failed logins</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web/xliff/pseudo-LOCALE.xlf
+++ b/web/xliff/pseudo-LOCALE.xlf
@@ -7848,4 +7848,10 @@ Bindings to groups/users are checked against the user of the event.</source>
 <trans-unit id="s32babfed740fd3c1">
   <source>User type used for newly created users.</source>
 </trans-unit>
+<trans-unit id="s4a34a6be4c68ec87">
+  <source>Users created</source>
+</trans-unit>
+<trans-unit id="s275c956687e2e656">
+  <source>Failed logins</source>
+</trans-unit>
 </body></file></xliff>

--- a/web/xliff/tr.xlf
+++ b/web/xliff/tr.xlf
@@ -5946,6 +5946,12 @@ Bindings to groups/users are checked against the user of the event.</source>
 <trans-unit id="s32babfed740fd3c1">
   <source>User type used for newly created users.</source>
 </trans-unit>
+<trans-unit id="s4a34a6be4c68ec87">
+  <source>Users created</source>
+</trans-unit>
+<trans-unit id="s275c956687e2e656">
+  <source>Failed logins</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web/xliff/zh-Hans.xlf
+++ b/web/xliff/zh-Hans.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" ?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+<?xml version="1.0"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file target-language="zh-Hans" source-language="en" original="lit-localize-inputs" datatype="plaintext">
     <body>
       <trans-unit id="s4caed5b7a7e5d89b">
@@ -613,9 +613,9 @@
         
       </trans-unit>
       <trans-unit id="saa0e2675da69651b">
-        <source>The URL &quot;<x id="0" equiv-text="${this.url}"/>&quot; was not found.</source>
-        <target>未找到 URL &quot; 
-        <x id="0" equiv-text="${this.url}"/>&quot;。</target>
+        <source>The URL "<x id="0" equiv-text="${this.url}"/>" was not found.</source>
+        <target>未找到 URL " 
+        <x id="0" equiv-text="${this.url}"/>"。</target>
         
       </trans-unit>
       <trans-unit id="s58cd9c2fe836d9c6">
@@ -1057,8 +1057,8 @@
         
       </trans-unit>
       <trans-unit id="sa8384c9c26731f83">
-        <source>To allow any redirect URI, set this value to &quot;.*&quot;. Be aware of the possible security implications this can have.</source>
-        <target>要允许任何重定向 URI，请将此值设置为 &quot;.*&quot;。请注意这可能带来的安全影响。</target>
+        <source>To allow any redirect URI, set this value to ".*". Be aware of the possible security implications this can have.</source>
+        <target>要允许任何重定向 URI，请将此值设置为 ".*"。请注意这可能带来的安全影响。</target>
         
       </trans-unit>
       <trans-unit id="s55787f4dfcdce52b">
@@ -1799,8 +1799,8 @@
         
       </trans-unit>
       <trans-unit id="sa90b7809586c35ce">
-        <source>Either input a full URL, a relative path, or use 'fa://fa-test' to use the Font Awesome icon &quot;fa-test&quot;.</source>
-        <target>输入完整 URL、相对路径，或者使用 'fa://fa-test' 来使用 Font Awesome 图标 &quot;fa-test&quot;。</target>
+        <source>Either input a full URL, a relative path, or use 'fa://fa-test' to use the Font Awesome icon "fa-test".</source>
+        <target>输入完整 URL、相对路径，或者使用 'fa://fa-test' 来使用 Font Awesome 图标 "fa-test"。</target>
         
       </trans-unit>
       <trans-unit id="s0410779cb47de312">
@@ -3013,8 +3013,8 @@ doesn't pass when either or both of the selected options are equal or above the 
         
       </trans-unit>
       <trans-unit id="s76768bebabb7d543">
-        <source>Field which contains members of a group. Note that if using the &quot;memberUid&quot; field, the value is assumed to contain a relative distinguished name. e.g. 'memberUid=some-user' instead of 'memberUid=cn=some-user,ou=groups,...'</source>
-        <target>包含组成员的字段。请注意，如果使用 &quot;memberUid&quot; 字段，则假定该值包含相对可分辨名称。例如，'memberUid=some-user' 而不是 'memberUid=cn=some-user,ou=groups,...'</target>
+        <source>Field which contains members of a group. Note that if using the "memberUid" field, the value is assumed to contain a relative distinguished name. e.g. 'memberUid=some-user' instead of 'memberUid=cn=some-user,ou=groups,...'</source>
+        <target>包含组成员的字段。请注意，如果使用 "memberUid" 字段，则假定该值包含相对可分辨名称。例如，'memberUid=some-user' 而不是 'memberUid=cn=some-user,ou=groups,...'</target>
         
       </trans-unit>
       <trans-unit id="s026555347e589f0e">
@@ -3806,8 +3806,8 @@ doesn't pass when either or both of the selected options are equal or above the 
         
       </trans-unit>
       <trans-unit id="s7b1fba26d245cb1c">
-        <source>When using an external logging solution for archiving, this can be set to &quot;minutes=5&quot;.</source>
-        <target>使用外部日志记录解决方案进行存档时，可以将其设置为 &quot;minutes=5&quot;。</target>
+        <source>When using an external logging solution for archiving, this can be set to "minutes=5".</source>
+        <target>使用外部日志记录解决方案进行存档时，可以将其设置为 "minutes=5"。</target>
         
       </trans-unit>
       <trans-unit id="s44536d20bb5c8257">
@@ -3816,8 +3816,8 @@ doesn't pass when either or both of the selected options are equal or above the 
         
       </trans-unit>
       <trans-unit id="s3bb51cabb02b997e">
-        <source>Format: &quot;weeks=3;days=2;hours=3,seconds=2&quot;.</source>
-        <target>格式：&quot;weeks=3;days=2;hours=3,seconds=2&quot;。</target>
+        <source>Format: "weeks=3;days=2;hours=3,seconds=2".</source>
+        <target>格式："weeks=3;days=2;hours=3,seconds=2"。</target>
         
       </trans-unit>
       <trans-unit id="s04bfd02201db5ab8">
@@ -4013,10 +4013,10 @@ doesn't pass when either or both of the selected options are equal or above the 
         
       </trans-unit>
       <trans-unit id="sa95a538bfbb86111">
-        <source>Are you sure you want to update <x id="0" equiv-text="${this.objectLabel}"/> &quot;<x id="1" equiv-text="${this.obj?.name}"/>&quot;?</source>
+        <source>Are you sure you want to update <x id="0" equiv-text="${this.objectLabel}"/> "<x id="1" equiv-text="${this.obj?.name}"/>"?</source>
         <target>您确定要更新 
-        <x id="0" equiv-text="${this.objectLabel}"/>&quot; 
-        <x id="1" equiv-text="${this.obj?.name}"/>&quot; 吗？</target>
+        <x id="0" equiv-text="${this.objectLabel}"/>" 
+        <x id="1" equiv-text="${this.obj?.name}"/>" 吗？</target>
         
       </trans-unit>
       <trans-unit id="sc92d7cfb6ee1fec6">
@@ -5102,7 +5102,7 @@ doesn't pass when either or both of the selected options are equal or above the 
         
       </trans-unit>
       <trans-unit id="sdf1d8edef27236f0">
-        <source>A &quot;roaming&quot; authenticator, like a YubiKey</source>
+        <source>A "roaming" authenticator, like a YubiKey</source>
         <target>像 YubiKey 这样的“漫游”身份验证器</target>
         
       </trans-unit>
@@ -5437,10 +5437,10 @@ doesn't pass when either or both of the selected options are equal or above the 
         
       </trans-unit>
       <trans-unit id="s2d5f69929bb7221d">
-        <source><x id="0" equiv-text="${prompt.name}"/> (&quot;<x id="1" equiv-text="${prompt.fieldKey}"/>&quot;, of type <x id="2" equiv-text="${prompt.type}"/>)</source>
+        <source><x id="0" equiv-text="${prompt.name}"/> ("<x id="1" equiv-text="${prompt.fieldKey}"/>", of type <x id="2" equiv-text="${prompt.type}"/>)</source>
         <target>
-        <x id="0" equiv-text="${prompt.name}"/>（&quot; 
-        <x id="1" equiv-text="${prompt.fieldKey}"/>&quot;，类型为 
+        <x id="0" equiv-text="${prompt.name}"/>（" 
+        <x id="1" equiv-text="${prompt.fieldKey}"/>"，类型为 
         <x id="2" equiv-text="${prompt.type}"/>）</target>
         
       </trans-unit>
@@ -5489,7 +5489,7 @@ doesn't pass when either or both of the selected options are equal or above the 
         
       </trans-unit>
       <trans-unit id="s1608b2f94fa0dbd4">
-        <source>If set to a duration above 0, the user will have the option to choose to &quot;stay signed in&quot;, which will extend their session by the time specified here.</source>
+        <source>If set to a duration above 0, the user will have the option to choose to "stay signed in", which will extend their session by the time specified here.</source>
         <target>如果设置时长大于 0，用户可以选择“保持登录”选项，这将使用户的会话延长此处设置的时间。</target>
         
       </trans-unit>
@@ -7941,6 +7941,12 @@ Bindings to groups/users are checked against the user of the event.</source>
 <trans-unit id="s32babfed740fd3c1">
   <source>User type used for newly created users.</source>
   <target>新创建用户使用的用户类型。</target>
+</trans-unit>
+<trans-unit id="s4a34a6be4c68ec87">
+  <source>Users created</source>
+</trans-unit>
+<trans-unit id="s275c956687e2e656">
+  <source>Failed logins</source>
 </trans-unit>
     </body>
   </file>

--- a/web/xliff/zh-Hant.xlf
+++ b/web/xliff/zh-Hant.xlf
@@ -5994,6 +5994,12 @@ Bindings to groups/users are checked against the user of the event.</source>
 <trans-unit id="s32babfed740fd3c1">
   <source>User type used for newly created users.</source>
 </trans-unit>
+<trans-unit id="s4a34a6be4c68ec87">
+  <source>Users created</source>
+</trans-unit>
+<trans-unit id="s275c956687e2e656">
+  <source>Failed logins</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web/xliff/zh_TW.xlf
+++ b/web/xliff/zh_TW.xlf
@@ -5993,6 +5993,12 @@ Bindings to groups/users are checked against the user of the event.</source>
 <trans-unit id="s32babfed740fd3c1">
   <source>User type used for newly created users.</source>
 </trans-unit>
+<trans-unit id="s4a34a6be4c68ec87">
+  <source>Users created</source>
+</trans-unit>
+<trans-unit id="s275c956687e2e656">
+  <source>Failed logins</source>
+</trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Sets labels in user statistics/dashboard user page charts via an optional parameter `label` for AdminModelPerDay-Component.
Includes a fallback to "Objects created" if label is not given.

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)
-   [x] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
