### PR TITLE
ci: fix permissions for release pipeline to publish binaries

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -187,6 +187,7 @@ jobs:
     needs: ci-core-mark
     runs-on: ubuntu-latest
     permissions:
+      # Needed to upload contianer images to ghcr.io
       packages: write
     timeout-minutes: 120
     steps:
@@ -239,6 +240,7 @@ jobs:
     needs: ci-core-mark
     runs-on: ubuntu-latest
     permissions:
+      # Needed to upload contianer images to ghcr.io
       packages: write
     timeout-minutes: 120
     steps:

--- a/.github/workflows/ci-outpost.yml
+++ b/.github/workflows/ci-outpost.yml
@@ -67,6 +67,7 @@ jobs:
           - radius
     runs-on: ubuntu-latest
     permissions:
+      # Needed to upload contianer images to ghcr.io
       packages: write
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-next-branch.yml
+++ b/.github/workflows/release-next-branch.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  # Needed to be able to push to the next branch
   contents: write
 
 jobs:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -8,6 +8,7 @@ jobs:
   build-server:
     runs-on: ubuntu-latest
     permissions:
+      # Needed to upload contianer images to ghcr.io
       packages: write
     steps:
       - uses: actions/checkout@v4
@@ -55,6 +56,7 @@ jobs:
   build-outpost:
     runs-on: ubuntu-latest
     permissions:
+      # Needed to upload contianer images to ghcr.io
       packages: write
     strategy:
       fail-fast: false
@@ -110,6 +112,9 @@ jobs:
   build-outpost-binary:
     timeout-minutes: 120
     runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload binaries to the release
+      contents: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/repo-stale.yml
+++ b/.github/workflows/repo-stale.yml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
 
 permissions:
+  # Needed to update issues and PRs
   issues: write
-  pull-requests: write
 
 jobs:
   stale:


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

- fix permissions for release pipeline to publish binaries on the release
- add comments explaining why permissions are needed in certain places
- remove pull-request permission from stale bot since we don't stale PRs

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
