### PR TITLE
internal: remove special route for /outpost.goauthentik.io

### DIFF
--- a/internal/outpost/proxyv2/application/application.go
+++ b/internal/outpost/proxyv2/application/application.go
@@ -235,7 +235,10 @@ func (a *Application) Mode() api.ProxyMode {
 	return *a.proxyConfig.Mode
 }
 
-func (a *Application) HasQuerySignature(r *http.Request) bool {
+func (a *Application) ShouldHandleURL(r *http.Request) bool {
+	if strings.HasPrefix(r.URL.Path, "/outpost.goauthentik.io") {
+		return true
+	}
 	if strings.EqualFold(r.URL.Query().Get(CallbackSignature), "true") {
 		return true
 	}

--- a/internal/outpost/proxyv2/proxyv2.go
+++ b/internal/outpost/proxyv2/proxyv2.go
@@ -74,7 +74,7 @@ func (ps *ProxyServer) HandleHost(rw http.ResponseWriter, r *http.Request) bool 
 	if a == nil {
 		return false
 	}
-	if a.HasQuerySignature(r) || a.Mode() == api.PROXYMODE_PROXY {
+	if a.ShouldHandleURL(r) || a.Mode() == api.PROXYMODE_PROXY {
 		a.ServeHTTP(rw, r)
 		return true
 	}


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

With this special route for outpost.goauthentik.io, misdirected requests to /outpost.goauthentik.io/auth/start will create a cookie for the domain authentik is accessed under, which will cause issues with the actual full auth flow. Requests to /outpost.goauthentik.io will still be routed to the outpost, but with this change only when the hostname matches

related to forward_auth login loops (#7435, others)

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
