### PR TITLE
stages/email: use uuid for email confirmation token instead of username

### DIFF
--- a/authentik/stages/email/stage.py
+++ b/authentik/stages/email/stage.py
@@ -1,5 +1,6 @@
 """authentik multi-stage authentication engine"""
 from datetime import timedelta
+from uuid import uuid4
 
 from django.contrib import messages
 from django.http import HttpRequest, HttpResponse
@@ -71,7 +72,7 @@ class EmailStageView(ChallengeStageView):
         valid_delta = timedelta(
             minutes=current_stage.token_expiry + 1
         )  # + 1 because django timesince always rounds down
-        identifier = slugify(f"ak-email-stage-{current_stage.name}-{pending_user}")
+        identifier = slugify(f"ak-email-stage-{current_stage.name}-{str(uuid4())}")
         # Don't check for validity here, we only care if the token exists
         tokens = FlowToken.objects.filter(identifier=identifier)
         if not tokens.exists():


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

This fixes an issue where a user could create a token with the username of any user and prevent that user from using this stage, the issue is non-exploitable as creating a token manually with this identifier doesn't have a flow plan and hence just leads to an error

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
