### PR TITLE
website/docs: fixed formatting on tabs

### DIFF
--- a/website/docs/installation/configuration.mdx
+++ b/website/docs/installation/configuration.mdx
@@ -20,20 +20,23 @@ All of these variables can be set to values, but you can also use a URI-like for
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-<Tabs>
+<Tabs groupId="platform">
   <TabItem value="docker-compose" label="Docker Compose" default>
     If you are using Docker Compose, edit your <code>.env</code> file to append any keys that you want to add, and then run the following command to apply them:
 
-    `docker-compose up -d`
+    ```
+    docker-compose up -d
+    ```
 
   </TabItem>
   <TabItem value="kubernetes" label="Kubernetes">
     If you are running in Kubernetes, edit your <code>values.yaml</code> file to append any keys that you want to add, and then run the following commands to apply:
 
-```
+    ```
     helm repo update
     helm upgrade --install authentik authentik/authentik -f values.yaml
-```
+    ```
+
   </TabItem>
 
 </Tabs>
@@ -42,15 +45,19 @@ import TabItem from "@theme/TabItem";
 
 To check if your config has been applied correctly, you can run the following command to output the full config:
 
-<Tabs>
+<Tabs groupId="platform">
   <TabItem value="docker-compose" label="Docker Compose" default>
 
-    `docker-compose run --rm worker dump_config`
+    ```
+    docker-compose run --rm worker dump_config
+    ```
 
   </TabItem>
   <TabItem value="kubernetes" label="Kubernetes">
 
-    `kubectl exec -it deployment/authentik-worker -c authentik -- ak dump_config`
+    ```
+    kubectl exec -it deployment/authentik-worker -c authentik -- ak dump_config
+    ```
 
   </TabItem>
 

--- a/website/docs/installation/configuration.mdx
+++ b/website/docs/installation/configuration.mdx
@@ -24,15 +24,16 @@ import TabItem from "@theme/TabItem";
   <TabItem value="docker-compose" label="Docker Compose" default>
     If you are using Docker Compose, edit your <code>.env</code> file to append any keys that you want to add, and then run the following command to apply them:
 
-    docker-compose up -d
+    `docker-compose up -d`
 
   </TabItem>
   <TabItem value="kubernetes" label="Kubernetes">
     If you are running in Kubernetes, edit your <code>values.yaml</code> file to append any keys that you want to add, and then run the following commands to apply:
 
+```
     helm repo update
     helm upgrade --install authentik authentik/authentik -f values.yaml
-
+```
   </TabItem>
 
 </Tabs>
@@ -44,12 +45,12 @@ To check if your config has been applied correctly, you can run the following co
 <Tabs>
   <TabItem value="docker-compose" label="Docker Compose" default>
 
-    docker-compose run --rm worker dump_config
+    `docker-compose run --rm worker dump_config`
 
   </TabItem>
   <TabItem value="kubernetes" label="Kubernetes">
 
-    kubectl exec -it deployment/authentik-worker -c authentik -- ak dump_config
+    `kubectl exec -it deployment/authentik-worker -c authentik -- ak dump_config`
 
   </TabItem>
 


### PR DESCRIPTION

Added formatting to the commands in the Docker and K8s tabs.

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
