### PR TITLE
events: don't update internal service accounts unless needed

### DIFF
--- a/authentik/core/api/users.py
+++ b/authentik/core/api/users.py
@@ -171,6 +171,11 @@ class UserSerializer(ModelSerializer):
             raise ValidationError("Setting a user to internal service account is not allowed.")
         return user_type
 
+    def validate(self, attrs: dict) -> dict:
+        if self.instance and self.instance.type == UserTypes.INTERNAL_SERVICE_ACCOUNT:
+            raise ValidationError("Can't modify internal service account users")
+        return super().validate(attrs)
+
     class Meta:
         model = User
         fields = [

--- a/authentik/events/middleware.py
+++ b/authentik/events/middleware.py
@@ -19,7 +19,6 @@ from authentik.core.models import (
     Source,
     User,
     UserSourceConnection,
-    UserTypes,
 )
 from authentik.events.models import Event, EventAction, Notification
 from authentik.events.utils import model_to_dict
@@ -63,19 +62,11 @@ def should_log_model(model: Model) -> bool:
     # Check for silk by string so this comparison doesn't fail when silk isn't installed
     if model.__module__.startswith("silk"):
         return False
-    # Special case for users, ignore updates to internal service accounts
-    if isinstance(model, User):
-        if model.type == UserTypes.INTERNAL_SERVICE_ACCOUNT:
-            return False
     return model.__class__ not in IGNORED_MODELS
 
 
 def should_log_m2m(model: Model) -> bool:
     """Return true if m2m operation should be logged"""
-    # Special case for users, ignore updates to internal service accounts
-    if isinstance(model, User):
-        if model.type == UserTypes.INTERNAL_SERVICE_ACCOUNT:
-            return False
     if model.__class__ in [User, Group]:
         return True
     return False

--- a/authentik/events/middleware.py
+++ b/authentik/events/middleware.py
@@ -28,6 +28,7 @@ from authentik.lib.sentry import before_send
 from authentik.lib.utils.errors import exception_to_string
 from authentik.outposts.models import OutpostServiceConnection
 from authentik.policies.models import Policy, PolicyBindingModel
+from authentik.policies.reputation.models import Reputation
 from authentik.providers.oauth2.models import AccessToken, AuthorizationCode, RefreshToken
 from authentik.providers.scim.models import SCIMGroup, SCIMUser
 from authentik.stages.authenticator_static.models import StaticToken
@@ -53,6 +54,7 @@ IGNORED_MODELS = (
     RefreshToken,
     SCIMUser,
     SCIMGroup,
+    Reputation,
 )
 
 

--- a/authentik/outposts/models.py
+++ b/authentik/outposts/models.py
@@ -354,7 +354,7 @@ class Outpost(SerializerModel, ManagedModel):
         for key, value in attrs.items():
             if getattr(user, key) != value:
                 dirty = True
-                setattr(user, value)
+                setattr(user, key, value)
         if user.has_usable_password():
             user.set_unusable_password()
             dirty = True

--- a/authentik/outposts/models.py
+++ b/authentik/outposts/models.py
@@ -344,12 +344,22 @@ class Outpost(SerializerModel, ManagedModel):
         user_created = False
         if not user:
             user: User = User.objects.create(username=self.user_identifier)
-            user.set_unusable_password()
             user_created = True
-        user.type = UserTypes.INTERNAL_SERVICE_ACCOUNT
-        user.name = f"Outpost {self.name} Service-Account"
-        user.path = USER_PATH_OUTPOSTS
-        user.save()
+        attrs = {
+            "type": UserTypes.INTERNAL_SERVICE_ACCOUNT,
+            "name": f"Outpost {self.name} Service-Account",
+            "path": USER_PATH_OUTPOSTS,
+        }
+        dirty = False
+        for key, value in attrs.items():
+            if getattr(user, key) != value:
+                dirty = True
+                setattr(user, value)
+        if user.has_usable_password():
+            user.set_unusable_password()
+            dirty = True
+        if dirty:
+            user.save()
         if user_created:
             self.build_user_permissions(user)
         return user


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

Since https://github.com/goauthentik/authentik/pull/7597 the event log gets spammed by Model Updated events, mostly due to the `/api/v3/outposts/instances/` endpoint triggering at least one user update.

With this we use some better logic to only update the user when needed, and also further prevent any updates to internal service accounts

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
