### PR TITLE
sources/ldap: clean-up certs written from db

### DIFF
--- a/authentik/sources/ldap/models.py
+++ b/authentik/sources/ldap/models.py
@@ -1,5 +1,7 @@
 """authentik LDAP Models"""
 from os import chmod
+from os.path import dirname, exists
+from shutil import rmtree
 from ssl import CERT_REQUIRED
 from tempfile import NamedTemporaryFile, mkdtemp
 from typing import Optional
@@ -189,6 +191,9 @@ class LDAPSource(Source):
                 raise exc
             server_kwargs["get_info"] = NONE
             return self.connection(server, server_kwargs, connection_kwargs)
+        finally:
+            if exists(connection.server.tls.certificate_file):
+                rmtree(dirname(connection.server.tls.certificate_file))
         return RuntimeError("Failed to bind")
 
     @property

--- a/authentik/sources/ldap/models.py
+++ b/authentik/sources/ldap/models.py
@@ -192,7 +192,9 @@ class LDAPSource(Source):
             server_kwargs["get_info"] = NONE
             return self.connection(server, server_kwargs, connection_kwargs)
         finally:
-            if exists(connection.server.tls.certificate_file):
+            if connection.server.tls.certificate_file is not None and exists(
+                connection.server.tls.certificate_file
+            ):
                 rmtree(dirname(connection.server.tls.certificate_file))
         return RuntimeError("Failed to bind")
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
Cert based ldap auth introduced in #5850 does not clean-up the temporary certificate files written out from the DB - when running in Kubernetes this eventually fills up `/dev/shm` and causes the worker to crashloop. 

This PR ensures the files are cleaned up in a `finally` block.

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
