### PR TITLE
tests: fix flaky tests

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -117,7 +117,7 @@ jobs:
         uses: helm/kind-action@v1.8.0
       - name: run integration
         run: |
-          poetry run coverage run manage.py test --randomly-seed=2100196988 tests/integration
+          poetry run coverage run manage.py test tests/integration
           poetry run coverage xml
       - if: ${{ always() }}
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -62,7 +62,7 @@ jobs:
           cp authentik/lib/default.yml local.env.yml
           cp -R .github ..
           cp -R scripts ..
-          git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
+          git checkout $(python -c "from authentik import __version__; print(__version__)")
           rm -rf .github/ scripts/
           mv ../.github ../scripts .
       - name: Setup authentik env (ensure stable deps are installed)

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -62,7 +62,7 @@ jobs:
           cp authentik/lib/default.yml local.env.yml
           cp -R .github ..
           cp -R scripts ..
-          git checkout $(python -c "from authentik import __version__; print(__version__)")
+          git checkout version/$(python -c "from authentik import __version__; print(__version__)")
           rm -rf .github/ scripts/
           mv ../.github ../scripts .
       - name: Setup authentik env (ensure stable deps are installed)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ const-rgx = "[a-zA-Z0-9_]{1,40}$"
 
 ignored-modules = ["binascii", "socket", "zlib"]
 generated-members = ["xmlsec.constants.*", "xmlsec.tree.*", "xmlsec.template.*"]
-ignore = "migrations"
+ignore = ["migrations", "tests"]
 max-attributes = 12
 max-branches = 20
 

--- a/tests/e2e/test_provider_oauth2_github.py
+++ b/tests/e2e/test_provider_oauth2_github.py
@@ -36,8 +36,8 @@ class TestProviderOAuth2Github(SeleniumTestCase):
             "auto_remove": True,
             "healthcheck": Healthcheck(
                 test=["CMD", "wget", "--spider", "http://localhost:3000"],
-                interval=5 * 100 * 1000000,
-                start_period=1 * 100 * 1000000,
+                interval=5 * 1_000 * 1_000_000,
+                start_period=1 * 1_000 * 1_000_000,
             ),
             "environment": {
                 "GF_AUTH_GITHUB_ENABLED": "true",

--- a/tests/e2e/test_provider_oauth2_grafana.py
+++ b/tests/e2e/test_provider_oauth2_grafana.py
@@ -42,8 +42,8 @@ class TestProviderOAuth2OAuth(SeleniumTestCase):
             "auto_remove": True,
             "healthcheck": Healthcheck(
                 test=["CMD", "wget", "--spider", "http://localhost:3000"],
-                interval=5 * 100 * 1000000,
-                start_period=1 * 100 * 1000000,
+                interval=5 * 1_000 * 1_000_000,
+                start_period=1 * 1_000 * 1_000_000,
             ),
             "environment": {
                 "GF_AUTH_GENERIC_OAUTH_ENABLED": "true",

--- a/tests/e2e/test_source_oauth.py
+++ b/tests/e2e/test_source_oauth.py
@@ -113,8 +113,8 @@ class TestSourceOAuth2(SeleniumTestCase):
             "command": "dex serve /config.yml",
             "healthcheck": Healthcheck(
                 test=["CMD", "wget", "--spider", "http://localhost:5556/dex/healthz"],
-                interval=5 * 100 * 1000000,
-                start_period=1 * 100 * 1000000,
+                interval=5 * 1_000 * 1_000_000,
+                start_period=1 * 1_000 * 1_000_000,
             ),
             "volumes": {str(Path(CONFIG_PATH).absolute()): {"bind": "/config.yml", "mode": "ro"}},
         }

--- a/tests/e2e/test_source_saml.py
+++ b/tests/e2e/test_source_saml.py
@@ -83,8 +83,8 @@ class TestSourceSAML(SeleniumTestCase):
             "auto_remove": True,
             "healthcheck": Healthcheck(
                 test=["CMD", "curl", "http://localhost:8080"],
-                interval=5 * 100 * 1000000,
-                start_period=1 * 100 * 1000000,
+                interval=5 * 1_000 * 1_000_000,
+                start_period=1 * 1_000 * 1_000_000,
             ),
             "environment": {
                 "SIMPLESAMLPHP_SP_ENTITY_ID": "entity-id",

--- a/tests/integration/test_outpost_docker.py
+++ b/tests/integration/test_outpost_docker.py
@@ -35,8 +35,8 @@ class OutpostDockerTests(DockerTestCase, ChannelsLiveServerTestCase):
             privileged=True,
             healthcheck=Healthcheck(
                 test=["CMD", "docker", "info"],
-                interval=5 * 100 * 1000000,
-                start_period=5 * 100 * 1000000,
+                interval=5 * 1_000 * 1_000_000,
+                start_period=5 * 1_000 * 1_000_000,
             ),
             environment={"DOCKER_TLS_CERTDIR": "/ssl"},
             volumes={

--- a/tests/integration/test_proxy_docker.py
+++ b/tests/integration/test_proxy_docker.py
@@ -35,8 +35,8 @@ class TestProxyDocker(DockerTestCase, ChannelsLiveServerTestCase):
             privileged=True,
             healthcheck=Healthcheck(
                 test=["CMD", "docker", "info"],
-                interval=5 * 100 * 1000000,
-                start_period=5 * 100 * 1000000,
+                interval=5 * 1_000 * 1_000_000,
+                start_period=5 * 1_000 * 1_000_000,
             ),
             environment={"DOCKER_TLS_CERTDIR": "/ssl"},
             volumes={


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

So the Docker API takes healthcheck intervals/delays as nanoseconds (most likely due to the Golang's handling of time/duration), and the containers in our e2e tests should've been using a  5s initial delay and then a 5s interval. However due to maths being...hard, they were actually being healthchecked every 500ms, due to a missing 0.

I'm honestly surprised this hasn't broken more things, although I suppose we'll never know how many test failures this caused by hogging all the CPU to do healthchecks.

The main culprit that brought this to light was `docker:dind`, which would crash consistently (at least locally) with those insane intervals set.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
