### PR TITLE
events: add better fallback for sanitize_item to ensure everything can be saved as JSON

### DIFF
--- a/authentik/events/utils.py
+++ b/authentik/events/utils.py
@@ -5,12 +5,13 @@ from dataclasses import asdict, is_dataclass
 from datetime import date, datetime, time, timedelta
 from enum import Enum
 from pathlib import Path
-from types import GeneratorType
+from types import GeneratorType, NoneType
 from typing import Any, Optional
 from uuid import UUID
 
 from django.contrib.auth.models import AnonymousUser
 from django.core.handlers.wsgi import WSGIRequest
+from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 from django.db.models.base import Model
 from django.http.request import HttpRequest
@@ -159,7 +160,13 @@ def sanitize_item(value: Any) -> Any:
             "name": value.__name__,
             "module": value.__module__,
         }
-    return value
+    # List taken from the stdlib's JSON encoder (_make_iterencode, encoder.py:415)
+    if isinstance(value, (bool, int, float, NoneType, list, tuple, dict)):
+        return value
+    try:
+        return DjangoJSONEncoder.default(value)
+    finally:
+        return str(value)
 
 
 def sanitize_dict(source: dict[Any, Any]) -> dict[Any, Any]:

--- a/authentik/stages/authenticator_sms/stage.py
+++ b/authentik/stages/authenticator_sms/stage.py
@@ -69,7 +69,6 @@ class AuthenticatorSMSStageView(ChallengeStageView):
         stage: AuthenticatorSMSStage = self.executor.current_stage
         hashed_number = hash_phone_number(phone_number)
         query = Q(phone_number=hashed_number) | Q(phone_number=phone_number)
-        print(SMSDevice.objects.filter(query, stage=stage.pk))
         if SMSDevice.objects.filter(query, stage=stage.pk).exists():
             raise ValidationError(_("Invalid phone number"))
         # No code yet, but we have a phone number, so send a verification message

--- a/authentik/stages/authenticator_sms/tests.py
+++ b/authentik/stages/authenticator_sms/tests.py
@@ -199,11 +199,9 @@ class AuthenticatorSMSStageTests(FlowTestCase):
                 sms_send_mock,
             ),
         ):
-            print(self.client.session[SESSION_KEY_PLAN])
             response = self.client.get(
                 reverse("authentik_api:flow-executor", kwargs={"flow_slug": self.flow.slug}),
             )
-        print(response.content.decode())
         self.assertStageResponse(
             response,
             self.flow,

--- a/authentik/stages/email/stage.py
+++ b/authentik/stages/email/stage.py
@@ -59,7 +59,6 @@ class EmailStageView(ChallengeStageView):
         query_params = QueryDict(self.request.GET.get(QS_QUERY), mutable=True)
         query_params.pop(QS_KEY_TOKEN, None)
         query_params.update(kwargs)
-        print(query_params)
         full_url = base_url
         if len(query_params) > 0:
             full_url = f"{full_url}?{query_params.urlencode()}"


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

The `sanitize_item` function already has a lot of special case, but there wasn't really a guarantee that what it returned was JSON-able.

closes #7691

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
