### PR TITLE
website/docs: add link to install video

### DIFF
--- a/website/docs/installation/docker-compose.md
+++ b/website/docs/installation/docker-compose.md
@@ -4,6 +4,10 @@ title: Docker Compose installation
 
 This installation method is for test-setups and small-scale production setups.
 
+:::info
+You can also view a [video walk-through](https://youtu.be/owk1a_1xYe4) of the installation process on Docker (with bonus details about email configuration and other important options).
+:::
+
 ## Requirements
 
 -   A host with at least 2 CPU cores and 2 GB of RAM

--- a/website/docs/installation/docker-compose.md
+++ b/website/docs/installation/docker-compose.md
@@ -5,7 +5,7 @@ title: Docker Compose installation
 This installation method is for test-setups and small-scale production setups.
 
 :::info
-You can also view a [video walk-through](https://youtu.be/owk1a_1xYe4) of the installation process on Docker (with bonus details about email configuration and other important options).
+You can also [view a video walk-through](https://youtu.be/owk1a_1xYe4) of the installation process on Docker (with bonus details about email configuration and other important options).
 :::
 
 ## Requirements

--- a/website/docs/installation/kubernetes.md
+++ b/website/docs/installation/kubernetes.md
@@ -5,7 +5,7 @@ title: Kubernetes installation
 You can install authentik to run on Kubernetes using Helm Chart.
 
 :::info
-You can also view a [video walk-through](https://youtu.be/owk1a_1xYe4) of the installation process on Kubernetes (with bonus details about email configuration and other important options).
+You can also [view a video walk-through](https://youtu.be/owk1a_1xYe4) of the installation process on Kubernetes (with bonus details about email configuration and other important options).
 :::
 
 ### Requirements

--- a/website/docs/installation/kubernetes.md
+++ b/website/docs/installation/kubernetes.md
@@ -4,6 +4,10 @@ title: Kubernetes installation
 
 You can install authentik to run on Kubernetes using Helm Chart.
 
+:::info
+You can also view a [video walk-through](https://youtu.be/owk1a_1xYe4) of the installation process on Kubernetes (with bonus details about email configuration and other important options).
+:::
+
 ### Requirements
 
 -   Kubernetes


### PR DESCRIPTION
Added a link to Cooptonian's video about installtion, on both Docker and K8s install pages.

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
