### PR TITLE
website/docs: add expression example for geoip

### DIFF
--- a/website/docs/policies/expression.mdx
+++ b/website/docs/policies/expression.mdx
@@ -58,6 +58,7 @@ import Objects from "../expressions/_objects.md";
     ```python
     return context["geoip"].country.iso_code == "US"
     ```
+
 -   `ak_is_sso_flow`: Boolean which is true if request was initiated by authenticating through an external provider.
 -   `ak_client_ip`: Client's IP Address or 255.255.255.255 if no IP Address could be extracted. Can be [compared](#comparing-ip-addresses), for example
 

--- a/website/docs/policies/expression.mdx
+++ b/website/docs/policies/expression.mdx
@@ -54,6 +54,10 @@ import Objects from "../expressions/_objects.md";
     -   `request.context`: A dictionary with dynamic data. This depends on the origin of the execution.
 
 -   `geoip`: GeoIP object, see [GeoIP](https://geoip2.readthedocs.io/en/latest/#geoip2.models.City)
+
+    ```python
+    return context["geoip"].country.iso_code == "US"
+    ```
 -   `ak_is_sso_flow`: Boolean which is true if request was initiated by authenticating through an external provider.
 -   `ak_client_ip`: Client's IP Address or 255.255.255.255 if no IP Address could be extracted. Can be [compared](#comparing-ip-addresses), for example
 


### PR DESCRIPTION
Added example for GeoIP
`return context["geoip"].country.iso_code == "US"`


## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
