### PR TITLE
stages/email: improve error handling for incorrect template syntax

### DIFF
--- a/authentik/core/api/sources.py
+++ b/authentik/core/api/sources.py
@@ -38,7 +38,7 @@ class SourceSerializer(ModelSerializer, MetaNameSerializer):
 
     managed = ReadOnlyField()
     component = SerializerMethodField()
-    icon = ReadOnlyField(source="get_icon")
+    icon = ReadOnlyField(source="icon_url")
 
     def get_component(self, obj: Source) -> str:
         """Get object component so that we know how to edit the object"""

--- a/authentik/flows/stage.py
+++ b/authentik/flows/stage.py
@@ -167,7 +167,11 @@ class ChallengeStageView(StageView):
                 stage_type=self.__class__.__name__, method="get_challenge"
             ).time(),
         ):
-            challenge = self.get_challenge(*args, **kwargs)
+            try:
+                challenge = self.get_challenge(*args, **kwargs)
+            except StageInvalidException as exc:
+                self.logger.debug("Got StageInvalidException", exc=exc)
+                return self.executor.stage_invalid()
         with Hub.current.start_span(
             op="authentik.flow.stage._get_challenge",
             description=self.__class__.__name__,

--- a/authentik/stages/email/stage.py
+++ b/authentik/stages/email/stage.py
@@ -148,7 +148,11 @@ class EmailStageView(ChallengeStageView):
             return self.executor.stage_invalid()
         # Check if we've already sent the initial e-mail
         if PLAN_CONTEXT_EMAIL_SENT not in self.executor.plan.context:
-            self.send_email()
+            try:
+                self.send_email()
+            except StageInvalidException as exc:
+                self.logger.debug("Got StageInvalidException", exc=exc)
+                return self.executor.stage_invalid()
             self.executor.plan.context[PLAN_CONTEXT_EMAIL_SENT] = True
         return super().get(request, *args, **kwargs)
 

--- a/authentik/stages/email/tests/test_templates.py
+++ b/authentik/stages/email/tests/test_templates.py
@@ -4,11 +4,20 @@ from pathlib import Path
 from shutil import rmtree
 from tempfile import mkdtemp, mkstemp
 from typing import Any
+from unittest.mock import PropertyMock, patch
 
 from django.conf import settings
-from django.test import TestCase
+from django.core.mail.backends.locmem import EmailBackend
+from django.urls import reverse
 
-from authentik.stages.email.models import get_template_choices
+from authentik.core.tests.utils import create_test_admin_user, create_test_flow
+from authentik.events.models import Event, EventAction
+from authentik.flows.markers import StageMarker
+from authentik.flows.models import FlowDesignation, FlowStageBinding
+from authentik.flows.planner import PLAN_CONTEXT_PENDING_USER, FlowPlan
+from authentik.flows.tests import FlowTestCase
+from authentik.flows.views.executor import SESSION_KEY_PLAN
+from authentik.stages.email.models import EmailStage, get_template_choices
 
 
 def get_templates_setting(temp_dir: str) -> dict[str, Any]:
@@ -18,11 +27,18 @@ def get_templates_setting(temp_dir: str) -> dict[str, Any]:
     return templates_setting
 
 
-class TestEmailStageTemplates(TestCase):
+class TestEmailStageTemplates(FlowTestCase):
     """Email tests"""
 
     def setUp(self) -> None:
-        self.dir = mkdtemp()
+        self.dir = Path(mkdtemp())
+        self.user = create_test_admin_user()
+
+        self.flow = create_test_flow(FlowDesignation.AUTHENTICATION)
+        self.stage = EmailStage.objects.create(
+            name="email",
+        )
+        self.binding = FlowStageBinding.objects.create(target=self.flow, stage=self.stage, order=2)
 
     def tearDown(self) -> None:
         rmtree(self.dir)
@@ -38,3 +54,37 @@ class TestEmailStageTemplates(TestCase):
             self.assertEqual(len(choices), 3)
             unlink(file)
             unlink(file2)
+
+    def test_custom_template_invalid_syntax(self):
+        """Test with custom template"""
+        with open(self.dir / Path("invalid.html"), "w+", encoding="utf-8") as _invalid:
+            _invalid.write("{% blocktranslate %}")
+        with self.settings(TEMPLATES=get_templates_setting(self.dir)):
+            self.stage.template = "invalid.html"
+            plan = FlowPlan(
+                flow_pk=self.flow.pk.hex, bindings=[self.binding], markers=[StageMarker()]
+            )
+            plan.context[PLAN_CONTEXT_PENDING_USER] = self.user
+            session = self.client.session
+            session[SESSION_KEY_PLAN] = plan
+            session.save()
+
+            url = reverse("authentik_api:flow-executor", kwargs={"flow_slug": self.flow.slug})
+            with patch(
+                "authentik.stages.email.models.EmailStage.backend_class",
+                PropertyMock(return_value=EmailBackend),
+            ):
+                response = self.client.get(url)
+                self.assertEqual(response.status_code, 200)
+                self.assertStageResponse(
+                    response,
+                    self.flow,
+                    error_message="Unknown error",
+                )
+                events = Event.objects.filter(action=EventAction.CONFIGURATION_ERROR)
+                self.assertEqual(len(events), 1)
+                event = events.first()
+                self.assertEqual(
+                    event.context["message"], "Exception occurred while rendering E-mail template"
+                )
+                self.assertEqual(event.context["template"], "invalid.html")


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

closes #7755

When an errors occurs while rendering an email template, handle the error, log it as event and mark the stage as invalid

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
