### PR TITLE
root: fix 100% CPU for worker container (#7025)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,10 @@ services:
     image: ${AUTHENTIK_IMAGE:-ghcr.io/goauthentik/server}:${AUTHENTIK_TAG:-2023.10.4}
     restart: unless-stopped
     command: worker
+    ulimits:
+      nofile:
+        soft: 10240
+        hard: 10240
     environment:
       AUTHENTIK_REDIS__HOST: redis
       AUTHENTIK_POSTGRESQL__HOST: postgresql


### PR DESCRIPTION
Some linux users (arch linux, for example) are running docker with default service file that set NOFILES to infiite, which will cause celery to hang for hours to days taking 100% CPU to close all fds by enumerating from NOFILES to 3.

This commit override ulimit for container without touching user docker service configuration.

For details see #7025 