### PR TITLE
website/integrations: add Chronograf

### DIFF
--- a/website/integrations/services/chronograf/index.md
+++ b/website/integrations/services/chronograf/index.md
@@ -1,0 +1,66 @@
+---
+title: Chronograf oauth
+---
+
+<span class="badge badge--secondary">Support level: Community</span>
+
+## Chronograf
+
+Part of the TICK stack from Influxdata (https://www.influxdata.com/). 
+
+Influxdata say: "Chronograf allows you to quickly see the data that you have stored in InfluxDB so you can build robust queries and alerts. It is simple to use and includes templates and libraries to allow you to rapidly build dashboards with real-time visualizations of your data."
+[Read more](https://www.influxdata.com/time-series-platform/chronograf/).
+
+## Preparation
+
+The following placeholders will be used:
+
+-   `service.company` is the FQDN of the Chronograf install. E.g. chronograf.domain.tld
+-   `authentik.company` is the FQDN of the authentik install.
+
+## Service Configuration
+
+:::Note
+In this configuration, "GENERIC_NAME" is what will appear on the Chronograf login page.
+:::
+
+The following environement variables can be configured using the official Chronograf docker container (https://hub.docker.com/_/chronograf?tab=description). They are also valid for a standalone configuration using an environment file. You may wish to limit/alter the 'GENERIC_SCOPES' and GENERERIC_API_KEY to match your install preferences.
+
+Additional resources for service configuraton:
+https://docs.influxdata.com/chronograf/v1/administration/config-options/
+```
+      PUBLIC_URL: "https://service.company"
+      TOKEN_SECRET: "<generate_a_token_secret>"
+      JWKS_URL: "https://auth.authentik.company/application/o/chrono/jwks/"
+      GENERIC_NAME: "Authentik"
+      GENERIC_CLIENT_ID: "<client id from Authentik>"
+      GENERIC_CLIENT_SECRET: "<client secret from Authentik>"
+      GENERIC_SCOPES: "email,profile,openid"
+      GENERIC_DOMAINS: "authentik.company"
+      GENERIC_AUTH_URL: "https://auth.authentik.company/application/o/authorize/"
+      GENERIC_TOKEN_URL: "https://auth.authentik.company/application/o/token/"
+      GENERIC_API_URL: "https://auth.authentik.company/application/o/userinfo/"
+      GENERIC_API_KEY: "email"
+```
+In this configuration, "GENERIC_NAME" is what will appear on the Chronograf login page:
+
+![image](https://github.com/tomlawesome/authentik/assets/76453276/c14a4694-563b-4a94-9cd4-162c4e543bd7)
+
+
+## Authentik configuration
+
+Create an oAuth provider for your service, along with an application. Authentik makes the required endpoints available by default, so no advanced/special configuration is required for generic oauth.  
+
+:::Note
+Only settings that have been modified from default have been listed.
+:::
+
+Protocol Settings
+
+    Name: Chronograf
+
+    Signing Key: Select any available key
+
+    Redirect URIs/Origins: Authentik will save the first succesful redirect URI if you enter * in this field, but the following should work..https://servuce.company/oauth/Authentik/callback
+
+

--- a/website/integrations/services/chronograf/index.md
+++ b/website/integrations/services/chronograf/index.md
@@ -61,6 +61,6 @@ Protocol Settings
 
     Signing Key: Select any available key
 
-    Redirect URIs/Origins: Authentik will save the first succesful redirect URI if you enter * in this field, but the following should work..https://servuce.company/oauth/Authentik/callback
+    Redirect URIs/Origins: Authentik will save the first succesful redirect URI if you enter * in this field, but the following should work: `https://service.company/oauth/Authentik/callback`
 
 


### PR DESCRIPTION
Add Chronograf oauth integration to website.

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
Chronograf is not listed yet in integrations, but it's working well for me using their generic oauth and Authentik's oauth endpoints generated by simply creating an oauth provider.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
