### PR TITLE
outposts/ldap: avoid nil ptr deref in MemorySearcher

### DIFF
--- a/internal/outpost/ldap/search/memory/memory.go
+++ b/internal/outpost/ldap/search/memory/memory.go
@@ -147,7 +147,11 @@ func (ms *MemorySearcher) Search(req *search.Request) (ldap.ServerSearchResult, 
 						fg := api.NewGroup(g.Pk, g.NumPk, g.Name, g.ParentName, []api.GroupMember{u}, []api.Role{})
 						fg.SetUsers([]int32{flag.UserPk})
 						if g.Parent.IsSet() {
-							fg.SetParent(*g.Parent.Get())
+							if p := g.Parent.Get(); p != nil {
+								fg.SetParent(*p)
+							} else {
+								fg.SetParentNil()
+							}
 						}
 						fg.SetAttributes(g.Attributes)
 						fg.SetIsSuperuser(*g.IsSuperuser)


### PR DESCRIPTION
When cloning a group in Search (due to !flag.CanSearch for the requesting user), a nil group parent leads the code to dereference a nil pointer. Avoid this and propagate the nil parent to the cloned group.