### PR TITLE
providers/scim: change familyName default

### DIFF
--- a/blueprints/system/providers-scim.yaml
+++ b/blueprints/system/providers-scim.yaml
@@ -11,7 +11,7 @@ entries:
       name: "authentik default SCIM Mapping: User"
       expression: |
         # Some implementations require givenName and familyName to be set
-        givenName, familyName = request.user.name, ""
+        givenName, familyName = request.user.name, " "
         # This default sets givenName to the name before the first space
         # and the remainder as family name
         # if the user's name has no space the givenName is the entire name

--- a/blueprints/system/providers-scim.yaml
+++ b/blueprints/system/providers-scim.yaml
@@ -19,6 +19,8 @@ entries:
         if " " in request.user.name:
             givenName, _, familyName = request.user.name.partition(" ")
 
+        formatted = givenName + familyName
+
         # photos supports URLs to images, however authentik might return data URIs
         avatar = request.user.avatar
         photos = None
@@ -39,7 +41,7 @@ entries:
         return {
             "userName": request.user.username,
             "name": {
-                "formatted": request.user.name,
+                "formatted": formatted,
                 "givenName": givenName,
                 "familyName": familyName,
             },


### PR DESCRIPTION
## Details

In some SCIM implementations, the familyName cannot be empty (such as the AWS implementation). This quick fix adds a space for the familyName in the default SCIM property mapping and concats the givenName & familyName for the formatted value.

From the initial PR #7690 

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
