### PR TITLE
website/docs: change links to point to our YouTube

### DIFF
--- a/website/docs/installation/docker-compose.md
+++ b/website/docs/installation/docker-compose.md
@@ -5,7 +5,7 @@ title: Docker Compose installation
 This installation method is for test-setups and small-scale production setups.
 
 :::info
-You can also [view a video walk-through](https://youtu.be/owk1a_1xYe4) of the installation process on Docker (with bonus details about email configuration and other important options).
+You can also [view a video walk-through](https://www.youtube.com/watch?v=O1qUbrk4Yc8) of the installation process on Docker (with bonus details about email configuration and other important options).
 :::
 
 ## Requirements

--- a/website/docs/installation/kubernetes.md
+++ b/website/docs/installation/kubernetes.md
@@ -5,7 +5,7 @@ title: Kubernetes installation
 You can install authentik to run on Kubernetes using Helm Chart.
 
 :::info
-You can also [view a video walk-through](https://youtu.be/owk1a_1xYe4) of the installation process on Kubernetes (with bonus details about email configuration and other important options).
+You can also [view a video walk-through](https://www.youtube.com/watch?v=O1qUbrk4Yc8) of the installation process on Kubernetes (with bonus details about email configuration and other important options).
 :::
 
 ### Requirements


### PR DESCRIPTION
This PR changes the links in our install docs to point to the video on our YouTube channel, instead of Chris' channel.

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
