### PR TITLE
root: Fix cache related image build issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 # Stage 1: Build website
 FROM --platform=${BUILDPLATFORM} docker.io/node:21 as website-builder
 
@@ -7,7 +9,7 @@ WORKDIR /work/website
 
 RUN --mount=type=bind,target=/work/website/package.json,src=./website/package.json \
     --mount=type=bind,target=/work/website/package-lock.json,src=./website/package-lock.json \
-    --mount=type=cache,target=/root/.npm \
+    --mount=type=cache,id=npm-website,sharing=shared,target=/root/.npm \
     npm ci --include=dev
 
 COPY ./website /work/website/
@@ -25,7 +27,7 @@ WORKDIR /work/web
 
 RUN --mount=type=bind,target=/work/web/package.json,src=./web/package.json \
     --mount=type=bind,target=/work/web/package-lock.json,src=./web/package-lock.json \
-    --mount=type=cache,target=/root/.npm \
+    --mount=type=cache,id=npm-web,sharing=shared,target=/root/.npm \
     npm ci --include=dev
 
 COPY ./web /work/web/
@@ -62,8 +64,8 @@ COPY ./go.sum /go/src/goauthentik.io/go.sum
 
 ENV CGO_ENABLED=0
 
-RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target=/root/.cache/go-build \
+RUN --mount=type=cache,sharing=locked,target=/go/pkg/mod \
+    --mount=type=cache,id=go-build-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/root/.cache/go-build \
     GOARM="${TARGETVARIANT#v}" go build -o /go/authentik ./cmd/server
 
 # Stage 4: MaxMind GeoIP
@@ -89,7 +91,9 @@ ENV VENV_PATH="/ak-root/venv" \
     POETRY_VIRTUALENVS_CREATE=false \
     PATH="/ak-root/venv/bin:$PATH"
 
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+
+RUN --mount=type=cache,id=apt-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/var/cache/apt \
     apt-get update && \
     # Required for installing pip packages
     apt-get install -y --no-install-recommends build-essential pkg-config libxmlsec1-dev zlib1g-dev libpq-dev

--- a/ldap.Dockerfile
+++ b/ldap.Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 # Stage 1: Build
 FROM --platform=${BUILDPLATFORM} docker.io/golang:1.21.5-bookworm AS builder
 
@@ -18,8 +20,8 @@ RUN --mount=type=bind,target=/go/src/goauthentik.io/go.mod,src=./go.mod \
 
 ENV CGO_ENABLED=0
 COPY . .
-RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target=/root/.cache/go-build \
+RUN --mount=type=cache,sharing=locked,target=/go/pkg/mod \
+    --mount=type=cache,id=go-build-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/root/.cache/go-build \
     GOARM="${TARGETVARIANT#v}" go build -o /go/ldap ./cmd/ldap
 
 # Stage 2: Run

--- a/proxy.Dockerfile
+++ b/proxy.Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 # Stage 1: Build website
 FROM --platform=${BUILDPLATFORM} docker.io/node:21 as web-builder
 
@@ -34,8 +36,8 @@ RUN --mount=type=bind,target=/go/src/goauthentik.io/go.mod,src=./go.mod \
 
 ENV CGO_ENABLED=0
 COPY . .
-RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target=/root/.cache/go-build \
+RUN --mount=type=cache,sharing=locked,target=/go/pkg/mod \
+    --mount=type=cache,id=go-build-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/root/.cache/go-build \
     GOARM="${TARGETVARIANT#v}" go build -o /go/proxy ./cmd/proxy
 
 # Stage 3: Run

--- a/radius.Dockerfile
+++ b/radius.Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 # Stage 1: Build
 FROM --platform=${BUILDPLATFORM} docker.io/golang:1.21.5-bookworm AS builder
 
@@ -18,8 +20,8 @@ RUN --mount=type=bind,target=/go/src/goauthentik.io/go.mod,src=./go.mod \
 
 ENV CGO_ENABLED=0
 COPY . .
-RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target=/root/.cache/go-build \
+RUN --mount=type=cache,sharing=locked,target=/go/pkg/mod \
+    --mount=type=cache,id=go-build-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/root/.cache/go-build \
     GOARM="${TARGETVARIANT#v}" go build -o /go/radius ./cmd/radius
 
 # Stage 2: Run


### PR DESCRIPTION
## Details

This PR fixes issues with the caching of dependencies when building multi arch images.

In particular the locking of apt caused issues when the same cache was reused for multiple target architectures.
Adding a custom id for each architecture fixes this as a separate cache will be created for each of them.

This is enabled by [a recent change in buildkit](https://github.com/moby/buildkit/issues/815) that added the ability to use variables in the mount options.