### PR TITLE
web: fix overflow glitch on ak-page-header

### DIFF
--- a/web/src/elements/PageHeader.ts
+++ b/web/src/elements/PageHeader.ts
@@ -79,6 +79,7 @@ export class PageHeader extends AKElement {
                 }
                 .pf-c-page__main-section {
                     flex-grow: 1;
+                    flex-shrink: 1;
                     display: flex;
                     flex-direction: column;
                     justify-content: center;


### PR DESCRIPTION
## Details

By adding 'grow' but not 'shrink' to the header section, the page was allowed to allocate as much width as was available when the window opened, but not allowed to resize the width if it was pushed closed by zoom, page resize, or summon sidebar.

This commit adds 'shrink' to the capabilities of the header.


## Checklist

-   [X] Local tests pass (`ak test authentik/`)
-   [X] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [X] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
