### PR TITLE
root: fix static templates

### DIFF
--- a/authentik/core/templates/login/base_full.html
+++ b/authentik/core/templates/login/base_full.html
@@ -44,28 +44,14 @@
 
 {% block body %}
 <div class="pf-c-background-image">
-    <svg xmlns="http://www.w3.org/2000/svg" class="pf-c-background-image__filter" width="0" height="0">
-        <filter id="image_overlay">
-            <feColorMatrix in="SourceGraphic" type="matrix" values="1.3 0 0 0 0 0 1.3 0 0 0 0 0 1.3 0 0 0 0 0 1 0" />
-            <feComponentTransfer color-interpolation-filters="sRGB" result="duotone">
-                <feFuncR type="table" tableValues="0.086274509803922 0.43921568627451"></feFuncR>
-                <feFuncG type="table" tableValues="0.086274509803922 0.43921568627451"></feFuncG>
-                <feFuncB type="table" tableValues="0.086274509803922 0.43921568627451"></feFuncB>
-                <feFuncA type="table" tableValues="0 1"></feFuncA>
-            </feComponentTransfer>
-        </filter>
-    </svg>
 </div>
 <ak-message-container></ak-message-container>
-<div class="pf-c-login">
+<div class="pf-c-login stacked">
     <div class="ak-login-container">
-        <header class="pf-c-login__header">
-            <div class="pf-c-brand ak-brand">
+        <main class="pf-c-login__main">
+            <div class="pf-c-login__main-header pf-c-brand ak-brand">
                 <img src="{{ tenant.branding_logo }}" alt="authentik Logo" />
             </div>
-        </header>
-        {% block main_container %}
-        <main class="pf-c-login__main">
             <header class="pf-c-login__main-header">
                 <h1 class="pf-c-title pf-m-3xl">
                     {% block card_title %}
@@ -77,7 +63,6 @@
                 {% endblock %}
             </div>
         </main>
-        {% endblock %}
         <footer class="pf-c-login__footer">
             <ul class="pf-c-list pf-m-inline">
                 {% for link in footer_links %}

--- a/internal/outpost/proxyv2/templates/error.html
+++ b/internal/outpost/proxyv2/templates/error.html
@@ -26,26 +26,13 @@
     </head>
     <body>
         <div class="pf-c-background-image">
-            <svg xmlns="http://www.w3.org/2000/svg" class="pf-c-background-image__filter" width="0" height="0">
-                <filter id="image_overlay">
-                    <feColorMatrix in="SourceGraphic" type="matrix" values="1.3 0 0 0 0 0 1.3 0 0 0 0 0 1.3 0 0 0 0 0 1 0" />
-                    <feComponentTransfer color-interpolation-filters="sRGB" result="duotone">
-                        <feFuncR type="table" tableValues="0.086274509803922 0.43921568627451"></feFuncR>
-                        <feFuncG type="table" tableValues="0.086274509803922 0.43921568627451"></feFuncG>
-                        <feFuncB type="table" tableValues="0.086274509803922 0.43921568627451"></feFuncB>
-                        <feFuncA type="table" tableValues="0 1"></feFuncA>
-                    </feComponentTransfer>
-                </filter>
-            </svg>
         </div>
-        <div class="pf-c-login">
+        <div class="pf-c-login stacked">
             <div class="ak-login-container">
-                <header class="pf-c-login__header">
-                    <div class="pf-c-brand ak-brand">
+                <main class="pf-c-login__main">
+                    <div class="pf-c-login__main-header pf-c-brand ak-brand">
                         <img src="/outpost.goauthentik.io/static/dist/assets/icons/icon_left_brand.svg" alt="authentik Logo" />
                     </div>
-                </header>
-                <main class="pf-c-login__main">
                     <header class="pf-c-login__main-header">
                         <h1 class="pf-c-title pf-m-3xl">
                             {{ .Title }}

--- a/web/src/common/styles/authentik.css
+++ b/web/src/common/styles/authentik.css
@@ -143,6 +143,8 @@ html > form > input {
     max-height: inherit;
 }
 
-.pf-c-login.stacked .pf-c-login__main {
-    margin-top: 13rem;
+@media (min-height: 60rem) {
+    .pf-c-login.stacked .pf-c-login__main {
+        margin-top: 13rem;
+    }
 }

--- a/web/src/common/styles/authentik.css
+++ b/web/src/common/styles/authentik.css
@@ -124,3 +124,25 @@ html > form > input {
     margin-right: 6px;
     margin-bottom: 6px;
 }
+
+/* Flow-card adjustments for static pages */
+.pf-c-brand {
+    padding-top: calc(
+        var(--pf-c-login__main-footer-links--PaddingTop) +
+            var(--pf-c-login__main-footer-links--PaddingBottom) +
+            var(--pf-c-login__main-body--PaddingBottom)
+    );
+    max-height: 9rem;
+}
+.ak-brand {
+    display: flex;
+    justify-content: center;
+}
+.ak-brand img {
+    padding: 0 2rem;
+    max-height: inherit;
+}
+
+.pf-c-login.stacked .pf-c-login__main {
+    margin-top: 13rem;
+}

--- a/web/src/flow/FlowExecutor.ts
+++ b/web/src/flow/FlowExecutor.ts
@@ -115,8 +115,10 @@ export class FlowExecutor extends Interface implements StageHost {
                 background-color: transparent;
             }
             /* layouts */
-            .pf-c-login.stacked .pf-c-login__main {
-                margin-top: 13rem;
+            @media (min-height: 60rem) {
+                .pf-c-login.stacked .pf-c-login__main {
+                    margin-top: 13rem;
+                }
             }
             .pf-c-login__container.content-right {
                 grid-template-areas:


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

When we adjusted the flow design to include the logo in the card, the static templates were missed, so this PR removes the background filter on the static templates

Additionally, this also makes the top margin only show if the viewport is tall enough

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
