### PR TITLE
providers/scim: set timeout based on page and page count

### DIFF
--- a/authentik/providers/scim/clients/__init__.py
+++ b/authentik/providers/scim/clients/__init__.py
@@ -1,2 +1,3 @@
 """SCIM constants"""
 PAGE_SIZE = 100
+PAGE_TIMEOUT = 60 * 60 * 0.5  # Half an hour

--- a/authentik/providers/scim/tasks.py
+++ b/authentik/providers/scim/tasks.py
@@ -12,7 +12,7 @@ from structlog.stdlib import get_logger
 from authentik.core.models import Group, User
 from authentik.events.monitored_tasks import MonitoredTask, TaskResult, TaskResultStatus
 from authentik.lib.utils.reflection import path_to_class
-from authentik.providers.scim.clients import PAGE_SIZE
+from authentik.providers.scim.clients import PAGE_SIZE, PAGE_TIMEOUT
 from authentik.providers.scim.clients.base import SCIMClient
 from authentik.providers.scim.clients.exceptions import SCIMRequestException, StopSync
 from authentik.providers.scim.clients.group import SCIMGroupClient
@@ -53,6 +53,9 @@ def scim_sync(self: MonitoredTask, provider_pk: int) -> None:
     LOGGER.debug("Starting SCIM sync")
     users_paginator = Paginator(provider.get_user_qs(), PAGE_SIZE)
     groups_paginator = Paginator(provider.get_group_qs(), PAGE_SIZE)
+    self.soft_time_limit = self.time_limit = (
+        users_paginator.count + groups_paginator.count
+    ) * PAGE_TIMEOUT
     with allow_join_result():
         try:
             for page in users_paginator.page_range:
@@ -69,7 +72,10 @@ def scim_sync(self: MonitoredTask, provider_pk: int) -> None:
     self.set_status(result)
 
 
-@CELERY_APP.task()
+@CELERY_APP.task(
+    soft_time_limit=PAGE_TIMEOUT,
+    task_time_limit=PAGE_TIMEOUT,
+)
 def scim_sync_users(page: int, provider_pk: int):
     """Sync single or multiple users to SCIM"""
     messages = []


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

Set total sync timeout based on amount of pages, and set individual page timeout

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
