### PR TITLE
sources/ldap: fix Issue with changing passwords with eDirectory

### DIFF
--- a/authentik/sources/ldap/password.py
+++ b/authentik/sources/ldap/password.py
@@ -4,7 +4,7 @@ from re import split
 from typing import Optional
 
 from ldap3 import BASE
-from ldap3.core.exceptions import LDAPAttributeError, LDAPUnwillingToPerformResult
+from ldap3.core.exceptions import LDAPAttributeError, LDAPUnwillingToPerformResult, LDAPNoSuchAttributeResult
 from structlog.stdlib import get_logger
 
 from authentik.core.models import User
@@ -97,7 +97,7 @@ class LDAPPasswordChanger:
             return
         try:
             self._connection.extend.microsoft.modify_password(user_dn, password)
-        except (LDAPAttributeError, LDAPUnwillingToPerformResult):
+        except (LDAPAttributeError, LDAPUnwillingToPerformResult, LDAPNoSuchAttributeResult):
             self._connection.extend.standard.modify_password(user_dn, new_password=password)
 
     def _ad_check_password_existing(self, password: str, user_dn: str) -> bool:

--- a/authentik/sources/ldap/password.py
+++ b/authentik/sources/ldap/password.py
@@ -4,7 +4,11 @@ from re import split
 from typing import Optional
 
 from ldap3 import BASE
-from ldap3.core.exceptions import LDAPAttributeError, LDAPUnwillingToPerformResult, LDAPNoSuchAttributeResult
+from ldap3.core.exceptions import (
+    LDAPAttributeError,
+    LDAPNoSuchAttributeResult,
+    LDAPUnwillingToPerformResult,
+)
 from structlog.stdlib import get_logger
 
 from authentik.core.models import User


### PR DESCRIPTION
## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
Bugfix for Issue #5851

Had issue with an unknown attribute when Authentik by default used Microsoft AD for password writeback, which threw an uncaught exception. 

To fix this one, I just added LDAPNoSuchAttributeResult to the exception catch statement to process standard LDAP change password extensions which worked with Microfocus eDirectory perfectly.