### PR TITLE
outposts/ldap: allow overriding gidNumber for a user

### DIFF
--- a/internal/outpost/ldap/entries.go
+++ b/internal/outpost/ldap/entries.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"beryju.io/ldap"
+
 	"goauthentik.io/api/v3"
 	"goauthentik.io/internal/outpost/ldap/constants"
 	"goauthentik.io/internal/outpost/ldap/utils"
@@ -49,8 +50,8 @@ func (pi *ProviderInstance) UserEntry(u api.User) *ldap.Entry {
 			constants.OCPosixAccount,
 			constants.OCAKUser,
 		},
-		"uidNumber":     {pi.GetUidNumber(u)},
-		"gidNumber":     {pi.GetUidNumber(u)},
+		"uidNumber":     {pi.GetUserUidNumber(u)},
+		"gidNumber":     {pi.GetUserGidNumber(u)},
 		"homeDirectory": {fmt.Sprintf("/home/%s", u.Username)},
 		"sn":            {u.Name},
 	})

--- a/internal/outpost/ldap/group/group.go
+++ b/internal/outpost/ldap/group/group.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	"beryju.io/ldap"
+
 	"goauthentik.io/api/v3"
 	"goauthentik.io/internal/outpost/ldap/constants"
 	"goauthentik.io/internal/outpost/ldap/server"
@@ -50,7 +51,7 @@ func FromAPIGroup(g api.Group, si server.LDAPServerInstance) *LDAPGroup {
 		DN:             si.GetGroupDN(g.Name),
 		CN:             g.Name,
 		Uid:            string(g.Pk),
-		GidNumber:      si.GetGidNumber(g),
+		GidNumber:      si.GetGroupGidNumber(g),
 		Member:         si.UsersForGroup(g),
 		IsVirtualGroup: false,
 		IsSuperuser:    *g.IsSuperuser,
@@ -63,7 +64,7 @@ func FromAPIUser(u api.User, si server.LDAPServerInstance) *LDAPGroup {
 		DN:             si.GetVirtualGroupDN(u.Username),
 		CN:             u.Username,
 		Uid:            u.Uid,
-		GidNumber:      si.GetUidNumber(u),
+		GidNumber:      si.GetUserGidNumber(u),
 		Member:         []string{si.GetUserDN(u.Username)},
 		IsVirtualGroup: true,
 		IsSuperuser:    false,

--- a/internal/outpost/ldap/server/base.go
+++ b/internal/outpost/ldap/server/base.go
@@ -3,6 +3,7 @@ package server
 import (
 	"beryju.io/ldap"
 	"github.com/go-openapi/strfmt"
+
 	"goauthentik.io/api/v3"
 	"goauthentik.io/internal/outpost/ldap/flags"
 )
@@ -28,8 +29,9 @@ type LDAPServerInstance interface {
 	GetGroupDN(string) string
 	GetVirtualGroupDN(string) string
 
-	GetUidNumber(api.User) string
-	GetGidNumber(api.Group) string
+	GetUserUidNumber(api.User) string
+	GetUserGidNumber(api.User) string
+	GetGroupGidNumber(api.Group) string
 
 	UsersForGroup(api.Group) []string
 

--- a/internal/outpost/ldap/utils.go
+++ b/internal/outpost/ldap/utils.go
@@ -35,7 +35,7 @@ func (pi *ProviderInstance) GetVirtualGroupDN(group string) string {
 	return fmt.Sprintf("cn=%s,%s", group, pi.VirtualGroupDN)
 }
 
-func (pi *ProviderInstance) GetUidNumber(user api.User) string {
+func (pi *ProviderInstance) GetUserUidNumber(user api.User) string {
 	uidNumber, ok := user.GetAttributes()["uidNumber"].(string)
 
 	if ok {
@@ -45,7 +45,17 @@ func (pi *ProviderInstance) GetUidNumber(user api.User) string {
 	return strconv.FormatInt(int64(pi.uidStartNumber+user.Pk), 10)
 }
 
-func (pi *ProviderInstance) GetGidNumber(group api.Group) string {
+func (pi *ProviderInstance) GetUserGidNumber(user api.User) string {
+	gidNumber, ok := user.GetAttributes()["gidNumber"].(string)
+
+	if ok {
+		return gidNumber
+	}
+
+	return pi.GetUserUidNumber(user)
+}
+
+func (pi *ProviderInstance) GetGroupGidNumber(group api.Group) string {
 	gidNumber, ok := group.GetAttributes()["gidNumber"].(string)
 
 	if ok {


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

Closes #7524

Currently, the `gidNumber` attribute set on a user is ignored and the `uidNumber` attribute is used instead. This PR allows that attribute to be overridden in the LDAP schema.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
