### PR TITLE
outpost: improved set secret answers for flow execution

### DIFF
--- a/internal/outpost/flow/solvers_mfa.go
+++ b/internal/outpost/flow/solvers_mfa.go
@@ -10,39 +10,44 @@ const CodePasswordSeparator = ";"
 
 var alphaNum = regexp.MustCompile(`^[a-zA-Z0-9]*$`)
 
-// CheckPasswordInlineMFA For protocols that only support username/password, check if the password
-// contains the TOTP code
-func (fe *FlowExecutor) CheckPasswordInlineMFA() {
-	password := fe.Answers[StagePassword]
-	// We already have an authenticator answer
-	if fe.Answers[StageAuthenticatorValidate] != "" {
+// SetSecrets sets the secret answers for the flow executor for protocols that only support username/password
+// acccording to used options
+func (fe *FlowExecutor) SetSecrets(password string, mfacodebased bool) {
+	if fe.Answers[StageAuthenticatorValidate] != "" || fe.Answers[StagePassword] != "" {
 		return
 	}
-	// password doesn't contain the separator
-	if !strings.Contains(password, CodePasswordSeparator) {
-		return
-	}
-	// password ends with the separator, so it won't contain an answer
-	if strings.HasSuffix(password, CodePasswordSeparator) {
-		return
-	}
-	idx := strings.LastIndex(password, CodePasswordSeparator)
-	authenticator := password[idx+1:]
-	// Authenticator is either 6 chars (totp code) or 8 chars (long totp or static)
-	if len(authenticator) == 6 {
-		// authenticator answer isn't purely numerical, so won't be value
-		if _, err := strconv.Atoi(authenticator); err != nil {
+	fe.Answers[StagePassword] = password
+	if mfacodebased {
+		// password doesn't contain the separator
+		if !strings.Contains(password, CodePasswordSeparator) {
 			return
 		}
-	} else if len(authenticator) == 8 {
-		// 8 chars can be a long totp or static token, so it needs to be alphanumerical
-		if !alphaNum.MatchString(authenticator) {
+		// password ends with the separator, so it won't contain an answer
+		if strings.HasSuffix(password, CodePasswordSeparator) {
 			return
 		}
+		idx := strings.LastIndex(password, CodePasswordSeparator)
+		authenticator := password[idx+1:]
+		// Authenticator is either 6 chars (totp code) or 8 chars (long totp or static)
+		if len(authenticator) == 6 {
+			// authenticator answer isn't purely numerical, so won't be value
+			if _, err := strconv.Atoi(authenticator); err != nil {
+				return
+			}
+		} else if len(authenticator) == 8 {
+			// 8 chars can be a long totp or static token, so it needs to be alphanumerical
+			if !alphaNum.MatchString(authenticator) {
+				return
+			}
+		} else {
+			// Any other length, doesn't contain an answer
+			return
+		}
+		fe.Answers[StagePassword] = password[:idx]
+		fe.Answers[StageAuthenticatorValidate] = authenticator
 	} else {
-		// Any other length, doesn't contain an answer
-		return
+		// If code-based MFA is disabled StageAuthenticatorValidate answer is set to password.
+		// This allows flows with a mfa stage only.
+		fe.Answers[StageAuthenticatorValidate] = password
 	}
-	fe.Answers[StagePassword] = password[:idx]
-	fe.Answers[StageAuthenticatorValidate] = authenticator
 }

--- a/internal/outpost/flow/solvers_mfa.go
+++ b/internal/outpost/flow/solvers_mfa.go
@@ -10,44 +10,44 @@ const CodePasswordSeparator = ";"
 
 var alphaNum = regexp.MustCompile(`^[a-zA-Z0-9]*$`)
 
-// SetSecrets sets the secret answers for the flow executor for protocols that only support username/password
-// acccording to used options
-func (fe *FlowExecutor) SetSecrets(password string, mfacodebased bool) {
+// Sets the secret answers for the flow executor for protocols that only support username/password
+// according to used options
+func (fe *FlowExecutor) SetSecrets(password string, mfaCodeBased bool) {
 	if fe.Answers[StageAuthenticatorValidate] != "" || fe.Answers[StagePassword] != "" {
 		return
 	}
 	fe.Answers[StagePassword] = password
-	if mfacodebased {
-		// password doesn't contain the separator
-		if !strings.Contains(password, CodePasswordSeparator) {
-			return
-		}
-		// password ends with the separator, so it won't contain an answer
-		if strings.HasSuffix(password, CodePasswordSeparator) {
-			return
-		}
-		idx := strings.LastIndex(password, CodePasswordSeparator)
-		authenticator := password[idx+1:]
-		// Authenticator is either 6 chars (totp code) or 8 chars (long totp or static)
-		if len(authenticator) == 6 {
-			// authenticator answer isn't purely numerical, so won't be value
-			if _, err := strconv.Atoi(authenticator); err != nil {
-				return
-			}
-		} else if len(authenticator) == 8 {
-			// 8 chars can be a long totp or static token, so it needs to be alphanumerical
-			if !alphaNum.MatchString(authenticator) {
-				return
-			}
-		} else {
-			// Any other length, doesn't contain an answer
-			return
-		}
-		fe.Answers[StagePassword] = password[:idx]
-		fe.Answers[StageAuthenticatorValidate] = authenticator
-	} else {
+	if !mfaCodeBased {
 		// If code-based MFA is disabled StageAuthenticatorValidate answer is set to password.
 		// This allows flows with a mfa stage only.
 		fe.Answers[StageAuthenticatorValidate] = password
+		return
 	}
+	// password doesn't contain the separator
+	if !strings.Contains(password, CodePasswordSeparator) {
+		return
+	}
+	// password ends with the separator, so it won't contain an answer
+	if strings.HasSuffix(password, CodePasswordSeparator) {
+		return
+	}
+	idx := strings.LastIndex(password, CodePasswordSeparator)
+	authenticator := password[idx+1:]
+	// Authenticator is either 6 chars (totp code) or 8 chars (long totp or static)
+	if len(authenticator) == 6 {
+		// authenticator answer isn't purely numerical, so won't be value
+		if _, err := strconv.Atoi(authenticator); err != nil {
+			return
+		}
+	} else if len(authenticator) == 8 {
+		// 8 chars can be a long totp or static token, so it needs to be alphanumerical
+		if !alphaNum.MatchString(authenticator) {
+			return
+		}
+	} else {
+		// Any other length, doesn't contain an answer
+		return
+	}
+	fe.Answers[StagePassword] = password[:idx]
+	fe.Answers[StageAuthenticatorValidate] = authenticator
 }

--- a/internal/outpost/ldap/bind/direct/bind.go
+++ b/internal/outpost/ldap/bind/direct/bind.go
@@ -23,10 +23,7 @@ func (db *DirectBinder) Bind(username string, req *bind.Request) (ldap.LDAPResul
 	fe.Params.Add("goauthentik.io/outpost/ldap", "true")
 
 	fe.Answers[flow.StageIdentification] = username
-	fe.Answers[flow.StagePassword] = req.BindPW
-	if db.si.GetMFASupport() {
-		fe.CheckPasswordInlineMFA()
-	}
+	fe.SetSecrets(req.BindPW, db.si.GetMFASupport())
 
 	passed, err := fe.Execute()
 	flags := flags.UserFlags{

--- a/internal/outpost/radius/handle_access_request.go
+++ b/internal/outpost/radius/handle_access_request.go
@@ -21,14 +21,7 @@ func (rs *RadiusServer) Handle_AccessRequest(w radius.ResponseWriter, r *RadiusR
 	fe.Params.Add("goauthentik.io/outpost/radius", "true")
 
 	fe.Answers[flow.StageIdentification] = username
-	fe.Answers[flow.StagePassword] = rfc2865.UserPassword_GetString(r.Packet)
-	if r.pi.MFASupport {
-		fe.CheckPasswordInlineMFA()
-	} else {
-		// If code-based MFA is disabled StageAuthenticatorValidate answer is set to StagePassword answer.
-		// This allows flows with only a mfa stage
-		fe.Answers[flow.StageAuthenticatorValidate] = fe.Answers[flow.StagePassword]
-	}
+	fe.SetSecrets(rfc2865.UserPassword_GetString(r.Packet), r.pi.MFASupport)
 
 	passed, err := fe.Execute()
 	if err != nil {

--- a/internal/outpost/radius/handle_access_request.go
+++ b/internal/outpost/radius/handle_access_request.go
@@ -24,6 +24,10 @@ func (rs *RadiusServer) Handle_AccessRequest(w radius.ResponseWriter, r *RadiusR
 	fe.Answers[flow.StagePassword] = rfc2865.UserPassword_GetString(r.Packet)
 	if r.pi.MFASupport {
 		fe.CheckPasswordInlineMFA()
+	} else {
+		// If code-based MFA is disabled StageAuthenticatorValidate answer is set to StagePassword answer.
+		// This allows flows with only a mfa stage
+		fe.Answers[flow.StageAuthenticatorValidate] = fe.Answers[flow.StagePassword]
 	}
 
 	passed, err := fe.Execute()


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
Set the flow answer for StageAuthenticatorValidate equal to StagePassword if code-based MFA is not enabled.
This change is valid for the radius outpost handle function.

Reason for this PR is:
I need to validate a user's MFA (in my case a TOTP token) against authentik which is not possible in its current state
(Password validation is done by an other system)

A possible but  very dirty workaround would be to prepend a semicolon to the MFA token. But my system doesn't allow this.

As a sidemark:
If necessary this could be implemented for ldap outpost aswell.

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
