### PR TITLE
outposts: fix Outpost reconcile not re-assigning managed attribute

### DIFF
--- a/authentik/blueprints/apps.py
+++ b/authentik/blueprints/apps.py
@@ -40,7 +40,7 @@ class ManagedAppConfig(AppConfig):
                 meth()
                 self._logger.debug("Successfully reconciled", name=name)
             except (DatabaseError, ProgrammingError, InternalError) as exc:
-                self._logger.debug("Failed to run reconcile", name=name, exc=exc)
+                self._logger.warning("Failed to run reconcile", name=name, exc=exc)
 
 
 class AuthentikBlueprintsConfig(ManagedAppConfig):

--- a/authentik/outposts/apps.py
+++ b/authentik/outposts/apps.py
@@ -40,12 +40,16 @@ class AuthentikOutpostConfig(ManagedAppConfig):
             OutpostType,
         )
 
+        if outpost := Outpost.objects.filter(name=MANAGED_OUTPOST_NAME, managed="").first():
+            outpost.managed = MANAGED_OUTPOST
+            outpost.save()
+            return
         outpost, updated = Outpost.objects.update_or_create(
             defaults={
                 "type": OutpostType.PROXY,
-                "managed": MANAGED_OUTPOST,
+                "name": MANAGED_OUTPOST_NAME,
             },
-            name=MANAGED_OUTPOST_NAME,
+            managed=MANAGED_OUTPOST,
         )
         if updated:
             if KubernetesServiceConnection.objects.exists():

--- a/authentik/outposts/apps.py
+++ b/authentik/outposts/apps.py
@@ -15,6 +15,7 @@ GAUGE_OUTPOSTS_LAST_UPDATE = Gauge(
     ["outpost", "uid", "version"],
 )
 MANAGED_OUTPOST = "goauthentik.io/outposts/embedded"
+MANAGED_OUTPOST_NAME = "authentik Embedded Outpost"
 
 
 class AuthentikOutpostConfig(ManagedAppConfig):
@@ -41,10 +42,10 @@ class AuthentikOutpostConfig(ManagedAppConfig):
 
         outpost, updated = Outpost.objects.update_or_create(
             defaults={
-                "name": "authentik Embedded Outpost",
                 "type": OutpostType.PROXY,
+                "managed": MANAGED_OUTPOST,
             },
-            managed=MANAGED_OUTPOST,
+            name=MANAGED_OUTPOST_NAME,
         )
         if updated:
             if KubernetesServiceConnection.objects.exists():


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

If for some reason the managed outpost losses its managed attribute, the reconcile on startup would fail. This should prevent the reconcile from failing and also prevents the API from changing the managed attribute or the name of the embedded outpost

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
