### PR TITLE
outposts: disable deployment and secret reconciler for embedded outpost in code instead of in config

### DIFF
--- a/authentik/outposts/api/outposts.py
+++ b/authentik/outposts/api/outposts.py
@@ -51,7 +51,7 @@ class OutpostSerializer(ModelSerializer):
         """Validate name (especially for embedded outpost)"""
         if not self.instance:
             return name
-        if self.instance.managed == MANAGED_OUTPOST:
+        if self.instance.managed == MANAGED_OUTPOST and name != MANAGED_OUTPOST_NAME:
             raise ValidationError("Embedded outpost's name cannot be changed")
         if self.instance.name == MANAGED_OUTPOST_NAME:
             self.instance.managed = MANAGED_OUTPOST

--- a/authentik/outposts/apps.py
+++ b/authentik/outposts/apps.py
@@ -36,7 +36,6 @@ class AuthentikOutpostConfig(ManagedAppConfig):
             DockerServiceConnection,
             KubernetesServiceConnection,
             Outpost,
-            OutpostConfig,
             OutpostType,
         )
 
@@ -56,10 +55,4 @@ class AuthentikOutpostConfig(ManagedAppConfig):
                 outpost.service_connection = KubernetesServiceConnection.objects.first()
             elif DockerServiceConnection.objects.exists():
                 outpost.service_connection = DockerServiceConnection.objects.first()
-            outpost.config = OutpostConfig(
-                kubernetes_disabled_components=[
-                    "deployment",
-                    "secret",
-                ]
-            )
             outpost.save()

--- a/authentik/outposts/controllers/k8s/deployment.py
+++ b/authentik/outposts/controllers/k8s/deployment.py
@@ -43,6 +43,10 @@ class DeploymentReconciler(KubernetesObjectReconciler[V1Deployment]):
         self.api = AppsV1Api(controller.client)
         self.outpost = self.controller.outpost
 
+    @property
+    def noop(self) -> bool:
+        return self.is_embedded
+
     @staticmethod
     def reconciler_name() -> str:
         return "deployment"

--- a/authentik/outposts/controllers/k8s/secret.py
+++ b/authentik/outposts/controllers/k8s/secret.py
@@ -24,6 +24,10 @@ class SecretReconciler(KubernetesObjectReconciler[V1Secret]):
         super().__init__(controller)
         self.api = CoreV1Api(controller.client)
 
+    @property
+    def noop(self) -> bool:
+        return self.is_embedded
+
     @staticmethod
     def reconciler_name() -> str:
         return "secret"

--- a/authentik/outposts/controllers/k8s/service_monitor.py
+++ b/authentik/outposts/controllers/k8s/service_monitor.py
@@ -77,7 +77,10 @@ class PrometheusServiceMonitorReconciler(KubernetesObjectReconciler[PrometheusSe
 
     @property
     def noop(self) -> bool:
-        return (not self._crd_exists()) or (self.is_embedded)
+        if not self._crd_exists():
+            self.logger.debug("CRD doesn't exist")
+            return True
+        return self.is_embedded
 
     def _crd_exists(self) -> bool:
         """Check if the Prometheus ServiceMonitor exists"""


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

Instead of relying on disabling the reconcilers in the outpost config, use the standard noop property

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
