### PR TITLE
providers/proxy: use access token

### DIFF
--- a/internal/outpost/proxyv2/application/oauth_callback.go
+++ b/internal/outpost/proxyv2/application/oauth_callback.go
@@ -31,16 +31,11 @@ func (a *Application) redeemCallback(savedState string, u *url.URL, c context.Co
 		return nil, err
 	}
 
-	// Extract the ID Token from OAuth2 token.
-	rawIDToken, ok := oauth2Token.Extra("id_token").(string)
-	if !ok {
-		return nil, fmt.Errorf("missing id_token")
-	}
-
-	a.log.WithField("id_token", rawIDToken).Trace("id_token")
+	jwt := oauth2Token.AccessToken
+	a.log.WithField("jwt", jwt).Trace("access_token")
 
 	// Parse and verify ID Token payload.
-	idToken, err := a.tokenVerifier.Verify(ctx, rawIDToken)
+	idToken, err := a.tokenVerifier.Verify(ctx, jwt)
 	if err != nil {
 		return nil, err
 	}
@@ -53,6 +48,6 @@ func (a *Application) redeemCallback(savedState string, u *url.URL, c context.Co
 	if claims.Proxy == nil {
 		claims.Proxy = &ProxyClaims{}
 	}
-	claims.RawToken = rawIDToken
+	claims.RawToken = jwt
 	return claims, nil
 }

--- a/internal/outpost/proxyv2/application/session.go
+++ b/internal/outpost/proxyv2/application/session.go
@@ -62,7 +62,7 @@ func (a *Application) getStore(p api.ProxyOutpostConfig, externalHost *url.URL) 
 	// https://github.com/markbates/goth/commit/7276be0fdf719ddff753f3574ef0f967e4a5a5f7
 	// set the maxLength of the cookies stored on the disk to a larger number to prevent issues with:
 	// securecookie: the value is too long
-	// when using OpenID Connect , since this can contain a large amount of extra information in the id_token
+	// when using OpenID Connect, since this can contain a large amount of extra information in the id_token
 
 	// Note, when using the FilesystemStore only the session.ID is written to a browser cookie, so this is explicit for the storage on disk
 	cs.MaxLength(math.MaxInt)


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

The id_token in the token response is for the refresh token, not the access token

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
