### PR TITLE
outposts/proxy: better Redis error message

### DIFF
--- a/internal/outpost/proxyv2/application/session.go
+++ b/internal/outpost/proxyv2/application/session.go
@@ -41,8 +41,7 @@ func (a *Application) getStore(p api.ProxyOutpostConfig, externalHost *url.URL) 
 		// New default RedisStore
 		rs, err := redisstore.NewRedisStore(context.Background(), client)
 		if err != nil {
-			a.log.Error("cannot connect to redis")
-			panic(err)
+			a.log.WithError(err).Panic("failed to connect to redis")
 		}
 
 		rs.KeyPrefix(RedisKeyPrefix)

--- a/internal/outpost/proxyv2/application/session.go
+++ b/internal/outpost/proxyv2/application/session.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gorilla/securecookie"
 	"github.com/gorilla/sessions"
 	"github.com/redis/go-redis/v9"
+
 	"goauthentik.io/api/v3"
 	"goauthentik.io/internal/config"
 	"goauthentik.io/internal/outpost/proxyv2/codecs"
@@ -40,6 +41,7 @@ func (a *Application) getStore(p api.ProxyOutpostConfig, externalHost *url.URL) 
 		// New default RedisStore
 		rs, err := redisstore.NewRedisStore(context.Background(), client)
 		if err != nil {
+			a.log.Error("cannot connect to redis")
 			panic(err)
 		}
 


### PR DESCRIPTION
## Details

Currently this can fail with an ugly:

```
panic: i/o timeout

goroutine 90 [running]:
goauthentik.io/internal/outpost/proxyv2/application.(*Application).getStore(_, {0x1, {0xc00090c7c4, 0x9}, 0xc000e82c30, {0xc000602840, 0x1f}, 0xc00090c7cd, 0xc000e82c40, 0xc000e82c50, ...}, ...)
	/go/src/goauthentik.io/internal/outpost/proxyv2/application/session.go:43 +0x439
goauthentik.io/internal/outpost/proxyv2/application.NewApplication({0x1, {0xc00090c7c4, 0x9}, 0xc000e82c30, {0xc000602840, 0x1f}, 0xc00090c7cd, 0xc000e82c40, 0xc000e82c50, {{0xc001a82cc0, ...}, ...}, ...}, ...)
	/go/src/goauthentik.io/internal/outpost/proxyv2/application/application.go:140 +0xfce
goauthentik.io/internal/outpost/proxyv2.(*ProxyServer).Refresh(0xc0006e4160)
	/go/src/goauthentik.io/internal/outpost/proxyv2/refresh.go:37 +0x587
goauthentik.io/internal/outpost/ak.(*APIController).OnRefresh(0xc0001d8a80)
	/go/src/goauthentik.io/internal/outpost/ak/api.go:180 +0x314
goauthentik.io/internal/outpost/ak.(*APIController).startIntervalUpdater(0xc0001d8a80)
	/go/src/goauthentik.io/internal/outpost/ak/api_ws.go:191 +0x17b
goauthentik.io/internal/outpost/ak.(*APIController).StartBackgroundTasks.func3()
	/go/src/goauthentik.io/internal/outpost/ak/api.go:218 +0x5d
created by goauthentik.io/internal/outpost/ak.(*APIController).StartBackgroundTasks in goroutine 102
	/go/src/goauthentik.io/internal/outpost/ak/api.go:216 +0x38d
```

This adds a bit of context.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
