### PR TITLE
website/docs: remove references to legacy Docker Compose v1

### DIFF
--- a/website/developer-docs/setup/frontend-dev-environment.md
+++ b/website/developer-docs/setup/frontend-dev-environment.md
@@ -45,7 +45,7 @@ Depending on platform, some native dependencies might be required. On macOS, run
 
     This makes the local web files and the config file available to the authentik server.
 
-5. Run `docker-compose up -d` to apply those changes to your containers.
+5. Run `docker compose up -d` to apply those changes to your containers.
 6. `cd web`
 7. Run `npm i` and then `npm run watch` to start the build process.
 

--- a/website/docs/core/certificates.md
+++ b/website/docs/core/certificates.md
@@ -98,7 +98,7 @@ services:
             - --dns-route53
 ```
 
-Afterwards, run `docker-compose up -d`, which will start certbot and generate your certificate. Within a few minutes, you'll see the certificate in your authentik interface. (If the certificate does not appear, restart the worker container. This is caused by incompatible permissions set by certbot).
+Afterwards, run `docker compose up -d`, which will start certbot and generate your certificate. Within a few minutes, you'll see the certificate in your authentik interface. (If the certificate does not appear, restart the worker container. This is caused by incompatible permissions set by certbot).
 
 Navigate to _System -> Tenants_, edit any tenant and select the certificate of your choice.
 

--- a/website/docs/flow/stages/email/index.mdx
+++ b/website/docs/flow/stages/email/index.mdx
@@ -72,7 +72,7 @@ volumeMounts:
 </Tabs>
 
 :::info
-If you've add the line and created a file, and can't see if, check the worker logs using `docker-compose logs -f worker` or `kubectl logs -f deployment/authentik-worker`.
+If you've add the line and created a file, and can't see if, check the worker logs using `docker compose logs -f worker` or `kubectl logs -f deployment/authentik-worker`.
 :::
 
 ![](custom_template.png)

--- a/website/docs/installation/beta.mdx
+++ b/website/docs/installation/beta.mdx
@@ -64,8 +64,8 @@ Next, run the upgrade commands below.
   <TabItem value="docker-compose">
 
 ```shell
-docker-compose pull
-docker-compose up -d
+docker compose pull
+docker compose up -d
 ```
 
   </TabItem>

--- a/website/docs/installation/configuration.mdx
+++ b/website/docs/installation/configuration.mdx
@@ -25,7 +25,7 @@ import TabItem from "@theme/TabItem";
     If you are using Docker Compose, edit your <code>.env</code> file to append any keys that you want to add, and then run the following command to apply them:
 
     ```
-    docker-compose up -d
+    docker compose up -d
     ```
 
   </TabItem>
@@ -49,7 +49,7 @@ To check if your config has been applied correctly, you can run the following co
   <TabItem value="docker-compose" label="Docker Compose" default>
 
     ```
-    docker-compose run --rm worker dump_config
+    docker compose run --rm worker dump_config
     ```
 
   </TabItem>

--- a/website/docs/installation/docker-compose.md
+++ b/website/docs/installation/docker-compose.md
@@ -76,7 +76,7 @@ COMPOSE_PORT_HTTP=80
 COMPOSE_PORT_HTTPS=443
 ```
 
-See [Configuration](../installation/configuration) to change the internal ports. Be sure to run `docker-compose up -d` to rebuild with the new port numbers.
+See [Configuration](../installation/configuration) to change the internal ports. Be sure to run `docker compose up -d` to rebuild with the new port numbers.
 
 ## Startup
 
@@ -90,8 +90,8 @@ This will not give any advantages. It will cause problems with OAuth and SAML au
 Afterwards, run these commands to finish:
 
 ```shell
-docker-compose pull
-docker-compose up -d
+docker compose pull
+docker compose up -d
 ```
 
 The `docker-compose.yml` file statically references the latest version available at the time of downloading the compose file. Each time you upgrade to a newer version of authentik, you download a new `docker-compose.yml` file, which points to the latest available version. For more information, refer to the **Upgrading** section in the [Release Notes](../releases).

--- a/website/docs/releases/2024/v2024.1.md
+++ b/website/docs/releases/2024/v2024.1.md
@@ -39,7 +39,7 @@ To upgrade, download the new docker-compose file and update the Docker stack wit
 
 ```
 wget -O docker-compose.yml https://goauthentik.io/version/2024.1/docker-compose.yml
-docker-compose up -d
+docker compose up -d
 ```
 
 The `-O` flag retains the downloaded file's name, overwriting any existing local file with the same name.

--- a/website/docs/releases/_template.md
+++ b/website/docs/releases/_template.md
@@ -17,7 +17,7 @@ To upgrade, download the new docker-compose file and update the Docker stack wit
 
 ```
 wget -O docker-compose.yml https://goauthentik.io/version/xxxx.x/docker-compose.yml
-docker-compose up -d
+docker compose up -d
 ```
 
 The `-O` flag retains the downloaded file's name, overwriting any existing local file with the same name.

--- a/website/docs/troubleshooting/emails.md
+++ b/website/docs/troubleshooting/emails.md
@@ -17,7 +17,7 @@ If you omit the `-s` parameter, the email will be sent using the global settings
 To run this command with docker-compose, use
 
 ```
-docker-compose exec worker ak test_email [...]
+docker compose exec worker ak test_email [...]
 ```
 
 To run this command with Kubernetes, use

--- a/website/docs/troubleshooting/forward_auth/general.mdx
+++ b/website/docs/troubleshooting/forward_auth/general.mdx
@@ -29,7 +29,7 @@ Add the following block to your `.env` file:
 AUTHENTIK_LOG_LEVEL=trace
 ```
 
-Afterwards, run `docker-compose up -d`.
+Afterwards, run `docker compose up -d`.
 
   </TabItem>
   <TabItem value="kubernetes">

--- a/website/docs/troubleshooting/ldap_source.md
+++ b/website/docs/troubleshooting/ldap_source.md
@@ -5,7 +5,7 @@ title: Troubleshooting LDAP Synchronization
 To troubleshoot LDAP sources, you can run the command below to run a synchronization in the foreground and see any errors or warnings that might happen directly
 
 ```
-docker-compose run --rm worker ldap_sync *slug of the source*
+docker compose run --rm worker ldap_sync *slug of the source*
 ```
 
 or, for Kubernetes, run
@@ -17,7 +17,7 @@ kubectl exec -it deployment/authentik-worker -c authentik -- ak ldap_sync *slug 
 Starting with authentik 2023.10, you can also run command below to explicitly check the connectivity to the configured LDAP Servers:
 
 ```
-docker-compose run --rm worker ldap_check_connection *slug of the source*
+docker compose run --rm worker ldap_check_connection *slug of the source*
 ```
 
 or, for Kubernetes, run

--- a/website/docs/troubleshooting/login.md
+++ b/website/docs/troubleshooting/login.md
@@ -11,7 +11,7 @@ This recovery key will give whoever has the link direct access to your instances
 To create the key, run the following command:
 
 ```
-docker-compose run --rm server create_recovery_key 10 akadmin
+docker compose run --rm server create_recovery_key 10 akadmin
 ```
 
 For Kubernetes, run

--- a/website/docs/troubleshooting/missing_admin_group.md
+++ b/website/docs/troubleshooting/missing_admin_group.md
@@ -7,7 +7,7 @@ If all of the Admin groups have been deleted, or misconfigured during sync, you 
 Run the following command, where _username_ is the user you want to add to the newly created group:
 
 ```
-docker-compose run --rm server create_admin_group username
+docker compose run --rm server create_admin_group username
 ```
 
 or, for Kubernetes, run

--- a/website/docs/troubleshooting/missing_permission.md
+++ b/website/docs/troubleshooting/missing_permission.md
@@ -9,7 +9,7 @@ The error should be temporary and not occur after initial installation.
 If it does, you can run the following command to ensure all permissions exist:
 
 ```
-docker-compose run --rm worker repair_permissions
+docker compose run --rm worker repair_permissions
 ```
 
 or, for Kubernetes, run

--- a/website/integrations/services/paperless-ng/index.md
+++ b/website/integrations/services/paperless-ng/index.md
@@ -36,7 +36,7 @@ PAPERLESS_HTTP_REMOTE_USER_HEADER_NAME=HTTP_X_AUTHENTIK_USERNAME
 Authentik automatically sets this header when we use a proxy outpost.
 
 Now restart your container:
-`docker-compose down && docker-compose up -d`
+`docker compose down && docker compose up -d`
 
 ## authentik
 


### PR DESCRIPTION
## Details

Docker Compose v2 was released in 2020. v1 was deprecated in 2021 and no longer receives any updates as of July 2023. v2 uses `docker compose` rather than `docker-compose`.

I updated all references *except* for those in older releases.


---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
