### PR TITLE
website/integrations: Oracle Cloud: add SAML for accounts with federation enabled

### DIFF
--- a/website/integrations/services/oracle-cloud/index.md
+++ b/website/integrations/services/oracle-cloud/index.md
@@ -75,7 +75,7 @@ In authentik, under _Providers_, create an _SAML Provider from Metadata_ with th
 
 -   Name: Oracle Cloud SAML <your tenancy> (or whatever you like as name for this provider)
 -   Authorization flow: default-provider-authorization-explicit-consent (Authorize Application), implicit-consent may work too.
--   Metadata: Browse to the downloaded XML Document and 
+-   Metadata: select to the downloaded XML Document
 
 Click Finish. Edit the Provider, below Protocol settings:
 

--- a/website/integrations/services/oracle-cloud/index.md
+++ b/website/integrations/services/oracle-cloud/index.md
@@ -80,7 +80,7 @@ In authentik, under _Providers_, create an _SAML Provider from Metadata_ with th
 Click Finish. Edit the Provider, below Protocol settings:
 
 -   ACS URL: Copy this URL
--   Audicence: If empty, paste the ACS URL
+-   Audience: If empty, paste the ACS URL
 
 Click Update. Click on the name of the new provider in the list to see the overview. Use the link _Create Application_ on this page to create the application for the provider.
 

--- a/website/integrations/services/oracle-cloud/index.md
+++ b/website/integrations/services/oracle-cloud/index.md
@@ -53,7 +53,7 @@ When the Orancle Cloud tenancy does not have an _Identity & Security_ menu and d
 
 In contrast to the OpenID Method, no OCI user is used or created for the SAML logins, but a Group Mapping is used instead.
 
-Also Policies have to be created which allow the Federated users access. By default, tehy can log in, but cannot see or do anything.
+Also Policies have to be created which allow the Federated users access. By default, they can log in, but cannot see or do anything.
 
 Creating Policies has not been tested and is not described here.
 

--- a/website/integrations/services/oracle-cloud/index.md
+++ b/website/integrations/services/oracle-cloud/index.md
@@ -86,8 +86,8 @@ Click Update. Click on the name of the new provider in the list to see the overv
 
 Create an application which uses this provider. Optionally apply access restrictions to the application using policy bindings.
 
--   Name: Oracle Cloud SAML <your tenancy> (or whatever you like as name for this application)
--   Slug: oracle-cloud-saml-<your tenancy> (or whatever yoou like)
+-   Name: Oracle Cloud SAML <your tenancy>
+-   Slug: oracle-cloud-saml-<your tenancy>
 -   Group: You may want to enter a group name like Cloud-Admins (and create it) or use the Administriators group, note it for later.
 -   Provider: Select the provider you created from the list.
 

--- a/website/integrations/services/oracle-cloud/index.md
+++ b/website/integrations/services/oracle-cloud/index.md
@@ -49,7 +49,7 @@ Navigate to _IdP Policies_ in the sidebar and open the default policy by clickin
 
 ## Alternative method: Federation using a SAML Provider from Metadata
 
-When the Orancle Cloud tenancy does not have _Identity & Security_ menu does not have the _Domains_ entry but _Federation_, then this method will have to be used instead.
+When the Orancle Cloud tenancy does not have an _Identity & Security_ menu and does not have the _Domains_ entry but _Federation_, then this method will have to be used instead.
 
 In contrast to the OpenID Method, you no OCI user is used or created for our the SAML logins, but the a Group Mapping is used instead.
 

--- a/website/integrations/services/oracle-cloud/index.md
+++ b/website/integrations/services/oracle-cloud/index.md
@@ -46,3 +46,76 @@ Create a new _Social IdP_ via the _Add IdP_ button. Set the name to authentik an
 Set the _Discovery service URL_ to `https://authentik.company/application/o/oracle-cloud/.well-known/openid-configuration` and save the IdP. The IdP has now been created but must be enabled before it can be used to login with.
 
 Navigate to _IdP Policies_ in the sidebar and open the default policy by clicking on it. Edit the first rule within the policy. Add authentik under _Assign identity providers_. Here you can optionally also remove username-based logins, however it is recommended to not remove the option until you've verified SSO works.
+
+## Alternative method: Federation using a SAML Provider from Metadata
+
+When the Orancle Cloud tenancy does not have _Identity & Security_ menu does not have the _Domains_ entry but _Federation_, then this method will have to be used instead.
+
+In contrast to the OpenID Method, you no OCI user is used or created for our the SAML logins, but the a Group Mapping is used instead.
+
+Also Policies have to be created which allow the Federated users access. By default, tehy can log in, but cannot see or do anything.
+
+Creating Policies has not been tested and is not described here.
+
+See https://docs.oracle.com/en-us/iaas/Content/Identity/Concepts/federation.htm for more information.
+
+### Federation Method, Step 1 - Oracle Cloud
+
+In Oracle Cloud, open the top-left navigation and go to _Identity & Security_ and then _Federation_.
+
+Below the list of active Identity Providers, you should see an information panel with this message:
+
+> (i) You need the Oracle Cloud Infrastructure Federation Metadata document when setting up a trust with Microsoft Active Directory Federation Services or with other SAML 2.0-compliant identity providers. This is an XML document that describes Oracle Cloud Infrastructure endpoint and certificate information. __Download this document__ or Learn more.
+
+Download the XML Document behind the link behind __Download this document__.
+
+### Federation Method, Step 2 - authentik
+
+In authentik, under _Providers_, create an _SAML Provider from Metadata_ with these settings:
+
+-   Name: Oracle Cloud SAML <your tenancy> (or whatever you like as name for this provider)
+-   Authorization flow: default-provider-authorization-explicit-consent (Authorize Application), implicit-consent may work too.
+-   Metadata: Browse to the downloaded XML Document and 
+
+Click Finish. Edit the Provider, below Protocol settings:
+
+-   ACS URL: Copy this URL
+-   Audicence: If empty, paste the ACS URL
+
+Click Update. Click on the name of the new provider in the list to see the overview. Use the link _Create Application_ on this page to create the application for the provider.
+
+Create an application which uses this provider. Optionally apply access restrictions to the application using policy bindings.
+
+-   Name: Oracle Cloud SAML <your tenancy> (or whatever you like as name for this application)
+-   Slug: oracle-cloud-saml-<your tenancy> (or whatever yoou like)
+-   Group: You may want to enter a group name like Cloud-Admins (and create it) or use the Administriators group, note it for later.
+-   Provider: Select the provider you created from the list.
+
+Click Create. Back on the overview page page of the SAML provider, you show now see new information blocks.
+
+The 2nd is titled __Related objects__ below the title, the label __Metadata__, and below it a __Download__ button. Download the Metadata using this button.
+
+### Federation Method, Step 3 - Oracle Cloud
+
+In Oracle Cloud, open the top-left navigation and go to _Identity & Security_ and then _Federation_.
+
+In the title bar of the list of Identity Providers, you should see the button "Add Identity Provider"
+
+Name: The name you enter here will be shown to the users when they select an Identity Provider from the list at long
+Description: Whatever you like.
+Type: SAML 2.0 Compliant Identity Provider
+Upload the FederationMetadata.xml document from your Active Directory Federation Services server: Upload or drop the Metadata file downloaded from the authentik provider's Overview page.
+Authentication Context Class References: Don't select any, as Authentik provides different references that are not listed here. If they do not match, the user gets an XML error showing both.
+
+Click Continue
+
+Here you’ll map groups defined in your Identity Provider to groups defined in Oracle Cloud Infrastructure (OCI). Each group can be mapped to one or more groups of the other kind.
+
+Identity Provider Group: If you entered a Group for this provider in Authentik, you may have to use the same same Group here.
+OCI Group: Select the OCI group to use for this Identity Provider Group in OCI.
+
+Click the button _+ Add Another Mapping__ to add more user group mapping.
+
+To log in, Users start from https://www.oracle.com/cloud/sign-in.html:
+Cloud Accound Name: Name of the tenancy
+Select your Identity Provider below: Select the name of the created Identity Provider from the list.

--- a/website/integrations/services/oracle-cloud/index.md
+++ b/website/integrations/services/oracle-cloud/index.md
@@ -88,7 +88,6 @@ Create an application which uses this provider. Optionally apply access restrict
 
 -   Name: Oracle Cloud SAML <your tenancy>
 -   Slug: oracle-cloud-saml-<your tenancy>
--   Group: You may want to enter a group name like Cloud-Admins (and create it) or use the Administriators group, note it for later.
 -   Provider: Select the provider you created from the list.
 
 Click Create. Back on the overview page page of the SAML provider, you show now see new information blocks.

--- a/website/integrations/services/oracle-cloud/index.md
+++ b/website/integrations/services/oracle-cloud/index.md
@@ -51,7 +51,7 @@ Navigate to _IdP Policies_ in the sidebar and open the default policy by clickin
 
 When the Orancle Cloud tenancy does not have an _Identity & Security_ menu and does not have the _Domains_ entry but _Federation_, then this method will have to be used instead.
 
-In contrast to the OpenID Method, you no OCI user is used or created for our the SAML logins, but the a Group Mapping is used instead.
+In contrast to the OpenID Method, no OCI user is used or created for the SAML logins, but a Group Mapping is used instead.
 
 Also Policies have to be created which allow the Federated users access. By default, tehy can log in, but cannot see or do anything.
 

--- a/website/integrations/services/oracle-cloud/index.md
+++ b/website/integrations/services/oracle-cloud/index.md
@@ -49,7 +49,7 @@ Navigate to _IdP Policies_ in the sidebar and open the default policy by clickin
 
 ## Alternative method: Federation using a SAML Provider from Metadata
 
-When the Orancle Cloud tenancy does not have an _Identity & Security_ menu and does not have the _Domains_ entry but _Federation_, then this method will have to be used instead.
+When the Oracle Cloud tenancy does not have an _Identity & Security_ menu and does not have the _Domains_ entry but _Federation_, then this method will have to be used instead.
 
 In contrast to the OpenID Method, no OCI user is used or created for the SAML logins, but a Group Mapping is used instead.
 
@@ -104,7 +104,7 @@ Name: The name you enter here will be shown to the users when they select an Ide
 Description: Whatever you like.
 Type: SAML 2.0 Compliant Identity Provider
 Upload the FederationMetadata.xml document from your Active Directory Federation Services server: Upload or drop the Metadata file downloaded from the authentik provider's Overview page.
-Authentication Context Class References: Don't select any, as Authentik provides different references that are not listed here. If they do not match, the user gets an XML error showing both.
+Authentication Context Class References: Don't select any, as authentik provides different references that are not listed here. If they do not match, the user gets an XML error showing both.
 
 Click Continue
 


### PR DESCRIPTION
## Details

I tried to link my Oracle Cloud account, but it did not support OpenID, and had a Federation menu with SAML instead.

This PR extends the Oracle Cloud setup documentation with this alternate method for accounts which use Federation.
---

## Checklist

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)

This commit was made from "Edit this page" directly on GitHub.com.