### PR TITLE
Change docker compose commands to new format

### DIFF
--- a/website/docs/installation/docker-compose.md
+++ b/website/docs/installation/docker-compose.md
@@ -76,7 +76,7 @@ COMPOSE_PORT_HTTP=80
 COMPOSE_PORT_HTTPS=443
 ```
 
-See [Configuration](../installation/configuration) to change the internal ports. Be sure to run `docker-compose up -d` to rebuild with the new port numbers.
+See [Configuration](../installation/configuration) to change the internal ports. Be sure to run `docker compose up -d` to rebuild with the new port numbers.
 
 ## Startup
 
@@ -90,8 +90,8 @@ This will not give any advantages. It will cause problems with OAuth and SAML au
 Afterwards, run these commands to finish:
 
 ```shell
-docker-compose pull
-docker-compose up -d
+docker compose pull
+docker compose up -d
 ```
 
 The `docker-compose.yml` file statically references the latest version available at the time of downloading the compose file. Each time you upgrade to a newer version of authentik, you download a new `docker-compose.yml` file, which points to the latest available version. For more information, refer to the **Upgrading** section in the [Release Notes](../releases).

--- a/website/docs/troubleshooting/login.md
+++ b/website/docs/troubleshooting/login.md
@@ -11,7 +11,7 @@ This recovery key will give whoever has the link direct access to your instances
 To create the key, run the following command:
 
 ```
-docker-compose run --rm server create_recovery_key 10 akadmin
+docker compose run --rm server create_recovery_key 10 akadmin
 ```
 
 For Kubernetes, run

--- a/website/docs/troubleshooting/missing_admin_group.md
+++ b/website/docs/troubleshooting/missing_admin_group.md
@@ -7,7 +7,7 @@ If all of the Admin groups have been deleted, or misconfigured during sync, you 
 Run the following command, where _username_ is the user you want to add to the newly created group:
 
 ```
-docker-compose run --rm server create_admin_group username
+docker compose run --rm server create_admin_group username
 ```
 
 or, for Kubernetes, run


### PR DESCRIPTION
compose v1 (docker-compose) stopped recieving updates. new command is "docker compose"

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
Docker compose now uses the command "docker compose" not "docker-compose"(https://docs.docker.com/compose/migrate/#docker-compose-vs-docker-compose)

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
