### PR TITLE
website/docs: Improve example nginx reverse proxy config

### DIFF
--- a/website/docs/installation/reverse-proxy.md
+++ b/website/docs/installation/reverse-proxy.md
@@ -13,6 +13,8 @@ If you want to access authentik behind a reverse-proxy, there are a few headers 
 -   `Host`: Required for various security checks, WebSocket handshake, and Outpost and Proxy Provider communication.
 -   `Connection: Upgrade` and `Upgrade: WebSocket`: Required to upgrade protocols for requests to the WebSocket endpoints under HTTP/1.1.
 
+It is also recommended to use a [modern TLS configuration](https://ssl-config.mozilla.org/) and disable SSL/TLS protocols older than TLS 1.3.
+
 The following nginx configuration can be used as a starting point for your own configuration.
 
 ```
@@ -32,21 +34,21 @@ map $http_upgrade $connection_upgrade_keepalive {
 server {
     # HTTP server config
     listen 80;
+    listen [::]:80;
     server_name sso.domain.tld;
-
     # 301 redirect to HTTPS
-    location / {
-            return 301 https://$host$request_uri;
-    }
+    return 301 https://$host$request_uri;
 }
 server {
     # HTTPS server config
     listen 443 ssl http2;
+    listen [::]:443 ssl http2;
     server_name sso.domain.tld;
 
     # TLS certificates
     ssl_certificate /etc/letsencrypt/live/domain.tld/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/domain.tld/privkey.pem;
+    add_header Strict-Transport-Security "max-age=63072000" always;
 
     # Proxy site
     location / {


### PR DESCRIPTION
## Details

Some improvements to the example Nginx proxy config:

 - The HTTP server doesn't need a location block
 - Add `listen [::]:80` and `listen [::]:443` to listen on IPv6
 - Add `Strict-Transport-Security` header to avoid HTTPS downgrade attacks
 - Add link to Mozilla SSL config generator

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
