### PR TITLE
web: fix event propagation in search-select wrappers

### DIFF
--- a/web/src/admin/applications/wizard/methods/saml/saml-property-mappings-search.ts
+++ b/web/src/admin/applications/wizard/methods/saml/saml-property-mappings-search.ts
@@ -65,7 +65,6 @@ export class SAMLPropertyMappingSearch extends CustomListenerElement(AKElement) 
         super();
         this.selected = this.selected.bind(this);
         this.handleSearchUpdate = this.handleSearchUpdate.bind(this);
-        this.addCustomListener("ak-change", this.handleSearchUpdate);
     }
 
     get value() {
@@ -102,6 +101,7 @@ export class SAMLPropertyMappingSearch extends CustomListenerElement(AKElement) 
                 .renderElement=${renderElement}
                 .value=${renderValue}
                 .selected=${this.selected}
+                @ak-change=${this.handleSearchUpdate}
                 blankable
             >
             </ak-search-select>

--- a/web/src/admin/common/ak-core-group-search.ts
+++ b/web/src/admin/common/ak-core-group-search.ts
@@ -57,7 +57,6 @@ export class CoreGroupSearch extends CustomListenerElement(AKElement) {
         super();
         this.selected = this.selected.bind(this);
         this.handleSearchUpdate = this.handleSearchUpdate.bind(this);
-        this.addCustomListener("ak-change", this.handleSearchUpdate);
     }
 
     get value() {
@@ -94,6 +93,7 @@ export class CoreGroupSearch extends CustomListenerElement(AKElement) {
                 .renderElement=${renderElement}
                 .value=${renderValue}
                 .selected=${this.selected}
+                @ak-change=${this.handleSearchUpdate}
                 ?blankable=${true}
             >
             </ak-search-select>

--- a/web/src/admin/common/ak-crypto-certificate-search.ts
+++ b/web/src/admin/common/ak-crypto-certificate-search.ts
@@ -65,7 +65,6 @@ export class AkCryptoCertificateSearch extends CustomListenerElement(AKElement) 
         this.selected = this.selected.bind(this);
         this.fetchObjects = this.fetchObjects.bind(this);
         this.handleSearchUpdate = this.handleSearchUpdate.bind(this);
-        this.addCustomListener("ak-change", this.handleSearchUpdate);
     }
 
     get value() {
@@ -120,6 +119,7 @@ export class AkCryptoCertificateSearch extends CustomListenerElement(AKElement) 
                 .renderElement=${renderElement}
                 .value=${renderValue}
                 .selected=${this.selected}
+                @ak-change=${this.handleSearchUpdate}
                 ?blankable=${true}
             >
             </ak-search-select>

--- a/web/src/admin/common/ak-flow-search/FlowSearch.ts
+++ b/web/src/admin/common/ak-flow-search/FlowSearch.ts
@@ -74,7 +74,6 @@ export class FlowSearch<T extends Flow> extends CustomListenerElement(AKElement)
         this.fetchObjects = this.fetchObjects.bind(this);
         this.selected = this.selected.bind(this);
         this.handleSearchUpdate = this.handleSearchUpdate.bind(this);
-        this.addCustomListener("ak-change", this.handleSearchUpdate);
     }
 
     handleSearchUpdate(ev: CustomEvent) {
@@ -124,6 +123,7 @@ export class FlowSearch<T extends Flow> extends CustomListenerElement(AKElement)
                 .renderDescription=${renderDescription}
                 .value=${getFlowValue}
                 .name=${this.name}
+                @ak-change=${this.handleSearchUpdate}
                 ?blankable=${!this.required}
             >
             </ak-search-select>

--- a/web/src/admin/common/ak-flow-search/ak-flow-search-no-default.ts
+++ b/web/src/admin/common/ak-flow-search/ak-flow-search-no-default.ts
@@ -24,6 +24,7 @@ export class AkFlowSearchNoDefault<T extends Flow> extends FlowSearch<T> {
                 .renderElement=${renderElement}
                 .renderDescription=${renderDescription}
                 .value=${getFlowValue}
+                @ak-change=${this.handleSearchUpdate}
                 ?blankable=${!this.required}
             >
             </ak-search-select>

--- a/web/src/elements/forms/SearchSelect/ak-search-select.ts
+++ b/web/src/elements/forms/SearchSelect/ak-search-select.ts
@@ -220,6 +220,7 @@ export class SearchSelect<T> extends CustomEmitterElement(AKElement) {
     onMenuItemClick(obj: T | undefined) {
         return () => {
             this.selectedObject = obj;
+            this.dispatchCustomEvent("ak-change", { value: this.selectedObject });
             this.open = false;
         };
     }


### PR DESCRIPTION
Two different patches, an older one that extracted long search blocks that were cut-and-pasted into a standalone component, and a newer one that fixed displaying placeholder values properly, conflicted and broke a relationship that allowed for the values to be propagated through those standalone components correctly.

This restores the event handling and updates the listener set-ups with more idiomatic hooks into Lit's event system.

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [X] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
