### PR TITLE
website/docs: fix application hiding instructions

### DIFF
--- a/website/docs/core/applications.md
+++ b/website/docs/core/applications.md
@@ -27,7 +27,7 @@ The following aspects can be configured:
 
     Starting with authentik 2022.2, you can use placeholders in the launch url to build them dynamically based on logged in user. For example, you can set the Launch URL to `https://goauthentik.io/%(username)s`, which will be replaced with the currently logged in user's username.
 
-    Only applications whose launch URL starts with `http://` or `https://` or are relative URLs are shown on the users's **My applications** page. This can also be used to hide applications that shouldn't be visible on the **My applications** page but are still accessible by users, by setting the _Launch URL_ to `hidden://`.
+    Only applications whose launch URL starts with `http://` or `https://` or are relative URLs are shown on the users's **My applications** page. This can also be used to hide applications that shouldn't be visible on the **My applications** page but are still accessible by users, by setting the _Launch URL_ to `blank://blank`.
 
 -   _Icon (URL)_: Optionally configure an Icon for the application
 


### PR DESCRIPTION
Fixed an error in the docs on how to hide applications.

The correct method (`blank://blank`) was described in line 48
This PR fixes an earlier mention in the docs where it's described you can use `hidden://` to hide an application (which doesn't work)