### PR TITLE
website/docs: fix nginx ingress proxy example

### DIFF
--- a/website/docs/providers/proxy/_nginx_ingress.md
+++ b/website/docs/providers/proxy/_nginx_ingress.md
@@ -8,7 +8,6 @@ metadata:
 spec:
   rules:
     - host: app.company
-      ingressClassName: nginx
       http:
         paths: 
           - path: /outpost.goauthentik.io

--- a/website/docs/providers/proxy/_nginx_ingress.md
+++ b/website/docs/providers/proxy/_nginx_ingress.md
@@ -4,21 +4,21 @@ Create a new ingress for the outpost
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: authentik-outpost
+    name: authentik-outpost
 spec:
-  rules:
-    - host: app.company
-      http:
-        paths: 
-          - path: /outpost.goauthentik.io
-            pathType: Prefix
-            backend:
-              # Or, to use an external Outpost, create an ExternalName service and reference that here.
-              # See https://kubernetes.io/docs/concepts/services-networking/service/#externalname
-              service:
-                name: ak-outpost-example-outpost
-                port:
-                  number: 9000
+    rules:
+        - host: app.company
+          http:
+              paths:
+                  - path: /outpost.goauthentik.io
+                    pathType: Prefix
+                    backend:
+                        # Or, to use an external Outpost, create an ExternalName service and reference that here.
+                        # See https://kubernetes.io/docs/concepts/services-networking/service/#externalname
+                        service:
+                            name: ak-outpost-example-outpost
+                            port:
+                                number: 9000
 ```
 
 This ingress handles authentication requests, and the sign-in flow.

--- a/website/docs/providers/proxy/_nginx_ingress.md
+++ b/website/docs/providers/proxy/_nginx_ingress.md
@@ -4,20 +4,22 @@ Create a new ingress for the outpost
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-    name: authentik-outpost
+  name: authentik-outpost
 spec:
-    rules:
-        - host: app.company
-          http:
-              paths: /outpost.goauthentik.io
-              pathType: Prefix
-              backend:
-                  # Or, to use an external Outpost, create an ExternalName service and reference that here.
-                  # See https://kubernetes.io/docs/concepts/services-networking/service/#externalname
-                  service:
-                      name: ak-outpost-example-outpost
-                      port:
-                          number: 9000
+  rules:
+    - host: app.company
+      ingressClassName: nginx
+      http:
+        paths: 
+          - path: /outpost.goauthentik.io
+            pathType: Prefix
+            backend:
+              # Or, to use an external Outpost, create an ExternalName service and reference that here.
+              # See https://kubernetes.io/docs/concepts/services-networking/service/#externalname
+              service:
+                name: ak-outpost-example-outpost
+                port:
+                  number: 9000
 ```
 
 This ingress handles authentication requests, and the sign-in flow.


### PR DESCRIPTION
## Details

👋 Hey,

I was trying to add an ingress for my k8s cluster to setup a proxy application and copy-pasting the example clearly did not work. Here is a fix for that.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
