### PR TITLE
stages/authenticator_validate: use friendly_name for stage selector when enrolling

### DIFF
--- a/authentik/stages/authenticator_static/migrations/0009_throttling.py
+++ b/authentik/stages/authenticator_static/migrations/0009_throttling.py
@@ -38,4 +38,11 @@ class Migration(migrations.Migration):
             name="statictoken",
             options={"verbose_name": "Static Token", "verbose_name_plural": "Static Tokens"},
         ),
+        migrations.AlterModelOptions(
+            name="authenticatorstaticstage",
+            options={
+                "verbose_name": "Static Authenticator Setup Stage",
+                "verbose_name_plural": "Static Authenticator Setup Stages",
+            },
+        ),
     ]

--- a/authentik/stages/authenticator_static/models.py
+++ b/authentik/stages/authenticator_static/models.py
@@ -46,11 +46,11 @@ class AuthenticatorStaticStage(ConfigurableStage, FriendlyNamedStage, Stage):
         )
 
     def __str__(self) -> str:
-        return f"Static Authenticator Stage {self.name}"
+        return f"Static Authenticator Setup Stage {self.name}"
 
     class Meta:
-        verbose_name = _("Static Authenticator Stage")
-        verbose_name_plural = _("Static Authenticator Stages")
+        verbose_name = _("Static Authenticator Setup Stage")
+        verbose_name_plural = _("Static Authenticator Setup Stages")
 
 
 class StaticDevice(SerializerModel, ThrottlingMixin, Device):

--- a/authentik/stages/authenticator_validate/stage.py
+++ b/authentik/stages/authenticator_validate/stage.py
@@ -301,7 +301,9 @@ class AuthenticatorValidateStageView(ChallengeStageView):
                 data={
                     "pk": stage.pk,
                     "name": stage.friendly_name or stage.name,
-                    "verbose_name": str(stage._meta.verbose_name).replace("Setup Stage", "").strip(),
+                    "verbose_name": str(stage._meta.verbose_name)
+                    .replace("Setup Stage", "")
+                    .strip(),
                     "meta_model_name": f"{stage._meta.app_label}.{stage._meta.model_name}",
                 }
             )

--- a/authentik/stages/authenticator_validate/stage.py
+++ b/authentik/stages/authenticator_validate/stage.py
@@ -300,8 +300,8 @@ class AuthenticatorValidateStageView(ChallengeStageView):
             serializer = SelectableStageSerializer(
                 data={
                     "pk": stage.pk,
-                    "name": stage.name,
-                    "verbose_name": str(stage._meta.verbose_name),
+                    "name": stage.friendly_name or stage.name,
+                    "verbose_name": str(stage._meta.verbose_name).replace("Setup Stage", "").strip(),
                     "meta_model_name": f"{stage._meta.app_label}.{stage._meta.model_name}",
                 }
             )

--- a/authentik/stages/authenticator_validate/tests/test_stage.py
+++ b/authentik/stages/authenticator_validate/tests/test_stage.py
@@ -11,6 +11,7 @@ from authentik.flows.tests import FlowTestCase
 from authentik.flows.views.executor import SESSION_KEY_PLAN
 from authentik.lib.generators import generate_id, generate_key
 from authentik.stages.authenticator_duo.models import AuthenticatorDuoStage, DuoDevice
+from authentik.stages.authenticator_static.models import AuthenticatorStaticStage
 from authentik.stages.authenticator_validate.api import AuthenticatorValidateStageSerializer
 from authentik.stages.authenticator_validate.models import AuthenticatorValidateStage, DeviceClasses
 from authentik.stages.authenticator_validate.stage import PLAN_CONTEXT_DEVICE_CHALLENGES
@@ -26,11 +27,14 @@ class AuthenticatorValidateStageTests(FlowTestCase):
 
     def test_not_configured_action(self):
         """Test not_configured_action"""
-        conf_stage = IdentificationStage.objects.create(
+        ident_stage = IdentificationStage.objects.create(
             name=generate_id(),
             user_fields=[
                 UserFields.USERNAME,
             ],
+        )
+        conf_stage = AuthenticatorStaticStage.objects.create(
+            name=generate_id(),
         )
         stage = AuthenticatorValidateStage.objects.create(
             name=generate_id(),
@@ -38,7 +42,7 @@ class AuthenticatorValidateStageTests(FlowTestCase):
         )
         stage.configuration_stages.set([conf_stage])
         flow = create_test_flow()
-        FlowStageBinding.objects.create(target=flow, stage=conf_stage, order=0)
+        FlowStageBinding.objects.create(target=flow, stage=ident_stage, order=0)
         FlowStageBinding.objects.create(target=flow, stage=stage, order=1)
 
         response = self.client.get(
@@ -57,27 +61,22 @@ class AuthenticatorValidateStageTests(FlowTestCase):
         self.assertStageResponse(
             response,
             flow,
-            component="ak-stage-identification",
-            password_fields=False,
-            primary_action="Continue",
-            user_fields=["username"],
-            sources=[],
-            show_source_labels=False,
+            component="ak-stage-authenticator-static",
         )
 
     def test_not_configured_action_multiple(self):
         """Test not_configured_action"""
-        conf_stage = IdentificationStage.objects.create(
+        ident_stage = IdentificationStage.objects.create(
             name=generate_id(),
             user_fields=[
                 UserFields.USERNAME,
             ],
         )
-        conf_stage2 = IdentificationStage.objects.create(
+        conf_stage = AuthenticatorStaticStage.objects.create(
             name=generate_id(),
-            user_fields=[
-                UserFields.USERNAME,
-            ],
+        )
+        conf_stage2 = AuthenticatorStaticStage.objects.create(
+            name=generate_id(),
         )
         stage = AuthenticatorValidateStage.objects.create(
             name=generate_id(),
@@ -85,7 +84,7 @@ class AuthenticatorValidateStageTests(FlowTestCase):
         )
         stage.configuration_stages.set([conf_stage, conf_stage2])
         flow = create_test_flow()
-        FlowStageBinding.objects.create(target=flow, stage=conf_stage, order=0)
+        FlowStageBinding.objects.create(target=flow, stage=ident_stage, order=0)
         FlowStageBinding.objects.create(target=flow, stage=stage, order=1)
 
         # Get initial identification stage
@@ -118,12 +117,7 @@ class AuthenticatorValidateStageTests(FlowTestCase):
         self.assertStageResponse(
             response,
             flow,
-            component="ak-stage-identification",
-            password_fields=False,
-            primary_action="Continue",
-            user_fields=["username"],
-            sources=[],
-            show_source_labels=False,
+            component="ak-stage-authenticator-static",
         )
 
     def test_stage_validation(self):

--- a/blueprints/default/flow-default-authenticator-static-setup.yaml
+++ b/blueprints/default/flow-default-authenticator-static-setup.yaml
@@ -14,6 +14,7 @@ entries:
 - attrs:
     configure_flow: !KeyOf flow
     token_count: 6
+    friendly_name: Static tokens
   identifiers:
     name: default-authenticator-static-setup
   id: default-authenticator-static-setup

--- a/blueprints/default/flow-default-authenticator-totp-setup.yaml
+++ b/blueprints/default/flow-default-authenticator-totp-setup.yaml
@@ -14,6 +14,7 @@ entries:
 - attrs:
     configure_flow: !KeyOf flow
     digits: 6
+    friendly_name: TOTP Device
   identifiers:
     name: default-authenticator-totp-setup
   id: default-authenticator-totp-setup

--- a/blueprints/default/flow-default-authenticator-webauthn-setup.yaml
+++ b/blueprints/default/flow-default-authenticator-webauthn-setup.yaml
@@ -13,6 +13,7 @@ entries:
   id: flow
 - attrs:
     configure_flow: !KeyOf flow
+    friendly_name: WebAuthn device
   identifiers:
     name: default-authenticator-webauthn-setup
   id: default-authenticator-webauthn-setup


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

#8154

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
