### PR TITLE
root: fix system check warnings

### DIFF
--- a/authentik/root/settings.py
+++ b/authentik/root/settings.py
@@ -453,6 +453,17 @@ _DISALLOWED_ITEMS = [
     "CELERY",
 ]
 
+SILENCED_SYSTEM_CHECKS = [
+    # We use our own subclass of django.middleware.csrf.CsrfViewMiddleware
+    "security.W003",
+    # We don't set SESSION_COOKIE_SECURE since we use a custom SessionMiddleware subclass
+    "security.W010",
+    # HSTS: This is configured in reverse proxies/the go proxy, not in django
+    "security.W004",
+    # https redirect: This is configured in reverse proxies/the go proxy, not in django
+    "security.W008",
+]
+
 
 def _update_settings(app_path: str):
     try:

--- a/lifecycle/ak
+++ b/lifecycle/ak
@@ -50,10 +50,6 @@ function set_mode {
     trap cleanup EXIT
 }
 
-function run_django_checks {
-    python -m manage check --deploy
-}
-
 function cleanup {
     rm -f ${MODE_FILE}
 }
@@ -71,7 +67,6 @@ fi
 if [[ "$1" == "server" ]]; then
     wait_for_db
     set_mode "server"
-    run_django_checks
     # If we have bootstrap credentials set, run bootstrap tasks outside of main server
     # sync, so that we can sure the first start actually has working bootstrap
     # credentials
@@ -82,7 +77,6 @@ if [[ "$1" == "server" ]]; then
 elif [[ "$1" == "worker" ]]; then
     wait_for_db
     set_mode "worker"
-    run_django_checks
     check_if_root "python -m manage worker"
 elif [[ "$1" == "worker-status" ]]; then
     wait_for_db

--- a/lifecycle/migrate.py
+++ b/lifecycle/migrate.py
@@ -111,5 +111,8 @@ if __name__ == "__main__":
             ) from exc
         execute_from_command_line(["", "migrate_schemas"])
         execute_from_command_line(["", "migrate_schemas", "--schema", "template", "--tenant"])
+        execute_from_command_line(
+            ["", "check"] + ([] if CONFIG.get_bool("debug") else ["--deploy"])
+        )
     finally:
         release_lock(curr)


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

- Move django check command to migrate script so we can use the config loader to set `--deploy` correctly based on `debug` setting
- Disable some warnings which are caused by us using custom session and csrf middleware subclasses
- Disable some warnings which are handled by the reverse proxy (either external or go) (HSTS, https redirect)

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
