### PR TITLE
web/admin: fix footer links not being parsed on settings page

### DIFF
--- a/web/src/admin/admin-settings/AdminSettingsForm.ts
+++ b/web/src/admin/admin-settings/AdminSettingsForm.ts
@@ -156,12 +156,11 @@ export class AdminSettingsForm extends Form<SettingsRequest> {
             <ak-form-element-horizontal label=${msg("Footer links")} name="footerLinks">
                 <ak-codemirror
                     mode=${CodeMirrorMode.YAML}
-                    .parseValue=${false}
-                    value="${first(this._settings?.footerLinks, [])}"
+                    .value="${first(this._settings?.footerLinks, [])}"
                 ></ak-codemirror>
                 <p class="pf-c-form__helper-text">
                     ${msg(
-                        "This option configures the footer links on the flow executor pages. It must be a valid JSON list and can be used as follows:",
+                        "This option configures the footer links on the flow executor pages. It must be a valid YAML or JSON list and can be used as follows:",
                     )}
                     <code>[{"name": "Link Name","href":"https://goauthentik.io"}]</code>
                 </p>


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
