### PR TITLE
root: split makefile to be usable in web/ and website/

### DIFF
--- a/scripts/ci.mk
+++ b/scripts/ci.mk
@@ -1,0 +1,33 @@
+#########################
+## CI
+#########################
+# These targets are use by GitHub actions to allow usage of matrix
+# which makes the YAML File a lot smaller
+
+_meta-debug:
+	python -V
+	node --version
+
+pylint: _meta-debug
+	pylint $(PY_SOURCES)
+
+black: _meta-debug
+	black --check $(PY_SOURCES)
+
+ruff: _meta-debug
+	ruff check $(PY_SOURCES)
+
+codespell: _meta-debug
+	codespell $(CODESPELL_ARGS) -s
+
+isort: _meta-debug
+	isort --check $(PY_SOURCES)
+
+bandit: _meta-debug
+	bandit -r $(PY_SOURCES)
+
+pyright: _meta-debug
+	${BUILDDIR}/web/node_modules/.bin/pyright $(PY_SOURCES)
+
+pending-migrations: _meta-debug
+	ak makemigrations --check

--- a/scripts/common.mk
+++ b/scripts/common.mk
@@ -1,0 +1,23 @@
+.SHELLFLAGS += ${SHELLFLAGS} -e
+UID = $(shell id -u)
+GID = $(shell id -g)
+NPM_VERSION = $(shell python -m scripts.npm_version)
+PY_SOURCES = authentik tests scripts lifecycle
+DOCKER_IMAGE ?= "authentik:test"
+BUILDDIR = $(shell git rev-parse --show-toplevel)
+MAKE = $(shell which make)
+
+pg_user := $(shell python -m authentik.lib.config postgresql.user 2>/dev/null)
+pg_host := $(shell python -m authentik.lib.config postgresql.host 2>/dev/null)
+pg_name := $(shell python -m authentik.lib.config postgresql.name 2>/dev/null)
+
+
+HELP_WIDTH := $(shell grep -h '^[a-z][^ ]*:.*\#\#' $(MAKEFILE_LIST) 2>/dev/null | \
+	cut -d':' -f1 | awk '{printf "%d\n", length}' | sort -rn | head -1)
+
+help:  ## Show this help
+	@echo "\nSpecify a command. The choices are:\n"
+	@grep -Eh '^[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[0;36m%-$(HELP_WIDTH)s  \033[m %s\n", $$1, $$2}' | \
+		sort
+	@echo ""

--- a/web/Makefile
+++ b/web/Makefile
@@ -1,0 +1,62 @@
+.PHONY: all
+
+all: lint-fix lint check-compile i18n-extract  ## Automatically fix formatting issues in the Authentik UI source code, lint the code, and compile it
+
+BUILDDIR = $(shell git rev-parse --show-toplevel)
+include ${BUILDDIR}/scripts/common.mk
+
+#########################
+## API Client
+#########################
+
+gen-clean-ts:  ## Remove generated API client for Typescript
+	rm -rf ${BUILDDIR}/gen-ts-api/
+	rm -rf ${BUILDDIR}/web/node_modules/@goauthentik/api/
+
+gen-client-ts: gen-clean-ts  ## Build and install the authentik API for Typescript into the authentik UI Application
+	docker run \
+		--rm -v ${BUILDDIR}:/local \
+		--user ${UID}:${GID} \
+		docker.io/openapitools/openapi-generator-cli:v6.5.0 generate \
+		-i /local/schema.yml \
+		-g typescript-fetch \
+		-o /local/gen-ts-api \
+		-c /local/scripts/api-ts-config.yaml \
+		--additional-properties=npmVersion=${NPM_VERSION} \
+		--git-repo-id authentik \
+		--git-user-id goauthentik
+	mkdir -p ${BUILDDIR}/web/node_modules/@goauthentik/api
+	cd ${BUILDDIR}/gen-ts-api && npm i
+	cp -rf ${BUILDDIR}/gen-ts-api/* ${BUILDDIR}/web/node_modules/@goauthentik/api
+
+#########################
+## Web
+#########################
+
+build: install  ## Build the Authentik UI
+	cd ${BUILDDIR}/web && npm run build
+
+install:  ## Install the necessary libraries to build the Authentik UI
+	cd ${BUILDDIR}/web && npm ci
+
+watch:  ## Build and watch the Authentik UI for changes, updating automatically
+	rm -rf web/dist/
+	mkdir web/dist/
+	touch web/dist/.gitkeep
+	cd ${BUILDDIR}/web && npm run watch
+
+storybook-watch:  ## Build and run the storybook documentation server
+	cd ${BUILDDIR}/web && npm run storybook
+
+lint-fix:
+	cd ${BUILDDIR}/web && npm run prettier
+
+lint:
+	cd ${BUILDDIR}/web && npm run lint
+	cd ${BUILDDIR}/web && npm run lit-analyse
+
+check-compile:
+	cd ${BUILDDIR}/web && npm run tsc
+
+i18n-extract:
+	cd ${BUILDDIR}/web && npm run extract-locales

--- a/website/Makefile
+++ b/website/Makefile
@@ -1,0 +1,22 @@
+.PHONY: all
+
+BUILDDIR = $(shell git rev-parse --show-toplevel)
+include ${BUILDDIR}/scripts/common.mk
+
+#########################
+## Website
+#########################
+
+all: lint-fix build  ## Automatically fix formatting issues in the Authentik website/docs source code, lint the code, and compile it
+
+install:
+	cd ${BUILDDIR}/website && npm ci
+
+lint-fix:
+	cd ${BUILDDIR}/website && npm run prettier
+
+build:
+	cd ${BUILDDIR}/website && npm run build
+
+watch:  ## Build and watch the documentation website, updating automatically
+	cd ${BUILDDIR}/website && npm run watch


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

This splits the main makefile apart to also be usable when working in `web/` and `website/` subdirectories

The one current downside is that this breaks the `help` target as this relies on shelling out to make

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)
-   [ ] The translation files have been updated (`make i18n-extract`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
