### PR TITLE
website: add solve gitea group does not take effect

### DIFF
--- a/website/integrations/services/gitea/index.md
+++ b/website/integrations/services/gitea/index.md
@@ -132,6 +132,10 @@ Click `Update` and the configuration authentik is done.
 
 #### Configure Gitea to use the new claims
 
+:::note
+Gitea must set `ENABLE_AUTO_REGISTRATION: true`.
+:::
+
 Navigate to the _Authentication Sources_ page at https://gitea.company/admin/auths and edit the **authentik** Authentication Source.
 
 Change the following fields


### PR DESCRIPTION
When config my gitea Follow [step 4](https://goauthentik.io/integrations/services/gitea/#step-4-optional-claims-for-authorization-management)，I find new user create by authentik flow don't have group role.

I debug gitea found out why.  gitea `ENABLE_AUTO_REGISTRATION` is false by default. So new user is create by gitab default method  `showLinkingLogin`.
https://github.com/go-gitea/gitea/blob/6992ef98fc227a60cf06e0a06b9ae2492b3d61be/routers/web/auth/oauth.go#L953
https://docs.gitea.com/administration/config-cheat-sheet?_highlight=enable_auto_registration#oauth2-client-oauth2_client

We need to remind this gitea configuration item——`ENABLE_AUTO_REGISTRATION: true`.