### PR TITLE
ci: adapt for release candidates

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 current_version = 2024.2.0-rc1
-tag = False
+tag = True
 commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<rc_t>[a-zA-Z-]+)(?P<rc_n>0|[1-9]\\d*))?
 serialize =

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2024.2.0-rc0
+current_version = 2024.2.0-rc1
 tag = False
 commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<rc_t>[a-zA-Z-]+)(?P<rc_n>0|[1-9]\\d*))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,11 +1,19 @@
 [bumpversion]
-current_version = 2023.10.7
-tag = True
-commit = True
-parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
-serialize = {major}.{minor}.{patch}
+current_version = 2024.2.0-rc0
+tag = False
+commit = False
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<rc_t>[a-zA-Z-]+)(?P<rc_n>0|[1-9]\\d*))?
+serialize =
+	{major}.{minor}.{patch}-{rc_t}{rc_n}
+	{major}.{minor}.{patch}
 message = release: {new_version}
 tag_name = version/{new_version}
+
+[bumpversion:part:rc_t]
+values =
+	rc
+	final
+optional_value = final
 
 [bumpversion:file:pyproject.toml]
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2024.2.0-rc1
+current_version = 2023.10.7
 tag = True
 commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<rc_t>[a-zA-Z-]+)(?P<rc_n>[1-9]\\d*))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 current_version = 2024.2.0-rc0
 tag = False
-commit = False
+commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<rc_t>[a-zA-Z-]+)(?P<rc_n>0|[1-9]\\d*))?
 serialize =
 	{major}.{minor}.{patch}-{rc_t}{rc_n}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,7 +2,7 @@
 current_version = 2024.2.0-rc1
 tag = True
 commit = True
-parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<rc_t>[a-zA-Z-]+)(?P<rc_n>0|[1-9]\\d*))?
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<rc_t>[a-zA-Z-]+)(?P<rc_n>[1-9]\\d*))?
 serialize =
 	{major}.{minor}.{patch}-{rc_t}{rc_n}
 	{major}.{minor}.{patch}

--- a/.github/actions/comment-pr-instructions/action.yml
+++ b/.github/actions/comment-pr-instructions/action.yml
@@ -9,9 +9,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Generate config
-      id: ev
-      uses: ./.github/actions/docker-push-variables
     - name: Find Comment
       uses: peter-evans/find-comment@v2
       id: fc

--- a/.github/actions/docker-push-variables/action.yml
+++ b/.github/actions/docker-push-variables/action.yml
@@ -53,7 +53,7 @@ runs:
         image_arch = "${{ inputs.image-arch }}" or None
 
         is_pull_request = bool("${{ github.event.pull_request.head.sha }}")
-        is_release = "dev" not in image_name
+        is_release = "dev" not in image_names[0]
 
         sha = os.environ["GITHUB_SHA"] if not is_pull_request else "${{ github.event.pull_request.head.sha }}"
 

--- a/.github/actions/docker-push-variables/action.yml
+++ b/.github/actions/docker-push-variables/action.yml
@@ -23,6 +23,12 @@ outputs:
   version:
     description: "version"
     value: ${{ steps.ev.outputs.version }}
+  prerelease:
+    description: "prerelease"
+    value: ${{ steps.ev.outputs.prerelease }}
+  versionRC:
+    description: "versionRC"
+    value: ${{ steps.ev.outputs.versionRC }}
   versionFamily:
     description: "versionFamily"
     value: ${{ steps.ev.outputs.versionFamily }}
@@ -47,7 +53,11 @@ runs:
             branch_name = os.environ["GITHUB_HEAD_REF"]
 
         should_build = str(os.environ.get("DOCKER_USERNAME", "") != "").lower()
-        version = parser.get("bumpversion", "current_version")
+        full_version = parser.get("bumpversion", "current_version")
+        version = full_version.split("-", 1)[0]
+        rc = full_version.split("-", 1)[1] if "-" in full_version else None
+        version_rc = f"-{rc}" if rc else ""
+        prerelease = str(rc is not None).lower()
         version_family = ".".join(version.split(".")[:-1])
         safe_branch_name = branch_name.replace("refs/heads/", "").replace("/", "-")
 
@@ -61,4 +71,6 @@ runs:
             print("shortHash=%s" % sha[:7], file=_output)
             print("shouldBuild=%s" % should_build, file=_output)
             print("version=%s" % version, file=_output)
+            print("versionRC=%s" % version_rc, file=_output)
+            print("prerelease=%s" % prerelease, file=_output)
             print("versionFamily=%s" % version_family, file=_output)

--- a/.github/actions/docker-push-variables/action.yml
+++ b/.github/actions/docker-push-variables/action.yml
@@ -49,8 +49,8 @@ runs:
             branch_name = os.environ["GITHUB_HEAD_REF"]
         safe_branch_name = branch_name.replace("refs/heads/", "").replace("/", "-")
 
-        image_names = os.environ.get("INPUT_IMAGE-NAME").split(",")
-        image_arch = os.environ.get("INPUT_IMAGE-ARCH", None)
+        image_names = "${{ inputs.image-name }}".split(",")
+        image_arch = "${{ inputs.image-arch }}" or None
 
         is_pull_request = bool("${{ github.event.pull_request.head.sha }}")
         is_release = "dev" not in image_name

--- a/.github/actions/docker-push-variables/action.yml
+++ b/.github/actions/docker-push-variables/action.yml
@@ -1,37 +1,33 @@
+---
 name: "Prepare docker environment variables"
 description: "Prepare docker environment variables"
 
+inputs:
+  image-name:
+    required: true
+    description: "Docker image prefix"
+  image-arch:
+    required: false
+    description: "Docker image arch"
+
 outputs:
-  shouldBuild:
-    description: "Whether to build image or not"
-    value: ${{ steps.ev.outputs.shouldBuild }}
-  branchName:
-    description: "Branch name"
-    value: ${{ steps.ev.outputs.branchName }}
-  branchNameContainer:
-    description: "Branch name (for containers)"
-    value: ${{ steps.ev.outputs.branchNameContainer }}
-  timestamp:
-    description: "Timestamp"
-    value: ${{ steps.ev.outputs.timestamp }}
   sha:
     description: "sha"
     value: ${{ steps.ev.outputs.sha }}
-  shortHash:
-    description: "shortHash"
-    value: ${{ steps.ev.outputs.shortHash }}
+
   version:
-    description: "version"
+    description: "Version"
     value: ${{ steps.ev.outputs.version }}
   prerelease:
-    description: "prerelease"
+    description: "Prerelease"
     value: ${{ steps.ev.outputs.prerelease }}
-  versionRC:
-    description: "versionRC"
-    value: ${{ steps.ev.outputs.versionRC }}
-  versionFamily:
-    description: "versionFamily"
-    value: ${{ steps.ev.outputs.versionFamily }}
+
+  imageTags:
+    description: "Docker image tags"
+    value: ${{ steps.ev.outputs.imageTags }}
+  imageMainTag:
+    description: "Docker image main tag"
+    value: ${{ steps.ev.outputs.imageMainTag }}
 
 runs:
   using: "composite"
@@ -51,26 +47,47 @@ runs:
         branch_name = os.environ["GITHUB_REF"]
         if os.environ.get("GITHUB_HEAD_REF", "") != "":
             branch_name = os.environ["GITHUB_HEAD_REF"]
-
-        should_build = str(os.environ.get("DOCKER_USERNAME", "") != "").lower()
-        full_version = parser.get("bumpversion", "current_version")
-        version = full_version.split("-", 1)[0]
-        rc = full_version.split("-", 1)[1] if "-" in full_version else None
-        version_rc = f"-{rc}" if rc else ""
-        prerelease = str(rc is not None).lower()
-        version_family = ".".join(version.split(".")[:-1])
         safe_branch_name = branch_name.replace("refs/heads/", "").replace("/", "-")
 
-        sha = os.environ["GITHUB_SHA"] if not "${{ github.event.pull_request.head.sha }}" else "${{ github.event.pull_request.head.sha }}"
+        image_names = os.environ.get("INPUT_IMAGE-NAME").split(",")
+        image_arch = os.environ.get("INPUT_IMAGE-ARCH", None)
+
+        is_pull_request = bool("${{ github.event.pull_request.head.sha }}")
+        is_release = "dev" not in image_name
+
+        sha = os.environ["GITHUB_SHA"] if not is_pull_request else "${{ github.event.pull_request.head.sha }}"
+
+        # 2042.1.0 or 2042.1.0-rc1
+        version = parser.get("bumpversion", "current_version")
+        # 2042.1
+        version_family = ".".join(version.split("-", 1)[0].split(".")[:-1])
+        prerelease = "-" in version
+
+        image_tags = []
+        if is_release:
+            for name in image_names:
+                image_tags += [
+                    f"{name}:{version}",
+                    f"{name}:{version_family}",
+                ]
+            if not prerelease:
+                image_tags += [f"{name}:latest"]
+        else:
+            suffix = ""
+            if image_arch and image_arch != "amd64":
+                suffix = f"-{image_arch}"
+            for name in image_names:
+                image_tags += [
+                    f"{name}:gh-{sha}{suffix}",
+                    f"{name}:gh-{safe_branch_name}{suffix}",
+                ]
+
+        image_main_tag = image_tags[0]
+        image_tags_rendered = ",".join(image_tags)
 
         with open(os.environ["GITHUB_OUTPUT"], "a+", encoding="utf-8") as _output:
-            print("branchName=%s" % branch_name, file=_output)
-            print("branchNameContainer=%s" % safe_branch_name, file=_output)
-            print("timestamp=%s" % int(time()), file=_output)
             print("sha=%s" % sha, file=_output)
-            print("shortHash=%s" % sha[:7], file=_output)
-            print("shouldBuild=%s" % should_build, file=_output)
             print("version=%s" % version, file=_output)
-            print("versionRC=%s" % version_rc, file=_output)
             print("prerelease=%s" % prerelease, file=_output)
-            print("versionFamily=%s" % version_family, file=_output)
+            print("imageTags=%s" % image_tags_rendered, file=_output)
+            print("imageMainTag=%s" % image_main_tag, file=_output)

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -1,3 +1,4 @@
+---
 name: authentik-ci-main
 
 on:
@@ -208,12 +209,19 @@ jobs:
     steps:
       - run: echo mark
   build:
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - amd64
+          - arm64
     needs: ci-core-mark
     runs-on: ubuntu-latest
     permissions:
       # Needed to upload contianer images to ghcr.io
       packages: write
     timeout-minutes: 120
+    if: "github.repository == 'goauthentik/authentik'"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -225,11 +233,11 @@ jobs:
       - name: prepare variables
         uses: ./.github/actions/docker-push-variables
         id: ev
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        with:
+          image-name: ghcr.io/goauthentik/dev-server
+          image-arch: ${{ matrix.arch }}
       - name: Login to Container Registry
         uses: docker/login-action@v3
-        if: ${{ steps.ev.outputs.shouldBuild == 'true' }}
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -243,69 +251,15 @@ jobs:
           secrets: |
             GEOIPUPDATE_ACCOUNT_ID=${{ secrets.GEOIPUPDATE_ACCOUNT_ID }}
             GEOIPUPDATE_LICENSE_KEY=${{ secrets.GEOIPUPDATE_LICENSE_KEY }}
-          push: ${{ steps.ev.outputs.shouldBuild == 'true' }}
-          tags: |
-            ghcr.io/goauthentik/dev-server:gh-${{ steps.ev.outputs.branchNameContainer }}
-            ghcr.io/goauthentik/dev-server:gh-${{ steps.ev.outputs.sha }}
-            ghcr.io/goauthentik/dev-server:gh-${{ steps.ev.outputs.branchNameContainer }}-${{ steps.ev.outputs.timestamp }}-${{ steps.ev.outputs.shortHash }}
+          tags: ${{ steps.ev.outputs.imageTags }}
           build-args: |
             GIT_BUILD_HASH=${{ steps.ev.outputs.sha }}
-            VERSION=${{ steps.ev.outputs.version }}
-            VERSION_FAMILY=${{ steps.ev.outputs.versionFamily }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-  build-arm64:
-    needs: ci-core-mark
-    runs-on: ubuntu-latest
-    permissions:
-      # Needed to upload contianer images to ghcr.io
-      packages: write
-    timeout-minutes: 120
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.0.0
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: prepare variables
-        uses: ./.github/actions/docker-push-variables
-        id: ev
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      - name: Login to Container Registry
-        uses: docker/login-action@v3
-        if: ${{ steps.ev.outputs.shouldBuild == 'true' }}
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: generate ts client
-        run: make gen-client-ts
-      - name: Build Docker Image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          secrets: |
-            GEOIPUPDATE_ACCOUNT_ID=${{ secrets.GEOIPUPDATE_ACCOUNT_ID }}
-            GEOIPUPDATE_LICENSE_KEY=${{ secrets.GEOIPUPDATE_LICENSE_KEY }}
-          push: ${{ steps.ev.outputs.shouldBuild == 'true' }}
-          tags: |
-            ghcr.io/goauthentik/dev-server:gh-${{ steps.ev.outputs.branchNameContainer }}-arm64
-            ghcr.io/goauthentik/dev-server:gh-${{ steps.ev.outputs.sha }}-arm64
-            ghcr.io/goauthentik/dev-server:gh-${{ steps.ev.outputs.branchNameContainer }}-${{ steps.ev.outputs.timestamp }}-${{ steps.ev.outputs.shortHash }}-arm64
-          build-args: |
-            GIT_BUILD_HASH=${{ steps.ev.outputs.sha }}
-            VERSION=${{ steps.ev.outputs.version }}
-            VERSION_FAMILY=${{ steps.ev.outputs.versionFamily }}
-          platforms: linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          platforms: linux/${{ matrix.arch }}
   pr-comment:
     needs:
       - build
-      - build-arm64
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' }}
     permissions:
@@ -319,9 +273,9 @@ jobs:
       - name: prepare variables
         uses: ./.github/actions/docker-push-variables
         id: ev
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        with:
+          image-name: ghcr.io/goauthentik/dev-server
       - name: Comment on PR
         uses: ./.github/actions/comment-pr-instructions
         with:
-          tag: gh-${{ steps.ev.outputs.branchNameContainer }}-${{ steps.ev.outputs.timestamp }}-${{ steps.ev.outputs.shortHash }}
+          tag: gh-${{ steps.ev.outputs.imageMainTag }}

--- a/.github/workflows/ci-outpost.yml
+++ b/.github/workflows/ci-outpost.yml
@@ -1,3 +1,4 @@
+---
 name: authentik-ci-outpost
 
 on:
@@ -74,6 +75,7 @@ jobs:
     permissions:
       # Needed to upload contianer images to ghcr.io
       packages: write
+    if: "github.repository == 'goauthentik/authentik'"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -85,11 +87,10 @@ jobs:
       - name: prepare variables
         uses: ./.github/actions/docker-push-variables
         id: ev
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        with:
+          image-name: ghcr.io/goauthentik/dev-${{ matrix.type }}
       - name: Login to Container Registry
         uses: docker/login-action@v3
-        if: ${{ steps.ev.outputs.shouldBuild == 'true' }}
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -99,15 +100,10 @@ jobs:
       - name: Build Docker Image
         uses: docker/build-push-action@v5
         with:
-          push: ${{ steps.ev.outputs.shouldBuild == 'true' }}
-          tags: |
-            ghcr.io/goauthentik/dev-${{ matrix.type }}:gh-${{ steps.ev.outputs.branchNameContainer }}
-            ghcr.io/goauthentik/dev-${{ matrix.type }}:gh-${{ steps.ev.outputs.sha }}
+          tags: ${{ steps.ev.outputs.imageTags }}
           file: ${{ matrix.type }}.Dockerfile
           build-args: |
             GIT_BUILD_HASH=${{ steps.ev.outputs.sha }}
-            VERSION=${{ steps.ev.outputs.version }}
-            VERSION_FAMILY=${{ steps.ev.outputs.versionFamily }}
           platforms: linux/amd64,linux/arm64
           context: .
           cache-from: type=gha

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -43,15 +43,15 @@ jobs:
             GEOIPUPDATE_ACCOUNT_ID=${{ secrets.GEOIPUPDATE_ACCOUNT_ID }}
             GEOIPUPDATE_LICENSE_KEY=${{ secrets.GEOIPUPDATE_LICENSE_KEY }}
           tags: |
-            beryju/authentik:${{ steps.ev.outputs.version }},
+            beryju/authentik:${{ steps.ev.outputs.version }}${{ steps.ev.outputs.versionRC }},
             beryju/authentik:${{ steps.ev.outputs.versionFamily }},
-            beryju/authentik:latest,
-            ghcr.io/goauthentik/server:${{ steps.ev.outputs.version }},
+            beryju/authentik:latest${{ steps.ev.outputs.versionRC }},
+            ghcr.io/goauthentik/server:${{ steps.ev.outputs.version }}${{ steps.ev.outputs.versionRC }},
             ghcr.io/goauthentik/server:${{ steps.ev.outputs.versionFamily }},
-            ghcr.io/goauthentik/server:latest
+            ghcr.io/goauthentik/server:latest${{ steps.ev.outputs.versionRC }}
           platforms: linux/amd64,linux/arm64
           build-args: |
-            VERSION=${{ steps.ev.outputs.version }}
+            VERSION=${{ steps.ev.outputs.version }}${{ steps.ev.outputs.versionRC }}
             VERSION_FAMILY=${{ steps.ev.outputs.versionFamily }}
   build-outpost:
     runs-on: ubuntu-latest
@@ -98,17 +98,17 @@ jobs:
         with:
           push: ${{ github.event_name == 'release' }}
           tags: |
-            beryju/authentik-${{ matrix.type }}:${{ steps.ev.outputs.version }},
+            beryju/authentik-${{ matrix.type }}:${{ steps.ev.outputs.version }}${{ steps.ev.outputs.versionRC }},
             beryju/authentik-${{ matrix.type }}:${{ steps.ev.outputs.versionFamily }},
-            beryju/authentik-${{ matrix.type }}:latest,
-            ghcr.io/goauthentik/${{ matrix.type }}:${{ steps.ev.outputs.version }},
+            beryju/authentik-${{ matrix.type }}:latest${{ steps.ev.outputs.versionRC }},
+            ghcr.io/goauthentik/${{ matrix.type }}:${{ steps.ev.outputs.version }}${{ steps.ev.outputs.versionRC }},
             ghcr.io/goauthentik/${{ matrix.type }}:${{ steps.ev.outputs.versionFamily }},
-            ghcr.io/goauthentik/${{ matrix.type }}:latest
+            ghcr.io/goauthentik/${{ matrix.type }}:latest${{ steps.ev.outputs.versionRC }}
           file: ${{ matrix.type }}.Dockerfile
           platforms: linux/amd64,linux/arm64
           context: .
           build-args: |
-            VERSION=${{ steps.ev.outputs.version }}
+            VERSION=${{ steps.ev.outputs.version }}${{ steps.ev.outputs.versionRC }}
             VERSION_FAMILY=${{ steps.ev.outputs.versionFamily }}
   build-outpost-binary:
     timeout-minutes: 120
@@ -183,8 +183,8 @@ jobs:
         id: ev
       - name: Get static files from docker image
         run: |
-          docker pull ghcr.io/goauthentik/server:latest
-          container=$(docker container create ghcr.io/goauthentik/server:latest)
+          docker pull ghcr.io/goauthentik/server:${{ steps.ev.outputs.version }}${{ steps.ev.outputs.versionRC }}
+          container=$(docker container create ghcr.io/goauthentik/server:${{ steps.ev.outputs.version }}${{ steps.ev.outputs.versionRC }})
           docker cp ${container}:web/ .
       - name: Create a Sentry.io release
         uses: getsentry/action-release@v1
@@ -195,6 +195,6 @@ jobs:
           SENTRY_ORG: authentik-security-inc
           SENTRY_PROJECT: authentik
         with:
-          version: authentik@${{ steps.ev.outputs.version }}
+          version: authentik@${{ steps.ev.outputs.version }}${{ steps.ev.outputs.versionRC }}
           sourcemaps: "./web/dist"
           url_prefix: "~/static/dist"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,3 +1,4 @@
+---
 name: authentik-on-release
 
 on:
@@ -19,6 +20,8 @@ jobs:
       - name: prepare variables
         uses: ./.github/actions/docker-push-variables
         id: ev
+        with:
+          image-name: ghcr.io/goauthentik/server,beryju/authentik
       - name: Docker Login Registry
         uses: docker/login-action@v3
         with:
@@ -38,21 +41,12 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: ${{ github.event_name == 'release' }}
+          push: true
           secrets: |
             GEOIPUPDATE_ACCOUNT_ID=${{ secrets.GEOIPUPDATE_ACCOUNT_ID }}
             GEOIPUPDATE_LICENSE_KEY=${{ secrets.GEOIPUPDATE_LICENSE_KEY }}
-          tags: |
-            beryju/authentik:${{ steps.ev.outputs.version }}${{ steps.ev.outputs.versionRC }},
-            beryju/authentik:${{ steps.ev.outputs.versionFamily }},
-            beryju/authentik:latest${{ steps.ev.outputs.versionRC }},
-            ghcr.io/goauthentik/server:${{ steps.ev.outputs.version }}${{ steps.ev.outputs.versionRC }},
-            ghcr.io/goauthentik/server:${{ steps.ev.outputs.versionFamily }},
-            ghcr.io/goauthentik/server:latest${{ steps.ev.outputs.versionRC }}
+          tags: ${{ steps.ev.outputs.imageTags }}
           platforms: linux/amd64,linux/arm64
-          build-args: |
-            VERSION=${{ steps.ev.outputs.version }}${{ steps.ev.outputs.versionRC }}
-            VERSION_FAMILY=${{ steps.ev.outputs.versionFamily }}
   build-outpost:
     runs-on: ubuntu-latest
     permissions:
@@ -78,6 +72,8 @@ jobs:
       - name: prepare variables
         uses: ./.github/actions/docker-push-variables
         id: ev
+        with:
+          image-name: ghcr.io/goauthentik/${{ matrix.type }},beryju/authentik-${{ matrix.type }}
       - name: make empty clients
         run: |
           mkdir -p ./gen-ts-api
@@ -96,20 +92,11 @@ jobs:
       - name: Build Docker Image
         uses: docker/build-push-action@v5
         with:
-          push: ${{ github.event_name == 'release' }}
-          tags: |
-            beryju/authentik-${{ matrix.type }}:${{ steps.ev.outputs.version }}${{ steps.ev.outputs.versionRC }},
-            beryju/authentik-${{ matrix.type }}:${{ steps.ev.outputs.versionFamily }},
-            beryju/authentik-${{ matrix.type }}:latest${{ steps.ev.outputs.versionRC }},
-            ghcr.io/goauthentik/${{ matrix.type }}:${{ steps.ev.outputs.version }}${{ steps.ev.outputs.versionRC }},
-            ghcr.io/goauthentik/${{ matrix.type }}:${{ steps.ev.outputs.versionFamily }},
-            ghcr.io/goauthentik/${{ matrix.type }}:latest${{ steps.ev.outputs.versionRC }}
+          push: true
+          tags: ${{ steps.ev.outputs.imageTags }}
           file: ${{ matrix.type }}.Dockerfile
           platforms: linux/amd64,linux/arm64
           context: .
-          build-args: |
-            VERSION=${{ steps.ev.outputs.version }}${{ steps.ev.outputs.versionRC }}
-            VERSION_FAMILY=${{ steps.ev.outputs.versionFamily }}
   build-outpost-binary:
     timeout-minutes: 120
     runs-on: ubuntu-latest
@@ -181,20 +168,21 @@ jobs:
       - name: prepare variables
         uses: ./.github/actions/docker-push-variables
         id: ev
+        with:
+          image-name: ghcr.io/goauthentik/server
       - name: Get static files from docker image
         run: |
-          docker pull ghcr.io/goauthentik/server:${{ steps.ev.outputs.version }}${{ steps.ev.outputs.versionRC }}
-          container=$(docker container create ghcr.io/goauthentik/server:${{ steps.ev.outputs.version }}${{ steps.ev.outputs.versionRC }})
+          docker pull ghcr.io/goauthentik/server:${{ steps.ev.outputs.imageMainTag }}
+          container=$(docker container create ghcr.io/goauthentik/server:${{ steps.ev.outputs.imageMainTag }})
           docker cp ${container}:web/ .
       - name: Create a Sentry.io release
         uses: getsentry/action-release@v1
         continue-on-error: true
-        if: ${{ github.event_name == 'release' }}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: authentik-security-inc
           SENTRY_PROJECT: authentik
         with:
-          version: authentik@${{ steps.ev.outputs.version }}${{ steps.ev.outputs.versionRC }}
+          version: authentik@${{ steps.ev.outputs.version }}
           sourcemaps: "./web/dist"
           url_prefix: "~/static/dist"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -28,13 +28,9 @@ jobs:
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-      - name: Extract version number
-        id: get_version
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ steps.generate_token.outputs.token }}
-          script: |
-            return context.payload.ref.replace(/\/refs\/tags\/version\//, '');
+      - name: prepare variables
+        uses: ./.github/actions/docker-push-variables
+        id: ev
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1.1.4
@@ -42,6 +38,6 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ steps.get_version.outputs.result }}
+          release_name: Release ${{ steps.ev.outputs.version }}
           draft: true
-          prerelease: false
+          prerelease: ${{ steps.ev.outputs.prerelease }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,3 +1,4 @@
+---
 name: authentik-on-tag
 
 on:
@@ -31,6 +32,8 @@ jobs:
       - name: prepare variables
         uses: ./.github/actions/docker-push-variables
         id: ev
+        with:
+          image-name: ghcr.io/goauthentik/server
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1.1.4
@@ -40,4 +43,4 @@ jobs:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ steps.ev.outputs.version }}
           draft: true
-          prerelease: ${{ steps.ev.outputs.prerelease }}
+          prerelease: ${{ steps.ev.outputs.prerelease == 'true' }}


### PR DESCRIPTION
## Details

- Edit bumpversion to allow for release candidates
  - Versions will now be of the form `2024.2.0` or `2024.2.0-rc0`
- Edit CI to publish RC images

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
