### PR TITLE
blueprints: use reconcile decorator instead of relying on function name prefix

### DIFF
--- a/authentik/core/apps.py
+++ b/authentik/core/apps.py
@@ -14,14 +14,16 @@ class AuthentikCoreConfig(ManagedAppConfig):
     mountpoint = ""
     default = True
 
-    def reconcile_global_debug_worker_hook(self):
+    @ManagedAppConfig.reconcile_global
+    def debug_worker_hook(self):
         """Dispatch startup tasks inline when debugging"""
         if settings.DEBUG:
             from authentik.root.celery import worker_ready_hook
 
             worker_ready_hook()
 
-    def reconcile_tenant_source_inbuilt(self):
+    @ManagedAppConfig.reconcile_tenant
+    def source_inbuilt(self):
         """Reconcile inbuilt source"""
         from authentik.core.models import Source
 

--- a/authentik/crypto/apps.py
+++ b/authentik/crypto/apps.py
@@ -36,7 +36,8 @@ class AuthentikCryptoConfig(ManagedAppConfig):
             },
         )
 
-    def reconcile_tenant_managed_jwt_cert(self):
+    @ManagedAppConfig.reconcile_tenant
+    def managed_jwt_cert(self):
         """Ensure managed JWT certificate"""
         from authentik.crypto.models import CertificateKeyPair
 
@@ -49,7 +50,8 @@ class AuthentikCryptoConfig(ManagedAppConfig):
         ):
             self._create_update_cert()
 
-    def reconcile_tenant_self_signed(self):
+    @ManagedAppConfig.reconcile_tenant
+    def self_signed(self):
         """Create self-signed keypair"""
         from authentik.crypto.builder import CertificateBuilder
         from authentik.crypto.models import CertificateKeyPair

--- a/authentik/enterprise/audit/apps.py
+++ b/authentik/enterprise/audit/apps.py
@@ -13,7 +13,8 @@ class AuthentikEnterpriseAuditConfig(EnterpriseConfig):
     verbose_name = "authentik Enterprise.Audit"
     default = True
 
-    def reconcile_global_install_middleware(self):
+    @EnterpriseConfig.reconcile_global
+    def install_middleware(self):
         """Install enterprise audit middleware"""
         orig_import = "authentik.events.middleware.AuditMiddleware"
         new_import = "authentik.enterprise.audit.middleware.EnterpriseAuditMiddleware"

--- a/authentik/events/apps.py
+++ b/authentik/events/apps.py
@@ -35,7 +35,8 @@ class AuthentikEventsConfig(ManagedAppConfig):
     verbose_name = "authentik Events"
     default = True
 
-    def reconcile_global_check_deprecations(self):
+    @ManagedAppConfig.reconcile_global
+    def check_deprecations(self):
         """Check for config deprecations"""
         from authentik.events.models import Event, EventAction
 
@@ -56,7 +57,8 @@ class AuthentikEventsConfig(ManagedAppConfig):
                 message=msg,
             ).save()
 
-    def reconcile_tenant_prefill_tasks(self):
+    @ManagedAppConfig.reconcile_tenant
+    def prefill_tasks(self):
         """Prefill tasks"""
         from authentik.events.models import SystemTask
         from authentik.events.system_tasks import _prefill_tasks
@@ -67,7 +69,8 @@ class AuthentikEventsConfig(ManagedAppConfig):
             task.save()
             self.logger.debug("prefilled task", task_name=task.name)
 
-    def reconcile_tenant_run_scheduled_tasks(self):
+    @ManagedAppConfig.reconcile_tenant
+    def run_scheduled_tasks(self):
         """Run schedule tasks which are behind schedule (only applies
         to tasks of which we keep metrics)"""
         from authentik.events.models import TaskStatus

--- a/authentik/flows/apps.py
+++ b/authentik/flows/apps.py
@@ -31,7 +31,8 @@ class AuthentikFlowsConfig(ManagedAppConfig):
     verbose_name = "authentik Flows"
     default = True
 
-    def reconcile_global_load_stages(self):
+    @ManagedAppConfig.reconcile_global
+    def load_stages(self):
         """Ensure all stages are loaded"""
         from authentik.flows.models import Stage
 

--- a/authentik/outposts/apps.py
+++ b/authentik/outposts/apps.py
@@ -30,7 +30,8 @@ class AuthentikOutpostConfig(ManagedAppConfig):
     verbose_name = "authentik Outpost"
     default = True
 
-    def reconcile_tenant_embedded_outpost(self):
+    @ManagedAppConfig.reconcile_tenant
+    def embedded_outpost(self):
         """Ensure embedded outpost"""
         from authentik.outposts.models import (
             DockerServiceConnection,

--- a/authentik/sources/oauth/apps.py
+++ b/authentik/sources/oauth/apps.py
@@ -32,7 +32,8 @@ class AuthentikSourceOAuthConfig(ManagedAppConfig):
     mountpoint = "source/oauth/"
     default = True
 
-    def reconcile_global_sources_loaded(self):
+    @ManagedAppConfig.reconcile_global
+    def load_source_types(self):
         """Load source_types from config file"""
         for source_type in AUTHENTIK_SOURCES_OAUTH_TYPES:
             try:

--- a/authentik/tenants/apps.py
+++ b/authentik/tenants/apps.py
@@ -28,7 +28,8 @@ class AuthentikTenantsConfig(ManagedAppConfig):
     verbose_name = "authentik Tenants"
     default = True
 
-    def reconcile_global_default_tenant(self):
+    @ManagedAppConfig.reconcile_global
+    def default_tenant(self):
         """Make sure default tenant exists, especially after a migration"""
         post_migrate.connect(ensure_default_tenant)
         ensure_default_tenant()

--- a/authentik/tenants/models.py
+++ b/authentik/tenants/models.py
@@ -136,7 +136,7 @@ def tenant_needs_sync(sender, tenant, **kwargs):
     with tenant:
         for app in apps.get_app_configs():
             if isinstance(app, ManagedAppConfig):
-                app._reconcile(ManagedAppConfig.RECONCILE_TENANT_PREFIX)
+                app._reconcile(ManagedAppConfig.RECONCILE_TENANT_CATEGORY)
 
     tenant.ready = True
     tenant.save()


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

closes #7852
---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
