### PR TITLE
web: fix save & reset behavior on System ➲ Settings page.

### DIFF
--- a/web/src/admin/admin-settings/AdminSettingsForm.ts
+++ b/web/src/admin/admin-settings/AdminSettingsForm.ts
@@ -10,6 +10,7 @@ import "@goauthentik/elements/forms/HorizontalFormElement";
 import "@goauthentik/elements/forms/Radio";
 import "@goauthentik/elements/forms/SearchSelect";
 import "@goauthentik/elements/utils/TimeDeltaHelp";
+import { CustomEmitterElement } from "@goauthentik/elements/utils/eventEmitter";
 
 import { msg } from "@lit/localize";
 import { CSSResult, TemplateResult, html } from "lit";
@@ -21,13 +22,26 @@ import PFList from "@patternfly/patternfly/components/List/list.css";
 import { AdminApi, Settings, SettingsRequest } from "@goauthentik/api";
 
 @customElement("ak-admin-settings-form")
-export class AdminSettingsForm extends Form<SettingsRequest> {
-    @property({ attribute: false })
+export class AdminSettingsForm extends CustomEmitterElement(Form<SettingsRequest>) {
+    //
+    // Custom property accessors in Lit 2 require a manual call to requestUpdate(). See:
+    // https://lit.dev/docs/v2/components/properties/#accessors-custom
+    //
     set settings(value: Settings) {
         this._settings = value;
+        this.requestUpdate();
+    }
+
+    @property({ type: Object })
+    get settings() {
+        return this._settings;
     }
 
     private _settings?: Settings;
+
+    static get styles(): CSSResult[] {
+        return super.styles.concat(PFList);
+    }
 
     getSuccessMessage(): string {
         return msg("Successfully updated settings.");
@@ -37,10 +51,7 @@ export class AdminSettingsForm extends Form<SettingsRequest> {
         return new AdminApi(DEFAULT_CONFIG).adminSettingsUpdate({
             settingsRequest: data,
         });
-    }
-
-    static get styles(): CSSResult[] {
-        return super.styles.concat(PFList);
+        this.dispatchCustomEvent("ak-admin-setting-changed");
     }
 
     renderForm(): TemplateResult {

--- a/web/src/admin/admin-settings/AdminSettingsForm.ts
+++ b/web/src/admin/admin-settings/AdminSettingsForm.ts
@@ -10,7 +10,6 @@ import "@goauthentik/elements/forms/HorizontalFormElement";
 import "@goauthentik/elements/forms/Radio";
 import "@goauthentik/elements/forms/SearchSelect";
 import "@goauthentik/elements/utils/TimeDeltaHelp";
-import { CustomEmitterElement } from "@goauthentik/elements/utils/eventEmitter";
 
 import { msg } from "@lit/localize";
 import { CSSResult, TemplateResult, html } from "lit";
@@ -22,12 +21,12 @@ import PFList from "@patternfly/patternfly/components/List/list.css";
 import { AdminApi, Settings, SettingsRequest } from "@goauthentik/api";
 
 @customElement("ak-admin-settings-form")
-export class AdminSettingsForm extends CustomEmitterElement(Form<SettingsRequest>) {
+export class AdminSettingsForm extends Form<SettingsRequest> {
     //
     // Custom property accessors in Lit 2 require a manual call to requestUpdate(). See:
     // https://lit.dev/docs/v2/components/properties/#accessors-custom
     //
-    set settings(value: Settings) {
+    set settings(value: Settings | undefined) {
         this._settings = value;
         this.requestUpdate();
     }
@@ -48,10 +47,11 @@ export class AdminSettingsForm extends CustomEmitterElement(Form<SettingsRequest
     }
 
     async send(data: SettingsRequest): Promise<Settings> {
-        return new AdminApi(DEFAULT_CONFIG).adminSettingsUpdate({
+        const result = await new AdminApi(DEFAULT_CONFIG).adminSettingsUpdate({
             settingsRequest: data,
         });
-        this.dispatchCustomEvent("ak-admin-setting-changed");
+        this.dispatchEvent(new CustomEvent("ak-admin-setting-changed"));
+        return result;
     }
 
     renderForm(): TemplateResult {

--- a/web/src/admin/admin-settings/AdminSettingsPage.ts
+++ b/web/src/admin/admin-settings/AdminSettingsPage.ts
@@ -14,7 +14,7 @@ import "@goauthentik/elements/buttons/SpinnerButton";
 import "@goauthentik/elements/forms/ModalForm";
 
 import { msg } from "@lit/localize";
-import { CSSResult, TemplateResult, html, nothing } from "lit";
+import { html, nothing } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
 
 import PFBanner from "@patternfly/patternfly/components/Banner/banner.css";
@@ -32,7 +32,7 @@ import { AdminApi, Settings } from "@goauthentik/api";
 
 @customElement("ak-admin-settings")
 export class AdminSettingsPage extends AKElement {
-    static get styles(): CSSResult[] {
+    static get styles() {
         return [
             PFBase,
             PFButton,
@@ -83,7 +83,7 @@ export class AdminSettingsPage extends AKElement {
         this.form?.resetForm();
     }
 
-    render(): TemplateResult {
+    render() {
         if (!this.settings) {
             return nothing;
         }


### PR DESCRIPTION
# Details

This page is different from our other pages in that the form is always visible and present and not removed from the DOM at any time during its interaction.  Part of the problem was a misapplication of the Lit event cycle, but part of it was just Lit being excessively aggressive with the relationship between values and what is displayed.

Primer: An HTML INPUT tag of any kind is either controlled or uncontrolled. An "uncontrolled" INPUT is managed by the browser; a "controlled" tag is managed by the framework, and changes to some state value in the current view dictates both what is shown and when to re-render. For a controlled text input, for example, every change to the input is captured, stored in the state variable, and the input re-rendered to reflect what the state variable says.

The confusion here is simple. Our form is usually uncontrolled. When you changed a toggle, the state variable (`this.settings`) *did not change*, so when you hit `[Reset]` Lit saw no reason to re-render the form; the control state hadn't changed at all! A reset form showed the wrong value(s). A call to forcibly `resetForm()` was needed.

The other bug, the problem with `[Save]`, was just a race condition. The value was sent to the back-end, then read back, `this.settings` updated, and the form re-rendered. The gap between the re-read and the render created a race condition, and the render usually won, reflecting the *earlier* value. This problem was exacerbated by the implementation of `this.setting`'s getter/setter pair following Lit 3's pattern, when we're currently using Lit 2.

Eventing the "update needed," putting an `await()` on the event handler after a save, and implementing the getter/setters correctly, created a better sequences of events:

1. The Form submits and sends a notification that the settings were changed.
2. When the Page receives a notification that the settings have changed, it retrieves the newly-stored settings and stores them locally.
3. When the local settings change, Lit schedules a re-render of the Page.
4. When the Page is re-rendered, the new settings are passed to the Form.
5. When the Form receives new settings, it re-renders the displayed HTML form.

You'll note that these are five *separate*, *independent* events. This isn't a sequence. Each of these is a mini-routine that does its job and quits. (2 is most explicit about this: "... a notification...", not "...the notification...")

Cleanups, comments, etc, added as needed.



## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [X] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
