### PR TITLE
web: change "delete" verb to "remove" for one-to-many relationships

### DIFF
--- a/web/src/admin/groups/RelatedGroupList.ts
+++ b/web/src/admin/groups/RelatedGroupList.ts
@@ -125,6 +125,7 @@ export class RelatedGroupList extends Table<Group> {
             actionSubtext=${msg(
                 str`Are you sure you want to remove user ${this.targetUser?.username} from the following groups?`,
             )}
+            buttonLabel=${msg("Remove")}
             .objects=${this.selectedElements}
             .delete=${(item: Group) => {
                 if (!this.targetUser) return;

--- a/web/src/elements/forms/DeleteBulkForm.ts
+++ b/web/src/elements/forms/DeleteBulkForm.ts
@@ -131,6 +131,9 @@ export class DeleteBulkForm<T> extends ModalButton {
     @property()
     actionSubtext?: string;
 
+    @property()
+    buttonLabel = msg("Delete");
+
     @property({ attribute: false })
     metadata: (item: T) => BulkDeleteMetadata = (item: T) => {
         const rec = item as Record<string, unknown>;
@@ -222,7 +225,7 @@ export class DeleteBulkForm<T> extends ModalButton {
                     }}
                     class="pf-m-danger"
                 >
-                    ${msg("Delete")} </ak-spinner-button
+                    ${this.buttonLabel} </ak-spinner-button
                 >&nbsp;
                 <ak-spinner-button
                     .callAction=${async () => {


### PR DESCRIPTION
Two changes here

- make a new property on the BulkDeleteForm view so an external user can set the button label dynamically, with the original "Delete" as default.
- Add the property to the RelatedGroupsList view, with the word "Remove," as requested by Tana.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [X] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
