### PR TITLE
website/docs: edited Docs about tenants

### DIFF
--- a/website/docs/advanced/tenancy.md
+++ b/website/docs/advanced/tenancy.md
@@ -18,21 +18,23 @@ This feature is available from 2024.2 and is not to be confused with [brands](..
 
 Starting with version 2024.2, authentik allows an administrator or operator to create multiple tenants. This means that an operator can manage several different and distinct authentik installations, each with it's own Install ID and license(s). The relationships between tenant and installation (Install ID) is a 1:1 relationship, so for each tenant, there is a unique Install ID.
 
+::::danger
+Expression policies currently have access to all tenants.
+::::
+
 The data for each tenant is stored in a separate PostgreSQL schema, providing full separation of user data. License data for the tenant is also stored in the schema.
 
 Note that creating and managing multiple tenants is handled using authentik APIs, not in the Admin interface. For typical authentik installations in which only a single tenant is needed, the default tenant is automatically created by authentik, and does not need to be managed in the Admin interface.
 
 ### Licensing
 
-For each additional tenant (beyond the default one), one or more licenses is required; a license key cannot be used for more than one tenant.
+For each additional tenant (beyond the default one), one or more licenses is required; a license key cannot be used for more than one tenant. Note that the license for the default tenant must be valid and up-to-date in order to create additional tenants.
 
 A single tenant and its corresponding installation can have multiple license keys. For example, a company might purchase one license for 50 users, and then later in the same year need to buy another license for 50 more users, due to company growth. Both licenses are associated to the one installation, the one tenant.
 
-### Important considerations
+Learn more in our documentation about [Enterprise licenses](../enterprise/manage-enterprise#license-management).
 
-::::warning
-Expression policies currently have access to all tenants.
-::::
+### Important considerations
 
 -   Upon creating another tenant, a new schema will be created by cloning the `template` schema. This special schema is like a tenant with no data created in it. Cloning an existing schema instead of creating a new one and running migrations on it is done for efficiency purposes.
 
@@ -48,7 +50,7 @@ To create one or more additional tenants (beyond the default tenant), use the fo
 
 First, enable with the `AUTHENTIK_TENANTS__ENABLED=true` [configuration setting](../installation/configuration.mdx).
 
-Then set `AUTHENTIK_TENANTS__API_KEY` to a random string, which will be used to authenticate to the tenancy API. This key allows the creation of recovery keys for every tenant hosted by authentik, so be sure to _store it securely_.
+Then set `AUTHENTIK_TENANTS__API_KEY` to a random string, which will be used to authenticate to the tenancy API. This key allows the creation of recovery keys for every tenant hosted by authentik, so be sure to _store it securely_. Be aware that creating a recovery key allows access to all data stored inside a tenant.
 
 You will need to disable the embedded outpost with `AUTHENTIK_OUTPOSTS__DISABLE_EMBEDDED_OUTPOST=true` because it is not supported with tenants.
 

--- a/website/docs/advanced/tenancy.md
+++ b/website/docs/advanced/tenancy.md
@@ -11,28 +11,34 @@ This feature is in alpha. Use at your own risk.
 ::::
 
 ::::info
-This feature is available from 2024.2 and is not to be confused with brands, which used to be called tenants.
+This feature is available from 2024.2 and is not to be confused with [brands](../core/brands.md), which were previously called tenants.
 ::::
 
-## Preparations
+## About tenants
 
-Starting with 2024.2, authentik allows an administrator or operator to create multiple tenants. This means that an operator can manage several authentik installations without having to deploy additional instances.
+Starting with 2024.2, authentik allows an administrator or operator to create multiple tenants. This means that an operator can manage several different and distinct authentik installations, each with it's own Install ID and license(s).
 
-Note that creating and managing tenants is handled using authentik APIs, not in the Admin interface.
+The data for each tenant is stored in a separate PostgreSQL schema, providing full separation of user data. License data for the tenant is also stored in the schema.
 
-authentik manages tenants by storing data for each tenant in a separate PostgreSQL schema.
+Note that creating and managing multiple tenants is handled using authentik APIs, not in the Admin interface. For typical authentik installations in which only a single tenant is needed, the default tenant is deployed and used, and does not need to be managed in the Admin interface.
 
-This feature needs to be enabled with the `AUTHENTIK_TENANTS__ENABLED=true`. You also need to set `AUTHENTIK_TENANTS__API_KEY` to a random string, which will be used to authenticate to the tenancy API. This key will allow the creation of recovery keys for every tenant hosted by authentik, store it securely. You will also need to disable the embedded outpost with `AUTHENTIK_OUTPOSTS__DISABLE_EMBEDDED_OUTPOST=true` as it is not supported with tenants.
+For each additional tenant (beyond the default one), one or more licenses is required; a license key cannot be used for more than one tenant. The relationships between tenant, installation (Install ID), and licesense are 1:1, so for each tenant, there is a unique Install ID, and a unique license key (or set of keys).
 
 ## Usage
 
-Tenants can be created using the API routes associated. Search for `tenant` in the [API browser](../../developer-docs/api/) for the available endpoints.
+The multi-tenants feature must be enabled with the `AUTHENTIK_TENANTS__ENABLED=true`.
+
+You also need to set `AUTHENTIK_TENANTS__API_KEY` to a random string, which will be used to authenticate to the tenancy API. This key will allow the creation of recovery keys for every tenant hosted by authentik, store it securely. You will also need to disable the embedded outpost with `AUTHENTIK_OUTPOSTS__DISABLE_EMBEDDED_OUTPOST=true` as it is not supported with tenants.
+
+Tenants are created using the API routes associated. Search for `tenant` in the [API browser](../../developer-docs/api/) for the available endpoints.
 
 When creating a tenant, you must specify a `name`, used for display purposes, and a `schema_name`, used to create the PostgreSQL schema associated with the tenant. That `schema_name` must start with `t_` and not be more than 64 characters long.
 
 There is always at least one tenant, `public`. This is the default tenant and cannot be deleted. Despite its name, it is not freely available to the world. Instead, it is stored in the `public` schema of the PostgreSQL database.
 
-By default, all requests that do not explicitly belong to a tenant are redirected to the default tenant. Thus, after creating a tenant, you must associate a domain for which incoming requests will be redirected to said tenant. You can do so with API endpoints. After creating a domain `example.org` that is associated to the tenant `t_example`, all requests made to `example.org` will use the `t_example` tenant. However, requests made to `authentik.tld`, `subdomain.example.org` and all other domains will use the default tenant.
+By default, all requests that do not explicitly belong to a tenant are redirected to the default tenant. Thus, after creating a tenant, you must associate a domain for which incoming requests will be redirected to said tenant. You can do so with API endpoints. After creating a domain `example.org` that is associated to the tenant `t_example`, all requests made to `example.org` will use the `t_example` tenant. However, requests made to `authentik.tld`, `subdomain.example.org` and any other domain that is not associated with the `t_example` tenant will use the default tenant.
+
+In summary, if you access a domain that is not explicitly associated with a specific tenant, it will be routed to the default tenant.
 
 ::::warning
 Expression policies currently have access to all tenants.

--- a/website/docs/advanced/tenancy.md
+++ b/website/docs/advanced/tenancy.md
@@ -56,7 +56,7 @@ You will need to disable the embedded outpost with `AUTHENTIK_OUTPOSTS__DISABLE_
 
 Tenants are created using the API routes associated. Search for `tenant` in the [API browser](../../developer-docs/api/) for the available endpoints.
 
-When creating a tenant, you must specify a `name`, used for display purposes, and a `schema_name`, used to create the PostgreSQL schema associated with the tenant.
+When creating a tenant you must specify a `name`, used for display purposes, and a `schema_name`, used to create the PostgreSQL schema associated with the tenant.
 
 :::info
 The `schema_name` must start with `t_` and not be more than 64 characters long.

--- a/website/docs/advanced/tenancy.md
+++ b/website/docs/advanced/tenancy.md
@@ -42,7 +42,7 @@ Learn more in our documentation about [Enterprise licenses](../enterprise/manage
 
 -   Files are isolated on a per-tenant basis, with each tenant folder named according to the schema_name. For example, `/media/t_example`. The same is true regardless of the storage backend.
 
--   Using an [embedded outpost](../outposts/embedded/embedded.mdx) with multi-tenancy is not currently suppported. Disable the embedded outpost with `AUTHENTIK_OUTPOSTS__DISABLE_EMBEDDED_OUTPOST=true` configuration setting.
+-   Using an [embedded outpost](../outposts/embedded/embedded.mdx) with multi-tenancy is not currently supported. Disable the embedded outpost with `AUTHENTIK_OUTPOSTS__DISABLE_EMBEDDED_OUTPOST=true` configuration setting.
 
 ## Usage
 

--- a/website/docs/advanced/tenancy.md
+++ b/website/docs/advanced/tenancy.md
@@ -16,19 +16,25 @@ This feature is available from 2024.2 and is not to be confused with [brands](..
 
 ## About tenants
 
-Starting with 2024.2, authentik allows an administrator or operator to create multiple tenants. This means that an operator can manage several different and distinct authentik installations, each with it's own Install ID and license(s).
+Starting with version 2024.2, authentik allows an administrator or operator to create multiple tenants. This means that an operator can manage several different and distinct authentik installations, each with it's own Install ID and license(s).
 
 The data for each tenant is stored in a separate PostgreSQL schema, providing full separation of user data. License data for the tenant is also stored in the schema.
 
 Note that creating and managing multiple tenants is handled using authentik APIs, not in the Admin interface. For typical authentik installations in which only a single tenant is needed, the default tenant is deployed and used, and does not need to be managed in the Admin interface.
 
-For each additional tenant (beyond the default one), one or more licenses is required; a license key cannot be used for more than one tenant. The relationships between tenant, installation (Install ID), and licesense are 1:1, so for each tenant, there is a unique Install ID, and a unique license key (or set of keys).
+For each additional tenant (beyond the default one), one or more licenses is required; a license key cannot be used for more than one tenant. The relationships between tenant and installation (Install ID) is a 1:1 relationship, so for each tenant, there is a unique Install ID.
+
+A single tenant and its installation can have multiple license keys. For example, a company might purchase one license for 50 users, and then later in the same year need to buy another license for 50 more users, due to company growth. Both licenses are associated to the one installation, the one tenant.
 
 ## Usage
 
-The multi-tenants feature must be enabled with the `AUTHENTIK_TENANTS__ENABLED=true`.
+The multi-tenants feature must be enabled with the `AUTHENTIK_TENANTS__ENABLED=true`[configuration setting](../installation/configuration.mdx).
 
-You also need to set `AUTHENTIK_TENANTS__API_KEY` to a random string, which will be used to authenticate to the tenancy API. This key will allow the creation of recovery keys for every tenant hosted by authentik, store it securely. You will also need to disable the embedded outpost with `AUTHENTIK_OUTPOSTS__DISABLE_EMBEDDED_OUTPOST=true` as it is not supported with tenants.
+You also need to set `AUTHENTIK_TENANTS__API_KEY` to a random string, which will be used to authenticate to the tenancy API. This key allows the creation of recovery keys for every tenant hosted by authentik, so be sure to store it securely.
+
+:::info
+You will also need to disable the embedded outpost with `AUTHENTIK_OUTPOSTS__DISABLE_EMBEDDED_OUTPOST=true` because it is not supported with tenants.
+:::
 
 Tenants are created using the API routes associated. Search for `tenant` in the [API browser](../../developer-docs/api/) for the available endpoints.
 

--- a/website/docs/advanced/tenancy.md
+++ b/website/docs/advanced/tenancy.md
@@ -38,9 +38,11 @@ Learn more in our documentation about [Enterprise licenses](../enterprise/manage
 
 -   Upon creating another tenant, a new schema will be created by cloning the `template` schema. This special schema is like a tenant with no data created in it. Cloning an existing schema instead of creating a new one and running migrations on it is done for efficiency purposes.
 
--   Data stored in Redis (cache, tasks, locks) will usually get its keys prefixed by the `schema_name`.
+-   In a typical deployment, all data stored in Redis (such as tasks, locks, and cached objects) will have its keys prefixed by the `schema_name`.
 
--   Files are stored by-tenant, under a `schema_name` directory. For example, `/media/t_example`. The same is true regardless of the storage backend.
+-   Files are isolated on a per-tenant basis, with each tenant folder named according to the schema_name. For example, `/media/t_example`. The same is true regardless of the storage backend.
+
+-   Using an [embedded outpost](../outposts/embedded/embedded.mdx) with multi-tenancy is not currently suppported. Disable the embedded outpost with `AUTHENTIK_OUTPOSTS__DISABLE_EMBEDDED_OUTPOST=true` configuration setting.
 
 ## Usage
 
@@ -48,11 +50,11 @@ To create one or more additional tenants (beyond the default tenant) use the fol
 
 ### 1. Configure authentik to allow multiple tenants
 
-First, enable with the `AUTHENTIK_TENANTS__ENABLED=true` [configuration setting](../installation/configuration.mdx).
+First, enable the multi-tenancy feature with the `AUTHENTIK_TENANTS__ENABLED=true` [configuration setting](../installation/configuration.mdx).
 
-Then set `AUTHENTIK_TENANTS__API_KEY` to a random string, which will be used to authenticate to the tenancy API. This key allows the creation of recovery keys for every tenant hosted by authentik, so be sure to _store it securely_. Be aware that creating a recovery key allows access to all data stored inside a tenant.
+Next, set `AUTHENTIK_TENANTS__API_KEY` to a random string. This string will be used to authenticate to the tenancy API. This key allows the creation of recovery keys for every tenant hosted by authentik, so be sure to _store it securely_. Be aware that creating a recovery key allows access to all data stored inside a tenant.
 
-You will need to disable the embedded outpost with `AUTHENTIK_OUTPOSTS__DISABLE_EMBEDDED_OUTPOST=true` because it is not supported with tenants.
+Be sure to disable the embedded outpost with `AUTHENTIK_OUTPOSTS__DISABLE_EMBEDDED_OUTPOST=true` because it is not supported with tenants.
 
 ### 2. Create a new tenant with authentik API endpoints
 

--- a/website/docs/advanced/tenancy.md
+++ b/website/docs/advanced/tenancy.md
@@ -44,7 +44,7 @@ Learn more in our documentation about [Enterprise licenses](../enterprise/manage
 
 ## Usage
 
-To create one or more additional tenants (beyond the default tenant), use the following instructions.
+To create one or more additional tenants (beyond the default tenant) use the following instructions.
 
 ### 1. Configure authentik to allow multiple tenants
 

--- a/website/docs/advanced/tenancy.md
+++ b/website/docs/advanced/tenancy.md
@@ -18,23 +18,43 @@ This feature is available from 2024.2 and is not to be confused with [brands](..
 
 Starting with version 2024.2, authentik allows an administrator or operator to create multiple tenants. This means that an operator can manage several different and distinct authentik installations, each with it's own Install ID and license(s).
 
+The relationships between tenant and installation (Install ID) is a 1:1 relationship, so for each tenant, there is a unique Install ID.
+
 The data for each tenant is stored in a separate PostgreSQL schema, providing full separation of user data. License data for the tenant is also stored in the schema.
 
-Note that creating and managing multiple tenants is handled using authentik APIs, not in the Admin interface. For typical authentik installations in which only a single tenant is needed, the default tenant is deployed and used, and does not need to be managed in the Admin interface.
+Note that creating and managing multiple tenants is handled using authentik APIs, not in the Admin interface. For typical authentik installations in which only a single tenant is needed, the default tenant is automatically deployed by authentik, and does not need to be managed in the Admin interface.
 
-For each additional tenant (beyond the default one), one or more licenses is required; a license key cannot be used for more than one tenant. The relationships between tenant and installation (Install ID) is a 1:1 relationship, so for each tenant, there is a unique Install ID.
+### Licensing
 
-A single tenant and its installation can have multiple license keys. For example, a company might purchase one license for 50 users, and then later in the same year need to buy another license for 50 more users, due to company growth. Both licenses are associated to the one installation, the one tenant.
+For each additional tenant (beyond the default one), one or more licenses is required; a license key cannot be used for more than one tenant.
+
+A single tenant and its corresponding installation can have multiple license keys. For example, a company might purchase one license for 50 users, and then later in the same year need to buy another license for 50 more users, due to company growth. Both licenses are associated to the one installation, the one tenant.
+
+### Important considerations
+
+::::warning
+Expression policies currently have access to all tenants.
+::::
+
+*   Upon creating another tenant, a new schema will be created by cloning the `template` schema. This special schema is like a tenant with no data created in it. Cloning an existing schema instead of creating a new one and running migrations on it is done for efficiency purposes.
+
+*   Data stored in Redis (cache, tasks, locks) will usually get its keys prefixed by the `schema_name`.
+
+*   Files are stored by-tenant, under a `schema_name` directory. For example, `/media/t_example`. The same is true regardless of the storage backend.
 
 ## Usage
 
-The multi-tenants feature must be enabled with the `AUTHENTIK_TENANTS__ENABLED=true`[configuration setting](../installation/configuration.mdx).
+To create one or more additional tenants (beyond the default tenant), follow these steps:
 
-You also need to set `AUTHENTIK_TENANTS__API_KEY` to a random string, which will be used to authenticate to the tenancy API. This key allows the creation of recovery keys for every tenant hosted by authentik, so be sure to store it securely.
+### Configure authentik to allow multiple tenants
 
-:::info
-You will also need to disable the embedded outpost with `AUTHENTIK_OUTPOSTS__DISABLE_EMBEDDED_OUTPOST=true` because it is not supported with tenants.
-:::
+Step 1. Enable with the `AUTHENTIK_TENANTS__ENABLED=true` [configuration setting](../installation/configuration.mdx).
+
+Step 2. Set `AUTHENTIK_TENANTS__API_KEY` to a random string, which will be used to authenticate to the tenancy API. This key allows the creation of recovery keys for every tenant hosted by authentik, so be sure to _store it securely_.
+
+Step 4. Disable the embedded outpost with `AUTHENTIK_OUTPOSTS__DISABLE_EMBEDDED_OUTPOST=true` because it is not supported with tenants.
+
+### Create a new tenant with authentik API endpoints
 
 Tenants are created using the API routes associated. Search for `tenant` in the [API browser](../../developer-docs/api/) for the available endpoints.
 
@@ -42,18 +62,10 @@ When creating a tenant, you must specify a `name`, used for display purposes, an
 
 There is always at least one tenant, `public`. This is the default tenant and cannot be deleted. Despite its name, it is not freely available to the world. Instead, it is stored in the `public` schema of the PostgreSQL database.
 
-By default, all requests that do not explicitly belong to a tenant are redirected to the default tenant. Thus, after creating a tenant, you must associate a domain for which incoming requests will be redirected to said tenant. You can do so with API endpoints. After creating a domain `example.org` that is associated to the tenant `t_example`, all requests made to `example.org` will use the `t_example` tenant. However, requests made to `authentik.tld`, `subdomain.example.org` and any other domain that is not associated with the `t_example` tenant will use the default tenant.
+### Associate the new tenant with a domain
+
+By default, all requests that do not explicitly belong to a tenant are redirected to the default tenant. Thus, after creating a tenant, you must associate a domain for which incoming requests will be redirected to said tenant.
+
+You can do so with API endpoints. After creating a domain `example.org` that is associated to the tenant `t_example`, all requests made to `example.org` will use the `t_example` tenant. However, requests made to `authentik.tld`, `subdomain.example.org` and any other domain that is not associated with the `t_example` tenant will use the default tenant.
 
 In summary, if you access a domain that is not explicitly associated with a specific tenant, it will be routed to the default tenant.
-
-::::warning
-Expression policies currently have access to all tenants.
-::::
-
-## Notes
-
-Upon creating another tenant, a new schema will be created by cloning the `template` schema. This special schema is like a tenant with no data created in it. Cloning an existing schema instead of creating a new one and running migrations on it is done for efficiency purposes.
-
-Data stored in Redis (cache, tasks, locks) will usually get its keys prefixed by the `schema_name`.
-
-Files are stored by-tenant, under a `schema_name` directory. For example, `/media/t_example`. The same is true regardless of the storage backend.

--- a/website/docs/advanced/tenancy.md
+++ b/website/docs/advanced/tenancy.md
@@ -16,9 +16,7 @@ This feature is available from 2024.2 and is not to be confused with [brands](..
 
 ## About tenants
 
-Starting with version 2024.2, authentik allows an administrator or operator to create multiple tenants. This means that an operator can manage several different and distinct authentik installations, each with it's own Install ID and license(s).
-
-The relationships between tenant and installation (Install ID) is a 1:1 relationship, so for each tenant, there is a unique Install ID.
+Starting with version 2024.2, authentik allows an administrator or operator to create multiple tenants. This means that an operator can manage several different and distinct authentik installations, each with it's own Install ID and license(s). The relationships between tenant and installation (Install ID) is a 1:1 relationship, so for each tenant, there is a unique Install ID.
 
 The data for each tenant is stored in a separate PostgreSQL schema, providing full separation of user data. License data for the tenant is also stored in the schema.
 
@@ -36,33 +34,37 @@ A single tenant and its corresponding installation can have multiple license key
 Expression policies currently have access to all tenants.
 ::::
 
-*   Upon creating another tenant, a new schema will be created by cloning the `template` schema. This special schema is like a tenant with no data created in it. Cloning an existing schema instead of creating a new one and running migrations on it is done for efficiency purposes.
+-   Upon creating another tenant, a new schema will be created by cloning the `template` schema. This special schema is like a tenant with no data created in it. Cloning an existing schema instead of creating a new one and running migrations on it is done for efficiency purposes.
 
-*   Data stored in Redis (cache, tasks, locks) will usually get its keys prefixed by the `schema_name`.
+-   Data stored in Redis (cache, tasks, locks) will usually get its keys prefixed by the `schema_name`.
 
-*   Files are stored by-tenant, under a `schema_name` directory. For example, `/media/t_example`. The same is true regardless of the storage backend.
+-   Files are stored by-tenant, under a `schema_name` directory. For example, `/media/t_example`. The same is true regardless of the storage backend.
 
 ## Usage
 
-To create one or more additional tenants (beyond the default tenant), follow these steps:
+To create one or more additional tenants (beyond the default tenant), use the following instructions.
 
-### Configure authentik to allow multiple tenants
+### 1. Configure authentik to allow multiple tenants
 
-Step 1. Enable with the `AUTHENTIK_TENANTS__ENABLED=true` [configuration setting](../installation/configuration.mdx).
+First, enable with the `AUTHENTIK_TENANTS__ENABLED=true` [configuration setting](../installation/configuration.mdx).
 
-Step 2. Set `AUTHENTIK_TENANTS__API_KEY` to a random string, which will be used to authenticate to the tenancy API. This key allows the creation of recovery keys for every tenant hosted by authentik, so be sure to _store it securely_.
+Then set `AUTHENTIK_TENANTS__API_KEY` to a random string, which will be used to authenticate to the tenancy API. This key allows the creation of recovery keys for every tenant hosted by authentik, so be sure to _store it securely_.
 
-Step 4. Disable the embedded outpost with `AUTHENTIK_OUTPOSTS__DISABLE_EMBEDDED_OUTPOST=true` because it is not supported with tenants.
+You will need to disable the embedded outpost with `AUTHENTIK_OUTPOSTS__DISABLE_EMBEDDED_OUTPOST=true` because it is not supported with tenants.
 
-### Create a new tenant with authentik API endpoints
+### 2. Create a new tenant with authentik API endpoints
 
 Tenants are created using the API routes associated. Search for `tenant` in the [API browser](../../developer-docs/api/) for the available endpoints.
 
-When creating a tenant, you must specify a `name`, used for display purposes, and a `schema_name`, used to create the PostgreSQL schema associated with the tenant. That `schema_name` must start with `t_` and not be more than 64 characters long.
+When creating a tenant, you must specify a `name`, used for display purposes, and a `schema_name`, used to create the PostgreSQL schema associated with the tenant.
+
+:::info
+The `schema_name` must start with `t_` and not be more than 64 characters long.
+:::
 
 There is always at least one tenant, `public`. This is the default tenant and cannot be deleted. Despite its name, it is not freely available to the world. Instead, it is stored in the `public` schema of the PostgreSQL database.
 
-### Associate the new tenant with a domain
+### 3. Associate the new tenant with a domain
 
 By default, all requests that do not explicitly belong to a tenant are redirected to the default tenant. Thus, after creating a tenant, you must associate a domain for which incoming requests will be redirected to said tenant.
 

--- a/website/docs/advanced/tenancy.md
+++ b/website/docs/advanced/tenancy.md
@@ -20,7 +20,7 @@ Starting with version 2024.2, authentik allows an administrator or operator to c
 
 The data for each tenant is stored in a separate PostgreSQL schema, providing full separation of user data. License data for the tenant is also stored in the schema.
 
-Note that creating and managing multiple tenants is handled using authentik APIs, not in the Admin interface. For typical authentik installations in which only a single tenant is needed, the default tenant is automatically deployed by authentik, and does not need to be managed in the Admin interface.
+Note that creating and managing multiple tenants is handled using authentik APIs, not in the Admin interface. For typical authentik installations in which only a single tenant is needed, the default tenant is automatically created by authentik, and does not need to be managed in the Admin interface.
 
 ### Licensing
 


### PR DESCRIPTION
Added a bit more info about tenants, and separated the Usage section into the three main parts, wrote to be more procedural style.

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
