### PR TITLE
website/docs: remove tenants docs from sidebar for now

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -423,17 +423,6 @@ const docsSidebar = {
                 "security/CVE-2022-46172",
             ],
         },
-        {
-            type: "category",
-            label: "Advanced topics",
-            link: {
-                type: "generated-index",
-                title: "Advanced topics",
-                slug: "advanced",
-                description: "Documentation for advanced features",
-            },
-            items: ["advanced/tenancy"],
-        },
     ],
 };
 


### PR DESCRIPTION
We agreed to remove the docs about Tenants form sidebar.js, for now.

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
