### PR TITLE
website/docs: remove outdated info

### DIFF
--- a/website/docs/outposts/embedded/embedded.mdx
+++ b/website/docs/outposts/embedded/embedded.mdx
@@ -8,7 +8,7 @@ The embedded outpost runs in the main `server` container, and is managed by auth
 
 You can access the embedded outpost on the same ports as authentik itself, 9000 and 9443.
 
-The embedded outpost cannot be disabled, if it doesn't make sense to use it in your deployment you can simply ignore it.
+The embedded outpost is not required unless you are using the Proxy provider; if it doesn't make sense to use it in your deployment you can simply ignore it.
 
 ### Configuration
 

--- a/website/docs/outposts/embedded/embedded.mdx
+++ b/website/docs/outposts/embedded/embedded.mdx
@@ -8,7 +8,7 @@ The embedded outpost runs in the main `server` container, and is managed by auth
 
 You can access the embedded outpost on the same ports as authentik itself, 9000 and 9443.
 
-The embedded outpost is not required unless you are using the Proxy provider; if it doesn't make sense to use it in your deployment you can simply ignore it.
+If the embedded outpost doesn't make sense for your deployment, you can simply ignore it.
 
 ### Configuration
 


### PR DESCRIPTION
Removed a sentence stating "The embedded outpost cannot be disabled" since apparently it can be disabled, per our new Tenant docs.

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
