### PR TITLE
website/docs: added a new template for "combo" topics

### DIFF
--- a/website/developer-docs/docs/templates/combo.md
+++ b/website/developer-docs/docs/templates/combo.md
@@ -1,0 +1,51 @@
+---
+title: "Combination topic"
+---
+
+:::info
+**How to use this template**: start with the markdown version of the template, either by copying the [`combo.tmpl.md`](https://github.com/goauthentik/authentik/tree/main/website/developer-docs/docs/templates) file from our GitHub repo or downloading the template file using the following command:
+
+```
+wget https://raw.githubusercontent.com/goauthentik/authentik/main/website/developer-docs/docs/templates/combo.tmpl.md
+```
+
+Edit your markdown file as you work, reading this page for the descriptions of each section. You can build out a "stub file" with just headers, then gradually add content to each section. Use screenshots sparingly, only for complex UIs where it is difficult to describe a UI element with words. Refer to our [General Guidelines](../writing-documentation#general-guidelines) for writing tips and authentik-specific rules.
+:::
+
+For a combo topic, the title is typically the name of the feature ("Branding" or "Remote Access Control").
+
+In this first section, right after the title but with no header, write one or two sentences about the task. Keep it brief, just an overview.
+
+## About <feature XYZ>
+
+In this section, go into a deeper explanation of the feature, provide typical use cases, etc.
+
+## Prerequisites (optional section)
+
+In this section, inform the reader of anything they need to do, or have configured or installed, before they start following the procedural instructions below.
+
+## Overview of steps/workflow (optional section)
+
+If the task is quite long or complex, it might be good to add a bullet list of the main steps, or even a diagram of the workflow, just so that the reader can first familairize themselves with the 50,000 meter view before they dive into the detailed steps.
+
+## First several group steps
+
+If the task involves a lot of steps, try to group them into similar steps and have a Head3 or Head4 title for each group.
+
+In this section, help the reader get oriented... where do they need to be (i.e. in the GUI, on a CLI, etc).
+
+Have a separate paragraph for each step.
+
+*Start instructions with the desired goal*, followed by the instructions. For example, in this sentence: "To define a new port number, navigate to the Admin interface, and then to the **Settings** tab." we first read the goal (to define a new port) and then we see the instructions.
+
+## Next step of grouped steps (if a second group is needed)
+
+Continue with the steps...
+
+Use screenshots sparingly, only for complex UIs where it is difficult to describe a UI element with words.
+
+Provide as many code snippets and examples as needed.
+
+## Verify the steps
+
+Use a heading such as "Verify your installation" or "Verify successful configuration". Whenever possible, it is useful to add verification steps at the end of a procedural topic. For example, if the procedural was about installing a product, use this section to tell them how they can verify that the install was successful.

--- a/website/developer-docs/docs/templates/combo.md
+++ b/website/developer-docs/docs/templates/combo.md
@@ -20,6 +20,10 @@ In this first section, right after the title but with no header, write one or tw
 
 In this section, go into a deeper explanation of the feature, provide typical use cases, etc.
 
+### More info about the feature, a sub-category of info
+
+Use this section if there are several big topics or categories of info that the reader needs to know about the feature or task. Add as many of these sections as needed.
+
 ## Prerequisites (optional section)
 
 In this section, inform the reader of anything they need to do, or have configured or installed, before they start following the procedural instructions below.

--- a/website/developer-docs/docs/templates/combo.md
+++ b/website/developer-docs/docs/templates/combo.md
@@ -16,7 +16,7 @@ For a combo topic, the title is typically the name of the feature ("Branding" or
 
 In this first section, right after the title but with no header, write one or two sentences about the task. Keep it brief, just an overview.
 
-## About <feature XYZ>
+## About feature XYZ
 
 In this section, go into a deeper explanation of the feature, provide typical use cases, etc.
 
@@ -36,7 +36,7 @@ In this section, help the reader get oriented... where do they need to be (i.e. 
 
 Have a separate paragraph for each step.
 
-*Start instructions with the desired goal*, followed by the instructions. For example, in this sentence: "To define a new port number, navigate to the Admin interface, and then to the **Settings** tab." we first read the goal (to define a new port) and then we see the instructions.
+_Start instructions with the desired goal_, followed by the instructions. For example, in this sentence: "To define a new port number, navigate to the Admin interface, and then to the **Settings** tab." we first read the goal (to define a new port) and then we see the instructions.
 
 ## Next step of grouped steps (if a second group is needed)
 

--- a/website/developer-docs/docs/templates/combo.tmpl.md
+++ b/website/developer-docs/docs/templates/combo.tmpl.md
@@ -1,0 +1,39 @@
+---
+title: "Markdown template: combo"
+---
+
+add brief description of the feature/functionality
+
+## About <feature XYZ>
+
+In this section, go into a deeper explanation of the feature, provide typical use cases, etc.
+
+:::info
+if needed, use this syntax to add a note (info) or warning (warning).
+:::
+
+## Prerequisites
+
+bullet list of pre-reqs
+
+## Overview of steps/workflow (Optional, only if there are a lot of steps)
+
+describe the 50,000 meter view before they dive into the detailed steps, using a bullet list of the main steps, or even a diagram of the workflow.
+
+## first several group steps
+
+1. first step
+
+2. second step
+
+3. third step
+
+if you need a tabbed section to represent diff processes or code snippets for diff install environments, use an MDX tabbed component.
+
+## next step of grouped steps, if needed
+
+Continue with the steps...
+
+## verify the steps
+
+add verification steps

--- a/website/developer-docs/docs/templates/combo.tmpl.md
+++ b/website/developer-docs/docs/templates/combo.tmpl.md
@@ -4,7 +4,7 @@ title: "Markdown template: combo"
 
 add brief description of the feature/functionality
 
-## About <feature XYZ>
+## About feature XYZ
 
 In this section, go into a deeper explanation of the feature, provide typical use cases, etc.
 

--- a/website/developer-docs/docs/templates/combo.tmpl.md
+++ b/website/developer-docs/docs/templates/combo.tmpl.md
@@ -12,6 +12,10 @@ In this section, go into a deeper explanation of the feature, provide typical us
 if needed, use this syntax to add a note (info) or warning (warning).
 :::
 
+### More info about the feature, a sub-category of info
+
+Use this section if there are several big topics or categories of info that the reader needs to know about the feature or task. Add as many of these sections as needed.
+
 ## Prerequisites
 
 bullet list of pre-reqs

--- a/website/developer-docs/docs/templates/index.md
+++ b/website/developer-docs/docs/templates/index.md
@@ -6,7 +6,7 @@ In technical documentation, there are document "types" (similar to how there are
 
 The most common types are:
 
--   [**Combo**](): For most topics (unless they are very large and complex), we can combine the procedural and conceptual information into a single document. A handy guideline to follow is: "If the actual 1., 2., 3. steps are buried at the bottom, and a reader has to scroll multiple times to find them, then the combo apprach is *not* the right one".
+-   [**Combo**](./combo.md): For most topics (unless they are very large and complex), we can combine the procedural and conceptual information into a single document. A handy guideline to follow is: "If the actual 1., 2., 3. steps are buried at the bottom, and a reader has to scroll multiple times to find them, then the combo apprach is _not_ the right one".
 
 -   [**Procedural**](./procedural.md): these are How To docs, the HOW information, with step-by-step instructions for accomplishing a task. This is what most people are looking for when they open the docs... and best practice is to separate the procedural docs from long, lengthy conceptual or reference docs.
 

--- a/website/developer-docs/docs/templates/index.md
+++ b/website/developer-docs/docs/templates/index.md
@@ -6,6 +6,8 @@ In technical documentation, there are document "types" (similar to how there are
 
 The most common types are:
 
+-   [**Combo**](): For most topics (unless they are very large and complex), we can combine the procedural and conceptual information into a single document. A handy guideline to follow is: "If the actual 1., 2., 3. steps are buried at the bottom, and a reader has to scroll multiple times to find them, then the combo apprach is *not* the right one".
+
 -   [**Procedural**](./procedural.md): these are How To docs, the HOW information, with step-by-step instructions for accomplishing a task. This is what most people are looking for when they open the docs... and best practice is to separate the procedural docs from long, lengthy conceptual or reference docs.
 
 -   [**Conceptual**](./conceptual.md): these docs provide the WHY information, and explain when to use a feature (or when not to!), and general concepts behind the feature or functionality.

--- a/website/developer-docs/docs/templates/index.md
+++ b/website/developer-docs/docs/templates/index.md
@@ -6,7 +6,7 @@ In technical documentation, there are document "types" (similar to how there are
 
 The most common types are:
 
--   [**Combo**](./combo.md): For most topics (unless they are very large and complex), we can combine the procedural and conceptual information into a single document. A handy guideline to follow is: "If the actual 1., 2., 3. steps are buried at the bottom, and a reader has to scroll multiple times to find them, then the combo apprach is _not_ the right one".
+-   [**Combo**](./combo.md): For most topics (unless they are very large and complex), we can combine the procedural and conceptual information into a single document. A handy guideline to follow is: "If the actual 1., 2., 3. steps are buried at the bottom, and a reader has to scroll multiple times to find them, then the combo approach is _not_ the right one".
 
 -   [**Procedural**](./procedural.md): these are How To docs, the HOW information, with step-by-step instructions for accomplishing a task. This is what most people are looking for when they open the docs... and best practice is to separate the procedural docs from long, lengthy conceptual or reference docs.
 


### PR DESCRIPTION
Added a new template for combo topics, which works for the vast majority of our docs. It's a combination of conceptual and procedural information. Only really massive features need to have conceptual and procedual info split into two documents.

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
