### PR TITLE
web: spell customization with a Z

### DIFF
--- a/authentik/blueprints/v1/exporter.py
+++ b/authentik/blueprints/v1/exporter.py
@@ -74,7 +74,7 @@ class Exporter:
 
 
 class FlowExporter(Exporter):
-    """Exporter customised to only return objects related to `flow`"""
+    """Exporter customized to only return objects related to `flow`"""
 
     flow: Flow
     with_policies: bool

--- a/web/src/admin/AdminInterface/AdminSidebar.ts
+++ b/web/src/admin/AdminInterface/AdminSidebar.ts
@@ -122,7 +122,7 @@ export class AkAdminSidebar extends WithCapabilitiesConfig(AKElement) {
                 ["/events/log", msg("Logs"), [`^/events/log/(?<id>${UUID_REGEX})$`]],
                 ["/events/rules", msg("Notification Rules")],
                 ["/events/transports", msg("Notification Transports")]]],
-            [null, msg("Customisation"), null, [
+            [null, msg("Customization"), null, [
                 ["/policy/policies", msg("Policies")],
                 ["/core/property-mappings", msg("Property Mappings")],
                 ["/blueprints/instances", msg("Blueprints")],

--- a/web/xliff/de.xlf
+++ b/web/xliff/de.xlf
@@ -4951,7 +4951,7 @@ Bindings to groups/users are checked against the user of the event.</source>
         <target>Logs</target>
       </trans-unit>
       <trans-unit id="s1823625e6f831d73">
-        <source>Customisation</source>
+        <source>Customization</source>
         <target>Anpassung</target>
       </trans-unit>
       <trans-unit id="sc0829ee663ced008">

--- a/web/xliff/en.xlf
+++ b/web/xliff/en.xlf
@@ -5203,8 +5203,8 @@ Bindings to groups/users are checked against the user of the event.</source>
         <target>Logs</target>
       </trans-unit>
       <trans-unit id="s1823625e6f831d73">
-        <source>Customisation</source>
-        <target>Customisation</target>
+        <source>Customization</source>
+        <target>Customization</target>
       </trans-unit>
       <trans-unit id="sc0829ee663ced008">
         <source>Directory</source>

--- a/web/xliff/es.xlf
+++ b/web/xliff/es.xlf
@@ -4876,7 +4876,7 @@ Bindings to groups/users are checked against the user of the event.</source>
         <target>troncos</target>
       </trans-unit>
       <trans-unit id="s1823625e6f831d73">
-        <source>Customisation</source>
+        <source>Customization</source>
         <target>Personalización</target>
       </trans-unit>
       <trans-unit id="sc0829ee663ced008">

--- a/web/xliff/fr.xlf
+++ b/web/xliff/fr.xlf
@@ -6502,7 +6502,7 @@ Les liaisons avec les groupes/utilisateurs sont vérifiées par rapport à l'uti
         
       </trans-unit>
       <trans-unit id="s1823625e6f831d73">
-        <source>Customisation</source>
+        <source>Customization</source>
         <target>Personalisation</target>
         
       </trans-unit>

--- a/web/xliff/ko.xlf
+++ b/web/xliff/ko.xlf
@@ -6472,7 +6472,7 @@ Bindings to groups/users are checked against the user of the event.</source>
 
       </trans-unit>
       <trans-unit id="s1823625e6f831d73">
-        <source>Customisation</source>
+        <source>Customization</source>
         <target>사용자 정의</target>
 
       </trans-unit>

--- a/web/xliff/nl.xlf
+++ b/web/xliff/nl.xlf
@@ -6457,7 +6457,7 @@ Bindingen naar groepen/gebruikers worden gecontroleerd tegen de gebruiker van de
 
       </trans-unit>
       <trans-unit id="s1823625e6f831d73">
-        <source>Customisation</source>
+        <source>Customization</source>
         <target>Aanpassing</target>
 
       </trans-unit>

--- a/web/xliff/pl.xlf
+++ b/web/xliff/pl.xlf
@@ -5064,7 +5064,7 @@ Bindings to groups/users are checked against the user of the event.</source>
         <target>Logi</target>
       </trans-unit>
       <trans-unit id="s1823625e6f831d73">
-        <source>Customisation</source>
+        <source>Customization</source>
         <target>Dostosowywanie</target>
       </trans-unit>
       <trans-unit id="sc0829ee663ced008">

--- a/web/xliff/pseudo-LOCALE.xlf
+++ b/web/xliff/pseudo-LOCALE.xlf
@@ -6460,7 +6460,7 @@ Bindings to groups/users are checked against the user of the event.</source>
 
       </trans-unit>
       <trans-unit id="s1823625e6f831d73">
-        <source>Customisation</source>
+        <source>Customization</source>
   <target>Ćũśţōmĩśàţĩōń</target>
 
       </trans-unit>

--- a/web/xliff/tr.xlf
+++ b/web/xliff/tr.xlf
@@ -4869,7 +4869,7 @@ Bindings to groups/users are checked against the user of the event.</source>
         <target>Günlükler</target>
       </trans-unit>
       <trans-unit id="s1823625e6f831d73">
-        <source>Customisation</source>
+        <source>Customization</source>
         <target>Özelleştirme</target>
       </trans-unit>
       <trans-unit id="sc0829ee663ced008">

--- a/web/xliff/zh-CN.xlf
+++ b/web/xliff/zh-CN.xlf
@@ -2975,7 +2975,7 @@ doesn't pass when either or both of the selected options are equal or above the 
   <source>Notification Transports</source>
 </trans-unit>
 <trans-unit id="s1823625e6f831d73">
-  <source>Customisation</source>
+  <source>Customization</source>
 </trans-unit>
 <trans-unit id="saab79cd956ee56a9">
   <source>Blueprints</source>

--- a/web/xliff/zh-Hans.xlf
+++ b/web/xliff/zh-Hans.xlf
@@ -6504,7 +6504,7 @@ Bindings to groups/users are checked against the user of the event.</source>
         
       </trans-unit>
       <trans-unit id="s1823625e6f831d73">
-        <source>Customisation</source>
+        <source>Customization</source>
         <target>自定义</target>
         
       </trans-unit>

--- a/web/xliff/zh-Hant.xlf
+++ b/web/xliff/zh-Hant.xlf
@@ -4913,7 +4913,7 @@ Bindings to groups/users are checked against the user of the event.</source>
         <target>日志</target>
       </trans-unit>
       <trans-unit id="s1823625e6f831d73">
-        <source>Customisation</source>
+        <source>Customization</source>
         <target>定制</target>
       </trans-unit>
       <trans-unit id="sc0829ee663ced008">

--- a/web/xliff/zh_CN.xlf
+++ b/web/xliff/zh_CN.xlf
@@ -6504,7 +6504,7 @@ Bindings to groups/users are checked against the user of the event.</source>
         
       </trans-unit>
       <trans-unit id="s1823625e6f831d73">
-        <source>Customisation</source>
+        <source>Customization</source>
         <target>自定义</target>
         
       </trans-unit>

--- a/web/xliff/zh_TW.xlf
+++ b/web/xliff/zh_TW.xlf
@@ -6449,7 +6449,7 @@ Bindings to groups/users are checked against the user of the event.</source>
 
       </trans-unit>
       <trans-unit id="s1823625e6f831d73">
-        <source>Customisation</source>
+        <source>Customization</source>
         <target>客製化設定</target>
 
       </trans-unit>

--- a/website/docs/flow/stages/authenticator_sms/index.md
+++ b/website/docs/flow/stages/authenticator_sms/index.md
@@ -36,7 +36,7 @@ For the generic provider, a POST request will be sent to the URL you have specif
 
 Authentication can either be done as HTTP Basic, or via a Bearer Token. Any response with status 400 or above is counted as failed, and will prevent the user from proceeding.
 
-Starting with authentik 2022.10, a custom webhook mapping can be specified to freely customise the payload of the request. For example:
+Starting with authentik 2022.10, a custom webhook mapping can be specified to freely customize the payload of the request. For example:
 
 ```python
 return {

--- a/website/integrations/services/nextcloud/index.md
+++ b/website/integrations/services/nextcloud/index.md
@@ -53,7 +53,7 @@ authentik already provides some default _scopes_ with _claims_ inside them, such
 
 If you do not need storage quota or group information in Nextcloud [skip to the next step](#provider-and-application).
 
-However, if you want to be able to control how much storage users in Nextcloud can use, as well as which users are recognized as Nextcloud administrators, you would need to make this information available in Nextcloud. To achieve this you would need to create a custom `profile` scope. To do so, go to _Customisation_ -> _Property mappings_. Create a _Scope mapping_ with the following parameters:
+However, if you want to be able to control how much storage users in Nextcloud can use, as well as which users are recognized as Nextcloud administrators, you would need to make this information available in Nextcloud. To achieve this you would need to create a custom `profile` scope. To do so, go to _Customization_ -> _Property mappings_. Create a _Scope mapping_ with the following parameters:
 
 -   Name: Nextcloud Profile
 -   Scope name: profile

--- a/website/integrations/services/sharepoint-se/index.md
+++ b/website/integrations/services/sharepoint-se/index.md
@@ -79,7 +79,7 @@ Additional information from Microsoft documentation:
 
 From the authentik Admin Dashboard:
 
-1. Open **Customisation > Property Mappings** page from the sidebar.
+1. Open **Customization > Property Mappings** page from the sidebar.
 2. Click **Create** from the property mapping list command bar.
 3. Within the new property mapping form, select **Scope Mapping**.
 4. Click **Next** and enter the following values:
@@ -102,7 +102,7 @@ return {
 
 From the authentik Admin Dashboard:
 
-1. Open **Customisation > Property Mappings** page from the sidebar.
+1. Open **Customization > Property Mappings** page from the sidebar.
 2. Click **Create** from the property mapping list command bar.
 3. Within the new property mapping form, select **Scope Mapping**.
 4. Click **Next** and enter the following values:

--- a/website/integrations/services/snipe-it/index.md
+++ b/website/integrations/services/snipe-it/index.md
@@ -115,7 +115,7 @@ You must sync your LDAP database with Snipe-IT. Go to People on the sidebar menu
 
 ## authentik Property Mapping
 
-To create a policy mapping, go to _Customisation/Property Mappings_, click `Create` then `LDAP Property Mapping`. Name is 'sn' and set Object field to sn:
+To create a policy mapping, go to _Customization/Property Mappings_, click `Create` then `LDAP Property Mapping`. Name is 'sn' and set Object field to sn:
 
 ```ini
 def getLastName():

--- a/website/integrations/services/truecommand/index.md
+++ b/website/integrations/services/truecommand/index.md
@@ -36,7 +36,7 @@ Under _Advanced protocol settings_, set NameID Property to _authentik default SA
 
 The following custom property mappings are required.
 
-Under _Customisation_, select _Property Mappings_, then _Create_. Select _SAML Property Mapping_.
+Under _Customization_, select _Property Mappings_, then _Create_. Select _SAML Property Mapping_.
 
 ### Username
 

--- a/website/integrations/services/zammad/index.md
+++ b/website/integrations/services/zammad/index.md
@@ -22,7 +22,7 @@ The following placeholders will be used:
 
 ### Step 1 - Property Mappings
 
-Create two Mappings (under _Customisation/Property Mappings_) with these settings:
+Create two Mappings (under _Customization/Property Mappings_) with these settings:
 
 #### name mapping
 


### PR DESCRIPTION
Replace "customisation" with "customization" in all spellings.

-   [x] The documentation has been updated