### PR TITLE
web/flows: fix webauthn retry

### DIFF
--- a/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStageWebAuthn.ts
+++ b/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStageWebAuthn.ts
@@ -89,8 +89,8 @@ export class AuthenticatorValidateStageWebAuthn extends BaseDeviceStage<
         this.authenticating = true;
         this.authenticate()
             .catch((e: Error) => {
-                console.warn(`authentik/flows/authenticator_validate/webauthn: ${e.toString()}`);
-                this.errorMessage = msg("Authentication failed.");
+                console.warn("authentik/flows/authenticator_validate/webauthn: failed to auth", e);
+                this.errorMessage = msg("Authentication failed. Please try again.");
             })
             .finally(() => {
                 this.authenticating = false;
@@ -110,7 +110,7 @@ export class AuthenticatorValidateStageWebAuthn extends BaseDeviceStage<
                 >
                 </ak-empty-state>
                 <div class="pf-c-form__group pf-m-action">
-                    ${this.errorMessage
+                    ${!this.authenticating
                         ? html` <button
                               class="pf-c-button pf-m-primary pf-m-block"
                               @click=${() => {

--- a/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStageWebAuthn.ts
+++ b/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStageWebAuthn.ts
@@ -116,6 +116,7 @@ export class AuthenticatorValidateStageWebAuthn extends BaseDeviceStage<
                               @click=${() => {
                                   this.authenticateWrapper();
                               }}
+                              type="button"
                           >
                               ${msg("Retry authentication")}
                           </button>`


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

discovered while testing with @kensternberg-authentik, without this the retry button will "submit" the form causing the flow to go back to the device picker

this also fixes the styling for the webauthn enroll stage to match the design

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
