### PR TITLE
fix version

### DIFF
--- a/website/developer-docs/setup/frontend-dev-environment.md
+++ b/website/developer-docs/setup/frontend-dev-environment.md
@@ -32,7 +32,7 @@ Depending on platform, some native dependencies might be required. On macOS, run
 4. Add this volume mapping to your compose file
 
     ```yaml
-    version: "3.2"
+    version: "3.4"
 
     services:
         # [...]


### PR DESCRIPTION
Bumped Docker Compose version from 3.2 to 3.4 in our developer setup docs. Thanks @fheisler for catching this.

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
