### PR TITLE
core: rework recovery API to return better error messages

### DIFF
--- a/schema.yml
+++ b/schema.yml
@@ -4896,8 +4896,8 @@ paths:
                 $ref: '#/components/schemas/GenericError'
           description: ''
   /core/users/{id}/recovery/:
-    get:
-      operationId: core_users_recovery_retrieve
+    post:
+      operationId: core_users_recovery_create
       description: Create a temporary link that a user can use to recover their accounts
       parameters:
       - in: path
@@ -4917,12 +4917,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/Link'
           description: ''
-        '404':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Link'
-          description: ''
         '400':
           content:
             application/json:
@@ -4936,8 +4930,8 @@ paths:
                 $ref: '#/components/schemas/GenericError'
           description: ''
   /core/users/{id}/recovery_email/:
-    get:
-      operationId: core_users_recovery_email_retrieve
+    post:
+      operationId: core_users_recovery_email_create
       description: Create a temporary link that a user can use to recover their accounts
       parameters:
       - in: query
@@ -4958,8 +4952,6 @@ paths:
       responses:
         '204':
           description: Successfully sent recover email
-        '404':
-          description: Bad request
         '400':
           content:
             application/json:
@@ -17893,7 +17885,7 @@ paths:
         schema:
           type: string
           format: uuid
-        description: A UUID string identifying this connection token.
+        description: A UUID string identifying this RAC Connection token.
         required: true
       tags:
       - rac
@@ -17927,7 +17919,7 @@ paths:
         schema:
           type: string
           format: uuid
-        description: A UUID string identifying this connection token.
+        description: A UUID string identifying this RAC Connection token.
         required: true
       tags:
       - rac
@@ -17967,7 +17959,7 @@ paths:
         schema:
           type: string
           format: uuid
-        description: A UUID string identifying this connection token.
+        description: A UUID string identifying this RAC Connection token.
         required: true
       tags:
       - rac
@@ -18006,7 +17998,7 @@ paths:
         schema:
           type: string
           format: uuid
-        description: A UUID string identifying this connection token.
+        description: A UUID string identifying this RAC Connection token.
         required: true
       tags:
       - rac
@@ -18037,7 +18029,7 @@ paths:
         schema:
           type: string
           format: uuid
-        description: A UUID string identifying this connection token.
+        description: A UUID string identifying this RAC Connection token.
         required: true
       tags:
       - rac

--- a/web/src/admin/groups/RelatedUserList.ts
+++ b/web/src/admin/groups/RelatedUserList.ts
@@ -305,7 +305,7 @@ export class RelatedUserList extends WithBrandConfig(WithCapabilitiesConfig(Tabl
                                                   class="pf-m-secondary"
                                                   .apiRequest=${() => {
                                                       return new CoreApi(DEFAULT_CONFIG)
-                                                          .coreUsersRecoveryRetrieve({
+                                                          .coreUsersRecoveryCreate({
                                                               id: item.pk,
                                                           })
                                                           .then((rec) => {

--- a/web/src/admin/users/UserListPage.ts
+++ b/web/src/admin/users/UserListPage.ts
@@ -42,7 +42,7 @@ import { CoreApi, ResponseError, SessionUser, User, UserPath } from "@goauthenti
 
 export const requestRecoveryLink = (user: User) =>
     new CoreApi(DEFAULT_CONFIG)
-        .coreUsersRecoveryRetrieve({
+        .coreUsersRecoveryCreate({
             id: user.pk,
         })
         .then((rec) =>

--- a/web/src/admin/users/UserResetEmailForm.ts
+++ b/web/src/admin/users/UserResetEmailForm.ts
@@ -10,7 +10,7 @@ import { customElement, property } from "lit/decorators.js";
 
 import {
     CoreApi,
-    CoreUsersRecoveryEmailRetrieveRequest,
+    CoreUsersRecoveryEmailCreateRequest,
     Stage,
     StagesAllListRequest,
     StagesApi,
@@ -18,7 +18,7 @@ import {
 } from "@goauthentik/api";
 
 @customElement("ak-user-reset-email-form")
-export class UserResetEmailForm extends Form<CoreUsersRecoveryEmailRetrieveRequest> {
+export class UserResetEmailForm extends Form<CoreUsersRecoveryEmailCreateRequest> {
     @property({ attribute: false })
     user!: User;
 
@@ -26,9 +26,9 @@ export class UserResetEmailForm extends Form<CoreUsersRecoveryEmailRetrieveReque
         return msg("Successfully sent email.");
     }
 
-    async send(data: CoreUsersRecoveryEmailRetrieveRequest): Promise<void> {
+    async send(data: CoreUsersRecoveryEmailCreateRequest): Promise<void> {
         data.id = this.user.pk;
-        return new CoreApi(DEFAULT_CONFIG).coreUsersRecoveryEmailRetrieve(data);
+        return new CoreApi(DEFAULT_CONFIG).coreUsersRecoveryEmailCreate(data);
     }
 
     renderForm(): TemplateResult {


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

QoL improvements around the recovery API
- Turn requests from GET into POST since they are mutating
- Improve error response (instead of just returning a 404 and (debug) logging the error, raise a validation error with a usable message)

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
