### PR TITLE
root: ensure consistent install_id

### DIFF
--- a/authentik/root/install_id.py
+++ b/authentik/root/install_id.py
@@ -7,6 +7,8 @@ from psycopg import connect
 
 from authentik.lib.config import CONFIG
 
+QUERY = """SELECT id FROM public.authentik_install_id ORDER BY id LIMIT 1;"""
+
 
 @lru_cache
 def get_install_id() -> str:
@@ -18,7 +20,7 @@ def get_install_id() -> str:
     if settings.TEST:
         return str(uuid4())
     with connection.cursor() as cursor:
-        cursor.execute("SELECT id FROM public.authentik_install_id LIMIT 1;")
+        cursor.execute(QUERY)
         return cursor.fetchone()[0]
 
 
@@ -38,5 +40,5 @@ def get_install_id_raw():
         sslkey=CONFIG.get("postgresql.sslkey"),
     )
     cursor = conn.cursor()
-    cursor.execute("SELECT id FROM public.authentik_install_id LIMIT 1;")
+    cursor.execute(QUERY)
     return cursor.fetchone()[0]


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

Even though we use an advisory lock to prevent parallel migrations, it can happen that multiple install_id entries are created. This itself doesn't cause any issues, however this PR ensures that always the same install_id value will be returned

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
