### PR TITLE
stages/email: Disable autoescape for text templates

### DIFF
--- a/authentik/stages/email/templates/email/account_confirmation.txt
+++ b/authentik/stages/email/templates/email/account_confirmation.txt
@@ -4,6 +4,6 @@
 
 {{ url }}
 
---
+-- 
 Powered by goauthentik.io.
 {% endautoescape %}

--- a/authentik/stages/email/templates/email/account_confirmation.txt
+++ b/authentik/stages/email/templates/email/account_confirmation.txt
@@ -1,8 +1,9 @@
-{% load i18n %}{% translate "Welcome!" %}
+{% load i18n %}{% autoescape off %}{% translate "Welcome!" %}
 
 {% translate "We're excited to have you get started. First, you need to confirm your account. Just open the link below." %}
 
 {{ url }}
 
--- 
+--
 Powered by goauthentik.io.
+{% endautoescape %}

--- a/authentik/stages/email/templates/email/event_notification.txt
+++ b/authentik/stages/email/templates/email/event_notification.txt
@@ -1,4 +1,4 @@
-{% load authentik_stages_email %}{% load i18n %}{% translate "Dear authentik user," %}
+{% load authentik_stages_email %}{% load i18n %}{% autoescape off %}{% translate "Dear authentik user," %}
 
 {% translate "The following notification was created:" %}
 
@@ -14,5 +14,6 @@
 This email was sent from the notification transport {{ name }}.
 {% endblocktranslate %}{% endif %}
 
--- 
+--
 Powered by goauthentik.io.
+{% endautoescape %}

--- a/authentik/stages/email/templates/email/event_notification.txt
+++ b/authentik/stages/email/templates/email/event_notification.txt
@@ -14,6 +14,6 @@
 This email was sent from the notification transport {{ name }}.
 {% endblocktranslate %}{% endif %}
 
---
+-- 
 Powered by goauthentik.io.
 {% endautoescape %}

--- a/authentik/stages/email/templates/email/password_reset.txt
+++ b/authentik/stages/email/templates/email/password_reset.txt
@@ -8,6 +8,6 @@ You recently requested to change your password for your authentik account. Use t
 If you did not request a password change, please ignore this Email. The link above is valid for {{ expires }}.
 {% endblocktrans %}
 
---
+-- 
 Powered by goauthentik.io.
 {% endautoescape %}

--- a/authentik/stages/email/templates/email/password_reset.txt
+++ b/authentik/stages/email/templates/email/password_reset.txt
@@ -1,4 +1,4 @@
-{% load i18n %}{% load humanize %}{% blocktrans with username=user.username %}Hi {{ username }},{% endblocktrans %}
+{% load i18n %}{% load humanize %}{% autoescape off %}{% blocktrans with username=user.username %}Hi {{ username }},{% endblocktrans %}
 
 {% blocktrans %}
 You recently requested to change your password for your authentik account. Use the link below to set a new password.
@@ -8,5 +8,6 @@ You recently requested to change your password for your authentik account. Use t
 If you did not request a password change, please ignore this Email. The link above is valid for {{ expires }}.
 {% endblocktrans %}
 
--- 
+--
 Powered by goauthentik.io.
+{% endautoescape %}

--- a/authentik/stages/email/templates/email/setup.txt
+++ b/authentik/stages/email/templates/email/setup.txt
@@ -1,7 +1,8 @@
-{% load i18n %}authentik Test-Email
+{% load i18n %}{% autoescape off %}authentik Test-Email
 {% blocktrans %}
 This is a test email to inform you, that you've successfully configured authentik emails.
 {% endblocktrans %}
 
--- 
+--
 Powered by goauthentik.io.
+{% endautoescape %}

--- a/authentik/stages/email/templates/email/setup.txt
+++ b/authentik/stages/email/templates/email/setup.txt
@@ -3,6 +3,6 @@
 This is a test email to inform you, that you've successfully configured authentik emails.
 {% endblocktrans %}
 
---
+-- 
 Powered by goauthentik.io.
 {% endautoescape %}


### PR DESCRIPTION
Some Flows send links via e-mail. \
Those links have to be properly escaped to be embedded in the HTML-e-mail, e.g. like this: \
`https://sso.fachschaften.org/if/flow/auth/?next=%2F&amp;flow_token=<token>` \
But Authentik also sends the content in plaintext. In that case the link should not be html-escaped: \
`https://sso.fachschaften.org/if/flow/auth/?next=%2F&flow_token=<token>`

This currently this does not happen, so when users copy the link from the plaintext-mail, it does not work, because it contains the html-escaped link.

We solved this by adding Django's `{% autoescape off %}` tag to all `.txt`-templates.

An alternative could be to disable autoescape in code, that way custom text templates would automatically no longer be escaped.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
