### PR TITLE
enterprise: use tenant uuid instead of install_id when tenants are enabled

### DIFF
--- a/authentik/core/models.py
+++ b/authentik/core/models.py
@@ -33,7 +33,7 @@ from authentik.lib.models import (
     SerializerModel,
 )
 from authentik.policies.models import PolicyBindingModel
-from authentik.root.install_id import get_install_id
+from authentik.tenants.utils import get_unique_identifier
 
 LOGGER = get_logger()
 USER_ATTRIBUTE_DEBUG = "goauthentik.io/user/debug"
@@ -276,7 +276,7 @@ class User(SerializerModel, GuardianUserMixin, AbstractUser):
     @property
     def uid(self) -> str:
         """Generate a globally unique UID, based on the user ID and the hashed secret key"""
-        return sha256(f"{self.id}-{get_install_id()}".encode("ascii")).hexdigest()
+        return sha256(f"{self.id}-{get_unique_identifier()}".encode("ascii")).hexdigest()
 
     def locale(self, request: HttpRequest | None = None) -> str:
         """Get the locale the user has configured"""

--- a/authentik/enterprise/api.py
+++ b/authentik/enterprise/api.py
@@ -22,7 +22,7 @@ from authentik.core.models import User, UserTypes
 from authentik.enterprise.license import LicenseKey, LicenseSummarySerializer
 from authentik.enterprise.models import License
 from authentik.rbac.decorators import permission_required
-from authentik.root.install_id import get_install_id
+from authentik.tenants.utils import get_unique_identifier
 
 
 class EnterpriseRequiredMixin:
@@ -92,7 +92,7 @@ class LicenseViewSet(UsedByMixin, ModelViewSet):
         """Get install_id"""
         return Response(
             data={
-                "install_id": get_install_id(),
+                "install_id": get_unique_identifier(),
             }
         )
 

--- a/authentik/enterprise/license.py
+++ b/authentik/enterprise/license.py
@@ -21,7 +21,7 @@ from rest_framework.fields import BooleanField, DateTimeField, IntegerField
 from authentik.core.api.utils import PassiveSerializer
 from authentik.core.models import User, UserTypes
 from authentik.enterprise.models import License, LicenseUsage
-from authentik.root.install_id import get_install_id
+from authentik.tenants.utils import get_unique_identifier
 
 CACHE_KEY_ENTERPRISE_LICENSE = "goauthentik.io/enterprise/license"
 CACHE_EXPIRY_ENTERPRISE_LICENSE = 3 * 60 * 60  # 2 Hours
@@ -36,7 +36,7 @@ def get_licensing_key() -> Certificate:
 
 def get_license_aud() -> str:
     """Get the JWT audience field"""
-    return f"enterprise.goauthentik.io/license/{get_install_id()}"
+    return f"enterprise.goauthentik.io/license/{get_unique_identifier()}"
 
 
 class LicenseFlags(Enum):
@@ -142,13 +142,7 @@ class LicenseKey:
     @staticmethod
     def get_external_user_count():
         """Get current external user count"""
-        # Count since start of the month
-        last_month = now().replace(day=1)
-        return (
-            LicenseKey.base_user_qs()
-            .filter(type=UserTypes.EXTERNAL, last_login__gte=last_month)
-            .count()
-        )
+        return LicenseKey.base_user_qs().filter(type=UserTypes.EXTERNAL).count()
 
     def is_valid(self) -> bool:
         """Check if the given license body covers all users

--- a/authentik/flows/views/inspector.py
+++ b/authentik/flows/views/inspector.py
@@ -24,7 +24,6 @@ from authentik.flows.api.bindings import FlowStageBindingSerializer
 from authentik.flows.models import Flow
 from authentik.flows.planner import FlowPlan
 from authentik.flows.views.executor import SESSION_KEY_HISTORY, SESSION_KEY_PLAN
-from authentik.root.install_id import get_install_id
 
 MIN_FLOW_LENGTH = 2
 
@@ -54,9 +53,7 @@ class FlowInspectorPlanSerializer(PassiveSerializer):
     def get_session_id(self, _plan: FlowPlan) -> str:
         """Get a unique session ID"""
         request: Request = self.context["request"]
-        return sha256(
-            f"{request._request.session.session_key}-{get_install_id()}".encode("ascii")
-        ).hexdigest()
+        return sha256(request._request.session.session_key.encode("ascii")).hexdigest()
 
 
 class FlowInspectionSerializer(PassiveSerializer):

--- a/authentik/stages/authenticator_validate/stage.py
+++ b/authentik/stages/authenticator_validate/stage.py
@@ -18,7 +18,6 @@ from authentik.flows.models import FlowDesignation, NotConfiguredAction, Stage
 from authentik.flows.planner import PLAN_CONTEXT_PENDING_USER
 from authentik.flows.stage import ChallengeStageView
 from authentik.lib.utils.time import timedelta_from_string
-from authentik.root.install_id import get_install_id
 from authentik.stages.authenticator import devices_for_user
 from authentik.stages.authenticator.models import Device
 from authentik.stages.authenticator_sms.models import SMSDevice
@@ -34,6 +33,7 @@ from authentik.stages.authenticator_validate.challenge import (
 from authentik.stages.authenticator_validate.models import AuthenticatorValidateStage, DeviceClasses
 from authentik.stages.authenticator_webauthn.models import WebAuthnDevice
 from authentik.stages.password.stage import PLAN_CONTEXT_METHOD, PLAN_CONTEXT_METHOD_ARGS
+from authentik.tenants.utils import get_unique_identifier
 
 COOKIE_NAME_MFA = "authentik_mfa"
 
@@ -331,7 +331,7 @@ class AuthenticatorValidateStageView(ChallengeStageView):
     def cookie_jwt_key(self) -> str:
         """Signing key for MFA Cookie for this stage"""
         return sha256(
-            f"{get_install_id()}:{self.executor.current_stage.pk.hex}".encode("ascii")
+            f"{get_unique_identifier()}:{self.executor.current_stage.pk.hex}".encode("ascii")
         ).hexdigest()
 
     def check_mfa_cookie(self, allowed_devices: list[Device]):

--- a/authentik/tenants/apps.py
+++ b/authentik/tenants/apps.py
@@ -16,7 +16,7 @@ def ensure_default_tenant(*args, using=DEFAULT_DB_ALIAS, **kwargs):
     with schema_context(get_public_schema_name()):
         Tenant.objects.using(using).update_or_create(
             defaults={"name": "Default", "ready": True},
-            schema_name="public",
+            schema_name=get_public_schema_name(),
         )
 
 

--- a/authentik/tenants/utils.py
+++ b/authentik/tenants/utils.py
@@ -1,10 +1,26 @@
 """Tenant utils"""
 
 from django.db import connection
+from django_tenants.utils import get_public_schema_name
 
+from authentik.lib.config import CONFIG
+from authentik.root.install_id import get_install_id
 from authentik.tenants.models import Tenant
 
 
 def get_current_tenant() -> Tenant:
     """Get tenant for current request"""
     return Tenant.objects.get(schema_name=connection.schema_name)
+
+
+def get_unique_identifier() -> str:
+    """Get a globally unique identifier that does not change"""
+    install_id = get_install_id()
+    if CONFIG.get_bool("tenants.enabled"):
+        tenant = get_current_tenant()
+        # Only use tenant's uuid if this request is not from the "public"
+        # (i.e. default) tenant
+        if tenant.schema_name == get_public_schema_name():
+            return install_id
+        return str(get_current_tenant().tenant_uuid)
+    return install_id


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
