### PR TITLE
web: fix esbuild issue with style sheets

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -17059,6 +17059,7 @@
         },
         "node_modules/tree-sitter-json": {
             "version": "0.20.2",
+            "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -17067,6 +17068,7 @@
         },
         "node_modules/tree-sitter-yaml": {
             "version": "0.5.0",
+            "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {

--- a/web/src/elements/utils/ensureCSSStyleSheet.ts
+++ b/web/src/elements/utils/ensureCSSStyleSheet.ts
@@ -1,8 +1,35 @@
 import { CSSResult, unsafeCSS } from "lit";
 
+const supportsAdoptingStyleSheets: boolean =
+    window.ShadowRoot &&
+    (window.ShadyCSS === undefined || window.ShadyCSS.nativeShadow) &&
+    "adoptedStyleSheets" in Document.prototype &&
+    "replace" in CSSStyleSheet.prototype;
+
+function stringToStylesheet(css: string) {
+    if (supportsAdoptingStyleSheets) {
+        const sheet = unsafeCSS(css).styleSheet;
+        if (sheet === undefined) {
+            throw new Error(
+                `CSS processing error: undefined stylesheet from string.  Source: ${css}`,
+            );
+        }
+        return sheet;
+    }
+
+    const sheet = new CSSStyleSheet();
+    sheet.replaceSync(css);
+    return sheet;
+}
+
+function cssResultToStylesheet(css: CSSResult) {
+    const sheet = css.styleSheet;
+    return sheet ? sheet : stringToStylesheet(css.toString());
+}
+
 export const ensureCSSStyleSheet = (css: string | CSSStyleSheet | CSSResult): CSSStyleSheet =>
-    typeof css === "string"
-        ? (unsafeCSS(css).styleSheet as CSSStyleSheet)
-        : css instanceof CSSResult
-          ? (css.styleSheet as CSSStyleSheet)
+    css instanceof CSSResult
+        ? cssResultToStylesheet(css)
+        : typeof css === "string"
+          ? stringToStylesheet(css)
           : css;


### PR DESCRIPTION
Getting ESBuild, Lit, and Storybook to all agree on how to read and parse stylesheets is a serious pain. This fix better identifies the value types (instances) being passed from various sources in the repo to the three *different* kinds of style processors we're using (the native one, the polyfill one, and whatever the heck Storybook does internally).

Falling back to using older CSS instantiating techniques one era at a time seems to do the trick. It's ugly, but in the face of the aggressive styling we use to avoid Flashes of Unstyled Content (FLoUC), it's the logic with which we're left.

In standard mode, the following warning appears on the console when running a Flow:

```
Autofocus processing was blocked because a document already has a focused element.
```

In compatibility mode, the following **error** appears on the console when running a Flow:

```
crawler-inject.js:1106 Uncaught TypeError: Failed to execute 'observe' on 'MutationObserver': parameter 1 is not of type 'Node'.
    at initDomMutationObservers (crawler-inject.js:1106:18)
    at crawler-inject.js:1114:24
    at Array.forEach (<anonymous>)
    at initDomMutationObservers (crawler-inject.js:1114:10)
    at crawler-inject.js:1549:1
initDomMutationObservers @ crawler-inject.js:1106
(anonymous) @ crawler-inject.js:1114
initDomMutationObservers @ crawler-inject.js:1114
(anonymous) @ crawler-inject.js:1549
```

Despite this error, nothing seems to be broken and flows work as anticipated.

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
