### PR TITLE
crypto: fix type in managed JWT Cert reconciliation

### DIFF
--- a/authentik/crypto/apps.py
+++ b/authentik/crypto/apps.py
@@ -45,7 +45,7 @@ class AuthentikCryptoConfig(ManagedAppConfig):
         ).first()
         now = datetime.now(tz=UTC)
         if not cert or (
-            now < cert.certificate.not_valid_after_utc or now > cert.certificate.not_valid_after_utc
+            now < cert.certificate.not_valid_before_utc or now > cert.certificate.not_valid_after_utc
         ):
             self._create_update_cert()
 

--- a/authentik/crypto/tests.py
+++ b/authentik/crypto/tests.py
@@ -1,5 +1,5 @@
 """Crypto tests"""
-
+from datetime import datetime
 from json import loads
 from os import makedirs
 from tempfile import TemporaryDirectory
@@ -68,9 +68,9 @@ class TestCrypto(APITestCase):
             validity_days=3,
         )
         instance = builder.save()
-        _now = now()
+        now = datetime.now(tz=UTC)
         self.assertEqual(instance.name, name)
-        self.assertEqual((instance.certificate.not_valid_after_utc - _now).days, 2)
+        self.assertEqual((instance.certificate.not_valid_after_utc - now).days, 2)
 
     def test_builder_api(self):
         """Test Builder (via API)"""


### PR DESCRIPTION
Hello,

While trying to fix the deprecated [not_valid_before](https://cryptography.io/en/latest/x509/reference/#cryptography.x509.Certificate.not_valid_before) and [not_valid_after](
https://cryptography.io/en/latest/x509/reference/#cryptography.x509.Certificate.not_valid_after) in Python 3.12, you introduced a typo in authentik/crypto/apps.py with two not_valid_after_utc instead of a range with not_valid_before_utc and not_valid_after_utc.

I guess this regressed the validity of the JWT token and let it expire. 
You should probably add a unit test to check not_valid_before as well.

This PR will close #8834

As check and workaround, I used ghcr.io/goauthentik/server:2024.2 docker image and 
force replaced /authentik/crypto/apps.py using a volume in my docker stack.

``` yaml
  authentik-server:
    image: ghcr.io/goauthentik/server:2024.2
    command: server
    volumes:     
      - /tmp/apps.py:/authentik/crypto/apps.py:ro
    ...
    
  authentik-worker:
    image: ghcr.io/goauthentik/server:2024.2
    command: worker
    volumes:
      - /tmp/apps.py:/authentik/crypto/apps.py:ro        
```

N.B. I've also modified authentik/crypto/tests.py to align the "now" variable with the way it's defined in apps.py and rollback the change to use now from django.utils.timezone. I think the two should be unified.

Thank you in advance for considering and resolving this issue.

Related to issue [#8834](https://github.com/goauthentik/authentik/issues/8834) and pull [#8435](https://github.com/goauthentik/authentik/commit/84fdd4d737b2936da9c6a3ff1d6d0e20a7f3b8f5#diff-b04ef75e770df72d39b1eecffb7233d78235285ea038b36430bc095865279827)
