### PR TITLE
Update _envoy_istio.md

### DIFF
--- a/website/docs/providers/proxy/_envoy_istio.md
+++ b/website/docs/providers/proxy/_envoy_istio.md
@@ -20,6 +20,9 @@ spec:
                   headersToUpstreamOnAllow:
                       - set-cookie
                       - x-authentik-*
+                      # Add authorization headers to the allow list if you need proxy providers which
+                      # send a custom HTTP-Basic Authentication header based on values from authentik
+                      # - authorization
                   includeRequestHeadersInCheck:
                       - cookie
 ```


### PR DESCRIPTION
## Details
Added a comment about allowing the http authorization headers to upstream, necessary in an istio meshConfig if there are proxy providers which inject http basic auth headers.

---

## Checklist

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
