### PR TITLE
feat: add classlink federation

### DIFF
--- a/authentik/sources/oauth/types/classlink.py
+++ b/authentik/sources/oauth/types/classlink.py
@@ -1,0 +1,55 @@
+"""Classlink OAuth Views"""
+
+from typing import Any
+
+from requests.auth import HTTPBasicAuth
+
+from authentik.sources.oauth.clients.oauth2 import UserprofileHeaderAuthClient
+from authentik.sources.oauth.types.registry import SourceType, registry
+from authentik.sources.oauth.views.callback import OAuthCallback
+from authentik.sources.oauth.views.redirect import OAuthRedirect
+
+
+class ClasslinkOAuthRedirect(OAuthRedirect):
+    """Classlink OAuth2 Redirect"""
+    
+
+class ClasslinkOAuth2Client(UserprofileHeaderAuthClient):
+    """Classlink OAuth2 Client"""
+
+    def check_application_state(self) -> bool:
+        """Always return True"""
+        return True
+    
+class ClasslinkOAuth2Callback(OAuthCallback):
+    """Classlink OAuth2 Callback"""
+
+    client_class = ClasslinkOAuth2Client
+
+    def get_user_id(self, info: dict[str, str]) -> str:
+            return info.get("sub", None)
+
+    def get_user_enroll_context(
+        self,
+        info: dict[str, Any],
+    ) -> dict[str, Any]:
+        return {
+            "username": info.get("nickname", info.get("preferred_username")),
+            "email": info.get("email"),
+            "name": info.get("name"),
+        }
+
+
+@registry.register()
+class ClasslinkType(SourceType):
+    """Classlink Type definition"""
+
+    callback_view = ClasslinkOAuth2Callback
+    redirect_view = ClasslinkOAuthRedirect
+    
+    verbose_name = "Classlink"
+    name = "classlink"
+
+    authorization_url = "https://launchpad.classlink.com/oauth2/v2/auth"
+    access_token_url = "https://launchpad.classlink.com/oauth2/v2/token"
+    profile_url = "https://nodeapi.classlink.com/v2/my/profileinfo"


### PR DESCRIPTION
we need custom federation to support classlink launchpad. The workflow in classlink is to use the launchpad(classlink dashboard) to from where you can launch the application. The launchpad will open directly the callback url. Because of that we have to bypass csrf check for the callback url.

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
