### PR TITLE
outposts/proxy: Fix invalid redirect on external hosts containing path components

### DIFF
--- a/internal/outpost/proxyv2/application/mode_proxy_test.go
+++ b/internal/outpost/proxyv2/application/mode_proxy_test.go
@@ -56,7 +56,7 @@ func TestProxy_Redirect_Subdirectory(t *testing.T) {
 	loc, _ := rr.Result().Location()
 	assert.Equal(
 		t,
-		"https://ext.t.goauthentik.io/subdir/outpost.goauthentik.io/start?rd=https%3A%2F%2Fext.t.goauthentik.io%2Ffoo",
+		"https://ext.t.goauthentik.io/subdir/outpost.goauthentik.io/start?rd=https%3A%2F%2Fext.t.goauthentik.io%2Fsubdir%2Ffoo",
 		loc.String(),
 	)
 }

--- a/internal/outpost/proxyv2/application/utils.go
+++ b/internal/outpost/proxyv2/application/utils.go
@@ -3,7 +3,6 @@ package application
 import (
 	"net/http"
 	"net/url"
-	"path"
 	"strconv"
 	"strings"
 
@@ -11,22 +10,12 @@ import (
 	"goauthentik.io/internal/outpost/proxyv2/constants"
 )
 
-func urlPathSet(originalUrl string, newPath string) string {
-	u, err := url.Parse(originalUrl)
-	if err != nil {
-		return originalUrl
-	}
-	u.Path = newPath
-	return u.String()
-}
-
 func urlJoin(originalUrl string, newPath string) string {
-	u, err := url.Parse(originalUrl)
+	u, err := url.JoinPath(originalUrl, newPath)
 	if err != nil {
 		return originalUrl
 	}
-	u.Path = path.Join(u.Path, newPath)
-	return u.String()
+	return u
 }
 
 func (a *Application) redirectToStart(rw http.ResponseWriter, r *http.Request) {
@@ -46,7 +35,7 @@ func (a *Application) redirectToStart(rw http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	redirectUrl := urlPathSet(a.proxyConfig.ExternalHost, r.URL.Path)
+	redirectUrl := urlJoin(a.proxyConfig.ExternalHost, r.URL.Path)
 
 	if a.Mode() == api.PROXYMODE_FORWARD_DOMAIN {
 		dom := strings.TrimPrefix(*a.proxyConfig.CookieDomain, ".")


### PR DESCRIPTION
## Details

I was trying to setup a proxy provider (proxy mode, not forwarding) with an outpost. I'm using an external host that contains a path component, like this:

`External Host: https://example.com/myApp`

This generally works nicely with authentik, except for the login. Assume my webbrowser is currently on `https://example.com/myApp/resourceA` and the proxy detects that the user needs to (re-)login. Now, what happens is that after the login has completed, you get redirected back to `https://example.com/resourceA`. The path component `myApp` is simply cut off, which then causes 404 errors in my app (since that URL doesn't exist).

The reason for this misbehavior is the `urlPathSet()` function, which completely removes any path components set by the external host setting. This is apparently only done in one place (`redirectToStart()`) and no where else. It also seems to be unnecessary - why can't we simply join the base (the external host) and the target URL? This works just as before, but without the issue created by cutting off parts of the URL.

I also modernized the `urlJoin` function to use modern golang functions. The benefit is that the `url.JoinPath()` is smarter than `path.Join()` - for example, path.Join cuts off trailing slashes, which might be problematic for URLs. `url.JoinPath()` knows this and doesn't do this.

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
