### PR TITLE
website/docs: Upgrade nginx reverse porxy config

### DIFF
--- a/website/docs/installation/reverse-proxy.md
+++ b/website/docs/installation/reverse-proxy.md
@@ -56,7 +56,7 @@ server {
         proxy_http_version 1.1;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade_keepalive;
     }


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
The original nginx reverse proxy config is using `$host` var, which does not pass the port part to authentik.

When nginx host on different port rather than 443, is will make CSRF error.

with the `%host`, on page `https://authentik:port/api/v3/admin/system/` `HTTP_HOST` will only get `https://authentik` without port. However, when nginx host on different port, the origin in post headers will contain port number, which cause CSRF error.
