### PR TITLE
lifecycle: migrate: ensure template schema exists before migrating

### DIFF
--- a/authentik/tenants/migrations/0001_initial.py
+++ b/authentik/tenants/migrations/0001_initial.py
@@ -143,4 +143,8 @@ class Migration(migrations.Migration):
             },
         ),
         migrations.RunPython(code=create_default_tenant, reverse_code=migrations.RunPython.noop),
+        migrations.RunSQL(
+            sql="CREATE SCHEMA IF NOT EXISTS template;",
+            reverse_sql="DROP SCHEMA IF EXISTS template;",
+        ),
     ]

--- a/authentik/tenants/migrations/0001_initial.py
+++ b/authentik/tenants/migrations/0001_initial.py
@@ -143,8 +143,4 @@ class Migration(migrations.Migration):
             },
         ),
         migrations.RunPython(code=create_default_tenant, reverse_code=migrations.RunPython.noop),
-        migrations.RunSQL(
-            sql="CREATE SCHEMA IF NOT EXISTS template;",
-            reverse_sql="DROP SCHEMA IF EXISTS template;",
-        ),
     ]

--- a/lifecycle/migrate.py
+++ b/lifecycle/migrate.py
@@ -64,6 +64,7 @@ def release_lock(cursor: Cursor):
     """Release database lock"""
     if not LOCKED:
         return
+    LOGGER.info("releasing database lock")
     cursor.execute("SELECT pg_advisory_unlock(%s)", (ADV_LOCK_UID,))
 
 

--- a/lifecycle/system_migrations/template_schema.py
+++ b/lifecycle/system_migrations/template_schema.py
@@ -9,4 +9,4 @@ class Migration(BaseMigration):
         return not bool(self.cur.rowcount)
 
     def run(self):
-        self.cur.execute("CREATE SCHEMA IF NOT EXISTS template;")
+        self.cur.execute("CREATE SCHEMA IF NOT EXISTS template; COMMIT;")

--- a/lifecycle/system_migrations/template_schema.py
+++ b/lifecycle/system_migrations/template_schema.py
@@ -1,0 +1,9 @@
+from lifecycle.migrate import BaseMigration
+
+
+class Migration(BaseMigration):
+    def needs_migration(self) -> bool:
+        return True
+
+    def run(self):
+        self.cur.execute("CREATE SCHEMA IF NOT EXISTS template;")

--- a/lifecycle/system_migrations/template_schema.py
+++ b/lifecycle/system_migrations/template_schema.py
@@ -3,7 +3,10 @@ from lifecycle.migrate import BaseMigration
 
 class Migration(BaseMigration):
     def needs_migration(self) -> bool:
-        return True
+        self.cur.execute(
+            "SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'template';"
+        )
+        return not bool(self.cur.rowcount)
 
     def run(self):
         self.cur.execute("CREATE SCHEMA IF NOT EXISTS template;")


### PR DESCRIPTION
## Details

This is done in a migration, and thus isn't always run if the schema is somehow deleted.

Closes #8900

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
