### PR TITLE
website/integrations: portainer: match portainer settings order

### DIFF
--- a/website/integrations/services/portainer/index.md
+++ b/website/integrations/services/portainer/index.md
@@ -44,8 +44,8 @@ In Portainer, under _Settings_, _Authentication_, Select _OAuth_ and _Custom_
 -   Client Secret: Client Secret from step 1
 -   Authorization URL: `https://authentik.company/application/o/authorize/`
 -   Access Token URL: `https://authentik.company/application/o/token/`
--   Redirect URL: `https://portainer.company`
 -   Resource URL: `https://authentik.company/application/o/userinfo/`
+-   Redirect URL: `https://portainer.company`
 -   Logout URL: `https://authentik.company/application/o/portainer/end-session/`
 -   User Identifier: `preferred_username` (Or `email` if you want to use email addresses as identifiers)
 -   Scopes: `email openid profile`


### PR DESCRIPTION
Reorder settings in step 2 to match the order in Portainer's setings

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
A fairly trivial documentation update.
Bring the settings in step two of the portainer integration doc into the same order as they appear in portainer.
closes #8931.
No code changes.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
