### PR TITLE
website/deverlop-docs website/integrations: add links to integrations template

### DIFF
--- a/website/developer-docs/docs/templates/index.md
+++ b/website/developer-docs/docs/templates/index.md
@@ -14,4 +14,11 @@ The most common types are:
 
 -   [**Reference**](./reference.md): this is typically tables or lists of reference information, such as configuration values, or functions, or most commmonly APIs.
 
-To add documentation for a new [integration](../../../integrations/services/index.mdx) (with support level Community or Vendor), please use the [template](../../../integrations/_template/service.md).
+### Add a new integration
+
+To add documentation for a new [integration](../../../integrations/) (with support level Community or Vendor), please use the integration template [`service.md`](https://github.com/goauthentik/authentik/blob/main/website/integrations/_template/service.md) file from our GitHub repo. You can download the template file using the following command:
+
+```
+wget https://raw.githubusercontent.com/goauthentik/authentik/main/website/integrations/_template/service.md
+```
+

--- a/website/developer-docs/docs/templates/index.md
+++ b/website/developer-docs/docs/templates/index.md
@@ -21,4 +21,3 @@ To add documentation for a new [integration](../../../integrations/) (with suppo
 ```
 wget https://raw.githubusercontent.com/goauthentik/authentik/main/website/integrations/_template/service.md
 ```
-

--- a/website/developer-docs/docs/templates/index.md
+++ b/website/developer-docs/docs/templates/index.md
@@ -2,7 +2,7 @@
 title: "Templates"
 ---
 
-In technical documentation, there are document "types" (similar to how there are data types).
+In technical documentation, there are document "types" (similar to how there are data types). We have templates for the different types, to make it super-easy for whomever wants to contribute some documentation!
 
 The most common types are:
 
@@ -14,4 +14,4 @@ The most common types are:
 
 -   [**Reference**](./reference.md): this is typically tables or lists of reference information, such as configuration values, or functions, or most commmonly APIs.
 
-We have templates for the different types, to make it super-easy for whomever wants to contribute some documentation!
+To add documentation for a new [integration](../../../integrations/services/index.mdx) (with support level Community or Vendor), please use the [template](../../../integrations/_template/service.md).

--- a/website/integrations/services/index.mdx
+++ b/website/integrations/services/index.mdx
@@ -22,6 +22,6 @@ All integrations will have a combination of these badges:
 
     The integration is regularly tested by the authentik team.
 
-To add a new integration (with support level Community or Vendor), please use the [template](../_template/).
+To add documentation for a new integration (with support level Community or Vendor), please use the [template](../_template/).
 
 <DocCardList items={useCurrentSidebarCategory().items} />

--- a/website/integrations/services/index.mdx
+++ b/website/integrations/services/index.mdx
@@ -22,4 +22,6 @@ All integrations will have a combination of these badges:
 
     The integration is regularly tested by the authentik team.
 
+To add a new integration (with support level Community or Vendor), please use the [template](../_template/).
+
 <DocCardList items={useCurrentSidebarCategory().items} />

--- a/website/integrations/services/index.mdx
+++ b/website/integrations/services/index.mdx
@@ -8,11 +8,15 @@ import { useCurrentSidebarCategory } from "@docusaurus/theme-common";
 
 Below is a list of all integrations, or applications that are known to work with authentik. All integrations will have one of these badges:
 
--   <span class="badge badge--secondary">Support level: Community</span> The integration is community maintained.
+-   <span class="badge badge--secondary">Support level: Community</span> The integration
+    is community maintained.
 
--   <span class="badge badge--info">Support level: Vendor</span> The integration is supported by the vendor.
+-   <span class="badge badge--info">Support level: Vendor</span> The integration
+    is supported by the vendor.
 
--   <span class="badge badge--primary">Support level: authentik</span> The integration is regularly tested by the authentik team.
+-   <span class="badge badge--primary">Support level: authentik</span> The integration
+    is regularly tested by the authentik team.
+
 ### Add a new integration
 
 To add documentation for a new integration (with support level Community or Vendor), please use the integration template [`service.md`](https://github.com/goauthentik/authentik/blob/main/website/integrations/_template/service.md) file from our GitHub repo. You can download the template file using the following command:
@@ -22,4 +26,5 @@ wget https://raw.githubusercontent.com/goauthentik/authentik/main/website/integr
 ```
 
 ## Integration categories
+
 <DocCardList items={useCurrentSidebarCategory().items} />

--- a/website/integrations/services/index.mdx
+++ b/website/integrations/services/index.mdx
@@ -6,22 +6,20 @@ slug: /
 import DocCardList from "@theme/DocCardList";
 import { useCurrentSidebarCategory } from "@docusaurus/theme-common";
 
-Below is a list of all applications that are known to work with authentik.
+Below is a list of all integrations, or applications that are known to work with authentik. All integrations will have one of these badges:
 
-All integrations will have a combination of these badges:
+-   <span class="badge badge--secondary">Support level: Community</span> The integration is community maintained.
 
--   <span class="badge badge--secondary">Support level: Community</span>
+-   <span class="badge badge--info">Support level: Vendor</span> The integration is supported by the vendor.
 
-    The integration is community maintained.
+-   <span class="badge badge--primary">Support level: authentik</span> The integration is regularly tested by the authentik team.
+### Add a new integration
 
--   <span class="badge badge--info">Support level: Vendor</span>
+To add documentation for a new integration (with support level Community or Vendor), please use the integration template [`service.md`](https://github.com/goauthentik/authentik/blob/main/website/integrations/_template/service.md) file from our GitHub repo. You can download the template file using the following command:
 
-    The integration is supported by the vendor.
+```
+wget https://raw.githubusercontent.com/goauthentik/authentik/main/website/integrations/_template/service.md
+```
 
--   <span class="badge badge--primary">Support level: authentik</span>
-
-    The integration is regularly tested by the authentik team.
-
-To add documentation for a new integration (with support level Community or Vendor), please use the [template](../_template/).
-
+## Integration categories
 <DocCardList items={useCurrentSidebarCategory().items} />


### PR DESCRIPTION
add link

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
