### PR TITLE
website/integrations: Update OPNsense LDAP instructions

### DIFF
--- a/website/integrations/services/opnsense/index.md
+++ b/website/integrations/services/opnsense/index.md
@@ -11,7 +11,7 @@ title: OPNsense
 > -- https://opnsense.org/
 
 :::note
-This is based on authentik 2022.4.1 and OPNsense 22.1.6-amd64 installed using https://docs.opnsense.org/manual/install.html. Instructions may differ between versions.
+This is based on authentik 2024.2.2 and OPNsense 24.1.3_1-amd64 installed using https://docs.opnsense.org/manual/install.html. Instructions may differ between versions.
 :::
 
 ## Preparation
@@ -25,7 +25,7 @@ The following placeholders will be used:
 ### Step 1
 
 In authentik, go and 'Create Service account' (under _Directory/Users_) for OPNsense to use as the LDAP Binder, leaving 'Create group' ticked as we'll need that group for the provider.
-In this example, we'll use `opnsense` as the Service account's username
+In this example, we'll use `opnsense-user` as the Service account's username
 
 :::note
 Take note of the password for this user as you'll need to give it to OPNsense in _Step 4_.
@@ -91,6 +91,10 @@ Change the following fields
 In OPNsense, go to _System/Settings/Administration_ and under _Authentication_ at the bottom of that page, add `authentik` to the Server list
 
 ![](./opnsense2.png)
+
+### Step 7
+You can now either import user(s) or syncronise from Authentik LDAP. See https://docs.opnsense.org/manual/how-tos/user-ldap.html for more.
+
 
 ## Notes
 

--- a/website/integrations/services/opnsense/index.md
+++ b/website/integrations/services/opnsense/index.md
@@ -93,8 +93,8 @@ In OPNsense, go to _System/Settings/Administration_ and under _Authentication_ a
 ![](./opnsense2.png)
 
 ### Step 7
-You can now either import users, or synchronize from Authentik LDAP. See https://docs.opnsense.org/manual/how-tos/user-ldap.html for more.
 
+You can now either import users, or synchronize from Authentik LDAP. See https://docs.opnsense.org/manual/how-tos/user-ldap.html for more.
 
 ## Notes
 

--- a/website/integrations/services/opnsense/index.md
+++ b/website/integrations/services/opnsense/index.md
@@ -93,7 +93,7 @@ In OPNsense, go to _System/Settings/Administration_ and under _Authentication_ a
 ![](./opnsense2.png)
 
 ### Step 7
-You can now either import user(s) or syncronise from Authentik LDAP. See https://docs.opnsense.org/manual/how-tos/user-ldap.html for more.
+You can now either import users, or synchronize from Authentik LDAP. See https://docs.opnsense.org/manual/how-tos/user-ldap.html for more.
 
 
 ## Notes


### PR DESCRIPTION
Changes:
- Fixed a typo in OPNsense instruction for the service-account used for bind credentials
- Added additional step to clarify how to get the opnsense users setup up
- Updated versions numbers more recent/tested by me

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [X] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
