### PR TITLE
website/docs: email stage: fix example translation error

### DIFF
--- a/website/docs/flow/stages/email/index.mdx
+++ b/website/docs/flow/stages/email/index.mdx
@@ -107,9 +107,7 @@ Templates are rendered using Django's templating engine. The following variables
         <table width="100%" cellpadding="0" cellspacing="0">
             <tr>
                 <td class="content-block">
-                    {% blocktrans %}
-                    You recently requested to change your password for you authentik account. Use the button below to set a new password.
-                    {% endblocktrans %}
+                    {% trans 'You recently requested to change your password for you authentik account. Use the button below to set a new password.' %}                    
                 </td>
             </tr>
             <tr>


### PR DESCRIPTION
fixed configuration_error 
django.template.exceptions.TemplateSyntaxError: 'blocktrans' doesn't allow other block tags (seen 'blocktrans') inside it

👋 Hi there! 

## Details
website/docs : flow/stages/email)

Given template on website was faulty.

-   [x] The documentation has been updated
