### PR TITLE
website/docs: fix transports example

### DIFF
--- a/website/docs/events/transports.md
+++ b/website/docs/events/transports.md
@@ -27,7 +27,7 @@ Starting in 2021.9, you can also select a Notification mapping. This allows you 
 
 ```python
 return {
-    "foo": context['notification'].body,
+    "foo": request.context['notification'].body,
 }
 ```
 


### PR DESCRIPTION
Hello! this is a pull request for the wiki simply updating the correct way to use the api.


request.context['notification'].body is correct. the wiki gave context['notification'].body instead which is not correct.

this update is for userfriendliness!