### PR TITLE
Enhance OAuth Flow by Directing Users to Social Login

### DIFF
--- a/web/src/flow/stages/identification/IdentificationStage.ts
+++ b/web/src/flow/stages/identification/IdentificationStage.ts
@@ -62,8 +62,18 @@ export class IdentificationStage extends BaseStage<
             }
         `);
     }
-
+    checkSourceParameter(url: string): string | null {
+        const decodedUrl = decodeURIComponent(decodeURIComponent(url));
+        const urlSearchParams = new URLSearchParams(decodedUrl);
+        const sourceParam = urlSearchParams.get('source');
+        if (sourceParam) {
+            const source = this.challenge.sources.find((item: { challenge: { to: string; }; }) => item.challenge.to.endsWith(sourceParam+"/"));
+            this.host.challenge = source.challenge;
+        }
+        return null;
+    }
     firstUpdated(): void {
+        this.checkSourceParameter(window.location.href);
         this.autoRedirect();
         this.createHelperForm();
     }


### PR DESCRIPTION
This PR improves the Social OAuth flow by providing an option (source in URL) to redirect users directly to social login flows, instead of landing on the Authentik login page. This provides a way to have social login buttons like "Google" or "Microsoft" on the application itself, and pass on the additional parameter "source" (Flow Slug) in their respective Application OAuth flow params.

Changes Made:
Added checkSourceParameter to handle the source parameter for OAuth flow execution.
Allows specific social login options per flow action, useful for whitelabeling.

This improves user experience with smoother authentication and offers flexibility for whitelabeling social login options .
i.e it allows to have specific social for each flow action being executed from the app, e.g. having multiple google clients with different Project names/Logo, useful for whitelabeling.