### PR TITLE
website/docs:  update notes on SECRET_KEY

### DIFF
--- a/website/docs/installation/configuration.mdx
+++ b/website/docs/installation/configuration.mdx
@@ -153,7 +153,7 @@ These settings affect where media files are stored. Those files include applicat
 Secret key used for cookie signing. Changing this will invalidate active sessions.
 
 :::caution
-Prior to 2023.06.0 it was also used for unique user IDs. If running a pre-2023.06.0 version of authentik the key should not be changed after the first install.
+Prior to 2023.6.0 the secret key was also used for unique user IDs. When running a pre-2023.6.0 version of authentik the key should _not_ be changed after the first install.
 :::
 
 ### `AUTHENTIK_LOG_LEVEL`

--- a/website/docs/installation/configuration.mdx
+++ b/website/docs/installation/configuration.mdx
@@ -150,7 +150,11 @@ These settings affect where media files are stored. Those files include applicat
 
 ### `AUTHENTIK_SECRET_KEY`
 
-Secret key used for cookie signing and unique user IDs. Do not change this after the first install.
+Secret key used for cookie signing. Changing this will invalidate active sessions.
+
+:::caution
+Prior to 2023.06.0 it was also used for unique user IDs and should not be changed after the first install.
+:::
 
 ### `AUTHENTIK_LOG_LEVEL`
 

--- a/website/docs/installation/configuration.mdx
+++ b/website/docs/installation/configuration.mdx
@@ -153,7 +153,7 @@ These settings affect where media files are stored. Those files include applicat
 Secret key used for cookie signing. Changing this will invalidate active sessions.
 
 :::caution
-Prior to 2023.06.0 it was also used for unique user IDs and should not be changed after the first install.
+Prior to 2023.06.0 it was also used for unique user IDs. If running a pre-2023.06.0 version of authentik the key should not be changed after the first install.
 :::
 
 ### `AUTHENTIK_LOG_LEVEL`


### PR DESCRIPTION
## Details

The [docs](https://docs.goauthentik.io/docs/installation/configuration#authentik_secret_key) say the SECRET_KEY is used for 'unique user IDs' and to not change it.

This is no longer the case since 2023.06.0 and changing the SECRET_KEY only invalidates active sessions.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
