### PR TITLE
website/docs: add more info and links about enforciing unique email addresses

### DIFF
--- a/website/docs/flow/index.md
+++ b/website/docs/flow/index.md
@@ -12,7 +12,7 @@ For example, a standard login flow would consist of the following stages:
 
 Upon flow execution, a plan containing all stages is generated. This means that all attached policies are evaluated upon execution. This behaviour can be altered by enabling the **Evaluate when stage is run** option on the binding.
 
-To determine which flow is linked, authentik searches all flows with the required designation and chooses the first instance the current user has access to. Administrators can specify which flow is used, by using the Admin interface to edit the instance's [**Brand**](../core/brands.md) and specify the **Default flows** setting.
+To determine which flow is linked, authentik searches all flows with the required designation and chooses the first instance the current user has access to. Administrators can specify which flow is used; in the Admin interface edit the instance's [**Brand**](../core/brands.md) and specify which flow under the **Default flows** setting.
 
 ## Permissions
 

--- a/website/docs/flow/index.md
+++ b/website/docs/flow/index.md
@@ -12,7 +12,7 @@ For example, a standard login flow would consist of the following stages:
 
 Upon flow execution, a plan containing all stages is generated. This means that all attached policies are evaluated upon execution. This behaviour can be altered by enabling the **Evaluate when stage is run** option on the binding.
 
-To determine which flow is linked, authentik searches all flows with the required designation and chooses the first instance the current user has access to.
+To determine which flow is linked, authentik searches all flows with the required designation and chooses the first instance the current user has access to. Administrators can specify which flow is used, by using the Admin interface to edit the instance's [**Brand**](../core/brands.md) and specify the **Default flows** setting.
 
 ## Permissions
 
@@ -42,7 +42,7 @@ The authentication flow should always contain a [**User Login**](stages/user_log
 
 This designates a flow to be used to invalidate a session.
 
-This stage should always contain a [**User Logout**](stages/user_logout.md) stage, which resets the current session.
+This flow should always contain a [**User Logout**](stages/user_logout.md) stage, which resets the current session.
 
 #### Enrollment
 

--- a/website/docs/flow/index.md
+++ b/website/docs/flow/index.md
@@ -12,7 +12,7 @@ For example, a standard login flow would consist of the following stages:
 
 Upon flow execution, a plan containing all stages is generated. This means that all attached policies are evaluated upon execution. This behaviour can be altered by enabling the **Evaluate when stage is run** option on the binding.
 
-To determine which flow is linked, authentik searches all flows with the required designation and chooses the first instance the current user has access to. Administrators can specify which flow is used; in the Admin interface edit the instance's [**Brand**](../core/brands.md) and specify which flow under the **Default flows** setting.
+The determine which flow should be used, authentik will first check which default authentication flow is configured in the active [**Brand**](../core/brands.md). If no default is configured there, the policies in all flows with the matching designation are checked, and the first flow with matching policies sorted by `slug` will be used.
 
 ## Permissions
 

--- a/website/docs/policies/working_with_policies/unique_email.md
+++ b/website/docs/policies/working_with_policies/unique_email.md
@@ -4,7 +4,7 @@ title: Ensure unique email addresses
 
 Due to the database design of authentik, email addresses are by default not required to be unique. This behavior can however be changed by policies.
 
-The snippet below can as the expression in policies both with enrollment flows, where the policy should be bound to any stage before the [User write](../../flow/stages/user_write.md) stage, or it can be used with the [Prompt stage](../../flow/stages/prompt/index.md).
+The snippet below can be used as the expression in policies both with enrollment flows, where the policy should be bound to any stage before the [User write](../../flow/stages/user_write.md) stage, or with the [Prompt stage](../../flow/stages/prompt/index.md).
 
 ```python
 from authentik.core.models import User

--- a/website/docs/user-group-role/user/user_basic_operations.md
+++ b/website/docs/user-group-role/user/user_basic_operations.md
@@ -4,6 +4,8 @@ title: Manage users
 
 The following topics are for the basic management of users: how to create, modify, delete or deactivate users, and using a recovery email.
 
+[Policies](../../policies/index.md) can be used to further manage how users are authenticated. For example, in authentik email addresses are (by default) not required to be unique, but you can use a policy to [enforce unique email addresses](../../policies/working_with_policies/unique_email.md).
+
 ### Create a user
 
 > If you want to automate user creation, you can do that either by [invitations](./invitations.md), [`user_write` stage](../../flow/stages/user_write), or [using the API](/developer-docs/api/browser).

--- a/website/docs/user-group-role/user/user_basic_operations.md
+++ b/website/docs/user-group-role/user/user_basic_operations.md
@@ -4,7 +4,7 @@ title: Manage users
 
 The following topics are for the basic management of users: how to create, modify, delete or deactivate users, and using a recovery email.
 
-[Policies](../../policies/index.md) can be used to further manage how users are authenticated. For example, in authentik email addresses are (by default) not required to be unique, but you can use a policy to [enforce unique email addresses](../../policies/working_with_policies/unique_email.md).
+[Policies](../../policies/index.md) can be used to further manage how users are authenticated. For example, by default authentik does not require email addresses be unique, but you can use a policy to [enforce unique email addresses](../../policies/working_with_policies/unique_email.md).
 
 ### Create a user
 


### PR DESCRIPTION
This is a good first step in making it easier for readers to find info about unique email addresses, I think.

I ended up not moving the entire topic, but instead adding a link to it on the "Manage users" page. Since the topic is really about a policy (that happens to be about user emails), I think it is best to keep it under policies.

I don't want to move it until we look at all the options, and maybe use an <import> function to have it in several places. Because this [Examples page](https://docs.goauthentik.io/docs/flow/examples/snippets) also is a fine place to mention it.


-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
