### PR TITLE
website/docs: update Postgresql username

### DIFF
--- a/website/docs/troubleshooting/postgres/upgrade_kubernetes.md
+++ b/website/docs/troubleshooting/postgres/upgrade_kubernetes.md
@@ -27,7 +27,7 @@ cd /bitnami/postgresql/
 # Set the postgres password based on the `POSTGRES_POSTGRES_PASSWORD` environment variable
 export PGPASSWORD=$POSTGRES_POSTGRES_PASSWORD
 # Dump the authentik database into an sql file
-pg_dump -U postgres $POSTGRES_DB > dump-11.sql
+pg_dump -U $POSTGRES_USER $POSTGRES_DB > dump-11.sql
 ```
 
 ### Stop PostgreSQL and start the upgrade
@@ -88,7 +88,7 @@ Run the following commands to restore the data:
 cd /bitnami/postgresql/
 # Set the Postgres password based on the `POSTGRES_POSTGRES_PASSWORD` environment variable.
 export PGPASSWORD=$POSTGRES_POSTGRES_PASSWORD
-psql -U postgres $POSTGRES_DB < dump-11.sql
+psql -U $POSTGRES_USER $POSTGRES_DB < dump-11.sql
 ```
 
 After the last command finishes, all of the data is restored, and you can restart authentik.


### PR DESCRIPTION
## Details

I had some minor troubles during upgrading my database from version 15 to version 16.
The issue was, that the database user is called 'authentik' instead of 'postgres'.
I thought getting the user from the environment variable might be more reliable.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
