### PR TITLE
website/integrations: portainer: Fix Redirect URL mismatch

### DIFF
--- a/website/integrations/services/portainer/index.md
+++ b/website/integrations/services/portainer/index.md
@@ -45,7 +45,7 @@ In Portainer, under _Settings_, _Authentication_, Select _OAuth_ and _Custom_
 -   Authorization URL: `https://authentik.company/application/o/authorize/`
 -   Access Token URL: `https://authentik.company/application/o/token/`
 -   Resource URL: `https://authentik.company/application/o/userinfo/`
--   Redirect URL: `https://portainer.company`
+-   Redirect URL: `https://portainer.company/`
 -   Logout URL: `https://authentik.company/application/o/portainer/end-session/`
 -   User Identifier: `preferred_username` (Or `email` if you want to use email addresses as identifiers)
 -   Scopes: `email openid profile`


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
Without the "/" the given configuration doesn't work, because the Redirect URLs in Portainer and the Portainer Provider in Authentik don't match.

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
