### PR TITLE
core: replace authentik_signals_ignored_fields with audit_ignore

### DIFF
--- a/authentik/core/models.py
+++ b/authentik/core/models.py
@@ -54,9 +54,6 @@ options.DEFAULT_NAMES = options.DEFAULT_NAMES + (
     # used_by API that allows models to specify if they shadow an object
     # for example the proxy provider which is built on top of an oauth provider
     "authentik_used_by_shadows",
-    # List fields for which changes are not logged (due to them having dedicated objects)
-    # for example user's password and last_login
-    "authentik_signals_ignored_fields",
 )
 
 
@@ -334,14 +331,6 @@ class User(SerializerModel, GuardianUserMixin, AbstractUser):
             models.Index(fields=["uuid"]),
             models.Index(fields=["path"]),
             models.Index(fields=["type"]),
-        ]
-        authentik_signals_ignored_fields = [
-            # Logged by the events `password_set`
-            # the `password_set` action/signal doesn't currently convey which user
-            # initiated the password change, so for now we'll log two actions
-            # ("password", "password_change_date"),
-            # Logged by `login`
-            ("last_login",),
         ]
 
 

--- a/authentik/enterprise/audit/middleware.py
+++ b/authentik/enterprise/audit/middleware.py
@@ -102,9 +102,4 @@ class EnterpriseAuditMiddleware(AuditMiddleware):
             new_state = self.serialize_simple(instance)
             diff = self.diff(prev_state, new_state)
             thread_kwargs["diff"] = diff
-            if not created:
-                ignored_field_sets = getattr(instance._meta, "authentik_signals_ignored_fields", [])
-                for field_set in ignored_field_sets:
-                    if set(diff.keys()) == set(field_set):
-                        return None
         return super().post_save_handler(request, sender, instance, created, thread_kwargs, **_)


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

`authentik_signals_ignored_fields` is only respected by the enterprise audit middleware, which causes user logins to create two events on non-enterprise installs, as a `model_updated` event is logged, which the audit middleware correctly discards.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
