### PR TITLE
web: fix locale loading being skipped

### DIFF
--- a/web/src/elements/ak-locale-context/ak-locale-context.ts
+++ b/web/src/elements/ak-locale-context/ak-locale-context.ts
@@ -88,7 +88,7 @@ export class LocaleContext extends LitElement {
         }
         locale.locale().then(() => {
             console.debug(`authentik/locale: Loaded locale '${code}'`);
-            if (this.getLocale() === code) {
+            if (this.getLocale() === requestedLocale) {
                 return;
             }
             console.debug(`Setting Locale to ... ${locale.label()} (${locale.code})`);


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->

Hey there,

I noticed on authentik that no matter what browser locale I had set or what locale I passed to the query string, the locale would always be loaded as 'en'.

After looking at the code, I attributed a potential fix to the one line I reference in this PR. I did a Chrome local override and this fixed the issue with the query string being ignored, but it still doesn't seem to consider the browser headers.

The lack of consideration for browser headers may be due to an issue with `autoDetectLanguage` where it never defaults `requestedCode` to `TOMBSTONE` because `requestedCode` is always set to `en` from `DEFAULT_LOCALE` so it's not really an optional.

I'm at work so I didn't have sufficient time to determine if this is an acceptable fix for at least the query string issue, nor run any local tests, so this PR is more meant to serve as an Issue for review/discussion.

I'll see if I can explore it more in the future if I can find some time to set up a proper local dev environment.

Let me know if I can provide any more additional info.

Thanks,

Dylan

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
