### PR TITLE
events: fix incorrect user logged when using API token authentication

### DIFF
--- a/authentik/events/middleware.py
+++ b/authentik/events/middleware.py
@@ -110,26 +110,32 @@ class AuditMiddleware:
 
         self.anonymous_user = get_anonymous_user()
 
+    def get_user(self, request: HttpRequest) -> User:
+        user = _CTX_OVERWRITE_USER.get()
+        if user:
+            return user
+        user = getattr(request, "user", self.anonymous_user)
+        if not user.is_authenticated:
+            return self.anonymous_user
+        return user
+
     def connect(self, request: HttpRequest):
         """Connect signal for automatic logging"""
         self._ensure_fallback_user()
-        user = getattr(request, "user", self.anonymous_user)
-        if not user.is_authenticated:
-            user = self.anonymous_user
         if not hasattr(request, "request_id"):
             return
         post_save.connect(
-            partial(self.post_save_handler, user=user, request=request),
+            partial(self.post_save_handler, request=request),
             dispatch_uid=request.request_id,
             weak=False,
         )
         pre_delete.connect(
-            partial(self.pre_delete_handler, user=user, request=request),
+            partial(self.pre_delete_handler, request=request),
             dispatch_uid=request.request_id,
             weak=False,
         )
         m2m_changed.connect(
-            partial(self.m2m_changed_handler, user=user, request=request),
+            partial(self.m2m_changed_handler, request=request),
             dispatch_uid=request.request_id,
             weak=False,
         )
@@ -174,7 +180,6 @@ class AuditMiddleware:
 
     def post_save_handler(
         self,
-        user: User,
         request: HttpRequest,
         sender,
         instance: Model,
@@ -187,22 +192,20 @@ class AuditMiddleware:
             return
         if _CTX_IGNORE.get():
             return
-        if _new_user := _CTX_OVERWRITE_USER.get():
-            user = _new_user
+        user = self.get_user(request)
 
         action = EventAction.MODEL_CREATED if created else EventAction.MODEL_UPDATED
         thread = EventNewThread(action, request, user=user, model=model_to_dict(instance))
         thread.kwargs.update(thread_kwargs or {})
         thread.run()
 
-    def pre_delete_handler(self, user: User, request: HttpRequest, sender, instance: Model, **_):
+    def pre_delete_handler(self, request: HttpRequest, sender, instance: Model, **_):
         """Signal handler for all object's pre_delete"""
         if not should_log_model(instance):  # pragma: no cover
             return
         if _CTX_IGNORE.get():
             return
-        if _new_user := _CTX_OVERWRITE_USER.get():
-            user = _new_user
+        user = self.get_user(request)
 
         EventNewThread(
             EventAction.MODEL_DELETED,
@@ -211,9 +214,7 @@ class AuditMiddleware:
             model=model_to_dict(instance),
         ).run()
 
-    def m2m_changed_handler(
-        self, user: User, request: HttpRequest, sender, instance: Model, action: str, **_
-    ):
+    def m2m_changed_handler(self, request: HttpRequest, sender, instance: Model, action: str, **_):
         """Signal handler for all object's m2m_changed"""
         if action not in ["pre_add", "pre_remove", "post_clear"]:
             return
@@ -221,8 +222,7 @@ class AuditMiddleware:
             return
         if _CTX_IGNORE.get():
             return
-        if _new_user := _CTX_OVERWRITE_USER.get():
-            user = _new_user
+        user = self.get_user(request)
 
         EventNewThread(
             EventAction.MODEL_UPDATED,


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

This was introduced in 2024.2 by incorrectly caching the user from before the request instead of taking it from the request when an action was actually done. This works fine with the session auth as the session middleware happens before the event middleware, however since the token authentication modifies the user as part of the view and not the middleware, the user was updated too late.

This also adds a test that makes sure this doesn't happen again.

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
