### PR TITLE
website/docs: fix SECRET_KEY length

### DIFF
--- a/website/docs/installation/docker-compose.mdx
+++ b/website/docs/installation/docker-compose.mdx
@@ -51,7 +51,7 @@ Run the following commands to generate a password and secret key and write them 
 {/* prettier-ignore */}
 ```shell
 echo "PG_PASS=$(openssl rand -base64 36)" >> .env
-echo "AUTHENTIK_SECRET_KEY=$(openssl rand -base64 36)" >> .env
+echo "AUTHENTIK_SECRET_KEY=$(openssl rand -base64 60)" >> .env
 ```
 
 :::info


### PR DESCRIPTION
## Details

Django complains about 36-character keys. See `security.W009` on https://docs.djangoproject.com/en/5.0/ref/checks/. Skipping the checklist because this is so trivial.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
