### PR TITLE
website/docs: fix email template formatting

### DIFF
--- a/website/docs/flow/stages/email/index.mdx
+++ b/website/docs/flow/stages/email/index.mdx
@@ -98,8 +98,8 @@ Templates are rendered using Django's templating engine. The following variables
 {% block content %}
 <tr>
     <td class="alert alert-success">
-        {% blocktrans with username=user.username %} Hi {{ username }}, {%
-        endblocktrans %}
+        {% blocktrans with username=user.username %} Hi {{ username }}, 
+        {% endblocktrans %}
     </td>
 </tr>
 <tr>


### PR DESCRIPTION
Fixes:
django.template.exceptions.TemplateSyntaxError: 'blocktrans' doesn't allow other block tags (seen "trans 'You recently requested to change your password for you authentik account. Use the button below to set a new password.'") inside it

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
Fixes an issue in the documentation, which made the example code fail to run.
The newline caused the template not to work and cause the mentioned error.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
