### PR TITLE
website/integrations: fix typo

### DIFF
--- a/website/integrations/sources/ldap/index.md
+++ b/website/integrations/sources/ldap/index.md
@@ -54,7 +54,7 @@ Be aware of the following security considerations when turning on this functiona
 
 -   Updating the LDAP password does not invalid the password stored in authentik, however for LDAP Servers like FreeIPA and Active Directory, authentik will lock its internal password during the next LDAP sync. For other LDAP servers, the old passwords will still be valid indefinitely.
 -   Logging in via LDAP credentials overwrites the password stored in authentik if users have different passwords in LDAP and authentik.
--   Custom security measures used to secure the password in LDAP may differ from the ones used in authentik. Depending on thread model and security requirements this could lead to unknowingly being non-compliant.
+-   Custom security measures used to secure the password in LDAP may differ from the ones used in authentik. Depending on threat model and security requirements this could lead to unknowingly being non-compliant.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Changed typo "thread model" to, "threat model."

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
I was reading the LDAP documentation page and noticed a typo towards the bottom of the page. The documentation says "thread model" instead of "threat model."

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
