### PR TITLE
sources/ldap: fix default blueprint for mapping user DN to path

### DIFF
--- a/authentik/sources/ldap/tests/mock_ad.py
+++ b/authentik/sources/ldap/tests/mock_ad.py
@@ -34,7 +34,7 @@ def mock_ad_connection(password: str) -> Connection:
             "objectSid": "unique-test-group",
             "objectClass": "group",
             "distinguishedName": "cn=group1,ou=groups,dc=goauthentik,dc=io",
-            "member": ["cn=user0,ou=users,dc=goauthentik,dc=io"],
+            "member": ["cn=user,ou=users,dc=goauthentik,dc=io"],
         },
     )
     # Group without SID
@@ -47,7 +47,7 @@ def mock_ad_connection(password: str) -> Connection:
         },
     )
     connection.strategy.add_entry(
-        "cn=user0,ou=users,dc=goauthentik,dc=io",
+        "cn=user0,ou=foo,ou=users,dc=goauthentik,dc=io",
         {
             "userPassword": password,
             "sAMAccountName": "user0_sn",

--- a/authentik/sources/ldap/tests/test_auth.py
+++ b/authentik/sources/ldap/tests/test_auth.py
@@ -55,7 +55,7 @@ class LDAPSyncTests(TestCase):
             )
             connection.assert_called_with(
                 connection_kwargs={
-                    "user": "cn=user0,ou=users,dc=goauthentik,dc=io",
+                    "user": "cn=user0,ou=foo,ou=users,dc=goauthentik,dc=io",
                     "password": LDAP_PASSWORD,
                 }
             )

--- a/blueprints/system/sources-ldap.yaml
+++ b/blueprints/system/sources-ldap.yaml
@@ -11,7 +11,6 @@ entries:
       name: "authentik default LDAP Mapping: DN to User Path"
       object_field: "path"
       expression: |
-        dn = ldap.get("distinguishedName")
         path_elements = []
         for pair in dn.split(","):
             attr, _, value = pair.partition("=")


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

closes #8557

There's a globally defined variable in the LDAP Property mapping context `dn` which always works

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
