### PR TITLE
core: only prefetch related objects when required

### DIFF
--- a/authentik/core/api/groups.py
+++ b/authentik/core/api/groups.py
@@ -154,11 +154,17 @@ class GroupViewSet(UsedByMixin, ModelViewSet):
 
         pk = IntegerField(required=True)
 
-    queryset = Group.objects.all().select_related("parent").prefetch_related("users")
+    queryset = Group.objects.none()
     serializer_class = GroupSerializer
     search_fields = ["name", "is_superuser"]
     filterset_class = GroupFilter
     ordering = ["name"]
+
+    def get_queryset(self):
+        base_qs = Group.objects.all()
+        if self.serializer_class(context={"request": self.request})._should_include_users:
+            base_qs = base_qs.select_related("parent").prefetch_related("users")
+        return base_qs
 
     @extend_schema(
         parameters=[

--- a/authentik/core/api/groups.py
+++ b/authentik/core/api/groups.py
@@ -161,7 +161,7 @@ class GroupViewSet(UsedByMixin, ModelViewSet):
     ordering = ["name"]
 
     def get_queryset(self):
-        base_qs = Group.objects.all().select_related("parent", "roles")
+        base_qs = Group.objects.all().select_related("parent").prefetch_related("roles")
         if self.serializer_class(context={"request": self.request})._should_include_users:
             base_qs = base_qs.prefetch_related("users")
         return base_qs

--- a/authentik/core/api/groups.py
+++ b/authentik/core/api/groups.py
@@ -161,9 +161,9 @@ class GroupViewSet(UsedByMixin, ModelViewSet):
     ordering = ["name"]
 
     def get_queryset(self):
-        base_qs = Group.objects.all()
+        base_qs = Group.objects.all().select_related("parent", "roles")
         if self.serializer_class(context={"request": self.request})._should_include_users:
-            base_qs = base_qs.select_related("parent").prefetch_related("users")
+            base_qs = base_qs.prefetch_related("users")
         return base_qs
 
     @extend_schema(

--- a/authentik/core/api/users.py
+++ b/authentik/core/api/users.py
@@ -407,8 +407,11 @@ class UserViewSet(UsedByMixin, ModelViewSet):
     search_fields = ["username", "name", "is_active", "email", "uuid"]
     filterset_class = UsersFilter
 
-    def get_queryset(self):  # pragma: no cover
-        return User.objects.all().exclude_anonymous().prefetch_related("ak_groups")
+    def get_queryset(self):
+        base_qs = User.objects.all().exclude_anonymous()
+        if self.serializer_class(context={"request": self.request})._should_include_groups:
+            base_qs = base_qs.prefetch_related("ak_groups")
+        return base_qs
 
     @extend_schema(
         parameters=[

--- a/authentik/core/tests/test_groups_api.py
+++ b/authentik/core/tests/test_groups_api.py
@@ -16,16 +16,6 @@ class TestGroupsAPI(APITestCase):
         self.login_user = create_test_user()
         self.user = User.objects.create(username="test-user")
 
-    def test_list(self):
-        """Test listing"""
-        admin = create_test_admin_user()
-        self.client.force_login(admin)
-        # Since we're capturing the entire request, this includes things like tenant,
-        # session auth, etc
-        with self.assertNumQueries(13):
-            response = self.client.get(reverse("authentik_api:group-list"))
-            self.assertEqual(response.status_code, 200)
-
     def test_list_with_users(self):
         """Test listing with users"""
         admin = create_test_admin_user()

--- a/authentik/core/tests/test_groups_api.py
+++ b/authentik/core/tests/test_groups_api.py
@@ -5,7 +5,7 @@ from guardian.shortcuts import assign_perm
 from rest_framework.test import APITestCase
 
 from authentik.core.models import Group, User
-from authentik.core.tests.utils import create_test_user
+from authentik.core.tests.utils import create_test_admin_user, create_test_user
 from authentik.lib.generators import generate_id
 
 
@@ -15,6 +15,13 @@ class TestGroupsAPI(APITestCase):
     def setUp(self) -> None:
         self.login_user = create_test_user()
         self.user = User.objects.create(username="test-user")
+
+    def test_list_with_users(self):
+        """Test listing with users"""
+        admin = create_test_admin_user()
+        self.client.force_login(admin)
+        response = self.client.get(reverse("authentik_api:group-list"), {"include_users": "true"})
+        self.assertEqual(response.status_code, 200)
 
     def test_add_user(self):
         """Test add_user"""

--- a/authentik/core/tests/test_groups_api.py
+++ b/authentik/core/tests/test_groups_api.py
@@ -22,7 +22,7 @@ class TestGroupsAPI(APITestCase):
         self.client.force_login(admin)
         # Since we're capturing the entire request, this includes things like tenant,
         # session auth, etc
-        with self.assertNumQueries(14):
+        with self.assertNumQueries(13):
             response = self.client.get(reverse("authentik_api:group-list"))
             self.assertEqual(response.status_code, 200)
 

--- a/authentik/core/tests/test_groups_api.py
+++ b/authentik/core/tests/test_groups_api.py
@@ -16,6 +16,16 @@ class TestGroupsAPI(APITestCase):
         self.login_user = create_test_user()
         self.user = User.objects.create(username="test-user")
 
+    def test_list(self):
+        """Test listing"""
+        admin = create_test_admin_user()
+        self.client.force_login(admin)
+        # Since we're capturing the entire request, this includes things like tenant,
+        # session auth, etc
+        with self.assertNumQueries(14):
+            response = self.client.get(reverse("authentik_api:group-list"))
+            self.assertEqual(response.status_code, 200)
+
     def test_list_with_users(self):
         """Test listing with users"""
         admin = create_test_admin_user()

--- a/authentik/core/tests/test_users_api.py
+++ b/authentik/core/tests/test_users_api.py
@@ -41,6 +41,12 @@ class TestUsersAPI(APITestCase):
         )
         self.assertEqual(response.status_code, 200)
 
+    def test_list_with_groups(self):
+        """Test listing with groups"""
+        self.client.force_login(self.admin)
+        response = self.client.get(reverse("authentik_api:user-list"), {"include_groups": "true"})
+        self.assertEqual(response.status_code, 200)
+
     def test_metrics(self):
         """Test user's metrics"""
         self.client.force_login(self.admin)

--- a/authentik/core/tests/test_users_api.py
+++ b/authentik/core/tests/test_users_api.py
@@ -41,6 +41,15 @@ class TestUsersAPI(APITestCase):
         )
         self.assertEqual(response.status_code, 200)
 
+    def test_list(self):
+        """Test listing"""
+        self.client.force_login(self.admin)
+        # Since we're capturing the entire request, this includes things like tenant,
+        # session auth, etc
+        with self.assertNumQueries(16):
+            response = self.client.get(reverse("authentik_api:user-list"))
+            self.assertEqual(response.status_code, 200)
+
     def test_list_with_groups(self):
         """Test listing with groups"""
         self.client.force_login(self.admin)

--- a/authentik/core/tests/test_users_api.py
+++ b/authentik/core/tests/test_users_api.py
@@ -46,7 +46,7 @@ class TestUsersAPI(APITestCase):
         self.client.force_login(self.admin)
         # Since we're capturing the entire request, this includes things like tenant,
         # session auth, etc
-        with self.assertNumQueries(16):
+        with self.assertNumQueries(15):
             response = self.client.get(reverse("authentik_api:user-list"))
             self.assertEqual(response.status_code, 200)
 

--- a/authentik/core/tests/test_users_api.py
+++ b/authentik/core/tests/test_users_api.py
@@ -41,15 +41,6 @@ class TestUsersAPI(APITestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-    def test_list(self):
-        """Test listing"""
-        self.client.force_login(self.admin)
-        # Since we're capturing the entire request, this includes things like tenant,
-        # session auth, etc
-        with self.assertNumQueries(15):
-            response = self.client.get(reverse("authentik_api:user-list"))
-            self.assertEqual(response.status_code, 200)
-
     def test_list_with_groups(self):
         """Test listing with groups"""
         self.client.force_login(self.admin)

--- a/authentik/core/tests/test_users_avatars.py
+++ b/authentik/core/tests/test_users_avatars.py
@@ -8,7 +8,6 @@ from rest_framework.test import APITestCase
 
 from authentik.core.models import User
 from authentik.core.tests.utils import create_test_admin_user
-from authentik.lib.config import CONFIG
 from authentik.tenants.utils import get_current_tenant
 
 
@@ -25,7 +24,6 @@ class TestUsersAvatars(APITestCase):
         tenant.avatars = mode
         tenant.save()
 
-    @CONFIG.patch("avatars", "none")
     def test_avatars_none(self):
         """Test avatars none"""
         self.set_avatar_mode("none")

--- a/authentik/events/middleware.py
+++ b/authentik/events/middleware.py
@@ -116,12 +116,12 @@ class AuditMiddleware:
             return user
         user = getattr(request, "user", self.anonymous_user)
         if not user.is_authenticated:
+            self._ensure_fallback_user()
             return self.anonymous_user
         return user
 
     def connect(self, request: HttpRequest):
         """Connect signal for automatic logging"""
-        self._ensure_fallback_user()
         if not hasattr(request, "request_id"):
             return
         post_save.connect(


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

Currently we prefetch related objects for user/group queries even when explicitly set to not include those objects in the API response

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
