### PR TITLE
Caddy V2 Basic Auth missing header

### DIFF
--- a/website/docs/providers/proxy/_caddy_standalone.md
+++ b/website/docs/providers/proxy/_caddy_standalone.md
@@ -10,7 +10,7 @@ app.company {
         uri /outpost.goauthentik.io/auth/caddy
 
         # capitalization of the headers is important, otherwise they will be empty
-        copy_headers X-Authentik-Username X-Authentik-Groups X-Authentik-Email X-Authentik-Name X-Authentik-Uid X-Authentik-Jwt X-Authentik-Meta-Jwks X-Authentik-Meta-Outpost X-Authentik-Meta-Provider X-Authentik-Meta-App X-Authentik-Meta-Version authorization
+        copy_headers X-Authentik-Username X-Authentik-Groups X-Authentik-Email X-Authentik-Name X-Authentik-Uid X-Authentik-Jwt X-Authentik-Meta-Jwks X-Authentik-Meta-Outpost X-Authentik-Meta-Provider X-Authentik-Meta-App X-Authentik-Meta-Version
 
         # optional, in this config trust all private ranges, should probably be set to the outposts IP
         trusted_proxies private_ranges
@@ -23,8 +23,17 @@ app.company {
 
 If you're trying to proxy to an upstream over HTTPS, you need to set the `Host` header to the value they expect for it to work correctly.
 
-```
-reverse_proxy /outpost.goauthentik.io/* https://outpost.company {
-    header_up Host {http.reverse_proxy.upstream.hostport}
+## Additional Configuration for Reverse Proxies
+
+When configuring reverse proxies, it may be necessary to forward additional custom headers or include basic authentication details depending on your security requirements and the specific setup of your upstream services. 
+
+### Sending Basic Authentication
+
+If your upstream service requires basic authentication, ensure to configure your reverse proxy to send the appropriate `Authorization` header. Here's an example of how to add custom headers in a Caddy setup:
+
+```plaintext
+forward_auth http://outpost.company:9000 {
+    copy_headers  authorization
+    # Add other headers as needed
 }
 ```

--- a/website/docs/providers/proxy/_caddy_standalone.md
+++ b/website/docs/providers/proxy/_caddy_standalone.md
@@ -10,7 +10,7 @@ app.company {
         uri /outpost.goauthentik.io/auth/caddy
 
         # capitalization of the headers is important, otherwise they will be empty
-        copy_headers X-Authentik-Username X-Authentik-Groups X-Authentik-Email X-Authentik-Name X-Authentik-Uid X-Authentik-Jwt X-Authentik-Meta-Jwks X-Authentik-Meta-Outpost X-Authentik-Meta-Provider X-Authentik-Meta-App X-Authentik-Meta-Version
+        copy_headers X-Authentik-Username X-Authentik-Groups X-Authentik-Email X-Authentik-Name X-Authentik-Uid X-Authentik-Jwt X-Authentik-Meta-Jwks X-Authentik-Meta-Outpost X-Authentik-Meta-Provider X-Authentik-Meta-App X-Authentik-Meta-Version authorization
 
         # optional, in this config trust all private ranges, should probably be set to the outposts IP
         trusted_proxies private_ranges

--- a/website/docs/providers/proxy/_caddy_standalone.md
+++ b/website/docs/providers/proxy/_caddy_standalone.md
@@ -23,6 +23,12 @@ app.company {
 
 If you're trying to proxy to an upstream over HTTPS, you need to set the `Host` header to the value they expect for it to work correctly.
 
+```
+reverse_proxy /outpost.goauthentik.io/* https://outpost.company {
+    header_up Host {http.reverse_proxy.upstream.hostport}
+}
+```
+
 ## Additional Configuration for Reverse Proxies
 
 When configuring reverse proxies, it may be necessary to forward additional custom headers or include basic authentication details depending on your security requirements and the specific setup of your upstream services. 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
This PR is to fix the issue with the missing authorization header for the basic authentication

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
