### PR TITLE
web: Add missing integrity hashes to package-lock.json

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -6659,6 +6659,8 @@
         },
         "node_modules/@storybook/csf": {
             "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.2.tgz",
+            "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8653,6 +8655,8 @@
         },
         "node_modules/@types/find-cache-dir": {
             "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/@types/find-cache-dir/-/find-cache-dir-3.2.1.tgz",
+            "integrity": "sha512-frsJrz2t/CeGifcu/6uRo4b+SzAwT4NYCVPu1GN8IB9XTzrpPkGuV0tmh9mN+/L0PklAlsC3u5Fxt0ju00LXIw==",
             "dev": true,
             "license": "MIT"
         },


### PR DESCRIPTION
The cherry-pick of #9419 mostly worked, but two packages were left without integrity.