### PR TITLE
website/developer-docs: Add note for custom YAML tags in an IDE

### DIFF
--- a/website/developer-docs/blueprints/v1/tags.md
+++ b/website/developer-docs/blueprints/v1/tags.md
@@ -1,5 +1,26 @@
 # YAML Tags
 
+To use the custom tags with your preferred editor, you must make the editor aware of the custom tags.
+
+For VS Code, for example, add these entries to your `settings.json`:
+
+```
+{
+    "yaml.customTags": [
+        "!KeyOf scalar",
+        "!Env scalar",
+        "!Find sequence",
+        "!Context scalar",
+        "!Format sequence",
+        "!If sequence",
+        "!Condition sequence",
+        "!Enumerate sequence",
+        "!Index scalar",
+        "!Value scalar"
+    ]
+}
+```
+
 #### `!KeyOf`
 
 Example:


### PR DESCRIPTION
Custom tags are not provided via the schema file, but must be defined in the IDE. If this is not done, the IDE displays syntax errors when using the custom tags.

## Details

This PR adds a note in the Developer Docs indicating that custom tags must be added to the editor in order for them to be used correctly. In addition, an example of VS Code is provided.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [X] The documentation has been updated
-   [X] The documentation has been formatted (`make website`)
