### PR TITLE
root: allow for customisation of s3 default acl

### DIFF
--- a/authentik/root/settings.py
+++ b/authentik/root/settings.py
@@ -415,7 +415,7 @@ if CONFIG.get("storage.media.backend", "file") == "s3":
             "use_ssl": CONFIG.get_bool("storage.media.s3.use_ssl", True),
             "endpoint_url": CONFIG.get("storage.media.s3.endpoint", None),
             "bucket_name": CONFIG.get("storage.media.s3.bucket_name"),
-            "default_acl": "private",
+            "default_acl": CONFIG.get("storage.media.s3.default_acl", "private"),
             "querystring_auth": True,
             "signature_version": "s3v4",
             "file_overwrite": False,

--- a/website/docs/installation/configuration.mdx
+++ b/website/docs/installation/configuration.mdx
@@ -144,6 +144,7 @@ These settings affect where media files are stored. Those files include applicat
 -   `AUTHENTIK_STORAGE__MEDIA__S3__SECRET_KEY`: Secret key to authenticate to S3. May be omitted if using AWS SDK authentication. Supports hot-reloading.
 -   `AUTHENTIK_STORAGE__MEDIA__S3__SECURITY_TOKEN`: Security token to authenticate to S3. May be omitted. Supports hot-reloading.
 -   `AUTHENTIK_STORAGE__MEDIA__S3__BUCKET_NAME`: Name of the bucket to use to store files.
+-   `AUTHENTIK_STORAGE__MEDIA__S3__DEFAULT_ACL`: The default ACL that'll be used to store files. Defaults to `private`.
 -   `AUTHENTIK_STORAGE__MEDIA__S3__CUSTOM_DOMAIN`: Domain to use to create URLs for users. Mainly useful for non-AWS providers. May include a port. Must include the bucket. Example: `s3.company:8080/authentik-media`.
 -   `AUTHENTIK_STORAGE__MEDIA__S3__SECURE_URLS`: Whether URLs created use HTTPS (set to `true` by default) or HTTP.
 

--- a/website/docs/installation/storage-s3.md
+++ b/website/docs/installation/storage-s3.md
@@ -79,9 +79,17 @@ AUTHENTIK_STORAGE__MEDIA__S3__ENDPOINT=https://s3.provider
 AUTHENTIK_STORAGE__MEDIA__S3__CUSTOM_DOMAIN=s3.provider/authentik-media
 ```
 
+If you are using Backblaze B2 as your S3 provider, add the following:
+
+```env
+AUTHENTIK_STORAGE__MEDIA__S3__DEFAULT_ACL=public-read
+```
+
 The `ENDPOINT` setting specifies how authentik talks to the S3 provider.
 
 The `CUSTOM_DOMAIN` setting specifies how URLs are constructed to be shown on the web interface. For example, an object stored at `application-icons/application.png` with a `CUSTOM__DOMAIN` setting of `s3.provider/authentik-media` will result in a URL of `https://s3.provider/authentik-media/application-icons/application.png`. You can also use subdomains for your buckets depending on what your S3 provider offers: `authentik-media.s3.provider`. Whether HTTPS is used is controlled by `AUTHENTIK_STORAGE__MEDIA__S3__SECURE_URLS`, which defaults to true.
+
+The `DEFAULT_ACL` setting specifies what ACL will be used by authentik to write files.
 
 For more control over settings, refer to the [configuration reference](./configuration.mdx#media-storage-settings)
 

--- a/website/docs/installation/storage-s3.md
+++ b/website/docs/installation/storage-s3.md
@@ -79,7 +79,7 @@ AUTHENTIK_STORAGE__MEDIA__S3__ENDPOINT=https://s3.provider
 AUTHENTIK_STORAGE__MEDIA__S3__CUSTOM_DOMAIN=s3.provider/authentik-media
 ```
 
-If you are using Backblaze B2 as your S3 provider, add the following:
+If you are using Backblaze B2 as your S3 provider and the bucket is set to `Public`, add the following:
 
 ```env
 AUTHENTIK_STORAGE__MEDIA__S3__DEFAULT_ACL=public-read


### PR DESCRIPTION
## Details

This pull request adds a new config option: storage.media.s3.default_acl. The reason why this change has been made is to allow for Backblaze buckets to work under Authentik. Currently, the default ACL is forced as 'private' which Backblaze does not allow in a bucket set as `public`. Additionally, the documentation has been updated to mention the new config option.

> Access control lists (ACLs) are set at the bucket level, and only the canned ACL values "private" and “public-read” are supported. You cannot set complex ACLs via XML. Objects inherit their bucket's ACL. Attempting to set an object's ACL to a different value from its parent results in a 403 Forbidden error.

**Source:** https://www.backblaze.com/apidocs/introduction-to-the-s3-compatible-api#differences-from-aws-s3

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)