### PR TITLE
web/flows: fix error when enrolling multiple WebAuthn devices consecutively

### DIFF
--- a/web/src/flow/stages/authenticator_webauthn/WebAuthnAuthenticatorRegisterStage.ts
+++ b/web/src/flow/stages/authenticator_webauthn/WebAuthnAuthenticatorRegisterStage.ts
@@ -8,7 +8,7 @@ import "@goauthentik/elements/EmptyState";
 import { BaseStage } from "@goauthentik/flow/stages/base";
 
 import { msg, str } from "@lit/localize";
-import { CSSResult, TemplateResult, css, html, nothing } from "lit";
+import { CSSResult, PropertyValues, TemplateResult, css, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
@@ -115,14 +115,16 @@ export class WebAuthnAuthenticatorRegisterStage extends BaseStage<
             });
     }
 
-    firstUpdated(): void {
-        // convert certain members of the PublicKeyCredentialCreateOptions into
-        // byte arrays as expected by the spec.
-        this.publicKeyCredentialCreateOptions = transformCredentialCreateOptions(
-            this.challenge?.registration as PublicKeyCredentialCreationOptions,
-            this.challenge?.registration.user.id,
-        );
-        this.registerWrapper();
+    updated(changedProperties: PropertyValues<this>) {
+        if (changedProperties.has("challenge") && this.challenge !== undefined) {
+            // convert certain members of the PublicKeyCredentialCreateOptions into
+            // byte arrays as expected by the spec.
+            this.publicKeyCredentialCreateOptions = transformCredentialCreateOptions(
+                this.challenge?.registration as PublicKeyCredentialCreationOptions,
+                this.challenge?.registration.user.id,
+            );
+            this.registerWrapper();
+        }
     }
 
     render(): TemplateResult {


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

Due to registerWrapper only being called in `firstUpdated`, it wouldn't trigger when the same stage transitions to a new challenge

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
