### PR TITLE
core: fix source_flow_manager saving user-source connection too early

### DIFF
--- a/.github/actions/docker-push-variables/push_vars.py
+++ b/.github/actions/docker-push-variables/push_vars.py
@@ -12,7 +12,7 @@ should_build = str(os.environ.get("DOCKER_USERNAME", None) is not None).lower()
 branch_name = os.environ["GITHUB_REF"]
 if os.environ.get("GITHUB_HEAD_REF", "") != "":
     branch_name = os.environ["GITHUB_HEAD_REF"]
-safe_branch_name = branch_name.replace("refs/heads/", "").replace("/", "-")
+safe_branch_name = branch_name.replace("refs/heads/", "").replace("/", "-").replace("'", "-")
 
 image_names = os.getenv("IMAGE_NAME").split(",")
 image_arch = os.getenv("IMAGE_ARCH") or None

--- a/authentik/core/sources/flow_manager.py
+++ b/authentik/core/sources/flow_manager.py
@@ -100,8 +100,6 @@ class SourceFlowManager:
         if self.request.user.is_authenticated:
             new_connection.user = self.request.user
             new_connection = self.update_connection(new_connection, **kwargs)
-
-            new_connection.save()
             return Action.LINK, new_connection
 
         existing_connections = self.connection_type.objects.filter(
@@ -148,7 +146,6 @@ class SourceFlowManager:
         ]:
             new_connection.user = user
             new_connection = self.update_connection(new_connection, **kwargs)
-            new_connection.save()
             return Action.LINK, new_connection
         if self.source.user_matching_mode in [
             SourceUserMatchingModes.EMAIL_DENY,

--- a/authentik/core/tests/test_source_flow_manager.py
+++ b/authentik/core/tests/test_source_flow_manager.py
@@ -48,15 +48,21 @@ class TestSourceFlowManager(TestCase):
 
     def test_authenticated_link(self):
         """Test authenticated user linking"""
-        UserOAuthSourceConnection.objects.create(
-            user=get_anonymous_user(), source=self.source, identifier=self.identifier
-        )
         user = User.objects.create(username="foo", email="foo@bar.baz")
         flow_manager = OAuthSourceFlowManager(
             self.source, get_request("/", user=user), self.identifier, {}
         )
-        action, _ = flow_manager.get_action()
+        action, connection = flow_manager.get_action()
         self.assertEqual(action, Action.LINK)
+        self.assertIsNone(connection.pk)
+        flow_manager.get_flow()
+
+    def test_unauthenticated_link(self):
+        """Test un-authenticated user linking"""
+        flow_manager = OAuthSourceFlowManager(self.source, get_request("/"), self.identifier, {})
+        action, connection = flow_manager.get_action()
+        self.assertEqual(action, Action.LINK)
+        self.assertIsNone(connection.pk)
         flow_manager.get_flow()
 
     def test_unauthenticated_enroll_email(self):


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
