### PR TITLE
website/docs: refine intro page for sources

### DIFF
--- a/website/developer-docs/docs/templates/index.md
+++ b/website/developer-docs/docs/templates/index.md
@@ -16,7 +16,7 @@ The most common types are:
 
 ### Add a new integration
 
-To add documentation for a new integration (with support level Community or Vendor), please use the integration template [`service.md`](https://github.com/goauthentik/authentik/blob/main/website/integrations/_template/service.md) file from our GitHub repo. You can download the template file using the following command:
+To add documentation for a new integration (with support level Community or Vendor), please use the integration templates [`service.md`](https://github.com/goauthentik/authentik/blob/main/website/integrations/_template/service.md) from our GitHub repo. You can download the template using the following command:
 
 ```shell
 wget https://raw.githubusercontent.com/goauthentik/authentik/main/website/integrations/_template/service.md

--- a/website/docs/sources/apple/index.md
+++ b/website/docs/sources/apple/index.md
@@ -69,5 +69,5 @@ The following placeholders will be used:
 Save, and you now have Apple as a source.
 
 :::note
-For more details on how-to have the new source display on the Login Page see [here](../general#add-sources-to-default-login-page).
+For more details on how-to have the new source display on the Login Page see [here](../index.md#add-sources-to-default-login-page).
 :::

--- a/website/docs/sources/azure-ad/index.md
+++ b/website/docs/sources/azure-ad/index.md
@@ -47,7 +47,7 @@ If you kept the default _Supported account types_ selection of _Single tenant_, 
 Save, and you now have Azure AD as a source.
 
 :::note
-For more details on how-to have the new source display on the Login Page see [here](../general#add-sources-to-default-login-page).
+For more details on how-to have the new source display on the Login Page see [here](../index.md#add-sources-to-default-login-page).
 :::
 
 ### Automatic user enrollment and attribute mapping

--- a/website/docs/sources/discord/index.md
+++ b/website/docs/sources/discord/index.md
@@ -50,7 +50,7 @@ Here is an example of a complete authentik Discord OAuth Source
 Save, and you now have Discord as a source.
 
 :::note
-For more details on how-to have the new source display on the Login Page see [here](../general#add-sources-to-default-login-page).
+For more details on how-to have the new source display on the Login Page see [here](../index.md#add-sources-to-default-login-page).
 :::
 
 ### Checking for membership of a Discord Guild

--- a/website/docs/sources/general.md
+++ b/website/docs/sources/general.md
@@ -5,6 +5,16 @@ slug: general
 
 Sources allow you to connect authentik to an external user directory. Sources can also be used with social login providers such as Facebook, Twitter, or GitHub.
 
+### Find your source
+
+Sources are in three general categories:
+
+*   Directory synchronization (Active Directory, FreeIPA)
+*   Protocols (LDAP, OAuth, SAML, and SCIM)
+*   Social logins (Apple, Discord, Twitch, Twitter, and many others)
+
+For instructions to add a specific source, refer to the documentation links in the left navigation pane.
+
 ### Add Sources to Default Login Page
 
 To have sources show on the default login screen you will need to add them. The process below assumes that you have not created or renamed the default stages and flows.
@@ -14,3 +24,5 @@ To have sources show on the default login screen you will need to add them. The 
 3. Click the **Stage Bindings** tab.
 4. Chose **Edit Stage** for the _default-authentication-identification_ stage.
 5. Under **Sources** you should see the additional sources that you have configured. Click all applicable sources to have them displayed on the Login page.
+
+

--- a/website/docs/sources/general.md
+++ b/website/docs/sources/general.md
@@ -9,20 +9,18 @@ Sources allow you to connect authentik to an external user directory. Sources ca
 
 Sources are in three general categories:
 
-*   Directory synchronization (Active Directory, FreeIPA)
-*   Protocols (LDAP, OAuth, SAML, and SCIM)
-*   Social logins (Apple, Discord, Twitch, Twitter, and many others)
+-   **Directory synchronization** (Active Directory, FreeIPA)
+-   **Protocols** (LDAP, OAuth, SAML, and SCIM)
+-   **Social logins** (Apple, Discord, Twitch, Twitter, and many others)
 
 For instructions to add a specific source, refer to the documentation links in the left navigation pane.
 
 ### Add Sources to Default Login Page
 
-To have sources show on the default login screen you will need to add them. The process below assumes that you have not created or renamed the default stages and flows.
+To have sources show on the default login screen you will need to add them to the flow. The process below assumes that you have not created or renamed the default stages and flows.
 
 1. In the Admin interface, navigate to the **Flows** section.
 2. Click on **default-authentication-flow**.
 3. Click the **Stage Bindings** tab.
 4. Chose **Edit Stage** for the _default-authentication-identification_ stage.
 5. Under **Sources** you should see the additional sources that you have configured. Click all applicable sources to have them displayed on the Login page.
-
-

--- a/website/docs/sources/github/index.md
+++ b/website/docs/sources/github/index.md
@@ -47,7 +47,7 @@ Here is an example of a complete authentik Github OAuth Source
 Save, and you now have Github as a source.
 
 :::note
-For more details on how-to have the new source display on the Login Page see [here](../general#add-sources-to-default-login-page).
+For more details on how-to have the new source display on the Login Page see [here](../index.md#add-sources-to-default-login-page).
 :::
 
 ### Checking for membership of a GitHub Organisation

--- a/website/docs/sources/google/index.md
+++ b/website/docs/sources/google/index.md
@@ -79,7 +79,7 @@ Here is an example of a complete authentik Google OAuth Source
 Save, and you now have Google as a source.
 
 :::note
-For more details on how-to have the new source display on the Login Page see [here](../general#add-sources-to-default-login-page).
+For more details on how-to have the new source display on the Login Page see [here](../index.md#add-sources-to-default-login-page).
 :::
 
 ## Username mapping

--- a/website/docs/sources/index.md
+++ b/website/docs/sources/index.md
@@ -1,6 +1,6 @@
 ---
-title: Overview of sources
-slug: general
+title: Sources
+slug: /sources
 ---
 
 Sources allow you to connect authentik to an external user directory. Sources can also be used with social login providers such as Facebook, Twitter, or GitHub.

--- a/website/docs/sources/mailcow/index.md
+++ b/website/docs/sources/mailcow/index.md
@@ -50,5 +50,5 @@ Here is an example of a complete authentik Mailcow OAuth Source
 Save, and you now have Mailcow as a source.
 
 :::note
-For more details on how-to have the new source display on the Login Page see [here](../general#add-sources-to-default-login-page).
+For more details on how-to have the new source display on the Login Page see [here](../index.md#add-sources-to-default-login-page).
 :::

--- a/website/docs/sources/plex/index.md
+++ b/website/docs/sources/plex/index.md
@@ -23,5 +23,5 @@ Add _Plex_ as a _source_
 Save, and you now have Plex as a source.
 
 :::note
-For more details on how-to have the new source display on the Login Page see [here](../general#add-sources-to-default-login-page).
+For more details on how-to have the new source display on the Login Page see [here](../index.md#add-sources-to-default-login-page).
 :::

--- a/website/docs/sources/twitch/index.md
+++ b/website/docs/sources/twitch/index.md
@@ -56,5 +56,5 @@ Here is an example of a complete authentik Twitch OAuth Source
 Save, and you now have Twitch as a source.
 
 :::note
-For more details on how-to have the new source display on the Login Page see [here](../general#add-sources-to-default-login-page).
+For more details on how-to have the new source display on the Login Page see [here](../index.md#add-sources-to-default-login-page).
 :::

--- a/website/docs/sources/twitter/index.md
+++ b/website/docs/sources/twitter/index.md
@@ -44,5 +44,5 @@ You will need to create a new project, and OAuth credentials in the Twitter Deve
 5. **Consumer Secret:** Your Client Secret from step 25
 
 :::note
-For more details on how-to have the new source display on the Login Page see [here](../general#add-sources-to-default-login-page).
+For more details on how-to have the new source display on the Login Page see [here](../index.md#add-sources-to-default-login-page).
 :::

--- a/website/integrations/index.mdx
+++ b/website/integrations/index.mdx
@@ -15,6 +15,6 @@ authentik integrates with many applications. For a full list, and to learn more 
 
 In addition to applications, authentik also integrates with external sources, including federated directories like Active Directory and through protocols such as LDAP, OAuth, SAML, and SCIM sources. Sources are a way for authentik to use external credentials for authentication and verification. Sources in authentik can also be used for social logins, using external providers such as Facebook, Twitter, etc.
 
-To learn more, refer to the [Sources](../docs/sources/general) documentation.
+To learn more, refer to the [Sources](../docs/sources) documentation.
 
 ![](./sources-logo.png)

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -141,7 +141,7 @@ const docsSidebar = {
             collapsed: true,
             link: {
                 type: "doc",
-                id: "sources/general",
+                id: "sources/index",
             },
             items: [
                 {


### PR DESCRIPTION
added a section about the various sources we support. (Also adds a Ken edit that I thought was in a previous PR, but was not.)

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
