### PR TITLE
root: docker-compose: remove version top level element

### DIFF
--- a/.github/actions/setup/docker-compose.yml
+++ b/.github/actions/setup/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   postgresql:
     image: docker.io/library/postgres:${PSQL_TAG:-16}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 ---
-version: "3.4"
 
 services:
   postgresql:

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   postgresql:
     container_name: postgres

--- a/website/developer-docs/setup/frontend-dev-environment.md
+++ b/website/developer-docs/setup/frontend-dev-environment.md
@@ -32,8 +32,6 @@ Depending on platform, some native dependencies might be required. On macOS, run
 4. Add this volume mapping to your compose file
 
     ```yaml
-    version: "3.4"
-
     services:
         # [...]
         server:

--- a/website/docs/core/certificates.md
+++ b/website/docs/core/certificates.md
@@ -78,8 +78,6 @@ Starting with authentik 2021.12.4, you can configure the certificate authentik u
 To use Let's Encrypt certificates with this setup, using certbot, you can use this compose override (create or edit a file called `docker-compose.override.yml` in the same folder as the authentik docker-compose file)
 
 ```yaml
-version: "3.2"
-
 services:
     certbot:
         image: certbot/dns-route53:v1.22.0

--- a/website/docs/core/geoip.mdx
+++ b/website/docs/core/geoip.mdx
@@ -64,8 +64,6 @@ Sign up for a free MaxMind account [here](https://www.maxmind.com/en/geolite2/si
 Add the following block to a `docker-compose.override.yml` file in the same folder as the authentik docker-compose file:
 
 ```yaml
-version: "3.2"
-
 services:
     server:
         volumes:

--- a/website/docs/interfaces/_global/customcss.mdx
+++ b/website/docs/interfaces/_global/customcss.mdx
@@ -15,8 +15,6 @@ import TabItem from "@theme/TabItem";
 Create a `docker-compose.override.yml` file and add this block to mount the custom CSS file:
 
 ```yaml
-version: "3.2"
-
 services:
     server:
         volumes:

--- a/website/docs/outposts/manual-deploy-docker-compose.md
+++ b/website/docs/outposts/manual-deploy-docker-compose.md
@@ -9,8 +9,6 @@ You can also run the outpost in a separate docker-compose project, you just have
 ### Proxy outpost
 
 ```yaml
-version: "3.5"
-
 services:
     authentik_proxy:
         image: ghcr.io/goauthentik/proxy
@@ -33,8 +31,6 @@ services:
 ### LDAP outpost
 
 ```yaml
-version: "3.5"
-
 services:
     authentik_ldap:
         image: ghcr.io/goauthentik/ldap
@@ -54,8 +50,6 @@ services:
 ### RADIUS outpost
 
 ```yaml
-version: "3.5"
-
 services:
     radius_outpost:
         image: ghcr.io/goauthentik/radius

--- a/website/docs/providers/proxy/_traefik_compose.md
+++ b/website/docs/providers/proxy/_traefik_compose.md
@@ -1,5 +1,4 @@
 ```yaml
-version: "3.7"
 services:
     traefik:
         image: traefik:v2.2

--- a/website/integrations/services/powerdns-admin/index.md
+++ b/website/integrations/services/powerdns-admin/index.md
@@ -60,7 +60,6 @@ You must mount the certificate selected in authentik as a file in the Docker con
 ### docker-compose
 
 ```yaml
-version: "3.3"
 services:
     powerdns-admin:
         image: powerdnsadmin/pda-legacy:latest


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

This pull request removes the version top level element from the docker-compose.yml as it causes an unnecessary warning that can be avoided. See https://github.com/compose-spec/compose-spec/blob/master/04-version-and-name.md

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
