### PR TITLE
website/docs: add new doc about extra steps for hardening authentik

### DIFF
--- a/website/docs/security/security-hardening.md
+++ b/website/docs/security/security-hardening.md
@@ -1,0 +1,40 @@
+---
+title: Hardening your authentik deployment
+---
+
+authentik is secure out of the box; however as everyone knows there is a consequential tradeoff between security and convenience.
+
+With that in mind, you can take steps to further increase the security of an authentik instance by applying the steps below. All of these steps have an impact on the user experience and should only be applied knowing this tradeoff.
+
+### Expressions
+
+[Expressions](../property-mappings/expression.mdx) allow super-users and other highly privileged users to create custom logic within authentik to modify its behaviour. Editing/creating these expressions is, by default, limited to super-users and any related events are fully logged.
+
+For further hardening, it is possible to prevent any user (even super-users) from using expressions to create or edit any objects. To do so, configure your deployment to block API requests to these endpoints:
+
+-   `/api/v3/policies/expression*`
+-   `/api/v3/propertymappings*`
+-   `/api/v3/managed/blueprints*`
+
+With these restrictions in place, expressions can only be edited using [Blueprints on the file system](https://docs.goauthentik.io/developer-docs/blueprints/#storage---file).
+
+### Blueprints
+
+Blueprints allow for templating and managing the authentik configuration as code. Just like expressions, they can only be created/edited by super-users or users with specific permissions assigned to them. However, because they interact with the authentik API on a lower level, they can create other objects.
+
+To prevent any user from creating/editing blueprints, block API requests to this endpoint:
+
+-   `/api/v3/managed/blueprints*`
+
+With these restrictions in place, expressions can only be edited using Blueprints on the file system.
+
+### CAPTCHA Stage
+
+The CAPTCHA stage allows for additional verification of a user while authenticating or authorising an application. Because the CAPTCHA stage supports multiple different CAPTCHA providers, such as Google’s reCAPTCHA and Cloudflare’s Turnstile, the URL for the JavaScript snippet can be modified. Depending on the threat model, this could be exploited by a malicious internal actor.
+
+To prevent any user from creating/editing CAPTCHA stages block API requests to these endpoints:
+
+-   `/api/v3/stages/captcha*`
+-   `/api/v3/managed/blueprints*`
+
+With these restrictions in place, captcha stages can only be edited using Blueprints on the file system.

--- a/website/docs/security/security-hardening.md
+++ b/website/docs/security/security-hardening.md
@@ -35,4 +35,4 @@ To prevent any user from creating/editing CAPTCHA stages block API requests to t
 -   `/api/v3/stages/captcha*`
 -   `/api/v3/managed/blueprints*`
 
-With these restrictions in place, captcha stages can only be edited using [Blueprints on the file system](https://docs.goauthentik.io/developer-docs/blueprints/#storage---file).
+With these restrictions in place, CAPTCHA stages can only be edited using [Blueprints on the file system](https://docs.goauthentik.io/developer-docs/blueprints/#storage---file).

--- a/website/docs/security/security-hardening.md
+++ b/website/docs/security/security-hardening.md
@@ -24,7 +24,7 @@ To prevent any user from creating/editing blueprints, block API requests to this
 
 -   `/api/v3/managed/blueprints*`
 
-With these restrictions in place, expressions can only be edited using [Blueprints on the file system](https://docs.goauthentik.io/developer-docs/blueprints/#storage---file).
+With these restrictions in place, Blueprints can only be edited via [the file system](https://docs.goauthentik.io/developer-docs/blueprints/#storage---file).
 
 ### CAPTCHA Stage
 

--- a/website/docs/security/security-hardening.md
+++ b/website/docs/security/security-hardening.md
@@ -14,7 +14,7 @@ However, for further hardening, it is possible to prevent any user (even super-u
 -   `/api/v3/propertymappings*`
 -   `/api/v3/managed/blueprints*`
 
-With these restrictions in place, expressions can only be edited using [Blueprints on the file system](https://docs.goauthentik.io/developer-docs/blueprints/#storage---file). And of course, implement restricted access to the file system itself.
+With these restrictions in place, expressions can only be edited using [Blueprints on the file system](https://docs.goauthentik.io/developer-docs/blueprints/#storage---file). Take care to restrict access to the file system itself.
 
 ### Blueprints
 

--- a/website/docs/security/security-hardening.md
+++ b/website/docs/security/security-hardening.md
@@ -14,7 +14,7 @@ However, for further hardening, it is possible to prevent any user (even super-u
 -   `/api/v3/propertymappings*`
 -   `/api/v3/managed/blueprints*`
 
-With these restrictions in place, expressions can only be edited using [Blueprints on the file system](https://docs.goauthentik.io/developer-docs/blueprints/#storage---file).
+With these restrictions in place, expressions can only be edited using [Blueprints on the file system](https://docs.goauthentik.io/developer-docs/blueprints/#storage---file). And of course, implement restricted access to the file system itself.
 
 ### Blueprints
 
@@ -24,7 +24,7 @@ To prevent any user from creating/editing blueprints, block API requests to this
 
 -   `/api/v3/managed/blueprints*`
 
-With these restrictions in place, expressions can only be edited using Blueprints on the file system.
+With these restrictions in place, expressions can only be edited using [Blueprints on the file system](https://docs.goauthentik.io/developer-docs/blueprints/#storage---file).
 
 ### CAPTCHA Stage
 
@@ -35,4 +35,4 @@ To prevent any user from creating/editing CAPTCHA stages block API requests to t
 -   `/api/v3/stages/captcha*`
 -   `/api/v3/managed/blueprints*`
 
-With these restrictions in place, captcha stages can only be edited using Blueprints on the file system.
+With these restrictions in place, captcha stages can only be edited using [Blueprints on the file system](https://docs.goauthentik.io/developer-docs/blueprints/#storage---file).

--- a/website/docs/security/security-hardening.md
+++ b/website/docs/security/security-hardening.md
@@ -8,7 +8,7 @@ While authentik is secure out of the box, you can take steps to further increase
 
 [Expressions](../property-mappings/expression.mdx) allow super-users and other highly privileged users to create custom logic within authentik to modify its behaviour. Editing/creating these expressions is, by default, limited to super-users and any related events are fully logged.
 
-For further hardening, it is possible to prevent any user (even super-users) from using expressions to create or edit any objects. To do so, configure your deployment to block API requests to these endpoints:
+However, for further hardening, it is possible to prevent any user (even super-users) from using expressions to create or edit any objects. To do so, configure your deployment to block API requests to these endpoints:
 
 -   `/api/v3/policies/expression*`
 -   `/api/v3/propertymappings*`

--- a/website/docs/security/security-hardening.md
+++ b/website/docs/security/security-hardening.md
@@ -1,10 +1,8 @@
 ---
-title: Hardening your authentik deployment
+title: Hardening authentik
 ---
 
-authentik is secure out of the box; however as everyone knows there is a consequential tradeoff between security and convenience.
-
-With that in mind, you can take steps to further increase the security of an authentik instance by applying the steps below. All of these steps have an impact on the user experience and should only be applied knowing this tradeoff.
+While authentik is secure out of the box, you can take steps to further increase the security of an authentik instance. As everyone knows, there is a consequential tradeoff between security and convenience. All of these hardening practices have an impact on the user experience and should only be applied knowing this tradeoff.
 
 ### Expressions
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -479,6 +479,7 @@ const docsSidebar = {
                 slug: "security",
             },
             items: [
+                "security/security-hardening",
                 "security/policy",
                 "security/CVE-2024-23647",
                 "security/CVE-2024-21637",


### PR DESCRIPTION
Added extra verbiage, from Jen's doc: https://www.notion.so/authentiksecurity/Hardening-docs-684229e00cdd49bbaa5c4ffd10c59ee2?v=684229e00cdd49bbaa5c4ffd10c59ee2

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
