### PR TITLE
website/docs: add draft docs about Google Workspace

### DIFF
--- a/website/docs/providers/gws/add-gws-provider.md
+++ b/website/docs/providers/gws/add-gws-provider.md
@@ -2,6 +2,10 @@
 title: Create a Google Workspace provider
 ---
 
+<span class="badge badge--primary">Enterprise</span>
+
+---
+
 :::info
 This feature is in technical preview, so please report any bugs on [GitHub](https://github.com/goauthentik/authentik/issues).
 :::

--- a/website/docs/providers/gws/add-gws-provider.md
+++ b/website/docs/providers/gws/add-gws-provider.md
@@ -15,7 +15,7 @@ For more information about using a Google Workspace provider, see the [Overview]
 To create a Google Worksapce provider provider in authentik, you must have already [configured Google Workspace](./setup-gws.md) to integrate with authentik.
 
 :::info
-When adding the Google Workspace provider in authentik, you must define the **Backchannel provider* using the name of the Google Workspace provider that you created in authentik. Do NOT add any value in the **Provider** field (doing so will cause the provider to display as an application on the user interface, under **My apps**, which is not supported for Google Workspace).
+When adding the Google Workspace provider in authentik, you must define the **Backchannel provider\* using the name of the Google Workspace provider that you created in authentik. Do NOT add any value in the **Provider** field (doing so will cause the provider to display as an application on the user interface, under **My apps\*\*, which is not supported for Google Workspace).
 :::
 
 ### Create the Google Workspace provider in authentik
@@ -24,6 +24,4 @@ When adding the Google Workspace provider in authentik, you must define the **Ba
 
 2. In the Admin interface, navigate to **Applications -> Providers**.
 
-3. Click **Create**. Follow the [instructions](../../applications/manage_apps.md#instructions) to create your Google Workspace  provider.
-
-
+3. Click **Create**. Follow the [instructions](../../applications/manage_apps.md#instructions) to create your Google Workspace provider.

--- a/website/docs/providers/gws/add-gws-provider.md
+++ b/website/docs/providers/gws/add-gws-provider.md
@@ -17,7 +17,7 @@ For more information about using a Google Workspace provider, see the [Overview]
 To create a Google Workspace provider in authentik, you must have already [configured Google Workspace](./setup-gws.md) to integrate with authentik.
 
 :::info
-When adding the Google Workspace provider in authentik, you must define the **Backchannel provider** using the name of the Google Workspace provider that you created in authentik. Do NOT add any value in the **Provider** field (doing so will cause the provider to display as an application on the user interface, under **My apps**, which is not supported for Google Workspace).
+When adding the Google Workspace provider in authentik, you must define the **Backchannel provider** using the name of the Google Workspace provider that you created in authentik. If you have also configured Google Workspace to log in using authentik following [these](../../../integrations/services/google/), then this configuration can be done on the same app.
 :::
 
 ### Create the Google Workspace provider in authentik
@@ -26,24 +26,24 @@ When adding the Google Workspace provider in authentik, you must define the **Ba
 
 2. In the Admin interface, navigate to **Applications -> Providers**.
 
-3. Click **Create**, and in the **New provider** modal box, define the following fields:
+3. Click **Create**, and select **Google Workspace Provider**, and in the **New provider** modal box, define the following fields:
 
     - **Name**: define a descriptive name, such as "GWS provider".
 
-        **Protocol settings**
+    - **Protocol settings**
 
-        - **Client ID**: enter the Client ID that you [copied from your Google Workspace](./setup-gws.md).
-        - **Client Secret**: enter the secret from Google Workspace.
-        - **Tenant ID**: enter the Tenant ID from Google Workspace.
-        - **User deletion action**: determines what authentik will do when a user is deleted from the Google Workspace system.
-        - **Group deletion action**: determines what authentik will do when a group is deleted from the Google Workspace system.
+        - **Credentials**: paste the contents of the JSON file you downloaded earlier.
+        - **Delegated Subject**: enter the email address of the user all of authentik's actions should be delegated to
+        - **Default group email domain**: enter a default domain which will be used to generate the domain for groups synced from authentik.
+        - **User deletion action**: determines what authentik will do when a user is deleted from authentik.
+        - **Group deletion action**: determines what authentik will do when a group is deleted from authentik.
 
-        **User filtering**
+    - **User filtering**
 
         - **Exclude service accounts**: set whether to include or exclude service accounts.
         - **Group**: select any specific groups to enforce that filtering (for all actions) is done only for the selected groups.
 
-        **Attribute mapping**
+    - **Attribute mapping**
 
         - **User Property Mappings**: select any applicable mappings, or use the default.
         - **Group Property Mappings**: select any applicable mappings, or use the default.
@@ -54,13 +54,14 @@ When adding the Google Workspace provider in authentik, you must define the **Ba
 
 1. Log in as an admin to authentik, and go to the Admin interface.
 2. In the Admin interface, navigate to **Applications -> Applications**.
+   :::info
+   If you have also configured Google Workspace to log in using authentik following [these](../../../integrations/services/google/), then this configuration can be done on the same app by adding this new provider as a backchannel provider on the existing app instead of creating a new app.
+   :::
 3. Click **Create**, and in the **New provider** modal box, and define the following fields:
 
     - **Slug**: enter the name of the app as you want it to appear in the URL.
-    - **Group**: optionally, enter a group name, of you want this new application to be grouped with other similar apps.
-    - **Provider**: _leave this field empty_. For certain types of providers (Google Workspace, Entra ID, and SCIM, for example), a paired application is not needed.
+    - **Provider**: when not used in conjunction with the Google SAML configuration should be left empty.
     - **Backchannel Providers**: this field is required for Google Workspace. Select the name of the Google Workspace provider that you created in the steps above.
-    - **Policy engine mode**: select **any** or **a\*ll** to set your policy mode.
     - **UI settings**: leave these fields empty for Google Workspace.
 
 4. Click **Finish**.

--- a/website/docs/providers/gws/add-gws-provider.md
+++ b/website/docs/providers/gws/add-gws-provider.md
@@ -6,7 +6,7 @@ title: Create a Google Workspace provider
 This feature is in technical preview, so please report any bugs on [GitHub](https://github.com/goauthentik/authentik/issues).
 :::
 
-The GWS provider ... words here
+The GWS provider ... words here... s
 
 For more information about using a Google Workspace provider, see the [Overview](./index.md) documentation.
 
@@ -15,7 +15,7 @@ For more information about using a Google Workspace provider, see the [Overview]
 To create a Google Worksapce provider provider in authentik, you must have already [configured Google Workspace](./setup-gws.md) to integrate with authentik.
 
 :::info
-When adding the Google Workspace provider in authentik, you must define the **Backchannel provider\* using the name of the Google Workspace provider that you created in authentik. Do NOT add any value in the **Provider** field (doing so will cause the provider to display as an application on the user interface, under **My apps\*\*, which is not supported for Google Workspace).
+When adding the Google Workspace provider in authentik, you must define the **Backchannel provider* using the name of the Google Workspace provider that you created in authentik. Do NOT add any value in the **Provider** field (doing so will cause the provider to display as an application on the user interface, under **My apps**, which is not supported for Google Workspace).
 :::
 
 ### Create the Google Workspace provider in authentik
@@ -24,4 +24,6 @@ When adding the Google Workspace provider in authentik, you must define the **Ba
 
 2. In the Admin interface, navigate to **Applications -> Providers**.
 
-3. Click **Create**. Follow the [instructions](../../applications/manage_apps.md#instructions) to create your Google Workspace provider.
+3. Click **Create**. Follow the [instructions](../../applications/manage_apps.md#instructions) to create your Google Workspace  provider.
+
+

--- a/website/docs/providers/gws/add-gws-provider.md
+++ b/website/docs/providers/gws/add-gws-provider.md
@@ -15,7 +15,7 @@ For more information about using a Google Workspace provider, see the [Overview]
 To create a Google Worksapce provider provider in authentik, you must have already [configured Google Workspace](./setup-gws.md) to integrate with authentik.
 
 :::info
-When adding the Google Workspace provider in authentik, you must define the **Backchannel provider* using the name of the Google Workspace provider that you created in authentik. Do NOT add any value in the **Provider** field (doing so will cause the provider to display as an application on the user interface, under **My apps**, which is not supported for Google Workspace).
+When adding the Google Workspace provider in authentik, you must define the **Backchannel provider** using the name of the Google Workspace provider that you created in authentik. Do NOT add any value in the **Provider** field (doing so will cause the provider to display as an application on the user interface, under **My apps**, which is not supported for Google Workspace).
 :::
 
 ### Create the Google Workspace provider in authentik
@@ -24,6 +24,4 @@ When adding the Google Workspace provider in authentik, you must define the **Ba
 
 2. In the Admin interface, navigate to **Applications -> Providers**.
 
-3. Click **Create**. Follow the [instructions](../../applications/manage_apps.md#instructions) to create your Google Workspace  provider.
-
-
+3. Click **Create**. Follow the [instructions](../../applications/manage_apps.md#instructions) to create your Google Workspace provider.

--- a/website/docs/providers/gws/add-gws-provider.md
+++ b/website/docs/providers/gws/add-gws-provider.md
@@ -1,0 +1,43 @@
+---
+title: Create a Google Workspace provider
+---
+
+:::info
+This feature is in technical preview, so please report any bugs on [GitHub](https://github.com/goauthentik/authentik/issues).
+:::
+
+The GWS provider ...
+
+Fow more information about using a GWS provider, see the [Overview](./index.md) documentation.
+
+## Prereqisites
+
+The GWS provider requires...
+
+## Overview workflow to create a GWS provider
+
+The typical workflow to create and configure a GWS provider is....
+
+### Step 1. Create an application and GWS provider
+
+The first step is to create the GWS app and provider.
+
+1. Log in as an admin to authentik, and go to the Admin interface.
+
+2. In the Admin interface, navigate to **Applications -> Applications**.
+
+3. Click **Create with Wizard**. Follow the [instructions](../../applications/manage_apps.md#instructions) to create your RAC application and provider.
+
+### Step 2. descriptive title
+
+words here
+
+1. ---
+
+2. ---
+
+3. ---
+
+4. ----
+
+### Step 3. descriptive title

--- a/website/docs/providers/gws/add-gws-provider.md
+++ b/website/docs/providers/gws/add-gws-provider.md
@@ -60,7 +60,7 @@ When adding the Google Workspace provider in authentik, you must define the **Ba
 3. Click **Create**, and in the **New provider** modal box, and define the following fields:
 
     - **Slug**: enter the name of the app as you want it to appear in the URL.
-    - **Provider**: when not used in conjunction with the Google SAML configuration should be left empty.
+    - **Provider**: when _not_ used in conjunction with the Google SAML configuration should be left empty.
     - **Backchannel Providers**: this field is required for Google Workspace. Select the name of the Google Workspace provider that you created in the steps above.
     - **UI settings**: leave these fields empty for Google Workspace.
 

--- a/website/docs/providers/gws/add-gws-provider.md
+++ b/website/docs/providers/gws/add-gws-provider.md
@@ -6,38 +6,24 @@ title: Create a Google Workspace provider
 This feature is in technical preview, so please report any bugs on [GitHub](https://github.com/goauthentik/authentik/issues).
 :::
 
-The GWS provider ...
+The GWS provider ... words here
 
-Fow more information about using a GWS provider, see the [Overview](./index.md) documentation.
+For more information about using a Google Workspace provider, see the [Overview](./index.md) documentation.
 
 ## Prerequisites
 
-The GWS provider requires...
+To create a Google Worksapce provider provider in authentik, you must have already [configured Google Workspace](./setup-gws.md) to integrate with authentik.
 
-## Overview workflow to create a GWS provider
+:::info
+When adding the Google Workspace provider in authentik, you must define the **Backchannel provider* using the name of the Google Workspace provider that you created in authentik. Do NOT add any value in the **Provider** field (doing so will cause the provider to display as an application on the user interface, under **My apps**, which is not supported for Google Workspace).
+:::
 
-The typical workflow to create and configure a GWS provider is....
-
-### Step 1. Create an application and GWS provider
-
-The first step is to create the GWS app and provider.
+### Create the Google Workspace provider in authentik
 
 1. Log in as an admin to authentik, and go to the Admin interface.
 
-2. In the Admin interface, navigate to **Applications -> Applications**.
+2. In the Admin interface, navigate to **Applications -> Providers**.
 
-3. Click **Create with Wizard**. Follow the [instructions](../../applications/manage_apps.md#instructions) to create your RAC application and provider.
+3. Click **Create**. Follow the [instructions](../../applications/manage_apps.md#instructions) to create your Google Workspace  provider.
 
-### Step 2. descriptive title
 
-words here
-
-1. ***
-
-2. ***
-
-3. ***
-
-4. ***
-
-### Step 3. descriptive title

--- a/website/docs/providers/gws/add-gws-provider.md
+++ b/website/docs/providers/gws/add-gws-provider.md
@@ -10,8 +10,6 @@ title: Create a Google Workspace provider
 This feature is in technical preview, so please report any bugs on [GitHub](https://github.com/goauthentik/authentik/issues).
 :::
 
-
-
 For more information about using a Google Workspace provider, see the [Overview](./index.md) documentation.
 
 ## Prerequisites
@@ -62,7 +60,7 @@ When adding the Google Workspace provider in authentik, you must define the **Ba
     - **Group**: optionally, enter a group name, of you want this new application to be grouped with other similar apps.
     - **Provider**: _leave this field empty_. For certain types of providers (Google Workspace, Entra ID, and SCIM, for example), a paired application is not needed.
     - **Backchannel Providers**: this field is required for Google Workspace. Select the name of the Google Workspace provider that you created in the steps above.
-    - **Policy engine mode**: select **any** or **a*ll** to set your policy mode.
+    - **Policy engine mode**: select **any** or **a\*ll** to set your policy mode.
     - **UI settings**: leave these fields empty for Google Workspace.
 
 4. Click **Finish**.

--- a/website/docs/providers/gws/add-gws-provider.md
+++ b/website/docs/providers/gws/add-gws-provider.md
@@ -10,13 +10,13 @@ title: Create a Google Workspace provider
 This feature is in technical preview, so please report any bugs on [GitHub](https://github.com/goauthentik/authentik/issues).
 :::
 
-The GWS provider ... words here... s
+
 
 For more information about using a Google Workspace provider, see the [Overview](./index.md) documentation.
 
 ## Prerequisites
 
-To create a Google Worksapce provider provider in authentik, you must have already [configured Google Workspace](./setup-gws.md) to integrate with authentik.
+To create a Google Workspace provider in authentik, you must have already [configured Google Workspace](./setup-gws.md) to integrate with authentik.
 
 :::info
 When adding the Google Workspace provider in authentik, you must define the **Backchannel provider** using the name of the Google Workspace provider that you created in authentik. Do NOT add any value in the **Provider** field (doing so will cause the provider to display as an application on the user interface, under **My apps**, which is not supported for Google Workspace).
@@ -28,4 +28,41 @@ When adding the Google Workspace provider in authentik, you must define the **Ba
 
 2. In the Admin interface, navigate to **Applications -> Providers**.
 
-3. Click **Create**. Follow the [instructions](../../applications/manage_apps.md#instructions) to create your Google Workspace provider.
+3. Click **Create**, and in the **New provider** modal box, define the following fields:
+
+    - **Name**: define a descriptive name, such as "GWS provider".
+
+        **Protocol settings**
+
+        - **Client ID**: enter the Client ID that you [copied from your Google Workspace](./setup-gws.md).
+        - **Client Secret**: enter the secret from Google Workspace.
+        - **Tenant ID**: enter the Tenant ID from Google Workspace.
+        - **User deletion action**: determines what authentik will do when a user is deleted from the Google Workspace system.
+        - **Group deletion action**: determines what authentik will do when a group is deleted from the Google Workspace system.
+
+        **User filtering**
+
+        - **Exclude service accounts**: set whether to include or exclude service accounts.
+        - **Group**: select any specific groups to enforce that filtering (for all actions) is done only for the selected groups.
+
+        **Attribute mapping**
+
+        - **User Property Mappings**: select any applicable mappings, or use the default.
+        - **Group Property Mappings**: select any applicable mappings, or use the default.
+
+4. Click **Finish**.
+
+### Create a Google Workspace application in authentik
+
+1. Log in as an admin to authentik, and go to the Admin interface.
+2. In the Admin interface, navigate to **Applications -> Applications**.
+3. Click **Create**, and in the **New provider** modal box, and define the following fields:
+
+    - **Slug**: enter the name of the app as you want it to appear in the URL.
+    - **Group**: optionally, enter a group name, of you want this new application to be grouped with other similar apps.
+    - **Provider**: _leave this field empty_. For certain types of providers (Google Workspace, Entra ID, and SCIM, for example), a paired application is not needed.
+    - **Backchannel Providers**: this field is required for Google Workspace. Select the name of the Google Workspace provider that you created in the steps above.
+    - **Policy engine mode**: select **any** or **a*ll** to set your policy mode.
+    - **UI settings**: leave these fields empty for Google Workspace.
+
+4. Click **Finish**.

--- a/website/docs/providers/gws/add-gws-provider.md
+++ b/website/docs/providers/gws/add-gws-provider.md
@@ -10,7 +10,7 @@ The GWS provider ...
 
 Fow more information about using a GWS provider, see the [Overview](./index.md) documentation.
 
-## Prereqisites
+## Prerequisites
 
 The GWS provider requires...
 

--- a/website/docs/providers/gws/add-gws-provider.md
+++ b/website/docs/providers/gws/add-gws-provider.md
@@ -32,12 +32,12 @@ The first step is to create the GWS app and provider.
 
 words here
 
-1. ---
+1. ***
 
-2. ---
+2. ***
 
-3. ---
+3. ***
 
-4. ----
+4. ***
 
 ### Step 3. descriptive title

--- a/website/docs/providers/gws/index.md
+++ b/website/docs/providers/gws/index.md
@@ -6,6 +6,10 @@ title: Google Workspace provider
 
 ---
 
+:::info
+This feature is in technical preview, so please report any bugs on [GitHub](https://github.com/goauthentik/authentik/issues).
+:::
+
 With the Google Workspace provider, authentik serves as the single source of truth for all users and groups, even when using Google products like Gmail.
 
 -   For instructions to configure your Google Workspace to integrate with authentik, refer to [Configure Google Workspace](./setup-gws).
@@ -17,19 +21,19 @@ The following sections discuss how Google Workspace operates with authentik.
 
 ### Discovery
 
-When first creating the provider and setting it up correctly, the provider will run a discovery and query your google workspace for all users and groups, and attempt to match them with their respective counterparts in authentik. This matching is done by email address for users as google uses that as their primary identifier, and using group names for groups. This discovery also takes into consideration any **User filtering** options configured in the provider, such as only linking to authentik users in a specific group or excluding service accounts.
+When first creating the provider and setting it up correctly, the provider will run a discovery and query your google workspace for all users and groups, and attempt to match them with their respective counterparts in authentik.
 
-This discovery happens every time the provider is saved (**_this might change later to a separate action_**)
+This matching is done by email address for users as google uses that as their primary identifier, and using group names for groups. This discovery also takes into consideration any **User filtering** options configured in the provider, such as only linking to authentik users in a specific group or excluding service accounts. This discovery happens every time the provider is saved.
 
 ### Synchronization
 
 There are two types of synchronization: a direct sync and a full sync.
 
-A _direct sync_ happens when a user or group is created, updated or deleted in authentik, or when a user is added to or removed from a group. When one of these events happens, direct sync automatically forwards those changes to Entra ID.
+A _direct sync_ happens when a user or group is created, updated or deleted in authentik, or when a user is added to or removed from a group. When one of these events happens, direct sync automatically forwards those changes to Google Workspace.
 
-The _full sync_ happens when the provider is initially created and when it is saved. The full sync goes through all users and groups matching the **User filtering** options set and will create/update them in Entra ID. After the initial sync, authentik will run a full sync every four hours to ensure the consistency of users and groups.
+The _full sync_ happens when the provider is initially created and when it is saved. The full sync goes through all users and groups matching the **User filtering** options set and will create/update them in Google Workspace. After the initial sync, authentik will run a full sync every four hours to ensure the consistency of users and groups.
 
-During either sync, if a user or group was created in authentik and a matching user/group exists in Entra ID, authentik will automatically link them together. Furthermore, users present in authentik but not in Entra ID will be re-created and and re-linked.
+During either sync, if a user or group was created in authentik and a matching user/group exists in Google Workspace, authentik will automatically link them together. Furthermore, users present in authentik but not in Google Workspace will be re-created and and re-linked.
 
 When a property mapping has an invalid expression, it will cause the sync to stop to prevent errors from being spammed. To handle any kind of network interruptions, authentik will detect transient request failures and retry any sync tasks.
 

--- a/website/docs/providers/gws/index.md
+++ b/website/docs/providers/gws/index.md
@@ -2,8 +2,6 @@
 title: GWS provider
 ---
 
-
-
 ## Common use cases
 
 With the Google Workspace provider, authentik can be the single source of truth for all users and groups, even when using Google products like Gmail.
@@ -16,7 +14,7 @@ The following sections discuss how Google Workspace operates with authentik.
 
 When first creating the provider and setting it up correctly, the provider will run a discovery and query your google workspace for all users and groups, and attempt to match them with their respective counterparts in authentik. This matching is done by email address for users as google uses that as their primary identifier, and using group names for groups. This discovery also takes into consideration any **User filtering** options configured in the provider, such as only linking to authentik users in a specific group or excluding service accounts.
 
-This discovery happens every time the provider is saved (***this might change later to a separate action***)
+This discovery happens every time the provider is saved (**_this might change later to a separate action_**)
 
 ### Syncing
 
@@ -45,5 +43,6 @@ For Groups, as Google groups require an email address, the provider has a config
 By default, authentik maps a user’s email, a user’s name, and their active status. For groups, the name is synced.
 
 Refer to Google documentation for further details:
-*   https://developers.google.com/admin-sdk/directory/reference/rest/v1/users#User
-*   https://developers.google.com/admin-sdk/directory/reference/rest/v1/groups#Group
+
+-   https://developers.google.com/admin-sdk/directory/reference/rest/v1/users#User
+-   https://developers.google.com/admin-sdk/directory/reference/rest/v1/groups#Group

--- a/website/docs/providers/gws/index.md
+++ b/website/docs/providers/gws/index.md
@@ -2,6 +2,10 @@
 title: Google Workspace provider
 ---
 
+<span class="badge badge--primary">Enterprise</span>
+
+---
+
 With the Google Workspace provider, authentik can be the single source of truth for all users and groups, even when using Google products like Gmail.
 
 -   For instructions to configure your Google Workspace to integrate with authentik, refer to [Configure Google Workspace](./setup-gws).

--- a/website/docs/providers/gws/index.md
+++ b/website/docs/providers/gws/index.md
@@ -1,5 +1,5 @@
 ---
-title: GWS provider
+title: Google Workspace provider
 ---
 
 ## Common use cases

--- a/website/docs/providers/gws/index.md
+++ b/website/docs/providers/gws/index.md
@@ -4,9 +4,9 @@ title: Google Workspace provider
 
 With the Google Workspace provider, authentik can be the single source of truth for all users and groups, even when using Google products like Gmail.
 
-*   For instructions to configure your Google Workspace to integrate with authentik, refer to [Configure Google Workspace](./setup-gws).
+-   For instructions to configure your Google Workspace to integrate with authentik, refer to [Configure Google Workspace](./setup-gws).
 
-*   For instructions to add Google Workspace as a provider, refer to [Create a Google Workspace provider](./add-gws-provider).
+-   For instructions to add Google Workspace as a provider, refer to [Create a Google Workspace provider](./add-gws-provider).
 
 ## About using Google Workspace with authentik
 

--- a/website/docs/providers/gws/index.md
+++ b/website/docs/providers/gws/index.md
@@ -10,7 +10,7 @@ title: Google Workspace provider
 This feature is in technical preview, so please report any bugs on [GitHub](https://github.com/goauthentik/authentik/issues).
 :::
 
-With the Google Workspace provider, authentik serves as the single source of truth for all users and groups, even when using Google products like Gmail.
+With the Google Workspace provider, authentik serves as the single source of truth for all users and groups, when using Google products like Gmail.
 
 -   For instructions to configure your Google Workspace to integrate with authentik, refer to [Configure Google Workspace](./setup-gws).
 -   For instructions to add Google Workspace as a provider, refer to [Create a Google Workspace provider](./add-gws-provider).
@@ -23,17 +23,17 @@ The following sections discuss how Google Workspace operates with authentik.
 
 When first creating the provider and setting it up correctly, the provider will run a discovery and query your google workspace for all users and groups, and attempt to match them with their respective counterparts in authentik.
 
-This matching is done by email address for users as google uses that as their primary identifier, and using group names for groups. This discovery also takes into consideration any **User filtering** options configured in the provider, such as only linking to authentik users in a specific group or excluding service accounts. This discovery happens every time the provider is saved.
+This matching is done by email address for users as google uses that as their primary identifier, and using group names for groups. This discovery also takes into consideration any **User filtering** options configured in the provider, such as only linking to authentik users in a specific group or excluding service accounts. This discovery happens every time before a full sync is started.
 
 ### Synchronization
 
 There are two types of synchronization: a direct sync and a full sync.
 
-A _direct sync_ happens when a user or group is created, updated or deleted in authentik, or when a user is added to or removed from a group. When one of these events happens, direct sync automatically forwards those changes to Google Workspace.
+A _direct sync_ happens when a user or group is created, updated or deleted in authentik, or when a user is added to or removed from a group. When one of these events happens, the direct sync automatically forwards those changes to Google Workspace.
 
 The _full sync_ happens when the provider is initially created and when it is saved. The full sync goes through all users and groups matching the **User filtering** options set and will create/update them in Google Workspace. After the initial sync, authentik will run a full sync every four hours to ensure the consistency of users and groups.
 
-During either sync, if a user or group was created in authentik and a matching user/group exists in Google Workspace, authentik will automatically link them together. Furthermore, users present in authentik but not in Google Workspace will be re-created and and re-linked.
+During the full sync, if a user or group was created in authentik and a matching user/group exists in Google Workspace, authentik will automatically link them together. Furthermore, users present in authentik but not in Google Workspace will be created and and linked.
 
 When a property mapping has an invalid expression, it will cause the sync to stop to prevent errors from being spammed. To handle any kind of network interruptions, authentik will detect transient request failures and retry any sync tasks.
 
@@ -41,13 +41,13 @@ When a property mapping has an invalid expression, it will cause the sync to sto
 
 There are a couple of considerations in regard to how authentik data is mapped to google workspace user/group data by default.
 
--   For users, authentik only saves the full display name, while Google requires given/family name separately, and as such authentik tries to separate the full name automatically with the default User property mapping.
+-   For users, authentik only saves the full display name, while Google requires given/family name separately, and as such authentik attempts to separate the full name automatically with the default User property mapping.
 
 -   For groups, Google groups require an email address. Thus in authentik the provider configuration has an option **Default group email domain**, which will be used in conjunction with the group’s name to generate an email address. This can be customized with a property mapping.
 
 -   By default, authentik maps a user’s email, a user’s name, and their active status. For groups, the name is synced.
 
-Refer to Google documentation for further details:
+Refer to Google documentation for further details on which fields data can be mapped to:
 
 -   https://developers.google.com/admin-sdk/directory/reference/rest/v1/users#User
 -   https://developers.google.com/admin-sdk/directory/reference/rest/v1/groups#Group

--- a/website/docs/providers/gws/index.md
+++ b/website/docs/providers/gws/index.md
@@ -2,9 +2,11 @@
 title: Google Workspace provider
 ---
 
-## Common use cases
-
 With the Google Workspace provider, authentik can be the single source of truth for all users and groups, even when using Google products like Gmail.
+
+For instructions to configure your Google Workspace to integrate with authentik, refer to [Configure Google Workspace](./setup-gws).
+
+For instructions to add Google Workspce as a provider, refer to [Create a Google Workspace provider](./add-gws-provider).
 
 ## About using Google Workspace with authentik
 
@@ -32,17 +34,18 @@ When a property mapping has an invalid expression, it will cause the sync to sto
 
 To handle any kind of network interruptions, authentik will detect transient request failures and retry any sync tasks.
 
-### Customization / Mapping of data
+### Customization for data mapping
 
 There are a couple of considerations in regard to how authentik data is mapped to google workspace user/group data by default.
 
-For Users, as authentik only saves the full display name, while Google requires given/family name separately, and as such authentik tries to separate the full name automatically with the default User property mapping.
+*   For users, authentik only saves the full display name, while Google requires given/family name separately, and as such authentik tries to separate the full name automatically with the default User property mapping.
 
-For Groups, as Google groups require an email address, the provider has a configuration option **Default group email domain** which will be used in conjunction with the group’s name to generate an email address. This can be customized with a property mapping.
+*   For groups, Google groups require an email address. Thus in authentik the provider configuration has an option **Default group email domain**, which will be used in conjunction with the group’s name to generate an email address. This can be customized with a property mapping.
 
-By default, authentik maps a user’s email, a user’s name, and their active status. For groups, the name is synced.
+*   By default, authentik maps a user’s email, a user’s name, and their active status. For groups, the name is synced.
 
 Refer to Google documentation for further details:
 
 -   https://developers.google.com/admin-sdk/directory/reference/rest/v1/users#User
 -   https://developers.google.com/admin-sdk/directory/reference/rest/v1/groups#Group
+

--- a/website/docs/providers/gws/index.md
+++ b/website/docs/providers/gws/index.md
@@ -23,19 +23,15 @@ This discovery happens every time the provider is saved (**_this might change la
 
 ### Synchronization
 
-There are two types of sync; a direct sync and a full sync.
+There are two types of synchronization: a direct sync and a full sync.
 
-The full sync happens when the provider is initially created and when it is saved. The full sync goes through all users and groups matching the **User filtering** options set and will create/update them in Google Workspace. In addition to that, the full sync is also run on a schedule every 4 hours.
+A _direct sync_ happens when a user or group is created, updated or deleted in authentik, or when a user is added to or removed from a group. When one of these events happens, direct sync automatically forwards those changes to Entra ID.
 
-The direct sync happens when a user/group is created/updated/deleted in authentik, or a member is added/removed to/from a group. The direct sync will only forward those changes to Google Workspace
+The _full sync_ happens when the provider is initially created and when it is saved. The full sync goes through all users and groups matching the **User filtering** options set and will create/update them in Entra ID. After the initial sync, authentik will run a full sync every four hours to ensure the consistency of users and groups.
 
-During either sync, if a user/group was created in authentik and a matching user/group exists in Google Workspace, authentik will link them together as the discovery would do above.
+During either sync, if a user or group was created in authentik and a matching user/group exists in Entra ID, authentik will automatically link them together. Furthermore, users present in authentik but not in Entra ID will be re-created and and re-linked.
 
-If the user has been deleted in google workspace outside of authentik, authentik will notice this and re-create and re-link the user
-
-When a property mapping has an invalid expression, it will cause the sync to stop to prevent errors from being spammed.
-
-To handle any kind of network interruptions, authentik will detect transient request failures and retry any sync tasks.
+When a property mapping has an invalid expression, it will cause the sync to stop to prevent errors from being spammed. To handle any kind of network interruptions, authentik will detect transient request failures and retry any sync tasks.
 
 ### Customization for data mapping
 

--- a/website/docs/providers/gws/index.md
+++ b/website/docs/providers/gws/index.md
@@ -4,9 +4,9 @@ title: Google Workspace provider
 
 With the Google Workspace provider, authentik can be the single source of truth for all users and groups, even when using Google products like Gmail.
 
-For instructions to configure your Google Workspace to integrate with authentik, refer to [Configure Google Workspace](./setup-gws).
+*   For instructions to configure your Google Workspace to integrate with authentik, refer to [Configure Google Workspace](./setup-gws).
 
-For instructions to add Google Workspce as a provider, refer to [Create a Google Workspace provider](./add-gws-provider).
+*   For instructions to add Google Workspace as a provider, refer to [Create a Google Workspace provider](./add-gws-provider).
 
 ## About using Google Workspace with authentik
 
@@ -38,14 +38,13 @@ To handle any kind of network interruptions, authentik will detect transient req
 
 There are a couple of considerations in regard to how authentik data is mapped to google workspace user/group data by default.
 
-*   For users, authentik only saves the full display name, while Google requires given/family name separately, and as such authentik tries to separate the full name automatically with the default User property mapping.
+-   For users, authentik only saves the full display name, while Google requires given/family name separately, and as such authentik tries to separate the full name automatically with the default User property mapping.
 
-*   For groups, Google groups require an email address. Thus in authentik the provider configuration has an option **Default group email domain**, which will be used in conjunction with the group’s name to generate an email address. This can be customized with a property mapping.
+-   For groups, Google groups require an email address. Thus in authentik the provider configuration has an option **Default group email domain**, which will be used in conjunction with the group’s name to generate an email address. This can be customized with a property mapping.
 
-*   By default, authentik maps a user’s email, a user’s name, and their active status. For groups, the name is synced.
+-   By default, authentik maps a user’s email, a user’s name, and their active status. For groups, the name is synced.
 
 Refer to Google documentation for further details:
 
 -   https://developers.google.com/admin-sdk/directory/reference/rest/v1/users#User
 -   https://developers.google.com/admin-sdk/directory/reference/rest/v1/groups#Group
-

--- a/website/docs/providers/gws/index.md
+++ b/website/docs/providers/gws/index.md
@@ -6,10 +6,9 @@ title: Google Workspace provider
 
 ---
 
-With the Google Workspace provider, authentik can be the single source of truth for all users and groups, even when using Google products like Gmail.
+With the Google Workspace provider, authentik serves as the single source of truth for all users and groups, even when using Google products like Gmail.
 
 -   For instructions to configure your Google Workspace to integrate with authentik, refer to [Configure Google Workspace](./setup-gws).
-
 -   For instructions to add Google Workspace as a provider, refer to [Create a Google Workspace provider](./add-gws-provider).
 
 ## About using Google Workspace with authentik
@@ -22,7 +21,7 @@ When first creating the provider and setting it up correctly, the provider will 
 
 This discovery happens every time the provider is saved (**_this might change later to a separate action_**)
 
-### Syncing
+### Synchronization
 
 There are two types of sync; a direct sync and a full sync.
 

--- a/website/docs/providers/gws/index.md
+++ b/website/docs/providers/gws/index.md
@@ -1,0 +1,49 @@
+---
+title: GWS provider
+---
+
+
+
+## Common use cases
+
+With the Google Workspace provider, authentik can be the single source of truth for all users and groups, even when using Google products like Gmail.
+
+## About using Google Workspace with authentik
+
+The following sections discuss how Google Workspace operates with authentik.
+
+### Discovery
+
+When first creating the provider and setting it up correctly, the provider will run a discovery and query your google workspace for all users and groups, and attempt to match them with their respective counterparts in authentik. This matching is done by email address for users as google uses that as their primary identifier, and using group names for groups. This discovery also takes into consideration any **User filtering** options configured in the provider, such as only linking to authentik users in a specific group or excluding service accounts.
+
+This discovery happens every time the provider is saved (***this might change later to a separate action***)
+
+### Syncing
+
+There are two types of sync; a direct sync and a full sync.
+
+The full sync happens when the provider is initially created and when it is saved. The full sync goes through all users and groups matching the **User filtering** options set and will create/update them in Google Workspace. In addition to that, the full sync is also run on a schedule every 4 hours.
+
+The direct sync happens when a user/group is created/updated/deleted in authentik, or a member is added/removed to/from a group. The direct sync will only forward those changes to Google Workspace
+
+During either sync, if a user/group was created in authentik and a matching user/group exists in Google Workspace, authentik will link them together as the discovery would do above.
+
+If the user has been deleted in google workspace outside of authentik, authentik will notice this and re-create and re-link the user
+
+When a property mapping has an invalid expression, it will cause the sync to stop to prevent errors from being spammed.
+
+To handle any kind of network interruptions, authentik will detect transient request failures and retry any sync tasks.
+
+### Customization / Mapping of data
+
+There are a couple of considerations in regard to how authentik data is mapped to google workspace user/group data by default.
+
+For Users, as authentik only saves the full display name, while Google requires given/family name separately, and as such authentik tries to separate the full name automatically with the default User property mapping.
+
+For Groups, as Google groups require an email address, the provider has a configuration option **Default group email domain** which will be used in conjunction with the group’s name to generate an email address. This can be customized with a property mapping.
+
+By default, authentik maps a user’s email, a user’s name, and their active status. For groups, the name is synced.
+
+Refer to Google documentation for further details:
+*   https://developers.google.com/admin-sdk/directory/reference/rest/v1/users#User
+*   https://developers.google.com/admin-sdk/directory/reference/rest/v1/groups#Group

--- a/website/docs/providers/gws/setup-gws.md
+++ b/website/docs/providers/gws/setup-gws.md
@@ -2,18 +2,16 @@
 title: Configure Google Workspace
 ---
 
-
-
-- note about backchannel provider
-- create google cloud project
-- enable Admin SDK API
-- create credentials
-- Select Application data
-- Create key and download json
-- do the `Set up domain-wide delegation for a service account`
-    - Set the scopes to these
-    - `"https://www.googleapis.com/auth/admin.directory.user"`
-    - `"https://www.googleapis.com/auth/admin.directory.group"`
-    - `"https://www.googleapis.com/auth/admin.directory.group.member"`
-- need to get email of an admin user to delegate as?
-    - Not sure which permissions are required
+-   note about backchannel provider
+-   create google cloud project
+-   enable Admin SDK API
+-   create credentials
+-   Select Application data
+-   Create key and download json
+-   do the `Set up domain-wide delegation for a service account`
+    -   Set the scopes to these
+    -   `"https://www.googleapis.com/auth/admin.directory.user"`
+    -   `"https://www.googleapis.com/auth/admin.directory.group"`
+    -   `"https://www.googleapis.com/auth/admin.directory.group.member"`
+-   need to get email of an admin user to delegate as?
+    -   Not sure which permissions are required

--- a/website/docs/providers/gws/setup-gws.md
+++ b/website/docs/providers/gws/setup-gws.md
@@ -11,8 +11,8 @@ The main steps to set up your Google workspace are as follows:
 1. [Create your Google Cloud Project](#create-a-google-cloud-project)
 2. [Create a service account](#create-a-service-account)
 3. [Set credentials for the service account](#set-credentials-for-the-service-account)
-3. [Define access and scope in the Admin Console](#set-credentials-for-the-service-account)
-4. [Configure email address for the Delegated Subject](#configure-email-address-for-the-delegated-subject)
+4. [Define access and scope in the Admin Console](#set-credentials-for-the-service-account)
+5. [Select email address for the Delegated Subject](#select-email-address-for-the-delegated-subject)
 
 For detailed instructions, refer to Google documentation.
 
@@ -30,6 +30,7 @@ For detailed instructions, refer to Google documentation.
 2. Use the search bar to find and navigate to the **IAM** page.
 3. On the **IAM** page, click **Service Accounts** in the left navigation pane.
 4. At the top of the **Service Accounts** page, click **Create Service Account**.
+
 -   Under **Service account details** page, define the **Name** and **Description** for the new serice account, and then click **Create and Continue**.
 -   Under **Grant this service account access to project** you do not need to define a role, so click **Continue**.
 -   Under **Grant users access to project** you do not need to define a role, so click **Done** to complete the creation of the service account.
@@ -39,17 +40,17 @@ For detailed instructions, refer to Google documentation.
 1. On the **Service accounts** page, click the account that you just created.
 2. Click the **Keys** tab at top of the page, the click **Add Key -> Create new key**.
 3. In the Create modal box, select JSON as the key type, and then click **Create**.
-    A pop-up displays with the private key, and the key is saved to your computer as a JSON file.
-    Later, when you create your authentik provider for Google Workspace, you will add this key in the **Credentials** field.
+   A pop-up displays with the private key, and the key is saved to your computer as a JSON file.
+   Later, when you create your authentik provider for Google Workspace, you will add this key in the **Credentials** field.
 4. On the service acount page, click the **Details** tab, and expand the **Advanced serttings** area.
 5. Copy the **Client ID** (under **Domain-wide delegation**), and then click **View Google Workspace Admin Console**.
 6. Log in to the Admin Console, and then navigate to **Security -> Access and data control -> API controls**.
 7. On the **API controls** page, click **Manage Domain Wide Delegation**.
 8. On the **Domain Wide Delegation** page, click **Add new**.
 9. In the **Add a new client ID** modal box, paste in the Client ID that you copied from the Admin console earlier (the value from the downloaded JSON file) and paste in the following scope documents:
-    *   `https://www.googleapis.com/auth/admin.directory.user`
-    *   `https://www.googleapis.com/auth/admin.directory.group`
-    *   `https://www.googleapis.com/auth/admin.directory.group.member`
+    - `https://www.googleapis.com/auth/admin.directory.user`
+    - `https://www.googleapis.com/auth/admin.directory.group`
+    - `https://www.googleapis.com/auth/admin.directory.group.member`
 
 ### Select email address for the Delegated Subject
 
@@ -60,7 +61,3 @@ The Delegated Subject email address is a required field when creating the provid
 3. Save this email address to enter into authentik when you are creating the Google Workspace provider.
 
 Now that you have configured your Google Workspace, you are ready to [add it as a provider in authentik](./add-gws-provider.md).
-
-
-
-

--- a/website/docs/providers/gws/setup-gws.md
+++ b/website/docs/providers/gws/setup-gws.md
@@ -2,6 +2,10 @@
 title: Configure Google Workspace
 ---
 
+<span class="badge badge--primary">Enterprise</span>
+
+---
+
 The configuration and set up of your Google Workspace must be completed before you [add the new provider](./add-gws-provider.md) in authentik.
 
 ## Overview of steps

--- a/website/docs/providers/gws/setup-gws.md
+++ b/website/docs/providers/gws/setup-gws.md
@@ -1,0 +1,18 @@
+---
+title: Configure Google Workspace
+---
+
+
+- note about backchannel provider
+- create google cloud project
+- enable Admin SDK API
+- create credentials
+- Select Application data
+- Create key and download json
+- do the `Set up domain-wide delegation for a service account`
+    - Set the scopes to these
+    - `"https://www.googleapis.com/auth/admin.directory.user"`
+    - `"https://www.googleapis.com/auth/admin.directory.group"`
+    - `"https://www.googleapis.com/auth/admin.directory.group.member"`
+- need to get email of an admin user to delegate as?
+    - Not sure which permissions are requiredj

--- a/website/docs/providers/gws/setup-gws.md
+++ b/website/docs/providers/gws/setup-gws.md
@@ -2,52 +2,65 @@
 title: Configure Google Workspace
 ---
 
-The configuration and set up of your Google Workspace must be done before you add the new provider in authetnik.
+The configuration and set up of your Google Workspace must be completed before you [add the new provider](./add-gws-provider.md) in authentik.
 
-:::info
--   note about backchannel provider
-:::
-
-## Configure Google Workspace
-
-### Overview of steps
+## Overview of steps
 
 The main steps to set up your Google workspace are as follows:
 
-1. Create your Google Cloud Project
-2.
-3.
-4.
+1. [Create your Google Cloud Project](#create-a-google-cloud-project)
+2. [Create a service account](#create-a-service-account)
+3. [Set credentials for the service account](#set-credentials-for-the-service-account)
+3. [Define access and scope in the Admin Console](#set-credentials-for-the-service-account)
+4. [Configure email address for the Delegated Subject](#configure-email-address-for-the-delegated-subject)
 
 For detailed instructions, refer to Google documentation.
 
-#### Create a Google cloud project
+### Create a Google cloud project
+
 1. Open the Google Cloud Console (https://cloud.google.com/cloud-console).
 2. In upper left, click the drop-down box to open the **Select a project** modal box, and then select **New Project**.
 3. Use the search bar at the top of your new project page to search for "API Library".
 4. On the **API Library** page, use the search bar again to find "Admin SDK API".
 5. On the **Admin SDK API** page, click **Enable**.
 
-#### Create credentials
+### Create a service account
 
-1. After your new Admin SDK API is enabled (it might take a few minutes), return to the Google Cloud console home page (click on **Google Cloud** in upper left).
+1. After the new Admin SDK API is enabled (it might take a few minutes), return to the Google Cloud console home page (click on **Google Cloud** in upper left).
 2. Use the search bar to find and navigate to the **IAM** page.
 3. On the **IAM** page, click **Service Accounts** in the left navigation pane.
 4. At the top of the **Service Accounts** page, click **Create Service Account**.
-*   Under **Service account details** page, define the **Name** and **Description** for the new serice account, and then click **Create and Continue**.
-*   Under **Grant this service account access to project** you do not need to define a role, so click **Continue**.
-*   Under **Grant users access to project** you do not need to define a role, so click **Done** to complete the creation of the service account.
+-   Under **Service account details** page, define the **Name** and **Description** for the new serice account, and then click **Create and Continue**.
+-   Under **Grant this service account access to project** you do not need to define a role, so click **Continue**.
+-   Under **Grant users access to project** you do not need to define a role, so click **Done** to complete the creation of the service account.
+
+### Set credentials for the service account
+
+1. On the **Service accounts** page, click the account that you just created.
+2. Click the **Keys** tab at top of the page, the click **Add Key -> Create new key**.
+3. In the Create modal box, select JSON as the key type, and then click **Create**.
+    A pop-up displays with the private key, and the key is saved to your computer as a JSON file.
+    Later, when you create your authentik provider for Google Workspace, you will add this key in the **Credentials** field.
+4. On the service acount page, click the **Details** tab, and expand the **Advanced serttings** area.
+5. Copy the **Client ID** (under **Domain-wide delegation**), and then click **View Google Workspace Admin Console**.
+6. Log in to the Admin Console, and then navigate to **Security -> Access and data control -> API controls**.
+7. On the **API controls** page, click **Manage Domain Wide Delegation**.
+8. On the **Domain Wide Delegation** page, click **Add new**.
+9. In the **Add a new client ID** modal box, paste in the Client ID that you copied from the Admin console earlier (the value from the downloaded JSON file) and paste in the following scope documents:
+    *   `https://www.googleapis.com/auth/admin.directory.user`
+    *   `https://www.googleapis.com/auth/admin.directory.group`
+    *   `https://www.googleapis.com/auth/admin.directory.group.member`
+
+### Select email address for the Delegated Subject
+
+The Delegated Subject email address is a required field when creating the provider in authentik.
+
+1. Open to the main Admin console page, and navigate to **Directory -> Users**.
+2. You can either select an existing user's email address or **Add new user** and define the user and email address to use as the Delegated Subject.
+3. Save this email address to enter into authentik when you are creating the Google Workspace provider.
+
+Now that you have configured your Google Workspace, you are ready to [add it as a provider in authentik](./add-gws-provider.md).
 
 
 
--   enable Admin SDK API
--   create credentials
--   Select Application data
--   Create key and download json
--   do the `Set up domain-wide delegation for a service account`
-    -   Set the scopes to these
-    -   `"https://www.googleapis.com/auth/admin.directory.user"`
-    -   `"https://www.googleapis.com/auth/admin.directory.group"`
-    -   `"https://www.googleapis.com/auth/admin.directory.group.member"`
--   need to get email of an admin user to delegate as?
-    -   Not sure which permissions are required
+

--- a/website/docs/providers/gws/setup-gws.md
+++ b/website/docs/providers/gws/setup-gws.md
@@ -2,8 +2,44 @@
 title: Configure Google Workspace
 ---
 
+The configuration and set up of your Google Workspace must be done before you add the new provider in authetnik.
+
+:::info
 -   note about backchannel provider
--   create google cloud project
+:::
+
+## Configure Google Workspace
+
+### Overview of steps
+
+The main steps to set up your Google workspace are as follows:
+
+1. Create your Google Cloud Project
+2.
+3.
+4.
+
+For detailed instructions, refer to Google documentation.
+
+#### Create a Google cloud project
+1. Open the Google Cloud Console (https://cloud.google.com/cloud-console).
+2. In upper left, click the drop-down box to open the **Select a project** modal box, and then select **New Project**.
+3. Use the search bar at the top of your new project page to search for "API Library".
+4. On the **API Library** page, use the search bar again to find "Admin SDK API".
+5. On the **Admin SDK API** page, click **Enable**.
+
+#### Create credentials
+
+1. After your new Admin SDK API is enabled (it might take a few minutes), return to the Google Cloud console home page (click on **Google Cloud** in upper left).
+2. Use the search bar to find and navigate to the **IAM** page.
+3. On the **IAM** page, click **Service Accounts** in the left navigation pane.
+4. At the top of the **Service Accounts** page, click **Create Service Account**.
+*   Under **Service account details** page, define the **Name** and **Description** for the new serice account, and then click **Create and Continue**.
+*   Under **Grant this service account access to project** you do not need to define a role, so click **Continue**.
+*   Under **Grant users access to project** you do not need to define a role, so click **Done** to complete the creation of the service account.
+
+
+
 -   enable Admin SDK API
 -   create credentials
 -   Select Application data

--- a/website/docs/providers/gws/setup-gws.md
+++ b/website/docs/providers/gws/setup-gws.md
@@ -3,6 +3,7 @@ title: Configure Google Workspace
 ---
 
 
+
 - note about backchannel provider
 - create google cloud project
 - enable Admin SDK API
@@ -15,4 +16,4 @@ title: Configure Google Workspace
     - `"https://www.googleapis.com/auth/admin.directory.group"`
     - `"https://www.googleapis.com/auth/admin.directory.group.member"`
 - need to get email of an admin user to delegate as?
-    - Not sure which permissions are requiredj
+    - Not sure which permissions are required

--- a/website/docs/providers/gws/setup-gws.md
+++ b/website/docs/providers/gws/setup-gws.md
@@ -31,7 +31,7 @@ For detailed instructions, refer to Google documentation.
 3. On the **IAM** page, click **Service Accounts** in the left navigation pane.
 4. At the top of the **Service Accounts** page, click **Create Service Account**.
 
--   Under **Service account details** page, define the **Name** and **Description** for the new serice account, and then click **Create and Continue**.
+-   Under **Service account details** page, define the **Name** and **Description** for the new service account, and then click **Create and Continue**.
 -   Under **Grant this service account access to project** you do not need to define a role, so click **Continue**.
 -   Under **Grant users access to project** you do not need to define a role, so click **Done** to complete the creation of the service account.
 
@@ -42,7 +42,7 @@ For detailed instructions, refer to Google documentation.
 3. In the Create modal box, select JSON as the key type, and then click **Create**.
    A pop-up displays with the private key, and the key is saved to your computer as a JSON file.
    Later, when you create your authentik provider for Google Workspace, you will add this key in the **Credentials** field.
-4. On the service acount page, click the **Details** tab, and expand the **Advanced serttings** area.
+4. On the service account page, click the **Details** tab, and expand the **Advanced serttings** area.
 5. Copy the **Client ID** (under **Domain-wide delegation**), and then click **View Google Workspace Admin Console**.
 6. Log in to the Admin Console, and then navigate to **Security -> Access and data control -> API controls**.
 7. On the **API controls** page, click **Manage Domain Wide Delegation**.

--- a/website/docs/providers/gws/setup-gws.md
+++ b/website/docs/providers/gws/setup-gws.md
@@ -24,9 +24,10 @@ For detailed instructions, refer to Google documentation.
 
 1. Open the Google Cloud Console (https://cloud.google.com/cloud-console).
 2. In upper left, click the drop-down box to open the **Select a project** modal box, and then select **New Project**.
-3. Use the search bar at the top of your new project page to search for "API Library".
-4. On the **API Library** page, use the search bar again to find "Admin SDK API".
-5. On the **Admin SDK API** page, click **Enable**.
+3. Create a new project and give it a name like "authentik GWS"
+4. Use the search bar at the top of your new project page to search for "API Library".
+5. On the **API Library** page, use the search bar again to find "Admin SDK API".
+6. On the **Admin SDK API** page, click **Enable**.
 
 ### Create a service account
 
@@ -46,7 +47,7 @@ For detailed instructions, refer to Google documentation.
 3. In the Create modal box, select JSON as the key type, and then click **Create**.
    A pop-up displays with the private key, and the key is saved to your computer as a JSON file.
    Later, when you create your authentik provider for Google Workspace, you will add this key in the **Credentials** field.
-4. On the service account page, click the **Details** tab, and expand the **Advanced serttings** area.
+4. On the service account page, click the **Details** tab, and expand the **Advanced settings** area.
 5. Copy the **Client ID** (under **Domain-wide delegation**), and then click **View Google Workspace Admin Console**.
 6. Log in to the Admin Console, and then navigate to **Security -> Access and data control -> API controls**.
 7. On the **API controls** page, click **Manage Domain Wide Delegation**.
@@ -55,6 +56,7 @@ For detailed instructions, refer to Google documentation.
     - `https://www.googleapis.com/auth/admin.directory.user`
     - `https://www.googleapis.com/auth/admin.directory.group`
     - `https://www.googleapis.com/auth/admin.directory.group.member`
+    - `https://www.googleapis.com/auth/admin.directory.domain.readonly`
 
 ### Select email address for the Delegated Subject
 

--- a/website/docs/providers/scim/index.md
+++ b/website/docs/providers/scim/index.md
@@ -12,6 +12,10 @@ When configuring SCIM, you'll get an endpoint and a token from the application t
 
 The token given by the application will be sent with all outgoing SCIM requests to authenticate them.
 
+:::info
+When adding the SCIM provider, you must define the **Backchannel provider* using the name of the SCIM provider that you created in authentik. Do NOT add any value in the **Provider** field (doing so will cause the provider to display as an application on the user interface, under **My apps**, which is not supported for SCIM).
+:::
+
 ### Syncing
 
 Data is synchronized in multiple ways:

--- a/website/docs/providers/scim/index.md
+++ b/website/docs/providers/scim/index.md
@@ -13,7 +13,7 @@ When configuring SCIM, you'll get an endpoint and a token from the application t
 The token given by the application will be sent with all outgoing SCIM requests to authenticate them.
 
 :::info
-When adding the SCIM provider, you must define the **Backchannel provider* using the name of the SCIM provider that you created in authentik. Do NOT add any value in the **Provider** field (doing so will cause the provider to display as an application on the user interface, under **My apps**, which is not supported for SCIM).
+When adding the SCIM provider, you must define the **Backchannel provider\* using the name of the SCIM provider that you created in authentik. Do NOT add any value in the **Provider** field (doing so will cause the provider to display as an application on the user interface, under **My apps\*\*, which is not supported for SCIM).
 :::
 
 ### Syncing

--- a/website/docs/providers/scim/index.md
+++ b/website/docs/providers/scim/index.md
@@ -13,7 +13,7 @@ When configuring SCIM, you'll get an endpoint and a token from the application t
 The token given by the application will be sent with all outgoing SCIM requests to authenticate them.
 
 :::info
-When adding the SCIM provider, you must define the **Backchannel provider\* using the name of the SCIM provider that you created in authentik. Do NOT add any value in the **Provider** field (doing so will cause the provider to display as an application on the user interface, under **My apps\*\*, which is not supported for SCIM).
+When adding the SCIM provider, you must define the **Backchannel provider using the name of the SCIM provider that you created in authentik. Do NOT add any value in the **Provider** field (doing so will cause the provider to display as an application on the user interface, under **My apps**, which is not supported for SCIM).
 :::
 
 ### Syncing

--- a/website/docs/providers/scim/index.md
+++ b/website/docs/providers/scim/index.md
@@ -13,7 +13,7 @@ When configuring SCIM, you'll get an endpoint and a token from the application t
 The token given by the application will be sent with all outgoing SCIM requests to authenticate them.
 
 :::info
-When adding the SCIM provider, you must define the **Backchannel provider using the name of the SCIM provider that you created in authentik. Do NOT add any value in the **Provider** field (doing so will cause the provider to display as an application on the user interface, under **My apps**, which is not supported for SCIM).
+When adding the SCIM provider, you must define the **Backchannel provider using the name of the SCIM provider that you created in authentik. Do NOT add any value in the **Provider** field (doing so will cause the provider to display as an application on the user interface, under **My apps\*\*, which is not supported for SCIM).
 :::
 
 ### Syncing

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -88,6 +88,15 @@ const docsSidebar = {
                 },
                 {
                     type: "category",
+                    label: "LDAP Provider",
+                    link: {
+                        type: "doc",
+                        id: "providers/ldap/index",
+                    },
+                    items: ["providers/ldap/generic_setup"],
+                },
+                {
+                    type: "category",
                     label: "OAuth2 Provider",
                     link: {
                         type: "doc",
@@ -125,15 +134,6 @@ const docsSidebar = {
                             ],
                         },
                     ],
-                },
-                {
-                    type: "category",
-                    label: "LDAP Provider",
-                    link: {
-                        type: "doc",
-                        id: "providers/ldap/index",
-                    },
-                    items: ["providers/ldap/generic_setup"],
                 },
                 "providers/scim/index",
                 {

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -76,6 +76,18 @@ const docsSidebar = {
             items: [
                 {
                     type: "category",
+                    label: "Google Workspace Provider",
+                    link: {
+                        type: "doc",
+                        id: "providers/gws/index",
+                    },
+                    items: [
+                        "providers/gws/setup-gws",
+                        "providers/gws/add-gws-provider",
+                    ],
+                },
+                {
+                    type: "category",
                     label: "OAuth2 Provider",
                     link: {
                         type: "doc",


### PR DESCRIPTION
DRAFT

Adds three docs for GWS: Conceptual (index.md), how to setup GWS, and how to add a GWS provider in authentik.

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
