### PR TITLE
core: add include_users flag to single group retrieval

### DIFF
--- a/authentik/core/api/groups.py
+++ b/authentik/core/api/groups.py
@@ -178,6 +178,14 @@ class GroupViewSet(UsedByMixin, ModelViewSet):
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter("include_users", bool, default=True),
+        ]
+    )
+    def retrieve(self, request, *args, **kwargs):
+        return super().retrieve(request, *args, **kwargs)
+
     @permission_required("authentik_core.add_user_to_group")
     @extend_schema(
         request=UserAccountSerializer,

--- a/authentik/core/tests/test_groups_api.py
+++ b/authentik/core/tests/test_groups_api.py
@@ -23,6 +23,17 @@ class TestGroupsAPI(APITestCase):
         response = self.client.get(reverse("authentik_api:group-list"), {"include_users": "true"})
         self.assertEqual(response.status_code, 200)
 
+    def test_retrieve_with_users(self):
+        """Test retrieve with users"""
+        admin = create_test_admin_user()
+        group = Group.objects.create(name=generate_id())
+        self.client.force_login(admin)
+        response = self.client.get(
+            reverse("authentik_api:group-detail", kwargs={"pk": group.pk}),
+            {"include_users": "true"},
+        )
+        self.assertEqual(response.status_code, 200)
+
     def test_add_user(self):
         """Test add_user"""
         group = Group.objects.create(name=generate_id())

--- a/schema.yml
+++ b/schema.yml
@@ -3733,6 +3733,11 @@ paths:
           format: uuid
         description: A UUID string identifying this Group.
         required: true
+      - in: query
+        name: include_users
+        schema:
+          type: boolean
+          default: true
       tags:
       - core
       security:


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

To compliment https://github.com/goauthentik/terraform-provider-authentik/pull/510, expose the same flag for retrieving a single group

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
