### PR TITLE
core: fix auth_method and auth_method_args being overwritten by password stage

### DIFF
--- a/authentik/core/auth.py
+++ b/authentik/core/auth.py
@@ -31,8 +31,9 @@ class InbuiltBackend(ModelBackend):
         # Since we can't directly pass other variables to signals, and we want to log the method
         # and the token used, we assume we're running in a flow and set a variable in the context
         flow_plan: FlowPlan = request.session.get(SESSION_KEY_PLAN, FlowPlan(""))
-        flow_plan.context[PLAN_CONTEXT_METHOD] = method
-        flow_plan.context[PLAN_CONTEXT_METHOD_ARGS] = cleanse_dict(sanitize_dict(kwargs))
+        flow_plan.context.setdefault(PLAN_CONTEXT_METHOD, method)
+        flow_plan.context.setdefault(PLAN_CONTEXT_METHOD_ARGS, {})
+        flow_plan.context[PLAN_CONTEXT_METHOD_ARGS].update(cleanse_dict(sanitize_dict(kwargs)))
         request.session[SESSION_KEY_PLAN] = flow_plan
 
 

--- a/authentik/stages/authenticator_validate/stage.py
+++ b/authentik/stages/authenticator_validate/stage.py
@@ -411,9 +411,12 @@ class AuthenticatorValidateStageView(ChallengeStageView):
             webauthn_device: WebAuthnDevice = response.device
             self.logger.debug("Set user from user-less flow", user=webauthn_device.user)
             self.executor.plan.context[PLAN_CONTEXT_PENDING_USER] = webauthn_device.user
-            self.executor.plan.context[PLAN_CONTEXT_METHOD] = "auth_webauthn_pwl"
-            self.executor.plan.context[PLAN_CONTEXT_METHOD_ARGS] = {
-                "device": webauthn_device,
-                "device_type": webauthn_device.device_type,
-            }
+            self.executor.plan.context.setdefault(PLAN_CONTEXT_METHOD, "auth_webauthn_pwl")
+            self.executor.plan.context.setdefault(PLAN_CONTEXT_METHOD_ARGS, {})
+            self.executor.plan.context[PLAN_CONTEXT_METHOD_ARGS].update(
+                {
+                    "device": webauthn_device,
+                    "device_type": webauthn_device.device_type,
+                }
+            )
         return self.set_valid_mfa_cookie(response.device)


### PR DESCRIPTION
the assumption used to be that the password stage would always be first, but that doesn't have to be the case

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
