### PR TITLE
Fix: Application Search text color should be light in dark mode

### DIFF
--- a/web/src/user/LibraryPage/ApplicationSearch.ts
+++ b/web/src/user/LibraryPage/ApplicationSearch.ts
@@ -35,6 +35,9 @@ export class LibraryPageApplicationList extends AKElement {
                 input:focus {
                     outline: 0;
                 }
+                :host([theme="dark"]) input {
+                    color: var(--ak-dark-foreground) !important;
+                }
             `,
         ];
     }


### PR DESCRIPTION
Fixes #8707

## Details

In dark mode the Application Search input is not easy to read because the text is black on dark gray. This is a bit of a one-off design style (large search box in the header) that I'm not sure if it's easiest to just make the change here, or try and style it via dark-theme.css. Open to feedback

---

## Checklist

-   [x] The code has been formatted (`make web`)

I also tested this on my browser in both dark and light mode.

