### PR TITLE
closes #9797 add german login message missing blank

### DIFF
--- a/web/xliff/de.xlf
+++ b/web/xliff/de.xlf
@@ -5004,8 +5004,7 @@ Bindings to groups/users are checked against the user of the event.</source>
       </trans-unit>
       <trans-unit id="s670ad066cc0e50a3">
         <source>Login to continue to <x id="0" equiv-text="${this.challenge.applicationPre}"/>.</source>
-        <target>Anmelden um mit
-        <x id="0" equiv-text="${this.challenge.applicationPre}"/>fortzufahren.</target>
+        <target>Anmelden um mit <x id="0" equiv-text="${this.challenge.applicationPre}"/> fortzufahren.</target>
       </trans-unit>
       <trans-unit id="scf5ce91bfba10a61">
         <source>Please enter your password</source>


### PR DESCRIPTION
Fix for #9797 
---

## Checklist

-   [ X] Local tests pass (`ak test authentik/`)
-   [ X] The code has been formatted (`make lint-fix`)
-   [X ] The code has been formatted (`make web`)

