### PR TITLE
policies: fix ak_call_policy failing when used in testing

### DIFF
--- a/authentik/policies/process.py
+++ b/authentik/policies/process.py
@@ -128,8 +128,8 @@ class PolicyProcess(PROCESS_CLASS):
                 binding_order=self.binding.order,
                 binding_target_type=self.binding.target_type,
                 binding_target_name=self.binding.target_name,
-                object_pk=str(self.request.obj.pk),
-                object_type=class_to_path(self.request.obj.__class__),
+                object_pk=str(self.request.obj.pk) if self.request.obj else "",
+                object_type=class_to_path(self.request.obj.__class__) if self.request.obj else "",
                 mode="execute_process",
             ).time(),
         ):


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

closes #9010

note that the error in the issue only occurred when testing a policy via API

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
