### PR TITLE
lifecycle/migrate: only acquire lock once

### DIFF
--- a/lifecycle/migrate.py
+++ b/lifecycle/migrate.py
@@ -53,19 +53,20 @@ class BaseMigration:
 
 def wait_for_lock(cursor: Cursor):
     """lock an advisory lock to prevent multiple instances from migrating at once"""
+    global LOCKED  # noqa: PLW0603
     LOGGER.info("waiting to acquire database lock")
     cursor.execute("SELECT pg_advisory_lock(%s)", (ADV_LOCK_UID,))
-
-    global LOCKED  # noqa: PLW0603
     LOCKED = True
 
 
 def release_lock(cursor: Cursor):
     """Release database lock"""
+    global LOCKED  # noqa: PLW0603
     if not LOCKED:
         return
     LOGGER.info("releasing database lock")
     cursor.execute("SELECT pg_advisory_unlock(%s)", (ADV_LOCK_UID,))
+    LOCKED = False
 
 
 def run_migrations():
@@ -82,6 +83,7 @@ def run_migrations():
     )
     curr = conn.cursor()
     try:
+        wait_for_lock(curr)
         for migration_path in Path(__file__).parent.absolute().glob("system_migrations/*.py"):
             spec = spec_from_file_location("lifecycle.system_migrations", migration_path)
             if not spec:
@@ -94,14 +96,11 @@ def run_migrations():
                     continue
                 migration = sub(curr, conn)
                 if migration.needs_migration():
-                    wait_for_lock(curr)
                     LOGGER.info("Migration needs to be applied", migration=migration_path.name)
                     migration.run()
                     LOGGER.info("Migration finished applying", migration=migration_path.name)
-                    release_lock(curr)
         LOGGER.info("applying django migrations")
         environ.setdefault("DJANGO_SETTINGS_MODULE", "authentik.root.settings")
-        wait_for_lock(curr)
         try:
             from django.core.management import execute_from_command_line
         except ImportError as exc:


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
Maybe fix the race conditions we've been seeing with migrations?

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
