### PR TITLE
sources/oauth: use id_tokens for Azure AD source instead of the userinfo endpoint

### DIFF
--- a/authentik/sources/oauth/clients/base.py
+++ b/authentik/sources/oauth/clients/base.py
@@ -70,13 +70,16 @@ class BaseOAuthClient:
         parsed_url = urlparse(authorization_url)
         parsed_args = parse_qs(parsed_url.query)
         args = self.get_redirect_args()
+        self.logger.info("redirect args1", **args)
         args.update(parameters or {})
+        self.logger.info("redirect args2", **args)
         args.update(parsed_args)
+        self.logger.info("redirect args3", **args)
         # Special handling for scope, since it's set as array
         # to make additional scopes easier
         args["scope"] = " ".join(sorted(set(args["scope"])))
+        self.logger.info("redirect args4", **args)
         params = urlencode(args, quote_via=quote, doseq=True)
-        self.logger.info("redirect args", **args)
         return urlunparse(parsed_url._replace(query=params))
 
     def parse_raw_token(self, raw_token: str) -> dict[str, Any]:
@@ -85,6 +88,7 @@ class BaseOAuthClient:
 
     def do_request(self, method: str, url: str, **kwargs) -> Response:
         """Wrapper around self.session.request, which can add special headers"""
+        self.logger.debug("Executing request", method=method, url=url, **kwargs)
         return self.session.request(method, url, **kwargs)
 
     @property

--- a/authentik/sources/oauth/clients/oauth2.py
+++ b/authentik/sources/oauth/clients/oauth2.py
@@ -83,6 +83,12 @@ class OAuth2Client(BaseOAuthClient):
             response = self.do_request(
                 "post", access_token_url, data=args, headers=self._default_headers, **request_kwargs
             )
+            if response.status_code == 400:
+                LOGGER.error(
+                    "Error fetching access token",
+                    response=response.text,
+                    status=response.status_code,
+                )
             response.raise_for_status()
         except RequestException as exc:
             LOGGER.warning(

--- a/authentik/sources/oauth/types/azure_ad.py
+++ b/authentik/sources/oauth/types/azure_ad.py
@@ -2,9 +2,13 @@
 
 from typing import Any
 
+import jwt
+from django.http import HttpRequest
+from django.utils.crypto import get_random_string
 from structlog.stdlib import get_logger
 
 from authentik.sources.oauth.clients.oauth2 import UserprofileHeaderAuthClient
+from authentik.sources.oauth.models import OAuthSource
 from authentik.sources.oauth.types.oidc import OpenIDConnectOAuth2Callback
 from authentik.sources.oauth.types.registry import SourceType, registry
 from authentik.sources.oauth.views.redirect import OAuthRedirect
@@ -12,35 +16,67 @@ from authentik.sources.oauth.views.redirect import OAuthRedirect
 LOGGER = get_logger()
 
 
+class AzureADOAuthClient(UserprofileHeaderAuthClient):
+    def __init__(self, source: OAuthSource, request: HttpRequest, callback: str | None = None):
+        super().__init__(source, request, callback)
+        self.jwks = jwt.PyJWKClient(self.source.oidc_jwks_url)
+        self.nonce = None
+
+    def get_redirect_args(self) -> dict[str, str]:
+        args = super().get_redirect_args()
+        args["response_type"] = args.get("response_type", "code") + " id_token"
+        args["response_mode"] = "form_post"
+        args["nonce"] = get_random_string(48)
+        self.request.session[self.nonce_key] = args["nonce"]
+        return args
+
+    def get_access_token(self, **request_kwargs) -> dict[str, Any] | None:
+        token = super().get_access_token(**request_kwargs)
+        if token is None:
+            return None
+        self.logger.info("Query", query=self.request.POST)
+        token["id_token"] = self.request.POST.get("id_token")
+        return token
+
+    def get_profile_info(self, token: dict[str, str]) -> dict[str, Any] | None:
+        self.logger.info("ID Token", id_token=token["id_token"])
+        return jwt.decode(token["id_token"].encode(), )
+
+    @property
+    def nonce_key(self):
+        return f"{self.session_key}-nonce"
+
+
 class AzureADOAuthRedirect(OAuthRedirect):
     """Azure AD OAuth2 Redirect"""
+    client_class = AzureADOAuthClient
 
     def get_additional_parameters(self, source):  # pragma: no cover
         return {
-            "scope": ["openid", "https://graph.microsoft.com/User.Read"],
+            "scope": ["openid"],
         }
 
 
 class AzureADOAuthCallback(OpenIDConnectOAuth2Callback):
     """AzureAD OAuth2 Callback"""
 
-    client_class = UserprofileHeaderAuthClient
+    client_class = AzureADOAuthClient
 
-    def get_user_id(self, info: dict[str, str]) -> str:
-        # Default try to get `id` for the Graph API endpoint
-        # fallback to OpenID logic in case the profile URL was changed
-        return info.get("id", super().get_user_id(info))
+    # def get_user_id(self, info: dict[str, str]) -> str:
+    #     # Default try to get `id` for the Graph API endpoint
+    #     # fallback to OpenID logic in case the profile URL was changed
+    #     return info.get("id", super().get_user_id(info))
 
-    def get_user_enroll_context(
-        self,
-        info: dict[str, Any],
-    ) -> dict[str, Any]:
-        mail = info.get("mail", None) or info.get("otherMails", [None])[0]
-        return {
-            "username": info.get("userPrincipalName"),
-            "email": mail,
-            "name": info.get("displayName"),
-        }
+    # def get_user_enroll_context(
+    #     self,
+    #     info: dict[str, Any],
+    # ) -> dict[str, Any]:
+    #     mail = info.get("mail", None) or info.get("otherMails", [None])[0]
+    #     return {
+    #         "username": info.get("userPrincipalName"),
+    #         "email": mail,
+    #         "name": info.get("displayName"),
+    #     }
 
 
 @registry.register()


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
This PR replaces the userinfo request in Azure AD source by getting an id_token together with the authorization_code (#9871).

Closes #9871

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

~~If changes to the frontend have been made~~

~~-   [ ] The code has been formatted (`make web`)~~

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
