### PR TITLE
Fix Bug #9701

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ gunicorn = "*"
 jsonpatch = "*"
 kubernetes = "*"
 ldap3 = "*"
-lxml = "*"
+lxml = "^5.2.2"
 msgraph-sdk = "*"
 opencontainers = { extras = ["reggie"], version = "*" }
 packaging = "*"


### PR DESCRIPTION
Hello,
This PR fix a minimum version for lxml to 5.2.2. Indeed the version 5.2.1 raise a core dump on the server and worker image of Authentik as described in #9701