### PR TITLE
stages/authenticator_webauthn: migrate device type import to systemtask and schedule

### DIFF
--- a/authentik/stages/authenticator_validate/tests/test_webauthn.py
+++ b/authentik/stages/authenticator_validate/tests/test_webauthn.py
@@ -32,10 +32,7 @@ from authentik.stages.authenticator_webauthn.models import (
     WebAuthnDeviceType,
 )
 from authentik.stages.authenticator_webauthn.stage import SESSION_KEY_WEBAUTHN_CHALLENGE
-from authentik.stages.authenticator_webauthn.tasks import (
-    webauthn_aaguid_import,
-    webauthn_mds_import,
-)
+from authentik.stages.authenticator_webauthn.tasks import webauthn_mds_import
 from authentik.stages.identification.models import IdentificationStage, UserFields
 from authentik.stages.user_login.models import UserLoginStage
 
@@ -131,8 +128,7 @@ class AuthenticatorValidateStageWebAuthnTests(FlowTestCase):
     def test_device_challenge_webauthn_restricted(self):
         """Test webauthn (getting device challenges with a webauthn
         device that is not allowed due to aaguid restrictions)"""
-        webauthn_mds_import(force=True)
-        webauthn_aaguid_import()
+        webauthn_mds_import.delay(force=True).get()
         request = get_request("/")
         request.user = self.user
 
@@ -249,8 +245,7 @@ class AuthenticatorValidateStageWebAuthnTests(FlowTestCase):
 
     def test_validate_challenge_unrestricted(self):
         """Test webauthn authentication (unrestricted webauthn device)"""
-        webauthn_mds_import(force=True)
-        webauthn_aaguid_import()
+        webauthn_mds_import.delay(force=True).get()
         device = WebAuthnDevice.objects.create(
             user=self.user,
             public_key=(
@@ -323,8 +318,7 @@ class AuthenticatorValidateStageWebAuthnTests(FlowTestCase):
 
     def test_validate_challenge_restricted(self):
         """Test webauthn authentication (restricted device type, failure)"""
-        webauthn_mds_import(force=True)
-        webauthn_aaguid_import()
+        webauthn_mds_import.delay(force=True).get()
         device = WebAuthnDevice.objects.create(
             user=self.user,
             public_key=(

--- a/authentik/stages/authenticator_webauthn/apps.py
+++ b/authentik/stages/authenticator_webauthn/apps.py
@@ -10,13 +10,3 @@ class AuthentikStageAuthenticatorWebAuthnConfig(ManagedAppConfig):
     label = "authentik_stages_authenticator_webauthn"
     verbose_name = "authentik Stages.Authenticator.WebAuthn"
     default = True
-
-    @ManagedAppConfig.reconcile_tenant
-    def webauthn_device_types(self):
-        from authentik.stages.authenticator_webauthn.tasks import (
-            webauthn_aaguid_import,
-            webauthn_mds_import,
-        )
-
-        webauthn_mds_import.delay()
-        webauthn_aaguid_import.delay()

--- a/authentik/stages/authenticator_webauthn/settings.py
+++ b/authentik/stages/authenticator_webauthn/settings.py
@@ -1,0 +1,17 @@
+"""Stage authenticator webauthn Settings"""
+
+from celery.schedules import crontab
+
+from authentik.lib.utils.time import fqdn_rand
+
+CELERY_BEAT_SCHEDULE = {
+    "stages_authenticator_webauthn_import_mds": {
+        "task": "authentik.stages.authenticator_webauthn.tasks.webauthn_mds_import",
+        "schedule": crontab(
+            minute=fqdn_rand("webauthn_mds_import"),
+            hour=fqdn_rand("webauthn_mds_import", 24),
+            day_of_week=fqdn_rand("webauthn_mds_import", 7),
+        ),
+        "options": {"queue": "authentik_scheduled"},
+    },
+}

--- a/authentik/stages/authenticator_webauthn/tests.py
+++ b/authentik/stages/authenticator_webauthn/tests.py
@@ -19,10 +19,7 @@ from authentik.stages.authenticator_webauthn.models import (
     WebAuthnDeviceType,
 )
 from authentik.stages.authenticator_webauthn.stage import SESSION_KEY_WEBAUTHN_CHALLENGE
-from authentik.stages.authenticator_webauthn.tasks import (
-    webauthn_aaguid_import,
-    webauthn_mds_import,
-)
+from authentik.stages.authenticator_webauthn.tasks import webauthn_mds_import
 
 
 class TestAuthenticatorWebAuthnStage(FlowTestCase):
@@ -142,8 +139,7 @@ class TestAuthenticatorWebAuthnStage(FlowTestCase):
 
     def test_register_restricted_device_type_deny(self):
         """Test registration with restricted devices (fail)"""
-        webauthn_mds_import(force=True)
-        webauthn_aaguid_import()
+        webauthn_mds_import.delay(force=True).get()
         self.stage.device_type_restrictions.set(
             WebAuthnDeviceType.objects.filter(
                 description="Android Authenticator with SafetyNet Attestation"
@@ -208,8 +204,7 @@ class TestAuthenticatorWebAuthnStage(FlowTestCase):
 
     def test_register_restricted_device_type_allow(self):
         """Test registration with restricted devices (allow)"""
-        webauthn_mds_import(force=True)
-        webauthn_aaguid_import()
+        webauthn_mds_import.delay(force=True).get()
         self.stage.device_type_restrictions.set(
             WebAuthnDeviceType.objects.filter(description="iCloud Keychain")
         )
@@ -258,8 +253,7 @@ class TestAuthenticatorWebAuthnStage(FlowTestCase):
 
     def test_register_restricted_device_type_allow_unknown(self):
         """Test registration with restricted devices (allow, unknown device type)"""
-        webauthn_mds_import(force=True)
-        webauthn_aaguid_import()
+        webauthn_mds_import.delay(force=True).get()
         WebAuthnDeviceType.objects.filter(description="iCloud Keychain").delete()
         self.stage.device_type_restrictions.set(
             WebAuthnDeviceType.objects.filter(aaguid=UNKNOWN_DEVICE_TYPE_AAGUID)


### PR DESCRIPTION
## Details

Follow-up for https://github.com/goauthentik/authentik/pull/9932#pullrequestreview-2092051031

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
