### PR TITLE
website/docs: fixed broken links to helm repo

### DIFF
--- a/website/docs/outposts/integrations/kubernetes.md
+++ b/website/docs/outposts/integrations/kubernetes.md
@@ -37,7 +37,7 @@ The following outpost settings are used:
 
 ## Permissions
 
-The permissions required for this integration are documented in the helm chart, see [Cluster-level](https://github.com/goauthentik/helm/blob/main/charts/authentik-remote-cluster/templates/cluster-role-binding.yaml) and [Namespace-level](https://github.com/goauthentik/helm/blob/main/charts/authentik-remote-cluster/templates/role-binding.yaml).
+The permissions required for this integration are documented in the helm chart. See [Cluster-level](https://github.com/goauthentik/helm/blob/main/charts/authentik-remote-cluster/templates/clusterrolebinding.yaml) and [Namespace-level](https://github.com/goauthentik/helm/blob/main/charts/authentik-remote-cluster/templates/rolebinding.yaml).
 
 ## Remote clusters
 


### PR DESCRIPTION
the links to the helm repos were broken. The changes in https://github.com/goauthentik/helm/commit/b93bc6bb8e9346412c1d2161b9270c7cbf39ac11 changed the name of the files.
