### PR TITLE
core: groups api: prefetch users as required

### DIFF
--- a/authentik/core/api/groups.py
+++ b/authentik/core/api/groups.py
@@ -2,6 +2,7 @@
 
 from json import loads
 
+from django.db.models import Prefetch
 from django.http import Http404
 from django_filters.filters import CharFilter, ModelMultipleChoiceFilter
 from django_filters.filterset import FilterSet
@@ -165,12 +166,16 @@ class GroupViewSet(UsedByMixin, ModelViewSet):
     ordering = ["name"]
 
     def get_queryset(self):
-        return (
-            Group.objects.all()
-            .select_related("parent")
-            .prefetch_related("roles")
-            .prefetch_related("users")
-        )
+        base_qs = Group.objects.all().select_related("parent").prefetch_related("roles")
+
+        if self.serializer_class(context={"request": self.request})._should_include_users:
+            base_qs = base_qs.prefetch_related("users")
+        else:
+            base_qs = base_qs.prefetch_related(
+                Prefetch("users", queryset=User.objects.all().only("id"))
+            )
+
+        return base_qs
 
     @extend_schema(
         parameters=[

--- a/authentik/core/api/groups.py
+++ b/authentik/core/api/groups.py
@@ -165,10 +165,12 @@ class GroupViewSet(UsedByMixin, ModelViewSet):
     ordering = ["name"]
 
     def get_queryset(self):
-        base_qs = Group.objects.all().select_related("parent").prefetch_related("roles")
-        if self.serializer_class(context={"request": self.request})._should_include_users:
-            base_qs = base_qs.prefetch_related("users")
-        return base_qs
+        return (
+            Group.objects.all()
+            .select_related("parent")
+            .prefetch_related("roles")
+            .prefetch_related("users")
+        )
 
     @extend_schema(
         parameters=[


### PR DESCRIPTION
## Details

Currently makes a request per group in the response to get the `users` attribute. The number of db requests ends up being linear with $page_size. This reduces this to 1.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
