### PR TITLE
crypto: update fingerprint at same time as certificate

### DIFF
--- a/internal/outpost/ak/crypto.go
+++ b/internal/outpost/ak/crypto.go
@@ -38,7 +38,6 @@ func (cs *CryptoStore) AddKeypair(uuid string) error {
 	if err != nil {
 		return err
 	}
-	cs.fingerprints[uuid] = cs.getFingerprint(uuid)
 	return nil
 }
 
@@ -73,6 +72,7 @@ func (cs *CryptoStore) Fetch(uuid string) error {
 		return err
 	}
 	cs.certificates[uuid] = &x509cert
+	cs.fingerprints[uuid] = cfp
 	return nil
 }
 


### PR DESCRIPTION
## Details

Previously the fingerprint was only set when initially adding a key, if it changed for any reason (like a renewed certificate) then every execution of `Get` would lead to a full update. The certificate itself got cached, but the fingerprint remained stale for next time.

This increased the chance of a fatal race during the cache update.

Should fix https://github.com/goauthentik/authentik/issues/9907. I've been running it locally for a while with no more races of any kind, let alone ones that actually clash and crash.

## Checklist

-   [X] Local tests pass (`ak test authentik/`)
-   [X] The code has been formatted (`make lint-fix`)

If an API change has been made (n/a)
If changes to the frontend have been made (n/a)
If applicable (documentation n/a)
