### PR TITLE
docs/troubleshooting: upgrade docker: erroneous command

### DIFF
--- a/website/docs/troubleshooting/postgres/upgrade_docker.md
+++ b/website/docs/troubleshooting/postgres/upgrade_docker.md
@@ -36,7 +36,7 @@ Add `network_mode: none` to prevent connections being established to the databas
 
 Pull new images and re-create the PostgreSQL container: `docker compose pull && docker compose up --force-recreate -d postgresql`
 
-Apply your backup to the new database: `cat upgrade_backup_12.sql | docker compose exec postgresql psql -U authentik`
+Apply your backup to the new database: `cat upgrade_backup_12.sql | docker compose exec -T postgresql psql -U authentik`
 
 Remove the network configuration setting `network_mode: none` that you added to the Compose file in the previous step.
 


### PR DESCRIPTION
Pseudo-TTY Allocation fix in docker compose exec

see https://canary.discord.com/channels/809154715984199690/832612920113496144/1249159204204445807