### PR TITLE
website/docs: Specify Synology DSM Account type to use

### DIFF
--- a/website/integrations/services/synology-dsm/index.md
+++ b/website/integrations/services/synology-dsm/index.md
@@ -46,6 +46,7 @@ To configure Synology DSM to utilize authentik as an OpenID Connect 1.0 Provider
 3. Configure the following values:
 
 -   Profile: OIDC
+-   Account type: Domain/LDAP/local
 -   Name: authentik
 -   Well Known URL: Copy this from the 'OpenID Configuration URL' in the authentik provider (URL ends with '/.well-known/openid-configuration')
 -   Application ID: The 'Client ID' from the authentik provider


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
In order to use the SSO Client in Synology DSM with local users, you have to select "Domain/LDAP/local" for the account type.

See also the Synology documentation [here](https://kb.synology.com/en-af/DSM/help/DSM/AdminCenter/file_directory_service_sso?version=7).


Edit: I just found this Reddit thread which confirms the usage of this account type, see [here](https://www.reddit.com/r/Authentik/comments/1coqio6/synology_dsm_username_password_error/)


---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
