### PR TITLE
root: use custom model serializer that saves m2m without bulk

### DIFF
--- a/authentik/brands/api.py
+++ b/authentik/brands/api.py
@@ -11,14 +11,13 @@ from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.permissions import AllowAny
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.serializers import ModelSerializer
 from rest_framework.validators import UniqueValidator
 from rest_framework.viewsets import ModelViewSet
 
 from authentik.api.authorization import SecretKeyFilter
 from authentik.brands.models import Brand
 from authentik.core.api.used_by import UsedByMixin
-from authentik.core.api.utils import PassiveSerializer
+from authentik.core.api.utils import ModelSerializer, PassiveSerializer
 from authentik.tenants.utils import get_current_tenant
 
 

--- a/authentik/core/api/applications.py
+++ b/authentik/core/api/applications.py
@@ -17,7 +17,6 @@ from rest_framework.fields import CharField, ReadOnlyField, SerializerMethodFiel
 from rest_framework.parsers import MultiPartParser
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import ModelViewSet
 from structlog.stdlib import get_logger
 
@@ -26,6 +25,7 @@ from authentik.api.pagination import Pagination
 from authentik.blueprints.v1.importer import SERIALIZER_CONTEXT_BLUEPRINT
 from authentik.core.api.providers import ProviderSerializer
 from authentik.core.api.used_by import UsedByMixin
+from authentik.core.api.utils import ModelSerializer
 from authentik.core.models import Application, User
 from authentik.events.logs import LogEventSerializer, capture_logs
 from authentik.events.models import EventAction

--- a/authentik/core/api/authenticated_sessions.py
+++ b/authentik/core/api/authenticated_sessions.py
@@ -8,12 +8,12 @@ from rest_framework import mixins
 from rest_framework.fields import SerializerMethodField
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.request import Request
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import GenericViewSet
 from ua_parser import user_agent_parser
 
 from authentik.api.authorization import OwnerSuperuserPermissions
 from authentik.core.api.used_by import UsedByMixin
+from authentik.core.api.utils import ModelSerializer
 from authentik.core.models import AuthenticatedSession
 from authentik.events.context_processors.asn import ASN_CONTEXT_PROCESSOR, ASNDict
 from authentik.events.context_processors.geoip import GEOIP_CONTEXT_PROCESSOR, GeoIPDict

--- a/authentik/core/api/groups.py
+++ b/authentik/core/api/groups.py
@@ -17,12 +17,12 @@ from rest_framework.decorators import action
 from rest_framework.fields import CharField, IntegerField, SerializerMethodField
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.serializers import ListSerializer, ModelSerializer, ValidationError
+from rest_framework.serializers import ListSerializer, ValidationError
 from rest_framework.validators import UniqueValidator
 from rest_framework.viewsets import ModelViewSet
 
 from authentik.core.api.used_by import UsedByMixin
-from authentik.core.api.utils import JSONDictField, PassiveSerializer
+from authentik.core.api.utils import JSONDictField, ModelSerializer, PassiveSerializer
 from authentik.core.models import Group, User
 from authentik.rbac.api.roles import RoleSerializer
 from authentik.rbac.decorators import permission_required

--- a/authentik/core/api/property_mappings.py
+++ b/authentik/core/api/property_mappings.py
@@ -8,11 +8,10 @@ from guardian.shortcuts import get_objects_for_user
 from rest_framework import mixins
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
-from rest_framework.fields import BooleanField, CharField
+from rest_framework.fields import BooleanField, CharField, SerializerMethodField
 from rest_framework.relations import PrimaryKeyRelatedField
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.serializers import ModelSerializer, SerializerMethodField
 from rest_framework.viewsets import GenericViewSet
 
 from authentik.blueprints.api import ManagedSerializer
@@ -20,6 +19,7 @@ from authentik.core.api.object_types import TypesMixin
 from authentik.core.api.used_by import UsedByMixin
 from authentik.core.api.utils import (
     MetaNameSerializer,
+    ModelSerializer,
     PassiveSerializer,
 )
 from authentik.core.expression.evaluator import PropertyMappingEvaluator

--- a/authentik/core/api/providers.py
+++ b/authentik/core/api/providers.py
@@ -6,13 +6,12 @@ from django.utils.translation import gettext_lazy as _
 from django_filters.filters import BooleanFilter
 from django_filters.filterset import FilterSet
 from rest_framework import mixins
-from rest_framework.fields import ReadOnlyField
-from rest_framework.serializers import ModelSerializer, SerializerMethodField
+from rest_framework.fields import ReadOnlyField, SerializerMethodField
 from rest_framework.viewsets import GenericViewSet
 
 from authentik.core.api.object_types import TypesMixin
 from authentik.core.api.used_by import UsedByMixin
-from authentik.core.api.utils import MetaNameSerializer
+from authentik.core.api.utils import MetaNameSerializer, ModelSerializer
 from authentik.core.models import Provider
 
 

--- a/authentik/core/api/sources.py
+++ b/authentik/core/api/sources.py
@@ -11,7 +11,6 @@ from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.parsers import MultiPartParser
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import GenericViewSet
 from structlog.stdlib import get_logger
 
@@ -19,7 +18,7 @@ from authentik.api.authorization import OwnerFilter, OwnerSuperuserPermissions
 from authentik.blueprints.v1.importer import SERIALIZER_CONTEXT_BLUEPRINT
 from authentik.core.api.object_types import TypesMixin
 from authentik.core.api.used_by import UsedByMixin
-from authentik.core.api.utils import MetaNameSerializer
+from authentik.core.api.utils import MetaNameSerializer, ModelSerializer
 from authentik.core.models import Source, UserSourceConnection
 from authentik.core.types import UserSettingSerializer
 from authentik.lib.utils.file import (

--- a/authentik/core/api/tokens.py
+++ b/authentik/core/api/tokens.py
@@ -12,7 +12,6 @@ from rest_framework.fields import CharField
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import ModelViewSet
 
 from authentik.api.authorization import OwnerSuperuserPermissions
@@ -20,7 +19,7 @@ from authentik.blueprints.api import ManagedSerializer
 from authentik.blueprints.v1.importer import SERIALIZER_CONTEXT_BLUEPRINT
 from authentik.core.api.used_by import UsedByMixin
 from authentik.core.api.users import UserSerializer
-from authentik.core.api.utils import PassiveSerializer
+from authentik.core.api.utils import ModelSerializer, PassiveSerializer
 from authentik.core.models import (
     USER_ATTRIBUTE_TOKEN_EXPIRING,
     USER_ATTRIBUTE_TOKEN_MAXIMUM_LIFETIME,

--- a/authentik/core/api/users.py
+++ b/authentik/core/api/users.py
@@ -40,7 +40,6 @@ from rest_framework.serializers import (
     BooleanField,
     DateTimeField,
     ListSerializer,
-    ModelSerializer,
     PrimaryKeyRelatedField,
     ValidationError,
 )
@@ -52,7 +51,12 @@ from authentik.admin.api.metrics import CoordinateSerializer
 from authentik.blueprints.v1.importer import SERIALIZER_CONTEXT_BLUEPRINT
 from authentik.brands.models import Brand
 from authentik.core.api.used_by import UsedByMixin
-from authentik.core.api.utils import JSONDictField, LinkSerializer, PassiveSerializer
+from authentik.core.api.utils import (
+    JSONDictField,
+    LinkSerializer,
+    ModelSerializer,
+    PassiveSerializer,
+)
 from authentik.core.middleware import (
     SESSION_KEY_IMPERSONATE_ORIGINAL_USER,
     SESSION_KEY_IMPERSONATE_USER,

--- a/authentik/core/api/utils.py
+++ b/authentik/core/api/utils.py
@@ -12,9 +12,12 @@ from rest_framework.fields import (
     JSONField,
     SerializerMethodField,
 )
+from rest_framework.serializers import ModelSerializer as BaseModelSerializer
 from rest_framework.serializers import (
     Serializer,
     ValidationError,
+    model_meta,
+    raise_errors_on_nested_writes,
 )
 
 
@@ -23,6 +26,35 @@ def is_dict(value: Any):
     if isinstance(value, dict):
         return
     raise ValidationError("Value must be a dictionary, and not have any duplicate keys.")
+
+
+class ModelSerializer(BaseModelSerializer):
+
+    def update(self, instance: Model, validated_data):
+        raise_errors_on_nested_writes("update", self, validated_data)
+        info = model_meta.get_field_info(instance)
+
+        # Simply set each attribute on the instance, and then save it.
+        # Note that unlike `.create()` we don't need to treat many-to-many
+        # relationships as being a special case. During updates we already
+        # have an instance pk for the relationships to be associated with.
+        m2m_fields = []
+        for attr, value in validated_data.items():
+            if attr in info.relations and info.relations[attr].to_many:
+                m2m_fields.append((attr, value))
+            else:
+                setattr(instance, attr, value)
+
+        instance.save()
+
+        # Note that many-to-many fields are set after updating instance.
+        # Setting m2m fields triggers signals which could potentially change
+        # updated instance and we do not want it to collide with .update()
+        for attr, value in m2m_fields:
+            field = getattr(instance, attr)
+            field.set(value, bulk=False)
+
+        return instance
 
 
 class JSONDictField(JSONField):

--- a/authentik/core/api/utils.py
+++ b/authentik/core/api/utils.py
@@ -52,7 +52,11 @@ class ModelSerializer(BaseModelSerializer):
         # updated instance and we do not want it to collide with .update()
         for attr, value in m2m_fields:
             field = getattr(instance, attr)
-            field.set(value, bulk=False)
+            # We can't check for inheritance here as m2m managers are generated dynamically
+            if field.__class__.__name__ == "RelatedManager":
+                field.set(value, bulk=False)
+            else:
+                field.set(value)
 
         return instance
 

--- a/authentik/crypto/api.py
+++ b/authentik/crypto/api.py
@@ -24,13 +24,12 @@ from rest_framework.fields import (
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import ModelViewSet
 from structlog.stdlib import get_logger
 
 from authentik.api.authorization import SecretKeyFilter
 from authentik.core.api.used_by import UsedByMixin
-from authentik.core.api.utils import PassiveSerializer
+from authentik.core.api.utils import ModelSerializer, PassiveSerializer
 from authentik.crypto.apps import MANAGED_KEY
 from authentik.crypto.builder import CertificateBuilder, PrivateKeyAlg
 from authentik.crypto.models import CertificateKeyPair

--- a/authentik/enterprise/api.py
+++ b/authentik/enterprise/api.py
@@ -13,11 +13,10 @@ from rest_framework.fields import CharField, IntegerField
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import ModelViewSet
 
 from authentik.core.api.used_by import UsedByMixin
-from authentik.core.api.utils import PassiveSerializer
+from authentik.core.api.utils import ModelSerializer, PassiveSerializer
 from authentik.core.models import User, UserTypes
 from authentik.enterprise.license import LicenseKey, LicenseSummarySerializer
 from authentik.enterprise.models import License

--- a/authentik/enterprise/providers/google_workspace/api/groups.py
+++ b/authentik/enterprise/providers/google_workspace/api/groups.py
@@ -1,11 +1,11 @@
 """GoogleWorkspaceProviderGroup API Views"""
 
 from rest_framework import mixins
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import GenericViewSet
 
 from authentik.core.api.used_by import UsedByMixin
 from authentik.core.api.users import UserGroupSerializer
+from authentik.core.api.utils import ModelSerializer
 from authentik.enterprise.providers.google_workspace.models import GoogleWorkspaceProviderGroup
 from authentik.lib.sync.outgoing.api import OutgoingSyncConnectionCreateMixin
 

--- a/authentik/enterprise/providers/google_workspace/api/users.py
+++ b/authentik/enterprise/providers/google_workspace/api/users.py
@@ -1,11 +1,11 @@
 """GoogleWorkspaceProviderUser API Views"""
 
 from rest_framework import mixins
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import GenericViewSet
 
 from authentik.core.api.groups import GroupMemberSerializer
 from authentik.core.api.used_by import UsedByMixin
+from authentik.core.api.utils import ModelSerializer
 from authentik.enterprise.providers.google_workspace.models import GoogleWorkspaceProviderUser
 from authentik.lib.sync.outgoing.api import OutgoingSyncConnectionCreateMixin
 

--- a/authentik/enterprise/providers/microsoft_entra/api/groups.py
+++ b/authentik/enterprise/providers/microsoft_entra/api/groups.py
@@ -1,11 +1,11 @@
 """MicrosoftEntraProviderGroup API Views"""
 
 from rest_framework import mixins
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import GenericViewSet
 
 from authentik.core.api.used_by import UsedByMixin
 from authentik.core.api.users import UserGroupSerializer
+from authentik.core.api.utils import ModelSerializer
 from authentik.enterprise.providers.microsoft_entra.models import MicrosoftEntraProviderGroup
 from authentik.lib.sync.outgoing.api import OutgoingSyncConnectionCreateMixin
 

--- a/authentik/enterprise/providers/microsoft_entra/api/users.py
+++ b/authentik/enterprise/providers/microsoft_entra/api/users.py
@@ -1,11 +1,11 @@
 """MicrosoftEntraProviderUser API Views"""
 
 from rest_framework import mixins
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import GenericViewSet
 
 from authentik.core.api.groups import GroupMemberSerializer
 from authentik.core.api.used_by import UsedByMixin
+from authentik.core.api.utils import ModelSerializer
 from authentik.enterprise.providers.microsoft_entra.models import MicrosoftEntraProviderUser
 from authentik.lib.sync.outgoing.api import OutgoingSyncConnectionCreateMixin
 

--- a/authentik/enterprise/providers/rac/api/connection_tokens.py
+++ b/authentik/enterprise/providers/rac/api/connection_tokens.py
@@ -3,12 +3,12 @@
 from django_filters.rest_framework.backends import DjangoFilterBackend
 from rest_framework import mixins
 from rest_framework.filters import OrderingFilter, SearchFilter
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import GenericViewSet
 
 from authentik.api.authorization import OwnerFilter, OwnerSuperuserPermissions
 from authentik.core.api.groups import GroupMemberSerializer
 from authentik.core.api.used_by import UsedByMixin
+from authentik.core.api.utils import ModelSerializer
 from authentik.enterprise.api import EnterpriseRequiredMixin
 from authentik.enterprise.providers.rac.api.endpoints import EndpointSerializer
 from authentik.enterprise.providers.rac.api.providers import RACProviderSerializer

--- a/authentik/enterprise/providers/rac/api/endpoints.py
+++ b/authentik/enterprise/providers/rac/api/endpoints.py
@@ -8,11 +8,11 @@ from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_sche
 from rest_framework.fields import SerializerMethodField
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import ModelViewSet
 from structlog.stdlib import get_logger
 
 from authentik.core.api.used_by import UsedByMixin
+from authentik.core.api.utils import ModelSerializer
 from authentik.core.models import Provider
 from authentik.enterprise.api import EnterpriseRequiredMixin
 from authentik.enterprise.providers.rac.api.providers import RACProviderSerializer

--- a/authentik/events/api/events.py
+++ b/authentik/events/api/events.py
@@ -15,12 +15,11 @@ from rest_framework.decorators import action
 from rest_framework.fields import DictField, IntegerField
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import ModelViewSet
 
 from authentik.admin.api.metrics import CoordinateSerializer
 from authentik.core.api.object_types import TypeCreateSerializer
-from authentik.core.api.utils import PassiveSerializer
+from authentik.core.api.utils import ModelSerializer, PassiveSerializer
 from authentik.events.models import Event, EventAction
 
 

--- a/authentik/events/api/notification_mappings.py
+++ b/authentik/events/api/notification_mappings.py
@@ -1,9 +1,9 @@
 """NotificationWebhookMapping API Views"""
 
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import ModelViewSet
 
 from authentik.core.api.used_by import UsedByMixin
+from authentik.core.api.utils import ModelSerializer
 from authentik.events.models import NotificationWebhookMapping
 
 

--- a/authentik/events/api/notification_rules.py
+++ b/authentik/events/api/notification_rules.py
@@ -1,10 +1,10 @@
 """NotificationRule API Views"""
 
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import ModelViewSet
 
 from authentik.core.api.groups import GroupSerializer
 from authentik.core.api.used_by import UsedByMixin
+from authentik.core.api.utils import ModelSerializer
 from authentik.events.models import NotificationRule
 
 

--- a/authentik/events/api/notification_transports.py
+++ b/authentik/events/api/notification_transports.py
@@ -9,11 +9,10 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.fields import CharField, ListField, SerializerMethodField
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import ModelViewSet
 
 from authentik.core.api.used_by import UsedByMixin
-from authentik.core.api.utils import PassiveSerializer
+from authentik.core.api.utils import ModelSerializer, PassiveSerializer
 from authentik.events.models import (
     Event,
     Notification,

--- a/authentik/events/api/notifications.py
+++ b/authentik/events/api/notifications.py
@@ -9,11 +9,11 @@ from rest_framework.fields import ReadOnlyField
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import GenericViewSet
 
 from authentik.api.authorization import OwnerFilter, OwnerPermissions
 from authentik.core.api.used_by import UsedByMixin
+from authentik.core.api.utils import ModelSerializer
 from authentik.events.api.events import EventSerializer
 from authentik.events.models import Notification
 

--- a/authentik/events/api/tasks.py
+++ b/authentik/events/api/tasks.py
@@ -16,10 +16,10 @@ from rest_framework.fields import (
 )
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import ReadOnlyModelViewSet
 from structlog.stdlib import get_logger
 
+from authentik.core.api.utils import ModelSerializer
 from authentik.events.logs import LogEventSerializer
 from authentik.events.models import SystemTask, TaskStatus
 from authentik.rbac.decorators import permission_required

--- a/authentik/flows/api/bindings.py
+++ b/authentik/flows/api/bindings.py
@@ -3,10 +3,10 @@
 from typing import Any
 
 from rest_framework.exceptions import ValidationError
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import ModelViewSet
 
 from authentik.core.api.used_by import UsedByMixin
+from authentik.core.api.utils import ModelSerializer
 from authentik.flows.api.stages import StageSerializer
 from authentik.flows.models import FlowStageBinding
 

--- a/authentik/flows/api/flows.py
+++ b/authentik/flows/api/flows.py
@@ -7,18 +7,22 @@ from django.utils.translation import gettext as _
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework.decorators import action
-from rest_framework.fields import BooleanField, CharField, ReadOnlyField
+from rest_framework.fields import BooleanField, CharField, ReadOnlyField, SerializerMethodField
 from rest_framework.parsers import MultiPartParser
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.serializers import ModelSerializer, SerializerMethodField
 from rest_framework.viewsets import ModelViewSet
 from structlog.stdlib import get_logger
 
 from authentik.blueprints.v1.exporter import FlowExporter
 from authentik.blueprints.v1.importer import SERIALIZER_CONTEXT_BLUEPRINT, Importer
 from authentik.core.api.used_by import UsedByMixin
-from authentik.core.api.utils import CacheSerializer, LinkSerializer, PassiveSerializer
+from authentik.core.api.utils import (
+    CacheSerializer,
+    LinkSerializer,
+    ModelSerializer,
+    PassiveSerializer,
+)
 from authentik.events.logs import LogEventSerializer
 from authentik.flows.api.flows_diagram import FlowDiagram, FlowDiagramSerializer
 from authentik.flows.exceptions import FlowNonApplicableException

--- a/authentik/flows/api/stages.py
+++ b/authentik/flows/api/stages.py
@@ -4,15 +4,15 @@ from django.urls.base import reverse
 from drf_spectacular.utils import extend_schema
 from rest_framework import mixins
 from rest_framework.decorators import action
+from rest_framework.fields import SerializerMethodField
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.serializers import ModelSerializer, SerializerMethodField
 from rest_framework.viewsets import GenericViewSet
 from structlog.stdlib import get_logger
 
 from authentik.core.api.object_types import TypesMixin
 from authentik.core.api.used_by import UsedByMixin
-from authentik.core.api.utils import MetaNameSerializer
+from authentik.core.api.utils import MetaNameSerializer, ModelSerializer
 from authentik.core.types import UserSettingSerializer
 from authentik.flows.api.flows import FlowSetSerializer
 from authentik.flows.models import ConfigurableStage, Stage

--- a/authentik/lib/sync/outgoing/api.py
+++ b/authentik/lib/sync/outgoing/api.py
@@ -7,9 +7,8 @@ from rest_framework.decorators import action
 from rest_framework.fields import BooleanField
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.serializers import ModelSerializer
 
-from authentik.core.api.utils import PassiveSerializer
+from authentik.core.api.utils import ModelSerializer, PassiveSerializer
 from authentik.events.api.tasks import SystemTaskSerializer
 from authentik.lib.sync.outgoing.models import OutgoingSyncProvider
 

--- a/authentik/outposts/api/outposts.py
+++ b/authentik/outposts/api/outposts.py
@@ -6,17 +6,17 @@ from django_filters.filters import ModelMultipleChoiceFilter
 from django_filters.filterset import FilterSet
 from drf_spectacular.utils import extend_schema
 from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
 from rest_framework.fields import BooleanField, CharField, DateTimeField, SerializerMethodField
 from rest_framework.relations import PrimaryKeyRelatedField
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.serializers import ModelSerializer, ValidationError
 from rest_framework.viewsets import ModelViewSet
 
 from authentik import get_build_hash
 from authentik.core.api.providers import ProviderSerializer
 from authentik.core.api.used_by import UsedByMixin
-from authentik.core.api.utils import JSONDictField, PassiveSerializer
+from authentik.core.api.utils import JSONDictField, ModelSerializer, PassiveSerializer
 from authentik.core.models import Provider
 from authentik.enterprise.license import LicenseKey
 from authentik.enterprise.providers.rac.models import RACProvider

--- a/authentik/outposts/api/service_connections.py
+++ b/authentik/outposts/api/service_connections.py
@@ -12,13 +12,13 @@ from rest_framework.decorators import action
 from rest_framework.fields import BooleanField, CharField, ReadOnlyField
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import GenericViewSet, ModelViewSet
 
 from authentik.core.api.object_types import TypesMixin
 from authentik.core.api.used_by import UsedByMixin
 from authentik.core.api.utils import (
     MetaNameSerializer,
+    ModelSerializer,
     PassiveSerializer,
 )
 from authentik.outposts.models import (

--- a/authentik/policies/api/bindings.py
+++ b/authentik/policies/api/bindings.py
@@ -5,13 +5,15 @@ from collections import OrderedDict
 from django.core.exceptions import ObjectDoesNotExist
 from django_filters.filters import BooleanFilter, ModelMultipleChoiceFilter
 from django_filters.filterset import FilterSet
-from rest_framework.serializers import ModelSerializer, PrimaryKeyRelatedField, ValidationError
+from rest_framework.exceptions import ValidationError
+from rest_framework.serializers import PrimaryKeyRelatedField
 from rest_framework.viewsets import ModelViewSet
 from structlog.stdlib import get_logger
 
 from authentik.core.api.groups import GroupSerializer
 from authentik.core.api.used_by import UsedByMixin
 from authentik.core.api.users import UserSerializer
+from authentik.core.api.utils import ModelSerializer
 from authentik.policies.api.policies import PolicySerializer
 from authentik.policies.models import PolicyBinding, PolicyBindingModel
 

--- a/authentik/policies/api/policies.py
+++ b/authentik/policies/api/policies.py
@@ -6,9 +6,9 @@ from drf_spectacular.utils import OpenApiResponse, extend_schema
 from guardian.shortcuts import get_objects_for_user
 from rest_framework import mixins
 from rest_framework.decorators import action
+from rest_framework.fields import SerializerMethodField
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.serializers import ModelSerializer, SerializerMethodField
 from rest_framework.viewsets import GenericViewSet
 from structlog.stdlib import get_logger
 
@@ -18,6 +18,7 @@ from authentik.core.api.used_by import UsedByMixin
 from authentik.core.api.utils import (
     CacheSerializer,
     MetaNameSerializer,
+    ModelSerializer,
 )
 from authentik.events.logs import LogEventSerializer, capture_logs
 from authentik.policies.api.exec import PolicyTestResultSerializer, PolicyTestSerializer

--- a/authentik/policies/reputation/api.py
+++ b/authentik/policies/reputation/api.py
@@ -3,10 +3,10 @@
 from django.utils.translation import gettext_lazy as _
 from rest_framework import mixins
 from rest_framework.exceptions import ValidationError
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import GenericViewSet, ModelViewSet
 
 from authentik.core.api.used_by import UsedByMixin
+from authentik.core.api.utils import ModelSerializer
 from authentik.policies.api.policies import PolicySerializer
 from authentik.policies.reputation.models import Reputation, ReputationPolicy
 

--- a/authentik/providers/ldap/api.py
+++ b/authentik/providers/ldap/api.py
@@ -5,11 +5,11 @@ from django.db.models.query import Q
 from django_filters.filters import BooleanFilter
 from django_filters.filterset import FilterSet
 from rest_framework.fields import CharField, ListField, SerializerMethodField
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
 
 from authentik.core.api.providers import ProviderSerializer
 from authentik.core.api.used_by import UsedByMixin
+from authentik.core.api.utils import ModelSerializer
 from authentik.providers.ldap.models import LDAPProvider
 
 

--- a/authentik/providers/oauth2/api/tokens.py
+++ b/authentik/providers/oauth2/api/tokens.py
@@ -7,12 +7,11 @@ from guardian.utils import get_anonymous_user
 from rest_framework import mixins
 from rest_framework.fields import CharField, ListField, SerializerMethodField
 from rest_framework.filters import OrderingFilter, SearchFilter
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import GenericViewSet
 
 from authentik.core.api.used_by import UsedByMixin
 from authentik.core.api.users import UserSerializer
-from authentik.core.api.utils import MetaNameSerializer
+from authentik.core.api.utils import MetaNameSerializer, ModelSerializer
 from authentik.providers.oauth2.api.providers import OAuth2ProviderSerializer
 from authentik.providers.oauth2.models import AccessToken, AuthorizationCode, RefreshToken
 

--- a/authentik/providers/proxy/api.py
+++ b/authentik/providers/proxy/api.py
@@ -6,12 +6,11 @@ from django.utils.translation import gettext_lazy as _
 from drf_spectacular.utils import extend_schema_field
 from rest_framework.exceptions import ValidationError
 from rest_framework.fields import CharField, ListField, ReadOnlyField, SerializerMethodField
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
 
 from authentik.core.api.providers import ProviderSerializer
 from authentik.core.api.used_by import UsedByMixin
-from authentik.core.api.utils import PassiveSerializer
+from authentik.core.api.utils import ModelSerializer, PassiveSerializer
 from authentik.lib.utils.time import timedelta_from_string
 from authentik.providers.oauth2.models import ScopeMapping
 from authentik.providers.oauth2.views.provider import ProviderInfoView

--- a/authentik/providers/radius/api.py
+++ b/authentik/providers/radius/api.py
@@ -1,11 +1,11 @@
 """RadiusProvider API Views"""
 
 from rest_framework.fields import CharField, ListField
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
 
 from authentik.core.api.providers import ProviderSerializer
 from authentik.core.api.used_by import UsedByMixin
+from authentik.core.api.utils import ModelSerializer
 from authentik.providers.radius.models import RadiusProvider
 
 

--- a/authentik/providers/scim/api/groups.py
+++ b/authentik/providers/scim/api/groups.py
@@ -1,11 +1,11 @@
 """SCIMProviderGroup API Views"""
 
 from rest_framework import mixins
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import GenericViewSet
 
 from authentik.core.api.used_by import UsedByMixin
 from authentik.core.api.users import UserGroupSerializer
+from authentik.core.api.utils import ModelSerializer
 from authentik.lib.sync.outgoing.api import OutgoingSyncConnectionCreateMixin
 from authentik.providers.scim.models import SCIMProviderGroup
 

--- a/authentik/providers/scim/api/users.py
+++ b/authentik/providers/scim/api/users.py
@@ -1,11 +1,11 @@
 """SCIMProviderUser API Views"""
 
 from rest_framework import mixins
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import GenericViewSet
 
 from authentik.core.api.groups import GroupMemberSerializer
 from authentik.core.api.used_by import UsedByMixin
+from authentik.core.api.utils import ModelSerializer
 from authentik.lib.sync.outgoing.api import OutgoingSyncConnectionCreateMixin
 from authentik.providers.scim.models import SCIMProviderUser
 

--- a/authentik/rbac/api/rbac.py
+++ b/authentik/rbac/api/rbac.py
@@ -13,10 +13,9 @@ from rest_framework.fields import (
     ReadOnlyField,
     SerializerMethodField,
 )
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import ReadOnlyModelViewSet
 
-from authentik.core.api.utils import PassiveSerializer
+from authentik.core.api.utils import ModelSerializer, PassiveSerializer
 from authentik.core.models import User
 from authentik.lib.validators import RequiredTogetherValidator
 from authentik.policies.event_matcher.models import model_choices

--- a/authentik/rbac/api/rbac_assigned_by_roles.py
+++ b/authentik/rbac/api/rbac_assigned_by_roles.py
@@ -12,10 +12,9 @@ from rest_framework.fields import CharField, ReadOnlyField
 from rest_framework.mixins import ListModelMixin
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import GenericViewSet
 
-from authentik.core.api.utils import PassiveSerializer
+from authentik.core.api.utils import ModelSerializer, PassiveSerializer
 from authentik.policies.event_matcher.models import model_choices
 from authentik.rbac.api.rbac import PermissionAssignSerializer
 from authentik.rbac.decorators import permission_required

--- a/authentik/rbac/api/rbac_assigned_by_users.py
+++ b/authentik/rbac/api/rbac_assigned_by_users.py
@@ -13,10 +13,10 @@ from rest_framework.fields import BooleanField, ReadOnlyField
 from rest_framework.mixins import ListModelMixin
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import GenericViewSet
 
 from authentik.core.api.groups import GroupMemberSerializer
+from authentik.core.api.utils import ModelSerializer
 from authentik.core.models import User, UserTypes
 from authentik.policies.event_matcher.models import model_choices
 from authentik.rbac.api.rbac import PermissionAssignSerializer

--- a/authentik/rbac/api/roles.py
+++ b/authentik/rbac/api/roles.py
@@ -1,9 +1,9 @@
 """RBAC Roles"""
 
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import ModelViewSet
 
 from authentik.core.api.used_by import UsedByMixin
+from authentik.core.api.utils import ModelSerializer
 from authentik.rbac.models import Role
 
 

--- a/authentik/stages/authenticator_duo/api.py
+++ b/authentik/stages/authenticator_duo/api.py
@@ -12,12 +12,12 @@ from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.permissions import IsAdminUser
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import GenericViewSet, ModelViewSet
 from structlog.stdlib import get_logger
 
 from authentik.api.authorization import OwnerFilter, OwnerPermissions
 from authentik.core.api.used_by import UsedByMixin
+from authentik.core.api.utils import ModelSerializer
 from authentik.flows.api.stages import StageSerializer
 from authentik.rbac.decorators import permission_required
 from authentik.stages.authenticator_duo.models import AuthenticatorDuoStage, DuoDevice

--- a/authentik/stages/authenticator_sms/api.py
+++ b/authentik/stages/authenticator_sms/api.py
@@ -4,11 +4,11 @@ from django_filters.rest_framework.backends import DjangoFilterBackend
 from rest_framework import mixins
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.permissions import IsAdminUser
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import GenericViewSet, ModelViewSet
 
 from authentik.api.authorization import OwnerFilter, OwnerPermissions
 from authentik.core.api.used_by import UsedByMixin
+from authentik.core.api.utils import ModelSerializer
 from authentik.flows.api.stages import StageSerializer
 from authentik.stages.authenticator_sms.models import AuthenticatorSMSStage, SMSDevice
 

--- a/authentik/stages/authenticator_static/api.py
+++ b/authentik/stages/authenticator_static/api.py
@@ -4,11 +4,11 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import mixins
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.permissions import IsAdminUser
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import GenericViewSet, ModelViewSet
 
 from authentik.api.authorization import OwnerFilter, OwnerPermissions
 from authentik.core.api.used_by import UsedByMixin
+from authentik.core.api.utils import ModelSerializer
 from authentik.flows.api.stages import StageSerializer
 from authentik.stages.authenticator_static.models import (
     AuthenticatorStaticStage,

--- a/authentik/stages/authenticator_totp/api.py
+++ b/authentik/stages/authenticator_totp/api.py
@@ -5,11 +5,11 @@ from rest_framework import mixins
 from rest_framework.fields import ChoiceField
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.permissions import IsAdminUser
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import GenericViewSet, ModelViewSet
 
 from authentik.api.authorization import OwnerFilter, OwnerPermissions
 from authentik.core.api.used_by import UsedByMixin
+from authentik.core.api.utils import ModelSerializer
 from authentik.flows.api.stages import StageSerializer
 from authentik.stages.authenticator_totp.models import (
     AuthenticatorTOTPStage,

--- a/authentik/stages/authenticator_webauthn/api/devices.py
+++ b/authentik/stages/authenticator_webauthn/api/devices.py
@@ -4,11 +4,11 @@ from django_filters.rest_framework.backends import DjangoFilterBackend
 from rest_framework import mixins
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.permissions import IsAdminUser
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import GenericViewSet, ModelViewSet
 
 from authentik.api.authorization import OwnerFilter, OwnerPermissions
 from authentik.core.api.used_by import UsedByMixin
+from authentik.core.api.utils import ModelSerializer
 from authentik.stages.authenticator_webauthn.api.device_types import WebAuthnDeviceTypeSerializer
 from authentik.stages.authenticator_webauthn.models import WebAuthnDevice
 

--- a/authentik/stages/invitation/api.py
+++ b/authentik/stages/invitation/api.py
@@ -2,12 +2,11 @@
 
 from django_filters.filters import BooleanFilter
 from django_filters.filterset import FilterSet
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import ModelViewSet
 
 from authentik.core.api.groups import GroupMemberSerializer
 from authentik.core.api.used_by import UsedByMixin
-from authentik.core.api.utils import JSONDictField
+from authentik.core.api.utils import JSONDictField, ModelSerializer
 from authentik.flows.api.flows import FlowSerializer
 from authentik.flows.api.stages import StageSerializer
 from authentik.stages.invitation.models import Invitation, InvitationStage

--- a/authentik/tenants/api/domains.py
+++ b/authentik/tenants/api/domains.py
@@ -3,9 +3,9 @@
 from django.apps import apps
 from django.http import HttpResponseNotFound
 from rest_framework.filters import OrderingFilter, SearchFilter
-from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import ModelViewSet
 
+from authentik.core.api.utils import ModelSerializer
 from authentik.tenants.api.tenants import TenantApiKeyPermission
 from authentik.tenants.models import Domain
 

--- a/authentik/tenants/api/settings.py
+++ b/authentik/tenants/api/settings.py
@@ -3,8 +3,8 @@
 from django_tenants.utils import get_public_schema_name
 from rest_framework.generics import RetrieveUpdateAPIView
 from rest_framework.permissions import SAFE_METHODS
-from rest_framework.serializers import ModelSerializer
 
+from authentik.core.api.utils import ModelSerializer
 from authentik.rbac.permissions import HasPermission
 from authentik.tenants.models import Tenant
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

When using read replicas, saving m2m objects via the API will fail as by default rest_framework doesn't set `bulk=False` on the field setter, which causes django to throw an error about mismatched database aliases from different objects. We do receive some hints about the objects being fetched in the database router, but not always enough as some objects are fetched without related info, so that won't solve this issue.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
