### PR TITLE
events: provide the deleted model state in the event context #10169

### DIFF
--- a/authentik/enterprise/audit/middleware.py
+++ b/authentik/enterprise/audit/middleware.py
@@ -110,6 +110,17 @@ class EnterpriseAuditMiddleware(AuditMiddleware):
             thread_kwargs["diff"] = diff
         return super().post_save_handler(request, sender, instance, created, thread_kwargs, **_)
 
+
+    def pre_delete_handler(self, request: HttpRequest, sender, instance: Model, **_):
+        """Signal handler for all object's pre_delete"""
+        if not should_log_model(instance):  # pragma: no cover
+            return None
+        # Get current state
+        model_state = self.serialize_simple(instance)
+        sanitized_model_state = sanitize_item(model_state)
+        thread_kwargs = {"model_state": sanitized_model_state}
+        return super().pre_delete_handler(request, sender, instance, thread_kwargs, **_)
+
     def m2m_changed_handler(  # noqa: PLR0913
         self,
         request: HttpRequest,

--- a/authentik/enterprise/audit/middleware.py
+++ b/authentik/enterprise/audit/middleware.py
@@ -110,7 +110,6 @@ class EnterpriseAuditMiddleware(AuditMiddleware):
             thread_kwargs["diff"] = diff
         return super().post_save_handler(request, sender, instance, created, thread_kwargs, **_)
 
-
     def pre_delete_handler(self, request: HttpRequest, sender, instance: Model, **_):
         """Signal handler for all object's pre_delete"""
         if not should_log_model(instance):  # pragma: no cover

--- a/authentik/events/middleware.py
+++ b/authentik/events/middleware.py
@@ -199,7 +199,9 @@ class AuditMiddleware:
         thread.kwargs.update(thread_kwargs or {})
         thread.run()
 
-    def pre_delete_handler(self, request: HttpRequest, sender, instance: Model, thread_kwargs: dict | None = None, **_):
+    def pre_delete_handler(
+        self, request: HttpRequest, sender, instance: Model, thread_kwargs: dict | None = None, **_
+    ):
         """Signal handler for all object's pre_delete"""
         if not should_log_model(instance):  # pragma: no cover
             return

--- a/authentik/events/middleware.py
+++ b/authentik/events/middleware.py
@@ -199,7 +199,7 @@ class AuditMiddleware:
         thread.kwargs.update(thread_kwargs or {})
         thread.run()
 
-    def pre_delete_handler(self, request: HttpRequest, sender, instance: Model, **_):
+    def pre_delete_handler(self, request: HttpRequest, sender, instance: Model, thread_kwargs: dict | None = None, **_):
         """Signal handler for all object's pre_delete"""
         if not should_log_model(instance):  # pragma: no cover
             return
@@ -207,12 +207,14 @@ class AuditMiddleware:
             return
         user = self.get_user(request)
 
-        EventNewThread(
+        thread = EventNewThread(
             EventAction.MODEL_DELETED,
             request,
             user=user,
             model=model_to_dict(instance),
-        ).run()
+        )
+        thread.kwargs.update(thread_kwargs or {})
+        thread.run()
 
     def m2m_changed_handler(
         self,


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details
This PR closes #10169
It implements the sanitized model state as dict inside the `model_deleted` event.
Another option would be to implement it as `diff` like in the `model_created` event: https://github.com/goauthentik/authentik/blob/a448107feb5261cf133830148a938ea2368d3c9b/authentik/enterprise/audit/middleware.py#L109
As the `diff` field is implemented in `enterprise/audit/middleware.py` I've done the same with the `model_state`. 
I'm not sure if `events/middleware.py` would be the better place for it, but `enterprise/audit/middleware.py` already provides the `serialize_simple()` function.


---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
  - It passes the test if I apply the changes to the last release 2024.4.2 https://github.com/goauthentik/authentik/commit/6802614fbf878cec1d872bd01da922aa95b136fd
  - I can't get the current main running because of https://github.com/goauthentik/authentik/issues/9866 and the tests also won't pass for the current main (even without my changes)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
