### PR TITLE
website/docs: Remove hyphen in read replica in Release Notes

### DIFF
--- a/website/docs/releases/2024/v2024.6.md
+++ b/website/docs/releases/2024/v2024.6.md
@@ -11,9 +11,9 @@ To try out the release candidate, replace your Docker image tag with the latest 
 
 ## Highlights
 
--   **PostgreSQL read replicas** Optimize database query routing by using read replicas to balance the load
--   **New Enterprise providers** <span class="badge badge--primary">Enterprise</span> <span class="badge badge--info">Preview</span> Google Workspace and Microsoft Entra ID providers allow for user synchronization with authentik
--   **Improved CAPTCHA stage** Allows configurable dynamic use of CAPTCHAs
+-   **PostgreSQL read replicas**: Optimize database query routing by using read replicas to balance the load
+-   **New Enterprise providers**: <span class="badge badge--primary">Enterprise</span> <span class="badge badge--info">Preview</span> Google Workspace and Microsoft Entra ID providers allow for user synchronization with authentik
+-   **Improved CAPTCHA stage**: Allows configurable dynamic use of CAPTCHAs
 
 ## Breaking changes
 

--- a/website/docs/releases/2024/v2024.6.md
+++ b/website/docs/releases/2024/v2024.6.md
@@ -11,8 +11,8 @@ To try out the release candidate, replace your Docker image tag with the latest 
 
 ## Highlights
 
--   **PostgreSQL read-replica** Optimize database query routing by using read-replicas to balance the load
--   **New Enterprise providers** <span class="badge badge--primary">Enterprise</span> <span class="badge badge--info">Preview</span> Google Workspace and Microsoft Entra ID providers allows for user synchronization with authentik
+-   **PostgreSQL read replicas** Optimize database query routing by using read replicas to balance the load
+-   **New Enterprise providers** <span class="badge badge--primary">Enterprise</span> <span class="badge badge--info">Preview</span> Google Workspace and Microsoft Entra ID providers allow for user synchronization with authentik
 -   **Improved CAPTCHA stage** Allows configurable dynamic use of CAPTCHAs
 
 ## Breaking changes


### PR DESCRIPTION
Welp, not sure why I ever even put that hyphen in there in the first place... 

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
