### PR TITLE
website/docs: Fix nginx proxy_pass directive documentation

### DIFF
--- a/website/docs/providers/proxy/_nginx_proxy_manager.md
+++ b/website/docs/providers/proxy/_nginx_proxy_manager.md
@@ -48,7 +48,7 @@ location / {
 
 # all requests to /outpost.goauthentik.io must be accessible without authentication
 location /outpost.goauthentik.io {
-    proxy_pass              http://outpost.company:9000/outpost.goauthentik.io;
+    proxy_pass              http://outpost.company:9000;
     # ensure the host of this vserver matches your external URL you've configured
     # in authentik
     proxy_set_header        Host $host;

--- a/website/docs/providers/proxy/_nginx_standalone.md
+++ b/website/docs/providers/proxy/_nginx_standalone.md
@@ -52,7 +52,7 @@ server {
 
     # all requests to /outpost.goauthentik.io must be accessible without authentication
     location /outpost.goauthentik.io {
-        proxy_pass              http://outpost.company:9000/outpost.goauthentik.io;
+        proxy_pass              http://outpost.company:9000;
         # ensure the host of this vserver matches your external URL you've configured
         # in authentik
         proxy_set_header        Host $host;


### PR DESCRIPTION
## Details

As per the [nginx docs](https://docs.nginx.com/nginx/admin-guide/web-server/reverse-proxy/), `proxy_pass` sets the baseline for the reverse proxied URLs and will prepend the `proxy_pass` URL.

In the nginx docs in authentik, it's currently misdocumented and causes a duplicate `/outpost.goauthentik.io` path to be added during the rewrite, causing 404s with the forward auth (single domain) proxy setup and likely others?

I believe this might be the cause of a few github issues noticing 404s on the outpost, namely things like https://github.com/goauthentik/authentik/issues/9122 and maybe others.

Previous behavior (incorrect):

1. nginx proxy receives request for `https://some-proxy.company/outpost.goauthentik.io/auth/nginx`
2. nginx reverse proxies this to `http://outpost.company:9000/outpost.goauthentik.io/outpost.goauthentik.io/auth/nginx` (incorrect)

New behavior:

1. nginx proxy receives request for `https://some-proxy.company/outpost.goauthentik.io/auth/nginx`
2. nginx reverse proxies this to `http://outpost.company:9000/outpost.goauthentik.io/auth/nginx`