### PR TITLE
Add configurable hasher

### DIFF
--- a/authentik/lib/default.yml
+++ b/authentik/lib/default.yml
@@ -120,6 +120,7 @@ compliance:
     enabled: false
 
 cert_discovery_dir: /certs
+primary_password_encryption: null
 
 tenants:
   enabled: false

--- a/authentik/root/settings.py
+++ b/authentik/root/settings.py
@@ -211,6 +211,18 @@ CACHES = {
         "REVERSE_KEY_FUNCTION": "django_tenants.cache.reverse_key",
     }
 }
+
+PRIMARY_PASSWORD_ENCRYPTION = CONFIG.get("primary_password_encryption", None)
+if PRIMARY_PASSWORD_ENCRYPTION:
+    PASSWORD_HASHERS = [
+        PRIMARY_PASSWORD_ENCRYPTION,
+        "django.contrib.auth.hashers.PBKDF2PasswordHasher",
+        "django.contrib.auth.hashers.PBKDF2SHA1PasswordHasher",
+        "django.contrib.auth.hashers.Argon2PasswordHasher",
+        "django.contrib.auth.hashers.BCryptSHA256PasswordHasher",
+        "django.contrib.auth.hashers.BCryptPasswordHasher",
+    ]
+
 DJANGO_REDIS_SCAN_ITERSIZE = 1000
 DJANGO_REDIS_IGNORE_EXCEPTIONS = True
 DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS = True

--- a/website/docs/installation/configuration.mdx
+++ b/website/docs/installation/configuration.mdx
@@ -373,6 +373,12 @@ Configure Celery worker concurrency for authentik worker (see https://docs.celer
 
 Defaults to 2.
 
+### `AUTHENTIK_PRIMARY_PASSWORD_ENCRYPTION`
+
+Configure Django to use the given encrpytion as primary. It is used if LDAP passwords are encrypted and persisted in the Authentik database.
+
+Defaults to django.contrib.auth.hashers.PBKDF2PasswordHasher (current primary hasher of django).
+
 ## System settings
 
 :::info

--- a/website/docs/installation/configuration.mdx
+++ b/website/docs/installation/configuration.mdx
@@ -375,9 +375,9 @@ Defaults to 2.
 
 ### `AUTHENTIK_PRIMARY_PASSWORD_ENCRYPTION`
 
-Configure Django to use the given encrpytion as primary. It is used if LDAP passwords are encrypted and persisted in the Authentik database.
+Configure Django to use the given encryption as primary. It is used if LDAP passwords are encrypted and persisted in the Authentik database (see [Password Login](https://goauthentik.io/docs/sources/ldap/#password-login))
 
-Defaults to django.contrib.auth.hashers.PBKDF2PasswordHasher (current primary hasher of django).
+Defaults to django.contrib.auth.hashers.PBKDF2PasswordHasher (current primary hasher of Django).
 
 ## System settings
 


### PR DESCRIPTION
## Details

This pull request makes the primary django hasher configurable via the .env file. I would like to switch the internal hash algorithm to Argon2, due to its compatibility with OpenLDAP.  There is no breaking change and the parameter is optional. If not set, the standard django hasher hierarchy is used. I couldn't test it with the current main since the `ak server` commands gets stuck during migration processes (see https://github.com/goauthentik/authentik/issues/9866). It is tested with 2024.04 and works.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`) -> no because main is currently broken, tests are failing before changing anything
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] ~The API schema has been updated (`make gen-build`)~ -> no API changes

If changes to the frontend have been made

-   [ ] ~The code has been formatted (`make web`)~ -> no frontend changes

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
