### PR TITLE
website/docs: fix #9552 openssl rand base64 line wrap

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -155,8 +155,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run test suite in final docker images
         run: |
-          echo "PG_PASS=$(openssl rand 32 | base64)" >> .env
-          echo "AUTHENTIK_SECRET_KEY=$(openssl rand 32 | base64)" >> .env
+          echo "PG_PASS=$(openssl rand 32 | base64 -w 0)" >> .env
+          echo "AUTHENTIK_SECRET_KEY=$(openssl rand 32 | base64 -w 0)" >> .env
           docker compose pull -q
           docker compose up --no-start
           docker compose start postgresql redis

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -14,8 +14,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Pre-release test
         run: |
-          echo "PG_PASS=$(openssl rand 32 | base64)" >> .env
-          echo "AUTHENTIK_SECRET_KEY=$(openssl rand 32 | base64)" >> .env
+          echo "PG_PASS=$(openssl rand 32 | base64 -w 0)" >> .env
+          echo "AUTHENTIK_SECRET_KEY=$(openssl rand 32 | base64 -w 0)" >> .env
           docker buildx install
           mkdir -p ./gen-ts-api
           docker build -t testing:latest .

--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,8 @@ test-go:
 	go test -timeout 0 -v -race -cover ./...
 
 test-docker:  ## Run all tests in a docker-compose
-	echo "PG_PASS=$(shell openssl rand 32 | base64)" >> .env
-	echo "AUTHENTIK_SECRET_KEY=$(shell openssl rand 32 | base64)" >> .env
+	echo "PG_PASS=$(shell openssl rand 32 | base64 -w 0)" >> .env
+	echo "AUTHENTIK_SECRET_KEY=$(shell openssl rand 32 | base64 -w 0)" >> .env
 	docker compose pull -q
 	docker compose up --no-start
 	docker compose start postgresql redis

--- a/website/docs/installation/docker-compose.mdx
+++ b/website/docs/installation/docker-compose.mdx
@@ -50,8 +50,8 @@ Run the following commands to generate a password and secret key and write them 
 
 {/* prettier-ignore */}
 ```shell
-echo "PG_PASS=$(openssl rand 36 | base64)" >> .env
-echo "AUTHENTIK_SECRET_KEY=$(openssl rand 60 | base64)" >> .env
+echo "PG_PASS=$(openssl rand 36 | base64 -w 0)" >> .env
+echo "AUTHENTIK_SECRET_KEY=$(openssl rand 60 | base64 -w 0)" >> .env
 ```
 
 :::info

--- a/website/docs/installation/kubernetes.md
+++ b/website/docs/installation/kubernetes.md
@@ -23,7 +23,7 @@ Start by generating passwords for the database and cache. You can use either of 
 
 ```shell
 pwgen -s 50 1
-openssl rand 60 | base64
+openssl rand 60 | base64 -w 0
 ```
 
 ### Set Values

--- a/website/docs/sources/active-directory/index.md
+++ b/website/docs/sources/active-directory/index.md
@@ -19,7 +19,7 @@ The following placeholders will be used:
 
     ![](./01_user_create.png)
 
-3. Give the User a password, generated using for example `pwgen 64 1` or `openssl rand 36 | base64`.
+3. Give the User a password, generated using for example `pwgen 64 1` or `openssl rand 36 | base64 -w 0`.
 
 4. Open the Delegation of Control Wizard by right-clicking the domain and selecting "All Tasks".
 

--- a/website/docs/sources/freeipa/index.md
+++ b/website/docs/sources/freeipa/index.md
@@ -16,7 +16,7 @@ The following placeholders will be used:
 
 1. Log into FreeIPA.
 
-2. Create a user in FreeIPA, matching your naming scheme. Provide a strong password, example generation methods: `pwgen 64 1` or `openssl rand 36 | base64`. After you are done click **Add and Edit**.
+2. Create a user in FreeIPA, matching your naming scheme. Provide a strong password, example generation methods: `pwgen 64 1` or `openssl rand 36 | base64 -w 0`. After you are done click **Add and Edit**.
 
     ![](./01_user_create.png)
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
Closes #9552

The previous fix from #9554 did not resolve the case for `openssl rand 60 | base64` because by default base64 wraps lines above 76 characters. 60 bytes translates to 80 characters in base64, so above command still creates a newline


I've replaced all occurrences to explicitly disable line wrapping when piping to base64

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
