### PR TITLE
website/integrations: fix typo in documentation for OIDC setup with Paperless-ngx

### DIFF
--- a/website/integrations/services/paperless-ngx/index.md
+++ b/website/integrations/services/paperless-ngx/index.md
@@ -48,7 +48,7 @@ PAPERLESS_SOCIALACCOUNT_PROVIDERS: >
             "provider_id": "authentik",
             "name": "Authentik",
             "client_id": "< Client ID >",
-            "secret": "< Client Secret >,
+            "secret": "< Client Secret >",
             "settings": {
               "server_url": "https://authentik.company/application/o/paperless/.well-known/openid-configuration"
             }


### PR DESCRIPTION
Missing double quote cost me more time than I'd like to admit. Hopefully this helps someone else. 