### PR TITLE
web/flows: remove continue button from AutoSubmit stage

### DIFF
--- a/web/src/flow/stages/autosubmit/AutosubmitStage.ts
+++ b/web/src/flow/stages/autosubmit/AutosubmitStage.ts
@@ -51,11 +51,6 @@ export class AutosubmitStage extends BaseStage<
                         />`;
                     })}
                     <ak-empty-state ?loading="${true}"> </ak-empty-state>
-                    <div class="pf-c-form__group pf-m-action">
-                        <button type="submit" class="pf-c-button pf-m-primary pf-m-block">
-                            ${msg("Continue")}
-                        </button>
-                    </div>
                 </form>
             </div>
             <footer class="pf-c-login__main-footer">


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

Leftover from when we didnt fully require JS for the frontend, in case the automatic redirect didn't happen due to no JS. Now pressing the button will cause errors in 99% of the cases

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
