### PR TITLE
core: adjust styling to meet our standards

### DIFF
--- a/authentik/events/signals.py
+++ b/authentik/events/signals.py
@@ -76,7 +76,9 @@ def on_login_failed(
 ):
     """Failed Login, authentik custom event"""
     user = User.objects.filter(username=credentials.get("username")).first()
-    Event.new(EventAction.LOGIN_FAILED, **credentials, stage=stage, **kwargs).from_http(request, user)
+    Event.new(EventAction.LOGIN_FAILED, **credentials, stage=stage, **kwargs).from_http(
+        request, user
+    )
 
 
 @receiver(invitation_used)

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -16867,14 +16867,9 @@
             }
         },
         "node_modules/typescript": {
-<<<<<<< HEAD
-            "version": "5.4.5",
-            "license": "Apache-2.0",
-=======
             "version": "5.5.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
             "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
->>>>>>> main
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"


### PR DESCRIPTION
## Details

The last merge didn't check the styling, and `black` failed. This fixes that warning.

-   [X] **The code has been formatted (`make lint-fix`)**
