### PR TITLE
Fix version correspondence bug in website

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -16867,14 +16867,9 @@
             }
         },
         "node_modules/typescript": {
-<<<<<<< HEAD
-            "version": "5.4.5",
-            "license": "Apache-2.0",
-=======
             "version": "5.5.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
             "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
->>>>>>> main
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"


### PR DESCRIPTION
## Details

web: update lockfile to correspond to package.json, enabling npm-ci

Looks like someone updated `package.json` to have the latest version of Typescript, but failed to update `package-lock.json` to get that version into the cache. `npm ci` won’t work if the versions in the two files don’t correspond, as that means, well, exactly that: no one has checked that the versioning is correct.

The actual diff to `package-lock.json` is small enough it can be verified by eye, and it’s fine.

-   [X] The code has been formatted (`make lint-fix`)
-   [X] The documentation has been formatted (`make website`)
