### PR TITLE
core: fix URLValidator regex to allow single digit port

### DIFF
--- a/authentik/lib/models.py
+++ b/authentik/lib/models.py
@@ -62,7 +62,7 @@ class DomainlessURLValidator(URLValidator):
             r"^(?:[a-z0-9.+-]*)://"  # scheme is validated separately
             r"(?:[^\s:@/]+(?::[^\s:@/]*)?@)?"  # user:pass authentication
             r"(?:" + self.ipv4_re + "|" + self.ipv6_re + "|" + self.host_re + ")"
-            r"(?::\d{2,5})?"  # port
+            r"(?::\d{1,5})?"  # port
             r"(?:[/?#][^\s]*)?"  # resource path
             r"\Z",
             re.IGNORECASE,
@@ -88,7 +88,7 @@ class DomainlessFormattedURLValidator(DomainlessURLValidator):
             r"^(?:[a-z0-9.+-]*)://"  # scheme is validated separately
             r"(?:[^\s:@/]+(?::[^\s:@/]*)?@)?"  # user:pass authentication
             r"(?:" + self.ipv4_re + "|" + self.ipv6_re + "|" + self.host_re + ")"
-            r"(?::\d{2,5})?"  # port
+            r"(?::\d{1,5})?"  # port
             r"(?:[/?#][^\s]*)?"  # resource path
             r"\Z",
             re.IGNORECASE,


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
#9868 

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
