### PR TITLE
core: allow null application slug/name from related field

### DIFF
--- a/authentik/core/api/applications.py
+++ b/authentik/core/api/applications.py
@@ -53,9 +53,11 @@ class ApplicationSerializer(ModelSerializer):
     """Application Serializer"""
 
     launch_url = SerializerMethodField()
-    provider_obj = ProviderSerializer(source="get_provider", required=False, read_only=True)
+    provider_obj = ProviderSerializer(
+        source="get_provider", required=False, allow_null=True, read_only=True
+    )
     backchannel_providers_obj = ProviderSerializer(
-        source="backchannel_providers", required=False, read_only=True, many=True
+        source="backchannel_providers", required=False, allow_null=True, read_only=True, many=True
     )
 
     meta_icon = ReadOnlyField(source="get_meta_icon")

--- a/authentik/core/api/providers.py
+++ b/authentik/core/api/providers.py
@@ -18,10 +18,18 @@ from authentik.core.models import Provider
 class ProviderSerializer(ModelSerializer, MetaNameSerializer):
     """Provider Serializer"""
 
-    assigned_application_slug = ReadOnlyField(source="application.slug")
-    assigned_application_name = ReadOnlyField(source="application.name")
-    assigned_backchannel_application_slug = ReadOnlyField(source="backchannel_application.slug")
-    assigned_backchannel_application_name = ReadOnlyField(source="backchannel_application.name")
+    assigned_application_slug = ReadOnlyField(
+        source="application.slug", required=False, allow_null=True
+    )
+    assigned_application_name = ReadOnlyField(
+        source="application.name", required=False, allow_null=True
+    )
+    assigned_backchannel_application_slug = ReadOnlyField(
+        source="backchannel_application.slug", required=False, allow_null=True
+    )
+    assigned_backchannel_application_name = ReadOnlyField(
+        source="backchannel_application.name", required=False, allow_null=True
+    )
 
     component = SerializerMethodField()
 

--- a/schema.yml
+++ b/schema.yml
@@ -41584,6 +41584,7 @@ components:
           allOf:
           - $ref: '#/components/schemas/Provider'
           readOnly: true
+          nullable: true
         backchannel_providers:
           type: array
           items:
@@ -41593,6 +41594,7 @@ components:
           items:
             $ref: '#/components/schemas/Provider'
           readOnly: true
+          nullable: true
         launch_url:
           type: string
           nullable: true
@@ -46237,10 +46239,12 @@ components:
           type: string
           description: Internal application name, used in URLs.
           readOnly: true
+          nullable: true
         assigned_backchannel_application_name:
           type: string
           description: Application's display Name.
           readOnly: true
+          nullable: true
         verbose_name:
           type: string
           description: Return object's verbose_name
@@ -48004,18 +48008,22 @@ components:
           type: string
           description: Internal application name, used in URLs.
           readOnly: true
+          nullable: true
         assigned_application_name:
           type: string
           description: Application's display Name.
           readOnly: true
+          nullable: true
         assigned_backchannel_application_slug:
           type: string
           description: Internal application name, used in URLs.
           readOnly: true
+          nullable: true
         assigned_backchannel_application_name:
           type: string
           description: Application's display Name.
           readOnly: true
+          nullable: true
         verbose_name:
           type: string
           description: Return object's verbose_name
@@ -48736,10 +48744,12 @@ components:
           type: string
           description: Internal application name, used in URLs.
           readOnly: true
+          nullable: true
         assigned_backchannel_application_name:
           type: string
           description: Application's display Name.
           readOnly: true
+          nullable: true
         verbose_name:
           type: string
           description: Return object's verbose_name
@@ -49474,18 +49484,22 @@ components:
           type: string
           description: Internal application name, used in URLs.
           readOnly: true
+          nullable: true
         assigned_application_name:
           type: string
           description: Application's display Name.
           readOnly: true
+          nullable: true
         assigned_backchannel_application_slug:
           type: string
           description: Internal application name, used in URLs.
           readOnly: true
+          nullable: true
         assigned_backchannel_application_name:
           type: string
           description: Application's display Name.
           readOnly: true
+          nullable: true
         verbose_name:
           type: string
           description: Return object's verbose_name
@@ -57065,18 +57079,22 @@ components:
           type: string
           description: Internal application name, used in URLs.
           readOnly: true
+          nullable: true
         assigned_application_name:
           type: string
           description: Application's display Name.
           readOnly: true
+          nullable: true
         assigned_backchannel_application_slug:
           type: string
           description: Internal application name, used in URLs.
           readOnly: true
+          nullable: true
         assigned_backchannel_application_name:
           type: string
           description: Application's display Name.
           readOnly: true
+          nullable: true
         verbose_name:
           type: string
           description: Return object's verbose_name
@@ -57307,18 +57325,22 @@ components:
           type: string
           description: Internal application name, used in URLs.
           readOnly: true
+          nullable: true
         assigned_application_name:
           type: string
           description: Application's display Name.
           readOnly: true
+          nullable: true
         assigned_backchannel_application_slug:
           type: string
           description: Internal application name, used in URLs.
           readOnly: true
+          nullable: true
         assigned_backchannel_application_name:
           type: string
           description: Application's display Name.
           readOnly: true
+          nullable: true
         verbose_name:
           type: string
           description: Return object's verbose_name
@@ -57626,18 +57648,22 @@ components:
           type: string
           description: Internal application name, used in URLs.
           readOnly: true
+          nullable: true
         assigned_application_name:
           type: string
           description: Application's display Name.
           readOnly: true
+          nullable: true
         assigned_backchannel_application_slug:
           type: string
           description: Internal application name, used in URLs.
           readOnly: true
+          nullable: true
         assigned_backchannel_application_name:
           type: string
           description: Application's display Name.
           readOnly: true
+          nullable: true
         verbose_name:
           type: string
           description: Return object's verbose_name
@@ -57795,18 +57821,22 @@ components:
           type: string
           description: Internal application name, used in URLs.
           readOnly: true
+          nullable: true
         assigned_application_name:
           type: string
           description: Application's display Name.
           readOnly: true
+          nullable: true
         assigned_backchannel_application_slug:
           type: string
           description: Internal application name, used in URLs.
           readOnly: true
+          nullable: true
         assigned_backchannel_application_name:
           type: string
           description: Application's display Name.
           readOnly: true
+          nullable: true
         verbose_name:
           type: string
           description: Return object's verbose_name
@@ -58420,18 +58450,22 @@ components:
           type: string
           description: Internal application name, used in URLs.
           readOnly: true
+          nullable: true
         assigned_application_name:
           type: string
           description: Application's display Name.
           readOnly: true
+          nullable: true
         assigned_backchannel_application_slug:
           type: string
           description: Internal application name, used in URLs.
           readOnly: true
+          nullable: true
         assigned_backchannel_application_name:
           type: string
           description: Application's display Name.
           readOnly: true
+          nullable: true
         verbose_name:
           type: string
           description: Return object's verbose_name
@@ -59133,10 +59167,12 @@ components:
           type: string
           description: Internal application name, used in URLs.
           readOnly: true
+          nullable: true
         assigned_backchannel_application_name:
           type: string
           description: Application's display Name.
           readOnly: true
+          nullable: true
         verbose_name:
           type: string
           description: Return object's verbose_name

--- a/web/src/admin/applications/ApplicationViewPage.ts
+++ b/web/src/admin/applications/ApplicationViewPage.ts
@@ -190,20 +190,21 @@ export class ApplicationViewPage extends AKElement {
                                           <dd class="pf-c-description-list__description">
                                               <div class="pf-c-description-list__text">
                                                   <ul class="pf-c-list">
-                                                      ${this.application.backchannelProvidersObj.map(
-                                                          (provider) => {
-                                                              return html`
-                                                                  <li>
-                                                                      <a
-                                                                          href="#/core/providers/${provider.pk}"
-                                                                      >
-                                                                          ${provider.name}
-                                                                          (${provider.verboseName})
-                                                                      </a>
-                                                                  </li>
-                                                              `;
-                                                          },
-                                                      )}
+                                                      ${(
+                                                          this.application
+                                                              .backchannelProvidersObj || []
+                                                      ).map((provider) => {
+                                                          return html`
+                                                              <li>
+                                                                  <a
+                                                                      href="#/core/providers/${provider.pk}"
+                                                                  >
+                                                                      ${provider.name}
+                                                                      (${provider.verboseName})
+                                                                  </a>
+                                                              </li>
+                                                          `;
+                                                      })}
                                                   </ul>
                                               </div>
                                           </dd>

--- a/web/src/admin/outposts/OutpostForm.ts
+++ b/web/src/admin/outposts/OutpostForm.ts
@@ -34,8 +34,8 @@ import { map } from "lit/directives/map.js";
 interface ProviderBase {
     pk: number;
     name: string;
-    assignedBackchannelApplicationName?: string;
-    assignedApplicationName?: string;
+    assignedBackchannelApplicationName: string | null;
+    assignedApplicationName: string | null;
 }
 
 const api = () => new ProvidersApi(DEFAULT_CONFIG);
@@ -55,7 +55,7 @@ const dualSelectPairMaker = (item: ProviderBase): DualSelectPair => {
         `${item.pk}`,
         html`<div class="selection-main">${label}</div>
             <div class="selection-desc">${item.name}</div>`,
-        label,
+        label ?? undefined,
     ];
 };
 

--- a/web/src/admin/providers/oauth2/OAuth2ProviderViewPage.ts
+++ b/web/src/admin/providers/oauth2/OAuth2ProviderViewPage.ts
@@ -390,7 +390,7 @@ export class OAuth2ProviderViewPage extends AKElement {
                             .url=${MDProviderOAuth2}
                             .replacers=${[
                                 (input: string) => {
-                                    if (!this.provider) {
+                                    if (!this.provider || !this.provider.assignedApplicationSlug) {
                                         return input;
                                     }
                                     return input.replaceAll(


### PR DESCRIPTION

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->

Workaround for `required=False` not being honored by django-rest-framework and/or drf_spectacular. Fixes goauthentik#9787 (for python bindings, at least).

This at least allows responses to be validated, however schema.yml still lists these response fields as `required`.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [x] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
