### PR TITLE
core: remove transitionary old JS urls

### DIFF
--- a/authentik/core/templatetags/authentik_core.py
+++ b/authentik/core/templatetags/authentik_core.py
@@ -17,11 +17,5 @@ def versioned_script(path: str) -> str:
             f'<script src="{static_loader(path.replace("%v", get_full_version()))}'
             '" type="module"></script>'
         ),
-        # Legacy method of loading scripts used as a fallback, without the version in the filename
-        # TODO: Remove after 2024.6 or later
-        (
-            f'<script src="{static_loader(path.replace("-%v", ""))}?'
-            f'version={get_full_version()}" type="module"></script>'
-        ),
     ]
     return mark_safe("".join(returned_lines))  # nosec


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

This was part of the change to versioned file names, now that the that is released we can remove this again

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
