### PR TITLE
web/flows: remove background image link

### DIFF
--- a/web/src/flow/FlowExecutor.ts
+++ b/web/src/flow/FlowExecutor.ts
@@ -515,16 +515,6 @@ export class FlowExecutor extends Interface implements StageHost {
                                                         >${msg("Powered by authentik")}</a
                                                     >
                                                 </li>
-                                                ${this.flowInfo?.background?.startsWith("/static")
-                                                    ? html`
-                                                          <li>
-                                                              <a
-                                                                  href="https://unsplash.com/@benjaminpunzalan"
-                                                                  >${msg("Background image")}</a
-                                                              >
-                                                          </li>
-                                                      `
-                                                    : html``}
                                             </ul>
                                         </footer>
                                     </div>


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

Many instances replace the flow background image by replacing the file with the same path, which doesn't remove attribution link. Since attribution is not required, remove the link (and sign up for unsplash+ so people still get something)

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
