### PR TITLE
provider/scim: Fix exception handling for missing ServiceProviderConfig

### DIFF
--- a/authentik/providers/scim/clients/base.py
+++ b/authentik/providers/scim/clients/base.py
@@ -89,6 +89,6 @@ class SCIMClient[TModel: "Model", TConnection: "Model", TSchema: "BaseModel"](
             return ServiceProviderConfiguration.model_validate(
                 self._request("GET", "/ServiceProviderConfig")
             )
-        except (ValidationError, SCIMRequestException) as exc:
+        except (ValidationError, SCIMRequestException, NotFoundSyncException) as exc:
             self.logger.warning("failed to get ServiceProviderConfig", exc=exc)
             return default_config


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
In 2024.6, `get_service_provider_config` does not handle `NotFoundSyncException`, causing a full failure(stack below) rather than falling back to default config. This change adds the `NotFoundSyncException` to the list exceptions that fallback to a default config.

```
Exception
Task scim_sync encountered an error: Traceback (most recent call last):
  File "/ak-root/venv/lib/python3.12/site-packages/celery/app/trace.py", line 453, in trace_task
    R = retval = fun(*args, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^
  File "/ak-root/venv/lib/python3.12/site-packages/celery/app/trace.py", line 736, in __protected_call__
    return self.run(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ak-root/venv/lib/python3.12/site-packages/celery/app/autoretry.py", line 38, in run
    return task._orig_run(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/authentik/providers/scim/tasks.py", line 22, in scim_sync
    return sync_tasks.sync_single(self, provider_pk, scim_sync_objects)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/authentik/lib/sync/outgoing/tasks.py", line 86, in sync_single
    ).get():
      ^^^^^
  File "/ak-root/venv/lib/python3.12/site-packages/celery/result.py", line 251, in get
    return self.backend.wait_for_pending(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ak-root/venv/lib/python3.12/site-packages/celery/backends/asynchronous.py", line 223, in wait_for_pending
    return result.maybe_throw(callback=callback, propagate=propagate)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ak-root/venv/lib/python3.12/site-packages/celery/result.py", line 365, in maybe_throw
    self.throw(value, self._to_remote_traceback(tb))
  File "/ak-root/venv/lib/python3.12/site-packages/celery/result.py", line 358, in throw
    self.on_ready.throw(*args, **kwargs)
  File "/ak-root/venv/lib/python3.12/site-packages/vine/promises.py", line 235, in throw
    reraise(type(exc), exc, tb)
  File "/ak-root/venv/lib/python3.12/site-packages/vine/utils.py", line 27, in reraise
    raise value
authentik.lib.sync.outgoing.exceptions.NotFoundSyncException: <Response [404]>
--


```

---

## Checklist
* I unfortunately can't get a local environment up and running at the moment.
-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

~~-   [ ] The API schema has been updated (`make gen-build`)~~

If changes to the frontend have been made

~~-   [ ] The code has been formatted (`make web`)~~

If applicable

~~-   [ ] The documentation has been updated~~
~~-   [ ] The documentation has been formatted (`make website`)~~
