### PR TITLE
website/docs: add links and tweaks to existing docs on flow executors

### DIFF
--- a/website/developer-docs/api/flow-executor.md
+++ b/website/developer-docs/api/flow-executor.md
@@ -4,7 +4,7 @@ title: Flow executor (backend)
 
 A big focus of authentik is the flows system, which allows you to combine and build complex conditional processes using stages and policies.
 
-Normally, these flows are automatically executed in the browser using authentik's frontend [default flow executor (/if/flows)](../../docs/flow/executors/if-flow.md).
+Normally, these flows are automatically executed in the browser using authentik's frontend [default flow executor (/if/flows)](/docs/flow/executors/if-flow.md).
 
 However, any flow can be executed via an API from anywhere, in fact that is what the backend flow executor does. This means, you can, with a few requests, execute flows from anywhere, and integrate authentik even better.
 
@@ -14,7 +14,7 @@ Because the flow executor stores its state in the HTTP Session, so you need to e
 
 The main endpoint for flow execution is `/api/v3/flows/executor/:slug`.
 
-This endpoint accepts a query parameter called `query`, in which the flow executor sends the full Query-string.
+This endpoint accepts a query parameter called `query`, in which the flow executor sends the full query-string.
 
 To initiate a new flow, execute a GET request.
 

--- a/website/developer-docs/api/flow-executor.md
+++ b/website/developer-docs/api/flow-executor.md
@@ -2,7 +2,7 @@
 title: Flow executor (backend)
 ---
 
-A big focus of authentik is the flows system, which allows you to combine and build complex conditional processes using stages and policies. Normally, these flows are automatically executed in the browser using authentik's [standard browser-based flow executor (/if/flows)](../../docs/flow/executors/if-flow.md).
+A big focus of authentik is the flows system, which allows you to combine and build complex conditional processes using stages and policies. Normally, these flows are automatically executed in the browser using authentik's [standard browser-based flow executor (/if/flows)](/docs/flow/executors/if-flow.md).
 
 However, any flow can be executed via an API from anywhere, in fact that is what the backend flow executor does. With a few requests you can execute flows from anywhere, and integrate authentik even better.
 

--- a/website/developer-docs/api/flow-executor.md
+++ b/website/developer-docs/api/flow-executor.md
@@ -2,12 +2,12 @@
 title: Flow executor (backend)
 ---
 
-A big focus of authentik is the flows system, which allows you to combine and build complex conditional processes using stages and policies. Normally, these flows are automatically executed in the browser using authentik's frontend [default flow executor (/if/flows)](../../docs/flow/executors/if-flow.md).
+A big focus of authentik is the flows system, which allows you to combine and build complex conditional processes using stages and policies. Normally, these flows are automatically executed in the browser using authentik's [standard browser-based flow executor (/if/flows)](../../docs/flow/executors/if-flow.md).
 
-However, any flow can be executed via an API from anywhere, in fact that is what the backend flow executor does. This means, you can, with a few requests, execute flows from anywhere, and integrate authentik even better.
+However, any flow can be executed via an API from anywhere, in fact that is what the backend flow executor does. With a few requests you can execute flows from anywhere, and integrate authentik even better.
 
 :::info
-Because the flow executor stores its state in the HTTP Session, so you need to ensure cookies between flow executor requests are persisted.
+Because the flow executor stores its state in the HTTP Session, so you need to ensure that cookies between flow executor requests are persisted.
 :::
 
 The main endpoint for flow execution is `/api/v3/flows/executor/:slug`.

--- a/website/developer-docs/api/flow-executor.md
+++ b/website/developer-docs/api/flow-executor.md
@@ -1,10 +1,12 @@
 ---
-title: Flow executor
+title: Flow executor (backend)
 ---
 
-A big focus of authentik is the flows system, which allows you to combine and build complex conditional processes using stages and policies. Normally, these flows are executed in the browser using the authentik inbuilt flow executor (/if/flows).
+A big focus of authentik is the flows system, which allows you to combine and build complex conditional processes using stages and policies.
 
-However, any flow can be executed via an API from anywhere, in fact that is what the Web flow executor does. This means, you can, with a few requests, execute flows from anywhere, and integrate authentik even better.
+Normally, these flows are automatically executed in the browser using authentik's frontend [default flow executor (/if/flows)](../../docs/flow/executors/if-flow.md).
+
+However, any flow can be executed via an API from anywhere, in fact that is what the backend flow executor does. This means, you can, with a few requests, execute flows from anywhere, and integrate authentik even better.
 
 :::info
 Because the flow executor stores its state in the HTTP Session, so you need to ensure cookies between flow executor requests are persisted.

--- a/website/developer-docs/api/flow-executor.md
+++ b/website/developer-docs/api/flow-executor.md
@@ -2,7 +2,7 @@
 title: Flow executor (backend)
 ---
 
-A big focus of authentik is the flows system, which allows you to combine and build complex conditional processes using stages and policies. Normally, these flows are automatically executed in the browser using authentik's [standard browser-based flow executor (/if/flows)](/docs/flow/executors/if-flow.md).
+A big focus of authentik is the flows system, which allows you to combine and build complex conditional processes using stages and policies. Normally, these flows are automatically executed in the browser using authentik's [standard browser-based flow executor (/if/flows)](/docs/flow/executors/if-flow).
 
 However, any flow can be executed via an API from anywhere, in fact that is what the backend flow executor does. With a few requests you can execute flows from anywhere, and integrate authentik even better.
 

--- a/website/developer-docs/api/flow-executor.md
+++ b/website/developer-docs/api/flow-executor.md
@@ -2,9 +2,7 @@
 title: Flow executor (backend)
 ---
 
-A big focus of authentik is the flows system, which allows you to combine and build complex conditional processes using stages and policies.
-
-Normally, these flows are automatically executed in the browser using authentik's frontend [default flow executor (/if/flows)](/docs/flow/executors/if-flow.md).
+A big focus of authentik is the flows system, which allows you to combine and build complex conditional processes using stages and policies. Normally, these flows are automatically executed in the browser using authentik's frontend [default flow executor (/if/flows)](../../docs/flow/executors/if-flow.md).
 
 However, any flow can be executed via an API from anywhere, in fact that is what the backend flow executor does. This means, you can, with a few requests, execute flows from anywhere, and integrate authentik even better.
 

--- a/website/docs/core/brands.md
+++ b/website/docs/core/brands.md
@@ -9,7 +9,7 @@ The main settings that brands influence are flows and branding.
 
 ## Flows
 
-authentik picks a default flow by picking the flow that is selected in the current brand, otherwise any flow that
+authentik picks a default flow by selecting the flow that is configured in the current brand, otherwise any flow that:
 
     - matches the required designation
     - comes first sorted by slug
@@ -19,4 +19,4 @@ This means that if you want to select a default flow based on policy, you can le
 
 ## Branding
 
-The brand configuration controls the branding title (shown in website document title and several other places), and the sidebar/header logo that appears in the upper left of the product interface.
+The brand configuration controls the branding title (shown in website document title and several other places), the sidebar/header logo that appears in the upper left of the product interface, and the favicon on a browser tab.

--- a/website/docs/flow/executors/headless.md
+++ b/website/docs/flow/executors/headless.md
@@ -2,7 +2,7 @@
 title: Headless
 ---
 
-The headless flow executor is used by clients which don't have access to the web interface. It is currently used by the LDAP outpost to authenticate users.
+The headless flow executor is used by clients that don't have access to the web interface. It is currently used by the LDAP and Radius outposts to authenticate users.
 
 The following stages are supported:
 

--- a/website/docs/flow/executors/user-settings.md
+++ b/website/docs/flow/executors/user-settings.md
@@ -6,10 +6,10 @@ title: User settings
 Requires authentik 2022.3
 :::
 
-The user interface (`/if/user/`) embeds a downsized flow executor to allow the user to configure their profile using custom stages and prompts.
+The user interface (/if/user/) uses a specialized flow executor to allow individual users to customize their profile.  A user's profile consists of key/value fields, so this executor only supports Prompt or User Write stages. If the configured flow contains another stage, a button will be shown to open the default executor.
 
-This executor only supports [**prompt**](../stages/prompt/) stages. If the configured flow contains another stage, a button will be shown to open the default executor.
+Because the stages in a flow can change during its execution, be awre that configuring this executor to use any stage type other than Prompt or User Write will automatically trigger a redirect to the standard executor.
 
-Because the stages in a flow can change during its execution, this executor will redirect the user to the default interface _if_ a non-supported stage is returned.
+An admin can customize which fields can be changed by the user by updating the default-user-settings-flow, or copying it to create a new flow with a Prompt Stage and a User Write Stage.  Different variants of your flow can be applied to different [Brands](../../core/brands.md) on the same authentik instance.
 
-To configure which flow is used for this, configure it in the [Brand settings](../../core/brands.md).
+

--- a/website/docs/flow/executors/user-settings.md
+++ b/website/docs/flow/executors/user-settings.md
@@ -9,6 +9,7 @@ Requires authentik 2022.3
 The user interface (`/if/user/`) embeds a downsized flow executor to allow the user to configure their profile using custom stages and prompts.
 
 This executor only supports [**prompt**](../stages/prompt/) stages. If the configured flow contains another stage, a button will be shown to open the default executor.
-Because the stages in a flow can change during it execution, this executor will redirect the user to the default interface _if_ a non-supported stage is returned.
 
-To configure which flow is used for this, configure it in the brand settings.
+Because the stages in a flow can change during its execution, this executor will redirect the user to the default interface _if_ a non-supported stage is returned.
+
+To configure which flow is used for this, configure it in the [Brand settings](../../core/brands.md).

--- a/website/docs/flow/executors/user-settings.md
+++ b/website/docs/flow/executors/user-settings.md
@@ -6,10 +6,8 @@ title: User settings
 Requires authentik 2022.3
 :::
 
-The user interface (/if/user/) uses a specialized flow executor to allow individual users to customize their profile.  A user's profile consists of key/value fields, so this executor only supports Prompt or User Write stages. If the configured flow contains another stage, a button will be shown to open the default executor.
+The user interface (/if/user/) uses a specialized flow executor to allow individual users to customize their profile. A user's profile consists of key/value fields, so this executor only supports Prompt or User Write stages. If the configured flow contains another stage, a button will be shown to open the default executor.
 
 Because the stages in a flow can change during its execution, be awre that configuring this executor to use any stage type other than Prompt or User Write will automatically trigger a redirect to the standard executor.
 
-An admin can customize which fields can be changed by the user by updating the default-user-settings-flow, or copying it to create a new flow with a Prompt Stage and a User Write Stage.  Different variants of your flow can be applied to different [Brands](../../core/brands.md) on the same authentik instance.
-
-
+An admin can customize which fields can be changed by the user by updating the default-user-settings-flow, or copying it to create a new flow with a Prompt Stage and a User Write Stage. Different variants of your flow can be applied to different [Brands](../../core/brands.md) on the same authentik instance.


### PR DESCRIPTION
These changes add links between the backend Flow Exececutor and the frontend, defaul flow executor. Also a link to the Brands docs, and a few edits and clairifcations.

I did not add info about the upcoming SFE executor.

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
