### PR TITLE
core: add support to set policy bindings in transactional endpoint

### DIFF
--- a/authentik/blueprints/v1/importer.py
+++ b/authentik/blueprints/v1/importer.py
@@ -293,7 +293,11 @@ class Importer:
 
         serializer_kwargs = {}
         model_instance = existing_models.first()
-        if not isinstance(model(), BaseMetaModel) and model_instance:
+        if (
+            not isinstance(model(), BaseMetaModel)
+            and model_instance
+            and entry.state != BlueprintEntryDesiredState.MUST_CREATED
+        ):
             self.logger.debug(
                 "Initialise serializer with instance",
                 model=model,
@@ -303,11 +307,12 @@ class Importer:
             serializer_kwargs["instance"] = model_instance
             serializer_kwargs["partial"] = True
         elif model_instance and entry.state == BlueprintEntryDesiredState.MUST_CREATED:
+            msg = (
+                f"State is set to {BlueprintEntryDesiredState.MUST_CREATED.value} "
+                "and object exists already",
+            )
             raise EntryInvalidError.from_entry(
-                (
-                    f"State is set to {BlueprintEntryDesiredState.MUST_CREATED} "
-                    "and object exists already",
-                ),
+                ValidationError({k: msg for k in entry.identifiers.keys()}, "unique"),
                 entry,
             )
         else:

--- a/authentik/core/api/transactional_applications.py
+++ b/authentik/core/api/transactional_applications.py
@@ -163,13 +163,15 @@ class TransactionalApplicationView(APIView):
             app, __, model = full_model.partition(".")
             if not request.user.has_perm(f"{app}.add_{model}"):
                 raise PermissionDenied(
-                    _(
-                        "User lacks permission to create {model}".format_map(
-                            {
-                                "model": full_model,
-                            }
+                    {
+                        entry.id: _(
+                            "User lacks permission to create {model}".format_map(
+                                {
+                                    "model": full_model,
+                                }
+                            )
                         )
-                    )
+                    }
                 )
         importer = Importer(blueprint, {})
         applied = importer.apply()

--- a/authentik/core/tests/test_transactional_applications_api.py
+++ b/authentik/core/tests/test_transactional_applications_api.py
@@ -1,10 +1,11 @@
 """Test Transactional API"""
 
 from django.urls import reverse
+from guardian.shortcuts import assign_perm
 from rest_framework.test import APITestCase
 
 from authentik.core.models import Application, Group
-from authentik.core.tests.utils import create_test_admin_user, create_test_flow
+from authentik.core.tests.utils import create_test_flow, create_test_user
 from authentik.lib.generators import generate_id
 from authentik.policies.models import PolicyBinding
 from authentik.providers.oauth2.models import OAuth2Provider
@@ -14,7 +15,9 @@ class TestTransactionalApplicationsAPI(APITestCase):
     """Test Transactional API"""
 
     def setUp(self) -> None:
-        self.user = create_test_admin_user()
+        self.user = create_test_user()
+        assign_perm("authentik_core.add_application", self.user)
+        assign_perm("authentik_providers_oauth2.add_oauth2provider", self.user)
 
     def test_create_transactional(self):
         """Test transactional Application + provider creation"""
@@ -44,6 +47,7 @@ class TestTransactionalApplicationsAPI(APITestCase):
 
     def test_create_transactional_bindings(self):
         """Test transactional Application + provider creation"""
+        assign_perm("authentik_policies.add_policybinding", self.user)
         self.client.force_login(self.user)
         uid = generate_id()
         group = Group.objects.create(name=generate_id())

--- a/schema.yml
+++ b/schema.yml
@@ -54680,6 +54680,10 @@ components:
           $ref: '#/components/schemas/ProviderModelEnum'
         provider:
           $ref: '#/components/schemas/modelRequest'
+        policy_bindings:
+          type: array
+          items:
+            $ref: '#/components/schemas/TransactionPolicyBindingRequest'
       required:
       - app
       - provider
@@ -54697,6 +54701,41 @@ components:
       required:
       - applied
       - logs
+    TransactionPolicyBindingRequest:
+      type: object
+      description: PolicyBindingSerializer which does not require target as target
+        is set implicitly
+      properties:
+        policy:
+          type: string
+          format: uuid
+          nullable: true
+        group:
+          type: string
+          format: uuid
+          nullable: true
+        user:
+          type: integer
+          nullable: true
+        negate:
+          type: boolean
+          description: Negates the outcome of the policy. Messages are unaffected.
+        enabled:
+          type: boolean
+        order:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        timeout:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          description: Timeout after which Policy execution is terminated.
+        failure_result:
+          type: boolean
+          description: Result if the Policy execution fails.
+      required:
+      - order
     TypeCreate:
       type: object
       description: Types of an object that can be created


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

Preparing the backend API for future wizard improvements, that allows for creating policy bindings alongside the app

related to #3732

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
