### PR TITLE
providers/proxy: fix Traefik label generation for v3

### DIFF
--- a/authentik/providers/proxy/controllers/docker.py
+++ b/authentik/providers/proxy/controllers/docker.py
@@ -28,7 +28,7 @@ class ProxyDockerController(DockerController):
         labels = super()._get_labels()
         labels["traefik.enable"] = "true"
         labels[f"traefik.http.routers.{traefik_name}-router.rule"] = (
-            f"Host({','.join(hosts)}) && PathPrefix(`/outpost.goauthentik.io`)"
+            f"({' || '.join([f'Host(`{host}`)' for host in hosts])}) && PathPrefix(`/outpost.goauthentik.io`)"
         )
         labels[f"traefik.http.routers.{traefik_name}-router.tls"] = "true"
         labels[f"traefik.http.routers.{traefik_name}-router.service"] = f"{traefik_name}-service"

--- a/authentik/providers/proxy/controllers/docker.py
+++ b/authentik/providers/proxy/controllers/docker.py
@@ -28,7 +28,8 @@ class ProxyDockerController(DockerController):
         labels = super()._get_labels()
         labels["traefik.enable"] = "true"
         labels[f"traefik.http.routers.{traefik_name}-router.rule"] = (
-            f"({' || '.join([f'Host(`{host}`)' for host in hosts])}) && PathPrefix(`/outpost.goauthentik.io`)"
+            f"({' || '.join([f'Host(`{host}`)' for host in hosts])})"
+            f" && PathPrefix(`/outpost.goauthentik.io`)"
         )
         labels[f"traefik.http.routers.{traefik_name}-router.tls"] = "true"
         labels[f"traefik.http.routers.{traefik_name}-router.service"] = f"{traefik_name}-service"


### PR DESCRIPTION
Fixes #9786 

## Details

When deploying a proxy outpost, labels are added automatically which add the outpost to Traefik. For each single-forward provider a Host(<host>) label has to be used. Authentik generates these as Host(<host>, <host>, ...) which is not possible anymore since Traefik v3.0. This leads to an invalid deployment of the outpost.
This PR remedies that and created labels that separate the Host. i.e. (Host(<host>) || Host(<host>))

