### PR TITLE
website/docs: update nginx docs for embedded outposts

### DIFF
--- a/website/docs/providers/proxy/_nginx_proxy_manager.md
+++ b/website/docs/providers/proxy/_nginx_proxy_manager.md
@@ -48,9 +48,16 @@ location / {
 
 # all requests to /outpost.goauthentik.io must be accessible without authentication
 location /outpost.goauthentik.io {
-    proxy_pass              http://outpost.company:9000;
-    # ensure the host of this vserver matches your external URL you've configured
-    # in authentik
+    # When using the embedded outpost, use:
+    proxy_pass              http://authentik.company:9000/outpost.goauthentik.io;
+    # For manual outpost deployments:
+    # proxy_pass              http://outpost.company:9000;
+
+    # Note: ensure the Host header matches your external authentik URL:
+    proxy_set_header        Host $host;
+
+    # Ensure the host of this vserver matches your external URL you've configured
+    # in authentik.
     proxy_set_header        Host $host;
     proxy_set_header        X-Original-URL $scheme://$http_host$request_uri;
     add_header              Set-Cookie $auth_cookie;

--- a/website/docs/providers/proxy/_nginx_proxy_manager.md
+++ b/website/docs/providers/proxy/_nginx_proxy_manager.md
@@ -56,9 +56,6 @@ location /outpost.goauthentik.io {
     # Note: ensure the Host header matches your external authentik URL:
     proxy_set_header        Host $host;
 
-    # Ensure the host of this vserver matches your external URL you've configured
-    # in authentik.
-    proxy_set_header        Host $host;
     proxy_set_header        X-Original-URL $scheme://$http_host$request_uri;
     add_header              Set-Cookie $auth_cookie;
     auth_request_set        $auth_cookie $upstream_http_set_cookie;

--- a/website/docs/providers/proxy/_nginx_standalone.md
+++ b/website/docs/providers/proxy/_nginx_standalone.md
@@ -52,10 +52,14 @@ server {
 
     # all requests to /outpost.goauthentik.io must be accessible without authentication
     location /outpost.goauthentik.io {
-        proxy_pass              http://outpost.company:9000;
-        # ensure the host of this vserver matches your external URL you've configured
-        # in authentik
+        # When using the embedded outpost, use:
+        proxy_pass              http://authentik.company:9000/outpost.goauthentik.io;
+        # For manual outpost deployments:
+        # proxy_pass              http://outpost.company:9000;
+
+        # Note: ensure the Host header matches your external authentik URL:
         proxy_set_header        Host $host;
+
         proxy_set_header        X-Original-URL $scheme://$http_host$request_uri;
         add_header              Set-Cookie $auth_cookie;
         auth_request_set        $auth_cookie $upstream_http_set_cookie;


### PR DESCRIPTION
A followup to https://github.com/goauthentik/authentik/pull/10181 — that docs PR was partially correct, but does not work for the embedded outpost.

The way it works is:
* Manual outpost: when traffic flows to the proxy `/outpost.goauthentik.io/<PATH>` path, it should be stripped off and then sent to `outpost:company:9000/<PATH>`  (this is what the docs show now)
* Embedded outpost: when traffic flows to the proxy `/outpost.goauthentik.io/<PATH>` nginx proxy must prepend this path back again when sending it to the embedded outpost at `authentik.company:9000/outpost.goauthentik.io/<PATH>`

This PR clarifies how to make it work for both cases.