### PR TITLE
website/docs: air gapped: clarify .env usage at the top for Kubernetes installations

### DIFF
--- a/website/docs/installation/air-gapped.mdx
+++ b/website/docs/installation/air-gapped.mdx
@@ -11,7 +11,7 @@ By default, authentik creates outbound connections to the following URLs:
 -   https://secure.gravatar.com: Avatars for users
 -   https://authentik.error-reporting.a7k.io: Error reporting
 
-To disable these outbound connections, set the following in your `.env` file:
+To disable these outbound connections, adjust the settings as follows:
 
 ## Configuration options
 


### PR DESCRIPTION


<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
k8s doesn't use .env so the docs shouldn't say to add in .env

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
