### PR TITLE
core: revert backchannel only filtering

### DIFF
--- a/authentik/lib/sync/outgoing/tasks.py
+++ b/authentik/lib/sync/outgoing/tasks.py
@@ -5,6 +5,7 @@ from celery.exceptions import Retry
 from celery.result import allow_join_result
 from django.core.paginator import Paginator
 from django.db.models import Model, QuerySet
+from django.db.models.query import Q
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
 from structlog.stdlib import BoundLogger, get_logger
@@ -37,7 +38,9 @@ class SyncTasks:
         self._provider_model = provider_model
 
     def sync_all(self, single_sync: Callable[[int], None]):
-        for provider in self._provider_model.objects.filter(backchannel_application__isnull=False):
+        for provider in self._provider_model.objects.filter(
+            Q(backchannel_application__isnull=False) | Q(application__isnull=False)
+        ):
             self.trigger_single_task(provider, single_sync)
 
     def trigger_single_task(self, provider: OutgoingSyncProvider, sync_task: Callable[[int], None]):
@@ -62,7 +65,8 @@ class SyncTasks:
             provider_pk=provider_pk,
         )
         provider = self._provider_model.objects.filter(
-            pk=provider_pk, backchannel_application__isnull=False
+            Q(backchannel_application__isnull=False) | Q(application__isnull=False),
+            pk=provider_pk,
         ).first()
         if not provider:
             return
@@ -204,7 +208,9 @@ class SyncTasks:
         if not instance:
             return
         operation = Direction(raw_op)
-        for provider in self._provider_model.objects.filter(backchannel_application__isnull=False):
+        for provider in self._provider_model.objects.filter(
+            Q(backchannel_application__isnull=False) | Q(application__isnull=False)
+        ):
             client = provider.client_for_model(instance.__class__)
             # Check if the object is allowed within the provider's restrictions
             queryset = provider.get_object_qs(instance.__class__)
@@ -233,7 +239,9 @@ class SyncTasks:
         group = Group.objects.filter(pk=group_pk).first()
         if not group:
             return
-        for provider in self._provider_model.objects.filter(backchannel_application__isnull=False):
+        for provider in self._provider_model.objects.filter(
+            Q(backchannel_application__isnull=False) | Q(application__isnull=False)
+        ):
             # Check if the object is allowed within the provider's restrictions
             queryset: QuerySet = provider.get_object_qs(Group)
             # The queryset we get from the provider must include the instance we've got given

--- a/web/src/admin/applications/components/ak-provider-search-input.ts
+++ b/web/src/admin/applications/components/ak-provider-search-input.ts
@@ -15,7 +15,6 @@ const doGroupBy = (items: Provider[]) => groupBy(items, (item) => item.verboseNa
 async function fetch(query?: string) {
     const args: ProvidersAllListRequest = {
         ordering: "name",
-        backchannel: false,
     };
     if (query !== undefined) {
         args.search = query;


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

closes #10300

as part of the microsoft entra and google workspace providers, the UI was changed to only allow non-backchannel providers in the application form, however this also excluded LDAP providers which can be used for either

this removes the filter, and also adjusts all backchannel-only providers to also work as frontchannel providers

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
