### PR TITLE
website/docs: configuration: fix typo in kubectl command

### DIFF
--- a/website/docs/installation/configuration.mdx
+++ b/website/docs/installation/configuration.mdx
@@ -56,7 +56,7 @@ To check if your config has been applied correctly, you can run the following co
   <TabItem value="kubernetes" label="Kubernetes">
 
     ```
-    kubectl exec -it deployment/authentik-worker -c authentik -- ak dump_config
+    kubectl exec -it deployment/authentik-worker -c worker -- ak dump_config
     ```
 
   </TabItem>


### PR DESCRIPTION
fix typo in kubectl command

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
Update configuration.mdx fix typo in kubectl command to get configuration

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [X ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
