### PR TITLE
website/docs: installation:  ensures .env setup works consistently across GNU and BSD systems

### DIFF
--- a/website/docs/installation/docker-compose.mdx
+++ b/website/docs/installation/docker-compose.mdx
@@ -50,8 +50,8 @@ Run the following commands to generate a password and secret key and write them 
 
 {/* prettier-ignore */}
 ```shell
-echo "PG_PASS=$(openssl rand 36 | base64 -w 0)" >> .env
-echo "AUTHENTIK_SECRET_KEY=$(openssl rand 60 | base64 -w 0)" >> .env
+echo "PG_PASS=$(openssl rand -base64 36 | tr -d '\n')" >> .env
+echo "AUTHENTIK_SECRET_KEY=$(openssl rand -base64 60 | tr -d '\n')" >> .env
 ```
 
 :::info


### PR DESCRIPTION
closes #10539 

using `tr -d '\n'` command removes any newline characters, replicating the behavior of `base64 -w 0` in the GNU version