### PR TITLE
website/docs: fix typo in flows docs

### DIFF
--- a/website/docs/flow/index.md
+++ b/website/docs/flow/index.md
@@ -12,7 +12,7 @@ For example, a standard login flow would consist of the following stages:
 
 Upon flow execution, a plan containing all stages is generated. This means that all attached policies are evaluated upon execution. This behaviour can be altered by enabling the **Evaluate when stage is run** option on the binding.
 
-The determine which flow should be used, authentik will first check which default authentication flow is configured in the active [**Brand**](../core/brands.md). If no default is configured there, the policies in all flows with the matching designation are checked, and the first flow with matching policies sorted by `slug` will be used.
+To determine which flow should be used, authentik will first check which default authentication flow is configured in the active [**Brand**](../core/brands.md). If no default is configured there, the policies in all flows with the matching designation are checked, and the first flow with matching policies sorted by `slug` will be used.
 
 ## Permissions
 


### PR DESCRIPTION
## Details
Just replacing an english word in the doc because I think that was a typo.

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)
-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
