### PR TITLE
root: Make health checks compatible with cloud platform load balancers

### DIFF
--- a/authentik/root/monitoring.py
+++ b/authentik/root/monitoring.py
@@ -36,14 +36,14 @@ class MetricsView(View):
 
 
 class LiveView(View):
-    """View for liveness probe, always returns Http 204"""
+    """View for liveness probe, always returns Http 200"""
 
     def dispatch(self, request: HttpRequest) -> HttpResponse:
-        return HttpResponse(status=204)
+        return HttpResponse(status=200)
 
 
 class ReadyView(View):
-    """View for readiness probe, always returns Http 204, unless sql or redis is down"""
+    """View for readiness probe, always returns Http 200, unless sql or redis is down"""
 
     def dispatch(self, request: HttpRequest) -> HttpResponse:
         try:
@@ -56,4 +56,4 @@ class ReadyView(View):
             redis_conn.ping()
         except RedisError:  # pragma: no cover
             return HttpResponse(status=503)
-        return HttpResponse(status=204)
+        return HttpResponse(status=200)

--- a/authentik/root/tests.py
+++ b/authentik/root/tests.py
@@ -24,8 +24,8 @@ class TestRoot(TestCase):
 
     def test_monitoring_live(self):
         """Test LiveView"""
-        self.assertEqual(self.client.get(reverse("health-live")).status_code, 204)
+        self.assertEqual(self.client.get(reverse("health-live")).status_code, 200)
 
     def test_monitoring_ready(self):
         """Test ReadyView"""
-        self.assertEqual(self.client.get(reverse("health-ready")).status_code, 204)
+        self.assertEqual(self.client.get(reverse("health-ready")).status_code, 200)

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -89,7 +89,7 @@ func NewWebServer() *WebServer {
 		}
 		req.Header.Set("User-Agent", "goauthentik.io/router/healthcheck")
 		res, err := ws.upstreamHttpClient().Do(req)
-		if err == nil && res.StatusCode == 204 {
+		if err == nil && res.StatusCode >= 200 && res.StatusCode < 300 {
 			return true
 		}
 		return false

--- a/website/docs/installation/monitoring.md
+++ b/website/docs/installation/monitoring.md
@@ -6,7 +6,7 @@ authentik can be easily monitored in multiple ways.
 
 ## Server monitoring
 
-Configure your monitoring software to send requests to `/-/health/live/`, which will return a `HTTP 204` response as long as authentik is running. You can also send HTTP requests to `/-/health/ready/`, which will return `HTTP 204` if both PostgreSQL and Redis connections can be/have been established correctly.
+Configure your monitoring software to send requests to `/-/health/live/`, which will return a `HTTP 200` response as long as authentik is running. You can also send HTTP requests to `/-/health/ready/`, which will return `HTTP 200` if both PostgreSQL and Redis connections can be/have been established correctly.
 
 ## Worker monitoring
 

--- a/website/docs/installation/monitoring.md
+++ b/website/docs/installation/monitoring.md
@@ -8,6 +8,8 @@ authentik can be easily monitored in multiple ways.
 
 Configure your monitoring software to send requests to `/-/health/live/`, which will return a `HTTP 204` response as long as authentik is running. You can also send HTTP requests to `/-/health/ready/`, which will return `HTTP 204` if both PostgreSQL and Redis connections can be/have been established correctly.
 
+Updated in version ___: In previous versions, these endpoints returned an `HTTP 204` response.
+
 ## Worker monitoring
 
 The worker container can be monitored by running `ak healthcheck` in the worker container. This will ping the worker and ensure it can communicate with redis as required.

--- a/website/docs/installation/monitoring.md
+++ b/website/docs/installation/monitoring.md
@@ -8,8 +8,6 @@ authentik can be easily monitored in multiple ways.
 
 Configure your monitoring software to send requests to `/-/health/live/`, which will return a `HTTP 204` response as long as authentik is running. You can also send HTTP requests to `/-/health/ready/`, which will return `HTTP 204` if both PostgreSQL and Redis connections can be/have been established correctly.
 
-Updated in version ___: In previous versions, these endpoints returned an `HTTP 204` response.
-
 ## Worker monitoring
 
 The worker container can be monitored by running `ak healthcheck` in the worker container. This will ping the worker and ensure it can communicate with redis as required.

--- a/website/docs/releases/2024/v2024.8.md
+++ b/website/docs/releases/2024/v2024.8.md
@@ -1,0 +1,50 @@
+---
+title: Release 2024.8
+slug: "/releases/2024.8"
+---
+
+:::::note
+2024.8 has not been released yet! We're publishing these release notes as a preview of what's to come, and for our awesome beta testers trying out release candidates.
+
+To try out the release candidate, replace your Docker image tag with the latest release candidate number, such as 2024.8.0-rc1. You can find the latest one in [the latest releases on GitHub](https://github.com/goauthentik/authentik/releases). If you don't find any, it means we haven't released one yet.
+:::::
+
+## Breaking changes
+
+-   **Changed HTTP Healthcheck endpoints status code**
+
+    For increased compatibility, the `/-/health/live/` and `/-/health/ready/` endpoints return 200 HTTP Status codes for successful checks. Previously these endpoints returned 204, which means in most cases no changes are required.
+
+## New features
+
+## Upgrading
+
+This release does not introduce any new requirements.
+
+### docker-compose
+
+To upgrade, download the new docker-compose file and update the Docker stack with the new version, using these commands:
+
+```shell
+wget -O docker-compose.yml https://goauthentik.io/version/2024.8/docker-compose.yml
+docker compose up -d
+```
+
+The `-O` flag retains the downloaded file's name, overwriting any existing local file with the same name.
+
+### Kubernetes
+
+Upgrade the Helm Chart to the new version, using the following commands:
+
+```shell
+helm repo update
+helm upgrade authentik authentik/authentik -f values.yaml --version ^2024.8
+```
+
+## Minor changes/fixes
+
+<!-- _Insert the output of `make gen-changelog` here_ -->
+
+## API Changes
+
+<!-- _Insert output of `make gen-diff` here_ -->


### PR DESCRIPTION
## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->

Authentik currently returns `HTTP 204` for `/-/health/live` and `/-/health/ready`. This PR changes these to `HTTP 200` responses.

This fixes compatibility with deploying Authentik to multiple cloud platforms, where the cloud load balancers strictly require `HTTP 200` responses for health checks and (strangely) consider `HTTP 204` responses as UNHEALTHY.

There is some nuance here... native Kubernetes pods allow readinessProbe & livenessProbe http checks to return anything between 2XX-3XX to be considered healthy, which is why authentik's Kubernetes setup works currently. However, when deployed in Google Kubernetes Engine for example, the authentik helm chart creates an Ingress controller — on create, the linked load balancer reads the `readinessProbe` of the underlying k8s services, and constructs a [Google Cloud Healthcheck](https://github.com/GoogleCloudPlatform/gke-networking-recipes/tree/main/ingress/single-cluster/ingress-custom-http-health-check) which _strictly_ requires an `HTTP 200` response and is not configurable at all. So even though the pod comes up healthy, the load balancer in front sees it as unhealthy.

**The result being: authentik server is permanently in an UNHEALHTY state** from the cloud load balancer's perspective, with absolutely no mechanism to change this without modifying authentik itself, or wrapping it in a proxy to change the responses.

This is pretty much true across cloud providers — load balancer implementation in most cloud providers require `200 OK` as a standard for health check:

[GCP](https://cloud.google.com/load-balancing/docs/health-checks#optional-flags-hc-protocol-http):

```
If Google Cloud finds [...] and if the HTTP status is 200 (OK),
the probe is considered successful.
```

[AWS](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-healthchecks.html):

```
If the load balancer receives any response other than "200 OK" within the
response timeout period, the instance is considered unhealthy
```

[DigitalOcean](https://www.digitalocean.com/docs/app-platform/concepts/health-check/):

```
an HTTP health check can be configured to ping the root URL of your site and
ensure that the response is HTTP 200 (OK)
```

Also these precendents in other projects:
* https://github.com/meilisearch/meilisearch/issues/1282
* https://github.com/bitnami/charts/issues/2862 and https://github.com/influxdata/telegraf/issues/4935

I realize this may be considered a potentially backwards-incompatible change. I leave that to you authentik folks to decide what to do about that.

---

(Note: I wasn't able to get the full authentik dev environment up to get these pieces done — if you agree with this PR, can I get some help on this PR to do so from someone with a working dev env?)

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
