### PR TITLE
website/docs: explain guarantees around blueprint ordering

### DIFF
--- a/authentik/blueprints/v1/tasks.py
+++ b/authentik/blueprints/v1/tasks.py
@@ -121,7 +121,7 @@ def blueprints_find() -> list[BlueprintFile]:
     """Find blueprints and return valid ones"""
     blueprints = []
     root = Path(CONFIG.get("blueprints_dir"))
-    for path in root.rglob("**/*.yaml"):
+    for path in sorted(root.rglob("**/*.yaml")):
         rel_path = path.relative_to(root)
         # Check if any part in the path starts with a dot and assume a hidden file
         if any(part for part in path.parts if part.startswith(".")):

--- a/authentik/blueprints/v1/tasks.py
+++ b/authentik/blueprints/v1/tasks.py
@@ -121,7 +121,7 @@ def blueprints_find() -> list[BlueprintFile]:
     """Find blueprints and return valid ones"""
     blueprints = []
     root = Path(CONFIG.get("blueprints_dir"))
-    for path in sorted(root.rglob("**/*.yaml")):
+    for path in root.rglob("**/*.yaml"):
         rel_path = path.relative_to(root)
         # Check if any part in the path starts with a dot and assume a hidden file
         if any(part for part in path.parts if part.startswith(".")):

--- a/website/developer-docs/blueprints/index.md
+++ b/website/developer-docs/blueprints/index.md
@@ -36,6 +36,12 @@ To disable existing blueprints, an empty file can be mounted over the existing b
 
 File-based blueprints are automatically removed once they become unavailable, however none of the objects created by those blueprints afre affected by this.
 
+    :::info
+    Please note that, by default, blueprint discovery and evaluation is not guaranteed to follow any specific order.
+
+    If you have dependencies between blueprints, you should use [meta models](/developer-docs/blueprints/v1/meta#authentik_blueprintsmetaapplyblueprint) to make sure that objects are created in the correct order.
+    :::
+
 ## Storage - OCI
 
 Blueprints can also be stored in remote [OCI](https://opencontainers.org/) compliant registries. This includes GitHub Container Registry, Docker hub and many other registries.

--- a/website/developer-docs/blueprints/index.md
+++ b/website/developer-docs/blueprints/index.md
@@ -30,7 +30,7 @@ The authentik container by default looks for blueprints in `/blueprints`. Undern
 -   `/blueprints/example`: Example blueprints for common configurations and flows
 -   `/blueprints/system`: System blueprints for authentik managed Property mappings, etc
 
-Any additional `.yaml` file in `/blueprints` will be discovered and automatically instantiated, depending on their labels.
+Any additional `.yaml` file in `/blueprints` will be discovered and automatically instantiated, depending on their labels. Blueprints are loaded and instantiated in alphabetical order of the full filesystem path.
 
 To disable existing blueprints, an empty file can be mounted over the existing blueprint.
 

--- a/website/developer-docs/blueprints/index.md
+++ b/website/developer-docs/blueprints/index.md
@@ -30,7 +30,7 @@ The authentik container by default looks for blueprints in `/blueprints`. Undern
 -   `/blueprints/example`: Example blueprints for common configurations and flows
 -   `/blueprints/system`: System blueprints for authentik managed Property mappings, etc
 
-Any additional `.yaml` file in `/blueprints` will be discovered and automatically instantiated, depending on their labels. Blueprints are loaded and instantiated in alphabetical order of the full filesystem path.
+Any additional `.yaml` file in `/blueprints` will be discovered and automatically instantiated, depending on their labels.
 
 To disable existing blueprints, an empty file can be mounted over the existing blueprint.
 

--- a/website/developer-docs/blueprints/v1/meta.md
+++ b/website/developer-docs/blueprints/v1/meta.md
@@ -6,6 +6,8 @@ Since blueprints have a pretty strict mapping of each entry mapping to an instan
 
 This meta model can be used to apply another blueprint instance within a blueprint instance. This allows for dependency management and ensuring related objects are created.
 
+See [examples](https://github.com/search?q=repo%3Agoauthentik%2Fauthentik+path%3A%2F%5Eblueprints%5C%2F%2F+metaapplyblueprint&type=code) in the default blueprints for more information.
+
 #### Attributes
 
 -   `identifiers`: Key-value attributes used to match the blueprint instance


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

This PR updates documentation for how blueprint ordering works.

-- 
[previous description for posterity]

## Details

We have experimentally noticed flaky blueprint loading with custom blueprints when loading authentik from a blank slate. This seems to happen quite frequently—sometimes custom blueprints will work correctly, and sometimes they will fail silently without change. This happens especially when using custom blueprints that don't replace /blueprints/default but instead adds a custom directory that patches a default object.

Since there can be many dependencies between blueprints, the order in which each blueprint is discovered and loaded matters.

I believe this is flaky currently because `blueprints_find` is non-deterministic — it uses `Path.rglob` which does not guarantee any specific ordering and is filesystem-dependent.

This PR enforces a deterministic blueprint loading order by sorting the paths before load. (This is an easy and common pattern used in many "initialization" frameworks, like Rails bootup initializers).

Experimentally, this PR 100% eliminates these flakes and makes blueprint loading deterministic.

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
