### PR TITLE
events: fix race condition

### DIFF
--- a/authentik/events/models.py
+++ b/authentik/events/models.py
@@ -238,6 +238,8 @@ class Event(SerializerModel, ExpiringModel):
                 "args": cleanse_dict(QueryDict(request.META.get("QUERY_STRING", ""))),
                 "user_agent": request.META.get("HTTP_USER_AGENT", ""),
             }
+            if hasattr(request, "request_id"):
+                self.context["http_request"]["request_id"] = request.request_id
             # Special case for events created during flow execution
             # since they keep the http query within a wrapped query
             if QS_QUERY in self.context["http_request"]["args"]:

--- a/authentik/stages/authenticator_validate/tests/test_duo.py
+++ b/authentik/stages/authenticator_validate/tests/test_duo.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 from rest_framework.exceptions import ValidationError
 
 from authentik.brands.utils import get_brand_for_request
+from authentik.core.middleware import RESPONSE_HEADER_ID
 from authentik.core.tests.utils import create_test_admin_user, create_test_flow
 from authentik.events.models import Event, EventAction
 from authentik.flows.models import FlowDesignation, FlowStageBinding
@@ -186,6 +187,7 @@ class AuthenticatorValidateStageDuoTests(FlowTestCase):
                     "method": "GET",
                     "path": f"/api/v3/flows/executor/{flow.slug}/",
                     "user_agent": "",
+                    "request_id": response[RESPONSE_HEADER_ID],
                 },
             },
         )


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

Fix race condition due to signal handlers not being scoped. before this PR, it was possible that a new request was started and signal handlers were connected while the old signal handlers were not disconnected yet, hence causing the data from the requests to be mixed together

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
