### PR TITLE
stages/prompt: fix prompt not editable with invalid expression

### DIFF
--- a/authentik/stages/prompt/api.py
+++ b/authentik/stages/prompt/api.py
@@ -108,7 +108,7 @@ class PromptViewSet(UsedByMixin, ModelViewSet):
             return Response(
                 {
                     "non_field_errors": [
-                        exception_to_string(exc),
+                        exception_to_string(exc.exc),
                     ]
                 },
                 status=400,

--- a/authentik/stages/prompt/models.py
+++ b/authentik/stages/prompt/models.py
@@ -170,7 +170,7 @@ class Prompt(SerializerModel):
             try:
                 raw_choices = evaluator.evaluate(self.placeholder)
             except Exception as exc:  # pylint:disable=broad-except
-                wrapped = PropertyMappingExpressionException(str(exc))
+                wrapped = PropertyMappingExpressionException(exc, None)
                 LOGGER.warning(
                     "failed to evaluate prompt choices",
                     exc=wrapped,
@@ -208,7 +208,7 @@ class Prompt(SerializerModel):
             try:
                 return evaluator.evaluate(self.placeholder)
             except Exception as exc:  # pylint:disable=broad-except
-                wrapped = PropertyMappingExpressionException(str(exc), None)
+                wrapped = PropertyMappingExpressionException(exc, None)
                 LOGGER.warning(
                     "failed to evaluate prompt placeholder",
                     exc=wrapped,
@@ -237,7 +237,7 @@ class Prompt(SerializerModel):
             try:
                 value = evaluator.evaluate(self.initial_value)
             except Exception as exc:  # pylint:disable=broad-except
-                wrapped = PropertyMappingExpressionException(str(exc))
+                wrapped = PropertyMappingExpressionException(exc, None)
                 LOGGER.warning(
                     "failed to evaluate prompt initial value",
                     exc=wrapped,


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

closes #10592

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
