### PR TITLE
website/docs: fix typos in passwordless setup guide

### DIFF
--- a/.github/actions/docker-push-variables/push_vars.py
+++ b/.github/actions/docker-push-variables/push_vars.py
@@ -7,7 +7,7 @@ from time import time
 parser = configparser.ConfigParser()
 parser.read(".bumpversion.cfg")
 
-should_build = str(os.environ.get("DOCKER_USERNAME", None) is not None).lower()
+should_build = str(len(os.environ.get("DOCKER_USERNAME", "")) > 0).lower()
 
 branch_name = os.environ["GITHUB_REF"]
 if os.environ.get("GITHUB_HEAD_REF", "") != "":

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -259,10 +259,11 @@ jobs:
           platforms: linux/${{ matrix.arch }}
       - uses: actions/attest-build-provenance@v1
         id: attest
+        if: ${{ steps.ev.outputs.shouldBuild == 'true' }}
         with:
           subject-name: ${{ steps.ev.outputs.imageNames }}
           subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: ${{ steps.ev.outputs.shouldBuild == 'true' }}
+          push-to-registry: true
   pr-comment:
     needs:
       - build

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -255,7 +255,7 @@ jobs:
           build-args: |
             GIT_BUILD_HASH=${{ steps.ev.outputs.sha }}
           cache-from: type=registry,ref=ghcr.io/goauthentik/dev-server:buildcache
-          cache-to: type=registry,ref=ghcr.io/goauthentik/dev-server:buildcache,mode=max
+          cache-to: ${{ steps.ev.outputs.shouldBuild == 'true' && 'type=registry,ref=ghcr.io/goauthentik/dev-server:buildcache,mode=max' || '' }}
           platforms: linux/${{ matrix.arch }}
       - uses: actions/attest-build-provenance@v1
         id: attest

--- a/.github/workflows/ci-outpost.yml
+++ b/.github/workflows/ci-outpost.yml
@@ -110,7 +110,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           context: .
           cache-from: type=registry,ref=ghcr.io/goauthentik/dev-${{ matrix.type }}:buildcache
-          cache-to: type=registry,ref=ghcr.io/goauthentik/dev-${{ matrix.type }}:buildcache,mode=max
+          cache-to: ${{ steps.ev.outputs.shouldBuild == 'true' && 'type=registry,ref=ghcr.io/goauthentik/dev-${{ matrix.type }}:buildcache,mode=max' || '' }}
       - uses: actions/attest-build-provenance@v1
         id: attest
         with:

--- a/.github/workflows/ci-outpost.yml
+++ b/.github/workflows/ci-outpost.yml
@@ -113,10 +113,11 @@ jobs:
           cache-to: ${{ steps.ev.outputs.shouldBuild == 'true' && 'type=registry,ref=ghcr.io/goauthentik/dev-${{ matrix.type }}:buildcache,mode=max' || '' }}
       - uses: actions/attest-build-provenance@v1
         id: attest
+        if: ${{ steps.ev.outputs.shouldBuild == 'true' }}
         with:
           subject-name: ${{ steps.ev.outputs.imageNames }}
           subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: ${{ steps.ev.outputs.shouldBuild == 'true' }}
+          push-to-registry: true
   build-binary:
     timeout-minutes: 120
     needs:

--- a/website/docs/flow/stages/authenticator_validate/index.md
+++ b/website/docs/flow/stages/authenticator_validate/index.md
@@ -43,9 +43,9 @@ Firefox has some known issues regarding FIDO (see https://bugzilla.mozilla.org/s
 
 Passwordless authentication currently only supports WebAuthn devices, like security keys and biometrics. For an alternate passwordless setup, see [Password stage](../password/index.md#passwordless-login), which supports other types.
 
-To configure passwordless authentication, create a new Flow with the delegation set to _Authentication_.
+To configure passwordless authentication, create a new Flow with the designation set to _Authentication_.
 
-As first stage, add an _Authentication validation_ stage, with the WebAuthn device class allowed.
+As first stage, add an _Authenticator validation_ stage, with the WebAuthn device class allowed.
 After this stage you can bind any additional verification stages.
 As final stage, bind a _User login_ stage.
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

Some key words used in the setup are incorrect and caused confusion for me trying to setup passwordless flow.

User should pick Authentication from the "Designation" drop down when creating a flow.

Then the stage created should be "Authenticator Validation Stage", not Authentication.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
