### PR TITLE
provider/proxy: allow Cookie Domain with port when using ForwardAuth(domain level)

### DIFF
--- a/internal/outpost/proxyv2/application/session.go
+++ b/internal/outpost/proxyv2/application/session.go
@@ -77,10 +77,12 @@ func (a *Application) getStore(p api.ProxyOutpostConfig, externalHost *url.URL) 
 		}
 
 		rs.KeyPrefix(RedisKeyPrefix)
+
+		cookieDomain, err := url.Parse("//" + (*p.CookieDomain))
 		rs.Options(sessions.Options{
 			HttpOnly: true,
 			Secure:   strings.ToLower(externalHost.Scheme) == "https",
-			Domain:   *p.CookieDomain,
+			Domain:   cookieDomain.Hostname(),
 			SameSite: http.SameSiteLaxMode,
 			MaxAge:   maxAge,
 			Path:     "/",

--- a/internal/outpost/proxyv2/application/session.go
+++ b/internal/outpost/proxyv2/application/session.go
@@ -79,6 +79,9 @@ func (a *Application) getStore(p api.ProxyOutpostConfig, externalHost *url.URL) 
 		rs.KeyPrefix(RedisKeyPrefix)
 
 		cookieDomain, err := url.Parse("//" + (*p.CookieDomain))
+		if err != nil {
+			a.log.WithError(err).Panic("failed to parse cookie domain url")
+		}
 		rs.Options(sessions.Options{
 			HttpOnly: true,
 			Secure:   strings.ToLower(externalHost.Scheme) == "https",


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

Authentik now doesn't support Cookie Domain with port when using ForwardAuth(domain level). For example, when set `Cookie domain` as `localhost:1443`, following error will occur:
```
2024/07/31 10:09:05 net/http: invalid Cookie.Domain "localhost:1443"; dropping domain attribute
```

The root cause of this error is go's `net/http` lib will check whether domain is legal, the `:` is illegal, reference https://github.com/golang/go/blob/eea2e929fae6abbc1422f8ee26de02a4b7e4f8cd/src/net/http/cookie.go#L369

I think we can enable cookie domain with port in application level, it's convenient for some circumstances.

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
