### PR TITLE
core: daphne must be loaded first when provided in SHARED_APPS

### DIFF
--- a/authentik/root/settings.py
+++ b/authentik/root/settings.py
@@ -49,7 +49,8 @@ AUTHENTICATION_BACKENDS = [
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 # Application definition
-SHARED_APPS = [
+SHARED_APPS = ["daphne"] if DEBUG else []
+SHARED_APPS += [
     "django_tenants",
     "authentik.tenants",
     "django.contrib.messages",
@@ -63,6 +64,7 @@ SHARED_APPS = [
     "pglock",
     "channels",
 ]
+
 TENANT_APPS = [
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -516,7 +518,6 @@ if DEBUG:
     REST_FRAMEWORK["DEFAULT_RENDERER_CLASSES"].append(
         "rest_framework.renderers.BrowsableAPIRenderer"
     )
-    SHARED_APPS.append("daphne")
 
 TENANT_APPS.append("authentik.core")
 


### PR DESCRIPTION
## Details

### What:

Re-arranges the order in which the `SHARED_APPS` setting is initialized so that the 'Daphne' server is included first.

### Why

Fixes this error:

```
ERRORS:
?: (daphne.E001) Daphne must be listed before django.contrib.staticfiles in INSTALLED_APPS.
2024-08-01T16:55:31.769823 [info     ] releasing database lock        [__main__] domain_url=None pid=51805 schema_name=public
make: *** [migrate] Error 1
```

-   [X] Local tests pass (`ak test authentik/`)
-   [X] The code has been formatted (`make lint-fix`)
