### PR TITLE
internal: Use loop instead of recursion in NewAPIController

### DIFF
--- a/internal/outpost/ak/api.go
+++ b/internal/outpost/ak/api.go
@@ -77,11 +77,17 @@ func NewAPIController(akURL url.URL, token string) *APIController {
 
 	// Because we don't know the outpost UUID, we simply do a list and pick the first
 	// The service account this token belongs to should only have access to a single outpost
-	outposts, _, err := apiClient.OutpostsApi.OutpostsInstancesList(context.Background()).Execute()
-	if err != nil {
+	var outposts *api.PaginatedOutpostList
+	var err error
+	for {
+		outposts, _, err = apiClient.OutpostsApi.OutpostsInstancesList(context.Background()).Execute()
+
+		if err == nil {
+			break
+		}
+
 		log.WithError(err).Error("Failed to fetch outpost configuration, retrying in 3 seconds")
 		time.Sleep(time.Second * 3)
-		return NewAPIController(akURL, token)
 	}
 	if len(outposts.Results) < 1 {
 		panic("No outposts found with given token, ensure the given token corresponds to an authenitk Outpost")


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
Use loop instead of recursion in  `NewAPIController`.

Golang has no tail call optimization now, so the recursion `return NewAPIController(akURL, token)` will cause the stack too deep when OutpostsApi failed for a long time.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
