### PR TITLE
web: replace all occurences of the theme placeholder

### DIFF
--- a/web/src/elements/utils/images.ts
+++ b/web/src/elements/utils/images.ts
@@ -9,5 +9,5 @@ export function themeImage(rawPath: string) {
             ? UiThemeEnum.Light
             : UiThemeEnum.Dark;
     }
-    return rawPath.replace("%(theme)s", enabledTheme);
+    return rawPath.replaceAll("%(theme)s", enabledTheme);
 }


### PR DESCRIPTION
Allows the placeholder to occur multiple times in the theme url.

This is useful if the theme-url looks something like `images.example.org/dark/theme-image-dark.svg`.

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

~~If an API change has been made~~

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
