### PR TITLE
sources/ldap: Add enabled filter for ldap_password_validate signal

### DIFF
--- a/authentik/sources/ldap/signals.py
+++ b/authentik/sources/ldap/signals.py
@@ -42,7 +42,7 @@ def sync_ldap_source_on_save(sender, instance: LDAPSource, **_):
 @receiver(password_validate)
 def ldap_password_validate(sender, password: str, plan_context: dict[str, Any], **__):
     """if there's an LDAP Source with enabled password sync, check the password"""
-    sources = LDAPSource.objects.filter(sync_users_password=True)
+    sources = LDAPSource.objects.filter(sync_users_password=True, enabled=True)
     if not sources.exists():
         return
     source = sources.first()
@@ -59,7 +59,7 @@ def ldap_password_validate(sender, password: str, plan_context: dict[str, Any], 
 @receiver(password_changed)
 def ldap_sync_password(sender, user: User, password: str, **_):
     """Connect to ldap and update password."""
-    sources = LDAPSource.objects.filter(sync_users_password=True)
+    sources = LDAPSource.objects.filter(sync_users_password=True, enabled=True)
     if not sources.exists():
         return
     source = sources.first()


### PR DESCRIPTION
## Details

Disabled LDAP Sources are still queried causing issues when trying to change or validate passwords via Stages. The issues is a result of the line: ``sources = LDAPSource.objects.filter(sync_users_password=True)``

The filter only checks if the sync_users_password checkbox is true, but should additionally check if the Source is enabled.

closes #10822


---

## Checklist

-   [ x ] Local tests pass (`ak test authentik/`)
-   [ x ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
