### PR TITLE
website/docs: add link from Install docs to Enterprise docs

### DIFF
--- a/website/docs/installation/index.mdx
+++ b/website/docs/installation/index.mdx
@@ -2,7 +2,11 @@
 title: Installation
 ---
 
-Everything you need to get authentik up and running! For information about upgrading to a new version, refer to the <b>Upgrade</b> section in the relevant [Release Notes](../releases).
+Everything you need to get authentik up and running!
+
+For information about upgrading to a new version, refer to the <b>Upgrade</b> section in the relevant [Release Notes](../releases) and to our [Upgrade authentik documentation](../installation/upgrade.mdx).
+
+
 
 import DocCardList from "@theme/DocCardList";
 

--- a/website/docs/installation/index.mdx
+++ b/website/docs/installation/index.mdx
@@ -4,9 +4,9 @@ title: Installation
 
 Everything you need to get authentik up and running!
 
-For information about upgrading to a new version, refer to the <b>Upgrade</b> section in the relevant [Release Notes](../releases) and to our [Upgrade authentik documentation](../installation/upgrade.mdx).
+For information about upgrading to a new version, refer to the <b>Upgrade</b> section in the relevant [Release Notes](../releases) and to our [Upgrade authentik](../installation/upgrade.mdx) documentation.
 
-
+The installation process for our free open source version and our [Enterprise](../enterprise/index.md) version are exactly the same. For information about obtaining an Enterprise license, refer to [License management](../enterprise/manage-enterprise.md#license-management) documentation.
 
 import DocCardList from "@theme/DocCardList";
 


### PR DESCRIPTION
This PR adds a statement to the Install docs stating that the install process is the same for Enterprise, and links to Enterprise docs.

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
