### PR TITLE
website/docs: update docs about "stay logged in" option

### DIFF
--- a/website/docs/flow/stages/user_login/index.md
+++ b/website/docs/flow/stages/user_login/index.md
@@ -7,6 +7,7 @@ This stage attaches a currently pending user to the current session.
 It can be used after `user_write` during an enrollment flow, or after a `password` stage during an authentication flow.
 
 ## User login stage configuration options
+
 When creating or editing this stage in the UI of the Admin interface, you can set the following configuration options.
 
 **Name**: enter a descriptive name for the stage.
@@ -35,7 +36,7 @@ When creating or editing this stage in the UI of the Admin interface, you can se
 
     ![](./stay_signed_in.png)
 
--   **Network binding and GeoIP binding**
+-   **Network binding/GeoIP binding**
 
     When configured, all sessions authenticated by this stage will be bound to the selected network and/or GeoIP criteria.
 

--- a/website/docs/flow/stages/user_login/index.md
+++ b/website/docs/flow/stages/user_login/index.md
@@ -6,37 +6,40 @@ This stage attaches a currently pending user to the current session.
 
 It can be used after `user_write` during an enrollment flow, or after a `password` stage during an authentication flow.
 
-## Session duration
+## User login stage configuration options
+When creating or editing this stage in the UI of the Admin interface, you can set the following configuration options.
 
-By default, the authentik session expires when you close your browser (_seconds=0_).
+**Name**: enter a descriptive name for the stage.
 
-:::warning
-Different browsers handle session cookies differently, and might not remove them even when the browser is closed. See [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#expiresdate) for more info.
-:::
+**Stage-specific settings**
 
-You can set the session to expire after any duration using the syntax of `hours=1,minutes=2,seconds=3`. The following keys are allowed:
+-   **Session duration**: By default, the authentik session expires when you close your browser (_seconds=0_).
 
--   Microseconds
--   Milliseconds
--   Seconds
--   Minutes
--   Hours
--   Days
--   Weeks
+    :::warning
+    Different browsers handle session cookies differently, and might not remove them even when the browser is closed. See [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#expiresdate) for more info.
+    :::
 
-All values accept floating-point values.
+    You can set the session to expire after any duration using the syntax of `hours=1,minutes=2,seconds=3`. The following keys are allowed:
 
-## Stay signed in offset
+    -   Microseconds
+    -   Milliseconds
+    -   Seconds
+    -   Minutes
+    -   Hours
+    -   Days
+    -   Weeks
 
-When this is set to a higher value than the default _seconds=0_, a prompt is shown, allowing the users to choose if their session should be extended or not. The same syntax as for _Session duration_ applies.
+    All values accept floating-point values.
 
-![](./stay_signed_in.png)
+-   **Stay signed in offset**: When this is set to a higher value than the default _seconds=0_, the user logging in is shown a prompt, allowing the user to choose if their session should be extended or not. The same syntax as for _Session duration_ applies.
 
-## Network binding/GeoIP binding
+    ![](./stay_signed_in.png)
 
-When configured, all sessions authenticated by this stage will be bound to the selected network/GeoIP criteria.
+-   **Network binding and GeoIP binding**
 
-Sessions which break this binding will be terminated on use. The created [`logout`](../../../events/index.md#logout) event will contain additional data related to what caused the binding to be broken:
+    When configured, all sessions authenticated by this stage will be bound to the selected network and/or GeoIP criteria.
+
+    Sessions that break this binding will be terminated on use. The created [`logout`](../../../events/index.md#logout) event will contain additional data related to what caused the binding to be broken:
 
 ```json
 {
@@ -75,6 +78,6 @@ Sessions which break this binding will be terminated on use. The created [`logou
 }
 ```
 
-## Terminate other sessions
+-   **Terminate other sessions**
 
-When enabled, previous sessions of the user logging in will be revoked. This has no affect on OAuth refresh tokens.
+    When enabled, previous sessions of the user logging in will be revoked. This has no affect on OAuth refresh tokens.

--- a/website/docs/flow/stages/user_login/index.md
+++ b/website/docs/flow/stages/user_login/index.md
@@ -36,7 +36,7 @@ When creating or editing this stage in the UI of the Admin interface, you can se
 
     ![](./stay_signed_in.png)
 
--   **Network binding/GeoIP binding**
+-   **Network binding and GeoIP binding**
 
     When configured, all sessions authenticated by this stage will be bound to the selected network and/or GeoIP criteria.
 

--- a/website/docs/flow/stages/user_login/index.md
+++ b/website/docs/flow/stages/user_login/index.md
@@ -42,42 +42,42 @@ When creating or editing this stage in the UI of the Admin interface, you can se
 
     Sessions that break this binding will be terminated on use. The created [`logout`](../../../events/index.md#logout) event will contain additional data related to what caused the binding to be broken:
 
-```json
-{
-    "asn": {
-        "asn": 6805,
-        "as_org": "Telefonica Germany",
-        "network": "5.4.0.0/14"
-    },
-    "geo": {
-        "lat": 51.2993,
-        "city": "",
-        "long": 9.491,
-        "country": "DE",
-        "continent": "EU"
-    },
-    "binding": {
-        "reason": "network.missing",
-        "new_value": {
+    ```json
+    {
+        "asn": {
             "asn": 6805,
             "as_org": "Telefonica Germany",
             "network": "5.4.0.0/14"
         },
-        "previous_value": {}
-    },
-    "ip": {
-        "previous": "1.2.3.4",
-        "new": "5.6.7.8"
-    },
-    "http_request": {
-        "args": {},
-        "path": "/if/admin/",
-        "method": "GET",
-        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-    },
-    "logout_reason": "Session binding broken"
-}
-```
+        "geo": {
+            "lat": 51.2993,
+            "city": "",
+            "long": 9.491,
+            "country": "DE",
+            "continent": "EU"
+        },
+        "binding": {
+            "reason": "network.missing",
+            "new_value": {
+                "asn": 6805,
+                "as_org": "Telefonica Germany",
+                "network": "5.4.0.0/14"
+            },
+            "previous_value": {}
+        },
+        "ip": {
+            "previous": "1.2.3.4",
+            "new": "5.6.7.8"
+        },
+        "http_request": {
+            "args": {},
+            "path": "/if/admin/",
+            "method": "GET",
+            "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+        },
+        "logout_reason": "Session binding broken"
+    }
+    ```
 
 -   **Terminate other sessions**
 

--- a/website/docs/releases/2024/v2024.2.md
+++ b/website/docs/releases/2024/v2024.2.md
@@ -114,7 +114,7 @@ slug: /releases/2024.2
 
     Sessions for any users can now be bound to a specific geolocation (Continent, Country, City) or network (Autonomous System, subnet, IP address). If the session is accessed from a location/network that is different than that from which it was initially created, the session will be terminated.
 
-    Configuration steps are available [here](../../flow/stages/user_login/index.md#network-bindinggeoip-binding).
+    Configuration steps are available [here](../../flow/stages/user_login/index.md#user-login-stage-configuration-options).
 
 -   **S3 file storage**
 


### PR DESCRIPTION
This PR edits the User Login Stage docs to add an intro section for all Config options, and clarifies wording around how to use the Stay Logged In option. Also fixes a broken link to an old, now on-existent anchor.

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
