### PR TITLE
website/docs: add link from Ent to Upgrade

### DIFF
--- a/website/docs/enterprise/get-started.md
+++ b/website/docs/enterprise/get-started.md
@@ -6,7 +6,9 @@ Installing authentik is exactly the same process for both Enterprise version and
 
 ## Install Enterprise
 
-To get started working with Enterprise authentik, upgrade to the [2023.8.x](../releases) version or later. For installation steps, refer to our [technical documentation](../installation/index.mdx) for instructions to install and configure authentik.
+To get started working with Enterprise authentik, [upgrade](../installation/upgrade.mdx) to the [2023.8.x](../releases) version or later.
+
+If this is a fresh install, refer to our [technical documentation](../installation/index.mdx) for instructions to install and configure authentik.
 
 -   [Docker Compose installation](../installation/docker-compose.mdx)
 -   [Kubernetes installation](../installation/kubernetes.md)


### PR DESCRIPTION
This PR adds a link from the Enterprise "Get Started" docs to the Upgrade docs.

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
