### PR TITLE
website/docs: add content to certs page about config'ing a webhook

### DIFF
--- a/website/docs/core/certificates.md
+++ b/website/docs/core/certificates.md
@@ -9,6 +9,7 @@ Certificates in authentik are used for the following use cases:
 -   Connecting to remote docker hosts using the Docker integration
 -   Verifying LDAP Servers' certificates
 -   Encrypting outposts' endpoints
+-   Configure a webhook to use uploaded SSL certificates
 
 ## Default certificate
 
@@ -68,6 +69,24 @@ ak import_certificate --certificate /certs/mycert.pem --private-key /certs/somet
 ```
 
 This will import the certificate into authentik under the given name. This command is safe to run as a cron job; authentik will only re-import the certificate if it changes.
+
+## Configure a webhook to use uploaded SSL certificates
+
+When communicating with an external API, you will need to configure a generic webhook to utilize uploaded SSL certificates.
+
+1. Create a custom image with a Docker file that looks something like this:
+
+```
+FROM ghcr.io/goauthentik/server
+
+USER root
+COPY /ak-root/venv/lib/python3.12/site-packages/certifi/cacert.pem /etc/ssl/certs
+RUN update-ca-certificates
+USER authentik
+```
+
+2. Add your custom CA to /etc/ssl/certs
+3. Run `update-ca-certificates` as root to add the SSL certificates (CA) to the environment
 
 ## Web certificates
 

--- a/website/docs/core/certificates.md
+++ b/website/docs/core/certificates.md
@@ -85,8 +85,8 @@ RUN update-ca-certificates
 USER authentik
 ```
 
-2. Add your custom CA to /etc/ssl/certs
-3. Run `update-ca-certificates` as root to add the SSL certificates (CA) to the environment
+2. Add your custom SSL certificates (CA) to `/etc/ssl/certs`.
+3. Run `update-ca-certificates` as root to add the certificates to the environment.
 
 ## Web certificates
 

--- a/website/docs/core/certificates.md
+++ b/website/docs/core/certificates.md
@@ -9,7 +9,7 @@ Certificates in authentik are used for the following use cases:
 -   Connecting to remote docker hosts using the Docker integration
 -   Verifying LDAP Servers' certificates
 -   Encrypting outposts' endpoints
--   Configure a webhook to use uploaded SSL certificates
+-   Configure a webhook to use uploaded SSL certificates (CA)
 
 ## Default certificate
 
@@ -72,7 +72,7 @@ This will import the certificate into authentik under the given name. This comma
 
 ## Configure a webhook to use uploaded SSL certificates
 
-When communicating with an external API, you will need to configure a generic webhook to utilize uploaded SSL certificates.
+When communicating with an external API, you will need to configure a generic webhook to utilize uploaded SSL certificates (CA).
 
 1. Create a custom image with a Docker file that looks something like this:
 


### PR DESCRIPTION
UPDATE: We are putting this on hold for now because Jens wants to change how the product/UI handles this; users shouldn't have to create the image, etc.

This PR adds a section to the Certificates page about how to configure a webhook to use uploaded certs.

@BeryJu please review carefully; this new content is 50% guessage, based on what I could grok from the Issue.

User need to add a pointer to this image in their `.env` or `values.yaml` file.

Closes Issue #6586 


-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
