### PR TITLE
website/integrations: Add Semgrep

### DIFF
--- a/website/integrations/services/semgrep/index.md
+++ b/website/integrations/services/semgrep/index.md
@@ -37,7 +37,7 @@ The following placeholders will be used:
     - **Audience**: `semgrep-dev`
     - **Service Provider Binding**: `Post`
     - **Signing Keypair**: Select the RSA certificate you have generated previously.
-    - **Property mappings**: Select `semgrep-name` and `semgrep-email` mappings, replacing authentik-provided email and name mappings.
+    - **Property mappings**: Select `semgrep-name` and `semgrep-email` mappings, replacing authentik-provided email and name mappings. Keep other mappings default.
 9. Create a new application under **Applications** -> **Applications**, pick a name and a slug, and assign the provider that you have just created.
 
 ## Semgrep Configuration

--- a/website/integrations/services/semgrep/index.md
+++ b/website/integrations/services/semgrep/index.md
@@ -40,11 +40,11 @@ The following placeholders will be used:
     - **Service Provider Binding**: `Post`
     - **Signing Keypair**: Choose the RSA certificate you generated earlier.
     - **Property mappings**: `semgrep-name` and `semgrep-email`
-10. Create a new application under **Applications** -> **Applications**, pick a name and a slug, and assign the provider that you have just created.
+10. Create a new application under **Applications** -> **Applications**, pick a name and a slug, and assign the provider that you just created.
 
 ## Semgrep Configuration
 
-1. Login to Semgrep Cloud platform as an administrator.
+1. Log in to Semgrep Cloud platform as an administrator.
 2. Click **Settings** on bottom left corner.
 3. Navigate to **Access** -> **Login methods**.
 4. Locate Single sign-on entry, click **Add SSO configuration**, select **SAML2 SSO** from the drop down.
@@ -60,5 +60,5 @@ The following placeholders will be used:
 1. Open an Incaognito window and navigate to `https://semgrep.dev/login`
 2. Click **Use SSO** on the login screen.
 3. Enter the email address associated with the domain you provided earlier.
-4. Login with authentik.
-5. You will be redirected to home screen of Semgrep Cloud platform.
+4. Log in to authentik.
+5. You will be redirected to the home screen of Semgrep Cloud platform.

--- a/website/integrations/services/semgrep/index.md
+++ b/website/integrations/services/semgrep/index.md
@@ -1,0 +1,62 @@
+---
+title: Semgrep
+---
+
+<span class="badge badge--secondary">Support level: Community</span>
+
+## What is Semgrep
+
+> **Semgrep**: An application security solution that combines SAST, SCA, and secret detection.
+> -- https://semgrep.dev
+
+## Preparation
+
+The following placeholders will be used:
+
+-   `authentik.company.blah` is the FQDN of the authentik install.
+-   `devcompany` is the organization name on Semgrep Cloud platform.
+
+## authentik configuration
+
+1. Login into authentik instance as an administrator.
+2. Navigate to **Customization** -> **Property mappings**.
+3. Create a new SAML property mapping with these parameters:
+    - **Name**: `semgrep-name`
+    - **SAML Attribute name**: `name`
+    - **Expression**: `return request.user.name`
+4. Create another SAML property mapping with these parameters:
+    - **Name**: `semgrep-email`
+    - **SAML Attribute name**: `email`
+    - **Expression**: `return request.user.email`
+5. Navigate to **System** -> **Certificates**.
+6. Generate a new RSA certificate, pick a name.
+7. Download the generated certificate, as you will need it later.
+8. Create a new SAML provider under **Applications** -> **Providers** using the following settings:
+    - **ACS URL**: `https://semgrep.dev/api/auth/saml/devcompany/`
+    - **Issuer**: `https://authentik.company`
+    - **Audience**: `semgrep-dev`
+    - **Service Provider Binding**: `Post`
+    - **Signing Keypair**: Select the RSA certificate you have generated previously.
+    - **Property mappings**: Select `semgrep-name` and `semgrep-email` mappings, replacing authentik-provided email and name mappings.
+9. Create a new application under **Applications** -> **Applications**, pick a name and a slug, and assign the provider that you have just created.
+
+## Semgrep Configuration
+
+1. Login to Semgrep Cloud platform as an administrator.
+2. Click **Settings** on bottom left corner.
+3. Navigate to **Access** -> **Login methods**.
+4. Locate Single sign-on entry, click **Add SSO configuration**, select **SAML2 SSO** from the drop down.
+5. Fill in the following:
+    - **Display name**: Anything you like.
+    - **Email domain**: `company.blah`
+    - **IdP SSO URL**: `https://authentik.company.blah/application/saml/_slug_/sso/binding/post/`
+    - **IdP Issuer ID**: `https://authentik.company`
+    - **Upload/paste certificate**: Downloaded from the previous step.
+
+## Verification
+
+1. Go to `https://semgrep.dev/login` from Incognito mode.
+2. Click **Use SSO** on the login screen.
+3. Enter an email address that belongs to email domain you have entered earlier.
+4. Authorize with authentik.
+5. You will be redirected to home screen of Semgrep Cloud platform.

--- a/website/integrations/services/semgrep/index.md
+++ b/website/integrations/services/semgrep/index.md
@@ -7,38 +7,40 @@ title: Semgrep
 ## What is Semgrep
 
 > **Semgrep**: An application security solution that combines SAST, SCA, and secret detection.
+>
 > -- https://semgrep.dev
 
 ## Preparation
 
 The following placeholders will be used:
 
--   `authentik.company.blah` is the FQDN of the authentik install.
+-   `authentik.company` is the FQDN of the authentik install.
 -   `devcompany` is the organization name on Semgrep Cloud platform.
 
 ## authentik configuration
 
 1. Login into authentik instance as an administrator.
-2. Navigate to **Customization** -> **Property mappings**.
-3. Create a new SAML property mapping with these parameters:
+2. Go to the admin interface.
+3. Navigate to **Customization** -> **Property mappings**.
+4. Create a new SAML property mapping with these parameters:
     - **Name**: `semgrep-name`
     - **SAML Attribute name**: `name`
     - **Expression**: `return request.user.name`
-4. Create another SAML property mapping with these parameters:
+5. Create another SAML property mapping with these parameters:
     - **Name**: `semgrep-email`
     - **SAML Attribute name**: `email`
     - **Expression**: `return request.user.email`
-5. Navigate to **System** -> **Certificates**.
-6. Generate a new RSA certificate, pick a name.
-7. Download the generated certificate, as you will need it later.
-8. Create a new SAML provider under **Applications** -> **Providers** using the following settings:
+6. Navigate to **System** -> **Certificates**.
+7. Generate a new RSA certificate.
+8. Download the generated certificate, as you will need it later.
+9. Create a new SAML provider under **Applications** -> **Providers** using the following settings:
     - **ACS URL**: `https://semgrep.dev/api/auth/saml/devcompany/`
     - **Issuer**: `https://authentik.company`
     - **Audience**: `semgrep-dev`
     - **Service Provider Binding**: `Post`
-    - **Signing Keypair**: Select the RSA certificate you have generated previously.
-    - **Property mappings**: Select `semgrep-name` and `semgrep-email` mappings, replacing authentik-provided email and name mappings. Keep other mappings default.
-9. Create a new application under **Applications** -> **Applications**, pick a name and a slug, and assign the provider that you have just created.
+    - **Signing Keypair**: Choose the RSA certificate you generated earlier.
+    - **Property mappings**: `semgrep-name` and `semgrep-email`
+10. Create a new application under **Applications** -> **Applications**, pick a name and a slug, and assign the provider that you have just created.
 
 ## Semgrep Configuration
 
@@ -48,15 +50,15 @@ The following placeholders will be used:
 4. Locate Single sign-on entry, click **Add SSO configuration**, select **SAML2 SSO** from the drop down.
 5. Fill in the following:
     - **Display name**: Anything you like.
-    - **Email domain**: `company.blah`
-    - **IdP SSO URL**: `https://authentik.company.blah/application/saml/_slug_/sso/binding/post/`
+    - **Email domain**: `company`
+    - **IdP SSO URL**: `https://authentik.company/application/saml/<semgrep slug>/sso/binding/post/`
     - **IdP Issuer ID**: `https://authentik.company`
     - **Upload/paste certificate**: Downloaded from the previous step.
 
 ## Verification
 
-1. Go to `https://semgrep.dev/login` from Incognito mode.
+1. Open an Incaognito window and navigate to `https://semgrep.dev/login`
 2. Click **Use SSO** on the login screen.
-3. Enter an email address that belongs to email domain you have entered earlier.
-4. Authorize with authentik.
+3. Enter the email address associated with the domain you provided earlier.
+4. Login with authentik.
 5. You will be redirected to home screen of Semgrep Cloud platform.

--- a/website/integrations/services/semgrep/index.md
+++ b/website/integrations/services/semgrep/index.md
@@ -19,7 +19,7 @@ The following placeholders will be used:
 
 ## authentik configuration
 
-1. Login into authentik instance as an administrator.
+1. Log in to your authentik instance as an administrator.
 2. Go to the admin interface.
 3. Navigate to **Customization** -> **Property mappings**.
 4. Create a new SAML property mapping with these parameters:

--- a/website/integrations/services/semgrep/index.md
+++ b/website/integrations/services/semgrep/index.md
@@ -42,7 +42,7 @@ The following placeholders will be used:
     - **Property mappings**: `semgrep-name` and `semgrep-email`
 10. Create a new application under **Applications** -> **Applications**, pick a name and a slug, and assign the provider that you just created.
 
-## Semgrep Configuration
+## Semgrep configuration
 
 1. Log in to Semgrep Cloud platform as an administrator.
 2. Click **Settings** on bottom left corner.
@@ -57,7 +57,7 @@ The following placeholders will be used:
 
 ## Verification
 
-1. Open an Incaognito window and navigate to `https://semgrep.dev/login`
+1. Open an Incognito window and navigate to `https://semgrep.dev/login`
 2. Click **Use SSO** on the login screen.
 3. Enter the email address associated with the domain you provided earlier.
 4. Log in to authentik.

--- a/website/sidebarsIntegrations.js
+++ b/website/sidebarsIntegrations.js
@@ -96,6 +96,7 @@ module.exports = {
                         "services/powerdns-admin/index",
                         "services/proftpd/index",
                         "services/qnap-nas/index",
+                        "services/semgrep/index",
                         "services/synology-dsm/index",
                         "services/skyhigh/index",
                         "services/snipe-it/index",


### PR DESCRIPTION
## Details
Added Semgrep integration. Some things said there I found out a hard way.
1. EC certs did not quite work out
2. it requires SAML property mappings
---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
