### PR TITLE
outposts: add better UI for showing mismatched versions

### DIFF
--- a/authentik/outposts/api/outposts.py
+++ b/authentik/outposts/api/outposts.py
@@ -26,7 +26,6 @@ from authentik.outposts.apps import MANAGED_OUTPOST, MANAGED_OUTPOST_NAME
 from authentik.outposts.models import (
     Outpost,
     OutpostConfig,
-    OutpostState,
     OutpostType,
     default_outpost_config,
 )
@@ -182,7 +181,6 @@ class OutpostViewSet(UsedByMixin, ModelViewSet):
         outpost: Outpost = self.get_object()
         states = []
         for state in outpost.state:
-            state: OutpostState
             states.append(
                 {
                     "uid": state.uid,

--- a/authentik/outposts/models.py
+++ b/authentik/outposts/models.py
@@ -451,7 +451,7 @@ class OutpostState:
             return False
         if self.build_hash != get_build_hash():
             return False
-        return parse(self.version) < OUR_VERSION
+        return parse(self.version) != OUR_VERSION
 
     @staticmethod
     def for_outpost(outpost: Outpost) -> list["OutpostState"]:

--- a/authentik/policies/reputation/signals.py
+++ b/authentik/policies/reputation/signals.py
@@ -36,7 +36,7 @@ def update_score(request: HttpRequest, identifier: str, amount: int):
         if not created:
             reputation.score = F("score") + amount
             reputation.save()
-    LOGGER.debug("Updated score", amount=amount, for_user=identifier, for_ip=remote_ip)
+    LOGGER.info("Updated score", amount=amount, for_user=identifier, for_ip=remote_ip)
 
 
 @receiver(login_failed)

--- a/internal/outpost/ak/api.go
+++ b/internal/outpost/ak/api.go
@@ -187,7 +187,7 @@ func (a *APIController) OnRefresh() error {
 func (a *APIController) getWebsocketPingArgs() map[string]interface{} {
 	args := map[string]interface{}{
 		"version":        constants.VERSION,
-		"buildHash":      constants.BUILD("tagged"),
+		"buildHash":      constants.BUILD(""),
 		"uuid":           a.instanceUUID.String(),
 		"golangVersion":  runtime.Version(),
 		"opensslEnabled": cryptobackend.OpensslEnabled,
@@ -207,7 +207,7 @@ func (a *APIController) StartBackgroundTasks() error {
 		"outpost_type": a.Server.Type(),
 		"uuid":         a.instanceUUID.String(),
 		"version":      constants.VERSION,
-		"build":        constants.BUILD("tagged"),
+		"build":        constants.BUILD(""),
 	}).Set(1)
 	go func() {
 		a.logger.Debug("Starting WS Handler...")

--- a/internal/outpost/ak/api_ws.go
+++ b/internal/outpost/ak/api_ws.go
@@ -145,7 +145,7 @@ func (ac *APIController) startWSHandler() {
 					"outpost_type": ac.Server.Type(),
 					"uuid":         ac.instanceUUID.String(),
 					"version":      constants.VERSION,
-					"build":        constants.BUILD("tagged"),
+					"build":        constants.BUILD(""),
 				}).SetToCurrentTime()
 			}
 		} else if wsMsg.Instruction == WebsocketInstructionProviderSpecific {
@@ -207,7 +207,7 @@ func (ac *APIController) startIntervalUpdater() {
 				"outpost_type": ac.Server.Type(),
 				"uuid":         ac.instanceUUID.String(),
 				"version":      constants.VERSION,
-				"build":        constants.BUILD("tagged"),
+				"build":        constants.BUILD(""),
 			}).SetToCurrentTime()
 		}
 		ticker.Reset(getInterval())

--- a/schema.yml
+++ b/schema.yml
@@ -52712,9 +52712,14 @@ components:
           type: boolean
           description: Check if we're running the latest version
           readOnly: true
+        outpost_outdated:
+          type: boolean
+          description: Check if any outpost is outdated/has a version mismatch
+          readOnly: true
       required:
       - build_hash
       - outdated
+      - outpost_outdated
       - version_current
       - version_latest
       - version_latest_valid

--- a/web/src/admin/admin-overview/cards/VersionStatusCard.ts
+++ b/web/src/admin/admin-overview/cards/VersionStatusCard.ts
@@ -31,6 +31,13 @@ export class VersionStatusCard extends AdminStatusCard<Version> {
                 message: html`${msg(str`${value.versionLatest} is available!`)}`,
             });
         }
+        if (value.outpostOutdated) {
+            return Promise.resolve<AdminStatus>({
+                icon: "fa fa-exclamation-triangle pf-m-warning",
+                message: html`${msg("An outpost is on an incorrect version!")}
+                    <a href="#/outpost/outposts">${msg("Check outposts.")}</a>`,
+            });
+        }
         if (value.versionLatestValid) {
             return Promise.resolve<AdminStatus>({
                 icon: "fa fa-check-circle pf-m-success",

--- a/web/src/admin/outposts/OutpostHealth.ts
+++ b/web/src/admin/outposts/OutpostHealth.ts
@@ -1,3 +1,4 @@
+import { getRelativeTime } from "@goauthentik/common/utils";
 import { AKElement } from "@goauthentik/elements/Base";
 import { PFColor } from "@goauthentik/elements/Label";
 import "@goauthentik/elements/Spinner";
@@ -49,7 +50,9 @@ export class OutpostHealthElement extends AKElement {
                 <dd class="pf-c-description-list__description">
                     <div class="pf-c-description-list__text">
                         <ak-label color=${PFColor.Green} ?compact=${true}>
-                            ${this.outpostHealth.lastSeen?.toLocaleTimeString()}
+                            ${msg(
+                                str`${getRelativeTime(this.outpostHealth.lastSeen)} (${this.outpostHealth.lastSeen?.toLocaleTimeString()})`,
+                            )}
                         </ak-label>
                     </div>
                 </dd>

--- a/web/src/admin/outposts/OutpostHealthSimple.ts
+++ b/web/src/admin/outposts/OutpostHealthSimple.ts
@@ -1,12 +1,13 @@
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
 import { EVENT_REFRESH } from "@goauthentik/common/constants";
+import { getRelativeTime } from "@goauthentik/common/utils";
 import { AKElement } from "@goauthentik/elements/Base";
 import { PFColor } from "@goauthentik/elements/Label";
 import "@goauthentik/elements/Spinner";
 
 import { msg, str } from "@lit/localize";
 import { CSSResult, TemplateResult, html } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import { customElement, property, state } from "lit/decorators.js";
 
 import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
@@ -17,8 +18,8 @@ export class OutpostHealthSimpleElement extends AKElement {
     @property()
     outpostId?: string;
 
-    @property({ attribute: false })
-    outpostHealth?: OutpostHealth;
+    @state()
+    outpostHealths: OutpostHealth[] = [];
 
     @property({ attribute: false })
     loaded = false;
@@ -33,7 +34,7 @@ export class OutpostHealthSimpleElement extends AKElement {
     constructor() {
         super();
         window.addEventListener(EVENT_REFRESH, () => {
-            this.outpostHealth = undefined;
+            this.outpostHealths = [];
             this.firstUpdated();
         });
     }
@@ -46,9 +47,7 @@ export class OutpostHealthSimpleElement extends AKElement {
             })
             .then((health) => {
                 this.loaded = true;
-                if (health.length >= 1) {
-                    this.outpostHealth = health[0];
-                }
+                this.outpostHealths = health;
             });
     }
 
@@ -56,11 +55,22 @@ export class OutpostHealthSimpleElement extends AKElement {
         if (!this.outpostId || !this.loaded) {
             return html`<ak-spinner></ak-spinner>`;
         }
-        if (!this.outpostHealth) {
+        if (!this.outpostHealths || this.outpostHealths.length === 0) {
             return html`<ak-label color=${PFColor.Grey}>${msg("Not available")}</ak-label>`;
         }
+        const outdatedOutposts = this.outpostHealths.filter((h) => h.versionOutdated);
+        if (outdatedOutposts.length > 0) {
+            return html`<ak-label color=${PFColor.Red}>
+                ${msg(
+                    str`${outdatedOutposts[0].version}, should be ${outdatedOutposts[0].versionShould}`,
+                )}</ak-label
+            >`;
+        }
+        const lastSeen = this.outpostHealths[0].lastSeen;
         return html`<ak-label color=${PFColor.Green}>
-            ${msg(str`Last seen: ${this.outpostHealth.lastSeen?.toLocaleTimeString()}`)}</ak-label
+            ${msg(
+                str`Last seen: ${getRelativeTime(lastSeen)} (${lastSeen.toLocaleTimeString()})`,
+            )}</ak-label
         >`;
     }
 }

--- a/web/src/admin/outposts/OutpostListPage.ts
+++ b/web/src/admin/outposts/OutpostListPage.ts
@@ -70,7 +70,7 @@ export class OutpostListPage extends TablePage<Outpost> {
         const outposts = await new OutpostsApi(DEFAULT_CONFIG).outpostsInstancesList(
             await this.defaultEndpointConfig(),
         );
-        Promise.all(
+        await Promise.all(
             outposts.results.map((outpost) => {
                 return new OutpostsApi(DEFAULT_CONFIG)
                     .outpostsInstancesHealthList({


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

Highlight mismatched outpost versions (both outpost being too new or too old) in admin interface
- In outpost list in simple health
- In overview page as part of version card

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
