### PR TITLE
authentik/admin/api/version: minor change, Optimization for get_outpost_outdated method

### DIFF
--- a/authentik/admin/api/version.py
+++ b/authentik/admin/api/version.py
@@ -51,12 +51,8 @@ class VersionSerializer(PassiveSerializer):
 
     def get_outpost_outdated(self, _) -> bool:
         """Check if any outpost is outdated/has a version mismatch"""
-        any_outdated = False
-        for outpost in Outpost.objects.all():
-            for state in outpost.state:
-                if state.version_outdated:
-                    any_outdated = True
-        return any_outdated
+        return Outpost.objects.filter(state__version_outdated=True).exists()
+
 
 
 class VersionView(APIView):


### PR DESCRIPTION
instead of looping over all elements in database, using database filter query for checking any outdated version mismatch

<!--
minor changes
-->

## Details

<!--
instead of looping over all elements in database, using database filter query for checking any outdated version mismatch
-->


---

## Checklist

-   [X] Local tests pass (`ak test authentik/`)
-   [X] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
