### PR TITLE
website/docs: use default container name from helm chart in recovery documentation for kubernetes

### DIFF
--- a/website/docs/troubleshooting/emails.md
+++ b/website/docs/troubleshooting/emails.md
@@ -23,5 +23,5 @@ docker compose exec worker ak test_email [...]
 To run this command with Kubernetes, use
 
 ```shell
-kubectl exec -it deployment/authentik-worker -c authentik -- ak test_email [...]
+kubectl exec -it deployment/authentik-worker -c worker -- ak test_email [...]
 ```

--- a/website/docs/troubleshooting/ldap_source.md
+++ b/website/docs/troubleshooting/ldap_source.md
@@ -11,7 +11,7 @@ docker compose run --rm worker ldap_sync *slug of the source*
 or, for Kubernetes, run
 
 ```shell
-kubectl exec -it deployment/authentik-worker -c authentik -- ak ldap_sync *slug of the source*
+kubectl exec -it deployment/authentik-worker -c worker -- ak ldap_sync *slug of the source*
 ```
 
 Starting with authentik 2023.10, you can also run command below to explicitly check the connectivity to the configured LDAP Servers:
@@ -23,5 +23,5 @@ docker compose run --rm worker ldap_check_connection *slug of the source*
 or, for Kubernetes, run
 
 ```shell
-kubectl exec -it deployment/authentik-worker -c authentik -- ak ldap_check_connection *slug of the source*
+kubectl exec -it deployment/authentik-worker -c worker -- ak ldap_check_connection *slug of the source*
 ```

--- a/website/docs/troubleshooting/login.md
+++ b/website/docs/troubleshooting/login.md
@@ -17,7 +17,7 @@ docker compose run --rm server create_recovery_key 10 akadmin
 For Kubernetes, run
 
 ```shell
-kubectl exec -it deployment/authentik-worker -c authentik -- ak create_recovery_key 10 akadmin
+kubectl exec -it deployment/authentik-worker -c worker -- ak create_recovery_key 10 akadmin
 ```
 
 or, for CLI, run

--- a/website/docs/troubleshooting/missing_admin_group.md
+++ b/website/docs/troubleshooting/missing_admin_group.md
@@ -13,5 +13,5 @@ docker compose run --rm server create_admin_group username
 or, for Kubernetes, run
 
 ```shell
-kubectl exec -it deployment/authentik-worker -c authentik -- ak create_admin_group username
+kubectl exec -it deployment/authentik-worker -c worker -- ak create_admin_group username
 ```

--- a/website/docs/troubleshooting/missing_permission.md
+++ b/website/docs/troubleshooting/missing_permission.md
@@ -15,7 +15,7 @@ docker compose run --rm worker repair_permissions
 or, for Kubernetes, run
 
 ```shell
-kubectl exec -it deployment/authentik-worker -c authentik -- ak repair_permissions
+kubectl exec -it deployment/authentik-worker -c worker -- ak repair_permissions
 ```
 
 If the error persists after running this command, please open an Issue on [GitHub](https://github.com/goauthentik/authentik/issues/)


### PR DESCRIPTION
## Details

the default name for the worker container is [worker and not authentik](1).
I have stumbled upon this for the second time and got annoyed.

When installing from the Helm chart (without overriding `worker.name`), the following error appears.
Using the worker container fixes this issue. 
```console
$ kubectl exec -it deployment/authentik-worker -c authentik -- ak create_recovery_key 10 akadmin
Error from server (BadRequest): container authentik is not valid for pod authentik-worker-74cb6db9f9-z4djm
```

[1]: https://github.com/goauthentik/helm/blob/main/charts/authentik/values.yaml#L603

## Checklist

I did not and will not set up a local build for this single word correction.