### PR TITLE
web: remove cssImportMap hack from WDIO.  It's a storybook-only-ism.

### DIFF
--- a/web/wdio.conf.ts
+++ b/web/wdio.conf.ts
@@ -2,12 +2,9 @@ import replace from "@rollup/plugin-replace";
 import type { Options } from "@wdio/types";
 import { cwd } from "process";
 // @ts-ignore
-import * as modify from "rollup-plugin-modify";
 import * as postcssLit from "rollup-plugin-postcss-lit";
 import type { UserConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
-
-// import { cssImportMaps } from "./.storybook/css-import-maps";
 
 const isProdBuild = process.env.NODE_ENV === "production";
 const apiBasePath = process.env.AK_API_BASE_PATH || "";
@@ -25,7 +22,6 @@ export const config: Options.Testrunner = {
             viteConfig: (config: UserConfig = { plugins: [] }) => ({
                 ...config,
                 plugins: [
-                    // modify(cssImportMaps),
                     replace({
                         "process.env.NODE_ENV": JSON.stringify(
                             isProdBuild ? "production" : "development",

--- a/web/wdio.conf.ts
+++ b/web/wdio.conf.ts
@@ -7,7 +7,7 @@ import * as postcssLit from "rollup-plugin-postcss-lit";
 import type { UserConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
-import { cssImportMaps } from "./.storybook/css-import-maps";
+// import { cssImportMaps } from "./.storybook/css-import-maps";
 
 const isProdBuild = process.env.NODE_ENV === "production";
 const apiBasePath = process.env.AK_API_BASE_PATH || "";
@@ -25,7 +25,7 @@ export const config: Options.Testrunner = {
             viteConfig: (config: UserConfig = { plugins: [] }) => ({
                 ...config,
                 plugins: [
-                    modify(cssImportMaps),
+                    // modify(cssImportMaps),
                     replace({
                         "process.env.NODE_ENV": JSON.stringify(
                             isProdBuild ? "production" : "development",


### PR DESCRIPTION
web: remove cssImportHack from wdio build. It’s a storybook-only-ism

This was blocking the build under some circumstances. Turns out we do not need it for headless testing.

-   [X] The code has been formatted (`make web`)
