### PR TITLE
website/docs: Correct the forward authentication configuration template for Caddy

### DIFF
--- a/website/docs/providers/proxy/_caddy_standalone.md
+++ b/website/docs/providers/proxy/_caddy_standalone.md
@@ -2,22 +2,25 @@ Use the following configuration:
 
 ```
 app.company {
-    # always forward outpost path to actual outpost
-    reverse_proxy /outpost.goauthentik.io/* http://outpost.company:9000
+    # directive execution order is only as stated if enclosed with route.
+    route {
+        # always forward outpost path to actual outpost
+        reverse_proxy /outpost.goauthentik.io/* http://outpost.company:9000
 
-    # forward authentication to outpost
-    forward_auth http://outpost.company:9000 {
-        uri /outpost.goauthentik.io/auth/caddy
+        # forward authentication to outpost
+        forward_auth http://outpost.company:9000 {
+            uri /outpost.goauthentik.io/auth/caddy
 
-        # capitalization of the headers is important, otherwise they will be empty
-        copy_headers X-Authentik-Username X-Authentik-Groups X-Authentik-Email X-Authentik-Name X-Authentik-Uid X-Authentik-Jwt X-Authentik-Meta-Jwks X-Authentik-Meta-Outpost X-Authentik-Meta-Provider X-Authentik-Meta-App X-Authentik-Meta-Version
+            # capitalization of the headers is important, otherwise they will be empty
+            copy_headers X-Authentik-Username X-Authentik-Groups X-Authentik-Email X-Authentik-Name X-Authentik-Uid X-Authentik-Jwt X-Authentik-Meta-Jwks X-Authentik-Meta-Outpost X-Authentik-Meta-Provider X-Authentik-Meta-App X-Authentik-Meta-Version
 
-        # optional, in this config trust all private ranges, should probably be set to the outposts IP
-        trusted_proxies private_ranges
+            # optional, in this config trust all private ranges, should probably be set to the outposts IP
+            trusted_proxies private_ranges
+        }
+
+        # actual site configuration below, for example
+        reverse_proxy localhost:1234
     }
-
-    # actual site configuration below, for example
-    reverse_proxy localhost:1234
 }
 ```
 


### PR DESCRIPTION
## Details

The directives were not executed in the given order, but instead, using the implicit sequence defined in the documentation of the [Caddyfile Directives](https://caddyserver.com/docs/caddyfile/directives#directive-order). Surrounding the directives with `route {}` fixes this.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [X] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
