### PR TITLE
website/docs: fix outdated docs and typos

### DIFF
--- a/web/src/admin/policies/event_matcher/EventMatcherPolicyForm.ts
+++ b/web/src/admin/policies/event_matcher/EventMatcherPolicyForm.ts
@@ -117,7 +117,7 @@ export class EventMatcherPolicyForm extends BasePolicyForm<EventMatcherPolicy> {
                         />
                         <p class="pf-c-form__helper-text">
                             ${msg(
-                                "Matches Event's Client IP (strict matching, for network matching use an Expression Policy.",
+                                "Matches Event's Client IP (strict matching, for network matching use an Expression Policy).",
                             )}
                         </p>
                     </ak-form-element-horizontal>

--- a/website/developer-docs/api/making-schema-changes.md
+++ b/website/developer-docs/api/making-schema-changes.md
@@ -8,9 +8,9 @@ This will update the `schema.yml` file in the root of the repository.
 
 ## Building the Go Client
 
-The Go client is used by the Outpost to communicate with the backend authentik server. To build the go client, run `make gen-outpost`.
+The Go client is used by the Outpost to communicate with the backend authentik server. To build the go client, run `make gen-client-go`.
 
-The generated files are stored in `/api` in the root of the repository.
+The generated files are stored in `/gen-go-api` in the root of the repository.
 
 ## Building the Web Client
 

--- a/website/docs/flow/stages/authenticator_validate/index.md
+++ b/website/docs/flow/stages/authenticator_validate/index.md
@@ -38,7 +38,7 @@ Requires authentik 2021.12.4
 :::
 
 :::caution
-Firefox has some known issues regarding FIDO (see https://bugzilla.mozilla.org/show_bug.cgi?id=1530370) and TouchID (see https://bugzilla.mozilla.org/show_bug.cgi?id=1536482)
+Firefox has some known issues regarding TouchID (see https://bugzilla.mozilla.org/show_bug.cgi?id=1536482)
 :::
 
 Passwordless authentication currently only supports WebAuthn devices, like security keys and biometrics. For an alternate passwordless setup, see [Password stage](../password/index.md#passwordless-login), which supports other types.

--- a/website/docs/policies/expression.mdx
+++ b/website/docs/policies/expression.mdx
@@ -82,7 +82,7 @@ import Objects from "../expressions/_objects.md";
     return context["geoip"]["continent"] == "EU"
     ```
 
--   `asn`: ASN dictionary. The follow fields are available:
+-   `asn`: ASN dictionary. The following fields are available:
 
     :::info
     For basic ASN matching, consider using a [GeoIP policy](index.md#geoip-policy).


### PR DESCRIPTION
A collection of (potential?) small mistakes I've recently encountered.