### PR TITLE
enterprise: add up-to-date license status

### DIFF
--- a/authentik/enterprise/api.py
+++ b/authentik/enterprise/api.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 from django.utils.timezone import now
 from django.utils.translation import gettext as _
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import extend_schema, inline_serializer
+from drf_spectacular.utils import OpenApiParameter, extend_schema, inline_serializer
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.fields import CharField, IntegerField
@@ -86,7 +86,7 @@ class LicenseViewSet(UsedByMixin, ModelViewSet):
         },
     )
     @action(detail=False, methods=["GET"])
-    def get_install_id(self, request: Request) -> Response:
+    def install_id(self, request: Request) -> Response:
         """Get install_id"""
         return Response(
             data={
@@ -99,11 +99,22 @@ class LicenseViewSet(UsedByMixin, ModelViewSet):
         responses={
             200: LicenseSummarySerializer(),
         },
+        parameters=[
+            OpenApiParameter(
+                name="cached",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.BOOL,
+                default=True,
+            )
+        ],
     )
     @action(detail=False, methods=["GET"], permission_classes=[IsAuthenticated])
     def summary(self, request: Request) -> Response:
         """Get the total license status"""
-        response = LicenseSummarySerializer(instance=LicenseKey.cached_summary())
+        summary = LicenseKey.cached_summary()
+        if request.query_params.get("cached").lower() == "false":
+            summary = LicenseKey.get_total().summary()
+        response = LicenseSummarySerializer(instance=summary)
         return Response(response.data)
 
     @permission_required(None, ["authentik_enterprise.view_license"])

--- a/schema.yml
+++ b/schema.yml
@@ -5842,9 +5842,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
-  /enterprise/license/get_install_id/:
+  /enterprise/license/install_id/:
     get:
-      operationId: enterprise_license_get_install_id_retrieve
+      operationId: enterprise_license_install_id_retrieve
       description: Get install_id
       tags:
       - enterprise
@@ -5873,6 +5873,12 @@ paths:
     get:
       operationId: enterprise_license_summary_retrieve
       description: Get the total license status
+      parameters:
+      - in: query
+        name: cached
+        schema:
+          type: boolean
+          default: true
       tags:
       - enterprise
       security:

--- a/web/src/admin/enterprise/EnterpriseLicenseForm.ts
+++ b/web/src/admin/enterprise/EnterpriseLicenseForm.ts
@@ -30,7 +30,7 @@ export class EnterpriseLicenseForm extends ModelForm<License, string> {
 
     async load(): Promise<void> {
         this.installID = (
-            await new EnterpriseApi(DEFAULT_CONFIG).enterpriseLicenseGetInstallIdRetrieve()
+            await new EnterpriseApi(DEFAULT_CONFIG).enterpriseLicenseInstallIdRetrieve()
         ).installId;
     }
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

Since the current admin interface only uses the cached license status, it can happen that the cached status is out-dated, and enterprise features might not work as expected due to the difference

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
