### PR TITLE
website/integrations: Fix incorrect size redefinition for Discord avatar acquisition code.

### DIFF
--- a/website/docs/sources/discord/index.md
+++ b/website/docs/sources/discord/index.md
@@ -341,7 +341,7 @@ def get_as_base64(url):
 
 def get_avatar_from_avatar_url(url):
     """Returns an authentik-avatar-attributes-compatible string from an image url"""
-    cut_url = f"{url}?size=64"
+    cut_url = f"{url}"
     return AVATAR_STREAM_CONTENT.format(
         base64_string=(get_as_base64(cut_url).decode("utf-8"))
     )


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details
Apologies for the follow up given the recent merged PR, but it looks like there's a spurious redefinition that has still been causing issues after conducting some more tests with users today.

tl;dr if we defined the avatar size, the code should not arbitrarily add a new ``size=NN`` suffix.

![image](https://github.com/user-attachments/assets/4a88179d-d727-4cd7-af44-fb14281eb8a7)


---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
