### PR TITLE
website/docs: add info about external users

### DIFF
--- a/website/docs/enterprise/manage-enterprise.md
+++ b/website/docs/enterprise/manage-enterprise.md
@@ -107,7 +107,7 @@ The following events occur when a license expeires and is not renewed within two
 
 License usage is calculated based on total user counts that authentik regularly captures. This data is checked against all valid licenses, and the sum total of all users. Internal and external users are counted based on the number of active users of the respective type saved in authentik. Service account users are not counted towards the license.
 
-An **internal** user is typically a team member, such as company employees, who has access to the full Enterprise feature set. An **external** user might be an external consultant, a volunteer in a charitable site, or a B2C customer who logged onto your website to shop. External users don't get access to Enterprise features, nor to the **My applications** page in authentik. Instead, external users are authetnticated and then redirected to log directly into their [default application](../core/brands.md#external-user-settings).
+An **internal** user is typically a team member, such as a company employee, who has access to the full Enterprise feature set. An **external** user might be an external consultant, a volunteer in a charitable site, or a B2C customer who logged onto your website to shop. External users don't get access to Enterprise features, nor to the **My applications** page in authentik. Instead, external users are authenticated and then redirected to log directly into their [default application](../core/brands.md#external-user-settings).
 
 ### Upgrade the number of users in a license
 

--- a/website/docs/enterprise/manage-enterprise.md
+++ b/website/docs/enterprise/manage-enterprise.md
@@ -107,9 +107,7 @@ The following events occur when a license expeires and is not renewed within two
 
 License usage is calculated based on total user counts that authentik regularly captures. This data is checked against all valid licenses, and the sum total of all users. Internal and external users are counted based on the number of active users of the respective type saved in authentik. Service account users are not counted towards the license.
 
-:::info
-An **internal** user is typically a team member, such as company employees, who has access to the full Enterprise feature set. An **external** user might be an external consultant, a volunteer in a charitable site, or a B2C customer who logged onto your website to shop. These users don't get access to Enterprise features.
-:::
+An **internal** user is typically a team member, such as company employees, who has access to the full Enterprise feature set. An **external** user might be an external consultant, a volunteer in a charitable site, or a B2C customer who logged onto your website to shop. External users don't get access to Enterprise features, nor to the **My applications** page in authentik. Instead, external users are authetnticated and then redirected to log directly into their [default application](../core/brands.md#external-user-settings).
 
 ### Upgrade the number of users in a license
 

--- a/website/docs/user-group-role/user/index.mdx
+++ b/website/docs/user-group-role/user/index.mdx
@@ -6,6 +6,8 @@ import DocCardList from "@theme/DocCardList";
 
 In authentik you can create and manage users with fine-tuned access control, session and event details, group membership, super-user rights, impersonation, and password management and recovery.
 
+To learn more about Enterprise licenses with internal and external users, refer to our [Enterprise documentation](../../enterprise/manage-enterprise.md#about-users-and-licenses).
+
 To learn more about working with users in authentik, refer to the following topics:
 
 <DocCardList />


### PR DESCRIPTION
This PR adds more infomation about external users (that they cannot access the My applications page (but instead go straight to their default app), and adds links info about default apps. Also add links form regular User page to the Enterprise page about internal/external users.

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
