### PR TITLE
website/integrations: Fix Nextcloud SAML Docs for SLO

### DIFF
--- a/website/integrations/services/nextcloud/index.md
+++ b/website/integrations/services/nextcloud/index.md
@@ -251,7 +251,7 @@ Set the following values:
 -   Optional display name of the identity provider (default: "SSO & SAML log in"): `authentik`
 -   Identifier of the IdP entity (must be a URI): `https://authentik.company`
 -   URL Target of the IdP where the SP will send the Authentication Request Message: `https://authentik.company/application/saml/<application-slug>/sso/binding/redirect/`
--   URL Location of IdP where the SP will send the SLO Request: `https://authentik.company/application/saml/<application-slug>/slo/binding/redirect`
+-   URL Location of IdP where the SP will send the SLO Request: `https://authentik.company/application/saml/<application-slug>/slo/binding/redirect/`
 -   Public X.509 certificate of the IdP: Copy the PEM of the Selected Signing Certificate
 
 Under Attribute mapping, set these values:


### PR DESCRIPTION
## Details

The given SLO URL for authenticating in Nextcloud with SAML is missing a required trailing slash.

If it's not there, it will not be possible to log out in a Nextcloud instance that has been set up according to the docs.

This PR just adds that trailing slash to the Nextcloud documentation page.
