### PR TITLE
web: fix dual-select with dynamic selection

### DIFF
--- a/web/src/admin/stages/identification/IdentificationStageForm.ts
+++ b/web/src/admin/stages/identification/IdentificationStageForm.ts
@@ -46,7 +46,8 @@ async function makeSourcesSelector(instanceSources: string[] | undefined) {
 
     return localSources
         ? ([pk, _]: DualSelectPair) => localSources.has(pk)
-        : ([_0, _1, _2, source]: DualSelectPair<Source>) =>
+        : // Creating a new instance, auto-select built-in source only when no other sources exist
+          ([_0, _1, _2, source]: DualSelectPair<Source>) =>
               source !== undefined && source.component === "";
 }
 

--- a/web/src/admin/stages/identification/IdentificationStageForm.ts
+++ b/web/src/admin/stages/identification/IdentificationStageForm.ts
@@ -75,11 +75,11 @@ export class IdentificationStageForm extends BaseStageForm<IdentificationStage> 
                 stageUuid: this.instance.pk || "",
                 identificationStageRequest: data,
             });
-        } else {
-            return new StagesApi(DEFAULT_CONFIG).stagesIdentificationCreate({
-                identificationStageRequest: data,
-            });
         }
+
+        return new StagesApi(DEFAULT_CONFIG).stagesIdentificationCreate({
+            identificationStageRequest: data,
+        });
     }
 
     isUserFieldSelected(field: UserFieldsEnum): boolean {
@@ -232,12 +232,12 @@ export class IdentificationStageForm extends BaseStageForm<IdentificationStage> 
                         ?required=${true}
                         name="sources"
                     >
-                        <ak-dual-select-provider-dynamic-selected
+                        <ak-dual-select-dynamic-selected
                             .provider=${sourcesProvider}
-                            .selected=${makeSourcesSelector(this.instance?.sources)}
+                            .selector=${makeSourcesSelector(this.instance?.sources)}
                             available-label="${msg("Available Stages")}"
                             selected-label="${msg("Selected Stages")}"
-                        ></ak-dual-select-provider-dynamic-selected>
+                        ></ak-dual-select-dynamic-selected>
                         <p class="pf-c-form__helper-text">
                             ${msg(
                                 "Select sources should be shown for users to authenticate with. This only affects web-based sources, not LDAP.",

--- a/web/src/elements/ak-dual-select/ak-dual-select-dynamic-selected-provider.ts
+++ b/web/src/elements/ak-dual-select/ak-dual-select-dynamic-selected-provider.ts
@@ -50,3 +50,9 @@ export class AkDualSelectDynamic extends AkDualSelectProvider {
         ></ak-dual-select>`;
     }
 }
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "ak-dual-select-dynamic-selected": AkDualSelectDynamic;
+    }
+}


### PR DESCRIPTION
For dynamic selection, the property name is `.selector` to message that it's a function the API layer uses to select the elements.

closes #11132

A few bits of lint picked.

-   [X] The code has been formatted (`make web`)
