### PR TITLE
core: fix change_user_type always requiring usernames

### DIFF
--- a/authentik/core/management/commands/change_user_type.py
+++ b/authentik/core/management/commands/change_user_type.py
@@ -9,10 +9,11 @@ class Command(TenantCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("--type", type=str, required=True)
-        parser.add_argument("--all", action="store_true")
-        parser.add_argument("usernames", nargs="+", type=str)
+        parser.add_argument("--all", action="store_true", default=False)
+        parser.add_argument("usernames", nargs="*", type=str)
 
     def handle_per_tenant(self, **options):
+        print(options)
         new_type = UserTypes(options["type"])
         qs = (
             User.objects.exclude_anonymous()
@@ -21,6 +22,9 @@ class Command(TenantCommand):
         )
         if options["usernames"] and options["all"]:
             self.stderr.write("--all and usernames specified, only one can be specified")
+            return
+        if not options["usernames"] and not options["all"]:
+            self.stderr.write("--all or usernames must be specified")
             return
         if options["usernames"] and not options["all"]:
             qs = qs.filter(username__in=options["usernames"])


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

closes #10791

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
