### PR TITLE
core: fix missing argument name escaping for property mapping

### DIFF
--- a/authentik/core/models.py
+++ b/authentik/core/models.py
@@ -901,7 +901,7 @@ class PropertyMapping(SerializerModel, ManagedModel):
         except ControlFlowException as exc:
             raise exc
         except Exception as exc:
-            raise PropertyMappingExpressionException(self, exc) from exc
+            raise PropertyMappingExpressionException(exc, self) from exc
 
     def __str__(self):
         return f"Property Mapping {self.name}"

--- a/authentik/lib/expression/evaluator.py
+++ b/authentik/lib/expression/evaluator.py
@@ -27,9 +27,11 @@ from authentik.stages.authenticator import devices_for_user
 
 LOGGER = get_logger()
 
+ARG_SANITIZE = re.compile(r"[:.-]")
+
 
 def sanitize_arg(arg_name: str) -> str:
-    return slugify(arg_name).replace("-", "_")
+    return re.sub(ARG_SANITIZE, "_", arg_name)
 
 
 class BaseEvaluator:

--- a/authentik/lib/expression/evaluator.py
+++ b/authentik/lib/expression/evaluator.py
@@ -2,7 +2,6 @@
 
 import re
 import socket
-from collections.abc import Iterable
 from ipaddress import ip_address, ip_network
 from textwrap import indent
 from types import CodeType
@@ -27,6 +26,10 @@ from authentik.policies.types import PolicyRequest, PolicyResult
 from authentik.stages.authenticator import devices_for_user
 
 LOGGER = get_logger()
+
+
+def sanitize_arg(arg_name: str) -> str:
+    return slugify(arg_name).replace("-", "_")
 
 
 class BaseEvaluator:
@@ -177,9 +180,9 @@ class BaseEvaluator:
         proc = PolicyProcess(PolicyBinding(policy=policy), request=req, connection=None)
         return proc.profiling_wrapper()
 
-    def wrap_expression(self, expression: str, params: Iterable[str]) -> str:
+    def wrap_expression(self, expression: str) -> str:
         """Wrap expression in a function, call it, and save the result as `result`"""
-        handler_signature = ",".join(params)
+        handler_signature = ",".join(sanitize_arg(x) for x in self._context.keys())
         full_expression = ""
         full_expression += f"def handler({handler_signature}):\n"
         full_expression += indent(expression, "    ")
@@ -188,8 +191,8 @@ class BaseEvaluator:
 
     def compile(self, expression: str) -> CodeType:
         """Parse expression. Raises SyntaxError or ValueError if the syntax is incorrect."""
-        param_keys = self._context.keys()
-        return compile(self.wrap_expression(expression, param_keys), self._filename, "exec")
+        expression = self.wrap_expression(expression)
+        return compile(expression, self._filename, "exec")
 
     def evaluate(self, expression_source: str) -> Any:
         """Parse and evaluate expression. If the syntax is incorrect, a SyntaxError is raised.
@@ -205,7 +208,7 @@ class BaseEvaluator:
                 self.handle_error(exc, expression_source)
                 raise exc
             try:
-                _locals = self._context
+                _locals = {sanitize_arg(x): y for x, y in self._context.items()}
                 # Yes this is an exec, yes it is potentially bad. Since we limit what variables are
                 # available here, and these policies can only be edited by admins, this is a risk
                 # we're willing to take.

--- a/web/src/admin/property-mappings/PropertyMappingTestForm.ts
+++ b/web/src/admin/property-mappings/PropertyMappingTestForm.ts
@@ -61,7 +61,9 @@ export class PolicyTestForm extends Form<PropertyMappingTestRequest> {
                   </ak-codemirror>`
                 : html` <div class="pf-c-form__group-label">
                       <div class="c-form__horizontal-group">
-                          <span class="pf-c-form__label-text">${this.result?.result}</span>
+                          <span class="pf-c-form__label-text">
+                              <pre>${this.result?.result}</pre>
+                          </span>
                       </div>
                   </div>`}
         </ak-form-element-horizontal>`;

--- a/website/docs/sources/scim/index.md
+++ b/website/docs/sources/scim/index.md
@@ -34,6 +34,43 @@ See the [overview](../property-mappings/index.md) for information on how propert
 
 ### Expression data
 
-The following variables are available to SCIM source property mappings:
+Each top level SCIM attribute is available as a variable in the expression. For example given an SCIM request with the payload of
 
--   `data`: A Python dictionary containing data from the SCIM source.
+```json
+{
+    "schemas": [
+        "urn:scim:schemas:core:2.0",
+        "urn:scim:schemas:extension:enterprise:2.0"
+    ],
+    "userName": "foo.bar",
+    "name": {
+        "familyName": "bar",
+        "givenName": "foo",
+        "formatted": "foo.bar"
+    },
+    "emails": [
+        {
+            "value": "foo.bar@authentik.company",
+            "type": "work",
+            "primary": true
+        }
+    ],
+    "title": "",
+    "urn:scim:schemas:extension:enterprise:2.0": {
+        "department": ""
+    }
+}
+```
+
+The following variables are available in the expression:
+
+-   `schemas` as a list of strings
+-   `userName` as a string
+-   `name` as a dictionary
+-   `emails` as a dictionary
+-   `title` as a string
+-   `urn_scim_schemas_extension_enterprise_2_0` as a dictionary
+
+    :::info
+    Top-level keys which include symbols not allowed in python syntax are converted to `_`.
+    :::


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

closes #11230

especially for SCIM arguments might be named something like `urn:scim:schemas:extension:enterprise:2.0` which is not a valid python symbol name, and as how property mappings are executed this causes a syntax error

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
