### PR TITLE
root: fix ensure `outpost_connection_discovery runs on worker startup

### DIFF
--- a/authentik/root/celery.py
+++ b/authentik/root/celery.py
@@ -87,8 +87,11 @@ def task_error_hook(task_id: str, exception: Exception, traceback, *args, **kwar
 
 def _get_startup_tasks_default_tenant() -> list[Callable]:
     """Get all tasks to be run on startup for the default tenant"""
-    return []
+    from authentik.outposts.tasks import outpost_connection_discovery
 
+    return [
+        outpost_connection_discovery,
+    ]
 
 def _get_startup_tasks_all_tenants() -> list[Callable]:
     """Get all tasks to be run on startup for all tenants"""

--- a/authentik/root/celery.py
+++ b/authentik/root/celery.py
@@ -93,6 +93,7 @@ def _get_startup_tasks_default_tenant() -> list[Callable]:
         outpost_connection_discovery,
     ]
 
+
 def _get_startup_tasks_all_tenants() -> list[Callable]:
     """Get all tasks to be run on startup for all tenants"""
     from authentik.admin.tasks import clear_update_notifications


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

Make outpost_connection_discovery a startup task for default_tenant to ensure it's ran during worker startup. Without this waiting for the 8 hour schedule to fire is required.

fixes: https://github.com/goauthentik/authentik/issues/10933

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->

---

## Checklist

-   [X] Local tests pass (`ak test authentik/`)
-   [X] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
