### PR TITLE
web: fix readonly fields appearing white in dark theme

### DIFF
--- a/web/src/common/styles/theme-dark.css
+++ b/web/src/common/styles/theme-dark.css
@@ -155,7 +155,7 @@ select[multiple] option:checked {
     background-color: var(--ak-dark-background-light);
 }
 .pf-c-form-control[readonly] {
-    background-color: var(--ak-dark-background-light);
+    background-color: var(--ak-dark-background-light) !important;
 }
 .pf-c-switch__input:checked ~ .pf-c-switch__label {
     --pf-c-switch__input--checked__label--Color: var(--ak-dark-foreground);


### PR DESCRIPTION
## Details

Readonly text fields did not update their background in dark theme. Added the `!important` property to the background style to ensure it overrides the light theme.

---

## Checklist

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)