### PR TITLE
website/integrations: Add offline_access scope for WordPress

### DIFF
--- a/website/integrations/services/wordpress/index.md
+++ b/website/integrations/services/wordpress/index.md
@@ -59,7 +59,7 @@ Only settings that have been modified from default have been listed.
 -   End Session Endpoint URL: `https://authentik.company/application/o/wordpress/end-session/`
 
 :::note
-Make sure to include the _offline_access_ scope to ensure refresh tokens are generated. Otherwise your session will expire and force users to manually login again. Refer to the [OpenID Connect Core specification](https://openid.net/specs/openid-connect-core-1_0.html#OfflineAccess) for more information 
+Make sure to include the _offline_access_ scope to ensure refresh tokens are generated. Otherwise your session will expire and force users to manually log in again. Refer to the [OpenID Connect Core specification](https://openid.net/specs/openid-connect-core-1_0.html#OfflineAccess) for more information.
 :::
 
 :::note

--- a/website/integrations/services/wordpress/index.md
+++ b/website/integrations/services/wordpress/index.md
@@ -35,7 +35,7 @@ Only settings that have been modified from default have been listed.
 -   Client ID: Copy and Save this for Later
 -   Client Secret: Copy and Save this for later
 -   Redirect URIs/Origins: `https://wp.company/wp-admin/admin-ajax.php\?action=openid-connect-authorize`
--   Scopes: _email_, _offline_access_, _open_id_, _profile_
+-   Scopes: _email_, _offline_access_, _openid_, _profile_
 
 ### Step 2 - WordPress
 

--- a/website/integrations/services/wordpress/index.md
+++ b/website/integrations/services/wordpress/index.md
@@ -51,11 +51,15 @@ Only settings that have been modified from default have been listed.
 -   Login Type: OpenID Connect Button on Login (This option display a button to login using OpenID as well as local WP login)
 -   Client ID: Client ID from step 1
 -   Client Secret: Client Secret from step 1
--   OpenID Scope: `email profile openid`
+-   OpenID Scope: `email profile openid offline_access`
 -   Login Endpoint URL: `https://authentik.company/application/o/authorize/`
 -   Userinfo Endpoint URL: `https://authentik.company/application/o/userinfo/`
 -   Token Validation Endpoint URL: `https://authentik.company/application/o/token/`
 -   End Session Endpoint URL: `https://authentik.company/application/o/wordpress/end-session/`
+
+:::note
+Make sure to include the _offline_access_ scope to ensure refresh tokens are generated. Otherwise your session will expire and force users to manually login again. Refer to the [Oauth 2.0 Core specification](https://openid.net/specs/openid-connect-core-1_0.html#OfflineAccess) for more information 
+:::
 
 :::note
 Review each setting and choose the ones that you require for your installation. Examples of popular settings are _Link Existing Users_, _Create user if does not exist_, and _Enforce Privacy_

--- a/website/integrations/services/wordpress/index.md
+++ b/website/integrations/services/wordpress/index.md
@@ -58,7 +58,7 @@ Only settings that have been modified from default have been listed.
 -   End Session Endpoint URL: `https://authentik.company/application/o/wordpress/end-session/`
 
 :::note
-Make sure to include the _offline_access_ scope to ensure refresh tokens are generated. Otherwise your session will expire and force users to manually login again. Refer to the [Oauth 2.0 Core specification](https://openid.net/specs/openid-connect-core-1_0.html#OfflineAccess) for more information 
+Make sure to include the _offline_access_ scope to ensure refresh tokens are generated. Otherwise your session will expire and force users to manually login again. Refer to the [OpenID Connect Core specification](https://openid.net/specs/openid-connect-core-1_0.html#OfflineAccess) for more information 
 :::
 
 :::note

--- a/website/integrations/services/wordpress/index.md
+++ b/website/integrations/services/wordpress/index.md
@@ -35,6 +35,7 @@ Only settings that have been modified from default have been listed.
 -   Client ID: Copy and Save this for Later
 -   Client Secret: Copy and Save this for later
 -   Redirect URIs/Origins: `https://wp.company/wp-admin/admin-ajax.php\?action=openid-connect-authorize`
+-   Scopes: _email_, _offline_access_, _open_id_, _profile_
 
 ### Step 2 - WordPress
 


### PR DESCRIPTION
## Details
The offline_scope is required in order to allow refresh tokens to be generated otherwise the session will expire at Wordpress side.
This is just a documentation contribution.

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
