### PR TITLE
website/docs: clarify API browser access

### DIFF
--- a/website/developer-docs/api/api.md
+++ b/website/developer-docs/api/api.md
@@ -4,9 +4,9 @@ title: API
 
 Our API reference documentation is generated, and is included [here](../api/reference/authentik.info.mdx) in our regular documentation Table of Contents, under **API -> Reference**.
 
-You can also access your installation's own, instance-specific API Browser. Starting with 2021.3.5, every authentik instance has a built-in API browser, which can be accessed at <kbd>https://authentik.<em>company</em>/api/v3/</kbd>.
+You can also access your installation's own, instance-specific API Browser. Starting with 2021.3.5, every authentik instance has a built-in API browser, which can be accessed at <code>https://<em>authentik.company</em>/api/v3/</code>.
 
-To generate an API client you can use the OpenAPI v3 schema at <kbd>https://authentik.<em>company</em>/api/v3/schema/</kbd>.
+To generate an API client you can use the OpenAPI v3 schema at <code>https://<em>authentik.company</em>/api/v3/schema/</code>.
 
 While testing, the API requests are authenticated by your browser session.
 

--- a/website/developer-docs/api/api.md
+++ b/website/developer-docs/api/api.md
@@ -2,9 +2,11 @@
 title: API
 ---
 
-Starting with 2021.3.5, every authentik instance has a built-in API browser, which can be accessed at https://authentik.company/api/v3/.
+Our API reference documentation is generated, and is included [here](../api/reference/authentik.info.mdx) in our regular documentation Table of Contents, under **API -> Reference**.
 
-To generate an API client, you can use the OpenAPI v3 schema at https://authentik.company/api/v3/schema/.
+You can also access your installation's own, instance-specific API Browser. Starting with 2021.3.5, every authentik instance has a built-in API browser, which can be accessed at <kbd>https://authentik.<em>company</em>/api/v3/</kbd>.
+
+To generate an API client you can use the OpenAPI v3 schema at <kbd>https://authentik.<em>company</em>/api/v3/schema/</kbd>.
 
 While testing, the API requests are authenticated by your browser session.
 


### PR DESCRIPTION
This PR adds more clarity around the API Browser. 

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
