### PR TITLE
web: add missing id attribute for button in ak-flow-input-password

### DIFF
--- a/web/src/flow/components/ak-flow-password-input.ts
+++ b/web/src/flow/components/ak-flow-password-input.ts
@@ -161,6 +161,7 @@ export class InputPassword extends AKElement {
                 ${this.renderInput()}
                 ${this.allowShowPassword
                     ? html` <button
+                          id="${this.inputId}-visibility-toggle"
                           class="pf-c-button pf-m-control ak-stage-password-toggle-visibility"
                           type="button"
                           aria-label=${msg("Show password")}


### PR DESCRIPTION
Add missing id attribute to button in ak-flow-input-password 

## Details

Flow component password eye icon was missing id attribute hence the password icon was not changing properly and aria-label also not changing when the icon is clicked, both issues will be fixed in the PR,

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
