### PR TITLE
events: always use expiry from current tenant for events, not only when creating from HTTP request

### DIFF
--- a/authentik/events/tests/test_models.py
+++ b/authentik/events/tests/test_models.py
@@ -6,6 +6,7 @@ from django.db.models import Model
 from django.test import TestCase
 
 from authentik.core.models import default_token_key
+from authentik.events.models import default_event_duration
 from authentik.lib.utils.reflection import get_apps
 
 
@@ -20,7 +21,7 @@ def model_tester_factory(test_model: type[Model]) -> Callable:
         allowed = 0
         # Token-like objects need to lookup the current tenant to get the default token length
         for field in test_model._meta.fields:
-            if field.default == default_token_key:
+            if field.default in [default_token_key, default_event_duration]:
                 allowed += 1
         with self.assertNumQueries(allowed):
             str(test_model())


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

closes #11401

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
