### PR TITLE
website/integrations: remove sbus_timeout from sssd example

### DIFF
--- a/website/integrations/services/sssd/index.md
+++ b/website/integrations/services/sssd/index.md
@@ -78,7 +78,6 @@ reconnection_retries = 3
 [sssd]
 config_file_version = 2
 reconnection_retries = 3
-sbus_timeout = 30
 domains = ${ldap.domain}
 services = nss, pam, ssh
 


### PR DESCRIPTION


<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

Fixes an error

```
[rule/allowed_sssd_options]: Attribute 'sbus_timeout' is not allowed in section 'sssd'. Check for typos.
```

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
