### PR TITLE
providers/proxy: fix panic, keep session storages open

### DIFF
--- a/internal/outpost/proxyv2/application/application.go
+++ b/internal/outpost/proxyv2/application/application.go
@@ -137,7 +137,11 @@ func NewApplication(p api.ProxyOutpostConfig, c *http.Client, server Server) (*A
 		isEmbedded:           isEmbedded,
 	}
 	go a.authHeaderCache.Start()
-	a.sessions = a.getStore(p, externalHost)
+	sess, err := a.getStore(p, externalHost)
+	if err != nil {
+		return nil, err
+	}
+	a.sessions = sess
 	mux.Use(web.NewLoggingHandler(muxLogger, func(l *log.Entry, r *http.Request) *log.Entry {
 		c := a.getClaimsFromSession(r)
 		if c == nil {

--- a/internal/outpost/proxyv2/application/application.go
+++ b/internal/outpost/proxyv2/application/application.go
@@ -65,8 +65,11 @@ type Server interface {
 	CryptoStore() *ak.CryptoStore
 }
 
-func NewApplication(p api.ProxyOutpostConfig, c *http.Client, server Server) (*Application, error) {
+func init() {
 	gob.Register(Claims{})
+}
+
+func NewApplication(p api.ProxyOutpostConfig, c *http.Client, server Server, oldApp *Application) (*Application, error) {
 	muxLogger := log.WithField("logger", "authentik.outpost.proxyv2.application").WithField("name", p.Name)
 
 	externalHost, err := url.Parse(p.ExternalHost)
@@ -137,11 +140,15 @@ func NewApplication(p api.ProxyOutpostConfig, c *http.Client, server Server) (*A
 		isEmbedded:           isEmbedded,
 	}
 	go a.authHeaderCache.Start()
-	sess, err := a.getStore(p, externalHost)
-	if err != nil {
-		return nil, err
+	if oldApp != nil && oldApp.sessions != nil {
+		a.sessions = oldApp.sessions
+	} else {
+		sess, err := a.getStore(p, externalHost)
+		if err != nil {
+			return nil, err
+		}
+		a.sessions = sess
 	}
-	a.sessions = sess
 	mux.Use(web.NewLoggingHandler(muxLogger, func(l *log.Entry, r *http.Request) *log.Entry {
 		c := a.getClaimsFromSession(r)
 		if c == nil {
@@ -239,9 +246,8 @@ func NewApplication(p api.ProxyOutpostConfig, c *http.Client, server Server) (*A
 				// TODO: maybe create event for this?
 				a.log.WithError(err).Warning("failed to compile SkipPathRegex")
 				continue
-			} else {
-				a.UnauthenticatedRegex = append(a.UnauthenticatedRegex, re)
 			}
+			a.UnauthenticatedRegex = append(a.UnauthenticatedRegex, re)
 		}
 	}
 	return a, nil

--- a/internal/outpost/proxyv2/application/session.go
+++ b/internal/outpost/proxyv2/application/session.go
@@ -26,7 +26,7 @@ import (
 
 const RedisKeyPrefix = "authentik_proxy_session_"
 
-func (a *Application) getStore(p api.ProxyOutpostConfig, externalHost *url.URL) sessions.Store {
+func (a *Application) getStore(p api.ProxyOutpostConfig, externalHost *url.URL) (sessions.Store, error) {
 	maxAge := 0
 	if p.AccessTokenValidity.IsSet() {
 		t := p.AccessTokenValidity.Get()
@@ -73,7 +73,7 @@ func (a *Application) getStore(p api.ProxyOutpostConfig, externalHost *url.URL) 
 		// New default RedisStore
 		rs, err := redisstore.NewRedisStore(context.Background(), client)
 		if err != nil {
-			a.log.WithError(err).Panic("failed to connect to redis")
+			return nil, err
 		}
 
 		rs.KeyPrefix(RedisKeyPrefix)
@@ -87,7 +87,7 @@ func (a *Application) getStore(p api.ProxyOutpostConfig, externalHost *url.URL) 
 		})
 
 		a.log.Trace("using redis session backend")
-		return rs
+		return rs, nil
 	}
 	dir := os.TempDir()
 	cs := sessions.NewFilesystemStore(dir)
@@ -106,7 +106,7 @@ func (a *Application) getStore(p api.ProxyOutpostConfig, externalHost *url.URL) 
 	cs.Options.MaxAge = maxAge
 	cs.Options.Path = "/"
 	a.log.WithField("dir", dir).Trace("using filesystem session backend")
-	return cs
+	return cs, nil
 }
 
 func (a *Application) SessionName() string {

--- a/internal/outpost/proxyv2/application/test.go
+++ b/internal/outpost/proxyv2/application/test.go
@@ -66,6 +66,7 @@ func newTestApplication() *Application {
 		},
 		http.DefaultClient,
 		ts,
+		nil,
 	)
 	ts.apps = append(ts.apps, a)
 	return a


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

Fix panic
Re-connect to redis less often

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
