### PR TITLE
providers/proxy: fix traefik label generation

### DIFF
--- a/authentik/providers/proxy/controllers/docker.py
+++ b/authentik/providers/proxy/controllers/docker.py
@@ -28,7 +28,7 @@ class ProxyDockerController(DockerController):
         labels = super()._get_labels()
         labels["traefik.enable"] = "true"
         labels[f"traefik.http.routers.{traefik_name}-router.rule"] = (
-            f"({' || '.join([f'Host(`{host}`)' for host in hosts])})"
+            f"({' || '.join([f'Host({host})' for host in hosts])})"
             f" && PathPrefix(`/outpost.goauthentik.io`)"
         )
         labels[f"traefik.http.routers.{traefik_name}-router.tls"] = "true"


### PR DESCRIPTION
related to this issue: [https://github.com/goauthentik/authentik/issues/9786](url)

In the current version the outpost is creating a docker label like this:
```python
traefik.http.routers.ak-outpost-whoami-router.rule="(Host(``whoami.localhost``)) && PathPrefix(`/outpost.goauthentik.io`)"
```
the double quote on host gives a error on traefik.