### PR TITLE
website/docs: added a Docs banner to announce new docs structure

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -20,7 +20,7 @@ module.exports = async function (): Promise<Config> {
             announcementBar: {
                 id: "new_docs_structure",
                 content:
-                    'Change is hard, especially when a familiar site gets re-arranged. But we think the new layout is easier to navigate. Take a preview peek at the upcoming new <a target="_blank" rel="noopener noreferrer" href="https://docs.goauthentik.io/docs/"> Docs structure!</a>',
+                    'Change is hard, especially when a familiar site gets re-arranged. But we think the new layout is easier to navigate. Take a preview peek at the upcoming new <a target="_blank" rel="noopener noreferrer" href="https://deploy-preview-11522--authentik-docs.netlify.app/docs"> Docs structure!</a>',
                 backgroundColor: "#cc0099",
                 textColor: "#ffffff",
                 isCloseable: false,

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -17,6 +17,14 @@ module.exports = async function (): Promise<Config> {
         organizationName: "Authentik Security Inc.",
         projectName: "authentik",
         themeConfig: {
+            announcementBar: {
+                id: 'support_us',
+                content:
+                  'Change is hard. We hate it too when a familiar site or application gets re-arranged. But we did it anyway. Please let us <a target="_blank" rel="noopener noreferrer" href="https://docs.goauthentik.io/docs/">know what you think!</a>',
+                backgroundColor: '#fafbfc',
+                textColor: '#091E42',
+                isCloseable: false,
+              },
             image: "img/social.png",
             navbar: {
                 logo: {

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -18,13 +18,13 @@ module.exports = async function (): Promise<Config> {
         projectName: "authentik",
         themeConfig: {
             announcementBar: {
-                id: 'support_us',
+                id: "support_us",
                 content:
-                  'Change is hard. We hate it too when a familiar site or application gets re-arranged. But we did it anyway. Please let us <a target="_blank" rel="noopener noreferrer" href="https://docs.goauthentik.io/docs/">know what you think!</a>',
-                backgroundColor: '#fafbfc',
-                textColor: '#091E42',
+                    'Change is hard. We hate it too when a familiar site or application gets re-arranged. But we did it anyway. Please let us <a target="_blank" rel="noopener noreferrer" href="https://docs.goauthentik.io/docs/">know what you think of the new Docs structure!</a>',
+                backgroundColor: "#006699",
+                textColor: "#ffffff",
                 isCloseable: false,
-              },
+            },
             image: "img/social.png",
             navbar: {
                 logo: {

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -18,10 +18,10 @@ module.exports = async function (): Promise<Config> {
         projectName: "authentik",
         themeConfig: {
             announcementBar: {
-                id: "support_us",
+                id: "new_docs_structure",
                 content:
-                    'Change is hard. We hate it too when a familiar site or application gets re-arranged. But we did it anyway. Please let us <a target="_blank" rel="noopener noreferrer" href="https://docs.goauthentik.io/docs/">know what you think of the new Docs structure!</a>',
-                backgroundColor: "#006699",
+                    'Change is hard, especially when a familiar site gets re-arranged. But we think the new layout is easier to navigate. Take a preview peek at the upcoming new <a target="_blank" rel="noopener noreferrer" href="https://docs.goauthentik.io/docs/"> Docs structure!</a>',
+                backgroundColor: "#cc0099",
                 textColor: "#ffffff",
                 isCloseable: false,
             },


### PR DESCRIPTION
This PR adds a banner to our Docs website, announcing the upcoming change to the structure of the docs, and providing a link to the deploy preview.

-   [ ] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
