### PR TITLE
core: fix permission check for scoped impersonation

### DIFF
--- a/authentik/core/api/users.py
+++ b/authentik/core/api/users.py
@@ -679,7 +679,10 @@ class UserViewSet(UsedByMixin, ModelViewSet):
             LOGGER.debug("User attempted to impersonate", user=request.user)
             return Response(status=401)
         user_to_be = self.get_object()
-        if not request.user.has_perm("impersonate", user_to_be) and not request.user.has_perm("authentik_core.impersonate"):
+        # Check both object-level perms and global perms
+        if not request.user.has_perm(
+            "authentik_core.impersonate", user_to_be
+        ) and not request.user.has_perm("authentik_core.impersonate"):
             LOGGER.debug("User attempted to impersonate without permissions", user=request.user)
             return Response(status=401)
         if user_to_be.pk == self.request.user.pk:

--- a/authentik/core/api/users.py
+++ b/authentik/core/api/users.py
@@ -679,7 +679,7 @@ class UserViewSet(UsedByMixin, ModelViewSet):
             LOGGER.debug("User attempted to impersonate", user=request.user)
             return Response(status=401)
         user_to_be = self.get_object()
-        if not request.user.has_perm("impersonate", user_to_be):
+        if not request.user.has_perm("impersonate", user_to_be) and not request.user.has_perm("authentik_core.impersonate"):
             LOGGER.debug("User attempted to impersonate without permissions", user=request.user)
             return Response(status=401)
         if user_to_be.pk == self.request.user.pk:


### PR DESCRIPTION
set global permission to have higher priority than the permission on a specific object

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://goauthentik.io/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
