### PR TITLE
website/integrations: Apache Guacamole: Add openid-username-claim-type

### DIFF
--- a/website/integrations/services/apache-guacamole/index.mdx
+++ b/website/integrations/services/apache-guacamole/index.mdx
@@ -35,7 +35,7 @@ Note the Client ID value. Create an application, using the provider you've creat
 
 ## Guacamole
 
-It is recommended you configure an admin account in Guacamole before setting up SSO to make things easier. Create a user in Guacamole using the email address of your user in authentik and give them admin permissions. Without this, you might lose access to the Guacamole admin settings and have to revert the settings below.
+It is recommended you configure an admin account in Guacamole before setting up SSO to make things easier. Create a user in Guacamole using the username of your user in authentik and give them admin permissions. Without this, you might lose access to the Guacamole admin settings and have to revert the settings below.
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
@@ -55,6 +55,7 @@ OPENID_CLIENT_ID: # client ID from above
 OPENID_ISSUER: https://authentik.company/application/o/*Slug of the application from above*/
 OPENID_JWKS_ENDPOINT: https://authentik.company/application/o/*Slug of the application from above*/jwks/
 OPENID_REDIRECT_URI: https://guacamole.company/ # This must match the redirect URI above
+OPENID_USERNAME_CLAIM_TYPE: preferred_username
 ```
 
   </TabItem>
@@ -67,6 +68,7 @@ openid-client-id=# client ID from above
 openid-issuer=https://authentik.company/application/o/*Slug of the application from above*/
 openid-jwks-endpoint=https://authentik.company/application/o/*Slug of the application from above*/jwks/
 openid-redirect-uri=https://guacamole.company/ # This must match the redirect URI above
+openid-username-claim-type=preferred_username
 ```
 
   </TabItem>


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
Update username claim type in Apache Guacamole config to use a users preferred_username instead of email address as the username for their account. 

Links: 
- [https://guacamole.apache.org/doc/gug/openid-auth.html](https://guacamole.apache.org/doc/gug/openid-auth.html)
---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
