### PR TITLE
*: fix deprecated calls to sentry start_span

### DIFF
--- a/authentik/events/context_processors/asn.py
+++ b/authentik/events/context_processors/asn.py
@@ -50,7 +50,7 @@ class ASNContextProcessor(MMDBContextProcessor):
         """Wrapper for Reader.asn"""
         with start_span(
             op="authentik.events.asn.asn",
-            description=ip_address,
+            name=ip_address,
         ):
             if not self.configured():
                 return None

--- a/authentik/events/context_processors/geoip.py
+++ b/authentik/events/context_processors/geoip.py
@@ -51,7 +51,7 @@ class GeoIPContextProcessor(MMDBContextProcessor):
         """Wrapper for Reader.city"""
         with start_span(
             op="authentik.events.geo.city",
-            description=ip_address,
+            name=ip_address,
         ):
             if not self.configured():
                 return None

--- a/authentik/flows/planner.py
+++ b/authentik/flows/planner.py
@@ -166,7 +166,7 @@ class FlowPlanner:
     def plan(self, request: HttpRequest, default_context: dict[str, Any] | None = None) -> FlowPlan:
         """Check each of the flows' policies, check policies for each stage with PolicyBinding
         and return ordered list"""
-        with start_span(op="authentik.flow.planner.plan", description=self.flow.slug) as span:
+        with start_span(op="authentik.flow.planner.plan", name=self.flow.slug) as span:
             span: Span
             span.set_data("flow", self.flow)
             span.set_data("request", request)
@@ -233,7 +233,7 @@ class FlowPlanner:
         with (
             start_span(
                 op="authentik.flow.planner.build_plan",
-                description=self.flow.slug,
+                name=self.flow.slug,
             ) as span,
             HIST_FLOWS_PLAN_TIME.labels(flow_slug=self.flow.slug).time(),
         ):

--- a/authentik/flows/stage.py
+++ b/authentik/flows/stage.py
@@ -125,7 +125,7 @@ class ChallengeStageView(StageView):
             with (
                 start_span(
                     op="authentik.flow.stage.challenge_invalid",
-                    description=self.__class__.__name__,
+                    name=self.__class__.__name__,
                 ),
                 HIST_FLOWS_STAGE_TIME.labels(
                     stage_type=self.__class__.__name__, method="challenge_invalid"
@@ -135,7 +135,7 @@ class ChallengeStageView(StageView):
         with (
             start_span(
                 op="authentik.flow.stage.challenge_valid",
-                description=self.__class__.__name__,
+                name=self.__class__.__name__,
             ),
             HIST_FLOWS_STAGE_TIME.labels(
                 stage_type=self.__class__.__name__, method="challenge_valid"
@@ -161,7 +161,7 @@ class ChallengeStageView(StageView):
         with (
             start_span(
                 op="authentik.flow.stage.get_challenge",
-                description=self.__class__.__name__,
+                name=self.__class__.__name__,
             ),
             HIST_FLOWS_STAGE_TIME.labels(
                 stage_type=self.__class__.__name__, method="get_challenge"
@@ -174,7 +174,7 @@ class ChallengeStageView(StageView):
                 return self.executor.stage_invalid()
         with start_span(
             op="authentik.flow.stage._get_challenge",
-            description=self.__class__.__name__,
+            name=self.__class__.__name__,
         ):
             if not hasattr(challenge, "initial_data"):
                 challenge.initial_data = {}

--- a/authentik/flows/views/executor.py
+++ b/authentik/flows/views/executor.py
@@ -153,7 +153,7 @@ class FlowExecutorView(APIView):
         return plan
 
     def dispatch(self, request: HttpRequest, flow_slug: str) -> HttpResponse:
-        with start_span(op="authentik.flow.executor.dispatch", description=self.flow.slug) as span:
+        with start_span(op="authentik.flow.executor.dispatch", name=self.flow.slug) as span:
             span.set_data("authentik Flow", self.flow.slug)
             get_params = QueryDict(request.GET.get(QS_QUERY, ""))
             if QS_KEY_TOKEN in get_params:
@@ -273,7 +273,7 @@ class FlowExecutorView(APIView):
             with (
                 start_span(
                     op="authentik.flow.executor.stage",
-                    description=class_path,
+                    name=class_path,
                 ) as span,
                 HIST_FLOW_EXECUTION_STAGE_TIME.labels(
                     method=request.method.upper(),
@@ -324,7 +324,7 @@ class FlowExecutorView(APIView):
             with (
                 start_span(
                     op="authentik.flow.executor.stage",
-                    description=class_path,
+                    name=class_path,
                 ) as span,
                 HIST_FLOW_EXECUTION_STAGE_TIME.labels(
                     method=request.method.upper(),

--- a/authentik/policies/engine.py
+++ b/authentik/policies/engine.py
@@ -113,7 +113,7 @@ class PolicyEngine:
         with (
             start_span(
                 op="authentik.policy.engine.build",
-                description=self.__pbm,
+                name=self.__pbm,
             ) as span,
             HIST_POLICIES_ENGINE_TOTAL_TIME.labels(
                 obj_type=class_to_path(self.__pbm.__class__),

--- a/authentik/recovery/lib.py
+++ b/authentik/recovery/lib.py
@@ -22,7 +22,7 @@ def create_admin_group(user: User) -> Group:
     return group
 
 
-def create_recovery_token(user: User, expiry: datetime, generated_from: str) -> (Token, str):
+def create_recovery_token(user: User, expiry: datetime, generated_from: str) -> tuple[Token, str]:
     """Create recovery token and associated link"""
     _now = now()
     token = Token.objects.create(

--- a/authentik/stages/identification/stage.py
+++ b/authentik/stages/identification/stage.py
@@ -104,7 +104,7 @@ class IdentificationChallengeResponse(ChallengeResponse):
         if not pre_user:
             with start_span(
                 op="authentik.stages.identification.validate_invalid_wait",
-                description="Sleep random time on invalid user identifier",
+                name="Sleep random time on invalid user identifier",
             ):
                 # Sleep a random time (between 90 and 210ms) to "prevent" user enumeration attacks
                 sleep(0.030 * SystemRandom().randint(3, 7))
@@ -146,7 +146,7 @@ class IdentificationChallengeResponse(ChallengeResponse):
         try:
             with start_span(
                 op="authentik.stages.identification.authenticate",
-                description="User authenticate call (combo stage)",
+                name="User authenticate call (combo stage)",
             ):
                 user = authenticate(
                     self.stage.request,

--- a/authentik/stages/password/stage.py
+++ b/authentik/stages/password/stage.py
@@ -49,7 +49,7 @@ def authenticate(
         LOGGER.debug("Attempting authentication...", backend=backend_path)
         with start_span(
             op="authentik.stages.password.authenticate",
-            description=backend_path,
+            name=backend_path,
         ):
             user = backend.authenticate(request, **credentials)
         if user is None:


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Gets rid of most of the warnings when running tests

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
