### PR TITLE
website/integrations: Add note regarding custom scopes in Hashicorp Vault OIDC documentation

### DIFF
--- a/website/integrations/services/hashicorp-vault/index.md
+++ b/website/integrations/services/hashicorp-vault/index.md
@@ -87,6 +87,7 @@ vault write auth/oidc/role/reader \
       user_claim="sub" \
       policies="reader"
 ```
+
 :::note
 If you intend to create [external groups](https://developer.hashicorp.com/vault/tutorials/auth-methods/oidc-auth#create-an-external-vault-group) in Vault to manage user access the OIDC role will need to specifically request a custom scope using the `oidc_scopes` option when creating the OIDC role.
 :::

--- a/website/integrations/services/hashicorp-vault/index.md
+++ b/website/integrations/services/hashicorp-vault/index.md
@@ -88,7 +88,7 @@ vault write auth/oidc/role/reader \
       policies="reader"
 ```
 :::note
-If you intend to create [external groups](https://developer.hashicorp.com/vault/tutorials/auth-methods/oidc-auth#create-an-external-vault-group) in vault to manage user access the OIDC role will need to specifically request a custom scope using the `oidc_scopes` option when writing the OIDC role.
+If you intend to create [external groups](https://developer.hashicorp.com/vault/tutorials/auth-methods/oidc-auth#create-an-external-vault-group) in Vault to manage user access the OIDC role will need to specifically request a custom scope using the `oidc_scopes` option when creating the OIDC role.
 :::
 You should then be able to sign in via OIDC
 `vault login -method=oidc role="reader"`

--- a/website/integrations/services/hashicorp-vault/index.md
+++ b/website/integrations/services/hashicorp-vault/index.md
@@ -87,6 +87,8 @@ vault write auth/oidc/role/reader \
       user_claim="sub" \
       policies="reader"
 ```
-
+:::note
+If you intend to create [external groups](https://developer.hashicorp.com/vault/tutorials/auth-methods/oidc-auth#create-an-external-vault-group) in vault to manage user access the OIDC role will need to specifically request a custom scope using the `oidc_scopes` option when writing the OIDC role.
+:::
 You should then be able to sign in via OIDC
 `vault login -method=oidc role="reader"`


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

authentik's documentation does not cover policies for Hashicorp Vault, only the basic setup for OIDC. The documentation Hashicorp provides (which is based on Auth0) is not clear on what is required for user defined claims to be requested from the OIDC provider. It has taken me quite a while to figure out how to get Vault to cooperate with authentik and request the correct scope. While I understand policies are out of scope of the docs I believe the addition of this note will save a lot of time for anyone who want's to implement user assigned policies using external groups in Vault. 

I'm also willing to accept this ambiguity I perceive is the result of a skill issue on my part as I'm not very familiar with OIDC however, I think this addition to the docs makes it more useful for those not intimately familiar with OIDC.

---

## Checklist

-   N/A Local tests pass (`ak test authentik/`)
-   N/A The code has been formatted (`make lint-fix`)

If an API change has been made

-   N/A The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   N/A The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)

I haven't formatted the documentation changes as I'm not sure how to (apologies) but the markdown for the box formatting is the same as all other boxes on the page and the rest of the markdown shows fine with the Github preview