### PR TITLE
website/docs: add missing file to sidebar

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -361,6 +361,7 @@ export default {
                                 "customize/policies/working_with_policies/whitelist_email",
                             ],
                         },
+                        "customize/policies/expression",
                     ],
                 },
                 {


### PR DESCRIPTION
This PR adds an entry to the `sidebar.js` file... the entry for the doc on Policy Expressions was missing from the sidebar (was available only via search).

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
