### PR TITLE
core: add prompt_data to auth flow

### DIFF
--- a/authentik/core/sources/flow_manager.py
+++ b/authentik/core/sources/flow_manager.py
@@ -328,7 +328,6 @@ class SourceFlowManager:
         connection: UserSourceConnection,
     ) -> HttpResponse:
         """Login user and redirect."""
-        flow_kwargs = {PLAN_CONTEXT_PENDING_USER: connection.user}
         return self._prepare_flow(
             self.source.authentication_flow,
             connection,
@@ -342,7 +341,11 @@ class SourceFlowManager:
                     ),
                 )
             ],
-            **flow_kwargs,
+            **{
+                PLAN_CONTEXT_PENDING_USER: connection.user,
+                PLAN_CONTEXT_PROMPT: delete_none_values(self.user_properties),
+                PLAN_CONTEXT_USER_PATH: self.source.get_user_path(),
+            },
         )
 
     def handle_existing_link(


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
I added the prompt_data and user_path to the auth flow. This allows us to more easily sync users details whenever they're logged in through a Source by using the Write stage, identical to an  Enrolment flow (but we should ensure to disable that the Write stage will create new users).

This makes sure that mappings etc are automatically taken into consideration, and are passed to the Authentication flow. 

While I was at it, I made the code consistent with the `handle_enroll` method. I have this change running in production, and it's part of my effort to implement Social logins for customers, [as mentioned in this write up](https://gist.github.com/Wouter0100/5bd93ab88d5d7e706fef1832c90ff913) (which I have not updated yet, if this is merged I will update it).

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
