### PR TITLE
providers/proxy: fix handling of AUTHENTIK_HOST_BROWSER

### DIFF
--- a/internal/outpost/proxyv2/application/endpoint.go
+++ b/internal/outpost/proxyv2/application/endpoint.go
@@ -82,6 +82,9 @@ func GetOIDCEndpoint(p api.ProxyOutpostConfig, authentikHost string, embedded bo
 	if embedded {
 		ep.Issuer = updateURL(ep.Issuer, newHost.Scheme, newHost.Host)
 		ep.JwksUri = updateURL(jwksUri, newHost.Scheme, newHost.Host)
+	} else {
+		// Fixes: https://github.com/goauthentik/authentik/issues/9622 / ep.Issuer must be the HostBrowser URL
+		ep.Issuer = updateURL(ep.Issuer, newBrowserHost.Scheme, newBrowserHost.Host)
 	}
 	return ep
 }

--- a/internal/outpost/proxyv2/application/endpoint_test.go
+++ b/internal/outpost/proxyv2/application/endpoint_test.go
@@ -55,7 +55,7 @@ func TestEndpointAuthentikHostBrowser(t *testing.T) {
 	assert.Equal(t, "https://browser.test.goauthentik.io/application/o/authorize/", ep.AuthURL)
 	assert.Equal(t, "https://browser.test.goauthentik.io/application/o/test-app/end-session/", ep.EndSessionEndpoint)
 	assert.Equal(t, "https://test.goauthentik.io/application/o/token/", ep.TokenURL)
-	assert.Equal(t, "https://test.goauthentik.io/application/o/test-app/", ep.Issuer)
+	assert.Equal(t, "https://browser.test.goauthentik.io/application/o/test-app/", ep.Issuer)
 	assert.Equal(t, "https://test.goauthentik.io/application/o/test-app/jwks/", ep.JwksUri)
 	assert.Equal(t, "https://test.goauthentik.io/application/o/introspect/", ep.TokenIntrospection)
 }


### PR DESCRIPTION
## Details

This PR fixes the incorrect handling of the AUTHENTIK_HOST_BROWSER environment variable. When this variable is set, the OIDC issuer is now also adjusted to prevent the error: “oidc: id token issued by a different provider”.

This change is necessary because Authentik, as the OIDC issuer, uses the public browser URL for token issuance, but within environments like Kubernetes, the internal cluster URL is typically used. Therefore, the token must be validated against the public URL, not the internal one.

**Rationale**

The current behavior leads to mismatched issuer validation when tokens are issued by the public URL but verified using the internal URL. This PR addresses this by ensuring the issuer is correctly set based on the AUTHENTIK_HOST_BROWSER value.

**Linked Issues**

Closes #9622, #4688, #6476.

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
