### PR TITLE
root: rework CSRF middleware to set secure flag

### DIFF
--- a/authentik/core/urls.py
+++ b/authentik/core/urls.py
@@ -5,7 +5,6 @@ from channels.sessions import CookieMiddleware
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.urls import path
-from django.views.decorators.csrf import ensure_csrf_cookie
 
 from authentik.core.api.applications import ApplicationViewSet
 from authentik.core.api.authenticated_sessions import AuthenticatedSessionViewSet
@@ -44,19 +43,19 @@ urlpatterns = [
     # Interfaces
     path(
         "if/admin/",
-        ensure_csrf_cookie(BrandDefaultRedirectView.as_view(template_name="if/admin.html")),
+        BrandDefaultRedirectView.as_view(template_name="if/admin.html"),
         name="if-admin",
     ),
     path(
         "if/user/",
-        ensure_csrf_cookie(BrandDefaultRedirectView.as_view(template_name="if/user.html")),
+        BrandDefaultRedirectView.as_view(template_name="if/user.html"),
         name="if-user",
     ),
     path(
         "if/flow/<slug:flow_slug>/",
         # FIXME: move this url to the flows app...also will cause all
         # of the reverse calls to be adjusted
-        ensure_csrf_cookie(FlowInterfaceView.as_view()),
+        FlowInterfaceView.as_view(),
         name="if-flow",
     ),
     # Fallback for WS

--- a/authentik/enterprise/providers/rac/urls.py
+++ b/authentik/enterprise/providers/rac/urls.py
@@ -3,7 +3,6 @@
 from channels.auth import AuthMiddleware
 from channels.sessions import CookieMiddleware
 from django.urls import path
-from django.views.decorators.csrf import ensure_csrf_cookie
 
 from authentik.enterprise.providers.rac.api.connection_tokens import ConnectionTokenViewSet
 from authentik.enterprise.providers.rac.api.endpoints import EndpointViewSet
@@ -19,12 +18,12 @@ from authentik.root.middleware import ChannelsLoggingMiddleware
 urlpatterns = [
     path(
         "application/rac/<slug:app>/<uuid:endpoint>/",
-        ensure_csrf_cookie(RACStartView.as_view()),
+        RACStartView.as_view(),
         name="start",
     ),
     path(
         "if/rac/<str:token>/",
-        ensure_csrf_cookie(RACInterface.as_view()),
+        RACInterface.as_view(),
         name="if-rac",
     ),
 ]

--- a/authentik/root/middleware.py
+++ b/authentik/root/middleware.py
@@ -41,7 +41,9 @@ class SessionMiddleware(UpstreamSessionMiddleware):
             # Since go does not consider localhost with http a secure origin
             # we can't set the secure flag.
             user_agent = request.META.get("HTTP_USER_AGENT", "")
-            if user_agent.startswith("goauthentik.io/outpost/") or "safari" in user_agent.lower():
+            if user_agent.startswith("goauthentik.io/outpost/") or (
+                "safari" in user_agent.lower() and "chrome" not in user_agent.lower()
+            ):
                 return False
             return True
         return False


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Remove the custom CSRF subclass which sets the Secure flag dynamically, as when the SECURE flag is set statically it is still handled correctly for http/local

closes #11760

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
