### PR TITLE
web/rac: disable DPI scaling

### DIFF
--- a/web/src/enterprise/rac/index.ts
+++ b/web/src/enterprise/rac/index.ts
@@ -86,8 +86,8 @@ export class RacInterface extends Interface {
     static domSize(): { width: number; height: number } {
         const size = document.body.getBoundingClientRect();
         return {
-            width: size.width * window.devicePixelRatio,
-            height: size.height * window.devicePixelRatio,
+            width: size.width,
+            height: size.height,
         };
     }
 
@@ -175,7 +175,6 @@ export class RacInterface extends Interface {
         const params = new URLSearchParams();
         params.set("screen_width", Math.floor(RacInterface.domSize().width).toString());
         params.set("screen_height", Math.floor(RacInterface.domSize().height).toString());
-        params.set("screen_dpi", (window.devicePixelRatio * 96).toString());
         this.client.connect(params.toString());
     }
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

disable HiDPI scaling
- RDP correctly supports this and renders the UI in 2x style
- For SSH and VNC this causes the window to be rendered too big and scaled incorrectly

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
