### PR TITLE
providers/scim: fix scim sync (#11165)

### DIFF
--- a/authentik/lib/sync/outgoing/exceptions.py
+++ b/authentik/lib/sync/outgoing/exceptions.py
@@ -9,16 +9,16 @@ class TransientSyncException(BaseSyncException):
     """Transient sync exception which may be caused by network blips, etc"""
 
 
-class NotFoundSyncException(BaseSyncException):
+class BadRequestSyncException(BaseSyncException):
+    """Exception when invalid data was sent to the remote system"""
+
+
+class NotFoundSyncException(BadRequestSyncException):
     """Exception when an object was not found in the remote system"""
 
 
-class ObjectExistsSyncException(BaseSyncException):
+class ObjectExistsSyncException(BadRequestSyncException):
     """Exception when an object already exists in the remote system"""
-
-
-class BadRequestSyncException(BaseSyncException):
-    """Exception when invalid data was sent to the remote system"""
 
 
 class StopSync(BaseSyncException):


### PR DESCRIPTION
## Issue

Closes #11165

During SCIM synchronization, server can throw `ObjectExistsSyncException` to mark that one of the N objects are already synchronized. Authentik doesn't handle this error properly and crashes instead of displaying a simple warning. 

## Details

SCIM can throw these errors:

https://github.com/goauthentik/authentik/blob/eac3e88126c108bae1f575314efbb87eacfe3076/authentik/providers/scim/clients/base.py#L72-L77

But only `BadRequestSyncException` and `TransientSyncException` are caught and handled properly:

https://github.com/goauthentik/authentik/blob/eac3e88126c108bae1f575314efbb87eacfe3076/authentik/lib/sync/outgoing/tasks.py#L135

https://github.com/goauthentik/authentik/blob/eac3e88126c108bae1f575314efbb87eacfe3076/authentik/lib/sync/outgoing/tasks.py#L158

NotFoundSyncException and ObjectExistsSyncException are unhandled.

## Solution

I've come up with two solutions:
1. Add two another except cases: 'except NotFoundSyncException as exc: ' and 'except ObjectExistsSyncException as exc: ' to authentik/lib/sync/outgoing/tasks.py
2. Subclass these two unhandled exceptions to already-handled BadRequestSyncException

In this PR I've chosen the second option and looked up the code to make sure that this will create no conflicts.
