### PR TITLE
website/docs: fix release notes to say Federation

### DIFF
--- a/website/docs/releases/2024/v2024.10.md
+++ b/website/docs/releases/2024/v2024.10.md
@@ -34,7 +34,7 @@ We have no breaking changes this release!
 
 -   **Autoselect 2FA device**
 
-    Users who configure multiple 2FA devices will now land on their last used device's prompt, skipping the device picker. This should in lower total average time per flow for the end user.
+    Users who configure multiple 2FA devices will now land on their last used device's prompt, skipping the device picker. This should rsult in lower total average time per flow for the end user.
 
 -   **New structure for authentik's technical documentation**
 

--- a/website/docs/releases/2024/v2024.10.md
+++ b/website/docs/releases/2024/v2024.10.md
@@ -34,7 +34,7 @@ We have no breaking changes this release!
 
 -   **Autoselect 2FA device**
 
-    Users who configure multiple 2FA devices will now land on their last used device's prompt, skipping the device picker. This should rsult in lower total average time per flow for the end user.
+    Users who configure multiple 2FA devices will now land on their last used device's prompt, skipping the device picker. This should result in lower total average time per flow for the end user.
 
 -   **New structure for authentik's technical documentation**
 

--- a/website/docs/releases/2024/v2024.10.md
+++ b/website/docs/releases/2024/v2024.10.md
@@ -6,9 +6,9 @@ slug: "/releases/2024.10"
 ## Highlights
 
 -   **Chrome Device Trust** <span class="badge badge--primary">Enterprise</span> <span class="badge badge--info">Preview</span>: Verify that your users are logging in from managed devices and validate the devices' compliance with company policies.
--   **FIPS/FAL3 for FedRAMP "very high" compliance** <span class="badge badge--primary">Enterprise+</span>: with support for SAML encryption and now JWE (JSON Web Encryption) support, authentik can now be configured for FIPS compliance at Federal Assurance Level (FAL) 3.
+-   **FIPS/FAL3 for FedRAMP "very high" compliance** <span class="badge badge--primary">Enterprise+</span>: with support for SAML encryption and now JWE (JSON Web Encryption) support, authentik can now be configured for FIPS compliance at Federation Assurance Level (FAL) 3.
 -   **Captcha on Identification stage**: Run a CAPTCHA process in the background while the user is entering their identification.
--   **Kerberos source**: authentik can now integrate with existing Kerberos environments by allowing users to log in with their Kerberos credentials, SPNEGO or syncing users into authentik.
+-   **Kerberos source**: authentik can now integrate with existing Kerberos environments by allowing users to log in with their Kerberos credentials, SPNEGO, or syncing users into authentik.
 
 ## Breaking changes
 

--- a/website/docs/releases/2024/v2024.10.md
+++ b/website/docs/releases/2024/v2024.10.md
@@ -34,7 +34,7 @@ We have no breaking changes this release!
 
 -   **Autoselect 2FA device**
 
-    Users who configure multiple 2FA devices will now land on their last used device's prompt, skipping the device picker. This will hopefually result in lower total average time per flow for the end user.
+    Users who configure multiple 2FA devices will now land on their last used device's prompt, skipping the device picker. This should in lower total average time per flow for the end user.
 
 -   **New structure for authentik's technical documentation**
 


### PR DESCRIPTION
This PR fixes a typo in Rel Notes.

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
