### PR TITLE
website/docs: clarify traefik ingress setup

### DIFF
--- a/website/docs/add-secure-apps/providers/proxy/_traefik_ingress.md
+++ b/website/docs/add-secure-apps/providers/proxy/_traefik_ingress.md
@@ -7,6 +7,7 @@ metadata:
     name: authentik
 spec:
     forwardAuth:
+        # This address should point to the cluster endpoint provided by the kubernetes service, not the Ingress.
         address: http://outpost.company:9000/outpost.goauthentik.io/auth/traefik
         trustForwardHeader: true
         authResponseHeaders:


### PR DESCRIPTION

## Details

The instructions for adding middelware to a kubernetes cluster is vague and causes confusion. This change will help make it a little more clear that you should use internal service endpoints, not public ingress endpoints.

---

## Checklist

-   [✅ ] Local tests pass (`ak test authentik/`)
-   [✅ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
