### PR TITLE
website/integrations: jellyfin: update plugin catalog location

### DIFF
--- a/website/integrations/services/jellyfin/index.md
+++ b/website/integrations/services/jellyfin/index.md
@@ -121,11 +121,9 @@ Set the launch URL to `https://jellyfin.company/sso/OID/start/authentik`
 
 ### Jellyfin Configuration
 
-1. Navigate to your Jellyfin installation and log in with your admin account or a configured local admin account.
-2. Open the **Administrator Dashboard** and go to the **Plugins** section.
-3. Click the **Catalog** tab under **Plugins**.
-4. In the Catalog section, click the gear icon in the top-left corner.
-5. Click the **+** button to add a new repository, and enter the following URL with the repository name "SSO-Auth":
+1. Log in to Jellyfin with an admin account.
+2. Go to **Dashboard > Plugins > Catalog**.
+3. Click the gear icon in the top left, then click **+** to add a new repository. Use the following URL and name it "SSO-Auth":
 
 ```
 https://raw.githubusercontent.com/9p4/jellyfin-plugin-sso/manifest-release/manifest.json

--- a/website/integrations/services/jellyfin/index.md
+++ b/website/integrations/services/jellyfin/index.md
@@ -121,7 +121,7 @@ Set the launch URL to `https://jellyfin.company/sso/OID/start/authentik`
 
 ### Jellyfin Configuration
 
-1. Log in to Jellyfin with an admin account.
+1. Log in to Jellyfin with an admin account and navigate to the **Admin Dashboard** by selecting your profile icon in the top right, then clicking **Dashboard**.
 2. Go to **Dashboard > Plugins > Catalog**.
 3. Click the gear icon in the top left, then click **+** to add a new repository. Use the following URL and name it "SSO-Auth":
 

--- a/website/integrations/services/jellyfin/index.md
+++ b/website/integrations/services/jellyfin/index.md
@@ -121,9 +121,11 @@ Set the launch URL to `https://jellyfin.company/sso/OID/start/authentik`
 
 ### Jellyfin Configuration
 
-1. Navigate to your Jellyfin installation and log in with the admin account or currently configured local admin.
-2. Open the **Administrator dashboard** and go to the **Plugins** section.
-3. Then click the **Repositories** section at the top and add the below repository with the name of SSO-Auth
+1. Navigate to your Jellyfin installation and log in with your admin account or a configured local admin account.
+2. Open the **Administrator Dashboard** and go to the **Plugins** section.
+3. Click the **Catalog** tab under **Plugins**.
+4. In the Catalog section, click the gear icon in the top-left corner.
+5. Click the **+** button to add a new repository, and enter the following URL with the repository name "SSO-Auth":
 
 ```
 https://raw.githubusercontent.com/9p4/jellyfin-plugin-sso/manifest-release/manifest.json


### PR DESCRIPTION
The add repositories button is now under the Admin interface > Catalog > Gear icon. This PR reflects that change.

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
