### PR TITLE
providers/proxy: fix Issuer when AUTHENTIK_HOST_BROWSER is set

### DIFF
--- a/internal/utils/web/http_host_interceptor.go
+++ b/internal/utils/web/http_host_interceptor.go
@@ -14,8 +14,10 @@ type hostInterceptor struct {
 }
 
 func (t hostInterceptor) RoundTrip(r *http.Request) (*http.Response, error) {
-	r.Host = t.host
-	r.Header.Set("X-Forwarded-Proto", t.scheme)
+	if r.Host != t.host {
+		r.Host = t.host
+		r.Header.Set("X-Forwarded-Proto", t.scheme)
+	}
 	return t.inner.RoundTrip(r)
 }
 


### PR DESCRIPTION
correctly use host_browser's hostname as host header for token requests to ensure Issuer is identical

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

closes #11883

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
