### PR TITLE
website/integrations: nextcloud: add SSE warning

### DIFF
--- a/website/integrations/services/nextcloud/index.md
+++ b/website/integrations/services/nextcloud/index.md
@@ -14,7 +14,11 @@ sidebar_label: Nextcloud
 > -- https://en.wikipedia.org/wiki/Nextcloud
 
 :::caution
-This setup only works, when Nextcloud is running with HTTPS enabled. See [here](https://docs.nextcloud.com/server/stable/admin_manual/configuration_server/reverse_proxy_configuration.html?highlight=overwriteprotocol#overwrite-parameters) on how to configure this.
+If you require [Server Side Encryption](https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/encryption_configuration.html), you MUST use LDAP! OpenID and SAML will cause **irrevocable data loss**. Nextcoud Server-Side Encryption requires access to the user's cleartext password, which is not available through OpenID or SAML.
+:::
+
+:::caution
+This setup only works when Nextcloud is running with HTTPS enabled. See [here](https://docs.nextcloud.com/server/stable/admin_manual/configuration_server/reverse_proxy_configuration.html?highlight=overwriteprotocol#overwrite-parameters) on how to configure this.
 :::
 
 :::info
@@ -23,10 +27,11 @@ In case something goes wrong with the configuration, you can use the URL `http:/
 
 ## Authentication
 
-There are 2 ways to setup single sign on (SSO) for Nextcloud:
+There are 3 ways to setup single sign on (SSO) for Nextcloud:
 
 -   [via OIDC Connect (OAuth)](#openid-connect-auth)
 -   [via SAML](#saml-auth)
+-   via LDAP outpost
 
 ### OpenID Connect auth
 

--- a/website/integrations/services/nextcloud/index.md
+++ b/website/integrations/services/nextcloud/index.md
@@ -14,7 +14,7 @@ sidebar_label: Nextcloud
 > -- https://en.wikipedia.org/wiki/Nextcloud
 
 :::caution
-If you require [Server Side Encryption](https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/encryption_configuration.html), you MUST use LDAP! OpenID and SAML will cause **irrevocable data loss**. Nextcoud Server-Side Encryption requires access to the user's cleartext password, which is not available through OpenID or SAML.
+If you require [Server Side Encryption](https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/encryption_configuration.html), you must use LDAP. OpenID and SAML will cause **irrevocable data loss**. Nextcloud Server-Side Encryption requires access to the user's cleartext password, which is not available through OpenID or SAML.
 :::
 
 :::caution

--- a/website/integrations/services/nextcloud/index.md
+++ b/website/integrations/services/nextcloud/index.md
@@ -14,7 +14,7 @@ sidebar_label: Nextcloud
 > -- https://en.wikipedia.org/wiki/Nextcloud
 
 :::caution
-If you require [Server Side Encryption](https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/encryption_configuration.html), you must use LDAP. OpenID and SAML will cause **irrevocable data loss**. Nextcloud Server-Side Encryption requires access to the user's cleartext password, which is not available through OpenID or SAML.
+If you require [Server Side Encryption](https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/encryption_configuration.html), you must use LDAP. OpenID and SAML will cause **irrevocable data loss**. Nextcloud Server-Side Encryption requires access to the user's cleartext password, which Nextcloud only has access to when using LDAP as the user enters their password directly into Nextcloud.
 :::
 
 :::caution
@@ -31,7 +31,7 @@ There are 3 ways to setup single sign on (SSO) for Nextcloud:
 
 -   [via OIDC Connect (OAuth)](#openid-connect-auth)
 -   [via SAML](#saml-auth)
--   via LDAP outpost
+-   via LDAP outpost (required for SSE, not covered in this documentation)
 
 ### OpenID Connect auth
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`

-->
[Nextcloud server-side encryption](https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/encryption_configuration.html) requires access to the user's plaintext password. This adds a warning to the integration doc.

Closes #11975
---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [X] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
