### PR TITLE
website/integrations: vault: add external group documentation

### DIFF
--- a/website/integrations/services/hashicorp-vault/index.md
+++ b/website/integrations/services/hashicorp-vault/index.md
@@ -88,8 +88,64 @@ vault write auth/oidc/role/reader \
       policies="reader"
 ```
 
+## External Groups
+
+If you wish to manage group membership in vault via Authentik you have to use [external groups](https://developer.hashicorp.com/vault/tutorials/auth-methods/oidc-auth#create-an-external-vault-group).
+
 :::note
-If you intend to create [external groups](https://developer.hashicorp.com/vault/tutorials/auth-methods/oidc-auth#create-an-external-vault-group) in Vault to manage user access the OIDC role will need to specifically request a custom scope using the `oidc_scopes` option when creating the OIDC role.
+This assumes that the steps above have already been completed and tested.
 :::
+
+### Step 1
+
+In authentik, edit the oidc provider created above. Unser "Advanced protocol settings" add "authentik default OAuth Mapping: OpenID 'profile'". This includes the "groups" mapping.
+
+### Step 2
+
+In hashicorp vault, change the reader role
+
+```
+vault write auth/oidc/role/reader \
+      bound_audiences="Client ID" \
+      allowed_redirect_uris="https://vault.company/ui/vault/auth/oidc/oidc/callback" \
+      allowed_redirect_uris="https://vault.company/oidc/callback" \
+      allowed_redirect_uris="http://localhost:8250/oidc/callback" \
+      user_claim="sub" \
+      policies="reader" \
+      groups_claim="groups" \
+      oidc_scopes=[ "openid profile email" ]
+```
+
+Add a group
+
+```
+vault write identity/group/reader \
+    name="reader" \
+    policies=["reader"] \
+    type="external"
+```
+
+Get the canonical id of the group
+
+```
+vault list identity/group/id
+```
+
+Get the id of the oidc accessor
+
+```
+vault auth list
+```
+
+
+Add a group alias, this maps the group to the oidc backend
+
+```
+vault write identity/group-alias \
+    mount_accessor="auth_oidc_xxxxxx" \
+    canonical_id="group_id" \
+    name="group name in authentik"
+```
+
 You should then be able to sign in via OIDC
 `vault login -method=oidc role="reader"`

--- a/website/integrations/services/hashicorp-vault/index.md
+++ b/website/integrations/services/hashicorp-vault/index.md
@@ -90,7 +90,7 @@ vault write auth/oidc/role/reader \
 
 ## External Groups
 
-If you wish to manage group membership in vault via Authentik you have to use [external groups](https://developer.hashicorp.com/vault/tutorials/auth-methods/oidc-auth#create-an-external-vault-group).
+If you wish to manage group membership in Hashicorp Vault via Authentik you have to use [external groups](https://developer.hashicorp.com/vault/tutorials/auth-methods/oidc-auth#create-an-external-vault-group).
 
 :::note
 This assumes that the steps above have already been completed and tested.
@@ -98,11 +98,11 @@ This assumes that the steps above have already been completed and tested.
 
 ### Step 1
 
-In authentik, edit the oidc provider created above. Unser "Advanced protocol settings" add "authentik default OAuth Mapping: OpenID 'profile'". This includes the "groups" mapping.
+In authentik, edit the OIDC provider created above. Under **Advanced protocol settings** add `authentik default OAuth Mapping: OpenID 'profile'` This includes the groups mapping.
 
 ### Step 2
 
-In hashicorp vault, change the reader role
+In Vault, change the reader role to have the following settings:
 
 ```
 vault write auth/oidc/role/reader \
@@ -116,7 +116,7 @@ vault write auth/oidc/role/reader \
       oidc_scopes=[ "openid profile email" ]
 ```
 
-Add a group
+Add a group.
 
 ```
 vault write identity/group/reader \
@@ -125,20 +125,19 @@ vault write identity/group/reader \
     type="external"
 ```
 
-Get the canonical id of the group
+Get the canonical ID of the group.
 
 ```
 vault list identity/group/id
 ```
 
-Get the id of the oidc accessor
+Get the ID of the OIDC accessor.
 
 ```
 vault auth list
 ```
 
-
-Add a group alias, this maps the group to the oidc backend
+Add a group alias, this maps the group to the OIDC backend.
 
 ```
 vault write identity/group-alias \
@@ -147,5 +146,5 @@ vault write identity/group-alias \
     name="group name in authentik"
 ```
 
-You should then be able to sign in via OIDC
+You should then be able to sign in via OIDC.
 `vault login -method=oidc role="reader"`


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

This PR changes the documentation page https://docs.goauthentik.io/integrations/services/hashicorp-vault/.
It adds more in-depth explanation on how to integrate authentik with hashicorp vault when wanting to use external groups.

---

