### PR TITLE
website/docs: move S3 ad GeoIP to System Management/Operations

### DIFF
--- a/website/docs/add-secure-apps/applications/index.md
+++ b/website/docs/add-secure-apps/applications/index.md
@@ -34,7 +34,7 @@ The following options can be configured:
 
     If the authentik server does not have a volume mounted under `/media`, you'll get a text input. This accepts absolute URLs. If you've mounted single files into the container, you can reference them using `https://authentik.company/media/my-file.png`.
 
-    If there is a mount under `/media` or if [S3 storage](../../install-config/storage-s3.md) is configured, you'll instead see a field to upload a file.
+    If there is a mount under `/media` or if [S3 storage](../../sys-mgmt/ops/storage-s3.md) is configured, you'll instead see a field to upload a file.
 
 -   _Publisher_: Text shown below the application
 -   _Description_: Subtext shown on the application card below the publisher

--- a/website/docs/install-config/index.mdx
+++ b/website/docs/install-config/index.mdx
@@ -4,8 +4,6 @@ title: Installation and Configuration
 
 Everything you need to get authentik up and running!
 
-
-
 The installation process for our free open source version and our [Enterprise](../enterprise/index.md) version are exactly the same. For information about obtaining an Enterprise license, refer to [License management](../enterprise/manage-enterprise.md#license-management) documentation.
 
 For information about upgrading to a new version, refer to the <b>Upgrade</b> section in the relevant [Release Notes](../releases) and to our [Upgrade authentik](./upgrade.mdx) documentation.

--- a/website/docs/install-config/index.mdx
+++ b/website/docs/install-config/index.mdx
@@ -1,12 +1,14 @@
 ---
-title: Installation
+title: Installation and Configuration
 ---
 
 Everything you need to get authentik up and running!
 
-For information about upgrading to a new version, refer to the <b>Upgrade</b> section in the relevant [Release Notes](../releases) and to our [Upgrade authentik](./upgrade.mdx) documentation.
+
 
 The installation process for our free open source version and our [Enterprise](../enterprise/index.md) version are exactly the same. For information about obtaining an Enterprise license, refer to [License management](../enterprise/manage-enterprise.md#license-management) documentation.
+
+For information about upgrading to a new version, refer to the <b>Upgrade</b> section in the relevant [Release Notes](../releases) and to our [Upgrade authentik](./upgrade.mdx) documentation.
 
 import DocCardList from "@theme/DocCardList";
 

--- a/website/docs/releases/2022/v2022.12.md
+++ b/website/docs/releases/2022/v2022.12.md
@@ -13,7 +13,7 @@ slug: "/releases/2022.12"
 
 -   Bundled GeoIP City database
 
-    authentik now comes with a bundled MaxMind GeoLite2 City database. This allows everyone to take advantage of the extra data provided by GeoIP. The default docker-compose file removes the GeoIP update container as it is no longer needed. See more [here](../../install-config/geoip.mdx).
+    authentik now comes with a bundled MaxMind GeoLite2 City database. This allows everyone to take advantage of the extra data provided by GeoIP. The default docker-compose file removes the GeoIP update container as it is no longer needed. See more [here](../../sys-mgmt/ops/geoip.mdx).
 
 -   Improved UX for user & group management and stage/policy binding
 

--- a/website/docs/releases/2024/v2024.2.md
+++ b/website/docs/releases/2024/v2024.2.md
@@ -118,7 +118,7 @@ slug: /releases/2024.2
 
 -   **S3 file storage**
 
-    Media files can now be stored on S3. Follow the [setup guide](../../install-config/storage-s3.md) to get started.
+    Media files can now be stored on S3. Follow the [setup guide](../../sys-mgmt/ops/storage-s3.md) to get started.
 
 -   **_Pretend user exists_ option for Identification stage**
 

--- a/website/docs/sys-mgmt/ops/geoip.mdx
+++ b/website/docs/sys-mgmt/ops/geoip.mdx
@@ -1,6 +1,6 @@
 # GeoIP
 
-authentik supports GeoIP to add additional information to login/authorization/enrollment requests. Additionally, a [GeoIP policy](../customize/policies/index.md#geoip-policy) can be used to make policy decisions based on the lookup result.
+authentik supports GeoIP to add additional information to login/authorization/enrollment requests. Additionally, a [GeoIP policy](../../customize/policies/index.md#geoip-policy) can be used to make policy decisions based on the lookup result.
 
 ### Configuration
 

--- a/website/docs/sys-mgmt/ops/storage-s3.md
+++ b/website/docs/sys-mgmt/ops/storage-s3.md
@@ -83,7 +83,7 @@ The `ENDPOINT` setting specifies how authentik talks to the S3 provider.
 
 The `CUSTOM_DOMAIN` setting specifies how URLs are constructed to be shown on the web interface. For example, an object stored at `application-icons/application.png` with a `CUSTOM__DOMAIN` setting of `s3.provider/authentik-media` will result in a URL of `https://s3.provider/authentik-media/application-icons/application.png`. You can also use subdomains for your buckets depending on what your S3 provider offers: `authentik-media.s3.provider`. Whether HTTPS is used is controlled by `AUTHENTIK_STORAGE__MEDIA__S3__SECURE_URLS`, which defaults to true.
 
-For more control over settings, refer to the [configuration reference](./configuration/configuration.mdx#media-storage-settings)
+For more control over settings, refer to the [configuration reference](../../install-config/configuration/configuration.mdx#media-storage-settings)
 
 ### Migrating between storage backends
 

--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -1078,14 +1078,14 @@
 # Moved GeoIP and S3 under System Management/user_basic_operations
 
 [[redirects]]
-  from = "/install-config/storage-s3"
+  from = "/docs/install-config/storage-s3"
   to = "/docs/sys-mgmt/ops/storage-s3"
   status = 302
   force = true
 
 
 [[redirects]]
-  from = "/install-config/geoip"
+  from = "/docs/install-config/geoip"
   to = "/docs/sys-mgmt/ops/geoip"
   status = 302
   force = true

--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -1078,14 +1078,14 @@
 # Moved GeoIP and S3 under System Management/user_basic_operations
 
 [[redirects]]
-  from = "/install-config/storage-s3",
-  to = "/docs/sys-mgmt/ops/storage-s3",
+  from = "/install-config/storage-s3"
+  to = "/docs/sys-mgmt/ops/storage-s3"
   status = 302
   force = true
 
 
 [[redirects]]
-  from = "/install-config/geoip",
-  to = "/docs/sys-mgmt/ops/geoip",
+  from = "/install-config/geoip"
+  to = "/docs/sys-mgmt/ops/geoip"
   status = 302
   force = true

--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -1073,3 +1073,19 @@
   to = "/docs/developer-docs/translation"
   status = 302
   force = true
+
+
+# Moved GeoIP and S3 under System Management/user_basic_operations
+
+[[redirects]]
+  from = "/install-config/storage-s3",
+  to = "/docs/sys-mgmt/ops/storage-s3",
+  status = 302
+  force = true
+
+
+[[redirects]]
+  from = "/install-config/geoip",
+  to = "/docs/sys-mgmt/ops/geoip",
+  status = 302
+  force = true

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -111,10 +111,8 @@ export default {
                 "install-config/upgrade",
                 "install-config/beta",
                 "install-config/reverse-proxy",
-                "install-config/geoip",
                 "install-config/automated-install",
                 "install-config/air-gapped",
-                "install-config/storage-s3",
             ],
         },
         {
@@ -543,7 +541,11 @@ export default {
                     type: "category",
                     label: "Operations",
                     collapsed: true,
-                    items: ["sys-mgmt/ops/monitoring"],
+                    items: [
+                        "sys-mgmt/ops/monitoring",
+                        "sys-mgmt/ops/storage-s3",
+                        "sys-mgmt/ops/geoip",
+                    ],
                 },
                 {
                     type: "category",


### PR DESCRIPTION
This PR moves S3 ad GeoIP out of Install & Config to System Management/Operations

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
