### PR TITLE
core: use versioned_script for path only

### DIFF
--- a/authentik/api/templates/api/browser.html
+++ b/authentik/api/templates/api/browser.html
@@ -7,7 +7,7 @@ API Browser - {{ brand.branding_title }}
 {% endblock %}
 
 {% block head %}
-{% versioned_script "dist/standalone/api-browser/index-%v.js" %}
+<script src="{% versioned_script 'dist/standalone/api-browser/index-%v.js' %}" type="module"></script>
 <meta name="theme-color" content="#151515" media="(prefers-color-scheme: light)">
 <meta name="theme-color" content="#151515" media="(prefers-color-scheme: dark)">
 {% endblock %}

--- a/authentik/core/templates/base/skeleton.html
+++ b/authentik/core/templates/base/skeleton.html
@@ -15,8 +15,8 @@
         {% endblock %}
         <link rel="stylesheet" type="text/css" href="{% static 'dist/authentik.css' %}">
         <link rel="stylesheet" type="text/css" href="{% static 'dist/custom.css' %}" data-inject>
-        {% versioned_script "dist/poly-%v.js" %}
-        {% versioned_script "dist/standalone/loading/index-%v.js" %}
+        <script src="{% versioned_script 'dist/poly-%v.js' %}" type="module"></script>
+        <script src="{% versioned_script 'dist/standalone/loading/index-%v.js' %}" type="module"></script>
         {% block head %}
         {% endblock %}
         <meta name="sentry-trace" content="{{ sentry_trace }}" />

--- a/authentik/core/templates/if/admin.html
+++ b/authentik/core/templates/if/admin.html
@@ -3,7 +3,7 @@
 {% load authentik_core %}
 
 {% block head %}
-{% versioned_script "dist/admin/AdminInterface-%v.js" %}
+<script src="{% versioned_script 'dist/admin/AdminInterface-%v.js' %}" type="module"></script>
 <meta name="theme-color" content="#18191a" media="(prefers-color-scheme: dark)">
 <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
 {% include "base/header_js.html" %}

--- a/authentik/core/templates/if/user.html
+++ b/authentik/core/templates/if/user.html
@@ -3,7 +3,7 @@
 {% load authentik_core %}
 
 {% block head %}
-{% versioned_script "dist/user/UserInterface-%v.js" %}
+<script src="{% versioned_script 'dist/user/UserInterface-%v.js' %}" type="module"></script>
 <meta name="theme-color" content="#1c1e21" media="(prefers-color-scheme: light)">
 <meta name="theme-color" content="#1c1e21" media="(prefers-color-scheme: dark)">
 {% include "base/header_js.html" %}

--- a/authentik/core/templatetags/authentik_core.py
+++ b/authentik/core/templatetags/authentik_core.py
@@ -2,7 +2,6 @@
 
 from django import template
 from django.templatetags.static import static as static_loader
-from django.utils.safestring import mark_safe
 
 from authentik import get_full_version
 
@@ -12,10 +11,4 @@ register = template.Library()
 @register.simple_tag()
 def versioned_script(path: str) -> str:
     """Wrapper around {% static %} tag that supports setting the version"""
-    returned_lines = [
-        (
-            f'<script src="{static_loader(path.replace("%v", get_full_version()))}'
-            '" type="module"></script>'
-        ),
-    ]
-    return mark_safe("".join(returned_lines))  # nosec
+    return static_loader(path.replace("%v", get_full_version()))

--- a/authentik/enterprise/providers/rac/templates/if/rac.html
+++ b/authentik/enterprise/providers/rac/templates/if/rac.html
@@ -3,7 +3,7 @@
 {% load authentik_core %}
 
 {% block head %}
-{% versioned_script "dist/enterprise/rac/index-%v.js" %}
+<script src="{% versioned_script 'dist/enterprise/rac/index-%v.js' %}" type="module"></script>
 <meta name="theme-color" content="#18191a" media="(prefers-color-scheme: dark)">
 <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
 <link rel="icon" href="{{ tenant.branding_favicon }}">

--- a/authentik/flows/templates/if/flow.html
+++ b/authentik/flows/templates/if/flow.html
@@ -18,7 +18,7 @@ window.authentik.flow = {
 {% endblock %}
 
 {% block head %}
-{% versioned_script "dist/flow/FlowInterface-%v.js" %}
+<script src="{% versioned_script 'dist/flow/FlowInterface-%v.js' %}" type="module"></script>
 <style>
 :root {
     --ak-flow-background: url("{{ flow.background_url }}");


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

`versioned_script` used to return a list of HTML strings when we were migrating to versioned scripts (to fallback to loading un-versioned scripts). The fallback has since been removed in a release after the migration. This PR changes the template tag to only format the path

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
