### PR TITLE
sources/ldap: add rate limit delay, increase timeouts, add request to-restart

### DIFF
--- a/authentik/sources/ldap/models.py
+++ b/authentik/sources/ldap/models.py
@@ -11,7 +11,7 @@ import pglock
 from django.db import connection, models
 from django.templatetags.static import static
 from django.utils.translation import gettext_lazy as _
-from ldap3 import ALL, NONE, RANDOM, Connection, Server, ServerPool, Tls
+from ldap3 import ALL, NONE, RANDOM, RESTARTABLE, Connection, Server, ServerPool, Tls
 from ldap3.core.exceptions import LDAPException, LDAPInsufficientAccessRightsResult, LDAPSchemaError
 from rest_framework.serializers import Serializer
 
@@ -20,7 +20,7 @@ from authentik.crypto.models import CertificateKeyPair
 from authentik.lib.config import CONFIG
 from authentik.lib.models import DomainlessURLValidator
 
-LDAP_TIMEOUT = 15
+LDAP_TIMEOUT = 60
 LDAP_UNIQUENESS = "ldap_uniq"
 LDAP_DISTINGUISHED_NAME = "distinguishedName"
 
@@ -213,8 +213,8 @@ class LDAPSource(Source):
             connection_kwargs.setdefault("password", self.bind_password)
         conn = Connection(
             server or self.server(**server_kwargs),
-            raise_exceptions=True,
-            receive_timeout=LDAP_TIMEOUT,
+            raise_exceptions=CONFIG.get("ldap.raise_exceptions", True),
+            client_strategy=RESTARTABLE,
             **connection_kwargs,
         )
 


### PR DESCRIPTION

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
We continually run into rate limiting issues syncing against an upstream Google Secure LDAP service. This PR: 

- Adds a configurable pause between page searches
- Extends connect timeout
- Makes ldap3 exceptions togglable 
- Changes default `SYNC` client strategy to `RESTARTABLE` to handle connection failure retries, instead of halting the sync operation  

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
