### PR TITLE
core: fix source_flow_manager throwing error when authenticated user attempts to re-authenticate with existing link

### DIFF
--- a/authentik/core/sources/flow_manager.py
+++ b/authentik/core/sources/flow_manager.py
@@ -129,6 +129,11 @@ class SourceFlowManager:
             )
             new_connection.user = self.request.user
             new_connection = self.update_user_connection(new_connection, **kwargs)
+            if existing := self.user_connection_type.objects.filter(
+                source=self.source, identifier=self.identifier
+            ).first():
+                existing = self.update_user_connection(existing)
+                return Action.AUTH, existing
             return Action.LINK, new_connection
 
         action, connection = self.matcher.get_user_action(self.identifier, self.user_properties)


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

In previous versions we used to save the connection earlier which caused an Integrity Error which was caused and did a root redirect, however this was refactored to save the connection later and as such we don't redirect and don't catch the exception for this one specific user flow.

This user flow was also not tested, as it was assumed that the user would only authenticate with their source connection when they're not already authenticated, however this is something that might happen accidentally

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
