### PR TITLE
internal: add CSP header to files in `/media`

### DIFF
--- a/internal/web/static.go
+++ b/internal/web/static.go
@@ -42,8 +42,11 @@ func (ws *WebServer) configureStatic() {
 
 	// Media files, if backend is file
 	if config.Get().Storage.Media.Backend == "file" {
-		fsMedia := http.FileServer(http.Dir(config.Get().Storage.Media.File.Path))
-		staticRouter.PathPrefix("/media/").Handler(http.StripPrefix("/media", fsMedia))
+		fsMedia := http.StripPrefix("/media", http.FileServer(http.Dir(config.Get().Storage.Media.File.Path)))
+		staticRouter.PathPrefix("/media/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		    w.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; sandbox")
+		    fsMedia.ServeHTTP(w, r)
+		})
 	}
 
 	staticRouter.PathPrefix("/if/help/").Handler(http.StripPrefix("/if/help/", http.FileServer(http.Dir("./website/help/"))))


### PR DESCRIPTION
This fixes a security issue of stored cross-site scripting via embedding JavaScript in SVG files by a malicious user with `can_save_media` capability.

This can be exploited if:
- the uploaded file is served from the same origin as authentik, and
- the user opens the uploaded file directly in their browser
