### PR TITLE
providers/oauth2: fix migration dependencies

### DIFF
--- a/authentik/providers/oauth2/migrations/0022_remove_accesstoken_session_id_and_more.py
+++ b/authentik/providers/oauth2/migrations/0022_remove_accesstoken_session_id_and_more.py
@@ -37,7 +37,7 @@ def migrate_session(apps: Apps, schema_editor: BaseDatabaseSchemaEditor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("authentik_core", "0040_provider_invalidation_flow"),
+        ("authentik_core", "0039_source_group_matching_mode_alter_group_name_and_more"),
         ("authentik_providers_oauth2", "0021_oauth2provider_encryption_key_and_more"),
     ]
 

--- a/authentik/providers/oauth2/migrations/0023_alter_accesstoken_refreshtoken_use_hash_index.py
+++ b/authentik/providers/oauth2/migrations/0023_alter_accesstoken_refreshtoken_use_hash_index.py
@@ -8,7 +8,7 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("authentik_core", "0040_provider_invalidation_flow"),
+        ("authentik_core", "0039_source_group_matching_mode_alter_group_name_and_more"),
         ("authentik_providers_oauth2", "0022_remove_accesstoken_session_id_and_more"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]


### PR DESCRIPTION
we had to change these dependencies for 2024.8.x since that doesn't have invalidation flows

they also need to be changed for 2024.10 when upgrading, and these migrations don't need the invalidation flow migration at all

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
