### PR TITLE
website/docs: Fix documentation about attribute merging for indirect membership

### DIFF
--- a/website/docs/users-sources/groups/index.mdx
+++ b/website/docs/users-sources/groups/index.mdx
@@ -13,4 +13,4 @@ Recursion is limited to 20 levels to prevent deadlocks.
 
 ## Attributes
 
-Attributes of groups are recursively merged, for all groups the user is a _direct_ member of.
+Attributes of groups are recursively merged, for all groups the user is a member of.


### PR DESCRIPTION


tl;dr: the documentation about how attributes get merged was correct before #6017, but is now out of date. This change fixes that.

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

While for role memberships, it is true that they are only applied for _direct_ memberships, this does not appear to be the case for attributes (which is good as this also follows the "Hierarchy" system documented in the same file).

In terms of the implementation, this is the case due to the call to `all_groups()` in https://github.com/goauthentik/authentik/blob/3d5a189fa732ef462dbbd73b88c128ebaf1833f9/authentik/core/models.py#L312-L313, introduced in https://github.com/goauthentik/authentik/pull/6017. Looking through the files in there, it is clear that this line in the documentation is from before that point: https://github.com/goauthentik/authentik/blob/95e60a035df11d6f89db18cba3ae978d13d212b8/website/docs/user-group/group.md?plain=1#L15.

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
