### PR TITLE
website/docs: Add note about single group per role

### DIFF
--- a/website/docs/users-sources/roles/manage_roles.md
+++ b/website/docs/users-sources/roles/manage_roles.md
@@ -37,6 +37,10 @@ To delete a role, follow these steps:
 
 In authentik, roles are assigned to [groups](../groups/index.mdx), not to individual users.
 
+:::warning
+In authentik, each role can only be applied to a single group at the moment.
+:::
+
 1.  To assign the role to a group, navigate to **Directory -> Groups**.
 2.  Click the name of the group to which you want to add a role.
 3.  On the group's detail page, on the Overview tab, click **Edit** in the **Group Info** area.


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
This change adds an admonition to document the fact that every role can only ever be assigned to a single group at the same time. Since this is surprising based on a traditional understanding of role-based models, I've decided to make this a `:::warning`.

I'm undecided on the best place for this information, but for now, decided on putting it into the context of the action that can fail: assigning a role to a group.

While this does not close the issue, it documents this behavior to at least address the "needs documentation" aspect of #10983 .

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
