### PR TITLE
providers/oauth2: allow m2m for JWKS without alg in keys

### DIFF
--- a/website/docs/add-secure-apps/providers/oauth2/client_credentials.md
+++ b/website/docs/add-secure-apps/providers/oauth2/client_credentials.md
@@ -10,7 +10,7 @@ Hence identification is based on service-accounts, and authentication is based o
 
 An example request can look like this:
 
-```
+```http
 POST /application/o/token/ HTTP/1.1
 Host: authentik.company
 Content-Type: application/x-www-form-urlencoded
@@ -42,7 +42,7 @@ Starting with authentik 2022.6, you can define a JWKS URL/raw JWKS data in OAuth
 
 With this configure, any JWT issued by the configured certificates can be used to authenticate:
 
-```
+```http
 POST /application/o/token/ HTTP/1.1
 Host: authentik.company
 Content-Type: application/x-www-form-urlencoded

--- a/website/docs/add-secure-apps/providers/oauth2/device_code.md
+++ b/website/docs/add-secure-apps/providers/oauth2/device_code.md
@@ -14,7 +14,7 @@ authentik doesn't ship with a default flow for this usecase, so it is recommende
 
 The flow is initiated by sending a POST request to the device authorization endpoint, `/application/o/device/` with the following contents:
 
-```
+```http
 POST /application/o/device/ HTTP/1.1
 Host: authentik.company
 Content-Type: application/x-www-form-urlencoded
@@ -36,7 +36,7 @@ The response contains the following fields:
 
 With this response, the device can start checking the status of the token by sending requests to the token endpoint like this:
 
-```
+```http
 POST /application/o/token/ HTTP/1.1
 Host: authentik.company
 Content-Type: application/x-www-form-urlencoded

--- a/website/docs/users-sources/sources/social-logins/azure-ad/index.md
+++ b/website/docs/users-sources/sources/social-logins/azure-ad/index.md
@@ -111,3 +111,22 @@ return True
 9. Open **Flow settings** and choose _azure-ad-enrollment_ as enrollment flow.
 
 Try to login with a **_new_** user. You should see no prompts and the user should have the correct information.
+
+### Machine-to-machine authentication <span class="badge badge--version">authentik 2024.12+</span>
+
+When doing [Machine-to-Machine](../../../../add-secure-apps/providers/oauth2/client_credentials.md#jwt-authentication), some specific steps need to be considered.
+
+When getting the JWT token from Azure AD, the scope needs to be set to the Application ID URI, and _not_ the Graph URL, as otherwise the JWT will be in an invalid format.
+
+```http
+POST /<azure-ad-tenant-id>/oauth2/v2.0/token/ HTTP/1.1
+Host: login.microsoftonline.com
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=client_credentials&
+client_id=<application_client_id>&
+scope=api://<application_client_id>/.default&
+client_secret=<application_client_secret>
+```
+
+The JWT returned from the request above can be used with authentik to exchange it for an authentik JWT.

--- a/website/docs/users-sources/sources/social-logins/azure-ad/index.md
+++ b/website/docs/users-sources/sources/social-logins/azure-ad/index.md
@@ -114,7 +114,7 @@ Try to login with a **_new_** user. You should see no prompts and the user shoul
 
 ### Machine-to-machine authentication <span class="badge badge--version">authentik 2024.12+</span>
 
-When doing [Machine-to-Machine](../../../../add-secure-apps/providers/oauth2/client_credentials.md#jwt-authentication), some specific steps need to be considered.
+When using [Machine-to-Machine](../../../../add-secure-apps/providers/oauth2/client_credentials.md#jwt-authentication) authentication, some specific steps need to be considered.
 
 When getting the JWT token from Azure AD, the scope needs to be set to the Application ID URI, and _not_ the Graph URL, as otherwise the JWT will be in an invalid format.
 

--- a/website/docs/users-sources/sources/social-logins/azure-ad/index.md
+++ b/website/docs/users-sources/sources/social-logins/azure-ad/index.md
@@ -114,9 +114,9 @@ Try to login with a **_new_** user. You should see no prompts and the user shoul
 
 ### Machine-to-machine authentication <span class="badge badge--version">authentik 2024.12+</span>
 
-When using [Machine-to-Machine](../../../../add-secure-apps/providers/oauth2/client_credentials.md#jwt-authentication) authentication, some specific steps need to be considered.
+If using [Machine-to-Machine](../../../../add-secure-apps/providers/oauth2/client_credentials.md#jwt-authentication) authentication, some specific steps need to be considered.
 
-When getting the JWT token from Azure AD, the scope needs to be set to the Application ID URI, and _not_ the Graph URL, as otherwise the JWT will be in an invalid format.
+When getting the JWT token from Azure AD, set the scope to the Application ID URI, and _not_ the Graph URL; otherwise the JWT will be in an invalid format.
 
 ```http
 POST /<azure-ad-tenant-id>/oauth2/v2.0/token/ HTTP/1.1

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -80,7 +80,7 @@ module.exports = async function (): Promise<Config> {
             prism: {
                 theme: prismThemes.oneLight,
                 darkTheme: prismThemes.oneDark,
-                additionalLanguages: ["python", "diff", "json"],
+                additionalLanguages: ["python", "diff", "json", "http"],
             },
         },
         presets: [


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

the `alg` attribute in JWKS urls is optional, so if it's not set we use the `alg` from the raw JWT header

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
