### PR TITLE
website/integrations: Update Home Assistant integration docs

### DIFF
--- a/website/integrations/services/home-assistant/index.md
+++ b/website/integrations/services/home-assistant/index.md
@@ -16,6 +16,9 @@ sidebar_label: Home Assistant
 :::caution
 You might run into CSRF errors, this is caused by a technology Home-assistant uses and not authentik, see [this GitHub issue](https://github.com/goauthentik/authentik/issues/884#issuecomment-851542477).
 :::
+:::caution
+Only prefixes starting with `/auth` need to be proxied (excluding prefixes starting with `/auth/token`), see [this GitHub issue](https://github.com/BeryJu/hass-auth-header/issues/212). This can be configured in the reverse proxy (e.g. nginx, Traefik) or in authentik Provider's **Unauthorized Paths**.
+:::
 :::note
 For Home Assistant to work with authentik, a custom integration needs to be installed for Home Assistant.
 :::


### PR DESCRIPTION
Extra care should be taken to proxy through Authentik only prefixes starting with `/auth` (excluding prefixes starting with `/auth/token`). If everything is proxied - things break.

See https://github.com/BeryJu/hass-auth-header/issues/212.