### PR TITLE
website/docs: add page about the Cobalt pentest

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@ authentik takes security very seriously. We follow the rules of [responsible di
 
 ## Independent audits and pentests
 
-In May/June of 2023 [Cure53](https://cure53.de) conducted an audit and pentest. The [results](https://cure53.de/pentest-report_authentik.pdf) are published on the [Cure53 website](https://cure53.de/#publications-2023). For more details about authentik's response to the findings of the audit refer to [2023-06 Cure53 Code audit](https://goauthentik.io/docs/security/2023-06-cure53).
+We are committed to engaging in regular pentesting and security audits of authentik. Defining and adhering to a cadence of external testing ensures a stronger probability that our code base, our features, and our architecture is as secure and non-exploitable as possible. For more details about specfic audits and pentests, refer to "Audits and Certificates" in our [Security documentation]](https://docs.goauthentik.io/docs/security).
 
 ## What authentik classifies as a CVE
 

--- a/website/docs/security/audits-and-certs/2024-11-cobalt.md
+++ b/website/docs/security/audits-and-certs/2024-11-cobalt.md
@@ -10,9 +10,9 @@ Cobalt described their process for testing:
 
 ## Summary of findings
 
-Overall, we are pleased with the report’s findings, and grateful for the opportunity to improve in every area we can.
+Overall, we are pleased with the report's findings and grateful for the opportunity to improve in every area we can.
 
-> Cobalt reported “The pentesters found that the Authentik Security team implemented robust and up-to-date security practices throughout the application.”
+> Cobalt reported "The pentesters found that the Authentik Security team implemented robust and up-to-date security practices throughout the application."
 
 In total, there were 5 low-level and one info-level vulnerabilities reported. By early November 2024, all 6 vulnerabilities were addressed and released in the [2024.10.4 patch release](https://docs.goauthentik.io/docs/releases/2024.10#fixed-in-2024103).
 
@@ -22,42 +22,42 @@ From the audit, this is the complete list of findings, with information about h
 
 ### HTML Injection
 
-**Issue**: A vulnerability existed through user-supplied names in our Flow diagrams, where the application did not properly sanitize or escape HTML input when parsing user-entered names. As a result, an attacker could inject arbitrary HTML or JavaScript code into the application, potentially leading to manipulation of the web page or execution of malicious scripts in the context of the user's session.
+**Issue**: A vulnerability existed through user-supplied names in our Flow diagrams, where the application did not properly sanitize or escape HTML input when parsing user-entered names. As a result, an attacker could inject arbitrary HTML or JavaScript code into the application, potentially leading to manipulation of the web page or execution of malicious scripts in the context of the user's session. (This action could only be performed by an authenticated admin user, and thus had little practical value as an attack vector.)
 
 **Fix**: We added strict [DOMpurify](https://github.com/cure53/DOMPurify) configurations for any user-defined names in our diagrams. For details, refer to [Pull Request #11783](https://github.com/goauthentik/authentik/pull/11783).
 
 ### SVG images for icons possible XSS vulnerability
 
-**Issue**: The pentesters discovered that the application was susceptible to insecure file upload and stored Cross-Site Scripting (XSS) vulnerabilities by uploading crafted SVG files that were used as application icons.
+**Issue**: The pentesters discovered that the application was susceptible to insecure file upload and stored Cross-Site Scripting (XSS) vulnerabilities by uploading crafted SVG files that were used as application icons. (This action could only be performed by an authenticated admin user, and thus had little practical value as an attack vector.)
 
 **Fix**: The fix was to add a CSP header to files that are stored in the `/media` directory of the installation. For details, refer to [Pull Request #12092](https://github.com/goauthentik/authentik/pull/12092).
 
 ### Vulnerability through footer links on website
 
-**Issue**: It was found that the application was vulnerable to stored XSS through footer links. The footer section of the application accepted and displayed user-provided links without proper sanitization. This could allow an attacker to inject malicious scripts into these links, which would then stored and executed when other users access the footer links, leading to potential script execution in the context of the victim’s session.
+**Issue**: It was found that the application was vulnerable to stored XSS through footer links. The footer section of the application accepted and displayed user-provided links without proper sanitization. This could allow an attacker to inject malicious scripts into these links, which would then stored and executed when other users access the footer links, leading to potential script execution in the context of the victim's session. (This action could only be performed by an authenticated admin user, and thus had little practical value as an attack vector.)
 
 **Fix**: Again, as with the diagram issue above, we added strict [DOMpurify](https://github.com/cure53/DOMPurify) configurations. For more details, refer to [Pull Request #11773](https://github.com/goauthentik/authentik/pull/11773).
 
 ### Password policy weakness
 
-**Issue**: It was determined that the current password policy was weak, allowing users to create passwords that lacked complexity and were easily guessable. This made the application more susceptible to brute-force and dictionary attacks.
+**Issue**: It was determined that the password policy in place on the testing environment was weak, allowing users to create passwords that lacked complexity and were easily guessable. This made the application more susceptible to brute-force and dictionary attacks.
 
-**Fix**: We have created a more stringent password policy and are working on further configuration options to encourage users to strengthen their passwords yet further. For more details, refer to [Pull Request #11793](https://github.com/goauthentik/authentik/pull/11793).
+**Fix**: This was not a vulnerability in authentik, but rather a poor configuration of our provided test environment. Rather than simply improve our test instance’s configuration once, to make this issue easier to avoid for all our users and customers, we added a strong default password policy that applies to all new instances. (As always, admins can still configure their own custom policies.) For more details, refer to [Pull Request #11793](https://github.com/goauthentik/authentik/pull/11793).
 
 ### Lack of a CSP header
 
-The absence of a CSP (Content Security Policy) header means that the application lacks a mechanism to restrict sources of content and scripts, which can expose it to XSS attacks and other forms of content injection.
+The absence of Content Security Policy (CSP) headers means that the application may lack a mechanism to restrict sources of content and scripts, which can potentially expose it to XSS attacks and other forms of content injection.
 
-**Fix**: We added a Content Security Policy (CSP) header to control the sources of content and scripts that the application can load. For more details, refer to [Pull Request #12092](https://github.com/goauthentik/authentik/pull/12092).
+**Fix**: We added CSP headers to control the sources of content and scripts that the application can load for our provided test instance. Again, this is not a direct vulnerability in authentik itself. Given the variety of architectures in which authentik is deployed, adding our own CSP headers would be more likely to break functionality than to provide improved security.
 
 ### API endpoints strengthened
 
-**Issue**: Finally, the only informational level finding was the potential for unauthenticated download of private key and certificate values via direct URL. We had already fixed this issue in 2024.8.0, but the instance they were running was the immediately preceding version.
+**Issue**: Finally, the only informational level finding was the potential for the unauthenticated download of private key and certificate values via a direct URL. (Guessing the URL required the knowledge of the UUID of an object.) We had already fixed this issue in 2024.8.0, but the instance tested against was the immediately preceding version.
 
 **Fix**: For more details, refer to [CVE-2024-42490](https://docs.goauthentik.io/docs/security/cves/CVE-2024-42490).
 
 ## Retest results
 
-The subsequent retest conducted by Cobalt deemed that all issues were resolved. See page 17 of the [report](https://github.com/goauthentik/website/src/resources/final_fullReport_authentik-cobalt-test-instance-august-2024-pt26135.pdf) for the mitigation status (”fixed”) for each of the issues discovered in September.
+The subsequent retest conducted by Cobalt deemed all issues resolved. See page 17 of the [report](https://github.com/goauthentik/website/src/resources/final_fullReport_authentik-cobalt-test-instance-august-2024-pt26135.pdf) for the mitigation status ("fixed") for each of the issues discovered in September.
 
 We are pleased to share this pentest and the final results of the retest. We encourage an open and ongoing communication with our users and community. For more information abut our security stance, read our [Security Policy](https://docs.goauthentik.io/docs/security/policy), [Hardening authentik](https://docs.goauthentik.io/docs/security/security-hardening), and our other [security-related documentation](https://docs.goauthentik.io/docs/security). If you have any questions or feedback you can reach us on [GitHub](https://github.com/goauthentik/authentik), [Discord](https://discord.com/channels/809154715984199690/809154716507963434), or via email to [hello@goauthentik.io](mailto:hello@goauthentik.io).

--- a/website/docs/security/audits-and-certs/2024-11-cobalt.md
+++ b/website/docs/security/audits-and-certs/2024-11-cobalt.md
@@ -1,0 +1,65 @@
+# 2024-11 Cobalt pentest
+
+We are committed to engaging in regular pentesting and security audits of authentik. Defining and adhering to a cadence of external testing ensures a stronger probability that our code base, our features, and our architecture is as secure and non-exploitable as possible.
+
+In August-September of 2024, we had a pentest conducted by [Cobalt](https://www.cobalt.io). This document covers the findings of the audit, how we addressed the noted issues, and the subsequent [re-testing](https://github.com/goauthentik/website/src/resources/final_fullReport_authentik-cobalt-test-instance-august-2024-pt26135.pdf) by Cobalt to confirm that all issues were resolved.
+
+Cobalt described their process for testing:
+
+> This pentest was a manual assessment of the security of the application’s functionality, business logic, and vulnerabilities, such as those cataloged in the Open Web Application Security Project OWASP) Top 10. The assessment also included a review of security controls and requirements listed in the OWASP Application Security Verification Standard (ASVS).
+>
+
+## Summary of findings
+
+Overall, we are pleased with the report’s findings, and grateful for the opportunity to improve in every area we can.
+
+> Cobalt reported “The pentesters found that the Authentik Security team implemented robust and up-to-date security practices throughout the application.”
+>
+
+In total, there were 5 low-level and one info-level vulnerabilities reported. By early November 2024, all 6 vulnerabilities were addressed and released in the [2024.10.4 patch release](https://docs.goauthentik.io/docs/releases/2024.10#fixed-in-2024103).
+
+## Responses to specific findings
+
+From the audit, this is the complete list of findings, with information about how we  addressed each.
+
+### HTML Injection
+
+**Issue**: A vulnerability existed through user-supplied names in our Flow diagrams, where the application did not properly sanitize or escape HTML input when parsing user-entered names. As a result, an attacker could inject arbitrary HTML or JavaScript code into the application, potentially leading to manipulation of the web page or execution of malicious scripts in the context of the user's session.
+
+**Fix**: We added strict [DOMpurify](https://github.com/cure53/DOMPurify) configurations for any user-defined names in our diagrams. For details, refer to Pull Request [**#11783](https://github.com/goauthentik/authentik/pull/11783).**
+
+### SVG images for icons possible XSS vulnerability
+
+**Issue**: The pentesters discovered that the application was susceptible to insecure file upload and stored Cross-Site Scripting (XSS) vulnerabilities by uploading crafted SVG files that were used as application icons.
+
+**Fix**: The fix was to add a CSP header to files that are stored in the `/media` directory of the installation. For details, refer to [Pull Request **#12092](https://github.com/goauthentik/authentik/pull/12092).**
+
+### Vulnerability through footer links on website
+
+**Issue**: It was found that the application was vulnerable to stored XSS through footer links. The footer section of the application accepted and displayed user-provided links without proper sanitization. This could allow an attacker to inject malicious scripts into these links, which would then stored and executed when other users access the footer links, leading to potential script execution in the context of the victim’s session.
+
+**Fix**: Again, as with the diagram isue above, we added strict [DOMpurify](https://github.com/cure53/DOMPurify) configurations. For more details, refer to Pull Request [#11773](https://github.com/goauthentik/authentik/pull/11773).
+
+### Password policy weakness
+
+**Issue**: It was determined that the current password policy was weak, allowing users to create passwords that lacked complexity and were easily guessable. This made the application more susceptible to brute-force and dictionary attacks.
+
+**Fix**: We have created a more stringent password policy and are working on further configuration options to encourage users to strengthen their passwords yet further. For more details, refer to [Pull Request #11793](https://github.com/goauthentik/authentik/pull/11793).
+
+### Lack of a CSP header
+
+The absence of a CSP (Content Security Policy) header means that the application lacks a mechanism to restrict sources of content and scripts, which can expose it to XSS attacks and other forms of content injection.
+
+**Fix**: We added a Content Security Policy (CSP) header to control the sources of content and scripts that the application can load. For more details, refer to [Pull Request #12092](https://github.com/goauthentik/authentik/pull/12092).
+
+### API endpoints strengthened
+
+**Issue**: Finally, the only informational level finding was the potential for unauthenticated download of private key and certificate values via direct URL. We had already fixed this issue in 2024.8.0, but the instance they were running was the immediately preceding version.
+
+**Fix**: For more details, refer to [CVE-2024-42490](https://docs.goauthentik.io/docs/security/cves/CVE-2024-42490).
+
+## Retest results
+
+The subsequent retest conducted by Cobalt deemed that all issues were resolved. See page 17 of the [report](https://github.com/goauthentik/website/src/resources/final_fullReport_authentik-cobalt-test-instance-august-2024-pt26135.pdf) for the mitigation status (”fixed”) for each of the issues discovered in September.
+
+We are pleased to share this pentest and the final results of the retest. We encourage an open and ongoing communication with our users and community. For more information abut our security stance, read our [Security Policy](https://docs.goauthentik.io/docs/security/policy), [Hardening authentik](https://docs.goauthentik.io/docs/security/security-hardening), and our other [security-related documentation](https://docs.goauthentik.io/docs/security). If you have any questions or feedback you can reach us on [GitHub](https://github.com/goauthentik/authentik), [Discord](https://discord.com/channels/809154715984199690/809154716507963434), or via email to [hello@goauthentik.io](mailto:hello@goauthentik.io).

--- a/website/docs/security/audits-and-certs/2024-11-cobalt.md
+++ b/website/docs/security/audits-and-certs/2024-11-cobalt.md
@@ -7,38 +7,36 @@ In August-September of 2024, we had a pentest conducted by [Cobalt](https://www
 Cobalt described their process for testing:
 
 > This pentest was a manual assessment of the security of the application’s functionality, business logic, and vulnerabilities, such as those cataloged in the Open Web Application Security Project OWASP) Top 10. The assessment also included a review of security controls and requirements listed in the OWASP Application Security Verification Standard (ASVS).
->
 
 ## Summary of findings
 
 Overall, we are pleased with the report’s findings, and grateful for the opportunity to improve in every area we can.
 
 > Cobalt reported “The pentesters found that the Authentik Security team implemented robust and up-to-date security practices throughout the application.”
->
 
 In total, there were 5 low-level and one info-level vulnerabilities reported. By early November 2024, all 6 vulnerabilities were addressed and released in the [2024.10.4 patch release](https://docs.goauthentik.io/docs/releases/2024.10#fixed-in-2024103).
 
 ## Responses to specific findings
 
-From the audit, this is the complete list of findings, with information about how we  addressed each.
+From the audit, this is the complete list of findings, with information about how we addressed each.
 
 ### HTML Injection
 
 **Issue**: A vulnerability existed through user-supplied names in our Flow diagrams, where the application did not properly sanitize or escape HTML input when parsing user-entered names. As a result, an attacker could inject arbitrary HTML or JavaScript code into the application, potentially leading to manipulation of the web page or execution of malicious scripts in the context of the user's session.
 
-**Fix**: We added strict [DOMpurify](https://github.com/cure53/DOMPurify) configurations for any user-defined names in our diagrams. For details, refer to Pull Request [**#11783](https://github.com/goauthentik/authentik/pull/11783).**
+**Fix**: We added strict [DOMpurify](https://github.com/cure53/DOMPurify) configurations for any user-defined names in our diagrams. For details, refer to [Pull Request #11783](https://github.com/goauthentik/authentik/pull/11783).
 
 ### SVG images for icons possible XSS vulnerability
 
 **Issue**: The pentesters discovered that the application was susceptible to insecure file upload and stored Cross-Site Scripting (XSS) vulnerabilities by uploading crafted SVG files that were used as application icons.
 
-**Fix**: The fix was to add a CSP header to files that are stored in the `/media` directory of the installation. For details, refer to [Pull Request **#12092](https://github.com/goauthentik/authentik/pull/12092).**
+**Fix**: The fix was to add a CSP header to files that are stored in the `/media` directory of the installation. For details, refer to [Pull Request #12092](https://github.com/goauthentik/authentik/pull/12092).
 
 ### Vulnerability through footer links on website
 
 **Issue**: It was found that the application was vulnerable to stored XSS through footer links. The footer section of the application accepted and displayed user-provided links without proper sanitization. This could allow an attacker to inject malicious scripts into these links, which would then stored and executed when other users access the footer links, leading to potential script execution in the context of the victim’s session.
 
-**Fix**: Again, as with the diagram isue above, we added strict [DOMpurify](https://github.com/cure53/DOMPurify) configurations. For more details, refer to Pull Request [#11773](https://github.com/goauthentik/authentik/pull/11773).
+**Fix**: Again, as with the diagram issue above, we added strict [DOMpurify](https://github.com/cure53/DOMPurify) configurations. For more details, refer to [Pull Request #11773](https://github.com/goauthentik/authentik/pull/11773).
 
 ### Password policy weakness
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -649,7 +649,10 @@ export default {
                 {
                     type: "category",
                     label: "Audits and Certificates",
-                    items: ["security/audits-and-certs/2023-06-cure53"],
+                    items: [
+                        "security/audits-and-certs/2023-06-cure53",
+                        "security/audits-and-certs/2024-11-cobalt",
+                    ],
                 },
                 {
                     type: "category",


### PR DESCRIPTION
This PR adds a page to cover the Cobalt pentest in fall 2024.

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
