### PR TITLE
ci: switch to ubuntu-24.04 image for testing

### DIFF
--- a/.github/workflows/api-py-publish.yml
+++ b/.github/workflows/api-py-publish.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     if: ${{ github.repository != 'goauthentik/authentik-internal' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/api-ts-publish.yml
+++ b/.github/workflows/api-ts-publish.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     if: ${{ github.repository != 'goauthentik/authentik-internal' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - id: generate_token
         uses: tibdex/github-app-token@v2

--- a/.github/workflows/ci-aws-cfn.yml
+++ b/.github/workflows/ci-aws-cfn.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   check-changes-applied:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Setup authentik env
@@ -38,6 +38,6 @@ jobs:
   ci-aws-cfn-mark:
     needs:
       - check-changes-applied
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - run: echo mark

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -28,7 +28,7 @@ jobs:
           - codespell
           - pending-migrations
           - ruff
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Setup authentik env
@@ -36,7 +36,7 @@ jobs:
       - name: run job
         run: poetry run make ci-${{ matrix.job }}
   test-migrations:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Setup authentik env
@@ -45,7 +45,7 @@ jobs:
         run: poetry run python -m lifecycle.migrate
   test-migrations-from-stable:
     name: test-migrations-from-stable - PostgreSQL ${{ matrix.psql }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -97,7 +97,7 @@ jobs:
           poetry run make test
   test-unittest:
     name: test-unittest - PostgreSQL ${{ matrix.psql }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -127,7 +127,7 @@ jobs:
           file: unittest.xml
           token: ${{ secrets.CODECOV_TOKEN }}
   test-integration:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -152,7 +152,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
   test-e2e:
     name: test-e2e (${{ matrix.job.name }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -216,7 +216,7 @@ jobs:
       - test-unittest
       - test-integration
       - test-e2e
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - run: echo mark
   build:
@@ -227,7 +227,7 @@ jobs:
           - amd64
           - arm64
     needs: ci-core-mark
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       # Needed to upload contianer images to ghcr.io
       packages: write
@@ -285,7 +285,7 @@ jobs:
   pr-comment:
     needs:
       - build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.event_name == 'pull_request' }}
     permissions:
       # Needed to write comments on PRs

--- a/.github/workflows/ci-outpost.yml
+++ b/.github/workflows/ci-outpost.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   lint-golint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -35,7 +35,7 @@ jobs:
           args: --timeout 5000s --verbose
           skip-cache: true
   test-unittest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -52,7 +52,7 @@ jobs:
     needs:
       - lint-golint
       - test-unittest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - run: echo mark
   build-container:
@@ -67,7 +67,7 @@ jobs:
           - ldap
           - radius
           - rac
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       # Needed to upload contianer images to ghcr.io
       packages: write
@@ -122,7 +122,7 @@ jobs:
     timeout-minutes: 120
     needs:
       - ci-outpost-mark
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -45,7 +45,7 @@ jobs:
         working-directory: ${{ matrix.project }}/
         run: npm run ${{ matrix.command }}
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -64,13 +64,13 @@ jobs:
     needs:
       - build
       - lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - run: echo mark
   test:
     needs:
       - ci-web-mark
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci-website.yml
+++ b/.github/workflows/ci-website.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -28,7 +28,7 @@ jobs:
         working-directory: website/
         run: npm run ${{ matrix.command }}
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -42,7 +42,7 @@ jobs:
         working-directory: website/
         run: npm test
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: ${{ matrix.job }}
     strategy:
       fail-fast: false
@@ -66,6 +66,6 @@ jobs:
       - lint
       - test
       - build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - run: echo mark

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/gen-update-webauthn-mds.yml
+++ b/.github/workflows/gen-update-webauthn-mds.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   build:
     if: ${{ github.repository != 'goauthentik/authentik-internal' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - id: generate_token
         uses: tibdex/github-app-token@v2

--- a/.github/workflows/gha-cache-cleanup.yml
+++ b/.github/workflows/gha-cache-cleanup.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   cleanup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/ghcr-retention.yml
+++ b/.github/workflows/ghcr-retention.yml
@@ -9,7 +9,7 @@ jobs:
   clean-ghcr:
     if: ${{ github.repository != 'goauthentik/authentik-internal' }}
     name: Delete old unused container images
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - id: generate_token
         uses: tibdex/github-app-token@v2

--- a/.github/workflows/image-compress.yml
+++ b/.github/workflows/image-compress.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   compress:
     name: compress
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # Don't run on forks. Token will not be available. Will run on main and open a PR anyway
     if: |
       github.repository == 'goauthentik/authentik' &&

--- a/.github/workflows/publish-source-docs.yml
+++ b/.github/workflows/publish-source-docs.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   publish-source-docs:
     if: ${{ github.repository != 'goauthentik/authentik-internal' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-next-branch.yml
+++ b/.github/workflows/release-next-branch.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   update-next:
     if: ${{ github.repository != 'goauthentik/authentik-internal' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: internal-production
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-server:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       # Needed to upload contianer images to ghcr.io
       packages: write
@@ -62,7 +62,7 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
   build-outpost:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       # Needed to upload contianer images to ghcr.io
       packages: write
@@ -127,7 +127,7 @@ jobs:
           push-to-registry: true
   build-outpost-binary:
     timeout-minutes: 120
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       # Needed to upload binaries to the release
       contents: write
@@ -179,7 +179,7 @@ jobs:
       - build-outpost
     env:
       AWS_REGION: eu-central-1
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: aws-actions/configure-aws-credentials@v4
@@ -195,7 +195,7 @@ jobs:
       - build-server
       - build-outpost
       - build-outpost-binary
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Run test suite in final docker images
@@ -211,7 +211,7 @@ jobs:
       - build-server
       - build-outpost
       - build-outpost-binary
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: prepare variables

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Create Release from Tag
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Pre-release test

--- a/.github/workflows/repo-mirror.yml
+++ b/.github/workflows/repo-mirror.yml
@@ -5,7 +5,7 @@ on: [push, delete]
 jobs:
   to_internal:
     if: ${{ github.repository != 'goauthentik/authentik-internal' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/repo-stale.yml
+++ b/.github/workflows/repo-stale.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   stale:
     if: ${{ github.repository != 'goauthentik/authentik-internal' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - id: generate_token
         uses: tibdex/github-app-token@v2

--- a/.github/workflows/translation-advice.yml
+++ b/.github/workflows/translation-advice.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   post-comment:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Find Comment
         uses: peter-evans/find-comment@v3

--- a/.github/workflows/translation-extract-compile.yml
+++ b/.github/workflows/translation-extract-compile.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   compile:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - id: generate_token
         uses: tibdex/github-app-token@v2

--- a/.github/workflows/translation-rename.yml
+++ b/.github/workflows/translation-rename.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   rename_pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.event.pull_request.user.login == 'transifex-integration[bot]'}}
     steps:
       - id: generate_token


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

See https://github.com/actions/runner-images/issues/10636

Test our pipelines on ubuntu 24.04 to make sure everything still works when the image is rolled out.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
