### PR TITLE
website/docs: Update Traefik middleware example to reflect latest version of Traefik

### DIFF
--- a/website/docs/add-secure-apps/providers/proxy/_traefik_ingress.md
+++ b/website/docs/add-secure-apps/providers/proxy/_traefik_ingress.md
@@ -1,7 +1,7 @@
 Create a middleware:
 
 ```yaml
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
     name: authentik
@@ -23,6 +23,7 @@ spec:
             - X-authentik-meta-app
             - X-authentik-meta-version
 ```
+Note: Traefik changed the apiVersion of the middleware CRD in version 3.0,  for older versions please subsititue "apiVersion: traefik.containo.us/v1alpha1"
 
 Add the following settings to your IngressRoute
 

--- a/website/docs/add-secure-apps/providers/proxy/_traefik_ingress.md
+++ b/website/docs/add-secure-apps/providers/proxy/_traefik_ingress.md
@@ -24,7 +24,7 @@ spec:
             - X-authentik-meta-version
 ```
 :::info 
-Traefik changed the apiVersion of the middleware CRD in version 3.0,  for older versions please subsititue "apiVersion: traefik.containo.us/v1alpha1"
+Traefik changed the apiVersion of the middleware CRD in version 3.0, for older versions please subsititue "apiVersion: traefik.containo.us/v1alpha1"
 :::
 
 Add the following settings to your IngressRoute

--- a/website/docs/add-secure-apps/providers/proxy/_traefik_ingress.md
+++ b/website/docs/add-secure-apps/providers/proxy/_traefik_ingress.md
@@ -23,7 +23,8 @@ spec:
             - X-authentik-meta-app
             - X-authentik-meta-version
 ```
-Note: Traefik changed the apiVersion of the middleware CRD in version 3.0,  for older versions please subsititue "apiVersion: traefik.containo.us/v1alpha1"
+:::info Traefik changed the apiVersion of the middleware CRD in version 3.0,  for older versions please subsititue "apiVersion: traefik.containo.us/v1alpha1"
+:::
 
 Add the following settings to your IngressRoute
 

--- a/website/docs/add-secure-apps/providers/proxy/_traefik_ingress.md
+++ b/website/docs/add-secure-apps/providers/proxy/_traefik_ingress.md
@@ -23,7 +23,8 @@ spec:
             - X-authentik-meta-app
             - X-authentik-meta-version
 ```
-:::info Traefik changed the apiVersion of the middleware CRD in version 3.0,  for older versions please subsititue "apiVersion: traefik.containo.us/v1alpha1"
+:::info 
+Traefik changed the apiVersion of the middleware CRD in version 3.0,  for older versions please subsititue "apiVersion: traefik.containo.us/v1alpha1"
 :::
 
 Add the following settings to your IngressRoute


### PR DESCRIPTION
This changes the traefik forward authentication documentation to reflect the current CRD definitions, as well as adding an info block to explain needed changes to use with previous version of traefik.
