### PR TITLE
root: fix override locale only if it is not empty

### DIFF
--- a/authentik/brands/middleware.py
+++ b/authentik/brands/middleware.py
@@ -25,5 +25,7 @@ class BrandMiddleware:
             locale = brand.default_locale
             if locale != "":
                 locale_to_set = locale
-        with override(locale_to_set):
-            return self.get_response(request)
+        if locale_to_set:
+            with override(locale_to_set):
+                return self.get_response(request)
+        return self.get_response(request)

--- a/authentik/core/middleware.py
+++ b/authentik/core/middleware.py
@@ -42,8 +42,10 @@ class ImpersonateMiddleware:
             # Ensure that the user is active, otherwise nothing will work
             request.user.is_active = True
 
-        with override(locale_to_set):
-            return self.get_response(request)
+        if locale_to_set:
+            with override(locale_to_set):
+                return self.get_response(request)
+        return self.get_response(request)
 
 
 class RequestIDMiddleware:


### PR DESCRIPTION
ImpersonateMiddleware may override the BrandMiddleware's language

part of #12088 