### PR TITLE
enterprise: allow deletion/modification of users when in read-only mode

### DIFF
--- a/authentik/enterprise/middleware.py
+++ b/authentik/enterprise/middleware.py
@@ -6,6 +6,7 @@ from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.urls import resolve
 from structlog.stdlib import BoundLogger, get_logger
 
+from authentik.core.api.users import UserViewSet
 from authentik.enterprise.api import LicenseViewSet
 from authentik.enterprise.license import LicenseKey
 from authentik.enterprise.models import LicenseUsageStatus
@@ -58,6 +59,9 @@ class EnterpriseMiddleware:
             return True
         # Flow executor is mounted as an API path but explicitly allowed
         if request.resolver_match._func_path == class_to_path(FlowExecutorView):
+            return True
+        # Always allow making changes to users, even in case the license has ben exceeded
+        if request.resolver_match._func_path == class_to_path(UserViewSet):
             return True
         # Only apply these restrictions to the API
         if "authentik_api" not in request.resolver_match.app_names:

--- a/website/docs/enterprise/manage-enterprise.md
+++ b/website/docs/enterprise/manage-enterprise.md
@@ -107,7 +107,7 @@ The following events occur when a license expires or the internal/external user 
 
     - Users can authenticate and authorize applications
     - Licenses can be modified
-    - Users can be modified/deleted <span class="badge badge--version">authentik 2024.12+</span>
+    - Users can be modified/deleted <span class="badge badge--version">authentik 2024.10.5+</span>
 
     Once the user count returns to be within the limits of the license, authentik will return to the standard read-write mode and the notification will disappear.
 

--- a/website/docs/enterprise/manage-enterprise.md
+++ b/website/docs/enterprise/manage-enterprise.md
@@ -101,7 +101,15 @@ The following events occur when a license expires or the internal/external user 
 
 - After another 2 weeks, users get a warning banner
 
-- After another 2 weeks, the authentik Enterprise instance becomes “read-only”
+- After another 2 weeks, the authentik Enterprise instance becomes "read-only"
+
+    When an authentik instance has gone into read-only mode, the following actions can still be done:
+
+    - Users can authenticate and authorize applications
+    - Licenses can be modified
+    - Users can be modified/deleted <span class="badge badge--version">authentik 2024.12+</span>
+
+    Once the user count returns to be within the limits of the license, authentik will return to the standard read-write mode and the notification will disappear.
 
 ### About users and licenses
 

--- a/website/docs/enterprise/manage-enterprise.md
+++ b/website/docs/enterprise/manage-enterprise.md
@@ -103,13 +103,13 @@ The following events occur when a license expires or the internal/external user 
 
 - After another 2 weeks, the authentik Enterprise instance becomes "read-only"
 
-    When an authentik instance has gone into read-only mode, the following actions can still be done:
+    When an authentik instance is in read-only mode, the following actions are still possible:
 
     - Users can authenticate and authorize applications
     - Licenses can be modified
     - Users can be modified/deleted <span class="badge badge--version">authentik 2024.10.5+</span>
 
-    Once the user count returns to be within the limits of the license, authentik will return to the standard read-write mode and the notification will disappear.
+    After the violation is corrected (either the user count returns to be within the limits of the license or the license is renewed), authentik will return to the standard read-write mode and the notification will disappear.
 
 ### About users and licenses
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
