### PR TITLE
enterprise/stages/authenticator_endpoint_gdtc: don't set frame options globally

### DIFF
--- a/authentik/enterprise/stages/authenticator_endpoint_gdtc/views/dtc.py
+++ b/authentik/enterprise/stages/authenticator_endpoint_gdtc/views/dtc.py
@@ -4,7 +4,9 @@ from typing import Any
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
+from django.utils.decorators import method_decorator
 from django.views import View
+from django.views.decorators.clickjacking import xframe_options_sameorigin
 from googleapiclient.discovery import build
 
 from authentik.enterprise.stages.authenticator_endpoint_gdtc.models import (
@@ -26,6 +28,7 @@ HEADER_ACCESS_CHALLENGE_RESPONSE = "X-Verified-Access-Challenge-Response"
 DEVICE_TRUST_VERIFIED_ACCESS = "VerifiedAccess"
 
 
+@method_decorator(xframe_options_sameorigin, name="dispatch")
 class GoogleChromeDeviceTrustConnector(View):
     """Google Chrome Device-trust connector based endpoint authenticator"""
 

--- a/authentik/root/settings.py
+++ b/authentik/root/settings.py
@@ -40,7 +40,6 @@ LANGUAGE_COOKIE_NAME = "authentik_language"
 SESSION_COOKIE_NAME = "authentik_session"
 SESSION_COOKIE_DOMAIN = CONFIG.get("cookie_domain", None)
 APPEND_SLASH = False
-X_FRAME_OPTIONS = "SAMEORIGIN"
 
 AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Fix W019 error on startup

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
