### PR TITLE
website: enable docusaurus faster option

### DIFF
--- a/website/babel.config.js
+++ b/website/babel.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-    presets: [require.resolve("@docusaurus/core/lib/babel/preset")],
-};

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -166,6 +166,9 @@ const createConfig = (): Config => {
         markdown: {
             mermaid: true,
         },
+        future: {
+            experimental_faster: true,
+        },
         themes: ["@docusaurus/theme-mermaid", "docusaurus-theme-openapi-docs"],
     };
 };

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -51,6 +51,9 @@
                 "@rspack/binding-darwin-arm64": "1.1.6",
                 "@rspack/binding-linux-arm64-gnu": "1.1.6",
                 "@rspack/binding-linux-x64-gnu": "1.1.6",
+                "@swc/core-darwin-arm64": "1.10.1",
+                "@swc/core-linux-arm64-gnu": "1.10.1",
+                "@swc/core-linux-x64-gnu": "1.10.1",
                 "lightningcss-darwin-arm64": "1.28.2",
                 "lightningcss-linux-arm64-gnu": "1.28.2",
                 "lightningcss-linux-x64-gnu": "1.28.2"
@@ -5282,9 +5285,9 @@
             }
         },
         "node_modules/@swc/core-darwin-arm64": {
-            "version": "1.10.18",
-            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.10.18.tgz",
-            "integrity": "sha512-FdGqzAIKVQJu8ROlnHElP59XAUsUzCFSNsou+tY/9ba+lhu8R9v0OI5wXiPErrKGZpQFMmx/BPqqhx3X4SuGNg==",
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.10.1.tgz",
+            "integrity": "sha512-NyELPp8EsVZtxH/mEqvzSyWpfPJ1lugpTQcSlMduZLj1EASLO4sC8wt8hmL1aizRlsbjCX+r0PyL+l0xQ64/6Q==",
             "cpu": [
                 "arm64"
             ],
@@ -5330,9 +5333,9 @@
             }
         },
         "node_modules/@swc/core-linux-arm64-gnu": {
-            "version": "1.10.18",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.10.18.tgz",
-            "integrity": "sha512-8f1kSktWzMB6PG+r8lOlCfXz5E8Qhsmfwonn77T/OfjvGwQaWrcoASh2cdjpk3dydbf8jsKGPQE1lSc7GyjXRQ==",
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.10.1.tgz",
+            "integrity": "sha512-tNQHO/UKdtnqjc7o04iRXng1wTUXPgVd8Y6LI4qIbHVoVPwksZydISjMcilKNLKIwOoUQAkxyJ16SlOAeADzhQ==",
             "cpu": [
                 "arm64"
             ],
@@ -5362,9 +5365,9 @@
             }
         },
         "node_modules/@swc/core-linux-x64-gnu": {
-            "version": "1.10.18",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.10.18.tgz",
-            "integrity": "sha512-vTNmyRBVP+sZca+vtwygYPGTNudTU6Gl6XhaZZ7cEUTBr8xvSTgEmYXoK/2uzyXpaTUI4Bmtp1x81cGN0mMoLQ==",
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.10.1.tgz",
+            "integrity": "sha512-yyYEwQcObV3AUsC79rSzN9z6kiWxKAVJ6Ntwq2N9YoZqSPYph+4/Am5fM1xEQYf/kb99csj0FgOelomJSobxQA==",
             "cpu": [
                 "x64"
             ],
@@ -5436,6 +5439,54 @@
             "optional": true,
             "os": [
                 "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core/node_modules/@swc/core-darwin-arm64": {
+            "version": "1.10.18",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.10.18.tgz",
+            "integrity": "sha512-FdGqzAIKVQJu8ROlnHElP59XAUsUzCFSNsou+tY/9ba+lhu8R9v0OI5wXiPErrKGZpQFMmx/BPqqhx3X4SuGNg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core/node_modules/@swc/core-linux-arm64-gnu": {
+            "version": "1.10.18",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.10.18.tgz",
+            "integrity": "sha512-8f1kSktWzMB6PG+r8lOlCfXz5E8Qhsmfwonn77T/OfjvGwQaWrcoASh2cdjpk3dydbf8jsKGPQE1lSc7GyjXRQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core/node_modules/@swc/core-linux-x64-gnu": {
+            "version": "1.10.18",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.10.18.tgz",
+            "integrity": "sha512-vTNmyRBVP+sZca+vtwygYPGTNudTU6Gl6XhaZZ7cEUTBr8xvSTgEmYXoK/2uzyXpaTUI4Bmtp1x81cGN0mMoLQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
             ],
             "engines": {
                 "node": ">=10"

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -50,7 +50,10 @@
             "optionalDependencies": {
                 "@rspack/binding-darwin-arm64": "1.1.6",
                 "@rspack/binding-linux-arm64-gnu": "1.1.6",
-                "@rspack/binding-linux-x64-gnu": "1.1.6"
+                "@rspack/binding-linux-x64-gnu": "1.1.6",
+                "lightningcss-darwin-arm64": "1.28.2",
+                "lightningcss-linux-arm64-gnu": "1.28.2",
+                "lightningcss-linux-x64-gnu": "1.28.2"
             }
         },
         "node_modules/@algolia/autocomplete-core": {
@@ -4732,9 +4735,9 @@
             }
         },
         "node_modules/@rspack/binding-darwin-arm64": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.2.5.tgz",
-            "integrity": "sha512-ou0NXMLp6RxY9Bx8P9lA8ArVjz/WAI/gSu5kKrdKKtMs6WKutl4vvP9A4HHZnISd9Tn00dlvDwNeNSUR7fjoDQ==",
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.1.6.tgz",
+            "integrity": "sha512-x9dxm2yyiMuL1FBwvWNNMs2/mEUJmRoSRgYb8pblR7HDaTRORrjBFCqhaYlGyAqtQaeUy7o2VAQlE0BavIiFYA==",
             "cpu": [
                 "arm64"
             ],
@@ -4742,8 +4745,7 @@
             "optional": true,
             "os": [
                 "darwin"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rspack/binding-darwin-x64": {
             "version": "1.2.5",
@@ -4760,9 +4762,9 @@
             "peer": true
         },
         "node_modules/@rspack/binding-linux-arm64-gnu": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.5.tgz",
-            "integrity": "sha512-jznk/CI/wN93fr8I1j3la/CAiGf8aG7ZHIpRBtT4CkNze0c5BcF3AaJVSBHVNQqgSv0qddxMt3SADpzV8rWZ6g==",
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.6.tgz",
+            "integrity": "sha512-4atnoknJx/c3KaQElsMIxHMpPf2jcRRdWsH/SdqJIRSrkWWakMK9Yv4TFwH680I4HDTMf1XLboMVScHzW8e+Mg==",
             "cpu": [
                 "arm64"
             ],
@@ -4770,8 +4772,7 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rspack/binding-linux-arm64-musl": {
             "version": "1.2.5",
@@ -4788,9 +4789,9 @@
             "peer": true
         },
         "node_modules/@rspack/binding-linux-x64-gnu": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.5.tgz",
-            "integrity": "sha512-dzEKs8oi86Vi+TFRCPpgmfF5ANL0VmlZN45e1An7HipeI2C5B1xrz/H8V43vPy8XEvQuMmkXO6Sp82A0zlHvIA==",
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.6.tgz",
+            "integrity": "sha512-MTjDEfPn4TwHoqs5d5Fck06kmXiTHZctGIcRVfrpg0RK0r1NLEHN+oosavRZ9c9H70f34+NmcHk+/qvV4c8lWg==",
             "cpu": [
                 "x64"
             ],
@@ -4798,8 +4799,7 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rspack/binding-linux-x64-musl": {
             "version": "1.2.5",
@@ -4857,10 +4857,24 @@
             ],
             "peer": true
         },
-        "node_modules/@rspack/binding-linux-arm64-gnu": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.6.tgz",
-            "integrity": "sha512-4atnoknJx/c3KaQElsMIxHMpPf2jcRRdWsH/SdqJIRSrkWWakMK9Yv4TFwH680I4HDTMf1XLboMVScHzW8e+Mg==",
+        "node_modules/@rspack/binding/node_modules/@rspack/binding-darwin-arm64": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.2.5.tgz",
+            "integrity": "sha512-ou0NXMLp6RxY9Bx8P9lA8ArVjz/WAI/gSu5kKrdKKtMs6WKutl4vvP9A4HHZnISd9Tn00dlvDwNeNSUR7fjoDQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true
+        },
+        "node_modules/@rspack/binding/node_modules/@rspack/binding-linux-arm64-gnu": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.5.tgz",
+            "integrity": "sha512-jznk/CI/wN93fr8I1j3la/CAiGf8aG7ZHIpRBtT4CkNze0c5BcF3AaJVSBHVNQqgSv0qddxMt3SADpzV8rWZ6g==",
             "cpu": [
                 "arm64"
             ],
@@ -4868,12 +4882,13 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
-        "node_modules/@rspack/binding-linux-x64-gnu": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.6.tgz",
-            "integrity": "sha512-MTjDEfPn4TwHoqs5d5Fck06kmXiTHZctGIcRVfrpg0RK0r1NLEHN+oosavRZ9c9H70f34+NmcHk+/qvV4c8lWg==",
+        "node_modules/@rspack/binding/node_modules/@rspack/binding-linux-x64-gnu": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.5.tgz",
+            "integrity": "sha512-dzEKs8oi86Vi+TFRCPpgmfF5ANL0VmlZN45e1An7HipeI2C5B1xrz/H8V43vPy8XEvQuMmkXO6Sp82A0zlHvIA==",
             "cpu": [
                 "x64"
             ],
@@ -4881,7 +4896,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rspack/core": {
             "version": "1.2.5",
@@ -13497,9 +13513,9 @@
             }
         },
         "node_modules/lightningcss-darwin-arm64": {
-            "version": "1.29.1",
-            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.29.1.tgz",
-            "integrity": "sha512-HtR5XJ5A0lvCqYAoSv2QdZZyoHNttBpa5EP9aNuzBQeKGfbyH5+UipLWvVzpP4Uml5ej4BYs5I9Lco9u1fECqw==",
+            "version": "1.28.2",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.28.2.tgz",
+            "integrity": "sha512-/8cPSqZiusHSS+WQz0W4NuaqFjquys1x+NsdN/XOHb+idGHJSoJ7SoQTVl3DZuAgtPZwFZgRfb/vd1oi8uX6+g==",
             "cpu": [
                 "arm64"
             ],
@@ -13577,9 +13593,9 @@
             }
         },
         "node_modules/lightningcss-linux-arm64-gnu": {
-            "version": "1.29.1",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.29.1.tgz",
-            "integrity": "sha512-0+vClRIZ6mmJl/dxGuRsE197o1HDEeeRk6nzycSy2GofC2JsY4ifCRnvUWf/CUBQmlrvMzt6SMQNMSEu22csWQ==",
+            "version": "1.28.2",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.28.2.tgz",
+            "integrity": "sha512-nhfjYkfymWZSxdtTNMWyhFk2ImUm0X7NAgJWFwnsYPOfmtWQEapzG/DXZTfEfMjSzERNUNJoQjPAbdqgB+sjiw==",
             "cpu": [
                 "arm64"
             ],
@@ -13617,9 +13633,9 @@
             }
         },
         "node_modules/lightningcss-linux-x64-gnu": {
-            "version": "1.29.1",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.29.1.tgz",
-            "integrity": "sha512-u1S+xdODy/eEtjADqirA774y3jLcm8RPtYztwReEXoZKdzgsHYPl0s5V52Tst+GKzqjebkULT86XMSxejzfISw==",
+            "version": "1.28.2",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.28.2.tgz",
+            "integrity": "sha512-ZhQy0FcO//INWUdo/iEdbefntTdpPVQ0XJwwtdbBuMQe+uxqZoytm9M+iqR9O5noWFaxK+nbS2iR/I80Q2Ofpg==",
             "cpu": [
                 "x64"
             ],
@@ -13687,6 +13703,66 @@
             "optional": true,
             "os": [
                 "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss/node_modules/lightningcss-darwin-arm64": {
+            "version": "1.29.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.29.1.tgz",
+            "integrity": "sha512-HtR5XJ5A0lvCqYAoSv2QdZZyoHNttBpa5EP9aNuzBQeKGfbyH5+UipLWvVzpP4Uml5ej4BYs5I9Lco9u1fECqw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss/node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.29.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.29.1.tgz",
+            "integrity": "sha512-0+vClRIZ6mmJl/dxGuRsE197o1HDEeeRk6nzycSy2GofC2JsY4ifCRnvUWf/CUBQmlrvMzt6SMQNMSEu22csWQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss/node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.29.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.29.1.tgz",
+            "integrity": "sha512-u1S+xdODy/eEtjADqirA774y3jLcm8RPtYztwReEXoZKdzgsHYPl0s5V52Tst+GKzqjebkULT86XMSxejzfISw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
             ],
             "engines": {
                 "node": ">= 12.0.0"

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -10,6 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "@docusaurus/core": "^3.7.0",
+                "@docusaurus/faster": "^3.7.0",
                 "@docusaurus/plugin-client-redirects": "^3.7.0",
                 "@docusaurus/plugin-content-docs": "^3.7.0",
                 "@docusaurus/preset-classic": "^3.7.0",
@@ -3224,6 +3225,186 @@
                 "node": ">=18.0"
             }
         },
+        "node_modules/@docusaurus/faster": {
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/@docusaurus/faster/-/faster-3.7.0.tgz",
+            "integrity": "sha512-d+7uyOEs3SBk38i2TL79N6mFaP7J4knc5lPX/W9od+jplXZhnDdl5ZMh2u2Lg7JxGV/l33Bd7h/xwv4mr21zag==",
+            "license": "MIT",
+            "dependencies": {
+                "@docusaurus/types": "3.7.0",
+                "@rspack/core": "1.2.0-alpha.0",
+                "@swc/core": "^1.7.39",
+                "@swc/html": "^1.7.39",
+                "browserslist": "^4.24.2",
+                "lightningcss": "^1.27.0",
+                "swc-loader": "^0.2.6",
+                "tslib": "^2.6.0",
+                "webpack": "^5.95.0"
+            },
+            "engines": {
+                "node": ">=18.0"
+            },
+            "peerDependencies": {
+                "@docusaurus/types": "*"
+            }
+        },
+        "node_modules/@docusaurus/faster/node_modules/@rspack/binding": {
+            "version": "1.2.0-alpha.0",
+            "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.2.0-alpha.0.tgz",
+            "integrity": "sha512-rtmDScjtGUxv1zA1m3jXecuX2LsgNp4aWaAjOowHasoO1YqfHK0fMyprCiPowTjoHtpZ7Xt/tnMhii0GlGIITQ==",
+            "license": "MIT",
+            "optionalDependencies": {
+                "@rspack/binding-darwin-arm64": "1.2.0-alpha.0",
+                "@rspack/binding-darwin-x64": "1.2.0-alpha.0",
+                "@rspack/binding-linux-arm64-gnu": "1.2.0-alpha.0",
+                "@rspack/binding-linux-arm64-musl": "1.2.0-alpha.0",
+                "@rspack/binding-linux-x64-gnu": "1.2.0-alpha.0",
+                "@rspack/binding-linux-x64-musl": "1.2.0-alpha.0",
+                "@rspack/binding-win32-arm64-msvc": "1.2.0-alpha.0",
+                "@rspack/binding-win32-ia32-msvc": "1.2.0-alpha.0",
+                "@rspack/binding-win32-x64-msvc": "1.2.0-alpha.0"
+            }
+        },
+        "node_modules/@docusaurus/faster/node_modules/@rspack/binding-darwin-arm64": {
+            "version": "1.2.0-alpha.0",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.2.0-alpha.0.tgz",
+            "integrity": "sha512-EPprIe6BrkJ9XuWL5HBXJFaH4vvt5C2kBTvyu+t5E3wacyH9A0gIDaMOEmH30Kt3zl4B07OCBC1nCiJ1sTtimw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@docusaurus/faster/node_modules/@rspack/binding-darwin-x64": {
+            "version": "1.2.0-alpha.0",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.2.0-alpha.0.tgz",
+            "integrity": "sha512-ACwdgWg0V9j0o3gs1wvhqRJ4xui82L+Fii9Fa74az7P974iWO0ZHw4QIUaO5r434+v9OWMqpyBRN1M7cBrx3GA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@docusaurus/faster/node_modules/@rspack/binding-linux-arm64-gnu": {
+            "version": "1.2.0-alpha.0",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.0-alpha.0.tgz",
+            "integrity": "sha512-Ex9SviDikz9E36R4I5si/626FsYOJ35l1Lb+DCRUijjjsvoq4k8Shi8csyBfubR+JZ1M0uOXjJftu1Gm5z8Q0Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@docusaurus/faster/node_modules/@rspack/binding-linux-arm64-musl": {
+            "version": "1.2.0-alpha.0",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.0-alpha.0.tgz",
+            "integrity": "sha512-U320xZmTcTwQ0BR8yIzE1L4olMCqzYkT3VFjXPR6iok/Mj0xjfk/SiKhLoZml473qQrHSGaFJ321cp02zgTFJg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@docusaurus/faster/node_modules/@rspack/binding-linux-x64-gnu": {
+            "version": "1.2.0-alpha.0",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.0-alpha.0.tgz",
+            "integrity": "sha512-GNur7VXJ29NtJhY8PYgv3Fv1Zxbx0XZhDUj/+7Wp40CAXRFsLgXScZIRh2U30TECYaihboZ7BD+xugv8MQPDoA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@docusaurus/faster/node_modules/@rspack/binding-linux-x64-musl": {
+            "version": "1.2.0-alpha.0",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.0-alpha.0.tgz",
+            "integrity": "sha512-0IdswzpG9+sgxvGu7KTwSeqfV0hvciaHMoZvGklfZa2txpcUqAg4ASp7uxrNaUo+G2a1fTUMOtP9351Cnl8DBg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@docusaurus/faster/node_modules/@rspack/binding-win32-arm64-msvc": {
+            "version": "1.2.0-alpha.0",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.0-alpha.0.tgz",
+            "integrity": "sha512-FcFgoWGjSrCfJwDZY5bDA2aO02l5BP7qdyW6ehjwBiMxNZyeSbGvKz3jXl5TtTHR1IgdLzi9kEJkTPYLLMiE1A==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@docusaurus/faster/node_modules/@rspack/binding-win32-ia32-msvc": {
+            "version": "1.2.0-alpha.0",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.2.0-alpha.0.tgz",
+            "integrity": "sha512-cZYFJw6DKCaPPz9VDJPndZ9KSp+/eedgt11Mv8OTpq+MJTUjB2HjtcjqJh8xxVcp3IuwvSMndTkC69WWt/4feA==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@docusaurus/faster/node_modules/@rspack/binding-win32-x64-msvc": {
+            "version": "1.2.0-alpha.0",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.0-alpha.0.tgz",
+            "integrity": "sha512-gfOqb/rq5716NV+Vbk5MteBhV4VhJeSoh2+dRQjdy4EN1wPZ+Uebs9ORVrT9uRjY3JrPn/5PkAHJXtgaOA9Uyg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@docusaurus/faster/node_modules/@rspack/core": {
+            "version": "1.2.0-alpha.0",
+            "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.2.0-alpha.0.tgz",
+            "integrity": "sha512-YiD0vFDj+PfHs3ZqJwPNhTYyVTb4xR6FpOI5WJ4jJHV4lgdErS+RChTCPhf1xeqxfuTSSnFA7UeqosLhBuNSqQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/runtime-tools": "0.8.4",
+                "@rspack/binding": "1.2.0-alpha.0",
+                "@rspack/lite-tapable": "1.0.1",
+                "caniuse-lite": "^1.0.30001616"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@swc/helpers": ">=0.5.1"
+            },
+            "peerDependenciesMeta": {
+                "@swc/helpers": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@docusaurus/logger": {
             "version": "3.7.0",
             "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.7.0.tgz",
@@ -4062,6 +4243,51 @@
                 "langium": "3.0.0"
             }
         },
+        "node_modules/@module-federation/error-codes": {
+            "version": "0.8.4",
+            "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.8.4.tgz",
+            "integrity": "sha512-55LYmrDdKb4jt+qr8qE8U3al62ZANp3FhfVaNPOaAmdTh0jHdD8M3yf5HKFlr5xVkVO4eV/F/J2NCfpbh+pEXQ==",
+            "license": "MIT"
+        },
+        "node_modules/@module-federation/runtime": {
+            "version": "0.8.4",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.8.4.tgz",
+            "integrity": "sha512-yZeZ7z2Rx4gv/0E97oLTF3V6N25vglmwXGgoeju/W2YjsFvWzVtCDI7zRRb0mJhU6+jmSM8jP1DeQGbea/AiZQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/error-codes": "0.8.4",
+                "@module-federation/sdk": "0.8.4"
+            }
+        },
+        "node_modules/@module-federation/runtime-tools": {
+            "version": "0.8.4",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.8.4.tgz",
+            "integrity": "sha512-fjVOsItJ1u5YY6E9FnS56UDwZgqEQUrWFnouRiPtK123LUuqUI9FH4redZoKWlE1PB0ir1Z3tnqy8eFYzPO38Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/runtime": "0.8.4",
+                "@module-federation/webpack-bundler-runtime": "0.8.4"
+            }
+        },
+        "node_modules/@module-federation/sdk": {
+            "version": "0.8.4",
+            "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.8.4.tgz",
+            "integrity": "sha512-waABomIjg/5m1rPDBWYG4KUhS5r7OUUY7S+avpaVIY/tkPWB3ibRDKy2dNLLAMaLKq0u+B1qIdEp4NIWkqhqpg==",
+            "license": "MIT",
+            "dependencies": {
+                "isomorphic-rslog": "0.0.6"
+            }
+        },
+        "node_modules/@module-federation/webpack-bundler-runtime": {
+            "version": "0.8.4",
+            "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.8.4.tgz",
+            "integrity": "sha512-HggROJhvHPUX7uqBD/XlajGygMNM1DG0+4OAkk8MBQe4a18QzrRNzZt6XQbRTSG4OaEoyRWhQHvYD3Yps405tQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/runtime": "0.8.4",
+                "@module-federation/sdk": "0.8.4"
+            }
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4481,6 +4707,189 @@
                 }
             }
         },
+        "node_modules/@rspack/binding": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.2.5.tgz",
+            "integrity": "sha512-q9vQmGDFZyFVMULwOFL7488WNSgn4ue94R/njDLMMIPF4K0oEJP2QT02elfG4KVGv2CbP63D7vEFN4ZNreo/Rw==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "optionalDependencies": {
+                "@rspack/binding-darwin-arm64": "1.2.5",
+                "@rspack/binding-darwin-x64": "1.2.5",
+                "@rspack/binding-linux-arm64-gnu": "1.2.5",
+                "@rspack/binding-linux-arm64-musl": "1.2.5",
+                "@rspack/binding-linux-x64-gnu": "1.2.5",
+                "@rspack/binding-linux-x64-musl": "1.2.5",
+                "@rspack/binding-win32-arm64-msvc": "1.2.5",
+                "@rspack/binding-win32-ia32-msvc": "1.2.5",
+                "@rspack/binding-win32-x64-msvc": "1.2.5"
+            }
+        },
+        "node_modules/@rspack/binding-darwin-arm64": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.2.5.tgz",
+            "integrity": "sha512-ou0NXMLp6RxY9Bx8P9lA8ArVjz/WAI/gSu5kKrdKKtMs6WKutl4vvP9A4HHZnISd9Tn00dlvDwNeNSUR7fjoDQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true
+        },
+        "node_modules/@rspack/binding-darwin-x64": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.2.5.tgz",
+            "integrity": "sha512-RdvH9YongQlDE9+T2Xh5D2+dyiLHx2Gz38Af1uObyBRNWjF1qbuR51hOas0f2NFUdyA03j1+HWZCbE7yZrmI3w==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true
+        },
+        "node_modules/@rspack/binding-linux-arm64-gnu": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.5.tgz",
+            "integrity": "sha512-jznk/CI/wN93fr8I1j3la/CAiGf8aG7ZHIpRBtT4CkNze0c5BcF3AaJVSBHVNQqgSv0qddxMt3SADpzV8rWZ6g==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true
+        },
+        "node_modules/@rspack/binding-linux-arm64-musl": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.5.tgz",
+            "integrity": "sha512-oYzcaJ0xjb1fWbbtPmjjPXeehExEgwJ8fEGYQ5TikB+p9oCLkAghnNjsz9evUhgjByxi+NTZ1YmUNwxRuQDY1Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true
+        },
+        "node_modules/@rspack/binding-linux-x64-gnu": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.5.tgz",
+            "integrity": "sha512-dzEKs8oi86Vi+TFRCPpgmfF5ANL0VmlZN45e1An7HipeI2C5B1xrz/H8V43vPy8XEvQuMmkXO6Sp82A0zlHvIA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true
+        },
+        "node_modules/@rspack/binding-linux-x64-musl": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.5.tgz",
+            "integrity": "sha512-4ENeVPVSD97rRRGr6kJSm4sIPf1tKJ8vlr9hJi4sSvF7eMLWipSwIVmqRXJ2riVMRjYD2einmJ9KzI8rqQ2OwA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true
+        },
+        "node_modules/@rspack/binding-win32-arm64-msvc": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.5.tgz",
+            "integrity": "sha512-WUoJvX/z43MWeW1JKAQIxdvqH02oLzbaGMCzIikvniZnakQovYLPH6tCYh7qD3p7uQsm+IafFddhFxTtogC3pg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true
+        },
+        "node_modules/@rspack/binding-win32-ia32-msvc": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.2.5.tgz",
+            "integrity": "sha512-YzPvmt/gpiacE6aAacz4dxgEbNWwoKYPaT4WYy/oITobnAui++iCFXC4IICSmlpoA1y7O8K3Qb9jbaB/lLhbwA==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true
+        },
+        "node_modules/@rspack/binding-win32-x64-msvc": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.5.tgz",
+            "integrity": "sha512-QDDshfteMZiglllm7WUh/ITemFNuexwn1Yul7cHBFGQu6HqtqKNAR0kGR8J3e15MPMlinSaygVpfRE4A0KPmjQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true
+        },
+        "node_modules/@rspack/core": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.2.5.tgz",
+            "integrity": "sha512-x/riOl05gOVGgGQFimBqS5i8XbUpBxPIKUC+tDX4hmNNkzxRaGpspZfNtcL+1HBMyYuoM6fOWGyCp2R290Uy6g==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@module-federation/runtime-tools": "0.8.4",
+                "@rspack/binding": "1.2.5",
+                "@rspack/lite-tapable": "1.0.1",
+                "caniuse-lite": "^1.0.30001616"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@rspack/tracing": "^1.x",
+                "@swc/helpers": ">=0.5.1"
+            },
+            "peerDependenciesMeta": {
+                "@rspack/tracing": {
+                    "optional": true
+                },
+                "@swc/helpers": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rspack/lite-tapable": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rspack/lite-tapable/-/lite-tapable-1.0.1.tgz",
+            "integrity": "sha512-VynGOEsVw2s8TAlLf/uESfrgfrq2+rcXB1muPJYBWbsm1Oa6r5qVQhjA5ggM6z/coYPrsVMgovl3Ff7Q7OCp1w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/@sideway/address": {
             "version": "4.1.4",
             "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -4785,6 +5194,403 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/gregberge"
+            }
+        },
+        "node_modules/@swc/core": {
+            "version": "1.10.18",
+            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.10.18.tgz",
+            "integrity": "sha512-IUWKD6uQYGRy8w2X9EZrtYg1O3SCijlHbCXzMaHQYc1X7yjijQh4H3IVL9ssZZyVp2ZDfQZu4bD5DWxxvpyjvg==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@swc/counter": "^0.1.3",
+                "@swc/types": "^0.1.17"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/swc"
+            },
+            "optionalDependencies": {
+                "@swc/core-darwin-arm64": "1.10.18",
+                "@swc/core-darwin-x64": "1.10.18",
+                "@swc/core-linux-arm-gnueabihf": "1.10.18",
+                "@swc/core-linux-arm64-gnu": "1.10.18",
+                "@swc/core-linux-arm64-musl": "1.10.18",
+                "@swc/core-linux-x64-gnu": "1.10.18",
+                "@swc/core-linux-x64-musl": "1.10.18",
+                "@swc/core-win32-arm64-msvc": "1.10.18",
+                "@swc/core-win32-ia32-msvc": "1.10.18",
+                "@swc/core-win32-x64-msvc": "1.10.18"
+            },
+            "peerDependencies": {
+                "@swc/helpers": "*"
+            },
+            "peerDependenciesMeta": {
+                "@swc/helpers": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@swc/core-darwin-arm64": {
+            "version": "1.10.18",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.10.18.tgz",
+            "integrity": "sha512-FdGqzAIKVQJu8ROlnHElP59XAUsUzCFSNsou+tY/9ba+lhu8R9v0OI5wXiPErrKGZpQFMmx/BPqqhx3X4SuGNg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-darwin-x64": {
+            "version": "1.10.18",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.10.18.tgz",
+            "integrity": "sha512-RZ73gZRituL/ZVLgrW6BYnQ5g8tuStG4cLUiPGJsUZpUm0ullSH6lHFvZTCBNFTfpQChG6eEhi2IdG6DwFp1lw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-arm-gnueabihf": {
+            "version": "1.10.18",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.10.18.tgz",
+            "integrity": "sha512-8iJqI3EkxJuuq21UHoen1VS+QlS23RvynRuk95K+Q2HBjygetztCGGEc+Xelx9a0uPkDaaAtFvds4JMDqb9SAA==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-arm64-gnu": {
+            "version": "1.10.18",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.10.18.tgz",
+            "integrity": "sha512-8f1kSktWzMB6PG+r8lOlCfXz5E8Qhsmfwonn77T/OfjvGwQaWrcoASh2cdjpk3dydbf8jsKGPQE1lSc7GyjXRQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-arm64-musl": {
+            "version": "1.10.18",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.10.18.tgz",
+            "integrity": "sha512-4rv+E4VLdgQw6zjbTAauCAEExxChvxMpBUMCiZweTNPKbJJ2dY6BX2WGJ1ea8+RcgqR/Xysj3AFbOz1LBz6dGA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-x64-gnu": {
+            "version": "1.10.18",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.10.18.tgz",
+            "integrity": "sha512-vTNmyRBVP+sZca+vtwygYPGTNudTU6Gl6XhaZZ7cEUTBr8xvSTgEmYXoK/2uzyXpaTUI4Bmtp1x81cGN0mMoLQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-x64-musl": {
+            "version": "1.10.18",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.10.18.tgz",
+            "integrity": "sha512-1TZPReKhFCeX776XaT6wegknfg+g3zODve+r4oslFHI+g7cInfWlxoGNDS3niPKyuafgCdOjme2g3OF+zzxfsQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-win32-arm64-msvc": {
+            "version": "1.10.18",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.10.18.tgz",
+            "integrity": "sha512-o/2CsaWSN3bkzVQ6DA+BiFKSVEYvhWGA1h+wnL2zWmIDs2Knag54sOEXZkCaf8YQyZesGeXJtPEy9hh/vjJgkA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-win32-ia32-msvc": {
+            "version": "1.10.18",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.10.18.tgz",
+            "integrity": "sha512-eTPASeJtk4mJDfWiYEiOC6OYUi/N7meHbNHcU8e+aKABonhXrIo/FmnTE8vsUtC6+jakT1TQBdiQ8fzJ1kJVwA==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-win32-x64-msvc": {
+            "version": "1.10.18",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.10.18.tgz",
+            "integrity": "sha512-1Dud8CDBnc34wkBOboFBQud9YlV1bcIQtKSg7zC8LtwR3h+XAaCayZPkpGmmAlCv1DLQPvkF+s0JcaVC9mfffQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/counter": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+            "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+            "license": "Apache-2.0"
+        },
+        "node_modules/@swc/html": {
+            "version": "1.10.18",
+            "resolved": "https://registry.npmjs.org/@swc/html/-/html-1.10.18.tgz",
+            "integrity": "sha512-wGSDnY1yXOrSLyLPfl/SJqw785fa9djJCAFE/4/aaB1x1R78jDBNM9yL592IkKOXtGFZsshR9ecy26RT2PySIw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@swc/counter": "^0.1.3"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "optionalDependencies": {
+                "@swc/html-darwin-arm64": "1.10.18",
+                "@swc/html-darwin-x64": "1.10.18",
+                "@swc/html-linux-arm-gnueabihf": "1.10.18",
+                "@swc/html-linux-arm64-gnu": "1.10.18",
+                "@swc/html-linux-arm64-musl": "1.10.18",
+                "@swc/html-linux-x64-gnu": "1.10.18",
+                "@swc/html-linux-x64-musl": "1.10.18",
+                "@swc/html-win32-arm64-msvc": "1.10.18",
+                "@swc/html-win32-ia32-msvc": "1.10.18",
+                "@swc/html-win32-x64-msvc": "1.10.18"
+            }
+        },
+        "node_modules/@swc/html-darwin-arm64": {
+            "version": "1.10.18",
+            "resolved": "https://registry.npmjs.org/@swc/html-darwin-arm64/-/html-darwin-arm64-1.10.18.tgz",
+            "integrity": "sha512-D21RHFWy17nQePsHsqOgwXMl+fdnGSc5pV/R7/edFtZM71JOlnkO1NLX+W54cF18LtfNJ7aFrZ5Rr0YlPZd/Tw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html-darwin-x64": {
+            "version": "1.10.18",
+            "resolved": "https://registry.npmjs.org/@swc/html-darwin-x64/-/html-darwin-x64-1.10.18.tgz",
+            "integrity": "sha512-hLSM/jWz8msPXwH2siyhNfqG1LXB+24W67BHjFh0bS7eAuIvbj7wWiMBjf2KLLKlq5WlIEliiGB9qHB1Dyal3w==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html-linux-arm-gnueabihf": {
+            "version": "1.10.18",
+            "resolved": "https://registry.npmjs.org/@swc/html-linux-arm-gnueabihf/-/html-linux-arm-gnueabihf-1.10.18.tgz",
+            "integrity": "sha512-h4vdQk/AN2LfyinE6vqjeSwIP9uOj0uG3RB8Zj4F9qxIsKjk9WcZmCuyZKslLJM+a1DICtKJPu4poMtMXZJiLQ==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html-linux-arm64-gnu": {
+            "version": "1.10.18",
+            "resolved": "https://registry.npmjs.org/@swc/html-linux-arm64-gnu/-/html-linux-arm64-gnu-1.10.18.tgz",
+            "integrity": "sha512-hkqbeApRyldLLrrkU6tnXe06UrB97yFEDsJ4pyPIP5luWtoMAo0vz1UrOyBTN96rTF6Mocfk6huhVe2tnZQf8A==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html-linux-arm64-musl": {
+            "version": "1.10.18",
+            "resolved": "https://registry.npmjs.org/@swc/html-linux-arm64-musl/-/html-linux-arm64-musl-1.10.18.tgz",
+            "integrity": "sha512-4Xpl7WVDqOWWkTgkH5f0j3v3jLwYDKyhEwPLdGtKPwK0Oi2989Y+E09i093a4jSfpqeEN2IRgJJLOKC2jMZi1A==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html-linux-x64-gnu": {
+            "version": "1.10.18",
+            "resolved": "https://registry.npmjs.org/@swc/html-linux-x64-gnu/-/html-linux-x64-gnu-1.10.18.tgz",
+            "integrity": "sha512-Cf64i7gEMEzP/7SOpaqD41AMLpdSL+fbSIukVEFDJryttILahLWrHrVjpgXaQQfWqOsAYhFwVpn57Xd2WgD/Cg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html-linux-x64-musl": {
+            "version": "1.10.18",
+            "resolved": "https://registry.npmjs.org/@swc/html-linux-x64-musl/-/html-linux-x64-musl-1.10.18.tgz",
+            "integrity": "sha512-ThhW9E5zQkaAggNurHdCeEbZVj3fda5XBzxpO8h4kMW5qR5lChsB5tG3TDYLsNsaLDkGDaVFUd9lCpF5KEG6pQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html-win32-arm64-msvc": {
+            "version": "1.10.18",
+            "resolved": "https://registry.npmjs.org/@swc/html-win32-arm64-msvc/-/html-win32-arm64-msvc-1.10.18.tgz",
+            "integrity": "sha512-ON4RZD7gjVJOGBriNeU7q4xRS4OyRmn8hesU8GS5QZafy9jFPA/jUYDOfWC2ValfI6OkbXW6w3wECPUr3izm6Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html-win32-ia32-msvc": {
+            "version": "1.10.18",
+            "resolved": "https://registry.npmjs.org/@swc/html-win32-ia32-msvc/-/html-win32-ia32-msvc-1.10.18.tgz",
+            "integrity": "sha512-bfHqrSNk/dySpQp+AtCn4bz7CWoz6fBLAxzWlTihmBh5Fw/8k3mOWMEMGZgpAIDXbkaRW3SYpwtPEew/OH6uXw==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html-win32-x64-msvc": {
+            "version": "1.10.18",
+            "resolved": "https://registry.npmjs.org/@swc/html-win32-x64-msvc/-/html-win32-x64-msvc-1.10.18.tgz",
+            "integrity": "sha512-+cMUoUJTge8qh+2Ulx80YOdpf2dK04zvhv6q87DCNFuwMcCDnoSxop6S+fXV6n5pKNtBqHwpQAEH/LoMw5OyEg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/types": {
+            "version": "0.1.17",
+            "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.17.tgz",
+            "integrity": "sha512-V5gRru+aD8YVyCOMAjMpWR1Ui577DD5KSJsHP8RAxopAH22jFz6GZd/qxqjO6MJHQhcsjvjOFXyDhyLQUnMveQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@swc/counter": "^0.1.3"
             }
         },
         "node_modules/@szmarczak/http-timer": {
@@ -8388,7 +9194,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
             "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-            "optional": true,
             "bin": {
                 "detect-libc": "bin/detect-libc.js"
             },
@@ -12286,6 +13091,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/isomorphic-rslog": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/isomorphic-rslog/-/isomorphic-rslog-0.0.6.tgz",
+            "integrity": "sha512-HM0q6XqQ93psDlqvuViNs/Ea3hAyGDkIdVAHlrEocjjAwGrs1fZ+EdQjS9eUPacnYB7Y8SoDdSY3H8p3ce205A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.17.6"
+            }
+        },
         "node_modules/jackspeak": {
             "version": "2.3.6",
             "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
@@ -12621,6 +13435,234 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/lightningcss": {
+            "version": "1.29.1",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.29.1.tgz",
+            "integrity": "sha512-FmGoeD4S05ewj+AkhTY+D+myDvXI6eL27FjHIjoyUkO/uw7WZD1fBVs0QxeYWa7E17CUHJaYX/RUGISCtcrG4Q==",
+            "license": "MPL-2.0",
+            "dependencies": {
+                "detect-libc": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-darwin-arm64": "1.29.1",
+                "lightningcss-darwin-x64": "1.29.1",
+                "lightningcss-freebsd-x64": "1.29.1",
+                "lightningcss-linux-arm-gnueabihf": "1.29.1",
+                "lightningcss-linux-arm64-gnu": "1.29.1",
+                "lightningcss-linux-arm64-musl": "1.29.1",
+                "lightningcss-linux-x64-gnu": "1.29.1",
+                "lightningcss-linux-x64-musl": "1.29.1",
+                "lightningcss-win32-arm64-msvc": "1.29.1",
+                "lightningcss-win32-x64-msvc": "1.29.1"
+            }
+        },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.29.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.29.1.tgz",
+            "integrity": "sha512-HtR5XJ5A0lvCqYAoSv2QdZZyoHNttBpa5EP9aNuzBQeKGfbyH5+UipLWvVzpP4Uml5ej4BYs5I9Lco9u1fECqw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.29.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.29.1.tgz",
+            "integrity": "sha512-k33G9IzKUpHy/J/3+9MCO4e+PzaFblsgBjSGlpAaFikeBFm8B/CkO3cKU9oI4g+fjS2KlkLM/Bza9K/aw8wsNA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.29.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.29.1.tgz",
+            "integrity": "sha512-0SUW22fv/8kln2LnIdOCmSuXnxgxVC276W5KLTwoehiO0hxkacBxjHOL5EtHD8BAXg2BvuhsJPmVMasvby3LiQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.29.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.29.1.tgz",
+            "integrity": "sha512-sD32pFvlR0kDlqsOZmYqH/68SqUMPNj+0pucGxToXZi4XZgZmqeX/NkxNKCPsswAXU3UeYgDSpGhu05eAufjDg==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.29.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.29.1.tgz",
+            "integrity": "sha512-0+vClRIZ6mmJl/dxGuRsE197o1HDEeeRk6nzycSy2GofC2JsY4ifCRnvUWf/CUBQmlrvMzt6SMQNMSEu22csWQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.29.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.29.1.tgz",
+            "integrity": "sha512-UKMFrG4rL/uHNgelBsDwJcBqVpzNJbzsKkbI3Ja5fg00sgQnHw/VrzUTEc4jhZ+AN2BvQYz/tkHu4vt1kLuJyw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.29.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.29.1.tgz",
+            "integrity": "sha512-u1S+xdODy/eEtjADqirA774y3jLcm8RPtYztwReEXoZKdzgsHYPl0s5V52Tst+GKzqjebkULT86XMSxejzfISw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.29.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.29.1.tgz",
+            "integrity": "sha512-L0Tx0DtaNUTzXv0lbGCLB/c/qEADanHbu4QdcNOXLIe1i8i22rZRpbT3gpWYsCh9aSL9zFujY/WmEXIatWvXbw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.29.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.29.1.tgz",
+            "integrity": "sha512-QoOVnkIEFfbW4xPi+dpdft/zAKmgLgsRHfJalEPYuJDOWf7cLQzYg0DEh8/sn737FaeMJxHZRc1oBreiwZCjog==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.29.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.29.1.tgz",
+            "integrity": "sha512-NygcbThNBe4JElP+olyTI/doBNGJvLs3bFCRPdvuCcxZCcCZ71B858IHpdm7L1btZex0FvCmM17FK98Y9MRy1Q==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
             }
         },
         "node_modules/lilconfig": {
@@ -21006,6 +22048,19 @@
             },
             "funding": {
                 "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+            }
+        },
+        "node_modules/swc-loader": {
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/swc-loader/-/swc-loader-0.2.6.tgz",
+            "integrity": "sha512-9Zi9UP2YmDpgmQVbyOPJClY0dwf58JDyDMQ7uRc4krmc72twNI2fvlBWHLqVekBpPc7h5NJkGVT1zNDxFrqhvg==",
+            "license": "MIT",
+            "dependencies": {
+                "@swc/counter": "^0.1.3"
+            },
+            "peerDependencies": {
+                "@swc/core": "^1.2.147",
+                "webpack": ">=2"
             }
         },
         "node_modules/tapable": {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -54,6 +54,9 @@
                 "@swc/core-darwin-arm64": "1.10.1",
                 "@swc/core-linux-arm64-gnu": "1.10.1",
                 "@swc/core-linux-x64-gnu": "1.10.1",
+                "@swc/html-darwin-arm64": "1.10.1",
+                "@swc/html-linux-arm64-gnu": "1.10.1",
+                "@swc/html-linux-x64-gnu": "1.10.1",
                 "lightningcss-darwin-arm64": "1.28.2",
                 "lightningcss-linux-arm64-gnu": "1.28.2",
                 "lightningcss-linux-x64-gnu": "1.28.2"
@@ -5523,9 +5526,9 @@
             }
         },
         "node_modules/@swc/html-darwin-arm64": {
-            "version": "1.10.18",
-            "resolved": "https://registry.npmjs.org/@swc/html-darwin-arm64/-/html-darwin-arm64-1.10.18.tgz",
-            "integrity": "sha512-D21RHFWy17nQePsHsqOgwXMl+fdnGSc5pV/R7/edFtZM71JOlnkO1NLX+W54cF18LtfNJ7aFrZ5Rr0YlPZd/Tw==",
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/@swc/html-darwin-arm64/-/html-darwin-arm64-1.10.1.tgz",
+            "integrity": "sha512-Cp9yco2soX+RPbKRVn190CmMWghhX5c0SWabqvYRl6AjGzFH/2fDFeib4QRjWDdvJfiInFOMAu5WryVAZm8C6g==",
             "cpu": [
                 "arm64"
             ],
@@ -5571,9 +5574,9 @@
             }
         },
         "node_modules/@swc/html-linux-arm64-gnu": {
-            "version": "1.10.18",
-            "resolved": "https://registry.npmjs.org/@swc/html-linux-arm64-gnu/-/html-linux-arm64-gnu-1.10.18.tgz",
-            "integrity": "sha512-hkqbeApRyldLLrrkU6tnXe06UrB97yFEDsJ4pyPIP5luWtoMAo0vz1UrOyBTN96rTF6Mocfk6huhVe2tnZQf8A==",
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/@swc/html-linux-arm64-gnu/-/html-linux-arm64-gnu-1.10.1.tgz",
+            "integrity": "sha512-K9/8klH+S38CVQgkIND/vS3WsOvBGWR/rQum9NP3IHzrD+EJJKy4GYBSbUiw+lRZqNeXAaxfw2DL+DUCIyDotQ==",
             "cpu": [
                 "arm64"
             ],
@@ -5603,9 +5606,9 @@
             }
         },
         "node_modules/@swc/html-linux-x64-gnu": {
-            "version": "1.10.18",
-            "resolved": "https://registry.npmjs.org/@swc/html-linux-x64-gnu/-/html-linux-x64-gnu-1.10.18.tgz",
-            "integrity": "sha512-Cf64i7gEMEzP/7SOpaqD41AMLpdSL+fbSIukVEFDJryttILahLWrHrVjpgXaQQfWqOsAYhFwVpn57Xd2WgD/Cg==",
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/@swc/html-linux-x64-gnu/-/html-linux-x64-gnu-1.10.1.tgz",
+            "integrity": "sha512-wfiu2xYTKSpSh5bzTYw9uB9Bx+K4CBwF0GefdRfalOeQwOjmBhs00SqWdt707uFGJZkAw4nMkr62gxGSyLAxYQ==",
             "cpu": [
                 "x64"
             ],
@@ -5677,6 +5680,54 @@
             "optional": true,
             "os": [
                 "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html/node_modules/@swc/html-darwin-arm64": {
+            "version": "1.10.18",
+            "resolved": "https://registry.npmjs.org/@swc/html-darwin-arm64/-/html-darwin-arm64-1.10.18.tgz",
+            "integrity": "sha512-D21RHFWy17nQePsHsqOgwXMl+fdnGSc5pV/R7/edFtZM71JOlnkO1NLX+W54cF18LtfNJ7aFrZ5Rr0YlPZd/Tw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html/node_modules/@swc/html-linux-arm64-gnu": {
+            "version": "1.10.18",
+            "resolved": "https://registry.npmjs.org/@swc/html-linux-arm64-gnu/-/html-linux-arm64-gnu-1.10.18.tgz",
+            "integrity": "sha512-hkqbeApRyldLLrrkU6tnXe06UrB97yFEDsJ4pyPIP5luWtoMAo0vz1UrOyBTN96rTF6Mocfk6huhVe2tnZQf8A==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/html/node_modules/@swc/html-linux-x64-gnu": {
+            "version": "1.10.18",
+            "resolved": "https://registry.npmjs.org/@swc/html-linux-x64-gnu/-/html-linux-x64-gnu-1.10.18.tgz",
+            "integrity": "sha512-Cf64i7gEMEzP/7SOpaqD41AMLpdSL+fbSIukVEFDJryttILahLWrHrVjpgXaQQfWqOsAYhFwVpn57Xd2WgD/Cg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
             ],
             "engines": {
                 "node": ">=10"

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -46,6 +46,11 @@
             },
             "engines": {
                 "node": ">=20"
+            },
+            "optionalDependencies": {
+                "@rspack/binding-darwin-arm64": "1.1.6",
+                "@rspack/binding-linux-arm64-gnu": "1.1.6",
+                "@rspack/binding-linux-x64-gnu": "1.1.6"
             }
         },
         "node_modules/@algolia/autocomplete-core": {
@@ -4851,6 +4856,32 @@
                 "win32"
             ],
             "peer": true
+        },
+        "node_modules/@rspack/binding-linux-arm64-gnu": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.6.tgz",
+            "integrity": "sha512-4atnoknJx/c3KaQElsMIxHMpPf2jcRRdWsH/SdqJIRSrkWWakMK9Yv4TFwH680I4HDTMf1XLboMVScHzW8e+Mg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rspack/binding-linux-x64-gnu": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.6.tgz",
+            "integrity": "sha512-MTjDEfPn4TwHoqs5d5Fck06kmXiTHZctGIcRVfrpg0RK0r1NLEHN+oosavRZ9c9H70f34+NmcHk+/qvV4c8lWg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
         },
         "node_modules/@rspack/core": {
             "version": "1.2.5",

--- a/website/package.json
+++ b/website/package.json
@@ -73,7 +73,10 @@
         "lightningcss-linux-x64-gnu": "1.28.2",
         "@swc/core-darwin-arm64": "1.10.1",
         "@swc/core-linux-arm64-gnu": "1.10.1",
-        "@swc/core-linux-x64-gnu": "1.10.1"
+        "@swc/core-linux-x64-gnu": "1.10.1",
+        "@swc/html-darwin-arm64": "1.10.1",
+        "@swc/html-linux-arm64-gnu": "1.10.1",
+        "@swc/html-linux-x64-gnu": "1.10.1"
     },
     "wireit": {
         "lint:lockfile": {

--- a/website/package.json
+++ b/website/package.json
@@ -67,7 +67,10 @@
     "optionalDependencies": {
         "@rspack/binding-darwin-arm64": "1.1.6",
         "@rspack/binding-linux-arm64-gnu": "1.1.6",
-        "@rspack/binding-linux-x64-gnu": "1.1.6"
+        "@rspack/binding-linux-x64-gnu": "1.1.6",
+        "lightningcss-darwin-arm64": "1.28.2",
+        "lightningcss-linux-arm64-gnu": "1.28.2",
+        "lightningcss-linux-x64-gnu": "1.28.2"
     },
     "wireit": {
         "lint:lockfile": {

--- a/website/package.json
+++ b/website/package.json
@@ -19,6 +19,7 @@
     "dependencies": {
         "semver": "^7.7.1",
         "@docusaurus/core": "^3.7.0",
+        "@docusaurus/faster": "^3.7.0",
         "@docusaurus/plugin-client-redirects": "^3.7.0",
         "@docusaurus/plugin-content-docs": "^3.7.0",
         "@docusaurus/preset-classic": "^3.7.0",

--- a/website/package.json
+++ b/website/package.json
@@ -70,7 +70,10 @@
         "@rspack/binding-linux-x64-gnu": "1.1.6",
         "lightningcss-darwin-arm64": "1.28.2",
         "lightningcss-linux-arm64-gnu": "1.28.2",
-        "lightningcss-linux-x64-gnu": "1.28.2"
+        "lightningcss-linux-x64-gnu": "1.28.2",
+        "@swc/core-darwin-arm64": "1.10.1",
+        "@swc/core-linux-arm64-gnu": "1.10.1",
+        "@swc/core-linux-x64-gnu": "1.10.1"
     },
     "wireit": {
         "lint:lockfile": {

--- a/website/package.json
+++ b/website/package.json
@@ -64,6 +64,11 @@
         "typescript": "~5.7.3",
         "wireit": "^0.14.11"
     },
+    "optionalDependencies": {
+        "@rspack/binding-darwin-arm64": "1.1.6",
+        "@rspack/binding-linux-arm64-gnu": "1.1.6",
+        "@rspack/binding-linux-x64-gnu": "1.1.6"
+    },
     "wireit": {
         "lint:lockfile": {
             "__comment": "The lockfile-lint package does not have an option to ensure resolved hashes are set everywhere",


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Now that the OpenAPI plugin we use is update, we can enable this

(both on Apple M1 Pro 10 core)

Before:
```
________________________________________________________
Executed in  168.26 secs    fish           external
   usr time  286.63 secs   52.00 micros  286.63 secs
   sys time   24.98 secs  529.00 micros   24.98 secs
```

After:
```
________________________________________________________
Executed in   85.23 secs    fish           external
   usr time  116.19 secs    0.09 millis  116.19 secs
   sys time   16.43 secs    2.73 millis   16.43 secs
```

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
