### PR TITLE
website/docs: fix typo in device code auth example

### DIFF
--- a/website/docs/add-secure-apps/providers/oauth2/device_code.md
+++ b/website/docs/add-secure-apps/providers/oauth2/device_code.md
@@ -20,7 +20,7 @@ Host: authentik.company
 Content-Type: application/x-www-form-urlencoded
 
 client_id=application_client_id&
-scopes=openid email my-other-scope
+scope=openid email my-other-scope
 ```
 
 The response contains the following fields:


### PR DESCRIPTION
Corrected typo in device auth endpoint example. It's scope, not scopes.

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->

I was implementing a Device Code flow for the first time and was getting 403 errors with the received access token.
Upon decoding the token, I noticed a lack of claims/groups and such in the token.
Since I'd run into this problem before, I figured it was an issue with the scopes.
As it turns out, the example in this documentation lists "scopes" as the parameter, where it seems it is actually "scope" like the other auth endpoints.
Just changed that one letter. Did not run any tests or formatting. Just wanted to make sure this wasn't forgotten.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
