### PR TITLE
root: redis, make sure tlscacert isn't an empty string

### DIFF
--- a/internal/config/struct.go
+++ b/internal/config/struct.go
@@ -26,14 +26,14 @@ type Config struct {
 }
 
 type RedisConfig struct {
-	Host      string  `yaml:"host" env:"HOST, overwrite"`
-	Port      int     `yaml:"port" env:"PORT, overwrite"`
-	DB        int     `yaml:"db" env:"DB, overwrite"`
-	Username  string  `yaml:"username" env:"USERNAME, overwrite"`
-	Password  string  `yaml:"password" env:"PASSWORD, overwrite"`
-	TLS       bool    `yaml:"tls" env:"TLS, overwrite"`
-	TLSReqs   string  `yaml:"tls_reqs" env:"TLS_REQS, overwrite"`
-	TLSCaCert *string `yaml:"tls_ca_certs" env:"TLS_CA_CERT, overwrite"`
+	Host      string `yaml:"host" env:"HOST, overwrite"`
+	Port      int    `yaml:"port" env:"PORT, overwrite"`
+	DB        int    `yaml:"db" env:"DB, overwrite"`
+	Username  string `yaml:"username" env:"USERNAME, overwrite"`
+	Password  string `yaml:"password" env:"PASSWORD, overwrite"`
+	TLS       bool   `yaml:"tls" env:"TLS, overwrite"`
+	TLSReqs   string `yaml:"tls_reqs" env:"TLS_REQS, overwrite"`
+	TLSCaCert string `yaml:"tls_ca_certs" env:"TLS_CA_CERT, overwrite"`
 }
 
 type ListenConfig struct {

--- a/internal/outpost/proxyv2/application/session.go
+++ b/internal/outpost/proxyv2/application/session.go
@@ -45,15 +45,15 @@ func (a *Application) getStore(p api.ProxyOutpostConfig, externalHost *url.URL) 
 				break
 			}
 			ca := config.Get().Redis.TLSCaCert
-			if ca != nil && *ca != "" {
+			if ca != "" {
 				// Get the SystemCertPool, continue with an empty pool on error
 				rootCAs, _ := x509.SystemCertPool()
 				if rootCAs == nil {
 					rootCAs = x509.NewCertPool()
 				}
-				certs, err := os.ReadFile(*ca)
+				certs, err := os.ReadFile(ca)
 				if err != nil {
-					a.log.WithError(err).Fatalf("Failed to append %s to RootCAs", *ca)
+					a.log.WithError(err).Fatalf("Failed to append %s to RootCAs", ca)
 				}
 				// Append our cert to the system pool
 				if ok := rootCAs.AppendCertsFromPEM(certs); !ok {

--- a/internal/outpost/proxyv2/application/session.go
+++ b/internal/outpost/proxyv2/application/session.go
@@ -45,7 +45,7 @@ func (a *Application) getStore(p api.ProxyOutpostConfig, externalHost *url.URL) 
 				break
 			}
 			ca := config.Get().Redis.TLSCaCert
-			if ca != nil {
+			if ca != nil && *ca != "" {
 				// Get the SystemCertPool, continue with an empty pool on error
 				rootCAs, _ := x509.SystemCertPool()
 				if rootCAs == nil {


### PR DESCRIPTION
## Details

I'm provisioning Authentik via the Helm chart and I want to use Redis over TLS without CA validation:

```
authentik:
  redis:
    host: master.XYZ.euw1.cache.amazonaws.com
    tls: true
    tls_reqs: none
```

However, it's failing with:

```
"error":"open : no such file or directory","event":"Failed to append  to RootCAs
```

It looks like it got an empty string as tls ca cert and it tries to append that empty string to the rootcas. I think you can avoid that by ensuring the tls ca cert isn't an empty string.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
