### PR TITLE
website/docs: New "Whats Up Docker" URL

### DIFF
--- a/website/integrations/services/whats-up-docker/index.md
+++ b/website/integrations/services/whats-up-docker/index.md
@@ -11,7 +11,7 @@ sidebar_label: What's Up Docker
 
 > What's Up Docker (WUD) is an easy-to-use tool that alerts you whenever a new version of your Docker containers is released.
 >
-> -- https://fmartinou.github.io/whats-up-docker/
+> -- https://getwud.github.io/wud/
 
 ## Preparation
 


### PR DESCRIPTION
## Details

Heho
"Whats up docker" got renamed and has a new github website. So this PR replaces the URL


---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
