### PR TITLE
providers/saml: fix handle Accept: application/xml for SAML Metadata endpoint (#12483)

### DIFF
--- a/authentik/providers/saml/api/providers.py
+++ b/authentik/providers/saml/api/providers.py
@@ -40,9 +40,7 @@ LOGGER = get_logger()
 
 
 class RawXMLDataRenderer(BaseRenderer):
-    """
-    Renderer to allow application/xml as value for 'Accept' in the metadata endpoint.
-    """
+    """Renderer to allow application/xml as value for 'Accept' in the metadata endpoint."""
 
     media_type = "application/xml"
     format = "xml"
@@ -251,12 +249,12 @@ class SAMLProviderViewSet(UsedByMixin, ModelViewSet):
                 ],
                 description="Optionally force the metadata to only include one binding.",
             ),
+            # Explicitly excluded, because otherwise spectacular automatically
+            # add it when using multiple renderer_classes
             OpenApiParameter(
                 name="format",
                 exclude=True,
                 required=False,
-                description="Explicitly excluded, because otherwise spectacular automatically "
-                + "add it when using multiple renderer_classes",
             ),
         ],
     )

--- a/authentik/providers/saml/api/providers.py
+++ b/authentik/providers/saml/api/providers.py
@@ -16,6 +16,7 @@ from rest_framework.decorators import action
 from rest_framework.fields import CharField, FileField, SerializerMethodField
 from rest_framework.parsers import MultiPartParser
 from rest_framework.permissions import AllowAny
+from rest_framework.renderers import BaseRenderer, JSONRenderer
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import PrimaryKeyRelatedField, ValidationError
@@ -36,6 +37,18 @@ from authentik.rbac.decorators import permission_required
 from authentik.sources.saml.processors.constants import SAML_BINDING_POST, SAML_BINDING_REDIRECT
 
 LOGGER = get_logger()
+
+
+class RawXMLDataRenderer(BaseRenderer):
+    """
+    Renderer to allow application/xml as value for 'Accept' in the metadata endpoint.
+    """
+
+    media_type = "application/xml"
+    format = "xml"
+
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        return data
 
 
 class SAMLProviderSerializer(ProviderSerializer):
@@ -238,9 +251,21 @@ class SAMLProviderViewSet(UsedByMixin, ModelViewSet):
                 ],
                 description="Optionally force the metadata to only include one binding.",
             ),
+            OpenApiParameter(
+                name="format",
+                exclude=True,
+                required=False,
+                description="Explicitly excluded, because otherwise spectacular automatically "
+                + "add it when using multiple renderer_classes",
+            ),
         ],
     )
-    @action(methods=["GET"], detail=True, permission_classes=[AllowAny])
+    @action(
+        methods=["GET"],
+        detail=True,
+        permission_classes=[AllowAny],
+        renderer_classes=[JSONRenderer, RawXMLDataRenderer],
+    )
     def metadata(self, request: Request, pk: int) -> Response:
         """Return metadata as XML string"""
         # We don't use self.get_object() on purpose as this view is un-authenticated
@@ -258,9 +283,9 @@ class SAMLProviderViewSet(UsedByMixin, ModelViewSet):
                     f'attachment; filename="{provider.name}_authentik_meta.xml"'
                 )
                 return response
-            return Response({"metadata": metadata})
+            return Response({"metadata": metadata}, content_type="application/json")
         except Provider.application.RelatedObjectDoesNotExist:
-            return Response({"metadata": ""})
+            return Response({"metadata": ""}, content_type="application/json")
 
     @permission_required(
         None,

--- a/authentik/providers/saml/tests/test_api.py
+++ b/authentik/providers/saml/tests/test_api.py
@@ -104,6 +104,22 @@ class TestSAMLProviderAPI(APITestCase):
         )
         self.assertEqual(200, response.status_code)
         self.assertIn("Content-Disposition", response)
+        # Test download with Accept: application/xml
+        response = self.client.get(
+            reverse("authentik_api:samlprovider-metadata", kwargs={"pk": provider.pk})
+            + "?download",
+            HTTP_ACCEPT="application/xml",
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertIn("Content-Disposition", response)
+
+        response = self.client.get(
+            reverse("authentik_api:samlprovider-metadata", kwargs={"pk": provider.pk})
+            + "?download",
+            HTTP_ACCEPT="application/xml;charset=UTF-8",
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertIn("Content-Disposition", response)
 
     def test_metadata_invalid(self):
         """Test metadata export (invalid)"""
@@ -121,6 +137,11 @@ class TestSAMLProviderAPI(APITestCase):
             reverse("authentik_api:samlprovider-metadata", kwargs={"pk": "abc"}),
         )
         self.assertEqual(404, response.status_code)
+        response = self.client.get(
+            reverse("authentik_api:samlprovider-metadata", kwargs={"pk": provider.pk}),
+            HTTP_ACCEPT="application/invalid-mime-type",
+        )
+        self.assertEqual(406, response.status_code)
 
     def test_import_success(self):
         """Test metadata import (success case)"""

--- a/schema.yml
+++ b/schema.yml
@@ -22090,6 +22090,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SAMLMetadata'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/SAMLMetadata'
           description: ''
         '404':
           description: Provider has no application assigned


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
Currently when requesting SAML metadata download with `Accept: application/xml` it returns a status `406 Not Acceptable`.
Expected behavior would be to return the data as is done when no Accept header is sent.

This adds a new renderer_class to the SAML metadata download endpoint which allows application/xml in the Accept header.

Now both `curl "http://localhost:9000/api/v3/providers/saml/1/metadata/?download"`  
and  
`curl -H "Accept: application/xml" "http://localhost:9000/api/v3/providers/saml/1/metadata/?download"`  
produce the same output, instead of the latter returning 406.

closes #12483

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [x] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] ~~The code has been formatted (`make web`)~~ No frontend changes made

If applicable

-   [ ] ~~The documentation has been updated~~
-   [ ] ~~The documentation has been formatted (`make website`)~~
