### PR TITLE
Fix 'Fetch Failed' for next-auth when using OAuth behind proxy

### DIFF
--- a/website/integrations/services/hoarder/index.md
+++ b/website/integrations/services/hoarder/index.md
@@ -41,6 +41,7 @@ Optionally apply access restrictions to the application.
 In Hoarder, you'll need to add these environment variables:
 
 ```sh
+NEXTAUTH_URL_INTERNAL=http://localhost:DEFAULT_HOARDER_PORT
 NEXTAUTH_URL=https://hoarder.company
 OAUTH_CLIENT_ID=<Client ID from authentik>
 OAUTH_CLIENT_SECRET=<Client secret from authentik>


### PR DESCRIPTION
Without the NEXTAUTH_URL_INTERNAL env variable pointing to 'http://localhost:DEFAULT_HOARDER_PORT', Traefik (and possibly others) proxy report a fetch failed and refuse to show OAuth login button or allow OAuth login.

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
Without the NEXTAUTH_URL_INTERNAL env variable pointing to 'http://localhost:DEFAULT_HOARDER_PORT', Traefik (and possibly others) proxy report a fetch failed and refuse to show OAuth login button or allow OAuth login.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
