### PR TITLE
website/integrations: cloudflare access: upd placeholder for saas

### DIFF
--- a/website/integrations/services/cloudflare-access/index.mdx
+++ b/website/integrations/services/cloudflare-access/index.mdx
@@ -17,7 +17,7 @@ sidebar_label: Cloudflare Access
 
 The following placeholders are used in this guide:
 
-- `mysubdomain.cloudflareaccess.company` is the FQDN of your Cloudflare Access subdomain.
+- `company.cloudflareaccess.com` is the FQDN of your Cloudflare Access subdomain.
 - `authentik.company` is the FQDN of the authentik install.
 
 To proceed, you need to register for a free Cloudflare Access account and have both a Cloudflare account and a publicly accessible authentik instance with a trusted SSL certificate.
@@ -35,7 +35,7 @@ To proceed, you need to register for a free Cloudflare Access account and have b
 4. Choose **OAuth2/OpenID Provider** and then click **Next**.
 5. Set the authorization flow to **Authorize Application** (`default-provider-authorization-explicit-consent`).
 6. Set the client type to **Confidential**.
-7. Set the redirect URI to `https://mysubdomain.cloudflareaccess.company/cdn-cgi/access/callback`.
+7. Set the redirect URI to `https://company.cloudflareaccess.com/cdn-cgi/access/callback`.
 8. Ensure that the signing key is set to **Authentik Self-signed Certificate**.
 9. Click **Finish** to create the provider.
 


### PR DESCRIPTION
sdko/fix/integration/cloudflare-access/upd-saas-domain-format

Each Cloudflare Access company has a subdomain of `cloudflareaccess.com`. As a result, `cloudflareaccess.com` should be hardcoded into the documentation and only the company subdomain changes.

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
