### PR TITLE
sources/scim: fix user creation (duplicate userName)

### DIFF
--- a/authentik/sources/scim/tests/test_users.py
+++ b/authentik/sources/scim/tests/test_users.py
@@ -88,6 +88,53 @@ class TestSCIMUsers(APITestCase):
             ).exists()
         )
 
+    def test_user_create_duplicate_by_username(self):
+        """Test user create"""
+        user = create_test_user()
+        username = generate_id()
+        obj1 = {
+                    "userName": username,
+                    "externalId": generate_id(),
+                    "emails": [
+                        {
+                            "primary": True,
+                            "value": user.email,
+                        }
+                    ],
+                }
+        obj2 = obj1.copy()
+        obj2.update({"externalId": generate_id()})
+        response = self.client.post(
+            reverse(
+                "authentik_sources_scim:v2-users",
+                kwargs={
+                    "source_slug": self.source.slug,
+                },
+            ),
+            data=dumps(obj1),
+            content_type=SCIM_CONTENT_TYPE,
+            HTTP_AUTHORIZATION=f"Bearer {self.source.token.key}",
+        )
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(SCIMSourceUser.objects.filter(source=self.source, user__username=username).exists())
+        self.assertTrue(
+            Event.objects.filter(
+                action=EventAction.MODEL_CREATED, user__username=self.source.token.user.username
+            ).exists()
+        )
+        response = self.client.post(
+            reverse(
+                "authentik_sources_scim:v2-users",
+                kwargs={
+                    "source_slug": self.source.slug,
+                },
+            ),
+            data=dumps(obj2),
+            content_type=SCIM_CONTENT_TYPE,
+            HTTP_AUTHORIZATION=f"Bearer {self.source.token.key}",
+        )
+        self.assertEqual(response.status_code, 409)
+
     def test_user_property_mappings(self):
         """Test user property_mappings"""
         self.source.user_property_mappings.set(

--- a/authentik/sources/scim/tests/test_users.py
+++ b/authentik/sources/scim/tests/test_users.py
@@ -93,15 +93,15 @@ class TestSCIMUsers(APITestCase):
         user = create_test_user()
         username = generate_id()
         obj1 = {
-                    "userName": username,
-                    "externalId": generate_id(),
-                    "emails": [
-                        {
-                            "primary": True,
-                            "value": user.email,
-                        }
-                    ],
+            "userName": username,
+            "externalId": generate_id(),
+            "emails": [
+                {
+                    "primary": True,
+                    "value": user.email,
                 }
+            ],
+        }
         obj2 = obj1.copy()
         obj2.update({"externalId": generate_id()})
         response = self.client.post(
@@ -116,7 +116,9 @@ class TestSCIMUsers(APITestCase):
             HTTP_AUTHORIZATION=f"Bearer {self.source.token.key}",
         )
         self.assertEqual(response.status_code, 201)
-        self.assertTrue(SCIMSourceUser.objects.filter(source=self.source, user__username=username).exists())
+        self.assertTrue(
+            SCIMSourceUser.objects.filter(source=self.source, user__username=username).exists()
+        )
         self.assertTrue(
             Event.objects.filter(
                 action=EventAction.MODEL_CREATED, user__username=self.source.token.user.username

--- a/authentik/sources/scim/views/v2/users.py
+++ b/authentik/sources/scim/views/v2/users.py
@@ -2,6 +2,7 @@
 
 from uuid import uuid4
 
+from django.db.models import Q
 from django.db.transaction import atomic
 from django.http import Http404, QueryDict
 from django.urls import reverse
@@ -112,15 +113,12 @@ class UsersView(SCIMObjectView):
 
     def post(self, request: Request, **kwargs) -> Response:
         """Create user handler"""
-        connection = (
-            SCIMSourceUser.objects.filter(
-                source=self.source,
-                user__uuid=request.data.get("id"),
-            )
-            | SCIMSourceUser.objects.filter(
-                source=self.source,
-                user__username=request.data.get("userName"),
-            )
+        connection = SCIMSourceUser.objects.filter(
+            Q(
+                Q(user__uuid=request.data.get("id"))
+                | Q(user__username=request.data.get("userName"))
+            ),
+            source=self.source,
         ).first()
         if connection:
             self.logger.debug("Found existing user")

--- a/authentik/sources/scim/views/v2/users.py
+++ b/authentik/sources/scim/views/v2/users.py
@@ -112,9 +112,15 @@ class UsersView(SCIMObjectView):
 
     def post(self, request: Request, **kwargs) -> Response:
         """Create user handler"""
-        connection = SCIMSourceUser.objects.filter(
-            source=self.source,
-            user__uuid=request.data.get("id"),
+        connection = (
+            SCIMSourceUser.objects.filter(
+                source=self.source,
+                user__uuid=request.data.get("id"),
+            )
+            | SCIMSourceUser.objects.filter(
+                source=self.source,
+                user__username=request.data.get("userName"),
+            )
         ).first()
         if connection:
             self.logger.debug("Found existing user")


### PR DESCRIPTION
## Details

According to the SCIM standard both `id` and `userName` must be unique.
The current behaviour only rejects duplicate `id`s, and this PR fixes it.
A new test case has been added: `test_user_create_duplicate_by_username`, and run.
Results from [https://scimvalidator.microsoft.com/](https://scimvalidator.microsoft.com/) have been saved and replayed for local testing.

---

## Checklist

-   [x] Local tests pass (`sudo poetry run python -m manage test authentik/sources/scim/tests/test_users.py`)
-   [x] The code has been formatted (`make lint-fix`)

