### PR TITLE
website/docs: user-sources: fix FreeIPA docs

### DIFF
--- a/website/docs/users-sources/sources/directory-sync/freeipa/index.md
+++ b/website/docs/users-sources/sources/directory-sync/freeipa/index.md
@@ -43,7 +43,7 @@ Additional info: [22.1.2. Enabling Password Reset Without Prompting for a Passwo
 
 ## authentik Setup
 
-In authentik, create a new LDAP Source in Resources -> Sources.
+In authentik, create a new LDAP Source in Directory -> Federation & Social login.
 
 Use these settings:
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details
Was setting up a FreeIPA sync to Authentik and noticed that the location that the docs point to is incorrect, so this is a PR to correct this inline with the [Active Directory page](https://docs.goauthentik.io/docs/users-sources/sources/directory-sync/active-directory/).

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)
-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
