### PR TITLE
website: add api reference docs to redirect file

### DIFF
--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -1009,6 +1009,12 @@
   force = true
 
 [[redirects]]
+  from = "/developer-docs/api/reference/*"
+  to = "/docs/developer-docs/api/reference/:splat"
+  status = 302
+  force = true
+
+[[redirects]]
   from = "/developer-docs/api/flow-executor"
   to = "/docs/developer-docs/api/flow-executor"
   status = 302


### PR DESCRIPTION
This PR adds a section to the `netlify.toml` file to redirect api reference docs from their old, pre-migration location.

---

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
