### PR TITLE
website/integrations: Fix deprecated terraform ressource authentik_scope_mapping in docs

### DIFF
--- a/website/integrations/services/argocd/index.md
+++ b/website/integrations/services/argocd/index.md
@@ -110,9 +110,9 @@ resource "authentik_provider_oauth2" "argocd" {
   ]
 
   property_mappings = [
-    data.authentik_scope_mapping.scope-email.id,
-    data.authentik_scope_mapping.scope-profile.id,
-    data.authentik_scope_mapping.scope-openid.id,
+    data.authentik_property_mapping_provider_scope.scope-email.id,
+    data.authentik_property_mapping_provider_scope.scope-profile.id,
+    data.authentik_property_mapping_provider_scope.scope-openid.id,
   ]
 }
 

--- a/website/integrations/services/grafana/index.mdx
+++ b/website/integrations/services/grafana/index.mdx
@@ -38,15 +38,15 @@ data "authentik_flow" "default-provider-authorization-implicit-consent" {
   slug = "default-provider-authorization-implicit-consent"
 }
 
-data "authentik_scope_mapping" "scope-email" {
+data "authentik_property_mapping_provider_scope" "scope-email" {
   name = "authentik default OAuth Mapping: OpenID 'email'"
 }
 
-data "authentik_scope_mapping" "scope-profile" {
+data "authentik_property_mapping_provider_scope" "scope-profile" {
   name = "authentik default OAuth Mapping: OpenID 'profile'"
 }
 
-data "authentik_scope_mapping" "scope-openid" {
+data "authentik_property_mapping_provider_scope" "scope-openid" {
   name = "authentik default OAuth Mapping: OpenID 'openid'"
 }
 
@@ -64,9 +64,9 @@ resource "authentik_provider_oauth2" "grafana" {
   redirect_uris = ["https://grafana.company/login/generic_oauth"]
 
   property_mappings = [
-    data.authentik_scope_mapping.scope-email.id,
-    data.authentik_scope_mapping.scope-profile.id,
-    data.authentik_scope_mapping.scope-openid.id,
+    data.authentik_property_mapping_provider_scope.scope-email.id,
+    data.authentik_property_mapping_provider_scope.scope-profile.id,
+    data.authentik_property_mapping_provider_scope.scope-openid.id,
   ]
 }
 


### PR DESCRIPTION
Just replacing the deprecated Terraform ressource `authentik_scope_mapping` with the new `authentik_property_mapping_provider_scope` in the Grafana Application.

Also fixing in incomplete attempt to do the same with ArgoCD.