### PR TITLE
website/docs: add note for trailing-slash in initial setup

### DIFF
--- a/authentik/stages/redirect/stage.py
+++ b/authentik/stages/redirect/stage.py
@@ -83,7 +83,7 @@ class RedirectStageView(ChallengeStageView):
         target_url_override = self.executor.plan.context.get(PLAN_CONTEXT_REDIRECT_STAGE_TARGET, "")
         if target_url_override:
             target = self.parse_target(target_url_override)
-        # `target` is falsy if the override was to a Flow but that Flow doesn't exist.
+        # `target` is false if the override was to a Flow but that Flow doesn't exist.
         if not target:
             if current_stage.mode == RedirectMode.STATIC:
                 target = current_stage.target_static

--- a/website/docs/install-config/install/docker-compose.mdx
+++ b/website/docs/install-config/install/docker-compose.mdx
@@ -117,6 +117,8 @@ The `docker-compose.yml` file statically references the latest version available
 
 To start the initial setup, navigate to `http://<your server's IP or hostname>:9000/if/flow/initial-setup/`.
 
+> ⚠ Note: User would get `404 NOT FOUND` if initial setup URL doesn't enclude the trailing forward slash `/`. Make sure you use the complete url (`http://<your server's IP or hostname>:9000/if/flow/initial-setup/`) including the trailing forward slash. [Reference](https://github.com/goauthentik/authentik/issues/11046#issuecomment-2453449809)
+
 There you are prompted to set a password for the `akadmin` user (the default user).
 
 For an explanation about what each service in the docker compose file does, see [Architecture](../../core/architecture.md).

--- a/website/docs/install-config/install/docker-compose.mdx
+++ b/website/docs/install-config/install/docker-compose.mdx
@@ -117,7 +117,9 @@ The `docker-compose.yml` file statically references the latest version available
 
 To start the initial setup, navigate to `http://<your server's IP or hostname>:9000/if/flow/initial-setup/`.
 
-> ⚠ Note: User would get `404 NOT FOUND` if initial setup URL doesn't enclude the trailing forward slash `/`. Make sure you use the complete url (`http://<your server's IP or hostname>:9000/if/flow/initial-setup/`) including the trailing forward slash. [Reference](https://github.com/goauthentik/authentik/issues/11046#issuecomment-2453449809)
+:::info
+User will get a `404 NOT FOUND` if initial setup URL doesn't include the trailing forward slash `/`. Make sure you use the complete url (`http://<your server's IP or hostname>:9000/if/flow/initial-setup/`) including the trailing forward slash.
+:::
 
 There you are prompted to set a password for the `akadmin` user (the default user).
 

--- a/website/docs/install-config/install/docker-compose.mdx
+++ b/website/docs/install-config/install/docker-compose.mdx
@@ -118,7 +118,7 @@ The `docker-compose.yml` file statically references the latest version available
 To start the initial setup, navigate to `http://<your server's IP or hostname>:9000/if/flow/initial-setup/`.
 
 :::info
-User will get `Not Found` error if initial setup URL doesn't include the trailing forward slash `/`. Make sure you use the complete url (`http://<your server's IP or hostname>:9000/if/flow/initial-setup/`) including the trailing forward slash.
+You will get `Not Found` error if initial setup URL doesn't include the trailing forward slash `/`. Make sure you use the complete url (`http://<your server's IP or hostname>:9000/if/flow/initial-setup/`) including the trailing forward slash.
 :::
 
 There you are prompted to set a password for the `akadmin` user (the default user).

--- a/website/docs/install-config/install/docker-compose.mdx
+++ b/website/docs/install-config/install/docker-compose.mdx
@@ -118,7 +118,7 @@ The `docker-compose.yml` file statically references the latest version available
 To start the initial setup, navigate to `http://<your server's IP or hostname>:9000/if/flow/initial-setup/`.
 
 :::info
-User will get a `404 NOT FOUND` if initial setup URL doesn't include the trailing forward slash `/`. Make sure you use the complete url (`http://<your server's IP or hostname>:9000/if/flow/initial-setup/`) including the trailing forward slash.
+User will get `Not Found` error if initial setup URL doesn't include the trailing forward slash `/`. Make sure you use the complete url (`http://<your server's IP or hostname>:9000/if/flow/initial-setup/`) including the trailing forward slash.
 :::
 
 There you are prompted to set a password for the `akadmin` user (the default user).

--- a/website/docs/install-config/install/kubernetes.md
+++ b/website/docs/install-config/install/kubernetes.md
@@ -75,7 +75,7 @@ During the installation process, the database migrations will be applied automat
 After the installation is complete, access authentik at `https://<ingress-host-name>/if/flow/initial-setup/`. Here, you can set a password for the default `akadmin` user.
 
 :::info
-User will get `Not found` error if initial setup URL doesn't include the trailing forward slash `/`. Make sure you use the complete url (`http://<ingress-host-name>/if/flow/initial-setup/`) including the trailing forward slash.
+You will get `Not Found` error if initial setup URL doesn't include the trailing forward slash `/`. Make sure you use the complete url (`http://<ingress-host-name>/if/flow/initial-setup/`) including the trailing forward slash.
 :::
 
 ### Optional step: Configure global email credentials

--- a/website/docs/install-config/install/kubernetes.md
+++ b/website/docs/install-config/install/kubernetes.md
@@ -74,6 +74,10 @@ During the installation process, the database migrations will be applied automat
 
 After the installation is complete, access authentik at `https://<ingress-host-name>/if/flow/initial-setup/`. Here, you can set a password for the default `akadmin` user.
 
+:::info
+User will get a `404 NOT FOUND` if initial setup URL doesn't include the trailing forward slash `/`. Make sure you use the complete url (`http://<your server's IP or hostname>:9000/if/flow/initial-setup/`) including the trailing forward slash.
+:::
+
 ### Optional step: Configure global email credentials
 
 It is recommended to configure global email credentials as well. These are used by authentik to notify you about alerts and configuration issues. Additionally, they can be utilized by [Email stages](../../add-secure-apps/flows-stages/stages/email/index.mdx) to send verification and recovery emails.

--- a/website/docs/install-config/install/kubernetes.md
+++ b/website/docs/install-config/install/kubernetes.md
@@ -75,7 +75,7 @@ During the installation process, the database migrations will be applied automat
 After the installation is complete, access authentik at `https://<ingress-host-name>/if/flow/initial-setup/`. Here, you can set a password for the default `akadmin` user.
 
 :::info
-User will get a `404 NOT FOUND` if initial setup URL doesn't include the trailing forward slash `/`. Make sure you use the complete url (`http://<your server's IP or hostname>:9000/if/flow/initial-setup/`) including the trailing forward slash.
+User will get `Not found` error if initial setup URL doesn't include the trailing forward slash `/`. Make sure you use the complete url (`http://<ingress-host-name>/if/flow/initial-setup/`) including the trailing forward slash.
 :::
 
 ### Optional step: Configure global email credentials


### PR DESCRIPTION

## Details

Add reference to solution to `NOT FOUND` error users might get on initial setup if the trailing forward slash wasn't included in URL.
---

## Checklist

-   (N/A) Local tests pass (`ak test authentik/`)
-   (N/A) The code has been formatted (`make lint-fix`)

If an API change has been made

-   (N/A) The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   (N/A) The code has been formatted (`make web`)

If applicable

-   [X] The documentation has been updated
-   [X] The documentation has been formatted (`make website`)
