### PR TITLE
flow: fix regression in flow planner

### DIFF
--- a/authentik/flows/planner.py
+++ b/authentik/flows/planner.py
@@ -241,8 +241,8 @@ class FlowPlanner:
                 user = context[PLAN_CONTEXT_PENDING_USER]
             else:
                 user = request.user
+                context.update(self._check_authentication(request, context))
 
-            context.update(self._check_authentication(request, context))
             # First off, check the flow's direct policy bindings
             # to make sure the user even has access to the flow
             engine = PolicyEngine(self.flow, user, request)


### PR DESCRIPTION
## Details

I believe that during this commit 
https://github.com/goauthentik/authentik/commit/ff504a3b80e275f39633883025fd6b79e8aa4062#diff-a5c56bb7c60e27dda1b131b3fc2a17e3af6624e7cfaaa2337ec6b077ca489f34R245 the flow planner regressed, meaning that the authentication requirements are evaluated sometimes unnecessarily

This manifested in https://github.com/goauthentik/authentik/issues/12445 which seems to be occurring when the recovery flow has an Unauthenticated requirement and you try to generate a link via the Admin console, which sends a context user. 

closes #12445

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

