### PR TITLE
website/integrations: gitlab to have binding in saml section be post

### DIFF
--- a/website/integrations/services/gitlab/index.md
+++ b/website/integrations/services/gitlab/index.md
@@ -38,7 +38,7 @@ Create an application in authentik and note the slug, as this will be used later
 - ACS URL: `https://gitlab.company/users/auth/saml/callback`
 - Audience: `https://gitlab.company`
 - Issuer: `https://gitlab.company`
-- Binding: `Redirect`
+- Binding: `Post`
 
 Under _Advanced protocol settings_, set a certificate for _Signing Certificate_.
 


### PR DESCRIPTION
After upgrading to version 2024.12.2 SAML stopped working in gitlab and was causing 502 errors. After some troubleshooting I finally got it to work again by changing binding to "Post" instead of the recommended "Redirect" in this howto.

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
