### PR TITLE
website/integrations: snipe-it: remove ldap property mapping

### DIFF
--- a/website/integrations/services/snipe-it/index.md
+++ b/website/integrations/services/snipe-it/index.md
@@ -113,41 +113,9 @@ You must sync your LDAP database with Snipe-IT. Go to People on the sidebar menu
 - Select your Location
 - Click Synchronize
   :::note
-  Snipe-IT will only import users with both a first and last name set. If you do not have first and last names stored in your users attributes, you can create a property mapping to set first and last name.
+  Snipe-IT will only import users with both a first and last name set. You need to create user attributes with first and last names.
   :::
 
-## authentik Property Mapping
-
-To create a policy mapping, go to _Customization/Property Mappings_, click `Create` then `LDAP Property Mapping`. Name is 'sn' and set Object field to sn:
-
-```ini
-def getLastName():
-    if len(request.user.name) >= 1:
-     return request.user.name.split(" ")[1]
-    elif len(request.user.name) == 1:
-     return request.user.name.split(" ")[1]
-    else:
-      return ""
-
-return {
-    "sn": getLastName(),
-}
-
-```
-
-Create a second policy mapping, name it 'givenname' and set Object field to 'givenname'
-
-```
-def getFirstName():
-    if len(request.user.name) >= 1:
-     return request.user.name.split(" ")[0]
-    else:
-      return f"N/A"
-
-return {
-    "givenname": getFirstName(),
-}
-```
 
 ## authentik SAML Config
 

--- a/website/integrations/services/snipe-it/index.md
+++ b/website/integrations/services/snipe-it/index.md
@@ -116,7 +116,6 @@ You must sync your LDAP database with Snipe-IT. Go to People on the sidebar menu
   Snipe-IT will only import users with both a first and last name set. You need to create user attributes with first and last names.
   :::
 
-
 ## authentik SAML Config
 
 ### Step 1


### PR DESCRIPTION

## Details
 Property mapping for ldap outpost is not supported at the moment. 
I removed it, because it creates too much confusion.

closes https://github.com/goauthentik/authentik/issues/7058

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
