### PR TITLE
providers/oauth2: support token revocation for public clients

### DIFF
--- a/authentik/providers/oauth2/utils.py
+++ b/authentik/providers/oauth2/utils.py
@@ -178,12 +178,18 @@ def protected_resource_view(scopes: list[str]):
     return wrapper
 
 
-def authenticate_provider(request: HttpRequest) -> OAuth2Provider | None:
-    """Attempt to authenticate via Basic auth of client_id:client_secret"""
+def provider_from_request(request: HttpRequest) -> tuple[OAuth2Provider | None, str, str]:
+    """Get provider from Basic auth of client_id:client_secret. Does not perform authentication"""
     client_id, client_secret = extract_client_auth(request)
     if client_id == client_secret == "":
-        return None
+        return None, "", ""
     provider: OAuth2Provider | None = OAuth2Provider.objects.filter(client_id=client_id).first()
+    return provider, client_id, client_secret
+
+
+def authenticate_provider(request: HttpRequest) -> OAuth2Provider | None:
+    """Attempt to authenticate via Basic auth of client_id:client_secret"""
+    provider, client_id, client_secret = provider_from_request(request)
     if not provider:
         return None
     if client_id != provider.client_id or client_secret != provider.client_secret:


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Closes #12053

From the RFC:

>    A malicious client may attempt to guess valid tokens on this endpoint
   by making revocation requests against potential token strings.
   According to this specification, a client's request must contain a
   valid client_id, in the case of a public client, or valid client
   credentials, in the case of a confidential client.  The token being
   revoked must also belong to the requesting client.  If an attacker is
   able to successfully guess a public client's client_id and one of
   their tokens, or a private client's credentials and one of their
   tokens, they could do much worse damage by using the token elsewhere
   than by revoking it.  If they chose to revoke the token, the
   legitimate client will lose its authorization grant and will need to
   prompt the user again.  No further damage is done and the guessed
   token is now worthless.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
