### PR TITLE
sources/oauth: fix authentication only being sent in form body

### DIFF
--- a/authentik/sources/oauth/clients/oauth2.py
+++ b/authentik/sources/oauth/clients/oauth2.py
@@ -81,7 +81,12 @@ class OAuth2Client(BaseOAuthClient):
             if self.source.source_type.urls_customizable and self.source.access_token_url:
                 access_token_url = self.source.access_token_url
             response = self.do_request(
-                "post", access_token_url, data=args, headers=self._default_headers, **request_kwargs
+                "post",
+                access_token_url,
+                auth=(self.get_client_id(), self.get_client_secret()),
+                data=args,
+                headers=self._default_headers,
+                **request_kwargs,
             )
             response.raise_for_status()
         except RequestException as exc:


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

closes #9895

See https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1

We previously only sent credentials as part of the body which according to the RFC is optional, however sending the credentials as Authorization header is required

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
