### PR TITLE
website/integrations: Fix URL for authentik installation instead of mobilizon installation

### DIFF
--- a/website/integrations/services/mobilizon/index.md
+++ b/website/integrations/services/mobilizon/index.md
@@ -56,10 +56,10 @@ config :mobilizon, :auth,
 config :ueberauth, Ueberauth.Strategy.Keycloak.OAuth,
   client_id: "<Client ID>",
   client_secret: "<Client Secret>",
-  site: "https://mobilizon.company",
-  authorize_url: "https://mobilizon.company/application/o/authorize/",
-  token_url: "https://mobilizon.company/application/o/token/",
-  userinfo_url: "https://mobilizon.company/application/o/userinfo/",
+  site: "https://authentik.company",
+  authorize_url: "https://authentik.company/application/o/authorize/",
+  token_url: "https://authentik.company/application/o/token/",
+  userinfo_url: "https://authentik.company/application/o/userinfo/",
   token_method: :post
 ```
 


### PR DESCRIPTION
Mobilizon needs to know where to look to find authentik, not where to look to find itself.

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
Current documentation for Mobilizon integration says to point Mobilizon to itself. It should say to point Mobilizon to Authentik.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
