### PR TITLE
lifecycle: fix cryptography's OpenSSL path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -134,7 +134,6 @@ RUN --mount=type=bind,target=./pyproject.toml,src=./pyproject.toml \
     bash -c "source ${VENV_PATH}/bin/activate && \
     pip3 install --upgrade pip && \
     pip3 install poetry && \
-    poetry config --local installer.no-binary cryptography,xmlsec,lxml,python-kadmin-rs && \
     poetry install --only=main --no-ansi --no-interaction --no-root && \
     pip freeze | grep -E 'cryptography|xmlsec|lxml|python-kadmin-rs' > /tmp/req.txt && \
     pip install --no-cache --force-reinstall --no-binary :all: -r /tmp/req.txt && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -135,7 +135,10 @@ RUN --mount=type=bind,target=./pyproject.toml,src=./pyproject.toml \
     pip3 install --upgrade pip && \
     pip3 install poetry && \
     poetry config --local installer.no-binary cryptography,xmlsec,lxml,python-kadmin-rs && \
-    poetry install --only=main --no-ansi --no-interaction --no-root"
+    poetry install --only=main --no-ansi --no-interaction --no-root && \
+    pip freeze | grep -E 'cryptography|xmlsec|lxml|python-kadmin-rs' > /tmp/req.txt && \
+    pip install --no-cache --force-reinstall --no-binary :all: -r /tmp/req.txt && \
+    rm /tmp/req.txt"
 
 # Stage 6: Run
 FROM ghcr.io/goauthentik/fips-python:3.12.7-slim-bookworm-fips AS final-image

--- a/Dockerfile
+++ b/Dockerfile
@@ -132,12 +132,11 @@ RUN --mount=type=bind,target=./pyproject.toml,src=./pyproject.toml \
     . "$HOME/.cargo/env" && \
     python -m venv /ak-root/venv/ && \
     bash -c "source ${VENV_PATH}/bin/activate && \
-    pip3 install --upgrade pip && \
-    pip3 install poetry && \
+    pip3 install --upgrade pip poetry && \
+    poetry config --local installer.no-binary cryptography,xmlsec,lxml,python-kadmin-rs && \
     poetry install --only=main --no-ansi --no-interaction --no-root && \
-    pip freeze | grep -E 'cryptography|xmlsec|lxml|python-kadmin-rs' > /tmp/req.txt && \
-    pip install --no-cache --force-reinstall --no-binary :all: -r /tmp/req.txt && \
-    rm /tmp/req.txt"
+    pip uninstall cryptography -y && \
+    poetry install --only=main --no-ansi --no-interaction --no-root"
 
 # Stage 6: Run
 FROM ghcr.io/goauthentik/fips-python:3.12.7-slim-bookworm-fips AS final-image


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Somehow when installing cryptography from source with Poetry it gets the wrong path...?
followup for https://github.com/goauthentik/authentik/pull/12724

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
