### PR TITLE
flows: clear flow state before redirecting to final URL

### DIFF
--- a/authentik/flows/planner.py
+++ b/authentik/flows/planner.py
@@ -159,7 +159,10 @@ class FlowPlan:
             temp_exec.current_stage_view = final_stage
             temp_exec.setup(request, flow.slug)
             stage = final_stage(request=request, executor=temp_exec)
-            return stage.dispatch(request)
+            response = stage.dispatch(request)
+            # Ensure we clean the flow state we have in the session before we redirect away
+            temp_exec.stage_ok()
+            return response
 
         get_qs = request.GET.copy()
         if request.user.is_authenticated and (

--- a/authentik/flows/planner.py
+++ b/authentik/flows/planner.py
@@ -156,6 +156,8 @@ class FlowPlan:
             final_stage: type[StageView] = self.bindings[-1].stage.view
             temp_exec = FlowExecutorView(flow=flow, request=request, plan=self)
             temp_exec.current_stage = self.bindings[-1].stage
+            temp_exec.current_stage_view = final_stage
+            temp_exec.setup(request, flow.slug)
             stage = final_stage(request=request, executor=temp_exec)
             return stage.dispatch(request)
 

--- a/authentik/flows/planner.py
+++ b/authentik/flows/planner.py
@@ -109,6 +109,8 @@ class FlowPlan:
 
     def pop(self):
         """Pop next pending stage from bottom of list"""
+        if not self.markers and not self.bindings:
+            return
         self.markers.pop(0)
         self.bindings.pop(0)
 

--- a/authentik/flows/views/executor.py
+++ b/authentik/flows/views/executor.py
@@ -103,7 +103,7 @@ class FlowExecutorView(APIView):
 
     permission_classes = [AllowAny]
 
-    flow: Flow
+    flow: Flow = None
 
     plan: FlowPlan | None = None
     current_binding: FlowStageBinding | None = None

--- a/authentik/flows/views/executor.py
+++ b/authentik/flows/views/executor.py
@@ -114,7 +114,8 @@ class FlowExecutorView(APIView):
 
     def setup(self, request: HttpRequest, flow_slug: str):
         super().setup(request, flow_slug=flow_slug)
-        self.flow = get_object_or_404(Flow.objects.select_related(), slug=flow_slug)
+        if not self.flow:
+            self.flow = get_object_or_404(Flow.objects.select_related(), slug=flow_slug)
         self._logger = get_logger().bind(flow_slug=flow_slug)
         set_tag("authentik.flow", self.flow.slug)
 

--- a/authentik/providers/oauth2/views/authorize.py
+++ b/authentik/providers/oauth2/views/authorize.py
@@ -499,11 +499,11 @@ class OAuthFulfillmentStage(StageView):
             )
 
             challenge.is_valid()
-
+            self.executor.stage_ok()
             return HttpChallengeResponse(
                 challenge=challenge,
             )
-
+        self.executor.stage_ok()
         return HttpResponseRedirectScheme(uri, allowed_schemes=[parsed.scheme])
 
     def post(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:

--- a/authentik/providers/oauth2/views/authorize.py
+++ b/authentik/providers/oauth2/views/authorize.py
@@ -499,11 +499,11 @@ class OAuthFulfillmentStage(StageView):
             )
 
             challenge.is_valid()
-            self.executor.stage_ok()
+
             return HttpChallengeResponse(
                 challenge=challenge,
             )
-        self.executor.stage_ok()
+
         return HttpResponseRedirectScheme(uri, allowed_schemes=[parsed.scheme])
 
     def post(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

If a user re-loads the flow URL of an authorization flow after having used it, there may be left overs from the OAuth2 provider in the context which causes the flow to error. This PR clears the state before redirecting away.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
