### PR TITLE
web: Fix issue where Codemirror partially applies OneDark theme.

### DIFF
--- a/web/src/elements/CodeMirror.ts
+++ b/web/src/elements/CodeMirror.ts
@@ -52,10 +52,17 @@ export class CodeMirrorTextarea<T> extends AKElement {
     theme: Compartment = new Compartment();
     syntaxHighlighting: Compartment = new Compartment();
 
-    themeLight: Extension;
-    themeDark: Extension;
-    syntaxHighlightingLight: Extension;
-    syntaxHighlightingDark: Extension;
+    themeLight = EditorView.theme(
+        {
+            "&": {
+                backgroundColor: "var(--pf-global--BackgroundColor--light-300)",
+            },
+        },
+        { dark: false },
+    );
+    themeDark = oneDark;
+    syntaxHighlightingLight = syntaxHighlighting(defaultHighlightStyle);
+    syntaxHighlightingDark = syntaxHighlighting(oneDarkHighlightStyle);
 
     static get styles(): CSSResult[] {
         return [
@@ -121,21 +128,6 @@ export class CodeMirrorTextarea<T> extends AKElement {
         } catch (_e: unknown) {
             return this.getInnerValue();
         }
-    }
-
-    constructor() {
-        super();
-        this.themeLight = EditorView.theme(
-            {
-                "&": {
-                    backgroundColor: "var(--pf-global--BackgroundColor--light-300)",
-                },
-            },
-            { dark: false },
-        );
-        this.themeDark = oneDark;
-        this.syntaxHighlightingLight = syntaxHighlighting(defaultHighlightStyle);
-        this.syntaxHighlightingDark = syntaxHighlighting(oneDarkHighlightStyle);
     }
 
     private getInnerValue(): string {

--- a/web/src/elements/CodeMirror.ts
+++ b/web/src/elements/CodeMirror.ts
@@ -11,7 +11,7 @@ import {
 } from "@codemirror/language";
 import * as yamlMode from "@codemirror/legacy-modes/mode/yaml";
 import { Compartment, EditorState, Extension } from "@codemirror/state";
-import { oneDark } from "@codemirror/theme-one-dark";
+import { oneDark, oneDarkHighlightStyle } from "@codemirror/theme-one-dark";
 import { ViewUpdate } from "@codemirror/view";
 import { EditorView, drawSelection, keymap, lineNumbers } from "@codemirror/view";
 import { EVENT_THEME_CHANGE } from "@goauthentik/common/constants";
@@ -169,10 +169,13 @@ export class CodeMirrorTextarea<T> extends AKElement {
                 });
             }
         }) as EventListener);
+
+        const dark = this.activeTheme === UiThemeEnum.Dark;
+
         const extensions = [
             history(),
             keymap.of([...defaultKeymap, ...historyKeymap]),
-            syntaxHighlighting(defaultHighlightStyle),
+            syntaxHighlighting(dark ? oneDarkHighlightStyle : defaultHighlightStyle),
             this.getLanguageExtension(),
             lineNumbers(),
             drawSelection(),
@@ -189,7 +192,7 @@ export class CodeMirrorTextarea<T> extends AKElement {
             }),
             EditorState.readOnly.of(this.readOnly),
             EditorState.tabSize.of(2),
-            this.theme.of(this.activeTheme === UiThemeEnum.Dark ? this.themeDark : this.themeLight),
+            this.theme.of(dark ? this.themeDark : this.themeLight),
         ];
         this.editor = new EditorView({
             extensions: extensions.filter((p) => p) as Extension[],


### PR DESCRIPTION
## Details

First reported in #4622, partially fixed via fd9ce53

This one was tricky to track down since Codemirror's API docs omit full examples of how themes should be applied.

## Before

<img width="1470" alt="Screenshot 2025-01-25 at 01 17 46" src="https://github.com/user-attachments/assets/7948e197-d32c-478c-ad77-ba2c117b7020" />


## After

<img width="1470" alt="Screenshot 2025-01-25 at 01 17 25" src="https://github.com/user-attachments/assets/26f60b94-b8b6-448e-888c-6e4a3f040e1c" />



<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
