### PR TITLE
ci: run full docker test suite in built image on a schedule

### DIFF
--- a/.github/workflows/ci-main-daily.yml
+++ b/.github/workflows/ci-main-daily.yml
@@ -1,0 +1,28 @@
+---
+name: authentik-ci-main-daily
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every night at 3am
+    - cron: "0 3 * * *"
+
+jobs:
+  test-container:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - docs
+          - version-2024-12
+          - version-2024-10
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          current="$(pwd)"
+          dir="/tmp/authentik/${{ matrix.version }}"
+          mkdir -p $dir
+          cd $dir
+          wget https://${{ matrix.version }}.goauthentik.io/docker-compose.yml
+          ${current}/scripts/test_docker.sh


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Add a CI job that runs the full test suite in the actual release containers, on a schedule

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
