### PR TITLE
ci: fix test_docker.sh failing due to missing .env

### DIFF
--- a/scripts/test_docker.sh
+++ b/scripts/test_docker.sh
@@ -1,16 +1,19 @@
 #!/bin/bash
 set -e -x -o pipefail
+hash=$(git rev-parse HEAD || openssl rand -base64 36)
 
 export PG_PASS=$(openssl rand -base64 36 | tr -d '\n')
 export AUTHENTIK_SECRET_KEY=$(openssl rand -base64 60 | tr -d '\n')
 export AUTHENTIK_IMAGE="xghcr.io/goauthentik/server"
-export AUTHENTIK_TAG=$(git rev-parse HEAD | cut -c1-15)
+export AUTHENTIK_TAG=$(echo $hash | cut -c1-15)
 export COMPOSE_PROJECT_NAME="authentik-test-${AUTHENTIK_TAG}"
 
 # Ensure buildx is installed
 docker buildx install
 # For release builds we have an empty client here as we use the NPM package
 mkdir -p ./gen-ts-api
+touch .env
+
 docker build -t ${AUTHENTIK_IMAGE}:${AUTHENTIK_TAG} .
 docker compose up --no-start
 docker compose start postgresql redis


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Script fails due to missing .env, and also fails if not run in a git repo

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
