### PR TITLE
website/docs: fix 2 links to cobalt restesting pdf

### DIFF
--- a/website/docs/security/audits-and-certs/2024-11-cobalt.md
+++ b/website/docs/security/audits-and-certs/2024-11-cobalt.md
@@ -2,7 +2,7 @@
 
 We are committed to engaging in regular pentesting and security audits of authentik. Defining and adhering to a cadence of external testing ensures a stronger probability that our code base, our features, and our architecture is as secure and non-exploitable as possible.
 
-In August-September of 2024, we had a pentest conducted by [Cobalt](https://www.cobalt.io). This document covers the findings of the audit, how we addressed the noted issues, and the subsequent [re-testing](https://github.com/goauthentik/website/src/resources/final_fullReport_authentik-cobalt-test-instance-august-2024-pt26135.pdf) by Cobalt to confirm that all issues were resolved.
+In August-September of 2024, we had a pentest conducted by [Cobalt](https://www.cobalt.io). This document covers the findings of the audit, how we addressed the noted issues, and the subsequent [re-testing](https://goauthentik.io/resources/fullReport_authentik-cobalt-test-instance-august-2024-pt26135.pdf) by Cobalt to confirm that all issues were resolved.
 
 Cobalt described their process for testing:
 

--- a/website/docs/security/audits-and-certs/2024-11-cobalt.md
+++ b/website/docs/security/audits-and-certs/2024-11-cobalt.md
@@ -58,6 +58,6 @@ The absence of Content Security Policy (CSP) headers means that the application 
 
 ## Retest results
 
-The subsequent retest conducted by Cobalt deemed all issues resolved. See page 17 of the [report](https://github.com/goauthentik/website/src/resources/final_fullReport_authentik-cobalt-test-instance-august-2024-pt26135.pdf) for the mitigation status ("fixed") for each of the issues discovered in September.
+The subsequent retest conducted by Cobalt deemed all issues resolved. See page 17 of the [report](https://goauthentik.io/resources/fullReport_authentik-cobalt-test-instance-august-2024-pt26135.pdf) for the mitigation status ("fixed") for each of the issues discovered in September.
 
 We are pleased to share this pentest and the final results of the retest. We encourage an open and ongoing communication with our users and community. For more information abut our security stance, read our [Security Policy](https://docs.goauthentik.io/docs/security/policy), [Hardening authentik](https://docs.goauthentik.io/docs/security/security-hardening), and our other [security-related documentation](https://docs.goauthentik.io/docs/security). If you have any questions or feedback you can reach us on [GitHub](https://github.com/goauthentik/authentik), [Discord](https://discord.com/channels/809154715984199690/809154716507963434), or via email to [hello@goauthentik.io](mailto:hello@goauthentik.io).


### PR DESCRIPTION
This PR fixes the broken links raised in support ticket # 203.

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
