### PR TITLE
core: show last password change date

### DIFF
--- a/authentik/core/api/users.py
+++ b/authentik/core/api/users.py
@@ -236,9 +236,11 @@ class UserSerializer(ModelSerializer):
             "path",
             "type",
             "uuid",
+            "password_change_date",
         ]
         extra_kwargs = {
             "name": {"allow_blank": True},
+            "password_change_date": {"read_only": True},
         }
 
 

--- a/schema.yml
+++ b/schema.yml
@@ -56494,11 +56494,16 @@ components:
           type: string
           format: uuid
           readOnly: true
+        password_change_date:
+          type: string
+          format: date-time
+          readOnly: true
       required:
       - avatar
       - groups_obj
       - is_superuser
       - name
+      - password_change_date
       - pk
       - uid
       - username

--- a/web/src/admin/users/UserViewPage.ts
+++ b/web/src/admin/users/UserViewPage.ts
@@ -158,6 +158,10 @@ export class UserViewPage extends WithCapabilitiesConfig(AKElement) {
                 ? html`<div>${getRelativeTime(user.lastLogin)}</div>
                       <small>${user.lastLogin.toLocaleString()}</small>`
                 : html`${msg("-")}`],
+            [msg("Last password change"), user.passwordChangeDate
+                ? html`<div>${getRelativeTime(user.passwordChangeDate)}</div>
+                      <small>${user.passwordChangeDate.toLocaleString()}</small>`
+                : html`${msg("-")}`],
             [msg("Active"), html`<ak-status-label type="warning" ?good=${user.isActive}></ak-status-label>`],
             [msg("Type"), userTypeToLabel(user.type)],
             [msg("Superuser"), html`<ak-status-label type="warning" ?good=${user.isSuperuser}></ak-status-label>`],


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

We save the last password change date but its not exposed in the API

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
