### PR TITLE
root: revert install_id changes

### DIFF
--- a/authentik/root/install_id.py
+++ b/authentik/root/install_id.py
@@ -7,12 +7,7 @@ from psycopg import connect
 
 from authentik.lib.config import CONFIG
 
-# We need to string format the query as tables and schemas can't be set by parameters
-# not a security issue as the config value is set by the person installing authentik
-# which also has postgres credentials etc
-QUERY = """SELECT id FROM {}.authentik_install_id ORDER BY id LIMIT 1;""".format(  # nosec
-    CONFIG.get("postgresql.default_schema")
-)
+QUERY = """SELECT id FROM %s.authentik_install_id ORDER BY id LIMIT 1;"""
 
 
 @lru_cache
@@ -25,7 +20,7 @@ def get_install_id() -> str:
     if settings.TEST:
         return str(uuid4())
     with connection.cursor() as cursor:
-        cursor.execute(QUERY)
+        cursor.execute(QUERY, (CONFIG.get("postgresql.default_schema")))
         return cursor.fetchone()[0]
 
 
@@ -45,5 +40,5 @@ def get_install_id_raw():
         sslkey=CONFIG.get("postgresql.sslkey"),
     )
     cursor = conn.cursor()
-    cursor.execute(QUERY)
+    cursor.execute(QUERY, params=(CONFIG.get("postgresql.default_schema")))
     return cursor.fetchone()[0]

--- a/authentik/root/install_id.py
+++ b/authentik/root/install_id.py
@@ -7,7 +7,7 @@ from psycopg import connect
 
 from authentik.lib.config import CONFIG
 
-QUERY = """SELECT id FROM %s.authentik_install_id ORDER BY id LIMIT 1;"""
+QUERY = """SELECT id FROM public.authentik_install_id ORDER BY id LIMIT 1;"""
 
 
 @lru_cache
@@ -20,7 +20,7 @@ def get_install_id() -> str:
     if settings.TEST:
         return str(uuid4())
     with connection.cursor() as cursor:
-        cursor.execute(QUERY, (CONFIG.get("postgresql.default_schema")))
+        cursor.execute(QUERY)
         return cursor.fetchone()[0]
 
 
@@ -40,5 +40,5 @@ def get_install_id_raw():
         sslkey=CONFIG.get("postgresql.sslkey"),
     )
     cursor = conn.cursor()
-    cursor.execute(QUERY, params=(CONFIG.get("postgresql.default_schema")))
+    cursor.execute(QUERY)
     return cursor.fetchone()[0]


### PR DESCRIPTION
## Details

#13018 and #13006 are breaking, respectively, the install_id retrieval code and the CI. Reverting until we can find a proper solution

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
