### PR TITLE
web: Silence ESBuild warning.

### DIFF
--- a/web/build.mjs
+++ b/web/build.mjs
@@ -91,6 +91,15 @@ const baseArgs = {
     loader: { ".css": "text", ".md": "text" },
     define: definitions,
     format: "esm",
+    logOverride: {
+        /**
+         * HACK: Silences issue originating in ESBuild.
+         *
+         * @see {@link https://github.com/evanw/esbuild/blob/b914dd30294346aa15fcc04278f4b4b51b8b43b5/internal/logger/msg_ids.go#L211 ESBuild source}
+         * @expires 2025-08-11
+         */
+        "invalid-source-url": "silent",
+    },
 };
 
 function getVersion() {


### PR DESCRIPTION

## Details

This PR applies a minor fix while ESBuild investigates a sourcemap regression: https://github.com/evanw/esbuild/issues/4075
---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
