### PR TITLE
website/docs: troubleshooting: fix missing command prefix for create admin group command in Docker

### DIFF
--- a/website/docs/troubleshooting/missing_admin_group.md
+++ b/website/docs/troubleshooting/missing_admin_group.md
@@ -7,7 +7,7 @@ If all of the Admin groups have been deleted, or misconfigured during sync, you 
 Run the following command, where _username_ is the user you want to add to the newly created group:
 
 ```shell
-docker compose run --rm server create_admin_group username
+docker compose run --rm server ak create_admin_group username
 ```
 
 or, for Kubernetes, run


### PR DESCRIPTION

the create_admin_group command  is part of manage.py

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
