### PR TITLE
cmd: set version in outposts

### DIFF
--- a/cmd/ldap/main.go
+++ b/cmd/ldap/main.go
@@ -10,6 +10,7 @@ import (
 
 	"goauthentik.io/internal/common"
 	"goauthentik.io/internal/config"
+	"goauthentik.io/internal/constants"
 	"goauthentik.io/internal/debug"
 	"goauthentik.io/internal/outpost/ak"
 	"goauthentik.io/internal/outpost/ak/healthcheck"
@@ -24,7 +25,8 @@ Required environment variables:
 - AUTHENTIK_INSECURE: Skip SSL Certificate verification`
 
 var rootCmd = &cobra.Command{
-	Long: helpMessage,
+	Long:    helpMessage,
+	Version: constants.FullVersion(),
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		log.SetLevel(log.DebugLevel)
 		log.SetFormatter(&log.JSONFormatter{

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -10,6 +10,7 @@ import (
 
 	"goauthentik.io/internal/common"
 	"goauthentik.io/internal/config"
+	"goauthentik.io/internal/constants"
 	"goauthentik.io/internal/debug"
 	"goauthentik.io/internal/outpost/ak"
 	"goauthentik.io/internal/outpost/ak/healthcheck"
@@ -27,7 +28,8 @@ Optionally, you can set these:
 - AUTHENTIK_HOST_BROWSER: URL to use in the browser, when it differs from AUTHENTIK_HOST`
 
 var rootCmd = &cobra.Command{
-	Long: helpMessage,
+	Long:    helpMessage,
+	Version: constants.FullVersion(),
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		log.SetLevel(log.DebugLevel)
 		log.SetFormatter(&log.JSONFormatter{

--- a/cmd/rac/main.go
+++ b/cmd/rac/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"goauthentik.io/internal/common"
+	"goauthentik.io/internal/constants"
 	"goauthentik.io/internal/debug"
 	"goauthentik.io/internal/outpost/ak"
 	"goauthentik.io/internal/outpost/ak/healthcheck"
@@ -23,7 +24,8 @@ Required environment variables:
 - AUTHENTIK_INSECURE: Skip SSL Certificate verification`
 
 var rootCmd = &cobra.Command{
-	Long: helpMessage,
+	Long:    helpMessage,
+	Version: constants.FullVersion(),
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		log.SetLevel(log.DebugLevel)
 		log.SetFormatter(&log.JSONFormatter{

--- a/cmd/radius/main.go
+++ b/cmd/radius/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"goauthentik.io/internal/common"
+	"goauthentik.io/internal/constants"
 	"goauthentik.io/internal/debug"
 	"goauthentik.io/internal/outpost/ak"
 	"goauthentik.io/internal/outpost/ak/healthcheck"
@@ -23,7 +24,8 @@ Required environment variables:
 - AUTHENTIK_INSECURE: Skip SSL Certificate verification`
 
 var rootCmd = &cobra.Command{
-	Long: helpMessage,
+	Long:    helpMessage,
+	Version: constants.FullVersion(),
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		log.SetLevel(log.DebugLevel)
 		log.SetFormatter(&log.JSONFormatter{


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Make it easier to see which version an outpost is

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
