### PR TITLE
website/docs: fix typo

### DIFF
--- a/website/docs/add-secure-apps/providers/ldap/index.md
+++ b/website/docs/add-secure-apps/providers/ldap/index.md
@@ -64,7 +64,7 @@ Starting with 2023.3, periods and slashes in custom attributes will be sanitized
 
 You can also configure SSL for your LDAP Providers by selecting a certificate and a server name in the provider settings.
 
-Starting with authentik 2023.6, StartTLS is supported, and the provider will pick the correct certificate based on the configured _TLS Server name_ field. The certificate is not picked based on the Bind DN, as the StartTLS operation should happen be the bind request to ensure bind credentials are transmitted over TLS.
+Starting with authentik 2023.6, StartTLS is supported, and the provider will pick the correct certificate based on the configured _TLS Server name_ field. The certificate is not picked based on the Bind DN, as the StartTLS operation should happen before the bind request to ensure bind credentials are transmitted over TLS.
 
 This enables you to bind on port 636 using LDAPS.
 


### PR DESCRIPTION
## Details

The sentence was broken; fixing typo to clarify that a secure connection is established *before* an LDAP bind.