### PR TITLE
web/flow: grab focus to uid input field

### DIFF
--- a/web/src/flow/components/ak-flow-password-input.ts
+++ b/web/src/flow/components/ak-flow-password-input.ts
@@ -193,6 +193,9 @@ export class InputPassword extends AKElement {
      * the `autofocus` attribute isn't enough, due to timing within shadow doms and such.
      */
     observeInputFocus(): void {
+        if (!this.grabFocus) {
+            return;
+        }
         this.inputFocusIntervalID = setInterval(() => {
             const input = this.inputRef.value;
 
@@ -219,7 +222,9 @@ export class InputPassword extends AKElement {
     }
 
     disconnectedCallback() {
-        clearInterval(this.inputFocusIntervalID);
+        if (this.inputFocusIntervalID) {
+            clearInterval(this.inputFocusIntervalID);
+        }
 
         super.disconnectedCallback();
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Fix regression that focuses password field when using combo identification stage

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
