### PR TITLE
website/docs: update the 2025.2 rel notes

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,8 +20,8 @@ Even if the issue is not a CVE, we still greatly appreciate your help in hardeni
 
 | Version   | Supported |
 | --------- | --------- |
-| 2024.10.x | ✅        |
 | 2024.12.x | ✅        |
+| 2025.2.x  | ✅        |
 
 ## Reporting a Vulnerability
 

--- a/website/docs/releases/2025/v2025.2.md
+++ b/website/docs/releases/2025/v2025.2.md
@@ -23,37 +23,37 @@ slug: "/releases/2025.2"
 
 ## New features
 
-- SSF Provider <span class="badge badge--primary">Enterprise</span> <span class="badge badge--info">Preview</span>
+- **SSF Provider** <span class="badge badge--primary">Enterprise</span> <span class="badge badge--info">Preview</span>
 
     [Shared Signals Framework](../../add-secure-apps/providers/ssf/index.md) allows applications to register a stream with authentik within which they can received events from authentik such as when a session was revoked or a credential was add/changed/deleted and execute actions based on these events.
 
     Using a SSF provider as a backchannel provider allows admins to integrate authentik with Apple Business School Manager for federated Apple IDs.
 
-- RAC to open source
+- **RAC moved to open source**
 
     Remote access (RDP, VNC and SSH) has moved from enterprise to our free, open source code. We try our best to limit enterprise-specific functionality to features that would be non-essential to homelab users and far more valuable to enterprise use cases. We've had a variety of homelab users reach out with excellent use cases for RAC functionality, so while this will mean giving up some potential revenue, we think that opening up RAC to the community is the right thing to do!
 
-- GeoIP distance and impossible travel checks
+- **GeoIP distance and impossible travel checks**
 
     Add the ability to check for the distance a user has moved compared to a previous login, and add the option to check impossible travel distances based on client IP.
 
     These options can be used to detect and prevent access from potentially stolen authentik sessions or stolen devices. Refer to our [documentation](../../customize/policies/index.md#geoip-policy).
 
-- Email OTP Authenticator Setup Stage
+- **Email OTP Authenticator Setup Stage**
 
     Admins now have the ability to configure the option for users to use their email address as an authenticator. Users that already have an email address set on their account will be able to use that address to receive one-time-passwords. It is also possible to configure authentik to allow users to add additional email addresses as authenticators.
 
-    See [Authenticator Setup Stage](../../add-secure-apps/flows-stages/stages/authenticator_email/index.md).
+    See [Email Authenticator Setup Stage](../../add-secure-apps/flows-stages/stages/authenticator_email/index.md).
 
-- Application Wizard is the default way to create applications
+- **Application Wizard is the default way to create applications**
 
     The default way of creating an application now allows admins to configure the application and provider at the same time, and also add any kind of bindings without having to navigate through different sections of the UI. The previous way of creating a standalone application is and will stay available alongside the new and streamlined method.
 
-- Fine-grained permission for superuser toggle on groups
+- **Fine-grained permission for superuser toggle on groups**
 
     Setting the **Is superuser** toggle on a group now requires a separate permission, making it much easier to allow for delegated management of groups without risking the ability for users to self-elevate permissions. For details, refer to our [documentation](../../users-sources/groups/manage_groups.mdx#modify-a-group).
 
-- Improved debugging experience
+- **Improved debugging experienc**e
 
     For people developing authentik or building very complex, custom integrations, how to configure debugging in authentik is documented [here](../../developer-docs/setup/debugging.md).
 

--- a/website/docs/releases/2025/v2025.2.md
+++ b/website/docs/releases/2025/v2025.2.md
@@ -37,7 +37,7 @@ slug: "/releases/2025.2"
 
     Add the ability to check for the distance a user has moved compared to a previous login, and add the option to check impossible travel distances based on client IP.
 
-    These options can be used to detect and prevent access from potentially stolen authentik sessions or stolen devices. Refer to our [documentation](../../customize/policies/index.md#GeoIP-policy).
+    These options can be used to detect and prevent access from potentially stolen authentik sessions or stolen devices. Refer to our [documentation](../../customize/policies/index.md#geoip-policy).
 
 - Email OTP Authenticator Setup Stage
 
@@ -165,57 +165,57 @@ helm upgrade authentik authentik/authentik -f values.yaml --version ^2025.2
 
 ##### `POST` /authenticators/admin/email/
 
-##### `GET` /authenticators/admin/email/{id}/
+##### `GET` /authenticators/admin/email/&#123;id&#125;/
 
-##### `PUT` /authenticators/admin/email/{id}/
+##### `PUT` /authenticators/admin/email/&#123;id&#125;/
 
-##### `DELETE` /authenticators/admin/email/{id}/
+##### `DELETE` /authenticators/admin/email/&#123;id&#125;/
 
-##### `PATCH` /authenticators/admin/email/{id}/
+##### `PATCH` /authenticators/admin/email/&#123;id&#125;/
 
 ##### `GET` /authenticators/email/
 
-##### `GET` /authenticators/email/{id}/
+##### `GET` /authenticators/email/&#123;id&#125;/
 
-##### `PUT` /authenticators/email/{id}/
+##### `PUT` /authenticators/email/&#123;id&#125;/
 
-##### `DELETE` /authenticators/email/{id}/
+##### `DELETE` /authenticators/email/&#123;id&#125;/
 
-##### `PATCH` /authenticators/email/{id}/
+##### `PATCH` /authenticators/email/&#123;id&#125;/
 
-##### `GET` /authenticators/email/{id}/used_by/
+##### `GET` /authenticators/email/&#123;id&#125;/used_by/
 
 ##### `GET` /providers/ssf/
 
 ##### `POST` /providers/ssf/
 
-##### `GET` /providers/ssf/{id}/
+##### `GET` /providers/ssf/&#123;id&#125;/
 
-##### `PUT` /providers/ssf/{id}/
+##### `PUT` /providers/ssf/&#123;id&#125;/
 
-##### `DELETE` /providers/ssf/{id}/
+##### `DELETE` /providers/ssf/&#123;id&#125;/
 
-##### `PATCH` /providers/ssf/{id}/
+##### `PATCH` /providers/ssf/&#123;id&#125;/
 
-##### `GET` /providers/ssf/{id}/used_by/
+##### `GET` /providers/ssf/&#123;id&#125;/used_by/
 
 ##### `GET` /ssf/streams/
 
-##### `GET` /ssf/streams/{uuid}/
+##### `GET` /ssf/streams/&#123;uuid&#125;/
 
 ##### `GET` /stages/authenticator/email/
 
 ##### `POST` /stages/authenticator/email/
 
-##### `GET` /stages/authenticator/email/{stage_uuid}/
+##### `GET` /stages/authenticator/email/&#123;stage_uuid&#125;/
 
-##### `PUT` /stages/authenticator/email/{stage_uuid}/
+##### `PUT` /stages/authenticator/email/&#123;stage_uuid&#125;/
 
-##### `DELETE` /stages/authenticator/email/{stage_uuid}/
+##### `DELETE` /stages/authenticator/email/&#123;stage_uuid&#125;/
 
-##### `PATCH` /stages/authenticator/email/{stage_uuid}/
+##### `PATCH` /stages/authenticator/email/&#123;stage_uuid&#125;/
 
-##### `GET` /stages/authenticator/email/{stage_uuid}/used_by/
+##### `GET` /stages/authenticator/email/&#123;stage_uuid&#125;/used_by/
 
 #### What's Changed
 
@@ -229,7 +229,7 @@ Changed response : **200 OK**
 
 - Changed content type : `application/json`
 
-##### `GET` /authenticators/admin/duo/{id}/
+##### `GET` /authenticators/admin/duo/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -265,7 +265,7 @@ Changed response : **200 OK**
 
         - Property `uid` (string)
 
-##### `PUT` /authenticators/admin/duo/{id}/
+##### `PUT` /authenticators/admin/duo/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -279,7 +279,7 @@ Changed response : **200 OK**
 
     * Added property `user` (object)
 
-##### `PATCH` /authenticators/admin/duo/{id}/
+##### `PATCH` /authenticators/admin/duo/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -293,7 +293,7 @@ Changed response : **200 OK**
 
     * Added property `user` (object)
 
-##### `GET` /authenticators/admin/sms/{id}/
+##### `GET` /authenticators/admin/sms/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -307,7 +307,7 @@ Changed response : **200 OK**
 
     * Added property `user` (object)
 
-##### `PUT` /authenticators/admin/sms/{id}/
+##### `PUT` /authenticators/admin/sms/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -321,7 +321,7 @@ Changed response : **200 OK**
 
     * Added property `user` (object)
 
-##### `PATCH` /authenticators/admin/sms/{id}/
+##### `PATCH` /authenticators/admin/sms/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -335,7 +335,7 @@ Changed response : **200 OK**
 
     * Added property `user` (object)
 
-##### `GET` /authenticators/admin/totp/{id}/
+##### `GET` /authenticators/admin/totp/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -349,7 +349,7 @@ Changed response : **200 OK**
 
     * Added property `user` (object)
 
-##### `PUT` /authenticators/admin/totp/{id}/
+##### `PUT` /authenticators/admin/totp/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -363,7 +363,7 @@ Changed response : **200 OK**
 
     * Added property `user` (object)
 
-##### `PATCH` /authenticators/admin/totp/{id}/
+##### `PATCH` /authenticators/admin/totp/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -377,7 +377,7 @@ Changed response : **200 OK**
 
     * Added property `user` (object)
 
-##### `GET` /authenticators/admin/webauthn/{id}/
+##### `GET` /authenticators/admin/webauthn/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -391,7 +391,7 @@ Changed response : **200 OK**
 
     * Added property `user` (object)
 
-##### `PUT` /authenticators/admin/webauthn/{id}/
+##### `PUT` /authenticators/admin/webauthn/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -405,7 +405,7 @@ Changed response : **200 OK**
 
     * Added property `user` (object)
 
-##### `PATCH` /authenticators/admin/webauthn/{id}/
+##### `PATCH` /authenticators/admin/webauthn/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -419,7 +419,7 @@ Changed response : **200 OK**
 
     * Added property `user` (object)
 
-##### `GET` /authenticators/duo/{id}/
+##### `GET` /authenticators/duo/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -433,7 +433,7 @@ Changed response : **200 OK**
 
     * Added property `user` (object)
 
-##### `PUT` /authenticators/duo/{id}/
+##### `PUT` /authenticators/duo/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -447,7 +447,7 @@ Changed response : **200 OK**
 
     * Added property `user` (object)
 
-##### `PATCH` /authenticators/duo/{id}/
+##### `PATCH` /authenticators/duo/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -461,7 +461,7 @@ Changed response : **200 OK**
 
     * Added property `user` (object)
 
-##### `GET` /authenticators/sms/{id}/
+##### `GET` /authenticators/sms/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -475,7 +475,7 @@ Changed response : **200 OK**
 
     * Added property `user` (object)
 
-##### `PUT` /authenticators/sms/{id}/
+##### `PUT` /authenticators/sms/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -489,7 +489,7 @@ Changed response : **200 OK**
 
     * Added property `user` (object)
 
-##### `PATCH` /authenticators/sms/{id}/
+##### `PATCH` /authenticators/sms/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -503,7 +503,7 @@ Changed response : **200 OK**
 
     * Added property `user` (object)
 
-##### `GET` /authenticators/totp/{id}/
+##### `GET` /authenticators/totp/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -517,7 +517,7 @@ Changed response : **200 OK**
 
     * Added property `user` (object)
 
-##### `PUT` /authenticators/totp/{id}/
+##### `PUT` /authenticators/totp/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -531,7 +531,7 @@ Changed response : **200 OK**
 
     * Added property `user` (object)
 
-##### `PATCH` /authenticators/totp/{id}/
+##### `PATCH` /authenticators/totp/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -545,7 +545,7 @@ Changed response : **200 OK**
 
     * Added property `user` (object)
 
-##### `GET` /authenticators/webauthn/{id}/
+##### `GET` /authenticators/webauthn/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -559,7 +559,7 @@ Changed response : **200 OK**
 
     * Added property `user` (object)
 
-##### `PUT` /authenticators/webauthn/{id}/
+##### `PUT` /authenticators/webauthn/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -573,7 +573,7 @@ Changed response : **200 OK**
 
     * Added property `user` (object)
 
-##### `PATCH` /authenticators/webauthn/{id}/
+##### `PATCH` /authenticators/webauthn/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -587,7 +587,7 @@ Changed response : **200 OK**
 
     * Added property `user` (object)
 
-##### `GET` /policies/event_matcher/{policy_uuid}/
+##### `GET` /policies/event_matcher/&#123;policy_uuid&#125;/
 
 ###### Return Type:
 
@@ -618,7 +618,7 @@ Changed response : **200 OK**
         - `authentik_stages_authenticator_email.emaildevice`
         - `authentik_providers_ssf.ssfprovider`
 
-##### `PUT` /policies/event_matcher/{policy_uuid}/
+##### `PUT` /policies/event_matcher/&#123;policy_uuid&#125;/
 
 ###### Request:
 
@@ -676,7 +676,7 @@ Changed response : **200 OK**
         - `authentik_stages_authenticator_email.emaildevice`
         - `authentik_providers_ssf.ssfprovider`
 
-##### `PATCH` /policies/event_matcher/{policy_uuid}/
+##### `PATCH` /policies/event_matcher/&#123;policy_uuid&#125;/
 
 ###### Request:
 
@@ -734,7 +734,7 @@ Changed response : **200 OK**
         - `authentik_stages_authenticator_email.emaildevice`
         - `authentik_providers_ssf.ssfprovider`
 
-##### `GET` /providers/saml/{id}/metadata/
+##### `GET` /providers/saml/&#123;id&#125;/metadata/
 
 ###### Return Type:
 
@@ -806,7 +806,7 @@ Changed response : **200 OK**
 
         * Added property `user` (object)
 
-##### `GET` /authenticators/admin/static/{id}/
+##### `GET` /authenticators/admin/static/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -820,7 +820,7 @@ Changed response : **200 OK**
 
     * Added property `user` (object)
 
-##### `PUT` /authenticators/admin/static/{id}/
+##### `PUT` /authenticators/admin/static/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -834,7 +834,7 @@ Changed response : **200 OK**
 
     * Added property `user` (object)
 
-##### `PATCH` /authenticators/admin/static/{id}/
+##### `PATCH` /authenticators/admin/static/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -948,7 +948,7 @@ Changed response : **200 OK**
 
         * Added property `user` (object)
 
-##### `GET` /authenticators/static/{id}/
+##### `GET` /authenticators/static/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -962,7 +962,7 @@ Changed response : **200 OK**
 
     * Added property `user` (object)
 
-##### `PUT` /authenticators/static/{id}/
+##### `PUT` /authenticators/static/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -976,7 +976,7 @@ Changed response : **200 OK**
 
     * Added property `user` (object)
 
-##### `PATCH` /authenticators/static/{id}/
+##### `PATCH` /authenticators/static/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -1026,7 +1026,7 @@ Changed response : **200 OK**
 
         * Added property `user` (object)
 
-##### `GET` /core/tokens/{identifier}/
+##### `GET` /core/tokens/&#123;identifier&#125;/
 
 ###### Return Type:
 
@@ -1044,7 +1044,7 @@ Changed response : **200 OK**
 
         * Added property `password_change_date` (string)
 
-##### `PUT` /core/tokens/{identifier}/
+##### `PUT` /core/tokens/&#123;identifier&#125;/
 
 ###### Return Type:
 
@@ -1062,7 +1062,7 @@ Changed response : **200 OK**
 
         * Added property `password_change_date` (string)
 
-##### `PATCH` /core/tokens/{identifier}/
+##### `PATCH` /core/tokens/&#123;identifier&#125;/
 
 ###### Return Type:
 
@@ -1080,7 +1080,7 @@ Changed response : **200 OK**
 
         * Added property `password_change_date` (string)
 
-##### `GET` /core/users/{id}/
+##### `GET` /core/users/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -1094,7 +1094,7 @@ Changed response : **200 OK**
 
     * Added property `password_change_date` (string)
 
-##### `PUT` /core/users/{id}/
+##### `PUT` /core/users/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -1108,7 +1108,7 @@ Changed response : **200 OK**
 
     * Added property `password_change_date` (string)
 
-##### `PATCH` /core/users/{id}/
+##### `PATCH` /core/users/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -1122,7 +1122,7 @@ Changed response : **200 OK**
 
     * Added property `password_change_date` (string)
 
-##### `GET` /policies/bindings/{policy_binding_uuid}/
+##### `GET` /policies/bindings/&#123;policy_binding_uuid&#125;/
 
 ###### Return Type:
 
@@ -1140,7 +1140,7 @@ Changed response : **200 OK**
 
         * Added property `password_change_date` (string)
 
-##### `PUT` /policies/bindings/{policy_binding_uuid}/
+##### `PUT` /policies/bindings/&#123;policy_binding_uuid&#125;/
 
 ###### Return Type:
 
@@ -1158,7 +1158,7 @@ Changed response : **200 OK**
 
         * Added property `password_change_date` (string)
 
-##### `PATCH` /policies/bindings/{policy_binding_uuid}/
+##### `PATCH` /policies/bindings/&#123;policy_binding_uuid&#125;/
 
 ###### Return Type:
 
@@ -1269,7 +1269,7 @@ Changed response : **200 OK**
             - `authentik_stages_authenticator_email.emaildevice`
             - `authentik_providers_ssf.ssfprovider`
 
-##### `GET` /policies/geoip/{policy_uuid}/
+##### `GET` /policies/geoip/&#123;policy_uuid&#125;/
 
 ###### Return Type:
 
@@ -1289,7 +1289,7 @@ Changed response : **200 OK**
 
     - Added property `impossible_tolerance_km` (integer)
 
-##### `PUT` /policies/geoip/{policy_uuid}/
+##### `PUT` /policies/geoip/&#123;policy_uuid&#125;/
 
 ###### Request:
 
@@ -1325,7 +1325,7 @@ Changed response : **200 OK**
 
     - Added property `impossible_tolerance_km` (integer)
 
-##### `PATCH` /policies/geoip/{policy_uuid}/
+##### `PATCH` /policies/geoip/&#123;policy_uuid&#125;/
 
 ###### Request:
 
@@ -1361,7 +1361,7 @@ Changed response : **200 OK**
 
     - Added property `impossible_tolerance_km` (integer)
 
-##### `POST` /rbac/permissions/assigned_by_roles/{uuid}/assign/
+##### `POST` /rbac/permissions/assigned_by_roles/&#123;uuid&#125;/assign/
 
 ###### Request:
 
@@ -1375,7 +1375,7 @@ Changed content type : `application/json`
     - `authentik_stages_authenticator_email.emaildevice`
     - `authentik_providers_ssf.ssfprovider`
 
-##### `PATCH` /rbac/permissions/assigned_by_roles/{uuid}/unassign/
+##### `PATCH` /rbac/permissions/assigned_by_roles/&#123;uuid&#125;/unassign/
 
 ###### Request:
 
@@ -1389,7 +1389,7 @@ Changed content type : `application/json`
     - `authentik_stages_authenticator_email.emaildevice`
     - `authentik_providers_ssf.ssfprovider`
 
-##### `POST` /rbac/permissions/assigned_by_users/{id}/assign/
+##### `POST` /rbac/permissions/assigned_by_users/&#123;id&#125;/assign/
 
 ###### Request:
 
@@ -1403,7 +1403,7 @@ Changed content type : `application/json`
     - `authentik_stages_authenticator_email.emaildevice`
     - `authentik_providers_ssf.ssfprovider`
 
-##### `PATCH` /rbac/permissions/assigned_by_users/{id}/unassign/
+##### `PATCH` /rbac/permissions/assigned_by_users/&#123;id&#125;/unassign/
 
 ###### Request:
 
@@ -1417,7 +1417,7 @@ Changed content type : `application/json`
     - `authentik_stages_authenticator_email.emaildevice`
     - `authentik_providers_ssf.ssfprovider`
 
-##### `GET` /sources/scim/{slug}/
+##### `GET` /sources/scim/&#123;slug&#125;/
 
 ###### Return Type:
 
@@ -1439,7 +1439,7 @@ Changed response : **200 OK**
 
             * Added property `password_change_date` (string)
 
-##### `PUT` /sources/scim/{slug}/
+##### `PUT` /sources/scim/&#123;slug&#125;/
 
 ###### Return Type:
 
@@ -1461,7 +1461,7 @@ Changed response : **200 OK**
 
             * Added property `password_change_date` (string)
 
-##### `PATCH` /sources/scim/{slug}/
+##### `PATCH` /sources/scim/&#123;slug&#125;/
 
 ###### Return Type:
 
@@ -1573,7 +1573,7 @@ Changed response : **200 OK**
 
             * Added property `password_change_date` (string)
 
-##### `GET` /core/user_consent/{id}/
+##### `GET` /core/user_consent/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -1623,7 +1623,7 @@ Changed response : **200 OK**
 
         * Added property `password_change_date` (string)
 
-##### `GET` /flows/bindings/{fsb_uuid}/
+##### `GET` /flows/bindings/&#123;fsb_uuid&#125;/
 
 ###### Return Type:
 
@@ -1634,7 +1634,7 @@ Changed response : **200 OK**
     - Changed property `re_evaluate_policies` (boolean)
         > Evaluate policies when the Stage is presented to the user.
 
-##### `PUT` /flows/bindings/{fsb_uuid}/
+##### `PUT` /flows/bindings/&#123;fsb_uuid&#125;/
 
 ###### Request:
 
@@ -1652,7 +1652,7 @@ Changed response : **200 OK**
     - Changed property `re_evaluate_policies` (boolean)
         > Evaluate policies when the Stage is presented to the user.
 
-##### `PATCH` /flows/bindings/{fsb_uuid}/
+##### `PATCH` /flows/bindings/&#123;fsb_uuid&#125;/
 
 ###### Request:
 
@@ -1870,7 +1870,7 @@ Changed response : **200 OK**
 
                 * Added property `password_change_date` (string)
 
-##### `GET` /stages/authenticator/validate/{stage_uuid}/
+##### `GET` /stages/authenticator/validate/&#123;stage_uuid&#125;/
 
 ###### Return Type:
 
@@ -1888,7 +1888,7 @@ Changed response : **200 OK**
 
         - `email`
 
-##### `PUT` /stages/authenticator/validate/{stage_uuid}/
+##### `PUT` /stages/authenticator/validate/&#123;stage_uuid&#125;/
 
 ###### Request:
 
@@ -1920,7 +1920,7 @@ Changed response : **200 OK**
 
         - `email`
 
-##### `PATCH` /stages/authenticator/validate/{stage_uuid}/
+##### `PATCH` /stages/authenticator/validate/&#123;stage_uuid&#125;/
 
 ###### Request:
 
@@ -2007,7 +2007,7 @@ Changed response : **200 OK**
         - Changed property `re_evaluate_policies` (boolean)
             > Evaluate policies when the Stage is presented to the user.
 
-##### `GET` /flows/executor/{flow_slug}/
+##### `GET` /flows/executor/&#123;flow_slug&#125;/
 
 ###### Return Type:
 
@@ -2049,7 +2049,7 @@ Changed response : **200 OK**
 
     - Property `email_required` (boolean)
 
-##### `POST` /flows/executor/{flow_slug}/
+##### `POST` /flows/executor/&#123;flow_slug&#125;/
 
 ###### Request:
 
@@ -2071,7 +2071,7 @@ Changed response : **200 OK**
 
     Added 'ak-stage-authenticator-email' component:
 
-##### `GET` /flows/inspector/{flow_slug}/
+##### `GET` /flows/inspector/&#123;flow_slug&#125;/
 
 ###### Return Type:
 
@@ -2097,7 +2097,7 @@ Changed response : **200 OK**
             - Changed property `re_evaluate_policies` (boolean)
                 > Evaluate policies when the Stage is presented to the user.
 
-##### `GET` /oauth2/access_tokens/{id}/
+##### `GET` /oauth2/access_tokens/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -2115,7 +2115,7 @@ Changed response : **200 OK**
 
         * Added property `password_change_date` (string)
 
-##### `GET` /oauth2/authorization_codes/{id}/
+##### `GET` /oauth2/authorization_codes/&#123;id&#125;/
 
 ###### Return Type:
 
@@ -2133,7 +2133,7 @@ Changed response : **200 OK**
 
         * Added property `password_change_date` (string)
 
-##### `GET` /oauth2/refresh_tokens/{id}/
+##### `GET` /oauth2/refresh_tokens/&#123;id&#125;/
 
 ###### Return Type:
 

--- a/website/docs/releases/2025/v2025.2.md
+++ b/website/docs/releases/2025/v2025.2.md
@@ -3,12 +3,6 @@ title: Release 2025.2
 slug: "/releases/2025.2"
 ---
 
-:::::note
-2025.2 has not been released yet! We're publishing these release notes as a preview of what's to come, and for our awesome beta testers trying out release candidates.
-
-To try out the release candidate, replace your Docker image tag with the latest release candidate number, such as 2025.2.0-rc1. You can find the latest one in [the latest releases on GitHub](https://github.com/goauthentik/authentik/releases). If you don't find any, it means we haven't released one yet.
-:::::
-
 ## Highlights
 
 - **SSF Provider <span class="badge badge--primary">Enterprise</span> <span class="badge badge--info">Preview</span>** Add support for Shared Signals Framework
@@ -32,9 +26,9 @@ To try out the release candidate, replace your Docker image tag with the latest 
 
 - SSF Provider <span class="badge badge--primary">Enterprise</span> <span class="badge badge--info">Preview</span>
 
-    [Shared Signals Framework](#todo) allows applications to register a stream with authentik within which they can received events from authentik such as when a session was revoked or a credential was add/changed/deleted and execute actions based on these events.
+    [Shared Signals Framework](../../add-secure-apps/providers/ssf/index.md) allows applications to register a stream with authentik within which they can received events from authentik such as when a session was revoked or a credential was add/changed/deleted and execute actions based on these events.
 
-    This allows admins to integrate authentik with Apple Business/School Manager for federated Apple IDs. See the integration docs [here](#todo)
+    Using a SSF provider as a backchannel provider allows admins to integrate authentik with Apple Business School Manager for federated Apple IDs.
 
 - RAC to open source
 
@@ -44,29 +38,25 @@ To try out the release candidate, replace your Docker image tag with the latest 
 
     Add the ability to check for the distance a user has moved compared to a previous login, and add the option to check impossible travel distances based on client IP.
 
-    These options can be used to detect and prevent access from potentially stolen authentik sessions or stolen devices.
+    These options can be used to detect and prevent access from potentially stolen authentik sessions or stolen devices. Refer to our [documentation](../../customize/policies/index.md#GeoIP-policy).
 
-- Email OTP Stage
+- Email OTP Authenticator Setup Stage
 
-    Admins now have the ability to configure the option for users to use their email as an authenticator. Users that already have an email address set on their account will be able to use that address to receive one-time-passwords. It is also possible to configure authentik to allow users to add additional email addresses as authenticators.
+    Admins now have the ability to configure the option for users to use their email address as an authenticator. Users that already have an email address set on their account will be able to use that address to receive one-time-passwords. It is also possible to configure authentik to allow users to add additional email addresses as authenticators.
 
-    See [Email OTP Stage](#todo)
+    See [Authenticator Setup Stage](../../add-secure-apps/flows-stages/stages/authenticator_email/index.md).
 
 - Application Wizard is the default way to create applications
 
-    The default way of creating an application now allows admins to configure the provider and any kind of bindings without having to jump through different sections of the UI. The previous way of creating an application is and will stay available alongside the new and streamlined method.
+    The default way of creating an application now allows admins to configure the application and provider at the same time, and also add any kind of bindings without having to navigate through different sections of the UI. The previous way of creating a standalone application is and will stay available alongside the new and streamlined method.
 
 - Fine-grained permission for superuser toggle on groups
 
-    Setting the **Is superuser** toggle on a group now requires a separate permission, making it much easier to allow for delegated management of groups without risking the ability for users to self-elevate permissions.
+    Setting the **Is superuser** toggle on a group now requires a separate permission, making it much easier to allow for delegated management of groups without risking the ability for users to self-elevate permissions. For details, refer to our [documentation](../../users-sources/groups/manage_groups.mdx#modify-a-group).
 
 - Improved debugging experience
 
-    For people developing authentik or building very complex, custom integrations, configuring debugging in authentik is now documented [here](#todo)
-
-## TODO
-
-temp
+    For people developing authentik or building very complex, custom integrations, configuring debugging in authentik is documented [here](../../developer-docs/setup/debugging.md).
 
 ## Upgrading
 

--- a/website/docs/releases/2025/v2025.2.md
+++ b/website/docs/releases/2025/v2025.2.md
@@ -157,4 +157,2144 @@ helm upgrade authentik authentik/authentik -f values.yaml --version ^2025.2
 
 ## API Changes
 
-<!-- _Insert output of `make gen-diff` here_ -->
+#### What's New
+
+---
+
+##### `GET` /authenticators/admin/email/
+
+##### `POST` /authenticators/admin/email/
+
+##### `GET` /authenticators/admin/email/{id}/
+
+##### `PUT` /authenticators/admin/email/{id}/
+
+##### `DELETE` /authenticators/admin/email/{id}/
+
+##### `PATCH` /authenticators/admin/email/{id}/
+
+##### `GET` /authenticators/email/
+
+##### `GET` /authenticators/email/{id}/
+
+##### `PUT` /authenticators/email/{id}/
+
+##### `DELETE` /authenticators/email/{id}/
+
+##### `PATCH` /authenticators/email/{id}/
+
+##### `GET` /authenticators/email/{id}/used_by/
+
+##### `GET` /providers/ssf/
+
+##### `POST` /providers/ssf/
+
+##### `GET` /providers/ssf/{id}/
+
+##### `PUT` /providers/ssf/{id}/
+
+##### `DELETE` /providers/ssf/{id}/
+
+##### `PATCH` /providers/ssf/{id}/
+
+##### `GET` /providers/ssf/{id}/used_by/
+
+##### `GET` /ssf/streams/
+
+##### `GET` /ssf/streams/{uuid}/
+
+##### `GET` /stages/authenticator/email/
+
+##### `POST` /stages/authenticator/email/
+
+##### `GET` /stages/authenticator/email/{stage_uuid}/
+
+##### `PUT` /stages/authenticator/email/{stage_uuid}/
+
+##### `DELETE` /stages/authenticator/email/{stage_uuid}/
+
+##### `PATCH` /stages/authenticator/email/{stage_uuid}/
+
+##### `GET` /stages/authenticator/email/{stage_uuid}/used_by/
+
+#### What's Changed
+
+---
+
+##### `GET` /admin/workers/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+##### `GET` /authenticators/admin/duo/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+        - Property `pk` (integer)
+
+        - Property `username` (string)
+
+            > Required. 150 characters or fewer. Letters, digits and @/./+/-/\_ only.
+
+        - Property `name` (string)
+
+            > User's display name.
+
+        - Property `is_active` (boolean)
+
+            > Designates whether this user should be treated as active. Unselect this instead of deleting accounts.
+
+        - Property `last_login` (string)
+
+        - Property `email` (string)
+
+        - Property `attributes` (object)
+
+        - Property `uid` (string)
+
+##### `PUT` /authenticators/admin/duo/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `PATCH` /authenticators/admin/duo/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `GET` /authenticators/admin/sms/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `PUT` /authenticators/admin/sms/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `PATCH` /authenticators/admin/sms/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `GET` /authenticators/admin/totp/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `PUT` /authenticators/admin/totp/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `PATCH` /authenticators/admin/totp/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `GET` /authenticators/admin/webauthn/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `PUT` /authenticators/admin/webauthn/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `PATCH` /authenticators/admin/webauthn/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `GET` /authenticators/duo/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `PUT` /authenticators/duo/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `PATCH` /authenticators/duo/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `GET` /authenticators/sms/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `PUT` /authenticators/sms/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `PATCH` /authenticators/sms/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `GET` /authenticators/totp/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `PUT` /authenticators/totp/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `PATCH` /authenticators/totp/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `GET` /authenticators/webauthn/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `PUT` /authenticators/webauthn/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `PATCH` /authenticators/webauthn/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `GET` /policies/event_matcher/{policy_uuid}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `app` (string)
+
+        > Match events created by selected application. When left empty, all applications are matched.
+
+        Added enum values:
+
+        - `authentik.providers.rac`
+        - `authentik.stages.authenticator_email`
+        - `authentik.enterprise.providers.ssf`
+          Removed enum value:
+
+        - `authentik.enterprise.providers.rac`
+
+    - Changed property `model` (string)
+
+        > Match events created by selected model. When left empty, all models are matched. When an app is selected, all the application's models are matched.
+
+        Added enum values:
+
+        - `authentik_stages_authenticator_email.authenticatoremailstage`
+        - `authentik_stages_authenticator_email.emaildevice`
+        - `authentik_providers_ssf.ssfprovider`
+
+##### `PUT` /policies/event_matcher/{policy_uuid}/
+
+###### Request:
+
+Changed content type : `application/json`
+
+- Changed property `app` (string)
+
+    > Match events created by selected application. When left empty, all applications are matched.
+
+    Added enum values:
+
+    - `authentik.providers.rac`
+    - `authentik.stages.authenticator_email`
+    - `authentik.enterprise.providers.ssf`
+      Removed enum value:
+
+    - `authentik.enterprise.providers.rac`
+
+- Changed property `model` (string)
+
+    > Match events created by selected model. When left empty, all models are matched. When an app is selected, all the application's models are matched.
+
+    Added enum values:
+
+    - `authentik_stages_authenticator_email.authenticatoremailstage`
+    - `authentik_stages_authenticator_email.emaildevice`
+    - `authentik_providers_ssf.ssfprovider`
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `app` (string)
+
+        > Match events created by selected application. When left empty, all applications are matched.
+
+        Added enum values:
+
+        - `authentik.providers.rac`
+        - `authentik.stages.authenticator_email`
+        - `authentik.enterprise.providers.ssf`
+          Removed enum value:
+
+        - `authentik.enterprise.providers.rac`
+
+    - Changed property `model` (string)
+
+        > Match events created by selected model. When left empty, all models are matched. When an app is selected, all the application's models are matched.
+
+        Added enum values:
+
+        - `authentik_stages_authenticator_email.authenticatoremailstage`
+        - `authentik_stages_authenticator_email.emaildevice`
+        - `authentik_providers_ssf.ssfprovider`
+
+##### `PATCH` /policies/event_matcher/{policy_uuid}/
+
+###### Request:
+
+Changed content type : `application/json`
+
+- Changed property `app` (string)
+
+    > Match events created by selected application. When left empty, all applications are matched.
+
+    Added enum values:
+
+    - `authentik.providers.rac`
+    - `authentik.stages.authenticator_email`
+    - `authentik.enterprise.providers.ssf`
+      Removed enum value:
+
+    - `authentik.enterprise.providers.rac`
+
+- Changed property `model` (string)
+
+    > Match events created by selected model. When left empty, all models are matched. When an app is selected, all the application's models are matched.
+
+    Added enum values:
+
+    - `authentik_stages_authenticator_email.authenticatoremailstage`
+    - `authentik_stages_authenticator_email.emaildevice`
+    - `authentik_providers_ssf.ssfprovider`
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `app` (string)
+
+        > Match events created by selected application. When left empty, all applications are matched.
+
+        Added enum values:
+
+        - `authentik.providers.rac`
+        - `authentik.stages.authenticator_email`
+        - `authentik.enterprise.providers.ssf`
+          Removed enum value:
+
+        - `authentik.enterprise.providers.rac`
+
+    - Changed property `model` (string)
+
+        > Match events created by selected model. When left empty, all models are matched. When an app is selected, all the application's models are matched.
+
+        Added enum values:
+
+        - `authentik_stages_authenticator_email.authenticatoremailstage`
+        - `authentik_stages_authenticator_email.emaildevice`
+        - `authentik_providers_ssf.ssfprovider`
+
+##### `GET` /providers/saml/{id}/metadata/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- New content type : `application/xml`
+
+##### `POST` /authenticators/admin/duo/
+
+###### Return Type:
+
+Changed response : **201 Created**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `GET` /authenticators/admin/duo/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `results` (array)
+
+        Changed items (object): > Serializer for Duo authenticator devices
+
+        New required properties:
+
+        - `user`
+
+        * Added property `user` (object)
+
+##### `POST` /authenticators/admin/sms/
+
+###### Return Type:
+
+Changed response : **201 Created**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `GET` /authenticators/admin/sms/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `results` (array)
+
+        Changed items (object): > Serializer for sms authenticator devices
+
+        New required properties:
+
+        - `user`
+
+        * Added property `user` (object)
+
+##### `GET` /authenticators/admin/static/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `PUT` /authenticators/admin/static/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `PATCH` /authenticators/admin/static/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `POST` /authenticators/admin/totp/
+
+###### Return Type:
+
+Changed response : **201 Created**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `GET` /authenticators/admin/totp/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `results` (array)
+
+        Changed items (object): > Serializer for totp authenticator devices
+
+        New required properties:
+
+        - `user`
+
+        * Added property `user` (object)
+
+##### `POST` /authenticators/admin/webauthn/
+
+###### Return Type:
+
+Changed response : **201 Created**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `GET` /authenticators/admin/webauthn/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `results` (array)
+
+        Changed items (object): > Serializer for WebAuthn authenticator devices
+
+        New required properties:
+
+        - `user`
+
+        * Added property `user` (object)
+
+##### `GET` /authenticators/duo/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `results` (array)
+
+        Changed items (object): > Serializer for Duo authenticator devices
+
+        New required properties:
+
+        - `user`
+
+        * Added property `user` (object)
+
+##### `GET` /authenticators/sms/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `results` (array)
+
+        Changed items (object): > Serializer for sms authenticator devices
+
+        New required properties:
+
+        - `user`
+
+        * Added property `user` (object)
+
+##### `GET` /authenticators/static/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `PUT` /authenticators/static/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `PATCH` /authenticators/static/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `GET` /authenticators/totp/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `results` (array)
+
+        Changed items (object): > Serializer for totp authenticator devices
+
+        New required properties:
+
+        - `user`
+
+        * Added property `user` (object)
+
+##### `GET` /authenticators/webauthn/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `results` (array)
+
+        Changed items (object): > Serializer for WebAuthn authenticator devices
+
+        New required properties:
+
+        - `user`
+
+        * Added property `user` (object)
+
+##### `GET` /core/tokens/{identifier}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `user_obj` (object)
+
+        > User Serializer
+
+        New required properties:
+
+        - `password_change_date`
+
+        * Added property `password_change_date` (string)
+
+##### `PUT` /core/tokens/{identifier}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `user_obj` (object)
+
+        > User Serializer
+
+        New required properties:
+
+        - `password_change_date`
+
+        * Added property `password_change_date` (string)
+
+##### `PATCH` /core/tokens/{identifier}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `user_obj` (object)
+
+        > User Serializer
+
+        New required properties:
+
+        - `password_change_date`
+
+        * Added property `password_change_date` (string)
+
+##### `GET` /core/users/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `password_change_date`
+
+    * Added property `password_change_date` (string)
+
+##### `PUT` /core/users/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `password_change_date`
+
+    * Added property `password_change_date` (string)
+
+##### `PATCH` /core/users/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `password_change_date`
+
+    * Added property `password_change_date` (string)
+
+##### `GET` /policies/bindings/{policy_binding_uuid}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `user_obj` (object)
+
+        > User Serializer
+
+        New required properties:
+
+        - `password_change_date`
+
+        * Added property `password_change_date` (string)
+
+##### `PUT` /policies/bindings/{policy_binding_uuid}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `user_obj` (object)
+
+        > User Serializer
+
+        New required properties:
+
+        - `password_change_date`
+
+        * Added property `password_change_date` (string)
+
+##### `PATCH` /policies/bindings/{policy_binding_uuid}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `user_obj` (object)
+
+        > User Serializer
+
+        New required properties:
+
+        - `password_change_date`
+
+        * Added property `password_change_date` (string)
+
+##### `POST` /policies/event_matcher/
+
+###### Request:
+
+Changed content type : `application/json`
+
+- Changed property `app` (string)
+
+    > Match events created by selected application. When left empty, all applications are matched.
+
+    Added enum values:
+
+    - `authentik.providers.rac`
+    - `authentik.stages.authenticator_email`
+    - `authentik.enterprise.providers.ssf`
+      Removed enum value:
+
+    - `authentik.enterprise.providers.rac`
+
+- Changed property `model` (string)
+
+    > Match events created by selected model. When left empty, all models are matched. When an app is selected, all the application's models are matched.
+
+    Added enum values:
+
+    - `authentik_stages_authenticator_email.authenticatoremailstage`
+    - `authentik_stages_authenticator_email.emaildevice`
+    - `authentik_providers_ssf.ssfprovider`
+
+###### Return Type:
+
+Changed response : **201 Created**
+
+- Changed content type : `application/json`
+
+    - Changed property `app` (string)
+
+        > Match events created by selected application. When left empty, all applications are matched.
+
+        Added enum values:
+
+        - `authentik.providers.rac`
+        - `authentik.stages.authenticator_email`
+        - `authentik.enterprise.providers.ssf`
+          Removed enum value:
+
+        - `authentik.enterprise.providers.rac`
+
+    - Changed property `model` (string)
+
+        > Match events created by selected model. When left empty, all models are matched. When an app is selected, all the application's models are matched.
+
+        Added enum values:
+
+        - `authentik_stages_authenticator_email.authenticatoremailstage`
+        - `authentik_stages_authenticator_email.emaildevice`
+        - `authentik_providers_ssf.ssfprovider`
+
+##### `GET` /policies/event_matcher/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `results` (array)
+
+        Changed items (object): > Event Matcher Policy Serializer
+
+        - Changed property `app` (string)
+
+            > Match events created by selected application. When left empty, all applications are matched.
+
+            Added enum values:
+
+            - `authentik.providers.rac`
+            - `authentik.stages.authenticator_email`
+            - `authentik.enterprise.providers.ssf`
+              Removed enum value:
+
+            - `authentik.enterprise.providers.rac`
+
+        - Changed property `model` (string)
+
+            > Match events created by selected model. When left empty, all models are matched. When an app is selected, all the application's models are matched.
+
+            Added enum values:
+
+            - `authentik_stages_authenticator_email.authenticatoremailstage`
+            - `authentik_stages_authenticator_email.emaildevice`
+            - `authentik_providers_ssf.ssfprovider`
+
+##### `GET` /policies/geoip/{policy_uuid}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Added property `check_history_distance` (boolean)
+
+    - Added property `history_max_distance_km` (integer)
+
+    - Added property `distance_tolerance_km` (integer)
+
+    - Added property `history_login_count` (integer)
+
+    - Added property `check_impossible_travel` (boolean)
+
+    - Added property `impossible_tolerance_km` (integer)
+
+##### `PUT` /policies/geoip/{policy_uuid}/
+
+###### Request:
+
+Changed content type : `application/json`
+
+- Added property `check_history_distance` (boolean)
+
+- Added property `history_max_distance_km` (integer)
+
+- Added property `distance_tolerance_km` (integer)
+
+- Added property `history_login_count` (integer)
+
+- Added property `check_impossible_travel` (boolean)
+
+- Added property `impossible_tolerance_km` (integer)
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Added property `check_history_distance` (boolean)
+
+    - Added property `history_max_distance_km` (integer)
+
+    - Added property `distance_tolerance_km` (integer)
+
+    - Added property `history_login_count` (integer)
+
+    - Added property `check_impossible_travel` (boolean)
+
+    - Added property `impossible_tolerance_km` (integer)
+
+##### `PATCH` /policies/geoip/{policy_uuid}/
+
+###### Request:
+
+Changed content type : `application/json`
+
+- Added property `check_history_distance` (boolean)
+
+- Added property `history_max_distance_km` (integer)
+
+- Added property `distance_tolerance_km` (integer)
+
+- Added property `history_login_count` (integer)
+
+- Added property `check_impossible_travel` (boolean)
+
+- Added property `impossible_tolerance_km` (integer)
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Added property `check_history_distance` (boolean)
+
+    - Added property `history_max_distance_km` (integer)
+
+    - Added property `distance_tolerance_km` (integer)
+
+    - Added property `history_login_count` (integer)
+
+    - Added property `check_impossible_travel` (boolean)
+
+    - Added property `impossible_tolerance_km` (integer)
+
+##### `POST` /rbac/permissions/assigned_by_roles/{uuid}/assign/
+
+###### Request:
+
+Changed content type : `application/json`
+
+- Changed property `model` (string)
+
+    Added enum values:
+
+    - `authentik_stages_authenticator_email.authenticatoremailstage`
+    - `authentik_stages_authenticator_email.emaildevice`
+    - `authentik_providers_ssf.ssfprovider`
+
+##### `PATCH` /rbac/permissions/assigned_by_roles/{uuid}/unassign/
+
+###### Request:
+
+Changed content type : `application/json`
+
+- Changed property `model` (string)
+
+    Added enum values:
+
+    - `authentik_stages_authenticator_email.authenticatoremailstage`
+    - `authentik_stages_authenticator_email.emaildevice`
+    - `authentik_providers_ssf.ssfprovider`
+
+##### `POST` /rbac/permissions/assigned_by_users/{id}/assign/
+
+###### Request:
+
+Changed content type : `application/json`
+
+- Changed property `model` (string)
+
+    Added enum values:
+
+    - `authentik_stages_authenticator_email.authenticatoremailstage`
+    - `authentik_stages_authenticator_email.emaildevice`
+    - `authentik_providers_ssf.ssfprovider`
+
+##### `PATCH` /rbac/permissions/assigned_by_users/{id}/unassign/
+
+###### Request:
+
+Changed content type : `application/json`
+
+- Changed property `model` (string)
+
+    Added enum values:
+
+    - `authentik_stages_authenticator_email.authenticatoremailstage`
+    - `authentik_stages_authenticator_email.emaildevice`
+    - `authentik_providers_ssf.ssfprovider`
+
+##### `GET` /sources/scim/{slug}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `token_obj` (object)
+
+        > Token Serializer
+
+        - Changed property `user_obj` (object)
+
+            > User Serializer
+
+            New required properties:
+
+            - `password_change_date`
+
+            * Added property `password_change_date` (string)
+
+##### `PUT` /sources/scim/{slug}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `token_obj` (object)
+
+        > Token Serializer
+
+        - Changed property `user_obj` (object)
+
+            > User Serializer
+
+            New required properties:
+
+            - `password_change_date`
+
+            * Added property `password_change_date` (string)
+
+##### `PATCH` /sources/scim/{slug}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `token_obj` (object)
+
+        > Token Serializer
+
+        - Changed property `user_obj` (object)
+
+            > User Serializer
+
+            New required properties:
+
+            - `password_change_date`
+
+            * Added property `password_change_date` (string)
+
+##### `POST` /authenticators/admin/static/
+
+###### Return Type:
+
+Changed response : **201 Created**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `user`
+
+    * Added property `user` (object)
+
+##### `GET` /authenticators/admin/static/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `results` (array)
+
+        Changed items (object): > Serializer for static authenticator devices
+
+        New required properties:
+
+        - `user`
+
+        * Added property `user` (object)
+
+##### `GET` /authenticators/static/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `results` (array)
+
+        Changed items (object): > Serializer for static authenticator devices
+
+        New required properties:
+
+        - `user`
+
+        * Added property `user` (object)
+
+##### `POST` /core/tokens/
+
+###### Return Type:
+
+Changed response : **201 Created**
+
+- Changed content type : `application/json`
+
+    - Changed property `user_obj` (object)
+
+        > User Serializer
+
+        New required properties:
+
+        - `password_change_date`
+
+        * Added property `password_change_date` (string)
+
+##### `GET` /core/tokens/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `results` (array)
+
+        Changed items (object): > Token Serializer
+
+        - Changed property `user_obj` (object)
+
+            > User Serializer
+
+            New required properties:
+
+            - `password_change_date`
+
+            * Added property `password_change_date` (string)
+
+##### `GET` /core/user_consent/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `user` (object)
+
+        > User Serializer
+
+        New required properties:
+
+        - `password_change_date`
+
+        * Added property `password_change_date` (string)
+
+##### `POST` /core/users/
+
+###### Return Type:
+
+Changed response : **201 Created**
+
+- Changed content type : `application/json`
+
+    New required properties:
+
+    - `password_change_date`
+
+    * Added property `password_change_date` (string)
+
+##### `GET` /core/users/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `results` (array)
+
+        Changed items (object): > User Serializer
+
+        New required properties:
+
+        - `password_change_date`
+
+        * Added property `password_change_date` (string)
+
+##### `GET` /flows/bindings/{fsb_uuid}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `re_evaluate_policies` (boolean)
+        > Evaluate policies when the Stage is presented to the user.
+
+##### `PUT` /flows/bindings/{fsb_uuid}/
+
+###### Request:
+
+Changed content type : `application/json`
+
+- Changed property `re_evaluate_policies` (boolean)
+    > Evaluate policies when the Stage is presented to the user.
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `re_evaluate_policies` (boolean)
+        > Evaluate policies when the Stage is presented to the user.
+
+##### `PATCH` /flows/bindings/{fsb_uuid}/
+
+###### Request:
+
+Changed content type : `application/json`
+
+- Changed property `re_evaluate_policies` (boolean)
+    > Evaluate policies when the Stage is presented to the user.
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `re_evaluate_policies` (boolean)
+        > Evaluate policies when the Stage is presented to the user.
+
+##### `POST` /policies/bindings/
+
+###### Return Type:
+
+Changed response : **201 Created**
+
+- Changed content type : `application/json`
+
+    - Changed property `user_obj` (object)
+
+        > User Serializer
+
+        New required properties:
+
+        - `password_change_date`
+
+        * Added property `password_change_date` (string)
+
+##### `GET` /policies/bindings/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `results` (array)
+
+        Changed items (object): > PolicyBinding Serializer
+
+        - Changed property `user_obj` (object)
+
+            > User Serializer
+
+            New required properties:
+
+            - `password_change_date`
+
+            * Added property `password_change_date` (string)
+
+##### `POST` /policies/geoip/
+
+###### Request:
+
+Changed content type : `application/json`
+
+- Added property `check_history_distance` (boolean)
+
+- Added property `history_max_distance_km` (integer)
+
+- Added property `distance_tolerance_km` (integer)
+
+- Added property `history_login_count` (integer)
+
+- Added property `check_impossible_travel` (boolean)
+
+- Added property `impossible_tolerance_km` (integer)
+
+###### Return Type:
+
+Changed response : **201 Created**
+
+- Changed content type : `application/json`
+
+    - Added property `check_history_distance` (boolean)
+
+    - Added property `history_max_distance_km` (integer)
+
+    - Added property `distance_tolerance_km` (integer)
+
+    - Added property `history_login_count` (integer)
+
+    - Added property `check_impossible_travel` (boolean)
+
+    - Added property `impossible_tolerance_km` (integer)
+
+##### `GET` /policies/geoip/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `results` (array)
+
+        Changed items (object): > GeoIP Policy Serializer
+
+        - Added property `check_history_distance` (boolean)
+
+        - Added property `history_max_distance_km` (integer)
+
+        - Added property `distance_tolerance_km` (integer)
+
+        - Added property `history_login_count` (integer)
+
+        - Added property `check_impossible_travel` (boolean)
+
+        - Added property `impossible_tolerance_km` (integer)
+
+##### `GET` /rbac/permissions/assigned_by_roles/
+
+###### Parameters:
+
+Changed: `model` in `query`
+
+##### `GET` /rbac/permissions/assigned_by_users/
+
+###### Parameters:
+
+Changed: `model` in `query`
+
+##### `GET` /sources/all/
+
+###### Parameters:
+
+Added: `pbm_uuid` in `query`
+
+##### `GET` /sources/kerberos/
+
+###### Parameters:
+
+Added: `pbm_uuid` in `query`
+
+##### `GET` /sources/ldap/
+
+###### Parameters:
+
+Added: `pbm_uuid` in `query`
+
+##### `GET` /sources/oauth/
+
+###### Parameters:
+
+Added: `pbm_uuid` in `query`
+
+##### `GET` /sources/plex/
+
+###### Parameters:
+
+Added: `pbm_uuid` in `query`
+
+##### `GET` /sources/saml/
+
+###### Parameters:
+
+Added: `pbm_uuid` in `query`
+
+##### `POST` /sources/scim/
+
+###### Return Type:
+
+Changed response : **201 Created**
+
+- Changed content type : `application/json`
+
+    - Changed property `token_obj` (object)
+
+        > Token Serializer
+
+        - Changed property `user_obj` (object)
+
+            > User Serializer
+
+            New required properties:
+
+            - `password_change_date`
+
+            * Added property `password_change_date` (string)
+
+##### `GET` /sources/scim/
+
+###### Parameters:
+
+Added: `pbm_uuid` in `query`
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `results` (array)
+
+        Changed items (object): > SCIMSource Serializer
+
+        - Changed property `token_obj` (object)
+
+            > Token Serializer
+
+            - Changed property `user_obj` (object)
+
+                > User Serializer
+
+                New required properties:
+
+                - `password_change_date`
+
+                * Added property `password_change_date` (string)
+
+##### `GET` /stages/authenticator/validate/{stage_uuid}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `device_classes` (array)
+
+        > Device classes which can be used to authenticate
+
+        Changed items (string):
+
+        Added enum value:
+
+        - `email`
+
+##### `PUT` /stages/authenticator/validate/{stage_uuid}/
+
+###### Request:
+
+Changed content type : `application/json`
+
+- Changed property `device_classes` (array)
+
+    > Device classes which can be used to authenticate
+
+    Changed items (string):
+
+    Added enum value:
+
+    - `email`
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `device_classes` (array)
+
+        > Device classes which can be used to authenticate
+
+        Changed items (string):
+
+        Added enum value:
+
+        - `email`
+
+##### `PATCH` /stages/authenticator/validate/{stage_uuid}/
+
+###### Request:
+
+Changed content type : `application/json`
+
+- Changed property `device_classes` (array)
+
+    > Device classes which can be used to authenticate
+
+    Changed items (string):
+
+    Added enum value:
+
+    - `email`
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `device_classes` (array)
+
+        > Device classes which can be used to authenticate
+
+        Changed items (string):
+
+        Added enum value:
+
+        - `email`
+
+##### `GET` /core/user_consent/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `results` (array)
+
+        Changed items (object): > UserConsent Serializer
+
+        - Changed property `user` (object)
+
+            > User Serializer
+
+            New required properties:
+
+            - `password_change_date`
+
+            * Added property `password_change_date` (string)
+
+##### `POST` /flows/bindings/
+
+###### Request:
+
+Changed content type : `application/json`
+
+- Changed property `re_evaluate_policies` (boolean)
+    > Evaluate policies when the Stage is presented to the user.
+
+###### Return Type:
+
+Changed response : **201 Created**
+
+- Changed content type : `application/json`
+
+    - Changed property `re_evaluate_policies` (boolean)
+        > Evaluate policies when the Stage is presented to the user.
+
+##### `GET` /flows/bindings/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `results` (array)
+
+        Changed items (object): > FlowStageBinding Serializer
+
+        - Changed property `re_evaluate_policies` (boolean)
+            > Evaluate policies when the Stage is presented to the user.
+
+##### `GET` /flows/executor/{flow_slug}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    Added 'ak-stage-authenticator-email' component:
+
+    - Property `flow_info` (object)
+
+        > Contextual flow information for a challenge
+
+        - Property `title` (string)
+
+        - Property `background` (string)
+
+        - Property `cancel_url` (string)
+
+        - Property `layout` (string)
+
+            Enum values:
+
+            - `stacked`
+            - `content_left`
+            - `content_right`
+            - `sidebar_left`
+            - `sidebar_right`
+
+    - Property `component` (string)
+
+    - Property `response_errors` (object)
+
+    - Property `pending_user` (string)
+
+    - Property `pending_user_avatar` (string)
+
+    - Property `email` (string)
+
+    - Property `email_required` (boolean)
+
+##### `POST` /flows/executor/{flow_slug}/
+
+###### Request:
+
+Changed content type : `application/json`
+
+Added 'ak-stage-authenticator-email' component:
+
+- Property `component` (string)
+
+- Property `code` (integer)
+
+- Property `email` (string)
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    Added 'ak-stage-authenticator-email' component:
+
+##### `GET` /flows/inspector/{flow_slug}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `plans` (array)
+
+        Changed items (object): > Serializer for an active FlowPlan
+
+        - Changed property `next_planned_stage` (object)
+
+            > FlowStageBinding Serializer
+
+            - Changed property `re_evaluate_policies` (boolean)
+                > Evaluate policies when the Stage is presented to the user.
+
+        - Changed property `current_stage` (object)
+
+            > FlowStageBinding Serializer
+
+            - Changed property `re_evaluate_policies` (boolean)
+                > Evaluate policies when the Stage is presented to the user.
+
+##### `GET` /oauth2/access_tokens/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `user` (object)
+
+        > User Serializer
+
+        New required properties:
+
+        - `password_change_date`
+
+        * Added property `password_change_date` (string)
+
+##### `GET` /oauth2/authorization_codes/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `user` (object)
+
+        > User Serializer
+
+        New required properties:
+
+        - `password_change_date`
+
+        * Added property `password_change_date` (string)
+
+##### `GET` /oauth2/refresh_tokens/{id}/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `user` (object)
+
+        > User Serializer
+
+        New required properties:
+
+        - `password_change_date`
+
+        * Added property `password_change_date` (string)
+
+##### `POST` /stages/authenticator/validate/
+
+###### Request:
+
+Changed content type : `application/json`
+
+- Changed property `device_classes` (array)
+
+    > Device classes which can be used to authenticate
+
+    Changed items (string):
+
+    Added enum value:
+
+    - `email`
+
+###### Return Type:
+
+Changed response : **201 Created**
+
+- Changed content type : `application/json`
+
+    - Changed property `device_classes` (array)
+
+        > Device classes which can be used to authenticate
+
+        Changed items (string):
+
+        Added enum value:
+
+        - `email`
+
+##### `GET` /stages/authenticator/validate/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `results` (array)
+
+        Changed items (object): > AuthenticatorValidateStage Serializer
+
+        - Changed property `device_classes` (array)
+
+            > Device classes which can be used to authenticate
+
+            Changed items (string):
+
+            Added enum value:
+
+            - `email`
+
+##### `PUT` /core/transactional/applications/
+
+###### Request:
+
+Changed content type : `application/json`
+
+- Changed property `provider_model` (string)
+
+    Added enum value:
+
+    - `authentik_providers_ssf.ssfprovider`
+
+- Changed property `provider` (object)
+
+    Added 'authentik_providers_ssf.ssfprovider' provider_model:
+
+    - Property `name` (string)
+
+    - Property `signing_key` (string)
+
+        > Key used to sign the SSF Events.
+
+    - Property `oidc_auth_providers` (array)
+
+        Items (integer):
+
+    - Property `event_retention` (string)
+
+##### `GET` /oauth2/access_tokens/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `results` (array)
+
+        Changed items (object): > Serializer for BaseGrantModel and RefreshToken
+
+        - Changed property `user` (object)
+
+            > User Serializer
+
+            New required properties:
+
+            - `password_change_date`
+
+            * Added property `password_change_date` (string)
+
+##### `GET` /oauth2/authorization_codes/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `results` (array)
+
+        Changed items (object): > Serializer for BaseGrantModel and ExpiringBaseGrant
+
+        - Changed property `user` (object)
+
+            > User Serializer
+
+            New required properties:
+
+            - `password_change_date`
+
+            * Added property `password_change_date` (string)
+
+##### `GET` /oauth2/refresh_tokens/
+
+###### Return Type:
+
+Changed response : **200 OK**
+
+- Changed content type : `application/json`
+
+    - Changed property `results` (array)
+
+        Changed items (object): > Serializer for BaseGrantModel and RefreshToken
+
+        - Changed property `user` (object)
+
+            > User Serializer
+
+            New required properties:
+
+            - `password_change_date`
+
+            * Added property `password_change_date` (string)

--- a/website/docs/releases/2025/v2025.2.md
+++ b/website/docs/releases/2025/v2025.2.md
@@ -5,11 +5,10 @@ slug: "/releases/2025.2"
 
 ## Highlights
 
-- **SSF Provider <span class="badge badge--primary">Enterprise</span> <span class="badge badge--info">Preview</span>** Add support for Shared Signals Framework
-  TODO: Add preview banner to UI
+- **SSF Provider <span class="badge badge--primary">Enterprise</span> <span class="badge badge--info">Preview</span>** Add support for Shared Signals Framework.
 - **RAC moved open source** Remote access is now available to everyone!
-- **GeoIP distance and impossible travel checks** Add the ability to check for the distance a user has moved compared to a previous login, and if the user could have travelled the distance
-- **Email OTP Stage** Allow users to use their email accounts as a one-time-password during authentication
+- **GeoIP distance and impossible travel checks** Add the ability to check for the distance a user has moved compared to a previous login, and if the user could have travelled the distance.
+- **Email OTP Stage** Allow users to use their email accounts as a one-time-password during authentication.
 - **Fine-grained permission for superuser toggle on groups** Setting the **Is superuser** toggle on a group now requires a separate permission.
 
 ## Breaking changes

--- a/website/docs/releases/2025/v2025.2.md
+++ b/website/docs/releases/2025/v2025.2.md
@@ -55,7 +55,7 @@ slug: "/releases/2025.2"
 
 - Improved debugging experience
 
-    For people developing authentik or building very complex, custom integrations, configuring debugging in authentik is documented [here](../../developer-docs/setup/debugging.md).
+    For people developing authentik or building very complex, custom integrations, how to configure debugging in authentik is documented [here](../../developer-docs/setup/debugging.md).
 
 ## Upgrading
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -2,13 +2,14 @@ import { generateVersionDropdown } from "./src/utils.js";
 import apiReference from "./docs/developer-docs/api/reference/sidebar";
 
 const releases = [
+    "releases/2025/v2025.2",
     "releases/2024/v2024.12",
     "releases/2024/v2024.10",
-    "releases/2024/v2024.8",
     {
         type: "category",
         label: "Previous versions",
         items: [
+            "releases/2024/v2024.8",
             "releases/2024/v2024.6",
             "releases/2024/v2024.4",
             "releases/2024/v2024.2",


### PR DESCRIPTION
This PR updates the Release Notes for 2025.2; replaced ToDo for links to docs, and removed the note at top about it being an RC.

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
