### PR TITLE
website/docs: fix missing breaking entry for 2025.2 release notes

### DIFF
--- a/website/docs/releases/2025/v2025.2.md
+++ b/website/docs/releases/2025/v2025.2.md
@@ -13,6 +13,12 @@ slug: "/releases/2025.2"
 
 ## Breaking changes
 
+- **Fixed behaviour in Source stage <span class="badge badge--primary">Enterprise</span>**
+
+    In previous versions, the Source stage would incorrectly continue with the initial flow after returning from the source, which didn't match the documented behaviour.
+
+    With this release this behaviour has been corrected and the source stage will now correctly run the selected enrollment/authentication flow before returning to the flow the source stage was executed from.
+
 - **Deprecated and frozen `:latest` container image tag after 2025.2**
 
     Using the `:latest` tag with container images is not recommended as it can lead to unintentional updates and potentially broken setups.

--- a/website/docs/releases/2025/v2025.2.md
+++ b/website/docs/releases/2025/v2025.2.md
@@ -17,7 +17,7 @@ slug: "/releases/2025.2"
 
     In previous versions, the Source stage would incorrectly continue with the initial flow after returning from the source, which didn't match the documented behaviour.
 
-    With this release this behaviour has been corrected and the source stage will now correctly run the selected enrollment/authentication flow before returning to the flow the source stage was executed from.
+    With this release this behaviour has been corrected and the source stage will now correctly run the selected enrollment/authentication flow before returning to the flow from which the source stage was executed.
 
 - **Deprecated and frozen `:latest` container image tag after 2025.2**
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

see https://github.com/goauthentik/authentik/pull/12875

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
