### PR TITLE
website/docs: add enterprise label to SSF docs

### DIFF
--- a/website/docs/add-secure-apps/providers/ssf/create-ssf-provider.md
+++ b/website/docs/add-secure-apps/providers/ssf/create-ssf-provider.md
@@ -1,5 +1,8 @@
 ---
 title: Configure an SSF provider
+authentik_version: "2025.2.0"
+authentik_enterprise: true
+authentik_preview: true
 ---
 
 The workflow to implement an SSF provider as a [backchannel provider](../../applications/manage_apps#backchannel-providers) for an application/provider pair is as follows:

--- a/website/docs/add-secure-apps/providers/ssf/index.md
+++ b/website/docs/add-secure-apps/providers/ssf/index.md
@@ -1,7 +1,7 @@
 ---
 title: Shared Signals Framework (SSF) Provider
 sidebar_label: SSF Provider
-authentik_version: "2025.02.00"
+authentik_version: "2025.02.0"
 authentik_enterprise: true
 authentik_preview: true
 ---

--- a/website/docs/add-secure-apps/providers/ssf/index.md
+++ b/website/docs/add-secure-apps/providers/ssf/index.md
@@ -1,7 +1,7 @@
 ---
 title: Shared Signals Framework (SSF) Provider
 sidebar_label: SSF Provider
-authentik_version: "2025.02.0"
+authentik_version: "2025.2.0"
 authentik_enterprise: true
 authentik_preview: true
 ---

--- a/website/docs/add-secure-apps/providers/ssf/index.md
+++ b/website/docs/add-secure-apps/providers/ssf/index.md
@@ -1,11 +1,10 @@
 ---
 title: Shared Signals Framework (SSF) Provider
 sidebar_label: SSF Provider
+authentik_version: "2025.02.00"
+authentik_enterprise: true
+authentik_preview: true
 ---
-
-<span class="badge badge--preview">Preview</span>
-<span class="badge badge--version">authentik 2025.2+</span>
-&nbsp;
 
 Shared Signals Framework (SSF) is a common standard for sharing asynchronous real-time security signals and events across multiple applications and an identity provider. The framework is a collection of standards and communication processes, documented in a [specification](https://openid.net/specs/openid-sharedsignals-framework-1_0-ID3.html). SSF leverages the APIs of the application and the IdP, using privacy-protected, secure webhooks.
 


### PR DESCRIPTION
This PR adds the Enterprise label to the SSF docs, using the new process with the frontmatter, yay.

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
