### PR TITLE
stages/email: Fix email stage serialization

### DIFF
--- a/authentik/stages/email/tasks.py
+++ b/authentik/stages/email/tasks.py
@@ -63,7 +63,7 @@ def get_email_body(email: EmailMultiAlternatives) -> str:
 def send_mail(
     self: SystemTask,
     message: dict[Any, Any],
-    stage_class_path: str,
+    stage_class_path: str = "authentik.stages.email.models.EmailStage",
     email_stage_pk: str | None = None,
 ):
     """Send Email for Email Stage. Retries are scheduled automatically."""

--- a/authentik/stages/email/tasks.py
+++ b/authentik/stages/email/tasks.py
@@ -70,8 +70,14 @@ def send_mail(
     message_id = make_msgid(domain=DNS_NAME)
     self.set_uid(slugify(message_id.replace(".", "_").replace("@", "_")))
     try:
-        # Get the actual stage class from the name
-        stage_class = globals()[stage_class_name]
+        # Map stage class name to the actual class
+        if stage_class_name == "EmailStage":
+            stage_class = EmailStage
+        elif stage_class_name == "AuthenticatorEmailStage":
+            stage_class = AuthenticatorEmailStage
+        else:
+            raise ValueError(f"Invalid stage class name: {stage_class_name}")
+
         if not email_stage_pk:
             stage: EmailStage | AuthenticatorEmailStage = stage_class(use_global_settings=True)
         else:

--- a/authentik/stages/email/tasks.py
+++ b/authentik/stages/email/tasks.py
@@ -63,7 +63,7 @@ def get_email_body(email: EmailMultiAlternatives) -> str:
 def send_mail(
     self: SystemTask,
     message: dict[Any, Any],
-    stage_class_path: str = "authentik.stages.email.models.EmailStage",
+    stage_class_path: str | None = None,
     email_stage_pk: str | None = None,
 ):
     """Send Email for Email Stage. Retries are scheduled automatically."""

--- a/authentik/stages/email/tasks.py
+++ b/authentik/stages/email/tasks.py
@@ -12,11 +12,11 @@ from structlog.stdlib import get_logger
 
 from authentik.events.models import Event, EventAction, TaskStatus
 from authentik.events.system_tasks import SystemTask
+from authentik.lib.utils.reflection import class_to_path, path_to_class
 from authentik.root.celery import CELERY_APP
 from authentik.stages.authenticator_email.models import AuthenticatorEmailStage
 from authentik.stages.email.models import EmailStage
 from authentik.stages.email.utils import logo_data
-from authentik.lib.utils.reflection import class_to_path, path_to_class
 
 LOGGER = get_logger()
 

--- a/authentik/stages/email/tasks.py
+++ b/authentik/stages/email/tasks.py
@@ -63,7 +63,7 @@ def get_email_body(email: EmailMultiAlternatives) -> str:
 def send_mail(
     self: SystemTask,
     message: dict[Any, Any],
-    stage_class_path: str,
+    stage_class_path: str | None = None,
     email_stage_pk: str | None = None,
 ):
     """Send Email for Email Stage. Retries are scheduled automatically."""
@@ -71,12 +71,10 @@ def send_mail(
     message_id = make_msgid(domain=DNS_NAME)
     self.set_uid(slugify(message_id.replace(".", "_").replace("@", "_")))
     try:
-        # Map stage class path to the actual class
-        stage_class = path_to_class(stage_class_path)
-
-        if not email_stage_pk:
-            stage: EmailStage | AuthenticatorEmailStage = stage_class(use_global_settings=True)
+        if not stage_class_path or not email_stage_pk:
+            stage = EmailStage(use_global_settings=True)
         else:
+            stage_class = path_to_class(stage_class_path)
             stages = stage_class.objects.filter(pk=email_stage_pk)
             if not stages.exists():
                 self.set_status(

--- a/authentik/stages/email/tests/test_tasks.py
+++ b/authentik/stages/email/tests/test_tasks.py
@@ -6,6 +6,7 @@ from django.core.mail import EmailMultiAlternatives
 from django.test import TestCase
 
 from authentik.core.tests.utils import create_test_admin_user
+from authentik.lib.utils.reflection import class_to_path
 from authentik.stages.authenticator_email.models import AuthenticatorEmailStage
 from authentik.stages.email.models import EmailStage
 from authentik.stages.email.tasks import get_email_body, send_mail, send_mails
@@ -38,19 +39,14 @@ class TestEmailTasks(TestCase):
         message.body = "plain text"
         self.assertEqual(get_email_body(message), "plain text")
 
-    def test_send_mail_invalid_stage_class(self):
-        """Test send_mail with invalid stage class name"""
-        message = EmailMultiAlternatives()
-        with self.assertRaises(ValueError) as exc:
-            send_mail(message.__dict__, "InvalidStage")
-        self.assertEqual(str(exc.exception), "Invalid stage class name: InvalidStage")
-
     def test_send_mails_email_stage(self):
         """Test send_mails with EmailStage"""
         message = EmailMultiAlternatives()
         with patch("authentik.stages.email.tasks.send_mail") as mock_send:
             send_mails(self.stage, message)
-            mock_send.s.assert_called_once_with(message.__dict__, "EmailStage", str(self.stage.pk))
+            mock_send.s.assert_called_once_with(
+                message.__dict__, class_to_path(EmailStage), str(self.stage.pk)
+            )
 
     def test_send_mails_authenticator_stage(self):
         """Test send_mails with AuthenticatorEmailStage"""
@@ -58,5 +54,5 @@ class TestEmailTasks(TestCase):
         with patch("authentik.stages.email.tasks.send_mail") as mock_send:
             send_mails(self.auth_stage, message)
             mock_send.s.assert_called_once_with(
-                message.__dict__, "AuthenticatorEmailStage", str(self.auth_stage.pk)
+                message.__dict__, class_to_path(AuthenticatorEmailStage), str(self.auth_stage.pk)
             )

--- a/authentik/stages/email/tests/test_tasks.py
+++ b/authentik/stages/email/tests/test_tasks.py
@@ -1,11 +1,11 @@
 """Test email stage tasks"""
-from unittest.mock import MagicMock, patch
+
+from unittest.mock import patch
 
 from django.core.mail import EmailMultiAlternatives
 from django.test import TestCase
 
 from authentik.core.tests.utils import create_test_admin_user
-from authentik.events.models import TaskStatus
 from authentik.stages.authenticator_email.models import AuthenticatorEmailStage
 from authentik.stages.email.models import EmailStage
 from authentik.stages.email.tasks import get_email_body, send_mail, send_mails
@@ -50,9 +50,7 @@ class TestEmailTasks(TestCase):
         message = EmailMultiAlternatives()
         with patch("authentik.stages.email.tasks.send_mail") as mock_send:
             send_mails(self.stage, message)
-            mock_send.s.assert_called_once_with(
-                message.__dict__, "EmailStage", str(self.stage.pk)
-            )
+            mock_send.s.assert_called_once_with(message.__dict__, "EmailStage", str(self.stage.pk))
 
     def test_send_mails_authenticator_stage(self):
         """Test send_mails with AuthenticatorEmailStage"""

--- a/authentik/stages/email/tests/test_tasks.py
+++ b/authentik/stages/email/tests/test_tasks.py
@@ -45,9 +45,7 @@ class TestEmailTasks(TestCase):
         with patch("authentik.stages.email.tasks.send_mail") as mock_send:
             send_mails(self.stage, message)
             mock_send.s.assert_called_once_with(
-                message.__dict__,
-                "authentik.stages.email.models.EmailStage",
-                str(self.stage.pk)
+                message.__dict__, class_to_path(EmailStage), str(self.stage.pk)
             )
 
     def test_send_mails_authenticator_stage(self):
@@ -56,7 +54,5 @@ class TestEmailTasks(TestCase):
         with patch("authentik.stages.email.tasks.send_mail") as mock_send:
             send_mails(self.auth_stage, message)
             mock_send.s.assert_called_once_with(
-                message.__dict__,
-                "authentik.stages.authenticator_email.models.AuthenticatorEmailStage",
-                str(self.auth_stage.pk)
+                message.__dict__, class_to_path(AuthenticatorEmailStage), str(self.auth_stage.pk)
             )

--- a/authentik/stages/email/tests/test_tasks.py
+++ b/authentik/stages/email/tests/test_tasks.py
@@ -9,7 +9,7 @@ from authentik.core.tests.utils import create_test_admin_user
 from authentik.lib.utils.reflection import class_to_path
 from authentik.stages.authenticator_email.models import AuthenticatorEmailStage
 from authentik.stages.email.models import EmailStage
-from authentik.stages.email.tasks import get_email_body, send_mail, send_mails
+from authentik.stages.email.tasks import get_email_body, send_mails
 
 
 class TestEmailTasks(TestCase):

--- a/authentik/stages/email/tests/test_tasks.py
+++ b/authentik/stages/email/tests/test_tasks.py
@@ -38,19 +38,16 @@ class TestEmailTasks(TestCase):
         message.body = "plain text"
         self.assertEqual(get_email_body(message), "plain text")
 
-    def test_send_mail_invalid_stage_class(self):
-        """Test send_mail with invalid stage class name"""
-        message = EmailMultiAlternatives()
-        with self.assertRaises(ValueError) as exc:
-            send_mail(message.__dict__, "InvalidStage")
-        self.assertEqual(str(exc.exception), "Invalid stage class name: InvalidStage")
-
     def test_send_mails_email_stage(self):
         """Test send_mails with EmailStage"""
         message = EmailMultiAlternatives()
         with patch("authentik.stages.email.tasks.send_mail") as mock_send:
             send_mails(self.stage, message)
-            mock_send.s.assert_called_once_with(message.__dict__, "EmailStage", str(self.stage.pk))
+            mock_send.s.assert_called_once_with(
+                message.__dict__,
+                "authentik.stages.email.models.EmailStage",
+                str(self.stage.pk)
+            )
 
     def test_send_mails_authenticator_stage(self):
         """Test send_mails with AuthenticatorEmailStage"""
@@ -58,5 +55,7 @@ class TestEmailTasks(TestCase):
         with patch("authentik.stages.email.tasks.send_mail") as mock_send:
             send_mails(self.auth_stage, message)
             mock_send.s.assert_called_once_with(
-                message.__dict__, "AuthenticatorEmailStage", str(self.auth_stage.pk)
+                message.__dict__,
+                "authentik.stages.authenticator_email.models.AuthenticatorEmailStage",
+                str(self.auth_stage.pk)
             )

--- a/authentik/stages/email/tests/test_tasks.py
+++ b/authentik/stages/email/tests/test_tasks.py
@@ -1,0 +1,64 @@
+"""Test email stage tasks"""
+from unittest.mock import MagicMock, patch
+
+from django.core.mail import EmailMultiAlternatives
+from django.test import TestCase
+
+from authentik.core.tests.utils import create_test_admin_user
+from authentik.events.models import TaskStatus
+from authentik.stages.authenticator_email.models import AuthenticatorEmailStage
+from authentik.stages.email.models import EmailStage
+from authentik.stages.email.tasks import get_email_body, send_mail, send_mails
+
+
+class TestEmailTasks(TestCase):
+    """Test email stage tasks"""
+
+    def setUp(self):
+        self.user = create_test_admin_user()
+        self.stage = EmailStage.objects.create(
+            name="test-email",
+            use_global_settings=True,
+        )
+        self.auth_stage = AuthenticatorEmailStage.objects.create(
+            name="test-auth-email",
+            use_global_settings=True,
+        )
+
+    def test_get_email_body_html(self):
+        """Test get_email_body with HTML alternative"""
+        message = EmailMultiAlternatives()
+        message.body = "plain text"
+        message.attach_alternative("<p>html content</p>", "text/html")
+        self.assertEqual(get_email_body(message), "<p>html content</p>")
+
+    def test_get_email_body_plain(self):
+        """Test get_email_body with plain text only"""
+        message = EmailMultiAlternatives()
+        message.body = "plain text"
+        self.assertEqual(get_email_body(message), "plain text")
+
+    def test_send_mail_invalid_stage_class(self):
+        """Test send_mail with invalid stage class name"""
+        message = EmailMultiAlternatives()
+        with self.assertRaises(ValueError) as exc:
+            send_mail(message.__dict__, "InvalidStage")
+        self.assertEqual(str(exc.exception), "Invalid stage class name: InvalidStage")
+
+    def test_send_mails_email_stage(self):
+        """Test send_mails with EmailStage"""
+        message = EmailMultiAlternatives()
+        with patch("authentik.stages.email.tasks.send_mail") as mock_send:
+            send_mails(self.stage, message)
+            mock_send.s.assert_called_once_with(
+                message.__dict__, "EmailStage", str(self.stage.pk)
+            )
+
+    def test_send_mails_authenticator_stage(self):
+        """Test send_mails with AuthenticatorEmailStage"""
+        message = EmailMultiAlternatives()
+        with patch("authentik.stages.email.tasks.send_mail") as mock_send:
+            send_mails(self.auth_stage, message)
+            mock_send.s.assert_called_once_with(
+                message.__dict__, "AuthenticatorEmailStage", str(self.auth_stage.pk)
+            )


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Fixed a serialization error in the email stage that occurred when trying to pass Django model classes through Celery tasks. The error manifested as `kombu.exceptions.EncodeError: Object of type ModelBase is not JSON serializable`.


closes #13232

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
