### PR TITLE
website/integrations: fix netbox env variables

### DIFF
--- a/website/integrations/services/netbox/index.md
+++ b/website/integrations/services/netbox/index.md
@@ -44,10 +44,10 @@ REMOTE_AUTH_ENABLED='true'
 REMOTE_AUTH_BACKEND='social_core.backends.open_id_connect.OpenIdConnectAuth'
 
 # python-social-auth config
-SOCIAL_AUTH_OIDC_ENDPOINT='https://authentik.company/application/o/<Application slug>/'
+SOCIAL_AUTH_OIDC_OIDC_ENDPOINT='https://authentik.company/application/o/<Application slug>/'
 SOCIAL_AUTH_OIDC_KEY='<Client ID>'
 SOCIAL_AUTH_OIDC_SECRET='<Client Secret>'
-SOCIAL_AUTH_OIDC_SCOPE = ["openid", "profile", "email", "roles"]
+SOCIAL_AUTH_OIDC_SCOPE=openid profile email roles
 LOGOUT_REDIRECT_URL='https://authentik.company/application/o/<Application slug>/end-session/'
 ```
 
@@ -61,10 +61,10 @@ from os import environ
 #############
 
 # python-social-auth configuration
-SOCIAL_AUTH_OIDC_ENDPOINT = environ.get('SOCIAL_AUTH_OIDC_ENDPOINT')
+SOCIAL_AUTH_OIDC_OIDC_ENDPOINT = environ.get('SOCIAL_AUTH_OIDC_OIDC_ENDPOINT')
 SOCIAL_AUTH_OIDC_KEY = environ.get('SOCIAL_AUTH_OIDC_KEY')
 SOCIAL_AUTH_OIDC_SECRET = environ.get('SOCIAL_AUTH_OIDC_SECRET')
-SOCIAL_AUTH_OIDC_SCOPE = ["openid", "profile", "email", "roles"]
+SOCIAL_AUTH_OIDC_SCOPE = environ.get('SOCIAL_AUTH_OIDC_SCOPE').split(' ')
 LOGOUT_REDIRECT_URL = environ.get('LOGOUT_REDIRECT_URL')
 
 


### PR DESCRIPTION
I updated SOCIAL_AUTH_OIDC_SCOPE so it can dynamically be updated using a Docker environment variable vs authentik.py.  

SOCIAL_AUTH_OIDC_ENDPOINT needs to be SOCIAL_AUTH_OIDC_OIDC_ENDPOINT.  I found the correct variable in venv/lib/python3.12/site-packages/social_core/backends/open_id_connect.py.

I couldn't get Netbox to work with Authentik without these changes.

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
