### PR TITLE
website/docs: remove Enterprise badge from RAC docs -- again

### DIFF
--- a/website/docs/add-secure-apps/providers/rac/index.md
+++ b/website/docs/add-secure-apps/providers/rac/index.md
@@ -1,6 +1,5 @@
 ---
 title: Remote Access Control (RAC) Provider
-authentik_enterprise: true
 ---
 
 :::info


### PR DESCRIPTION
Changes conflicted in d5572a25700c and a714c781a6a1.
