### PR TITLE
stages/authenticator_email: Fix Enroll dropdown in the MFA Devices page

### DIFF
--- a/authentik/stages/authenticator_email/models.py
+++ b/authentik/stages/authenticator_email/models.py
@@ -7,6 +7,7 @@ from django.utils.translation import gettext_lazy as _
 from django.views import View
 from rest_framework.serializers import BaseSerializer
 
+from authentik.core.types import UserSettingSerializer
 from authentik.events.models import Event, EventAction
 from authentik.flows.exceptions import StageInvalidException
 from authentik.flows.models import ConfigurableStage, FriendlyNamedStage, Stage
@@ -70,6 +71,14 @@ class AuthenticatorEmailStage(ConfigurableStage, FriendlyNamedStage, Stage):
     @property
     def component(self) -> str:
         return "ak-stage-authenticator-email-form"
+
+    def ui_user_settings(self) -> UserSettingSerializer | None:
+        return UserSettingSerializer(
+            data={
+                "title": self.friendly_name or str(self._meta.verbose_name),
+                "component": "ak-user-settings-authenticator-email",
+            }
+        )
 
     @property
     def backend_class(self) -> type[BaseEmailBackend]:


### PR DESCRIPTION
## Details

Implements ui_user_settings() method for the Email Authenticator stage, making it available in the MFA enrollment dropdown on the user settings page.

<img width="413" alt="image" src="https://github.com/user-attachments/assets/84d19b2f-c99b-410c-ae74-0bac629ebd75" />


closes #13230

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
