### PR TITLE
website/docs: note usage of `is_restored` by source stage

### DIFF
--- a/website/docs/add-secure-apps/flows-stages/flow/context/index.mdx
+++ b/website/docs/add-secure-apps/flows-stages/flow/context/index.mdx
@@ -74,7 +74,7 @@ This key is set to `True` when the flow is executed from an "SSO" context. For e
 
 #### `is_restored` (Token object)
 
-This key is set when a flow execution is continued from a token. This happens for example when an [Email stage](../../stages/email/index.mdx) is used and the user clicks on the link within the email. The token object contains the key that was used to restore the flow execution.
+This key is set when a flow execution is continued from a token. This happens for example when an [Email stage](../../stages/email/index.mdx) is used and the user clicks on the link within the email. The token object contains the key that was used to restore the flow execution. This field is also used by the [Source stage](../../stages/source/index.md) when returning back to the initial flow the Source stage was run on.
 
 #### `is_redirected` (Flow object):ak-version[2024.12]
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

https://github.com/goauthentik/authentik/pull/13604

Targets 2025.4

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
