### PR TITLE
website: edit the new footer with links

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -92,6 +92,7 @@ const createConfig = (): Config => {
                     "json",
                     "nginx",
                     "python",
+                    "bash",
                 ],
             },
         },

--- a/website/src/theme/EditMetaRow/index.tsx
+++ b/website/src/theme/EditMetaRow/index.tsx
@@ -31,21 +31,10 @@ const EditMetaRow: React.FC<Props> = ({
             >
                 <p>
                     <Translate
-                        id="theme.common.contributor.footerDescription1"
-                        description="The initial description for the contribution footer"
-                    >
-                        Documentation for authentik is made possible by
-                        contributors like you!
-                    </Translate>
-                </p>
-
-                <p>
-                    <Translate
                         id="theme.common.contributor.footerDescription2"
-                        description="The initial description for the contribution footer"
+                        description="The description for the contribution footer"
                     >
-                        You can help us improve this page, or let us know about
-                        an issue by opening a pull request on GitHub.
+                        We welcome your knowledge and expertise. If you see areas of the documentation that you can improve (fix a typo, correct a technical detail, add additional context, etc.) we would really appreciate your contribution.
                     </Translate>
                 </p>
 
@@ -75,7 +64,7 @@ const EditMetaRow: React.FC<Props> = ({
 
                             <li>
                                 <a
-                                    href="https://github.com/goauthentik/authentik/issues/new/choose"
+                                    href="https://github.com/goauthentik/authentik/issues/new"
                                     target="_blank"
                                     rel="noreferrer noopener"
                                 >

--- a/website/src/theme/EditMetaRow/index.tsx
+++ b/website/src/theme/EditMetaRow/index.tsx
@@ -31,7 +31,7 @@ const EditMetaRow: React.FC<Props> = ({
             >
                 <p>
                     <Translate
-                        id="theme.common.contributor.footerDescription2"
+                        id="theme.common.contributor.footerDescription1"
                         description="The description for the contribution footer"
                     >
                         We welcome your knowledge and expertise. If you see

--- a/website/src/theme/EditMetaRow/index.tsx
+++ b/website/src/theme/EditMetaRow/index.tsx
@@ -34,7 +34,11 @@ const EditMetaRow: React.FC<Props> = ({
                         id="theme.common.contributor.footerDescription2"
                         description="The description for the contribution footer"
                     >
-                        We welcome your knowledge and expertise. If you see areas of the documentation that you can improve (fix a typo, correct a technical detail, add additional context, etc.) we would really appreciate your contribution.
+                        We welcome your knowledge and expertise. If you see
+                        areas of the documentation that you can improve (fix a
+                        typo, correct a technical detail, add additional
+                        context, etc.) we would really appreciate your
+                        contribution.
                     </Translate>
                 </p>
 

--- a/website/src/theme/EditMetaRow/index.tsx
+++ b/website/src/theme/EditMetaRow/index.tsx
@@ -21,14 +21,20 @@ const EditMetaRow: React.FC<Props> = ({
 
             <Admonition
                 className={clsx(styles.admonitionContrib, className)}
-                icon={<IconNote className={styles.contribIcon} />}
-                title={
-                    <span className={styles.headerContent}>
-                        Help us improve this content
-                    </span>
-                }
-                type="info"
+                icon={null}
+                title={null}
+                type="note"
             >
+                <div className={clsx(styles.admonitionHeader)}>
+                    <strong>
+                        <Translate
+                            id="theme.common.contributor.footerHeader"
+                            description="The header for the contribution footer"
+                        >
+                            Help us improve this content
+                        </Translate>
+                    </strong>
+                </div>
                 <p>
                     <Translate
                         id="theme.common.contributor.footerDescription1"

--- a/website/src/theme/EditMetaRow/styles.module.css
+++ b/website/src/theme/EditMetaRow/styles.module.css
@@ -21,7 +21,7 @@
 }
 
 .admonitionContrib {
-    --ifm-h5-font-size: 1.25rem;
+    --ifm-h5-font-size: 1.00rem;
 
     display: block;
 
@@ -54,8 +54,8 @@
             display: inline-block;
             content: "•";
             list-style-type: "•";
-            font-size: 1em;
-            opacity: 0.75;
+            font-size: .75em;
+            opacity: 0.50;
             margin-inline-end: var(--ifm-spacing-horizontal);
         }
     }

--- a/website/src/theme/EditMetaRow/styles.module.css
+++ b/website/src/theme/EditMetaRow/styles.module.css
@@ -20,13 +20,18 @@
     text-transform: none;
 }
 
+.admonitionHeader {
+    padding-bottom: 8px;
+}
+
 .admonitionContrib {
     --ifm-h5-font-size: 1rem;
-
+    --ifm-alert-background-color: var(--ifm-color-secondary-lighter);
     display: block;
+    border-left-style: none;
 
     @media (min-width: 768px) {
-        --ifm-h5-font-size: 1.5rem;
+        --ifm-h5-font-size: 1.2rem;
         --ifm-paragraph-margin-bottom: 0;
 
         p:first-child {

--- a/website/src/theme/EditMetaRow/styles.module.css
+++ b/website/src/theme/EditMetaRow/styles.module.css
@@ -59,8 +59,8 @@
             display: inline-block;
             content: "•";
             list-style-type: "•";
-            font-size: 0.75em;
-            opacity: 0.5;
+            font-size: 1em;
+            opacity: 0.75;
             margin-inline-end: var(--ifm-spacing-horizontal);
         }
     }

--- a/website/src/theme/EditMetaRow/styles.module.css
+++ b/website/src/theme/EditMetaRow/styles.module.css
@@ -21,7 +21,7 @@
 }
 
 .admonitionContrib {
-    --ifm-h5-font-size: 1.00rem;
+    --ifm-h5-font-size: 1rem;
 
     display: block;
 
@@ -54,8 +54,8 @@
             display: inline-block;
             content: "•";
             list-style-type: "•";
-            font-size: .75em;
-            opacity: 0.50;
+            font-size: 0.75em;
+            opacity: 0.5;
             margin-inline-end: var(--ifm-spacing-horizontal);
         }
     }

--- a/website/src/theme/EditThisPage/index.tsx
+++ b/website/src/theme/EditThisPage/index.tsx
@@ -10,7 +10,7 @@ export default function EditThisPage({ editUrl }: Props): ReactNode {
             <Translate
                 id="theme.common.editThisPage"
                 values={{
-                    github: GitHub,
+                    github: "GitHub",
                 }}
                 description="The link label to edit the current page"
             >

--- a/website/src/theme/EditThisPage/index.tsx
+++ b/website/src/theme/EditThisPage/index.tsx
@@ -10,7 +10,7 @@ export default function EditThisPage({ editUrl }: Props): ReactNode {
             <Translate
                 id="theme.common.editThisPage"
                 values={{
-                    github: <strong>GitHub</strong>,
+                    github: GitHub,
                 }}
                 description="The link label to edit the current page"
             >


### PR DESCRIPTION
This PR attempts to edits the recently merged PR to add the enhanced "Edit this page" footer. However, the build fails with an "Error: Unable to build website for locale en" (maybe because I do not have the full dev system set up?).

But it shows the changes I would like to make, or at very least re-discuss, this time with true collaboration:

--remove the Last updated date (DONE in a PR by Marc)
--change the copy for the `footerDescription` to what I originally added to PR
--make the background more transparent
--make the font smaller
--change the link to the top-level Issues page, not to the list of Issue types (which doesn't include Docs)
--maybe something else I did and forgot

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
