### PR TITLE
outposts/controllers: k8s: sanitize resource names to comply with DNS subdomain standards

### DIFF
--- a/authentik/outposts/controllers/k8s/base.py
+++ b/authentik/outposts/controllers/k8s/base.py
@@ -1,9 +1,9 @@
 """Base Kubernetes Reconciler"""
 
+import re
 from dataclasses import asdict
 from json import dumps
 from typing import TYPE_CHECKING, Generic, TypeVar
-import re
 
 from dacite.core import from_dict
 from django.http import HttpResponseNotFound

--- a/authentik/outposts/controllers/k8s/base.py
+++ b/authentik/outposts/controllers/k8s/base.py
@@ -124,7 +124,6 @@ class KubernetesObjectReconciler(Generic[T]):
             try:
                 current = self.retrieve()
             except (OpenApiException, HTTPError) as exc:
-
                 if isinstance(exc, ApiException) and exc.status == HttpResponseNotFound.status_code:
                     self.logger.debug("Failed to get current, triggering recreate")
                     raise NeedsRecreate from exc
@@ -168,7 +167,6 @@ class KubernetesObjectReconciler(Generic[T]):
             self.delete(current)
             self.logger.debug("Removing")
         except (OpenApiException, HTTPError) as exc:
-
             if isinstance(exc, ApiException) and exc.status == HttpResponseNotFound.status_code:
                 self.logger.debug("Failed to get current, assuming non-existent")
                 return

--- a/authentik/outposts/controllers/kubernetes.py
+++ b/authentik/outposts/controllers/kubernetes.py
@@ -61,9 +61,14 @@ class KubernetesController(BaseController):
     client: KubernetesClient
     connection: KubernetesServiceConnection
 
-    def __init__(self, outpost: Outpost, connection: KubernetesServiceConnection) -> None:
+    def __init__(
+        self,
+        outpost: Outpost,
+        connection: KubernetesServiceConnection,
+        client: KubernetesClient | None = None,
+    ) -> None:
         super().__init__(outpost, connection)
-        self.client = KubernetesClient(connection)
+        self.client = client if client else KubernetesClient(connection)
         self.reconcilers = {
             SecretReconciler.reconciler_name(): SecretReconciler,
             DeploymentReconciler.reconciler_name(): DeploymentReconciler,

--- a/authentik/outposts/tests/test_controller_k8s.py
+++ b/authentik/outposts/tests/test_controller_k8s.py
@@ -1,0 +1,44 @@
+"""Kubernetes controller tests"""
+
+from django.test import TestCase
+
+from authentik.blueprints.tests import reconcile_app
+from authentik.lib.generators import generate_id
+from authentik.outposts.apps import MANAGED_OUTPOST
+from authentik.outposts.controllers.k8s.deployment import DeploymentReconciler
+from authentik.outposts.controllers.kubernetes import KubernetesController
+from authentik.outposts.models import KubernetesServiceConnection, Outpost, OutpostType
+
+
+class KubernetesControllerTests(TestCase):
+    """Kubernetes controller tests"""
+
+    @reconcile_app("authentik_outposts")
+    def setUp(self) -> None:
+        self.outpost = Outpost.objects.create(
+            name="test",
+            type=OutpostType.PROXY,
+        )
+        self.integration = KubernetesServiceConnection(name="test")
+
+    def test_gen_name(self):
+        """Ensure the generated name is valid"""
+        controller = KubernetesController(
+            Outpost.objects.filter(managed=MANAGED_OUTPOST).first(),
+            self.integration,
+            # Pass something not-none as client so we don't
+            # attempt to connect to K8s as that's not needed
+            client=self,
+        )
+        rec = DeploymentReconciler(controller)
+        self.assertEqual(rec.name, "ak-outpost-authentik-embedded-outpost")
+
+        controller.outpost.name = generate_id()
+        self.assertLess(len(rec.name), 64)
+
+        # Test custom naming template
+        _cfg = controller.outpost.config
+        _cfg.object_naming_template = ""
+        controller.outpost.config = _cfg
+        self.assertEqual(rec.name, f"outpost-{controller.outpost.uuid.hex}")
+        self.assertLess(len(rec.name), 64)


### PR DESCRIPTION
This commit addresses an issue where Outpost deployments using underscores in their names would fail to create Kubernetes resources due to invalid naming conventions. Kubernetes resource names must adhere to DNS subdomain standards (RFC 1123), and prohibit underscores and require lowercase characters.

Closes https://github.com/goauthentik/authentik/issues/12568

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
