### PR TITLE
website/docs: in developer docs replace deprecated poetry shell command

### DIFF
--- a/website/docs/developer-docs/setup/full-dev-environment.mdx
+++ b/website/docs/developer-docs/setup/full-dev-environment.mdx
@@ -81,7 +81,7 @@ instructions](https://golangci-lint.run/welcome/install/#other-ci).
 1. Create an isolated Python environment. To create the environment and install dependencies, run the following commands in the same directory as your local authentik git repository:
 
 ```shell
-poetry shell   # Creates a python virtualenv, and activates it in a new shell
+eval $(poetry env activate)  # Creates and activates a python virtualenv
 make install   # Installs all required dependencies for Python and Javascript, including development dependencies
 ```
 

--- a/website/docs/developer-docs/setup/full-dev-environment.mdx
+++ b/website/docs/developer-docs/setup/full-dev-environment.mdx
@@ -81,7 +81,7 @@ instructions](https://golangci-lint.run/welcome/install/#other-ci).
 1. Create an isolated Python environment. To create the environment and install dependencies, run the following commands in the same directory as your local authentik git repository:
 
 ```shell
-eval $(poetry env activate)  # Creates and activates a python virtualenv
+eval $(poetry env activate)  # Creates a python virtualenv, and activates it in a new shell
 make install   # Installs all required dependencies for Python and Javascript, including development dependencies
 ```
 


### PR DESCRIPTION
As of Poetry 2.0.0+, [`poetry shell` is deprecated and no longer recommended to create virtualenvs](https://python-poetry.org/blog/announcing-poetry-2.0.0/#poetry-export-and-poetry-shell-only-available-via-plugins).

> Although not announced before, we seized the chance of a major release to remove the poetry shell command . Due to several issues with poetry shell, we recommend to use the new poetry env activate command instead. 

This PR updates the full developer guide to replace the deprecated command with one which evaluates the output of the new command, `poetry env activate`, to activate the env.

Following: https://app.slack.com/archives/C088NSXCYE7/p1741659422388419

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
