### PR TITLE
souces/oauth: reddit: fix duplicate keyword auth

### DIFF
--- a/authentik/sources/oauth/types/reddit.py
+++ b/authentik/sources/oauth/types/reddit.py
@@ -25,7 +25,9 @@ class RedditOAuth2Client(UserprofileHeaderAuthClient):
 
     def get_access_token(self, **request_kwargs):
         "Fetch access token from callback request."
-        request_kwargs["auth"] = HTTPBasicAuth(self.source.consumer_key, self.source.consumer_secret)
+        request_kwargs["auth"] = HTTPBasicAuth(
+            self.source.consumer_key, self.source.consumer_secret
+        )
         return super().get_access_token(**request_kwargs)
 
 

--- a/authentik/sources/oauth/types/reddit.py
+++ b/authentik/sources/oauth/types/reddit.py
@@ -25,8 +25,8 @@ class RedditOAuth2Client(UserprofileHeaderAuthClient):
 
     def get_access_token(self, **request_kwargs):
         "Fetch access token from callback request."
-        auth = HTTPBasicAuth(self.source.consumer_key, self.source.consumer_secret)
-        return super().get_access_token(auth=auth)
+        request_kwargs["auth"] = HTTPBasicAuth(self.source.consumer_key, self.source.consumer_secret)
+        return super().get_access_token(**request_kwargs)
 
 
 class RedditOAuth2Callback(OAuthCallback):


### PR DESCRIPTION
Closes #13464

The issue was that the auth parameter was being passed twice:
Once directly in the get_access_token call: super().get_access_token(auth=auth)
And again in the parent class's get_access_token method where it sets auth=(self.get_client_id(), self.get_client_secret())

The fix:
Instead of passing auth directly to get_access_token, we now add it to the request_kwargs dictionary
Then we pass all the request kwargs to the parent method using **request_kwargs<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
