### PR TITLE
website/docs: refactor pip to pipx on linux and improve styling

### DIFF
--- a/website/docs/developer-docs/setup/full-dev-environment.mdx
+++ b/website/docs/developer-docs/setup/full-dev-environment.mdx
@@ -58,7 +58,7 @@ values={[
     To install native dependencies on Debian or Ubuntu, run:
 
     ```sh
-    $ pip install poetry poetry-plugin-shell
+    $ pipx install poetry poetry-plugin-shell
     $ sudo apt-get install  libgss-dev krb5-config libkrb5-dev postgresql-server-dev-all
     $ sudo apt-get install postresql redis
     ```

--- a/website/docs/developer-docs/setup/full-dev-environment.mdx
+++ b/website/docs/developer-docs/setup/full-dev-environment.mdx
@@ -45,34 +45,36 @@ values={[
 
   <TabItem value="mac">
     To install the native dependencies on macOS, run:
-    
+
     ```sh
     $ pip install poetry poetry-plugin-shell
     $ brew install libxmlsec1 libpq krb5   # Required development libraries,
     $ brew install postgresql redis node@22 golangci-lint   # Required CLI tools
-  ```
+    ```
 
   </TabItem>
 
   <TabItem value="linux">
-  To install native dependencies on Debian or Ubuntu, run:
+    To install native dependencies on Debian or Ubuntu, run:
 
-```sh
-$ pip install poetry poetry-plugin-shell
-$ sudo apt-get install  libgss-dev krb5-config libkrb5-dev postgresql-server-dev-all
-$ sudo apt-get install postresql redis
-```
+    ```sh
+    $ pip install poetry poetry-plugin-shell
+    $ sudo apt-get install  libgss-dev krb5-config libkrb5-dev postgresql-server-dev-all
+    $ sudo apt-get install postresql redis
+    ```
 
-Adjust your needs as required for other distributions such as Red Hat, SUSE, or Arch.
+    Adjust your needs as required for other distributions such as Red Hat, SUSE, or Arch.
 
-Install golangci-lint locally [from the site
-instructions](https://golangci-lint.run/welcome/install/#other-ci).
+    Install golangci-lint locally [from the site
+    instructions](https://golangci-lint.run/welcome/install/#other-ci).
 
   </TabItem>
 
-<TabItem value="windows">
+  <TabItem value="windows">
+
     [We request community input on running the full dev environment on Windows]
-</TabItem>
+
+  </TabItem>
 
 </Tabs>
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
When setting up a local authentik-install on Ubuntu 24.04 using the documentation provided command ``pip install poetry poetry-plugin-shell`` will fail with error ``error: externally-managed-environment`` due to [PEP 668](https://peps.python.org/pep-0668/).

It is generally understood that pipx should be used in place of pip due to security concerns.
To keep the documentation in line with modern practices, I changed the documentation to use pipx in place of pip for linux.

Maybe the same should be done for the mac tab-item.
If so, please let me know.

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
