### PR TITLE
website/docs: dev docs: full: remove note on installing shell plugin

### DIFF
--- a/website/docs/developer-docs/setup/full-dev-environment.mdx
+++ b/website/docs/developer-docs/setup/full-dev-environment.mdx
@@ -10,7 +10,6 @@ import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
 
 - [Python](https://www.python.org/) 3.12
 - [Poetry](https://python-poetry.org/), which is used to manage dependencies
-    - Poetry 2.0 or higher also requires the [poetry-plugin-shell](https://github.com/python-poetry/poetry-plugin-shell) extension.
 - [Go](https://go.dev/) 1.23 or newer
 - [Node.js](https://nodejs.org/en) 21 or newer
 - [PostgreSQL](https://www.postgresql.org/) 14 or newer


### PR DESCRIPTION
In https://github.com/goauthentik/authentik/pull/13460 , we replaced `poetry shell` with `poetry env activate`. As a result, we no longer need to tell the user to install this plugin.

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
