### PR TITLE
providers/rac: fix signals and Endpoint caching

### DIFF
--- a/authentik/providers/rac/apps.py
+++ b/authentik/providers/rac/apps.py
@@ -1,9 +1,9 @@
 """RAC app config"""
 
-from django.apps import AppConfig
+from authentik.blueprints.apps import ManagedAppConfig
 
 
-class AuthentikProviderRAC(AppConfig):
+class AuthentikProviderRAC(ManagedAppConfig):
     """authentik rac app config"""
 
     name = "authentik.providers.rac"


### PR DESCRIPTION
This will result in more invalidations, but it will also fix some
invalid Endpoint instances from showing up in Endpoint lists.

Since an Endpoint can be tied to a Policy, some invalid results can
still show up if the result of the Policy changes (either because the
Policy itself changes or because data checked by that Policy changes).

Even with those potentially invalid results, I believe the caching
itself is advantageous as long as the API provides an option for
`superuser_full_list`.

Closes #13231
Closes #13237