### PR TITLE
website/integrations: jellyfin: update OIDC plugin installation

### DIFF
--- a/website/integrations/services/jellyfin/index.md
+++ b/website/integrations/services/jellyfin/index.md
@@ -123,8 +123,8 @@ Set the launch URL to `https://jellyfin.company/sso/OID/start/authentik`
 ### Jellyfin Configuration
 
 1. Log in to Jellyfin with an admin account and navigate to the **Admin Dashboard** by selecting your profile icon in the top right, then clicking **Dashboard**.
-2. Go to **Dashboard > Plugins > Catalog**.
-3. Click the gear icon in the top left, then click **+** to add a new repository. Use the following URL and name it "SSO-Auth":
+2. Go to **Dashboard > Plugins > Repositories**.
+3. Click the **+** in the top left to add a new repository. Use the following URL and name it "SSO-Auth":
 
 ```
 https://raw.githubusercontent.com/9p4/jellyfin-plugin-sso/manifest-release/manifest.json


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
According to my jellyfin 10.9.11 installation the button to add new repository is no longer inside the "Catalog" submenu, but instead in it's own "Repositories".

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
