### PR TITLE
website/docs: revert token_expiry format in example blueprint

### DIFF
--- a/blueprints/example/flows-recovery-email-verification.yaml
+++ b/blueprints/example/flows-recovery-email-verification.yaml
@@ -57,7 +57,7 @@ entries:
       use_ssl: false
       timeout: 10
       from_address: system@authentik.local
-      token_expiry: minutes=30
+      token_expiry: 30
       subject: authentik
       template: email/password_reset.html
       activate_user_on_success: true

--- a/blueprints/example/flows-recovery-email-verification.yaml
+++ b/blueprints/example/flows-recovery-email-verification.yaml
@@ -57,7 +57,7 @@ entries:
       use_ssl: false
       timeout: 10
       from_address: system@authentik.local
-      token_expiry: 30
+      token_expiry: minutes=30
       subject: authentik
       template: email/password_reset.html
       activate_user_on_success: true

--- a/website/docs/add-secure-apps/flows-stages/flow/examples/flows.md
+++ b/website/docs/add-secure-apps/flows-stages/flow/examples/flows.md
@@ -42,7 +42,7 @@ By default, the captcha test keys are used. You can get a proper key [here](http
 
 ## Recovery with email verification
 
-Flow: right-click [here](/blueprints/example/flows-recovery-email-verification.yaml) and save the file.
+Flow: right-click [here](https://version-2024-12.goauthentik.io/assets/files/flows-recovery-email-verification-408d6afeff2fbf276bf43a949e332ef6.yaml) and save the file.
 
 Recovery flow, the user is sent an email after they've identified themselves. After they click on the link in the email, they are prompted for a new password and immediately logged on.
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Email Stage token_expiry format is going to be released in 2025.4.0 but the example blueprint with this change is already available in the documentation causing confusion

Closes #13542

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
