### PR TITLE
core: fix error when viewing used_by for built-in source

### DIFF
--- a/authentik/core/models.py
+++ b/authentik/core/models.py
@@ -770,6 +770,7 @@ class Source(ManagedModel, SerializerModel, PolicyBindingModel):
         """Return property mapping type used by this object"""
         if self.managed == self.MANAGED_INBUILT:
             from authentik.core.models import PropertyMapping
+
             return PropertyMapping
         raise NotImplementedError
 

--- a/authentik/core/models.py
+++ b/authentik/core/models.py
@@ -761,11 +761,16 @@ class Source(ManagedModel, SerializerModel, PolicyBindingModel):
     @property
     def component(self) -> str:
         """Return component used to edit this object"""
+        if self.managed == self.MANAGED_INBUILT:
+            return ""
         raise NotImplementedError
 
     @property
     def property_mapping_type(self) -> "type[PropertyMapping]":
         """Return property mapping type used by this object"""
+        if self.managed == self.MANAGED_INBUILT:
+            from authentik.core.models import PropertyMapping
+            return PropertyMapping
         raise NotImplementedError
 
     def ui_login_button(self, request: HttpRequest) -> UILoginButton | None:
@@ -780,10 +785,14 @@ class Source(ManagedModel, SerializerModel, PolicyBindingModel):
 
     def get_base_user_properties(self, **kwargs) -> dict[str, Any | dict[str, Any]]:
         """Get base properties for a user to build final properties upon."""
+        if self.managed == self.MANAGED_INBUILT:
+            return {}
         raise NotImplementedError
 
     def get_base_group_properties(self, **kwargs) -> dict[str, Any | dict[str, Any]]:
         """Get base properties for a group to build final properties upon."""
+        if self.managed == self.MANAGED_INBUILT:
+            return {}
         raise NotImplementedError
 
     def __str__(self):

--- a/authentik/core/tests/test_source_api.py
+++ b/authentik/core/tests/test_source_api.py
@@ -1,0 +1,19 @@
+from django.apps import apps
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+from authentik.core.tests.utils import create_test_admin_user
+
+
+class TestSourceAPI(APITestCase):
+    def setUp(self) -> None:
+        self.user = create_test_admin_user()
+        self.client.force_login(self.user)
+
+    def test_builtin_source_used_by(self):
+        """Test Providers's types endpoint"""
+        apps.get_app_config("authentik_core").source_inbuilt()
+        response = self.client.get(
+            reverse("authentik_api:source-used-by", kwargs={"slug": "authentik-built-in"}),
+        )
+        self.assertEqual(response.status_code, 200)

--- a/authentik/lib/models.py
+++ b/authentik/lib/models.py
@@ -18,6 +18,10 @@ class SerializerModel(models.Model):
     @property
     def serializer(self) -> type[BaseSerializer]:
         """Get serializer for this model"""
+        # Special handling for built-in source
+        if hasattr(self, 'managed') and hasattr(self, 'MANAGED_INBUILT') and self.managed == self.MANAGED_INBUILT:
+            from authentik.core.api.sources import SourceSerializer
+            return SourceSerializer
         raise NotImplementedError
 
 

--- a/authentik/lib/models.py
+++ b/authentik/lib/models.py
@@ -19,8 +19,13 @@ class SerializerModel(models.Model):
     def serializer(self) -> type[BaseSerializer]:
         """Get serializer for this model"""
         # Special handling for built-in source
-        if hasattr(self, 'managed') and hasattr(self, 'MANAGED_INBUILT') and self.managed == self.MANAGED_INBUILT:
+        if (
+            hasattr(self, "managed")
+            and hasattr(self, "MANAGED_INBUILT")
+            and self.managed == self.MANAGED_INBUILT
+        ):
             from authentik.core.api.sources import SourceSerializer
+
             return SourceSerializer
         raise NotImplementedError
 


### PR DESCRIPTION
## What
This PR fixes an error that occurs when trying to view the /used_by/ API endpoint for the built-in source. Previously, accessing this endpoint would raise a NotImplementedError because the built-in source doesn't properly implement the required abstract methods.

## How
* Added special handling in SerializerModel.serializer to return SourceSerializer for built-in sources
* Added implementations for component, property_mapping_type, get_base_user_properties, and get_base_group_properties methods in the Source class that handle the built-in source case

## Testing:
Confirmed the /api/v3/sources/all/authentik-built-in/used_by/ endpoint now returns a proper response instead of a 500 (I think) error

Closes #13587<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
