### PR TITLE
rac: prevent SSH connections from connecting to wrong endpoint

### DIFF
--- a/authentik/providers/rac/consumer_client.py
+++ b/authentik/providers/rac/consumer_client.py
@@ -51,6 +51,13 @@ class RACClientConsumer(AsyncWebsocketConsumer):
             self.channel_name,
         )
         await self.init_outpost_connection()
+        
+        # Add connection to token-specific group for token-based disconnection
+        if hasattr(self, 'token') and self.token:
+            await self.channel_layer.group_add(
+                RAC_CLIENT_GROUP_TOKEN % {"token": self.token.token},
+                self.channel_name,
+            )
 
     async def disconnect(self, code):
         self.logger.debug("Disconnecting")

--- a/docker-compose.ssh.yml
+++ b/docker-compose.ssh.yml
@@ -1,0 +1,36 @@
+services:
+  ssh-server-1:
+    image: linuxserver/openssh-server
+    container_name: ssh-server-1
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - USER_NAME=testuser
+      - PASSWORD_ACCESS=true
+      - USER_PASSWORD=testpass
+    ports:
+      - "2222:2222"
+    restart: unless-stopped
+
+  ssh-server-2:
+    image: linuxserver/openssh-server
+    container_name: ssh-server-2
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - USER_NAME=testuser
+      - PASSWORD_ACCESS=true
+      - USER_PASSWORD=testpass
+    ports:
+      - "2223:2222"
+    restart: unless-stopped
+
+  rac:
+    container_name: rac
+    image: ghcr.io/goauthentik/rac:2025.2.4@sha256:9b095d81cf12d758a65add05f1ea4b1a1feac8c52c66e28d73c31c0120ea41dd
+    restart: unless-stopped
+    environment:
+      - AUTHENTIK_HOST=http://localhost:9000
+      - AUTHENTIK_INSECURE=true
+      - AUTHENTIK_TOKEN=e
+


### PR DESCRIPTION
When using multiple SSH RAC endpoints, connections would sometimes connect to previously used endpoints instead of the newly selected one.

Closes #13609
Closes #13583

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
