### PR TITLE
policies: buffered policy access view for concurrent authorization attempts when unauthenticated

### DIFF
--- a/authentik/flows/views/executor.py
+++ b/authentik/flows/views/executor.py
@@ -69,6 +69,7 @@ SESSION_KEY_APPLICATION_PRE = "authentik/flows/application_pre"
 SESSION_KEY_GET = "authentik/flows/get"
 SESSION_KEY_POST = "authentik/flows/post"
 SESSION_KEY_HISTORY = "authentik/flows/history"
+SESSION_KEY_AUTH_STARTED = "authentik/flows/auth_started"
 QS_KEY_TOKEN = "flow_token"  # nosec
 QS_QUERY = "query"
 
@@ -453,6 +454,7 @@ class FlowExecutorView(APIView):
             SESSION_KEY_APPLICATION_PRE,
             SESSION_KEY_PLAN,
             SESSION_KEY_GET,
+            SESSION_KEY_AUTH_STARTED,
             # We might need the initial POST payloads for later requests
             # SESSION_KEY_POST,
             # We don't delete the history on purpose, as a user might

--- a/authentik/policies/apps.py
+++ b/authentik/policies/apps.py
@@ -35,3 +35,4 @@ class AuthentikPoliciesConfig(ManagedAppConfig):
     label = "authentik_policies"
     verbose_name = "authentik Policies"
     default = True
+    mountpoint = "policies"

--- a/authentik/policies/apps.py
+++ b/authentik/policies/apps.py
@@ -35,4 +35,4 @@ class AuthentikPoliciesConfig(ManagedAppConfig):
     label = "authentik_policies"
     verbose_name = "authentik Policies"
     default = True
-    mountpoint = "policies"
+    mountpoint = "policy/"

--- a/authentik/policies/templates/policies/buffer.html
+++ b/authentik/policies/templates/policies/buffer.html
@@ -30,11 +30,17 @@
     }
   };
   let timeout = 100;
+  let offset = 20;
+  let attempt = 0;
   const main = async () => {
+    attempt += 1;
     await checkAuth();
     console.debug(`authentik/policies/buffer: Waiting ${timeout}ms...`);
     setTimeout(main, timeout);
-    timeout += 10;
+    timeout += (offset * attempt);
+    if (timeout >= 2000) {
+      timeout = 2000;
+    }
   }
   document.addEventListener("visibilitychange", async () => {
     if (document.hidden) return;

--- a/authentik/policies/templates/policies/buffer.html
+++ b/authentik/policies/templates/policies/buffer.html
@@ -52,9 +52,11 @@
 
 {% block card %}
 <form class="pf-c-form" method="{{ auth_req_method }}" action="{{ continue_url }}">
-  {% for key, value in auth_req_body.items %}
-    <input type="hidden" name="{{ key }}" value="{{ value }}" />
-  {% endfor %}
+  {% if auth_req_method == "post" %}
+    {% for key, value in auth_req_body.items %}
+      <input type="hidden" name="{{ key }}" value="{{ value }}" />
+    {% endfor %}
+  {% endif %}
   <div class="pf-c-empty-state">
     <div class="pf-c-empty-state__content">
       <div class="pf-c-empty-state__icon">
@@ -65,12 +67,14 @@
         </span>
       </div>
       <h1 class="pf-c-title pf-m-lg">
-        You're already authenticating in another tab. This page will refresh once authentication is completed.
+        {% trans "You're already authenticating in another tab. This page will refresh once authentication is completed." %}
       </h1>
     </div>
   </div>
   <div class="pf-c-form__group pf-m-action">
-    <a href="{{ auth_req_url }}" class="pf-c-button pf-m-primary pf-m-block">Authenticate in this tab</a>
+    <a href="{{ auth_req_url }}" class="pf-c-button pf-m-primary pf-m-block">
+      {% trans "Authenticate in this tab" %}
+    </a>
   </div>
 </form>
 {% endblock %}

--- a/authentik/policies/templates/policies/buffer.html
+++ b/authentik/policies/templates/policies/buffer.html
@@ -6,7 +6,9 @@
 {% block head %}
 {{ block.super }}
 <script>
+  let redirecting = false;
   const checkAuth = async () => {
+    if (redirecting) return true;
     const url = "{{ check_auth_url }}";
     console.debug("authentik/policies/buffer: Checking authentication...");
     try {
@@ -17,6 +19,7 @@
         return false
       }
       console.debug("authentik/policies/buffer: Continuing");
+      redirecting = true;
       if ("{{ auth_req_method }}" === "post") {
         document.querySelector("form").submit();
       } else {

--- a/authentik/policies/templates/policies/buffer.html
+++ b/authentik/policies/templates/policies/buffer.html
@@ -7,7 +7,7 @@
 {{ block.super }}
 <script>
   const origRequest = {
-    url: "{{ url|escapejs }}",
+    url: "{{ redirect_url|escapejs }}",
     method: "{{ method }}",
     body: JSON.parse('{{ post|escapejs }}'),
   }

--- a/authentik/policies/templates/policies/buffer.html
+++ b/authentik/policies/templates/policies/buffer.html
@@ -1,0 +1,73 @@
+{% extends 'login/base_full.html' %}
+
+{% load static %}
+{% load i18n %}
+
+{% block head %}
+{{ block.super }}
+<script>
+  const origRequest = {
+    url: "{{ url|escapejs }}",
+    method: "{{ method }}",
+    body: JSON.parse('{{ post|escapejs }}'),
+  }
+  const checkAuth = async () => {
+    const url = "{{ check_auth_url }}";
+    try {
+      const result = await fetch(url, {
+        method: "HEAD",
+      });
+      if (result.status >= 400) {
+        return false
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  const redirect = () => {
+    if (origRequest.method.toLowerCase() === "get") {
+      window.location.assign(origRequest.url);
+    }
+  };
+  const main = async () => {
+    if (await checkAuth()) {
+      clearInterval(checker);
+      redirect();
+    }
+  }
+  let checker = setInterval(main, 150);
+  main();
+</script>
+{% endblock %}
+
+{% block title %}
+{% trans 'Waiting for authentication...' %} - {{ brand.branding_title }}
+{% endblock %}
+
+{% block card_title %}
+{% trans 'Waiting for authentication...' %}
+{% endblock %}
+
+{% block card %}
+<form class="pf-c-form">
+    {% csrf_token %}
+    <div class="pf-c-empty-state">
+      <div class="pf-c-empty-state__content">
+        <div class="pf-c-empty-state__icon">
+          <span class="pf-c-spinner pf-m-xl" role="progressbar">
+            <span class="pf-c-spinner__clipper"></span>
+            <span class="pf-c-spinner__lead-ball"></span>
+            <span class="pf-c-spinner__tail-ball"></span>
+          </span>
+        </div>
+        <h1 class="pf-c-title pf-m-lg">
+          You're already authenticating in another tab. This page will refresh once authentication is completed.
+        </h1>
+        <div class="pf-c-empty-state__primary">
+          <a href="{{auth_url}}" class="pf-c-button pf-m-primary pf-m-block">Authenticate in this tab</a>
+        </div>
+      </div>
+    </div>
+</form>
+{% endblock %}

--- a/authentik/policies/templates/policies/buffer.html
+++ b/authentik/policies/templates/policies/buffer.html
@@ -6,13 +6,9 @@
 {% block head %}
 {{ block.super }}
 <script>
-  const origRequest = {
-    url: "{{ redirect_url|escapejs }}",
-    method: "{{ method }}",
-    body: JSON.parse('{{ post|escapejs }}'),
-  }
   const checkAuth = async () => {
     const url = "{{ check_auth_url }}";
+    console.debug("authentik/policies/buffer: Checking authentication...");
     try {
       const result = await fetch(url, {
         method: "HEAD",
@@ -20,23 +16,28 @@
       if (result.status >= 400) {
         return false
       }
-      return true;
+      console.debug("authentik/policies/buffer: Continuing");
+      if ("{{ auth_req_method }}" === "post") {
+        document.querySelector("form").submit();
+      } else {
+        window.location.assign("{{ continue_url|escapejs }}");
+      }
     } catch {
       return false;
     }
   };
-  const redirect = () => {
-    if (origRequest.method.toLowerCase() === "get") {
-      window.location.assign(origRequest.url);
-    }
-  };
+  let timeout = 100;
   const main = async () => {
-    if (await checkAuth()) {
-      clearInterval(checker);
-      redirect();
-    }
+    await checkAuth();
+    console.debug(`authentik/policies/buffer: Waiting ${timeout}ms...`);
+    setTimeout(main, timeout);
+    timeout += 10;
   }
-  let checker = setInterval(main, 150);
+  document.addEventListener("visibilitychange", async () => {
+    if (document.hidden) return;
+    console.debug("authentik/policies/buffer: Checking authentication on tab activate...");
+    await checkAuth();
+  });
   main();
 </script>
 {% endblock %}
@@ -50,24 +51,26 @@
 {% endblock %}
 
 {% block card %}
-<form class="pf-c-form">
-    {% csrf_token %}
-    <div class="pf-c-empty-state">
-      <div class="pf-c-empty-state__content">
-        <div class="pf-c-empty-state__icon">
-          <span class="pf-c-spinner pf-m-xl" role="progressbar">
-            <span class="pf-c-spinner__clipper"></span>
-            <span class="pf-c-spinner__lead-ball"></span>
-            <span class="pf-c-spinner__tail-ball"></span>
-          </span>
-        </div>
-        <h1 class="pf-c-title pf-m-lg">
-          You're already authenticating in another tab. This page will refresh once authentication is completed.
-        </h1>
-        <div class="pf-c-empty-state__primary">
-          <a href="{{auth_url}}" class="pf-c-button pf-m-primary pf-m-block">Authenticate in this tab</a>
-        </div>
+<form class="pf-c-form" method="{{ auth_req_method }}" action="{{ continue_url }}">
+  {% for key, value in auth_req_body.items %}
+    <input type="hidden" name="{{ key }}" value="{{ value }}" />
+  {% endfor %}
+  <div class="pf-c-empty-state">
+    <div class="pf-c-empty-state__content">
+      <div class="pf-c-empty-state__icon">
+        <span class="pf-c-spinner pf-m-xl" role="progressbar">
+          <span class="pf-c-spinner__clipper"></span>
+          <span class="pf-c-spinner__lead-ball"></span>
+          <span class="pf-c-spinner__tail-ball"></span>
+        </span>
       </div>
+      <h1 class="pf-c-title pf-m-lg">
+        You're already authenticating in another tab. This page will refresh once authentication is completed.
+      </h1>
     </div>
+  </div>
+  <div class="pf-c-form__group pf-m-action">
+    <a href="{{ auth_req_url }}" class="pf-c-button pf-m-primary pf-m-block">Authenticate in this tab</a>
+  </div>
 </form>
 {% endblock %}

--- a/authentik/policies/tests/test_views.py
+++ b/authentik/policies/tests/test_views.py
@@ -1,0 +1,121 @@
+from django.contrib.auth.models import AnonymousUser
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.http import HttpResponse
+from django.test import RequestFactory, TestCase
+from django.urls import reverse
+
+from authentik.core.models import Application, Provider
+from authentik.core.tests.utils import create_test_flow, create_test_user
+from authentik.flows.models import FlowDesignation
+from authentik.flows.planner import FlowPlan
+from authentik.flows.views.executor import SESSION_KEY_PLAN
+from authentik.lib.generators import generate_id
+from authentik.lib.tests.utils import dummy_get_response
+from authentik.policies.views import (
+    QS_BUFFER_ID,
+    SESSION_KEY_BUFFER,
+    BufferedPolicyAccessView,
+    BufferView,
+    PolicyAccessView,
+)
+
+
+class TestPolicyViews(TestCase):
+    """Test PolicyAccessView"""
+
+    def setUp(self):
+        super().setUp()
+        self.factory = RequestFactory()
+        self.user = create_test_user()
+
+    def test_pav(self):
+        """Test simple policy access view"""
+        provider = Provider.objects.create(
+            name=generate_id(),
+        )
+        app = Application.objects.create(name=generate_id(), slug=generate_id(), provider=provider)
+
+        class TestView(PolicyAccessView):
+            def resolve_provider_application(self):
+                self.provider = provider
+                self.application = app
+
+            def get(self, *args, **kwargs):
+                return HttpResponse("foo")
+
+        req = self.factory.get("/")
+        req.user = self.user
+        res = TestView.as_view()(req)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.content, b"foo")
+
+    def test_pav_buffer(self):
+        """Test simple policy access view"""
+        provider = Provider.objects.create(
+            name=generate_id(),
+        )
+        app = Application.objects.create(name=generate_id(), slug=generate_id(), provider=provider)
+        flow = create_test_flow(FlowDesignation.AUTHENTICATION)
+
+        class TestView(BufferedPolicyAccessView):
+            def resolve_provider_application(self):
+                self.provider = provider
+                self.application = app
+
+            def get(self, *args, **kwargs):
+                return HttpResponse("foo")
+
+        req = self.factory.get("/")
+        req.user = AnonymousUser()
+        middleware = SessionMiddleware(dummy_get_response)
+        middleware.process_request(req)
+        req.session[SESSION_KEY_PLAN] = FlowPlan(flow.pk)
+        req.session.save()
+        res = TestView.as_view()(req)
+        self.assertEqual(res.status_code, 302)
+        self.assertTrue(res.url.startswith(reverse("authentik_policies:buffer")))
+
+    def test_pav_buffer_skip(self):
+        """Test simple policy access view (skip buffer)"""
+        provider = Provider.objects.create(
+            name=generate_id(),
+        )
+        app = Application.objects.create(name=generate_id(), slug=generate_id(), provider=provider)
+        flow = create_test_flow(FlowDesignation.AUTHENTICATION)
+
+        class TestView(BufferedPolicyAccessView):
+            def resolve_provider_application(self):
+                self.provider = provider
+                self.application = app
+
+            def get(self, *args, **kwargs):
+                return HttpResponse("foo")
+
+        req = self.factory.get("/?skip_buffer=true")
+        req.user = AnonymousUser()
+        middleware = SessionMiddleware(dummy_get_response)
+        middleware.process_request(req)
+        req.session[SESSION_KEY_PLAN] = FlowPlan(flow.pk)
+        req.session.save()
+        res = TestView.as_view()(req)
+        self.assertEqual(res.status_code, 302)
+        self.assertTrue(res.url.startswith(reverse("authentik_flows:default-authentication")))
+
+    def test_buffer(self):
+        """Test buffer view"""
+        uid = generate_id()
+        req = self.factory.get(f"/?{QS_BUFFER_ID}={uid}")
+        req.user = AnonymousUser()
+        middleware = SessionMiddleware(dummy_get_response)
+        middleware.process_request(req)
+        ts = generate_id()
+        req.session[SESSION_KEY_BUFFER % uid] = {
+            "method": "get",
+            "body": {},
+            "url": f"/{ts}",
+        }
+        req.session.save()
+
+        res = BufferView.as_view()(req)
+        self.assertEqual(res.status_code, 200)
+        self.assertIn(ts, res.render().content.decode())

--- a/authentik/policies/urls.py
+++ b/authentik/policies/urls.py
@@ -1,7 +1,14 @@
 """API URLs"""
 
+from django.urls import path
+
 from authentik.policies.api.bindings import PolicyBindingViewSet
 from authentik.policies.api.policies import PolicyViewSet
+from authentik.policies.views import BufferView
+
+urlpatterns = [
+    path("buffer", BufferView.as_view(), name="buffer"),
+]
 
 api_urlpatterns = [
     ("policies/all", PolicyViewSet),

--- a/authentik/policies/views.py
+++ b/authentik/policies/views.py
@@ -186,13 +186,7 @@ class BufferedPolicyAccessView(PolicyAccessView):
             "method": self.request.method.lower(),
         }
         return redirect(
-            reverse("authentik_policies:buffer")
-            + "?"
-            + urlencode(
-                {
-                    QS_BUFFER_ID: buffer_id,
-                }
-            )
+            url_with_qs(reverse("authentik_policies:buffer"), **{QS_BUFFER_ID: buffer_id})
         )
 
     def dispatch(self, request, *args, **kwargs):

--- a/authentik/providers/oauth2/views/authorize.py
+++ b/authentik/providers/oauth2/views/authorize.py
@@ -30,7 +30,7 @@ from authentik.flows.stage import StageView
 from authentik.lib.utils.time import timedelta_from_string
 from authentik.lib.views import bad_request_message
 from authentik.policies.types import PolicyRequest
-from authentik.policies.views import PolicyAccessView, RequestValidationError
+from authentik.policies.views import BufferedPolicyAccessView, RequestValidationError
 from authentik.providers.oauth2.constants import (
     PKCE_METHOD_PLAIN,
     PKCE_METHOD_S256,
@@ -328,7 +328,7 @@ class OAuthAuthorizationParams:
         return code
 
 
-class AuthorizationFlowInitView(PolicyAccessView):
+class AuthorizationFlowInitView(BufferedPolicyAccessView):
     """OAuth2 Flow initializer, checks access to application and starts flow"""
 
     params: OAuthAuthorizationParams

--- a/authentik/providers/rac/views.py
+++ b/authentik/providers/rac/views.py
@@ -18,11 +18,11 @@ from authentik.flows.planner import PLAN_CONTEXT_APPLICATION, FlowPlanner
 from authentik.flows.stage import RedirectStage
 from authentik.lib.utils.time import timedelta_from_string
 from authentik.policies.engine import PolicyEngine
-from authentik.policies.views import PolicyAccessView
+from authentik.policies.views import BufferedPolicyAccessView
 from authentik.providers.rac.models import ConnectionToken, Endpoint, RACProvider
 
 
-class RACStartView(PolicyAccessView):
+class RACStartView(BufferedPolicyAccessView):
     """Start a RAC connection by checking access and creating a connection token"""
 
     endpoint: Endpoint

--- a/authentik/providers/saml/views/sso.py
+++ b/authentik/providers/saml/views/sso.py
@@ -15,7 +15,7 @@ from authentik.flows.models import in_memory_stage
 from authentik.flows.planner import PLAN_CONTEXT_APPLICATION, PLAN_CONTEXT_SSO, FlowPlanner
 from authentik.flows.views.executor import SESSION_KEY_POST
 from authentik.lib.views import bad_request_message
-from authentik.policies.views import PolicyAccessView
+from authentik.policies.views import BufferedPolicyAccessView
 from authentik.providers.saml.exceptions import CannotHandleAssertion
 from authentik.providers.saml.models import SAMLBindings, SAMLProvider
 from authentik.providers.saml.processors.authn_request_parser import AuthNRequestParser
@@ -35,7 +35,7 @@ from authentik.stages.consent.stage import (
 LOGGER = get_logger()
 
 
-class SAMLSSOView(PolicyAccessView):
+class SAMLSSOView(BufferedPolicyAccessView):
     """SAML SSO Base View, which plans a flow and injects our final stage.
     Calls get/post handler."""
 
@@ -83,7 +83,7 @@ class SAMLSSOView(PolicyAccessView):
 
     def post(self, request: HttpRequest, application_slug: str) -> HttpResponse:
         """GET and POST use the same handler, but we can't
-        override .dispatch easily because PolicyAccessView's dispatch"""
+        override .dispatch easily because BufferedPolicyAccessView's dispatch"""
         return self.get(request, application_slug)
 
 

--- a/tests/e2e/test_provider_saml.py
+++ b/tests/e2e/test_provider_saml.py
@@ -20,7 +20,7 @@ from tests.e2e.utils import SeleniumTestCase, retry
 class TestProviderSAML(SeleniumTestCase):
     """test SAML Provider flow"""
 
-    def setup_client(self, provider: SAMLProvider, force_post: bool = False):
+    def setup_client(self, provider: SAMLProvider, force_post: bool = False, **kwargs):
         """Setup client saml-sp container which we test SAML against"""
         metadata_url = (
             self.url(
@@ -40,6 +40,7 @@ class TestProviderSAML(SeleniumTestCase):
                 "SP_ENTITY_ID": provider.issuer,
                 "SP_SSO_BINDING": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
                 "SP_METADATA_URL": metadata_url,
+                **kwargs
             },
         )
 
@@ -517,4 +518,82 @@ class TestProviderSAML(SeleniumTestCase):
         self.wait.until(
             lambda driver: driver.current_url.startswith(should_url),
             f"URL {self.driver.current_url} doesn't match expected URL {should_url}",
+        )
+
+    @retry()
+    @apply_blueprint(
+        "default/flow-default-authentication-flow.yaml",
+        "default/flow-default-invalidation-flow.yaml",
+    )
+    @apply_blueprint(
+        "default/flow-default-provider-authorization-implicit-consent.yaml",
+    )
+    @apply_blueprint(
+        "system/providers-saml.yaml",
+    )
+    @reconcile_app("authentik_crypto")
+    def test_sp_initiated_implicit_post_buffer(self):
+        """test SAML Provider flow SP-initiated flow (implicit consent)"""
+        # Bootstrap all needed objects
+        authorization_flow = Flow.objects.get(
+            slug="default-provider-authorization-implicit-consent"
+        )
+        provider: SAMLProvider = SAMLProvider.objects.create(
+            name="saml-test",
+            acs_url=f"http://{self.host}:9009/saml/acs",
+            audience="authentik-e2e",
+            issuer="authentik-e2e",
+            sp_binding=SAMLBindings.POST,
+            authorization_flow=authorization_flow,
+            signing_kp=create_test_cert(),
+        )
+        provider.property_mappings.set(SAMLPropertyMapping.objects.all())
+        provider.save()
+        Application.objects.create(
+            name="SAML",
+            slug="authentik-saml",
+            provider=provider,
+        )
+        self.setup_client(provider, True, SP_ROOT_URL=f"http://{self.host}:9009")
+
+        self.driver.get(self.live_server_url)
+        login_window = self.driver.current_window_handle
+        self.driver.switch_to.new_window("tab")
+        client_window = self.driver.current_window_handle
+        # We need to access the SP on the same host as the IdP for SameSite cookies
+        self.driver.get(f"http://{self.host}:9009")
+
+        self.driver.switch_to.window(login_window)
+        self.login()
+        self.driver.switch_to.window(client_window)
+
+        self.wait_for_url(f"http://{self.host}:9009/")
+
+        body = loads(self.driver.find_element(By.CSS_SELECTOR, "pre").text)
+
+        self.assertEqual(
+            body["attr"]["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"],
+            [self.user.name],
+        )
+        self.assertEqual(
+            body["attr"][
+                "http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"
+            ],
+            [self.user.username],
+        )
+        self.assertEqual(
+            body["attr"]["http://schemas.goauthentik.io/2021/02/saml/username"],
+            [self.user.username],
+        )
+        self.assertEqual(
+            body["attr"]["http://schemas.goauthentik.io/2021/02/saml/uid"],
+            [str(self.user.pk)],
+        )
+        self.assertEqual(
+            body["attr"]["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"],
+            [self.user.email],
+        )
+        self.assertEqual(
+            body["attr"]["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn"],
+            [self.user.email],
         )

--- a/tests/e2e/test_provider_saml.py
+++ b/tests/e2e/test_provider_saml.py
@@ -40,7 +40,7 @@ class TestProviderSAML(SeleniumTestCase):
                 "SP_ENTITY_ID": provider.issuer,
                 "SP_SSO_BINDING": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
                 "SP_METADATA_URL": metadata_url,
-                **kwargs
+                **kwargs,
             },
         )
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

related to #13579
related to #6954

this fixes the issue when a user has a lot of tabs with authentik-protected applications open and the session expires at the end of the day

currently they'd come back to many authentik tabs prompting them to login, but since only one flow can be executed at a time they'd have to re-launch all applications and state would get lost

with this, once the first tab has started the authentication flow, other tabs' requests are buffered and will in the background check if the user is authenticated yet and automatically resume the authorization. there is also an option to authenticate in a waiting tab in case the tab that starts the authentication flow is not the primary tab open.

this is not a full replacement for concurrent flow execution

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
