### PR TITLE
brands: fix migration 0008 by removing incorrect context manager usage

### DIFF
--- a/authentik/brands/migrations/0008_brand_branding_custom_css.py
+++ b/authentik/brands/migrations/0008_brand_branding_custom_css.py
@@ -15,8 +15,8 @@ def migrate_custom_css(apps: Apps, schema_editor: BaseDatabaseSchemaEditor):
     path = Path("/web/dist/custom.css")
     if not path.exists():
         return
-    with path.read_text() as css:
-        Brand.objects.using(db_alias).update(branding_custom_css=css)
+    css = path.read_text()
+    Brand.objects.using(db_alias).update(branding_custom_css=css)
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
The migration was incorrectly using Path.read_text() with a context manager,
which caused a TypeError. Fixed by directly reading the file content since
read_text() returns a string, not a context manager.

Error Log

```
worker-1      |   Applying authentik_brands.0008_brand_branding_custom_css...
server-1      | {"event":"backend not alive yet","level":"debug","logger":"authentik.router.unicorn","timestamp":"2025-03-22T18:17:19Z"}
worker-1      | {"domain_url": null, "event": "releasing database lock", "level": "info", "logger": "lifecycle.migrate", "pid": 7, "schema_name": "public", "timestamp": "2025-03-22T18:17:19.546815"}
worker-1      | Traceback (most recent call last):
worker-1      |   File "<frozen runpy>", line 198, in _run_module_as_main
worker-1      |   File "<frozen runpy>", line 88, in _run_code
worker-1      |   File "/manage.py", line 43, in <module>
worker-1      |     run_migrations()
worker-1      |   File "/lifecycle/migrate.py", line 115, in run_migrations
worker-1      |     execute_from_command_line(["", "migrate_schemas"])
worker-1      |   File "/ak-root/.venv/lib/python3.12/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
worker-1      |     utility.execute()
worker-1      |   File "/ak-root/.venv/lib/python3.12/site-packages/django/core/management/__init__.py", line 436, in execute
worker-1      |     self.fetch_command(subcommand).run_from_argv(self.argv)
worker-1      |   File "/ak-root/.venv/lib/python3.12/site-packages/django/core/management/base.py", line 413, in run_from_argv
worker-1      |     self.execute(*args, **cmd_options)
worker-1      |   File "/ak-root/.venv/lib/python3.12/site-packages/django/core/management/base.py", line 459, in execute
worker-1      |     output = self.handle(*args, **options)
worker-1      |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
worker-1      |   File "/ak-root/.venv/lib/python3.12/site-packages/django_tenants/management/commands/migrate_schemas.py", line 63, in handle
worker-1      |     executor.run_migrations(tenants=[self.PUBLIC_SCHEMA_NAME])
worker-1      |   File "/ak-root/.venv/lib/python3.12/site-packages/django_tenants/migration_executors/standard.py", line 11, in run_migrations
worker-1      |     run_migrations(self.args, self.options, self.codename, self.PUBLIC_SCHEMA_NAME)
worker-1      |   File "/ak-root/.venv/lib/python3.12/site-packages/django_tenants/migration_executors/base.py", line 61, in run_migrations
worker-1      |     migrate_command_class(stdout=stdout, stderr=stderr).execute(*args, **options)
worker-1      |   File "/ak-root/.venv/lib/python3.12/site-packages/django/core/management/base.py", line 459, in execute
worker-1      |     output = self.handle(*args, **options)
worker-1      |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
worker-1      |   File "/ak-root/.venv/lib/python3.12/site-packages/django/core/management/base.py", line 107, in wrapper
worker-1      |     res = handle_func(*args, **kwargs)
worker-1      |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
worker-1      |   File "/ak-root/.venv/lib/python3.12/site-packages/django/core/management/commands/migrate.py", line 356, in handle
worker-1      |     post_migrate_state = executor.migrate(
worker-1      |                          ^^^^^^^^^^^^^^^^^
worker-1      |   File "/ak-root/.venv/lib/python3.12/site-packages/django/db/migrations/executor.py", line 135, in migrate
worker-1      |     state = self._migrate_all_forwards(
worker-1      |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
worker-1      |   File "/ak-root/.venv/lib/python3.12/site-packages/django/db/migrations/executor.py", line 167, in _migrate_all_forwards
worker-1      |     state = self.apply_migration(
worker-1      |             ^^^^^^^^^^^^^^^^^^^^^
worker-1      |   File "/ak-root/.venv/lib/python3.12/site-packages/django/db/migrations/executor.py", line 252, in apply_migration
worker-1      |     state = migration.apply(state, schema_editor)
worker-1      |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
worker-1      |   File "/ak-root/.venv/lib/python3.12/site-packages/django/db/migrations/migration.py", line 132, in apply
worker-1      |     operation.database_forwards(
worker-1      |   File "/ak-root/.venv/lib/python3.12/site-packages/django/db/migrations/operations/special.py", line 193, in database_forwards
worker-1      |     self.code(from_state.apps, schema_editor)
worker-1      |   File "/authentik/brands/migrations/0008_brand_branding_custom_css.py", line 18, in migrate_custom_css
worker-1      |     with path.read_text() as css:
worker-1      |          ^^^^^^^^^^^^^^^^
worker-1      | TypeError: 'str' object does not support the context manager protocol
worker-1 exited with code 1
```

Tested-On: HEAD at 3eccef88a

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
