### PR TITLE
web: ensure wizard modal closes on first cancel click

### DIFF
--- a/web/src/elements/wizard/Wizard.ts
+++ b/web/src/elements/wizard/Wizard.ts
@@ -187,7 +187,11 @@ export class Wizard extends ModalButton {
     /**
      * Reset the wizard to it's initial state.
      */
-    reset = () => {
+    reset = (ev?: Event) => {
+        if (ev) {
+            ev.preventDefault();
+            ev.stopPropagation();
+        }
         this.open = false;
 
         this.querySelectorAll("[data-wizardmanaged=true]").forEach((el) => {
@@ -245,7 +249,7 @@ export class Wizard extends ModalButton {
                           class="pf-c-button pf-m-plain pf-c-wizard__close"
                           type="button"
                           aria-label="${msg("Close")}"
-                          @click=${this.reset}
+                          @click=${(ev: Event) => this.reset(ev)}
                       >
                           <i class="fas fa-times" aria-hidden="true"></i>
                       </button>`
@@ -332,9 +336,7 @@ export class Wizard extends ModalButton {
                               <button
                                   class="pf-c-button pf-m-link"
                                   type="button"
-                                  @click=${() => {
-                                      this.reset();
-                                  }}
+                                  @click=${(ev: Event) => this.reset(ev)}
                               >
                                   ${msg("Cancel")}
                               </button>


### PR DESCRIPTION
The application wizard modal previously required two clicks of the cancel button to close when opened from the User Interface. This was caused by improper event handling where events would propagate up the DOM tree potentially triggering multiple handlers.


qa:
https://github.com/user-attachments/assets/34ea6565-4424-4a8e-9ae0-7f91c0e43f1e

pr:
https://github.com/user-attachments/assets/7fcea70b-e268-424d-ad10-6827b9bc9815



<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
