### PR TITLE
providers/scim: fix group membership check failing

### DIFF
--- a/authentik/providers/scim/clients/groups.py
+++ b/authentik/providers/scim/clients/groups.py
@@ -243,9 +243,10 @@ class SCIMGroupClient(SCIMClient[Group, SCIMProviderGroup, SCIMGroupSchema]):
             if user.value not in users_should:
                 users_to_remove.append(user.value)
         # Check users that should be in the group and add them
-        for user in users_should:
-            if len([x for x in current_group.members if x.value == user]) < 1:
-                users_to_add.append(user)
+        if current_group.members is not None:
+            for user in users_should:
+                if len([x for x in current_group.members if x.value == user]) < 1:
+                    users_to_add.append(user)
         # Only send request if we need to make changes
         if len(users_to_add) < 1 and len(users_to_remove) < 1:
             return


### PR DESCRIPTION
closes #12917

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

the actual stacktrace for this one was

```
Traceback (most recent call last):
  File "/ak-root/.venv/lib/python3.12/site-packages/celery/app/trace.py", line 453, in trace_task
    R = retval = fun(*args, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^
  File "/ak-root/.venv/lib/python3.12/site-packages/sentry_sdk/utils.py", line 1783, in runner
    return sentry_patched_function(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ak-root/.venv/lib/python3.12/site-packages/sentry_sdk/integrations/celery/__init__.py", line 415, in _inner
    reraise(*exc_info)
  File "/ak-root/.venv/lib/python3.12/site-packages/sentry_sdk/utils.py", line 1718, in reraise
    raise value
  File "/ak-root/.venv/lib/python3.12/site-packages/sentry_sdk/integrations/celery/__init__.py", line 410, in _inner
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/ak-root/.venv/lib/python3.12/site-packages/celery/app/trace.py", line 736, in __protected_call__
    return self.run(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ak-root/.venv/lib/python3.12/site-packages/celery/app/autoretry.py", line 38, in run
    return task._orig_run(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/authentik/providers/scim/tasks.py", line 14, in scim_sync_objects
    return sync_tasks.sync_objects(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/authentik/lib/sync/outgoing/tasks.py", line 138, in sync_objects
    client.write(obj)
  File "/authentik/lib/sync/outgoing/base.py", line 74, in write
    self.update(obj, connection)
  File "/authentik/providers/scim/clients/groups.py", line 118, in update
    return self._update_put(group, scim_group, connection)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/authentik/providers/scim/clients/groups.py", line 158, in _update_put
    return self.patch_compare_users(group)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/authentik/providers/scim/clients/groups.py", line 247, in patch_compare_users
    if len([x for x in current_group.members if x.value == user]) < 1:
                       ^^^^^^^^^^^^^^^^^^^^^
builtins.TypeError: 'NoneType' object is not iterable
```

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
