### PR TITLE
root: new issue template for Docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs_issue.md
+++ b/.github/ISSUE_TEMPLATE/docs_issue.md
@@ -1,0 +1,19 @@
+---
+name: Documentatiotn issue
+about: Suggest an improvement or report a problem
+title: ""
+labels: documentation
+assignees: ""
+---
+
+**Do you see an area that can be clarified or expanded, a technical inaccuracy, or a broken link? Please describe.**
+A clear and concise description of what the problem is, or where the document can be improved. Ex. I believe we need more details about [...]
+
+**Provide the URL or link to the exact page in the documentation to which you are referring.**
+If there are multiple pages, list them all, and be sure to state the header or section where the content is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Additional context**
+Add any other context or screenshots about the documentation issue here.

--- a/.github/ISSUE_TEMPLATE/docs_issue.md
+++ b/.github/ISSUE_TEMPLATE/docs_issue.md
@@ -17,3 +17,6 @@ A clear and concise description of what you want to happen.
 
 **Additional context**
 Add any other context or screenshots about the documentation issue here.
+
+**Consider opening a PR!**
+If the issue is one that you can fix, or even make a good pass at, we'd appreciate a PR. For more information about making a contribution to the docs, and using our Style Guide and our templates, refer to ["Writing documentation"](https://docs.goauthentik.io/docs/developer-docs/docs/writing-documentation.)

--- a/.github/ISSUE_TEMPLATE/docs_issue.md
+++ b/.github/ISSUE_TEMPLATE/docs_issue.md
@@ -19,4 +19,4 @@ A clear and concise description of what you want to happen.
 Add any other context or screenshots about the documentation issue here.
 
 **Consider opening a PR!**
-If the issue is one that you can fix, or even make a good pass at, we'd appreciate a PR. For more information about making a contribution to the docs, and using our Style Guide and our templates, refer to ["Writing documentation"](https://docs.goauthentik.io/docs/developer-docs/docs/writing-documentation.)
+If the issue is one that you can fix, or even make a good pass at, we'd appreciate a PR. For more information about making a contribution to the docs, and using our Style Guide and our templates, refer to ["Writing documentation"](https://docs.goauthentik.io/docs/developer-docs/docs/writing-documentation).

--- a/.github/ISSUE_TEMPLATE/docs_issue.md
+++ b/.github/ISSUE_TEMPLATE/docs_issue.md
@@ -1,5 +1,5 @@
 ---
-name: Documentatiotn issue
+name: Documentation issue
 about: Suggest an improvement or report a problem
 title: ""
 labels: documentation


### PR DESCRIPTION
This PR adds a new Issue template, specifically for Docs. (The new footer calls for people to open an Issue, but there was no Docs-specific template.)

-   [ ] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
