### PR TITLE
stages/email: Clean newline characters in TemplateEmailMessage

### DIFF
--- a/authentik/stages/email/tests/test_sending.py
+++ b/authentik/stages/email/tests/test_sending.py
@@ -95,7 +95,7 @@ class TestEmailStageSending(FlowTestCase):
             )
             self.assertEqual(len(mail.outbox), 1)
             self.assertEqual(mail.outbox[0].subject, "authentik")
-            self.assertEqual(mail.outbox[0].to, [f"Test User  Many Words  <{long_user.email}>"])
+            self.assertEqual(mail.outbox[0].to, [f"Test User   Many Words   <{long_user.email}>"])
 
     def test_pending_fake_user(self):
         """Test with pending (fake) user"""

--- a/authentik/stages/email/tests/test_sending.py
+++ b/authentik/stages/email/tests/test_sending.py
@@ -95,7 +95,7 @@ class TestEmailStageSending(FlowTestCase):
             )
             self.assertEqual(len(mail.outbox), 1)
             self.assertEqual(mail.outbox[0].subject, "authentik")
-            self.assertEqual(mail.outbox[0].to, [f"Test User Many Words <{long_user.email}>"])
+            self.assertEqual(mail.outbox[0].to, [f"Test User  Many Words  <{long_user.email}>"])
 
     def test_pending_fake_user(self):
         """Test with pending (fake) user"""

--- a/authentik/stages/email/utils.py
+++ b/authentik/stages/email/utils.py
@@ -34,7 +34,7 @@ class TemplateEmailMessage(EmailMultiAlternatives):
         for recipient_name, recipient_email in to:
             # Remove any newline characters from name and email before sanitizing
             clean_name = (
-                recipient_name.replace("\n", "").replace("\r", "") if recipient_name else ""
+                recipient_name.replace("\n", " ").replace("\r", "") if recipient_name else ""
             )
             clean_email = (
                 recipient_email.replace("\n", "").replace("\r", "") if recipient_email else ""

--- a/authentik/stages/email/utils.py
+++ b/authentik/stages/email/utils.py
@@ -32,7 +32,14 @@ class TemplateEmailMessage(EmailMultiAlternatives):
         sanitized_to = []
         # Ensure that all recipients are valid
         for recipient_name, recipient_email in to:
-            sanitized_to.append(sanitize_address((recipient_name, recipient_email), "utf-8"))
+            # Remove any newline characters from name and email before sanitizing
+            clean_name = (
+                recipient_name.replace("\n", "").replace("\r", "") if recipient_name else ""
+            )
+            clean_email = (
+                recipient_email.replace("\n", "").replace("\r", "") if recipient_email else ""
+            )
+            sanitized_to.append(sanitize_address((clean_name, clean_email), "utf-8"))
         super().__init__(to=sanitized_to, **kwargs)
         if not template_name:
             return

--- a/authentik/stages/email/utils.py
+++ b/authentik/stages/email/utils.py
@@ -34,7 +34,7 @@ class TemplateEmailMessage(EmailMultiAlternatives):
         for recipient_name, recipient_email in to:
             # Remove any newline characters from name and email before sanitizing
             clean_name = (
-                recipient_name.replace("\n", " ").replace("\r", "") if recipient_name else ""
+                recipient_name.replace("\n", " ").replace("\r", " ") if recipient_name else ""
             )
             clean_email = (
                 recipient_email.replace("\n", "").replace("\r", "") if recipient_email else ""


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Added sanitization to remove newline characters from recipient names and email addresses 

closes #13649
closes #13104


---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
