### PR TITLE
website/docs: Fix Caddy forward auth example

### DIFF
--- a/website/docs/add-secure-apps/providers/proxy/_caddy_standalone.md
+++ b/website/docs/add-secure-apps/providers/proxy/_caddy_standalone.md
@@ -28,6 +28,6 @@ If you're trying to proxy to an upstream over HTTPS, you need to set the `Host` 
 
 ```conf
 reverse_proxy /outpost.goauthentik.io/* https://outpost.company {
-    header_up Host {http.reverse_proxy.upstream.hostport}
+    header_up Host {http.reverse_proxy.upstream.host}
 }
 ```


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->

This PR updates docs. Specifically it fixes Caddy forward_auth example configuration: https://docs.goauthentik.io/docs/add-secure-apps/providers/proxy/server_caddy.

Previously the config used `http.reverse_proxy.upstream.hostport` variable for `Host` header. I believe it is incorrect. According to Caddy docs, `hostport` contains `host:port`, e.g.: `example.com:443`. AFAIK `Host` header expects `host`, e.g.: `example.com`. Source: https://caddyserver.com/docs/json/apps/http/servers/routes/handle/reverse_proxy/#docs

Also, using `hostport` was giving me 404 with forward auth. Switching to `host` worked.

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
