### PR TITLE
website/docs: Updated redirect URI setup for Synology DSM

### DIFF
--- a/website/integrations/services/synology-dsm/index.md
+++ b/website/integrations/services/synology-dsm/index.md
@@ -38,7 +38,7 @@ To support the integration of Synology DSM with authentik, you need to create an
 - **Choose a Provider type**: select **OAuth2/OpenID Connect** as the provider type.
 - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
     - Note the **Client ID**,**Client Secret**, and **slug** values because they will be required later.
-    - Set a `Strict` redirect URI to <kbd>https://<em>synology.company</em>/#/signin</kbd>.
+    - Set a `Strict` redirect URI to <kbd>https://<em>synology.company</em></kbd>.
     - Select any available signing key.
     - Under **Advanced Protocol Settings**, set the **subject mode** to be based on the user's email.
 - **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/flows-stages/bindings/) (policy, group, or user) to manage the listing and access to applications on a user's **My applications** page.
@@ -59,7 +59,7 @@ To configure Synology DSM to utilize authentik as an OpenID Connect 1.0 Provider
 - Well Known URL: Copy this from the 'OpenID Configuration URL' in the authentik provider (URL ends with '/.well-known/openid-configuration')
 - Application ID: The 'Client ID' from the authentik provider
 - Application Key: The 'Client secret' from the authentik provider
-- Redirect URL: https://synology.company/#/signin (This should match the 'Redirect URI' in authentik exactly)
+- Redirect URL: https://synology.company (This should match the 'Redirect URI' in authentik exactly)
 - Authorization Scope: openid profile email
 - Username Claim: preferred_username
 - Save the settings.
@@ -69,6 +69,9 @@ To configure Synology DSM to utilize authentik as an OpenID Connect 1.0 Provider
 **Error `not privilege`**
 
 The log in process could fail with a `not privilege` error, when the SSO pop-up is blocked. Allowing pop-ups in the browser configuration resolves this (see https://github.com/authelia/authelia/discussions/6902#discussioncomment-9756400).
+
+This error can also happen when you have multiple Redirect URI entries, but only the last one is used when trying to log on from any of the URLs. For example, if using the Application portal, each service has its own URL.
+The DSM tries to match the right redirect URI based on the Host and HTTPS headers. This is why you should not add #/signin at the end of your redirect URIs.
 
 ## See also:
 


### PR DESCRIPTION
Based on the feedback from Synology's developers, and testing: the redirect URI should not contain #/signup as it breaks authentication if multiple redirect URIs are defined.

In DSM 7.2's code itself, Host and HTTPS headers are used internally to match the corresponding entry in the list.

I've lost a few days on that, figured that could help some users. Also, I've read the guidelines and hope it suits your requirements.