### PR TITLE
website/integrations: nextcloud: add warning about admin lockout

### DIFF
--- a/website/integrations/services/nextcloud/index.mdx
+++ b/website/integrations/services/nextcloud/index.mdx
@@ -174,7 +174,7 @@ Depending on your Nextcloud configuration, you might need to use `https://nextcl
       :::
 
       :::danger
-      If the custom profile scope is used and Administators should be able to login, deselected **Use unique user ID**. Else it removes Administrator users from the internal admin group and replace it with hashed group ID also called admin, but without actual admin access rights!
+      If you are using a custom profile scope and want administrators to be able to log in, ensure that **Use unique user ID** is deselected. Otherwise, this setting will remove Administrator users from the internal admin group and replace them with a hashed group ID named "admin", which lacks actual admin access rights.
       :::
 
 3. **Log in:**  

--- a/website/integrations/services/nextcloud/index.mdx
+++ b/website/integrations/services/nextcloud/index.mdx
@@ -173,6 +173,10 @@ Depending on your Nextcloud configuration, you might need to use `https://nextcl
       To avoid a hashed Federated Cloud ID, deselect **Use unique user ID** and use `user_id` for the User ID mapping.
       :::
 
+      :::danger
+      If the custom profile scope is used and Administators should be able to login, deselected **Use unique user ID**. Else it removes Administrator users from the internal admin group and replace it with hashed group ID also called admin, but without actual admin access rights!
+      :::
+
 3. **Log in:**  
    Once configured, single sign-on (SSO) login via authentik becomes available.
 

--- a/website/integrations/services/nextcloud/index.mdx
+++ b/website/integrations/services/nextcloud/index.mdx
@@ -173,9 +173,9 @@ Depending on your Nextcloud configuration, you might need to use `https://nextcl
       To avoid a hashed Federated Cloud ID, deselect **Use unique user ID** and use `user_id` for the User ID mapping.
       :::
 
-      :::danger
-      If you are using a custom profile scope and want administrators to be able to log in, ensure that **Use unique user ID** is deselected. Otherwise, this setting will remove Administrator users from the internal admin group and replace them with a hashed group ID named "admin", which lacks actual admin access rights.
-      :::
+        :::danger
+        If you are using a custom profile scope and want administrators to be able to log in, ensure that **Use unique user ID** is deselected. Otherwise, this setting will remove Administrator users from the internal admin group and replace them with a hashed group ID named "admin", which lacks actual admin access rights.
+        :::
 
 3. **Log in:**  
    Once configured, single sign-on (SSO) login via authentik becomes available.


### PR DESCRIPTION
If a user follwoing the guide for OpenID integration. They can lock out their Admin users, if used the customer profile scope and select the **use unique user ID** option.  So a danger box was added to let people know that can happen and why

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
