### PR TITLE
website/integrations: Open Web UI: add OPENID_REDIRECT_URI environment variable

### DIFF
--- a/website/integrations/services/open-webui/index.md
+++ b/website/integrations/services/open-webui/index.md
@@ -50,6 +50,7 @@ Enter the following details from the authentik provider:
 - Set **OAUTH_CLIENT_SECRET** to the Client Secret copied from authentik.
 - Set **OAUTH_PROVIDER_NAME** to `authentik`.
 - Set **OPENID_PROVIDER_URL** to <kbd>https://<em>authentik.company</em>/application/o/<em>your-slug-here</em>/.well-known/openid-configuration</kbd>.
+- Set **OPENID_REDIRECT_URI** to <kbd>https://<em>openwebui.company</em>/oauth/oidc/callback</kbd>.
 - If you wish for new users to be created on Open Web UI, set **ENABLE_OAUTH_SIGNUP** to 'true'.
 
 ## Configuration verification


### PR DESCRIPTION
## Details
Adding `OPENID_REDIRECT_URI` to Open WebUI integration documentation. Got me through a bit of trouble as it doesn't exist and I kept getting Redirect URI Error.
Finally found the appropriate fix [here](https://github.com/open-webui/open-webui/discussions/6257#discussioncomment-11053459) and it fixed the problem.

This is my first contributation here, hope I've done it correctly

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
