### PR TITLE
website/docs: Correcting IDP URLs on Mailcow integration page

### DIFF
--- a/website/integrations/services/mailcow/index.md
+++ b/website/integrations/services/mailcow/index.md
@@ -50,9 +50,9 @@ To configure mailcow with authentik, log in as an administrator and navigate to 
 Then, go to **Access** > **Identity Provider** and enter the following information in the form:
 
 - **Identity Provider**: <kbd>Generic-OIDC</kbd>
-- **Authorization endpoint**: <kbd>https://<em>mailcow.company</em>/application/o/authorize/</kbd>
-- **Token endpoint**: <kbd>https://<em>mailcow.company</em>/application/o/token/</kbd>
-- **User info endpoint**: <kbd>https://<em>mailcow.company</em>/application/o/userinfo/</kbd>
+- **Authorization endpoint**: <kbd>https://<em>authentik.company</em>/application/o/authorize/</kbd>
+- **Token endpoint**: <kbd>https://<em>authentik.company</em>/application/o/token/</kbd>
+- **User info endpoint**: <kbd>https://<em>authentik.company</em>/application/o/userinfo/</kbd>
 - **Client ID**: The `Client ID` from the authentik provider
 - **Client Secret**: The `Client secret` from the authentik provider
 - **Redirect Url**: <kbd>https://<em>mailcow.company</em></kbd>


### PR DESCRIPTION
## Details

Changing the URLs from `mailcow.company` to `authentik.company` on the Mailcow integration page for the Authorization, Token and User Info endpoints. Hope this PR is ok. 

---
