### PR TITLE
website/integrations: fix ArgoCD redirect paths

### DIFF
--- a/website/integrations/services/argocd/index.md
+++ b/website/integrations/services/argocd/index.md
@@ -34,7 +34,7 @@ To support the integration of ArgoCD with authentik, you need to create an appli
 - **Choose a Provider type**: select **OAuth2/OpenID Connect** as the provider type.
 - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
     - Note the **Client ID**,**Client Secret**, and **slug** values because they will be required later.
-    - Add two `Strict` redirect URI and set them to <kbd>https://<em>argocd.company</em>/api/dex/callback/</kbd> and <kbd>https://<em>localhost:8085</em>/auth/callback/</kbd>.
+    - Add two `Strict` redirect URI and set them to <kbd>https://<em>argocd.company</em>/api/dex/callback</kbd> and <kbd>https://<em>localhost:8085</em>/auth/callback</kbd>.
     - Select any available signing key.
 - **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/flows-stages/bindings/) (policy, group, or user) to manage the listing and access to applications on a user's **My applications** page.
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

As of argo 2.14.x it uses callback url without a trailing slash. the documentation is correct in the TF section, but the standalone section incorrectly added a trailing "/" which throws error.

---

## Checklist

-   [ x] Local tests pass (`ak test authentik/`)
-   [ x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x ] The documentation has been updated
-   [ x] The documentation has been formatted (`make website`)
