### PR TITLE
Fix redirect URL in wordpress integration guide

### DIFF
--- a/website/integrations/services/wordpress/index.md
+++ b/website/integrations/services/wordpress/index.md
@@ -38,7 +38,7 @@ To support the integration of WordPress with authentik, you need to create an ap
 - **Choose a Provider type**: select **OAuth2/OpenID Connect** as the provider type.
 - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
     - Note the **Client ID**,**Client Secret**, and **slug** values because they will be required later.
-    - Set a `Strict` redirect URI to <kbd>https://<em>wp.company</em>/admin-ajax.php\?action=openid-connect-authorize</kbd>.
+    - Set a `Strict` redirect URI to <kbd>https://<em>wp.company</em>/wp-admin/admin-ajax.php\?action=openid-connect-authorize</kbd>.
     - Select any available signing key.
     - Under **Advanced Protocol Settings**, add `offline_access` to the list of available scopes.
 - **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/flows-stages/bindings/) (policy, group, or user) to manage the listing and access to applications on a user's **My applications** page.


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
The integration guide for wordpress contained an incorrect redirect URL

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
