### PR TITLE
sources/oauth: fix apple authentication

### DIFF
--- a/authentik/sources/oauth/types/apple.py
+++ b/authentik/sources/oauth/types/apple.py
@@ -10,7 +10,7 @@ from rest_framework.fields import CharField
 from structlog.stdlib import get_logger
 
 from authentik.flows.challenge import Challenge, ChallengeResponse
-from authentik.sources.oauth.clients.oauth2 import OAuth2Client
+from authentik.sources.oauth.clients.oauth2 import OAuth2Client, AuthScheme
 from authentik.sources.oauth.models import OAuthSource
 from authentik.sources.oauth.types.registry import SourceType, registry
 from authentik.sources.oauth.views.callback import OAuthCallback
@@ -39,6 +39,8 @@ class AppleChallengeResponse(ChallengeResponse):
 
 class AppleOAuthClient(OAuth2Client):
     """Apple OAuth2 client"""
+
+    self._source_auth_scheme = AuthScheme.POST_BODY
 
     def get_client_id(self) -> str:
         parts: list[str] = self.source.consumer_key.split(";")

--- a/authentik/sources/oauth/types/apple.py
+++ b/authentik/sources/oauth/types/apple.py
@@ -40,7 +40,7 @@ class AppleChallengeResponse(ChallengeResponse):
 class AppleOAuthClient(OAuth2Client):
     """Apple OAuth2 client"""
 
-    self._source_auth_scheme = AuthScheme.POST_BODY
+    _source_auth_scheme: AuthScheme = AuthScheme.POST_BODY
 
     def get_client_id(self) -> str:
         parts: list[str] = self.source.consumer_key.split(";")


### PR DESCRIPTION
## Details

Fixes the previously removed post body authentication scheme that breaks Apple authentication.
Apple expects client credentials in the [token post body](https://developer.apple.com/documentation/signinwithapplerestapi/generate-and-validate-tokens#http-body), instead of basic auth.
This attempts to maintain the fix in the [previous PR](https://github.com/goauthentik/authentik/pull/13322) while addressing the [new issue](https://github.com/goauthentik/authentik/issues/13647) affecting the Apple source.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
