### PR TITLE
root: prevent docker-compose up when secret key is missing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
     restart: unless-stopped
     command: server
     environment:
+      AUTHENTIK_SECRET_KEY: ${AUTHENTIK_SECRET_KEY:?secret key required}
       AUTHENTIK_REDIS__HOST: redis
       AUTHENTIK_POSTGRESQL__HOST: postgresql
       AUTHENTIK_POSTGRESQL__USER: ${PG_USER:-authentik}
@@ -58,6 +59,7 @@ services:
     restart: unless-stopped
     command: worker
     environment:
+      AUTHENTIK_SECRET_KEY: ${AUTHENTIK_SECRET_KEY:?secret key required}
       AUTHENTIK_REDIS__HOST: redis
       AUTHENTIK_POSTGRESQL__HOST: postgresql
       AUTHENTIK_POSTGRESQL__USER: ${PG_USER:-authentik}


### PR DESCRIPTION
## Details

Use the same mechanism used by the postgres password environment variable `PG_PASS` to halt before booting the containers.

It's a small Quality-of-Life improvement for people that forget to read the docs. When `AUTHENTIK_SECRET_KEY` is not defined it'll error before starting any container with an error message similar to:

```
[...] authentik-lab/docker-compose.yml: error while interpolating AUTHENTIK_SECRET_KEY: required variable AUTHENTIK_SECRET_KEY is missing a value: secret key required
```

Which is a better signal than an container in restart loop.
---

## Checklist

-   [x] ~~Local tests pass (`ak test authentik/`)~~  (Not applicable)
-   [x] ~~The code has been formatted (`make lint-fix`)~~ (Not applicable)

If an API change has been made

-   [x] ~~The API schema has been updated (`make gen-build`)~~ (Not applicable)

If changes to the frontend have been made

-   [x] ~~The code has been formatted (`make web`)~~ (Not applicable)

If applicable

-   [x] ~~The documentation has been updated~~ (Not applicable)
-   [x] ~~The documentation has been formatted (`make website`)~~ (Not applicable)
