### PR TITLE
website/integrations: fix for actual-budget wiki guide

### DIFF
--- a/website/integrations/services/actual-budget/index.mdx
+++ b/website/integrations/services/actual-budget/index.mdx
@@ -37,7 +37,7 @@ To support the integration of Actual Budget with authentik, you need to create a
 - **Choose a Provider type**: select **OAuth2/OpenID Connect** as the provider type.
 - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
     - Note the **Client ID**,**Client Secret**, and **slug** values because they will be required later.
-    - Set a `Strict` redirect URI to <kbd>https://<em>actual.company</em>/openid/callback/</kbd>.
+    - Set a `Strict` redirect URI to <kbd>https://<em>actual.company</em>/openid/callback</kbd>.
     - Select any available signing key. Actual Budget only supports the RS256 algorithm. Be aware of this when choosing a signing key.
 - **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/flows-stages/bindings/) (policy, group, or user) to manage the listing and access to applications on a user's **My applications** page.
 


### PR DESCRIPTION


## Details

This is a simple fix: remove the front slash at the end of the redirect uri. Will not work if this slash exists in the redirect uri.
---


