### PR TITLE
website/docs: fix minor typo in working_with_policies.md

### DIFF
--- a/website/docs/customize/policies/working_with_policies.md
+++ b/website/docs/customize/policies/working_with_policies.md
@@ -8,7 +8,7 @@ authentik provides several [standard policy types](./index.md#standard-policies)
 
 We also document how to use a policy to [whitelist email domains](./expression/whitelist_email.md) and to [ensure unique email addresses](./expression/unique_email.md).
 
-To learn more see also [bindings](../../add-secure-apps/flows-stages/bindings/index.md) and how to [bind policy bindings to a new application when you create the application](../../add-secure-apps/applications/manage_apps.mdx#instructions) (for example, to configure application-specific access).
+To learn more see also [bindings](../../add-secure-apps/flows-stages/bindings/index.md) and how to [bind policy bindings to a new application when the application is created](../../add-secure-apps/applications/manage_apps.mdx#instructions) (for example, to configure application-specific access).
 
 ## Create a policy
 

--- a/website/docs/customize/policies/working_with_policies.md
+++ b/website/docs/customize/policies/working_with_policies.md
@@ -8,7 +8,7 @@ authentik provides several [standard policy types](./index.md#standard-policies)
 
 We also document how to use a policy to [whitelist email domains](./expression/whitelist_email.md) and to [ensure unique email addresses](./expression/unique_email.md).
 
-To learn more see also [bindings](../../add-secure-apps/flows-stages/bindings/index.md) and how to [bind policy bindings to a new application when yo create the application](../../add-secure-apps/applications/manage_apps.mdx#instructions) (for example, to configure application-specific access).
+To learn more see also [bindings](../../add-secure-apps/flows-stages/bindings/index.md) and how to [bind policy bindings to a new application when you create the application](../../add-secure-apps/applications/manage_apps.mdx#instructions) (for example, to configure application-specific access).
 
 ## Create a policy
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
Fix a minor typo in "Working with policies" section in website documentation

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
