### PR TITLE
website/docs: adds code examples for getting user objects from a group object

### DIFF
--- a/website/docs/users-sources/groups/group_ref.md
+++ b/website/docs/users-sources/groups/group_ref.md
@@ -9,7 +9,7 @@ The Group object has the following properties:
 - `name`: The group's display name.
 - `is_superuser`: A boolean field that determines if the group's users are superusers.
 - `parent`: The parent group of this group.
-- `attributes`: Dynamic attributes, see [Attributes](#attributes)
+- `attributes`: Dynamic attributes, see [Attributes](#attributes).
 
 ## Examples
 

--- a/website/docs/users-sources/groups/group_ref.md
+++ b/website/docs/users-sources/groups/group_ref.md
@@ -23,7 +23,7 @@ Use the following examples to list all users that are members of a group:
 group.users.all()
 ```
 
-```python title="Define a Group object based on name and get all of its members"
+```python title="Define a group object based on name and get all of its members"
 from authentik.core.models import Group
 Group.objects.get(name="name of group").users.all()
 ```

--- a/website/docs/users-sources/groups/group_ref.md
+++ b/website/docs/users-sources/groups/group_ref.md
@@ -13,7 +13,7 @@ The Group object has the following properties:
 
 ## Examples
 
-These are examples of how Group objects can be used within **Policies** and **Property Mappings**.
+These are examples of how group objects can be used within authentik policies and property mappings.
 
 ### List all group members
 

--- a/website/docs/users-sources/groups/group_ref.md
+++ b/website/docs/users-sources/groups/group_ref.md
@@ -8,7 +8,7 @@ The Group object has the following properties:
 
 - `name`: The group's display name.
 - `is_superuser`: A boolean field that determines if the Group's users are superusers.
-- `parent`: The parent Group of this Group.
+- `parent`: The parent group of this group.
 - `attributes`: Dynamic attributes, see [Attributes](#attributes)
 
 ## Examples

--- a/website/docs/users-sources/groups/group_ref.md
+++ b/website/docs/users-sources/groups/group_ref.md
@@ -11,6 +11,19 @@ The Group object has the following properties:
 - `parent` The parent Group of this Group.
 - `attributes` Dynamic attributes, see [Attributes](#attributes)
 
+## Examples
+
+### List all users in a group
+
+```python
+group.users.all()
+```
+
+```python
+from authentik.core.models import Group
+Group.objects.get(name="name of group").users.all()
+```
+
 ## Attributes
 
 See [the user reference](../user/user_ref.mdx#attributes) for well-known attributes.

--- a/website/docs/users-sources/groups/group_ref.md
+++ b/website/docs/users-sources/groups/group_ref.md
@@ -6,26 +6,30 @@ title: Group properties and attributes
 
 The Group object has the following properties:
 
-- `name` Group's display name.
-- `is_superuser` Boolean field if the group's users are superusers.
-- `parent` The parent Group of this Group.
-- `attributes` Dynamic attributes, see [Attributes](#attributes)
+- `name`: The Group's display name.
+- `is_superuser`: A boolean field that determines if the Group's users are superusers.
+- `parent`: The parent Group of this Group.
+- `attributes`: Dynamic attributes, see [Attributes](#attributes)
 
 ## Examples
 
+These are examples of how Group objects can be used within **Policies** and **Property Mappings**.
+
 ### List all group members
 
-Use the following examples to list all users that are members of a group:
+Use the following examples to list all users that are members of a Group:
 
-```python
+```python title="Get all members of a Group object"
 group.users.all()
 ```
 
-```python
+```python title="Define a Group object based on name and get all of its members"
 from authentik.core.models import Group
 Group.objects.get(name="name of group").users.all()
 ```
 
 ## Attributes
+
+By default, authentik Group objects are created with no attributes, however custom attributes can be set.
 
 See [the user reference](../user/user_ref.mdx#attributes) for well-known attributes.

--- a/website/docs/users-sources/groups/group_ref.md
+++ b/website/docs/users-sources/groups/group_ref.md
@@ -4,7 +4,7 @@ title: Group properties and attributes
 
 ## Object properties
 
-The Group object has the following properties:
+The group object has the following properties:
 
 - `name`: The group's display name.
 - `is_superuser`: A boolean field that determines if the group's users are superusers.
@@ -30,6 +30,6 @@ Group.objects.get(name="name of group").users.all()
 
 ## Attributes
 
-By default, authentik Group objects are created with no attributes, however custom attributes can be set.
+By default, authentik group objects are created with no attributes, however custom attributes can be set.
 
 See [the user reference](../user/user_ref.mdx#attributes) for well-known attributes.

--- a/website/docs/users-sources/groups/group_ref.md
+++ b/website/docs/users-sources/groups/group_ref.md
@@ -6,7 +6,7 @@ title: Group properties and attributes
 
 The Group object has the following properties:
 
-- `name`: The Group's display name.
+- `name`: The group's display name.
 - `is_superuser`: A boolean field that determines if the Group's users are superusers.
 - `parent`: The parent Group of this Group.
 - `attributes`: Dynamic attributes, see [Attributes](#attributes)

--- a/website/docs/users-sources/groups/group_ref.md
+++ b/website/docs/users-sources/groups/group_ref.md
@@ -19,11 +19,11 @@ These are examples of how group objects can be used within authentik policies an
 
 Use the following examples to list all users that are members of a group:
 
-```python title="Get all members of a Group object"
+```python title="Get all members of a group object"
 group.users.all()
 ```
 
-```python title="Define a group object based on name and get all of its members"
+```python title="Specify a group object based on name and get all of its members"
 from authentik.core.models import Group
 Group.objects.get(name="name of group").users.all()
 ```

--- a/website/docs/users-sources/groups/group_ref.md
+++ b/website/docs/users-sources/groups/group_ref.md
@@ -23,7 +23,7 @@ Use the following examples to list all users that are members of a group:
 group.users.all()
 ```
 
-```python title="Specify a group object based on name and get all of its members"
+```python title="Specify a group object based on name and return all of its members"
 from authentik.core.models import Group
 Group.objects.get(name="name of group").users.all()
 ```

--- a/website/docs/users-sources/groups/group_ref.md
+++ b/website/docs/users-sources/groups/group_ref.md
@@ -13,7 +13,9 @@ The Group object has the following properties:
 
 ## Examples
 
-### List all users in a group
+### List all group members
+
+Use the following examples to list all users that are members of a group:
 
 ```python
 group.users.all()

--- a/website/docs/users-sources/groups/group_ref.md
+++ b/website/docs/users-sources/groups/group_ref.md
@@ -7,7 +7,7 @@ title: Group properties and attributes
 The Group object has the following properties:
 
 - `name`: The group's display name.
-- `is_superuser`: A boolean field that determines if the Group's users are superusers.
+- `is_superuser`: A boolean field that determines if the group's users are superusers.
 - `parent`: The parent group of this group.
 - `attributes`: Dynamic attributes, see [Attributes](#attributes)
 

--- a/website/docs/users-sources/groups/group_ref.md
+++ b/website/docs/users-sources/groups/group_ref.md
@@ -17,7 +17,7 @@ These are examples of how Group objects can be used within **Policies** and **Pr
 
 ### List all group members
 
-Use the following examples to list all users that are members of a Group:
+Use the following examples to list all users that are members of a group:
 
 ```python title="Get all members of a Group object"
 group.users.all()


### PR DESCRIPTION
## Details

Closes #13813

Adds code examples of how to get user objects from from a group object.

---

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
