### PR TITLE
packages/docusaurus-theme: Fix header alignment, overscroll, vertical padding.

### DIFF
--- a/packages/docusaurus-config/css/badges.css
+++ b/packages/docusaurus-config/css/badges.css
@@ -18,9 +18,7 @@
 }
 
 .badge--support-community {
-    --ifm-badge-background-color: var(
-        --ifm-color-secondary-contrast-foreground
-    );
+    --ifm-badge-background-color: var(--ifm-color-secondary-contrast-foreground);
     --ifm-badge-border-color: var(--ifm-color-secondary-dark);
     --ifm-badge-color: var(--ifm-color-secondary-contrast-background);
 }

--- a/packages/docusaurus-config/css/fonts.css
+++ b/packages/docusaurus-config/css/fonts.css
@@ -1,12 +1,12 @@
 :root {
     --ifm-font-family-base:
-        RedHatVF, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell,
-        Noto Sans, sans-serif, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial,
-        sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        RedHatVF, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans,
+        sans-serif, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif,
+        "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 
     --ifm-font-family-monospace:
-        RedHatMonoVF, SFMono-Regular, Menlo, Monaco, Consolas,
-        "Liberation Mono", "Courier New", monospace;
+        RedHatMonoVF, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
+        monospace;
 
     --ifm-heading-font-family: RedHatDisplayVF, var(--ifm-font-family-base);
 

--- a/packages/docusaurus-config/css/homepage.css
+++ b/packages/docusaurus-config/css/homepage.css
@@ -7,11 +7,7 @@
 }
 
 .homepage_hero__subtitle p {
-    font-size: clamp(
-        1.125rem,
-        0.9946rem + 0.6522vi,
-        1.5rem
-    ); /* Adjust font as page scales */
+    font-size: clamp(1.125rem, 0.9946rem + 0.6522vi, 1.5rem); /* Adjust font as page scales */
     max-width: 28ch; /* Apply a maximum to keep everything in the box */
     text-wrap: balance; /* Prevent widows, orphans, and runts. Doesn't work in Safari */
 }

--- a/packages/docusaurus-config/css/menu.css
+++ b/packages/docusaurus-config/css/menu.css
@@ -1,5 +1,5 @@
 :root {
-    --ifm-menu-link-padding-vertical: 1em;
+    --ifm-menu-link-padding-vertical: 0.5em;
 }
 
 .menu__list-item {

--- a/packages/docusaurus-config/css/navbar.css
+++ b/packages/docusaurus-config/css/navbar.css
@@ -86,7 +86,6 @@
         margin: 0;
     }
 
-
     .navbar__item.navbar__link {
         font-size: 1.1rem;
     }
@@ -120,12 +119,8 @@
 
         @media (min-width: 999px) {
             border-inline-start: 1px solid var(--ifm-hover-overlay);
-            margin-inline-start: calc(
-                var(--ifm-navbar-item-padding-horizontal) / 2
-            );
-            padding-inline-start: calc(
-                var(--ifm-navbar-item-padding-horizontal) / 2
-            );
+            margin-inline-start: calc(var(--ifm-navbar-item-padding-horizontal) / 2);
+            padding-inline-start: calc(var(--ifm-navbar-item-padding-horizontal) / 2);
         }
     }
 
@@ -149,19 +144,14 @@
         hsl(236.84deg 34.55% 10.78%)
     );
     --docsearch-key-shadow:
-        inset 0 -2px 0 0 hsl(233.33deg 36% 24.51%),
-        inset 0 0 1px 1px hsl(232.11deg 34.86% 57.25%),
+        inset 0 -2px 0 0 hsl(233.33deg 36% 24.51%), inset 0 0 1px 1px hsl(232.11deg 34.86% 57.25%),
         0 2px 2px 0 rgba(3, 4, 9, 0.3);
     --docsearch-key-pressed-shadow:
-        inset 0 -2px 0 0 #282d55,
-        inset 0 0 1px 1px hsl(231.82deg 21.36% 40.39%),
+        inset 0 -2px 0 0 #282d55, inset 0 0 1px 1px hsl(231.82deg 21.36% 40.39%),
         0 1px 1px 0 hsl(230deg 50% 2.35% / 30.2%);
 
-    padding: var(--ifm-navbar-item-padding-vertical)
-        var(--ifm-navbar-item-padding-horizontal) !important;
-    padding-inline-end: calc(
-        var(--ifm-navbar-item-padding-horizontal) * 1.25
-    ) !important;
+    padding: var(--ifm-navbar-item-padding-vertical) var(--ifm-navbar-item-padding-horizontal) !important;
+    padding-inline-end: calc(var(--ifm-navbar-item-padding-horizontal) * 1.25) !important;
 
     .DocSearch-Button-Placeholder {
         font-family: var(--ifm-heading-font-family);

--- a/packages/docusaurus-config/css/navbar.css
+++ b/packages/docusaurus-config/css/navbar.css
@@ -75,19 +75,17 @@
         --ifm-navbar-item-padding-horizontal: 1rem;
     }
 
-    .docs-wrapper .navbar {
+    .navbar {
         margin: 0;
         padding-inline-start: 0;
     }
 
     .navbar__brand {
         justify-content: center;
-    }
-
-    .docs-wrapper .navbar__brand {
-        width: var(--doc-sidebar-width);
+        width: var(--doc-sidebar-width, 300px);
         margin: 0;
     }
+
 
     .navbar__item.navbar__link {
         font-size: 1.1rem;

--- a/packages/docusaurus-config/css/root.css
+++ b/packages/docusaurus-config/css/root.css
@@ -13,7 +13,3 @@
 
     --ifm-color-content: hsl(216 35% 3%);
 }
-
-body {
-    overscroll-behavior-x: none;
-}

--- a/packages/docusaurus-config/lib/common.js
+++ b/packages/docusaurus-config/lib/common.js
@@ -4,8 +4,8 @@
  * @import { Config as DocusaurusConfig } from "@docusaurus/types"
  * @import { UserThemeConfig } from "./theme.js"
  */
-
 import { deepmerge } from "deepmerge-ts";
+
 import { createThemeConfig } from "./theme.js";
 
 //#region Types

--- a/packages/docusaurus-config/lib/theme.js
+++ b/packages/docusaurus-config/lib/theme.js
@@ -4,7 +4,6 @@
  * @import { UserThemeConfig as UserThemeConfigCommon } from "@docusaurus/theme-common";
  * @import { UserThemeConfig as UserThemeConfigAlgolia } from "@docusaurus/theme-search-algolia";
  */
-
 import { deepmerge } from "deepmerge-ts";
 import { themes as prismThemes } from "prism-react-renderer";
 

--- a/packages/docusaurus-config/package-lock.json
+++ b/packages/docusaurus-config/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@goauthentik/docusaurus-config",
-    "version": "1.0.2",
+    "version": "1.0.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@goauthentik/docusaurus-config",
-            "version": "1.0.2",
+            "version": "1.0.5",
             "license": "MIT",
             "dependencies": {
                 "deepmerge-ts": "^7.1.5",

--- a/packages/docusaurus-config/package.json
+++ b/packages/docusaurus-config/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@goauthentik/docusaurus-config",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "description": "authentik's Docusaurus config",
     "license": "MIT",
     "scripts": {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -18,7 +18,6 @@
                 "@docusaurus/theme-mermaid": "^3.7.0",
                 "@goauthentik/docusaurus-config": "^1.0.4",
                 "@mdx-js/react": "^3.1.0",
-                "@swc/html-linux-x64-gnu": "1.11.21",
                 "clsx": "^2.1.1",
                 "disqus-react": "^1.1.6",
                 "docusaurus-plugin-openapi-docs": "4.3.4",


### PR DESCRIPTION
## Details

This PR resolves some feedback on the docs header redesign.

### ⚠️ This requires a second PR

**The preview links generated by Github will not show any effect. A second PR will be submitted once this is approved -- updating both the docs site and landing page.**

The upcoming TypeScript monorepo branch will make updates like this more seamless in the future. 

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
