### PR TITLE
website/docs: fix postgres pool recommended settings

### DIFF
--- a/website/docs/install-config/configuration/configuration.mdx
+++ b/website/docs/install-config/configuration/configuration.mdx
@@ -123,7 +123,7 @@ When your PostgreSQL database(s) are running behind a connection pooler, like Pg
 
 - `AUTHENTIK_POSTGRESQL__DISABLE_SERVER_SIDE_CURSORS`
 
-    Using a connection pooler in transaction pool mode (e.g. PgPool, or PgBouncer in transaction or statement pool mode) requires disabling server-side cursors, so this setting must be set to `false`.
+    Using a connection pooler in transaction pool mode (e.g. PgPool, or PgBouncer in transaction or statement pool mode) requires disabling server-side cursors, so this setting must be set to `true`.
 
 Additionally, you can set `AUTHENTIK_POSTGRESQL__CONN_HEALTH_CHECKS` to perform health checks on persistent database connections before they are reused.
 


### PR DESCRIPTION
Closes https://github.com/goauthentik/authentik/issues/14148

## Details

When using a connection pooler, the correct value of __DISABLE_SERVER_SIDE_CURSORS is 'true', not 'false'

---

## Checklist

If applicable

-   [X] The documentation has been updated

