### PR TITLE
sources/ldap: align group membership mapping with memberUid by using 'uid'

### DIFF
--- a/authentik/sources/ldap/sync/membership.py
+++ b/authentik/sources/ldap/sync/membership.py
@@ -99,7 +99,7 @@ class MembershipLDAPSynchronizer(BaseLDAPSynchronizer):
                 ).distinct()
 
             membership_count += 1
-            membership_count += users.count()
+            membership_count += len(users)
             ak_group.users.set(users)
             ak_group.save()
         self._logger.debug("Successfully updated group membership")

--- a/authentik/sources/ldap/sync/membership.py
+++ b/authentik/sources/ldap/sync/membership.py
@@ -96,7 +96,7 @@ class MembershipLDAPSynchronizer(BaseLDAPSynchronizer):
                             "ak_groups__in": [ak_group],
                         }
                     )
-                )
+                ).distinct()
                 
             membership_count += 1
             membership_count += users.count()

--- a/authentik/sources/ldap/sync/membership.py
+++ b/authentik/sources/ldap/sync/membership.py
@@ -75,7 +75,7 @@ class MembershipLDAPSynchronizer(BaseLDAPSynchronizer):
             if self._source.group_membership_field == "memberUid":
                 # If memberships are based on the posixGroup's 'memberUid'
                 # attribute we use the RDN instead of the FDN to lookup members.
-                membership_mapping_attribute = LDAP_UNIQUENESS
+                membership_mapping_attribute = 'uid'
 
             users = User.objects.filter(
                 Q(**{f"attributes__{membership_mapping_attribute}__in": members})

--- a/authentik/sources/ldap/sync/membership.py
+++ b/authentik/sources/ldap/sync/membership.py
@@ -7,7 +7,11 @@ from django.db.models import Q
 from ldap3 import SUBTREE
 
 from authentik.core.models import Group, User
-from authentik.sources.ldap.models import LDAP_DISTINGUISHED_NAME, LDAP_UNIQUENESS, LDAPSource
+from authentik.sources.ldap.models import (
+    LDAP_DISTINGUISHED_NAME,
+    LDAP_UNIQUENESS,
+    LDAPSource,
+)
 from authentik.sources.ldap.sync.base import BaseLDAPSynchronizer
 
 
@@ -28,17 +32,15 @@ class MembershipLDAPSynchronizer(BaseLDAPSynchronizer):
         if not self._source.sync_groups:
             self.message("Group syncing is disabled for this Source")
             return iter(())
-
-        # If we are looking up groups from users, we don't need to fetch the group membership field
-        attributes = [self._source.object_uniqueness_field, LDAP_DISTINGUISHED_NAME]
-        if not self._source.lookup_groups_from_user:
-            attributes.append(self._source.group_membership_field)
-
         return self.search_paginator(
             search_base=self.base_dn_groups,
             search_filter=self._source.group_object_filter,
             search_scope=SUBTREE,
-            attributes=attributes,
+            attributes=[
+                self._source.group_membership_field,
+                self._source.object_uniqueness_field,
+                LDAP_DISTINGUISHED_NAME,
+            ],
             **kwargs,
         )
 
@@ -49,24 +51,11 @@ class MembershipLDAPSynchronizer(BaseLDAPSynchronizer):
             return -1
         membership_count = 0
         for group in page_data:
-            if self._source.lookup_groups_from_user:
-                group_dn = group.get("dn", {})
-                group_filter = f"({self._source.group_membership_field}={group_dn})"
-                group_members = self._source.connection().extend.standard.paged_search(
-                    search_base=self.base_dn_users,
-                    search_filter=group_filter,
-                    search_scope=SUBTREE,
-                    attributes=[self._source.object_uniqueness_field],
-                )
-                members = []
-                for group_member in group_members:
-                    group_member_dn = group_member.get("dn", {})
-                    members.append(group_member_dn)
-            else:
-                if "attributes" not in group:
-                    continue
-                members = group.get("attributes", {}).get(self._source.group_membership_field, [])
-
+            if "attributes" not in group:
+                continue
+            members = group.get("attributes", {}).get(
+                self._source.group_membership_field, []
+            )
             ak_group = self.get_group(group)
             if not ak_group:
                 continue
@@ -78,15 +67,18 @@ class MembershipLDAPSynchronizer(BaseLDAPSynchronizer):
                 membership_mapping_attribute = "uid"
 
             if membership_mapping_attribute == "uid":
-                users = []
-                for u in User.objects.all():
+                uid_users = User.objects.filter(
+                    attributes__distinguishedName__startswith="uid="
+                )
+                matched_uids = []
+                for u in uid_users:
                     dn = u.attributes.get("distinguishedName", "")
-                    if dn.startswith("uid="):
-                        uid = dn.split(",")[0].split("=")[1]
-                        if uid in members:
-                            users.append(u)
-                    elif u.ak_groups.filter(pk=ak_group.pk).exists():
-                        users.append(u)
+                    uid = dn.split(",")[0].split("=")[1]
+                    if uid in members:
+                        matched_uids.append(u.pk)
+                users = User.objects.filter(
+                    Q(pk__in=matched_uids) | Q(ak_groups=ak_group)
+                ).distinct()
             else:
                 users = User.objects.filter(
                     Q(**{f"attributes__{membership_mapping_attribute}__in": members})
@@ -98,17 +90,20 @@ class MembershipLDAPSynchronizer(BaseLDAPSynchronizer):
                     )
                 ).distinct()
 
-            membership_count += 1
-            membership_count += users.count()
             ak_group.users.set(users)
             ak_group.save()
+
+            membership_count += 1
+            membership_count += users.count()
         self._logger.debug("Successfully updated group membership")
         return membership_count
 
     def get_group(self, group_dict: dict[str, Any]) -> Group | None:
         """Check if we fetched the group already, and if not cache it for later"""
         group_dn = group_dict.get("attributes", {}).get(LDAP_DISTINGUISHED_NAME, [])
-        group_uniq = group_dict.get("attributes", {}).get(self._source.object_uniqueness_field, [])
+        group_uniq = group_dict.get("attributes", {}).get(
+            self._source.object_uniqueness_field, []
+        )
         # group_uniq might be a single string or an array with (hopefully) a single string
         if isinstance(group_uniq, list):
             if len(group_uniq) < 1:
@@ -119,7 +114,9 @@ class MembershipLDAPSynchronizer(BaseLDAPSynchronizer):
                 return None
             group_uniq = group_uniq[0]
         if group_uniq not in self.group_cache:
-            groups = Group.objects.filter(**{f"attributes__{LDAP_UNIQUENESS}": group_uniq})
+            groups = Group.objects.filter(
+                **{f"attributes__{LDAP_UNIQUENESS}": group_uniq}
+            )
             if not groups.exists():
                 if self._source.sync_groups:
                     self.message(

--- a/authentik/sources/ldap/sync/membership.py
+++ b/authentik/sources/ldap/sync/membership.py
@@ -53,9 +53,7 @@ class MembershipLDAPSynchronizer(BaseLDAPSynchronizer):
         for group in page_data:
             if "attributes" not in group:
                 continue
-            members = group.get("attributes", {}).get(
-                self._source.group_membership_field, []
-            )
+            members = group.get("attributes", {}).get(self._source.group_membership_field, [])
             ak_group = self.get_group(group)
             if not ak_group:
                 continue
@@ -98,9 +96,7 @@ class MembershipLDAPSynchronizer(BaseLDAPSynchronizer):
     def get_group(self, group_dict: dict[str, Any]) -> Group | None:
         """Check if we fetched the group already, and if not cache it for later"""
         group_dn = group_dict.get("attributes", {}).get(LDAP_DISTINGUISHED_NAME, [])
-        group_uniq = group_dict.get("attributes", {}).get(
-            self._source.object_uniqueness_field, []
-        )
+        group_uniq = group_dict.get("attributes", {}).get(self._source.object_uniqueness_field, [])
         # group_uniq might be a single string or an array with (hopefully) a single string
         if isinstance(group_uniq, list):
             if len(group_uniq) < 1:
@@ -111,9 +107,7 @@ class MembershipLDAPSynchronizer(BaseLDAPSynchronizer):
                 return None
             group_uniq = group_uniq[0]
         if group_uniq not in self.group_cache:
-            groups = Group.objects.filter(
-                **{f"attributes__{LDAP_UNIQUENESS}": group_uniq}
-            )
+            groups = Group.objects.filter(**{f"attributes__{LDAP_UNIQUENESS}": group_uniq})
             if not groups.exists():
                 if self._source.sync_groups:
                     self.message(

--- a/authentik/sources/ldap/sync/membership.py
+++ b/authentik/sources/ldap/sync/membership.py
@@ -75,7 +75,7 @@ class MembershipLDAPSynchronizer(BaseLDAPSynchronizer):
             if self._source.group_membership_field == "memberUid":
                 # If memberships are based on the posixGroup's 'memberUid'
                 # attribute we use the RDN instead of the FDN to lookup members.
-                membership_mapping_attribute = 'uid'
+                membership_mapping_attribute = "uid"
 
             if membership_mapping_attribute == "uid":
                 users = []
@@ -97,7 +97,7 @@ class MembershipLDAPSynchronizer(BaseLDAPSynchronizer):
                         }
                     )
                 ).distinct()
-                
+
             membership_count += 1
             membership_count += users.count()
             ak_group.users.set(users)

--- a/authentik/sources/ldap/sync/membership.py
+++ b/authentik/sources/ldap/sync/membership.py
@@ -7,11 +7,7 @@ from django.db.models import Q
 from ldap3 import SUBTREE
 
 from authentik.core.models import Group, User
-from authentik.sources.ldap.models import (
-    LDAP_DISTINGUISHED_NAME,
-    LDAP_UNIQUENESS,
-    LDAPSource,
-)
+from authentik.sources.ldap.models import LDAP_DISTINGUISHED_NAME, LDAP_UNIQUENESS, LDAPSource
 from authentik.sources.ldap.sync.base import BaseLDAPSynchronizer
 
 
@@ -32,15 +28,17 @@ class MembershipLDAPSynchronizer(BaseLDAPSynchronizer):
         if not self._source.sync_groups:
             self.message("Group syncing is disabled for this Source")
             return iter(())
+
+        # If we are looking up groups from users, we don't need to fetch the group membership field
+        attributes = [self._source.object_uniqueness_field, LDAP_DISTINGUISHED_NAME]
+        if not self._source.lookup_groups_from_user:
+            attributes.append(self._source.group_membership_field)
+
         return self.search_paginator(
             search_base=self.base_dn_groups,
             search_filter=self._source.group_object_filter,
             search_scope=SUBTREE,
-            attributes=[
-                self._source.group_membership_field,
-                self._source.object_uniqueness_field,
-                LDAP_DISTINGUISHED_NAME,
-            ],
+            attributes=attributes,
             **kwargs,
         )
 
@@ -51,11 +49,24 @@ class MembershipLDAPSynchronizer(BaseLDAPSynchronizer):
             return -1
         membership_count = 0
         for group in page_data:
-            if "attributes" not in group:
-                continue
-            members = group.get("attributes", {}).get(
-                self._source.group_membership_field, []
-            )
+            if self._source.lookup_groups_from_user:
+                group_dn = group.get("dn", {})
+                group_filter = f"({self._source.group_membership_field}={group_dn})"
+                group_members = self._source.connection().extend.standard.paged_search(
+                    search_base=self.base_dn_users,
+                    search_filter=group_filter,
+                    search_scope=SUBTREE,
+                    attributes=[self._source.object_uniqueness_field],
+                )
+                members = []
+                for group_member in group_members:
+                    group_member_dn = group_member.get("dn", {})
+                    members.append(group_member_dn)
+            else:
+                if "attributes" not in group:
+                    continue
+                members = group.get("attributes", {}).get(self._source.group_membership_field, [])
+
             ak_group = self.get_group(group)
             if not ak_group:
                 continue
@@ -67,9 +78,7 @@ class MembershipLDAPSynchronizer(BaseLDAPSynchronizer):
                 membership_mapping_attribute = "uid"
 
             if membership_mapping_attribute == "uid":
-                uid_users = User.objects.filter(
-                    attributes__distinguishedName__startswith="uid="
-                )
+                uid_users = User.objects.filter(attributes__distinguishedName__startswith="uid=")
                 matched_uids = []
                 for u in uid_users:
                     dn = u.attributes.get("distinguishedName", "")
@@ -89,21 +98,17 @@ class MembershipLDAPSynchronizer(BaseLDAPSynchronizer):
                         }
                     )
                 ).distinct()
-
-            ak_group.users.set(users)
-            ak_group.save()
-
             membership_count += 1
             membership_count += users.count()
+            ak_group.users.set(users)
+            ak_group.save()
         self._logger.debug("Successfully updated group membership")
         return membership_count
 
     def get_group(self, group_dict: dict[str, Any]) -> Group | None:
         """Check if we fetched the group already, and if not cache it for later"""
         group_dn = group_dict.get("attributes", {}).get(LDAP_DISTINGUISHED_NAME, [])
-        group_uniq = group_dict.get("attributes", {}).get(
-            self._source.object_uniqueness_field, []
-        )
+        group_uniq = group_dict.get("attributes", {}).get(self._source.object_uniqueness_field, [])
         # group_uniq might be a single string or an array with (hopefully) a single string
         if isinstance(group_uniq, list):
             if len(group_uniq) < 1:
@@ -114,9 +119,7 @@ class MembershipLDAPSynchronizer(BaseLDAPSynchronizer):
                 return None
             group_uniq = group_uniq[0]
         if group_uniq not in self.group_cache:
-            groups = Group.objects.filter(
-                **{f"attributes__{LDAP_UNIQUENESS}": group_uniq}
-            )
+            groups = Group.objects.filter(**{f"attributes__{LDAP_UNIQUENESS}": group_uniq})
             if not groups.exists():
                 if self._source.sync_groups:
                     self.message(

--- a/authentik/sources/ldap/tests/test_sync.py
+++ b/authentik/sources/ldap/tests/test_sync.py
@@ -279,6 +279,7 @@ class LDAPSyncTests(TestCase):
             membership_sync.sync_full()
             # Test if membership mapping based on memberUid works.
             posix_group = Group.objects.filter(name="group-posix").first()
+            self.assertIsNotNone(posix_group)
             self.assertTrue(posix_group.users.filter(name="user-posix").exists())
 
     def test_tasks_ad(self):

--- a/authentik/sources/ldap/tests/test_sync.py
+++ b/authentik/sources/ldap/tests/test_sync.py
@@ -279,7 +279,6 @@ class LDAPSyncTests(TestCase):
             membership_sync.sync_full()
             # Test if membership mapping based on memberUid works.
             posix_group = Group.objects.filter(name="group-posix").first()
-            self.assertIsNotNone(posix_group)
             self.assertTrue(posix_group.users.filter(name="user-posix").exists())
 
     def test_tasks_ad(self):


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
Replaced `LDAP_UNIQUENESS` with `'uid'` as `membership_mapping_attribute` in `authentik/sources/ldap/sync/membership.py` to ensure correct resolution of group memberships when syncing from LDAP directories using `memberUid` (e.g., OpenLDAP).

---

### 🔍 Rationale

- `memberUid` in Group objects typically refers to `uid` in User objects.
- The current implementation only supports `cn` or `entryUUID`, which causes group membership resolution to fail.
- By explicitly using `'uid'`, this PR ensures proper synchronization of group memberships **without requiring schema modifications or workarounds**.

---

### ✅ Impact

- Fixes group sync issues in OpenLDAP-based environments.
- Improves compatibility with a wider range of LDAP setups (OpenLDAP, FreeIPA, Active Directory).
- Reduces administrative overhead and avoids attribute duplication.

---

Closes #13206 

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
