### PR TITLE
website/integrations: add xcreds

### DIFF
--- a/website/integrations/services/xcreds/index.mdx
+++ b/website/integrations/services/xcreds/index.mdx
@@ -40,7 +40,7 @@ To support the integration of XCreds with authentik, you need to create an appli
 
 ## XCreds configuration
 
-After XCreds is installed on a target Mac you will need to configure it by creating and installing and applying a profile. More information can be found in the [XCreds Admin Guide](https://twocanoes.com/knowledge-base/xcreds-admin-guide/).
+After XCreds is installed on a target Mac you will need to configure it by creating, installing, and applying a profile. More information can be found in the [XCreds Admin Guide](https://twocanoes.com/knowledge-base/xcreds-admin-guide/).
 
 ### ProfileCreator
 

--- a/website/integrations/services/xcreds/index.mdx
+++ b/website/integrations/services/xcreds/index.mdx
@@ -48,7 +48,7 @@ After XCreds is installed on a target Mac you will need to configure it by creat
 
 1. Open the **ProfileCreator** application and click on the `+` icon in the top left corner to create a new configuration policy:
 
-- Under **General**: provide a descriptive Payload Display Name, Payload Description, and Payload Organization.
+- Under **General** provide a descriptive Payload Display Name, Payload Description, and Payload Organization.
 
 2. Now you will need to add a XCreds payload to the configuration policy. Click on the **Application Managed Preferences** icon in the left hand column that looks like an `A` (Third icon from the left, in the left hand column).
 3. Select XCreds in the list and click the **Add** button in the top right corner of the screen.

--- a/website/integrations/services/xcreds/index.mdx
+++ b/website/integrations/services/xcreds/index.mdx
@@ -27,7 +27,7 @@ To support the integration of XCreds with authentik, you need to create an appli
     - **Choose a Provider type**: select **OAuth2/OpenID Connect** as the provider type.
     - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
         - Note the **Client ID**, and **Client Secret** values because they will be required later.
-    - Set a `Strict` redirect URI to `https://127.0.0.1/xcreds`
+        - Set a `Strict` redirect URI to `https://127.0.0.1/xcreds`
 - **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/flows-stages/bindings/) (policy, group, or user) to manage the listing and access to applications on a user's **My applications** page.
 
 3. Click **Submit** to save the new application and provider.

--- a/website/integrations/services/xcreds/index.mdx
+++ b/website/integrations/services/xcreds/index.mdx
@@ -40,7 +40,7 @@ To support the integration of XCreds with authentik, you need to create an appli
 
 ## XCreds configuration
 
-Once XCreds is installed on a target Mac you will need to configure it by creating and installing a profile. More information can be found in the [XCreds Admin Guide](https://twocanoes.com/knowledge-base/xcreds-admin-guide/)
+Once XCreds is installed on a target Mac you will need to configure it by creating and installing and applying a profile. More information can be found in the [XCreds Admin Guide](https://twocanoes.com/knowledge-base/xcreds-admin-guide/)
 
 ### ProfileCreator
 

--- a/website/integrations/services/xcreds/index.mdx
+++ b/website/integrations/services/xcreds/index.mdx
@@ -44,7 +44,7 @@ After XCreds is installed on a target Mac you will need to configure it by creat
 
 ### ProfileCreator
 
-[ProfileCreator](https://github.com/ProfileCreator/ProfileCreator) is an Open Source MacOS application used to create configuration policies. It is required to create a configuration policy for XCreds.
+[ProfileCreator](https://github.com/ProfileCreator/ProfileCreator) is an open source macOS application used to create configuration policies. It is required to create a configuration policy for XCreds.
 
 1. Open the **ProfileCreator** application and click on the `+` icon in the top left corner to create a new configuration policy:
 

--- a/website/integrations/services/xcreds/index.mdx
+++ b/website/integrations/services/xcreds/index.mdx
@@ -48,7 +48,7 @@ After XCreds is installed on a target Mac you will need to configure it by creat
 
 1. Open the **ProfileCreator** application and click on the `+` icon in the top left corner to create a new configuration policy:
 
-- Under **General** provide a descriptive Payload Display Name, Payload Description, and Payload Organization.
+    - Under **General** provide a descriptive Payload Display Name, Payload Description, and Payload Organization.
 
 2. Now you will need to add a XCreds payload to the configuration policy. Click on the **Application Managed Preferences** icon in the left hand column that looks like an `A` (Third icon from the left, in the left hand column).
 3. Select XCreds in the list and click the **Add** button in the top right corner of the screen.

--- a/website/integrations/services/xcreds/index.mdx
+++ b/website/integrations/services/xcreds/index.mdx
@@ -6,7 +6,7 @@ support_level: community
 
 ## What is XCreds
 
-> Open Source Project for Syncing IdP password with macOS login password.
+> Xcreds is an open source project for synchronizing IdP passwords with macOS login passwords. Xcreds replaces the macOS login window to provide authentication to the cloud provider; a user enters their cloud password for authentication and Xcreds keeps the local Mac password synchronized with the cloud password.
 >
 > -- https://twocanoes.com/products/mac/xcreds/
 

--- a/website/integrations/services/xcreds/index.mdx
+++ b/website/integrations/services/xcreds/index.mdx
@@ -40,7 +40,7 @@ To support the integration of XCreds with authentik, you need to create an appli
 
 ## XCreds configuration
 
-After XCreds is installed on a target Mac you will need to configure it by creating and installing and applying a profile. More information can be found in the [XCreds Admin Guide](https://twocanoes.com/knowledge-base/xcreds-admin-guide/)
+After XCreds is installed on a target Mac you will need to configure it by creating and installing and applying a profile. More information can be found in the [XCreds Admin Guide](https://twocanoes.com/knowledge-base/xcreds-admin-guide/).
 
 ### ProfileCreator
 

--- a/website/integrations/services/xcreds/index.mdx
+++ b/website/integrations/services/xcreds/index.mdx
@@ -28,7 +28,7 @@ To support the integration of XCreds with authentik, you need to create an appli
     - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
         - Note the **Client ID**, and **Client Secret** values because they will be required later.
         - Set a `Strict` redirect URI to `https://127.0.0.1/xcreds`
-- **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/flows-stages/bindings/) (policy, group, or user) to manage the listing and access to applications on a user's **My applications** page.
+    - **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/flows-stages/bindings/) (policy, group, or user) to manage the listing and access to applications on a user's **My applications** page.
 
 3. Click **Submit** to save the new application and provider.
 

--- a/website/integrations/services/xcreds/index.mdx
+++ b/website/integrations/services/xcreds/index.mdx
@@ -23,7 +23,7 @@ To support the integration of XCreds with authentik, you need to create an appli
 1. Log in to authentik as an admin, and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
-- **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
+    - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
 - **Choose a Provider type**: select **OAuth2/OpenID Connect** as the provider type.
 - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
     - Note the **Client ID**, and **Client Secret** values because they will be required later.

--- a/website/integrations/services/xcreds/index.mdx
+++ b/website/integrations/services/xcreds/index.mdx
@@ -1,0 +1,85 @@
+---
+title: Integrate with XCreds
+sidebar_label: XCreds
+support_level: community
+---
+
+## What is XCreds
+
+> Open Source Project for Syncing IdP password with macOS login password.
+>
+> -- https://twocanoes.com/products/mac/xcreds/
+
+## Preparation
+
+The following placeholders are used in this guide:
+
+- `authentik.company` is the FQDN of the authentik installation.
+
+:::note
+This documentation lists only the settings that you need to change from their default values. Be aware that any changes other than those explicitly mentioned in this guide could cause issues accessing your application.
+:::
+
+## authentik configuration
+
+To support the integration of XCreds with authentik, you need to create an application/provider pair in authentik.
+
+### Create an application and provider in authentik
+
+1. Log in to authentik as an admin, and open the authentik Admin interface.
+2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
+
+- **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
+- **Choose a Provider type**: select **OAuth2/OpenID Connect** as the provider type.
+- **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
+    - Note the **Client ID**, and **Client Secret** values because they will be required later.
+    - Set a `Strict` redirect URI to <kbd>https://<em>127.0.0.1</em>/xcreds</kbd>.
+- **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/flows-stages/bindings/) (policy, group, or user) to manage the listing and access to applications on a user's **My applications** page.
+
+3. Click **Submit** to save the new application and provider.
+
+### Copy OpenID configuration URL
+
+1. Log in to authentik as an admin, and open the authentik Admin interface.
+2. Navigate to **Applications** > **Providers** and click on the name of the newly created XCreds provider.
+3. Copy the **OpenID Configuration URL**. This will be required to configure XCreds in the next section.
+
+## XCreds configuration
+
+Once XCreds is installed on a target Mac you will need to configure it by creating and installing a profile. More information can be found in the [XCreds Admin Guide](https://twocanoes.com/knowledge-base/xcreds-admin-guide/)
+
+### ProfileCreator
+
+[ProfileCreator](https://github.com/ProfileCreator/ProfileCreator) is an Open Source MacOS application used to create configuration policies. It is required to create a configuration policy for XCreds.
+
+1. Open the **ProfileCreator** application and click on the `+` icon in the top left corner to create a new configuration policy:
+
+- Under **General**: provide a descriptive Payload Display Name, Payload Description, and Payload Organization.
+
+2. Now you will need to add a XCreds payload to the configuration policy. Click on the **Application Managed Preferences** icon in the left hand column that looks like an `A` (Third icon from the left, in the left hand column).
+3. Select XCreds in the list and click the **Add** button in the top right corner of the screen.
+4. Under **Disabled Keys** click the `+` icon next to the following keys and set the required configurations:
+    - **Client ID**: the authentik Client ID
+    - **Client Secret**: the authentik Client Secret
+    - **Discovery URL**: the authentik OpenID configuration URL
+    - **Redirect URI**: `https://127.0.0.1/xcreds`
+5. Click on the **Export Profile** icon at the top left of the screen and set the following required configurations:
+    - **Platform**: `macOS`
+    - **Scope**: `System`
+    - **Payload Content Type**: `Profile`
+6. Click **Save**.
+
+### Install the profile to the target Mac
+
+You will need to install the created profile on the target Mac.
+
+1. Login to the Mac and navigate to **System Settings** > **General** > **Device Management**.
+2. Under **Device**, click the `+` icon.
+3. Select the profile that was created in the previous section.
+4. Click **Continue** and **Install** and enter the device password.
+
+## Configuration verification
+
+To confirm that authentik is properly configured with XCreds, log out and log back in via the XCreds/authentik login screen.
+
+If you need to login to a local account on the mac, you can click on the **Mac Login Window** button.

--- a/website/integrations/services/xcreds/index.mdx
+++ b/website/integrations/services/xcreds/index.mdx
@@ -74,6 +74,6 @@ You will need to install the created profile on the target Mac.
 
 ## Configuration verification
 
-To confirm that authentik is properly configured with XCreds, log out and log back in via the XCreds/authentik login screen.
+To confirm that authentik is properly configured with XCreds on the target Mac, log out and log back in via the XCreds/authentik login screen.
 
 If you need to login to a local account on the mac, you can click on the **Mac Login Window** button.

--- a/website/integrations/services/xcreds/index.mdx
+++ b/website/integrations/services/xcreds/index.mdx
@@ -67,7 +67,7 @@ After XCreds is installed on a target Mac you will need to configure it by creat
 
 Next, you need to install the created profile on the target Mac.
 
-1. Log into the Mac and navigate to **System Settings** > **General** > **Device Management**.
+1. Log in to the Mac and navigate to **System Settings** > **General** > **Device Management**.
 2. Under **Device**, click the `+` icon.
 3. Select the profile that was created in the previous section.
 4. Click **Continue**, **Install** and enter the device password.

--- a/website/integrations/services/xcreds/index.mdx
+++ b/website/integrations/services/xcreds/index.mdx
@@ -40,7 +40,7 @@ To support the integration of XCreds with authentik, you need to create an appli
 
 ## XCreds configuration
 
-Once XCreds is installed on a target Mac you will need to configure it by creating and installing and applying a profile. More information can be found in the [XCreds Admin Guide](https://twocanoes.com/knowledge-base/xcreds-admin-guide/)
+After XCreds is installed on a target Mac you will need to configure it by creating and installing and applying a profile. More information can be found in the [XCreds Admin Guide](https://twocanoes.com/knowledge-base/xcreds-admin-guide/)
 
 ### ProfileCreator
 

--- a/website/integrations/services/xcreds/index.mdx
+++ b/website/integrations/services/xcreds/index.mdx
@@ -70,7 +70,7 @@ You will need to install the created profile on the target Mac.
 1. Login to the Mac and navigate to **System Settings** > **General** > **Device Management**.
 2. Under **Device**, click the `+` icon.
 3. Select the profile that was created in the previous section.
-4. Click **Continue** and **Install** and enter the device password.
+4. Click **Continue**, **Install** and enter the device password.
 
 ## Configuration verification
 

--- a/website/integrations/services/xcreds/index.mdx
+++ b/website/integrations/services/xcreds/index.mdx
@@ -50,7 +50,7 @@ After XCreds is installed on a target Mac you will need to configure it by creat
 
     - Under **General** provide a descriptive Payload Display Name, Payload Description, and Payload Organization.
 
-2. Now you will need to add a XCreds payload to the configuration policy. Click on the **Application Managed Preferences** icon in the left hand column that looks like an `A` (Third icon from the left, in the left hand column).
+2. Now you will need to add a XCreds payload to the configuration policy. Click on the **Application Managed Preferences** icon in the left hand column that looks like an `A` (third icon from the left, in the left hand column).
 3. Select XCreds in the list and click the **Add** button in the top right corner of the screen.
 4. Under **Disabled Keys** click the `+` icon next to the following keys and set the required configurations:
     - **Client ID**: the authentik Client ID

--- a/website/integrations/services/xcreds/index.mdx
+++ b/website/integrations/services/xcreds/index.mdx
@@ -65,7 +65,7 @@ After XCreds is installed on a target Mac you will need to configure it by creat
 
 ### Install the profile to the target Mac
 
-You will need to install the created profile on the target Mac.
+Next, you need to install the created profile on the target Mac.
 
 1. Log into the Mac and navigate to **System Settings** > **General** > **Device Management**.
 2. Under **Device**, click the `+` icon.

--- a/website/integrations/services/xcreds/index.mdx
+++ b/website/integrations/services/xcreds/index.mdx
@@ -50,7 +50,7 @@ After XCreds is installed on a target Mac you will need to configure it by creat
 
     - Under **General** provide a descriptive Payload Display Name, Payload Description, and Payload Organization.
 
-2. Now you will need to add a XCreds payload to the configuration policy. Click on the **Application Managed Preferences** icon in the left hand column that looks like an `A` (third icon from the left, in the left hand column).
+2. Now you need to add a XCreds payload to the configuration policy. Click on the **Application Managed Preferences** icon in the left hand column that looks like an `A` (third icon from the left, in the left hand column).
 3. Select XCreds in the list and click the **Add** button in the top right corner of the screen.
 4. Under **Disabled Keys** click the `+` icon next to the following keys and set the required configurations:
     - **Client ID**: the authentik Client ID

--- a/website/integrations/services/xcreds/index.mdx
+++ b/website/integrations/services/xcreds/index.mdx
@@ -76,4 +76,4 @@ Next, you need to install the created profile on the target Mac.
 
 To confirm that authentik is properly configured with XCreds on the target Mac, log out and log back in via the XCreds/authentik login screen.
 
-If you need to log into a local account on the mac, you can click on the **Mac Login Window** button.
+If you need to log into a local account on the Mac, you can click on the **Mac Login Window** button.

--- a/website/integrations/services/xcreds/index.mdx
+++ b/website/integrations/services/xcreds/index.mdx
@@ -10,12 +10,6 @@ support_level: community
 >
 > -- https://twocanoes.com/products/mac/xcreds/
 
-## Preparation
-
-The following placeholders are used in this guide:
-
-- `authentik.company` is the FQDN of the authentik installation.
-
 :::note
 This documentation lists only the settings that you need to change from their default values. Be aware that any changes other than those explicitly mentioned in this guide could cause issues accessing your application.
 :::
@@ -33,7 +27,7 @@ To support the integration of XCreds with authentik, you need to create an appli
 - **Choose a Provider type**: select **OAuth2/OpenID Connect** as the provider type.
 - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
     - Note the **Client ID**, and **Client Secret** values because they will be required later.
-    - Set a `Strict` redirect URI to <kbd>https://<em>127.0.0.1</em>/xcreds</kbd>.
+    - Set a `Strict` redirect URI to `https://127.0.0.1/xcreds`
 - **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/flows-stages/bindings/) (policy, group, or user) to manage the listing and access to applications on a user's **My applications** page.
 
 3. Click **Submit** to save the new application and provider.

--- a/website/integrations/services/xcreds/index.mdx
+++ b/website/integrations/services/xcreds/index.mdx
@@ -25,7 +25,7 @@ To support the integration of XCreds with authentik, you need to create an appli
 
     - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
     - **Choose a Provider type**: select **OAuth2/OpenID Connect** as the provider type.
-- **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
+    - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
     - Note the **Client ID**, and **Client Secret** values because they will be required later.
     - Set a `Strict` redirect URI to `https://127.0.0.1/xcreds`
 - **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/flows-stages/bindings/) (policy, group, or user) to manage the listing and access to applications on a user's **My applications** page.

--- a/website/integrations/services/xcreds/index.mdx
+++ b/website/integrations/services/xcreds/index.mdx
@@ -67,7 +67,7 @@ Once XCreds is installed on a target Mac you will need to configure it by creati
 
 You will need to install the created profile on the target Mac.
 
-1. Login to the Mac and navigate to **System Settings** > **General** > **Device Management**.
+1. Log into the Mac and navigate to **System Settings** > **General** > **Device Management**.
 2. Under **Device**, click the `+` icon.
 3. Select the profile that was created in the previous section.
 4. Click **Continue**, **Install** and enter the device password.
@@ -76,4 +76,4 @@ You will need to install the created profile on the target Mac.
 
 To confirm that authentik is properly configured with XCreds on the target Mac, log out and log back in via the XCreds/authentik login screen.
 
-If you need to login to a local account on the mac, you can click on the **Mac Login Window** button.
+If you need to log into a local account on the mac, you can click on the **Mac Login Window** button.

--- a/website/integrations/services/xcreds/index.mdx
+++ b/website/integrations/services/xcreds/index.mdx
@@ -24,7 +24,7 @@ To support the integration of XCreds with authentik, you need to create an appli
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
     - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
-- **Choose a Provider type**: select **OAuth2/OpenID Connect** as the provider type.
+    - **Choose a Provider type**: select **OAuth2/OpenID Connect** as the provider type.
 - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
     - Note the **Client ID**, and **Client Secret** values because they will be required later.
     - Set a `Strict` redirect URI to `https://127.0.0.1/xcreds`

--- a/website/integrations/services/xcreds/index.mdx
+++ b/website/integrations/services/xcreds/index.mdx
@@ -26,7 +26,7 @@ To support the integration of XCreds with authentik, you need to create an appli
     - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
     - **Choose a Provider type**: select **OAuth2/OpenID Connect** as the provider type.
     - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
-    - Note the **Client ID**, and **Client Secret** values because they will be required later.
+        - Note the **Client ID**, and **Client Secret** values because they will be required later.
     - Set a `Strict` redirect URI to `https://127.0.0.1/xcreds`
 - **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/flows-stages/bindings/) (policy, group, or user) to manage the listing and access to applications on a user's **My applications** page.
 

--- a/website/sidebarsIntegrations.js
+++ b/website/sidebarsIntegrations.js
@@ -113,6 +113,7 @@ module.exports = {
                         "services/terrakube/index",
                         "services/truecommand/index",
                         "services/veeam-enterprise-manager/index",
+                        "services/xcreds/index",
                         "services/zammad/index",
                     ],
                 },


### PR DESCRIPTION
## Details

Adds an integration guide for XCreds which allows integrating authentik with MacOS login.

---
If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
