### PR TITLE
website/integrations: paperless: use <slug>. instead of hardcoded slug value

### DIFF
--- a/website/integrations/services/paperless-ngx/index.mdx
+++ b/website/integrations/services/paperless-ngx/index.mdx
@@ -66,7 +66,7 @@ environment:
                 "client_id": "<Client ID>",
                 "secret": "<Client Secret>",
                 "settings": {
-                  "server_url": "https://authentik.company/application/o/paperless/.well-known/openid-configuration"
+                  "server_url": "https://authentik.company/application/o/<slug>/.well-known/openid-configuration"
                 }
               }
             ],


### PR DESCRIPTION
Updates the openid config url of the paperless ngx docs to use the `<slug>` placeholder as this value is user-customizable
Closes https://github.com/goauthentik/authentik/issues/13778

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
