### PR TITLE
website/docs: adds webfinger doc under oauth provider

### DIFF
--- a/website/docs/add-secure-apps/providers/oauth2/webfinger_support.mdx
+++ b/website/docs/add-secure-apps/providers/oauth2/webfinger_support.mdx
@@ -1,0 +1,13 @@
+---
+title: WebFinger support
+---
+
+## About WebFinger
+
+The [WebFinger protocol](https://webfinger.net/) allows for the discovery of information about individuals or entities on the Internet through standard HTTP methods. It enables the retrieval of information associated with a URI that might not be directly usable as a locator, such as those for accounts or email addresses.
+
+## authentik WebFinger support
+
+authentik provides a WebFinger endpoint when the **Default application** setting uses an OIDC provider. Instructions on how to set a **Default application** can be found in the [authentik Branding documentation](../../../sys-mgmt/brands.md#external-user-settings)
+
+The WebFinger endpoint is available at: `https://authentik.company/.well-known/webfinger` (where authentik.company is the FQDN of your authentik instance)

--- a/website/docs/add-secure-apps/providers/oauth2/webfinger_support.mdx
+++ b/website/docs/add-secure-apps/providers/oauth2/webfinger_support.mdx
@@ -8,6 +8,6 @@ The [WebFinger protocol](https://webfinger.net/) allows for the discovery of inf
 
 ## authentik WebFinger support
 
-authentik provides a WebFinger endpoint when the **Default application** setting uses an OIDC provider. Instructions on how to set a **Default application** can be found in the [authentik Branding documentation](../../../sys-mgmt/brands.md#external-user-settings)
+authentik provides a WebFinger endpoint when the **Default application** setting uses an OIDC provider. Instructions on how to set a **Default application** can be found in the [authentik Branding documentation](../../../sys-mgmt/brands.md#external-user-settings).
 
 The WebFinger endpoint is available at: `https://authentik.company/.well-known/webfinger` (where authentik.company is the FQDN of your authentik instance)

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -199,6 +199,7 @@ export default {
                                 "add-secure-apps/providers/oauth2/client_credentials",
                                 "add-secure-apps/providers/oauth2/device_code",
                                 "add-secure-apps/providers/oauth2/github-compatibility",
+                                "add-secure-apps/providers/oauth2/webfinger_support",
                             ],
                         },
                         {


### PR DESCRIPTION
## Details

Adds a doc under Oauth provider explaining webfinger protocol support. Also updates the sidebar

---

## Checklist
If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
