### PR TITLE
internal/outpost: fix incorrect usage of golang SHA API

### DIFF
--- a/internal/outpost/proxyv2/application/application.go
+++ b/internal/outpost/proxyv2/application/application.go
@@ -118,8 +118,8 @@ func NewApplication(p api.ProxyOutpostConfig, c *http.Client, server Server, old
 	mux := mux.NewRouter()
 
 	// Save cookie name, based on hashed client ID
-	h := sha256.New()
-	bs := string(h.Sum([]byte(*p.ClientId)))
+	h := sha256.Sum256([]byte(*p.ClientId))
+	bs := string(h[:])
 	sessionName := fmt.Sprintf("authentik_proxy_%s", bs[:8])
 
 	// When HOST_BROWSER is set, use that as Host header for token requests to make the issuer match

--- a/internal/outpost/radius/handler.go
+++ b/internal/outpost/radius/handler.go
@@ -68,8 +68,8 @@ func (rs *RadiusServer) ServeRADIUS(w radius.ResponseWriter, r *radius.Request) 
 		}
 	}
 	if pi == nil {
-		logValue := sha512.Sum512(r.Secret)
-		nr.Log().WithField("hashed_secret", string(logValue[:])).Warning("No provider found")
+		hashedSecret := sha512.Sum512(r.Secret)
+		nr.Log().WithField("hashed_secret", string(hashedSecret[:])).Warning("No provider found")
 		_ = w.Write(r.Response(radius.CodeAccessReject))
 		return
 	}

--- a/internal/outpost/radius/handler.go
+++ b/internal/outpost/radius/handler.go
@@ -68,7 +68,8 @@ func (rs *RadiusServer) ServeRADIUS(w radius.ResponseWriter, r *radius.Request) 
 		}
 	}
 	if pi == nil {
-		nr.Log().WithField("hashed_secret", string(sha512.New().Sum(r.Secret))).Warning("No provider found")
+		logValue := sha512.Sum512(r.Secret)
+		nr.Log().WithField("hashed_secret", string(logValue[:])).Warning("No provider found")
 		_ = w.Write(r.Response(radius.CodeAccessReject))
 		return
 	}


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Move away from 512 and 256 SHA hashes in golang and use checksums.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
