### PR TITLE
website/docs: initial permissions: fix usage of term admin

### DIFF
--- a/website/docs/users-sources/access-control/initial_permissions.mdx
+++ b/website/docs/users-sources/access-control/initial_permissions.mdx
@@ -9,7 +9,7 @@ Initial permissions automatically assigns [object-level permissions](./permissio
 
 The purpose of initial permissions is to assign a specific user (or role) a set of pre-selected permissions that are required for them to accomplish their tasks.
 
-An authentik administrator creates an initial permissions object (a set of selected permissions) and then associates it with either: 1. An individual user. 2. A role - in which case everyone in a group with that role will have the same initial permissions.
+An authentik administrator creates an initial permissions object (a set of selected permissions) and then associates it with either: 1) an individual user 2) a role - in which case everyone in a group with that role will have the same initial permissions.
 
 ## Common use cases
 

--- a/website/docs/users-sources/access-control/initial_permissions.mdx
+++ b/website/docs/users-sources/access-control/initial_permissions.mdx
@@ -9,7 +9,7 @@ Initial permissions automatically assigns [object-level permissions](./permissio
 
 The purpose of initial permissions is to assign a specific user (or role) a set of pre-selected permissions that are required for them to accomplish their tasks.
 
-An authentik Admin creates an initial permissions object (a set of selected permissions) and then associates it with either: 1. An individual user. 2. A role - in which case everyone in a group with that role will have the same initial permissions.
+An authentik administrator creates an initial permissions object (a set of selected permissions) and then associates it with either: 1. An individual user. 2. A role - in which case everyone in a group with that role will have the same initial permissions.
 
 ## Common use cases
 


### PR DESCRIPTION
Should be lowercase and use full word as it refers to an administrator. See pending PR for style guide

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
