### PR TITLE
web: Clean up browser-only module imports that crash WebDriverIO.

### DIFF
--- a/web/src/admin/admin-settings/AdminSettingsForm.ts
+++ b/web/src/admin/admin-settings/AdminSettingsForm.ts
@@ -1,5 +1,4 @@
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/components/ak-number-input";
 import "@goauthentik/components/ak-switch-input";
 import "@goauthentik/components/ak-text-input";
@@ -184,20 +183,14 @@ export class AdminSettingsForm extends Form<SettingsRequest> {
                 label=${msg("Reputation: lower limit")}
                 required
                 name="reputationLowerLimit"
-                value="${first(
-                    this._settings?.reputationLowerLimit,
-                    DEFAULT_REPUTATION_LOWER_LIMIT,
-                )}"
+                value="${this._settings?.reputationLowerLimit ?? DEFAULT_REPUTATION_LOWER_LIMIT}"
                 help=${msg("Reputation cannot decrease lower than this value. Zero or negative.")}
             ></ak-number-input>
             <ak-number-input
                 label=${msg("Reputation: upper limit")}
                 required
                 name="reputationUpperLimit"
-                value="${first(
-                    this._settings?.reputationUpperLimit,
-                    DEFAULT_REPUTATION_UPPER_LIMIT,
-                )}"
+                value="${this._settings?.reputationUpperLimit ?? DEFAULT_REPUTATION_UPPER_LIMIT}"
                 help=${msg("Reputation cannot increase higher than this value. Zero or positive.")}
             ></ak-number-input>
             <ak-form-element-horizontal label=${msg("Footer links")} name="footerLinks">
@@ -257,7 +250,7 @@ export class AdminSettingsForm extends Form<SettingsRequest> {
                 label=${msg("Default token length")}
                 required
                 name="defaultTokenLength"
-                value="${first(this._settings?.defaultTokenLength, 60)}"
+                value="${this._settings?.defaultTokenLength ?? 60}"
                 help=${msg("Default length of generated tokens")}
             ></ak-number-input>
         `;

--- a/web/src/admin/applications/ApplicationForm.ts
+++ b/web/src/admin/applications/ApplicationForm.ts
@@ -1,7 +1,6 @@
 import "@goauthentik/admin/applications/ProviderSelectModal";
 import { iconHelperText } from "@goauthentik/admin/helperText";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/components/ak-file-input";
 import "@goauthentik/components/ak-radio-input";
 import "@goauthentik/components/ak-switch-input";
@@ -194,7 +193,7 @@ export class ApplicationForm extends WithCapabilitiesConfig(ModelForm<Applicatio
                     ></ak-text-input>
                     <ak-switch-input
                         name="openInNewTab"
-                        ?checked=${first(this.instance?.openInNewTab, false)}
+                        ?checked=${this.instance?.openInNewTab ?? false}
                         label=${msg("Open in new tab")}
                         help=${msg(
                             "If checked, the launch URL will open in a new browser tab or window from the user's application library.",
@@ -221,7 +220,7 @@ export class ApplicationForm extends WithCapabilitiesConfig(ModelForm<Applicatio
                         : html` <ak-text-input
                               label=${msg("Icon")}
                               name="metaIcon"
-                              value=${first(this.instance?.metaIcon, "")}
+                              value=${this.instance?.metaIcon ?? ""}
                               help=${iconHelperText}
                           >
                           </ak-text-input>`}

--- a/web/src/admin/applications/entitlements/ApplicationEntitlementForm.ts
+++ b/web/src/admin/applications/entitlements/ApplicationEntitlementForm.ts
@@ -1,5 +1,4 @@
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/CodeMirror";
 import { CodeMirrorMode } from "@goauthentik/elements/CodeMirror";
 import "@goauthentik/elements/forms/HorizontalFormElement";
@@ -60,7 +59,7 @@ export class ApplicationEntitlementForm extends ModelForm<ApplicationEntitlement
         return html` <ak-form-element-horizontal label=${msg("Name")} ?required=${true} name="name">
                 <input
                     type="text"
-                    value="${first(this.instance?.name, "")}"
+                    value="${this.instance?.name ?? ""}"
                     class="pf-c-form-control"
                     required
                 />
@@ -72,7 +71,7 @@ export class ApplicationEntitlementForm extends ModelForm<ApplicationEntitlement
             >
                 <ak-codemirror
                     mode=${CodeMirrorMode.YAML}
-                    value="${YAML.stringify(first(this.instance?.attributes, {}))}"
+                    value="${YAML.stringify(this.instance?.attributes ?? {})}"
                 >
                 </ak-codemirror>
                 <p class="pf-c-form__helper-text">

--- a/web/src/admin/applications/wizard/steps/ak-application-wizard-application-step.ts
+++ b/web/src/admin/applications/wizard/steps/ak-application-wizard-application-step.ts
@@ -1,7 +1,6 @@
 import { policyOptions } from "@goauthentik/admin/applications/PolicyOptions.js";
 import { ApplicationWizardStep } from "@goauthentik/admin/applications/wizard/ApplicationWizardStep.js";
 import "@goauthentik/admin/applications/wizard/ak-wizard-title.js";
-import { isSlug } from "@goauthentik/common/utils.js";
 import { camelToSnake } from "@goauthentik/common/utils.js";
 import "@goauthentik/components/ak-radio-input";
 import "@goauthentik/components/ak-slug-input";
@@ -11,6 +10,7 @@ import { type NavigableButton, type WizardButton } from "@goauthentik/components
 import { type KeyUnknown } from "@goauthentik/elements/forms/Form";
 import "@goauthentik/elements/forms/FormGroup";
 import "@goauthentik/elements/forms/HorizontalFormElement";
+import { isSlug } from "@goauthentik/elements/router/utils.js";
 
 import { msg } from "@lit/localize";
 import { html } from "lit";

--- a/web/src/admin/blueprints/BlueprintForm.ts
+++ b/web/src/admin/blueprints/BlueprintForm.ts
@@ -1,6 +1,5 @@
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
 import { docLink } from "@goauthentik/common/global";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/components/ak-toggle-group";
 import "@goauthentik/elements/CodeMirror";
 import { CodeMirrorMode } from "@goauthentik/elements/CodeMirror";
@@ -80,7 +79,7 @@ export class BlueprintForm extends ModelForm<BlueprintInstance, string> {
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.enabled, true)}
+                        ?checked=${this.instance?.enabled ?? true}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">
@@ -184,7 +183,7 @@ export class BlueprintForm extends ModelForm<BlueprintInstance, string> {
                     <ak-form-element-horizontal label=${msg("Context")} name="context">
                         <ak-codemirror
                             mode=${CodeMirrorMode.YAML}
-                            value="${YAML.stringify(first(this.instance?.context, {}))}"
+                            value="${YAML.stringify(this.instance?.context ?? {})}"
                         >
                         </ak-codemirror>
                         <p class="pf-c-form__helper-text">

--- a/web/src/admin/brands/BrandForm.ts
+++ b/web/src/admin/brands/BrandForm.ts
@@ -2,7 +2,6 @@ import "@goauthentik/admin/common/ak-crypto-certificate-search";
 import "@goauthentik/admin/common/ak-flow-search/ak-flow-search";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
 import { DefaultBrand } from "@goauthentik/common/ui/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/CodeMirror";
 import { CodeMirrorMode } from "@goauthentik/elements/CodeMirror";
 import "@goauthentik/elements/forms/FormGroup";
@@ -54,7 +53,7 @@ export class BrandForm extends ModelForm<Brand, string> {
         return html` <ak-form-element-horizontal label=${msg("Domain")} required name="domain">
                 <input
                     type="text"
-                    value="${first(this.instance?.domain, window.location.host)}"
+                    value="${this.instance?.domain ?? window.location.host}"
                     class="pf-c-form-control pf-m-monospace"
                     autocomplete="off"
                     spellcheck="false"
@@ -72,7 +71,7 @@ export class BrandForm extends ModelForm<Brand, string> {
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?._default, false)}
+                        ?checked=${this.instance?._default ?? false}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">
@@ -92,10 +91,7 @@ export class BrandForm extends ModelForm<Brand, string> {
                     <ak-form-element-horizontal label=${msg("Title")} required name="brandingTitle">
                         <input
                             type="text"
-                            value="${first(
-                                this.instance?.brandingTitle,
-                                DefaultBrand.brandingTitle,
-                            )}"
+                            value="${this.instance?.brandingTitle ?? DefaultBrand.brandingTitle}"
                             class="pf-c-form-control"
                             required
                         />
@@ -106,7 +102,7 @@ export class BrandForm extends ModelForm<Brand, string> {
                     <ak-form-element-horizontal label=${msg("Logo")} required name="brandingLogo">
                         <input
                             type="text"
-                            value="${first(this.instance?.brandingLogo, DefaultBrand.brandingLogo)}"
+                            value="${this.instance?.brandingLogo ?? DefaultBrand.brandingLogo}"
                             class="pf-c-form-control pf-m-monospace"
                             autocomplete="off"
                             spellcheck="false"
@@ -123,10 +119,8 @@ export class BrandForm extends ModelForm<Brand, string> {
                     >
                         <input
                             type="text"
-                            value="${first(
-                                this.instance?.brandingFavicon,
-                                DefaultBrand.brandingFavicon,
-                            )}"
+                            value="${this.instance?.brandingFavicon ??
+                            DefaultBrand.brandingFavicon}"
                             class="pf-c-form-control pf-m-monospace"
                             autocomplete="off"
                             spellcheck="false"
@@ -143,10 +137,8 @@ export class BrandForm extends ModelForm<Brand, string> {
                     >
                         <input
                             type="text"
-                            value="${first(
-                                this.instance?.brandingDefaultFlowBackground,
-                                "/static/dist/assets/images/flow_background.jpg",
-                            )}"
+                            value="${this.instance?.brandingDefaultFlowBackground ??
+                            "/static/dist/assets/images/flow_background.jpg"}"
                             class="pf-c-form-control pf-m-monospace"
                             autocomplete="off"
                             spellcheck="false"
@@ -165,10 +157,8 @@ export class BrandForm extends ModelForm<Brand, string> {
                     >
                         <ak-codemirror
                             mode=${CodeMirrorMode.CSS}
-                            value="${first(
-                                this.instance?.brandingCustomCss,
-                                DefaultBrand.brandingCustomCss,
-                            )}"
+                            value="${this.instance?.brandingCustomCss ??
+                            DefaultBrand.brandingCustomCss}"
                         >
                         </ak-codemirror>
                         <p class="pf-c-form__helper-text">
@@ -317,7 +307,7 @@ export class BrandForm extends ModelForm<Brand, string> {
                     <ak-form-element-horizontal label=${msg("Attributes")} name="attributes">
                         <ak-codemirror
                             mode=${CodeMirrorMode.YAML}
-                            value="${YAML.stringify(first(this.instance?.attributes, {}))}"
+                            value="${YAML.stringify(this.instance?.attributes ?? {})}"
                         >
                         </ak-codemirror>
                         <p class="pf-c-form__helper-text">

--- a/web/src/admin/events/TransportForm.ts
+++ b/web/src/admin/events/TransportForm.ts
@@ -1,5 +1,4 @@
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/forms/HorizontalFormElement";
 import { ModelForm } from "@goauthentik/elements/forms/ModelForm";
 import "@goauthentik/elements/forms/Radio";
@@ -185,7 +184,7 @@ export class TransportForm extends ModelForm<NotificationTransport, string> {
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.sendOnce, false)}
+                        ?checked=${this.instance?.sendOnce ?? false}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">

--- a/web/src/admin/flows/FlowForm.ts
+++ b/web/src/admin/flows/FlowForm.ts
@@ -1,7 +1,6 @@
 import { DesignationToLabel, LayoutToLabel } from "@goauthentik/admin/flows/utils";
 import { AuthenticationEnum } from "@goauthentik/api/dist/models/AuthenticationEnum";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import {
     CapabilitiesEnum,
     WithCapabilitiesConfig,
@@ -227,7 +226,7 @@ export class FlowForm extends WithCapabilitiesConfig(ModelForm<Flow, string>) {
                             <input
                                 class="pf-c-switch__input"
                                 type="checkbox"
-                                ?checked=${first(this.instance?.compatibilityMode, false)}
+                                ?checked=${this.instance?.compatibilityMode ?? false}
                             />
                             <span class="pf-c-switch__toggle">
                                 <span class="pf-c-switch__toggle-icon">
@@ -407,7 +406,7 @@ export class FlowForm extends WithCapabilitiesConfig(ModelForm<Flow, string>) {
                           >
                               <input
                                   type="text"
-                                  value="${first(this.instance?.background, "")}"
+                                  value="${this.instance?.background ?? ""}"
                                   class="pf-c-form-control"
                               />
                               <p class="pf-c-form__helper-text">

--- a/web/src/admin/flows/StageBindingForm.ts
+++ b/web/src/admin/flows/StageBindingForm.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first, groupBy } from "@goauthentik/common/utils";
+import { groupBy } from "@goauthentik/common/utils";
 import "@goauthentik/elements/forms/HorizontalFormElement";
 import { ModelForm } from "@goauthentik/elements/forms/ModelForm";
 import "@goauthentik/elements/forms/Radio";
@@ -123,7 +123,7 @@ export class StageBindingForm extends ModelForm<FlowStageBinding, string> {
             <ak-form-element-horizontal label=${msg("Order")} ?required=${true} name="order">
                 <input
                     type="number"
-                    value="${first(this.instance?.order, this.defaultOrder)}"
+                    value="${this.instance?.order ?? this.defaultOrder}"
                     class="pf-c-form-control"
                     required
                 />
@@ -133,7 +133,7 @@ export class StageBindingForm extends ModelForm<FlowStageBinding, string> {
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.evaluateOnPlan, false)}
+                        ?checked=${this.instance?.evaluateOnPlan ?? false}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">
@@ -151,7 +151,7 @@ export class StageBindingForm extends ModelForm<FlowStageBinding, string> {
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.reEvaluatePolicies, true)}
+                        ?checked=${this.instance?.reEvaluatePolicies ?? true}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">

--- a/web/src/admin/groups/GroupForm.ts
+++ b/web/src/admin/groups/GroupForm.ts
@@ -1,6 +1,5 @@
 import "@goauthentik/admin/groups/MemberSelectModal";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/CodeMirror";
 import { CodeMirrorMode } from "@goauthentik/elements/CodeMirror";
 import "@goauthentik/elements/ak-dual-select/ak-dual-select-provider";
@@ -77,7 +76,7 @@ export class GroupForm extends ModelForm<Group, string> {
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.isSuperuser, false)}
+                        ?checked=${this.instance?.isSuperuser ?? false}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">
@@ -150,7 +149,7 @@ export class GroupForm extends ModelForm<Group, string> {
             >
                 <ak-codemirror
                     mode=${CodeMirrorMode.YAML}
-                    value="${YAML.stringify(first(this.instance?.attributes, {}))}"
+                    value="${YAML.stringify(this.instance?.attributes ?? {})}"
                 >
                 </ak-codemirror>
                 <p class="pf-c-form__helper-text">

--- a/web/src/admin/outposts/ServiceConnectionDockerForm.ts
+++ b/web/src/admin/outposts/ServiceConnectionDockerForm.ts
@@ -1,6 +1,5 @@
 import "@goauthentik/admin/common/ak-crypto-certificate-search";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/forms/HorizontalFormElement";
 import { ModelForm } from "@goauthentik/elements/forms/ModelForm";
 import "@goauthentik/elements/forms/SearchSelect";
@@ -53,7 +52,7 @@ export class ServiceConnectionDockerForm extends ModelForm<DockerServiceConnecti
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.local, false)}
+                        ?checked=${this.instance?.local ?? false}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">

--- a/web/src/admin/outposts/ServiceConnectionKubernetesForm.ts
+++ b/web/src/admin/outposts/ServiceConnectionKubernetesForm.ts
@@ -1,5 +1,4 @@
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/CodeMirror";
 import { CodeMirrorMode } from "@goauthentik/elements/CodeMirror";
 import "@goauthentik/elements/forms/HorizontalFormElement";
@@ -57,7 +56,7 @@ export class ServiceConnectionKubernetesForm extends ModelForm<
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.local, false)}
+                        ?checked=${this.instance?.local ?? false}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">
@@ -75,7 +74,7 @@ export class ServiceConnectionKubernetesForm extends ModelForm<
             <ak-form-element-horizontal label=${msg("Kubeconfig")} name="kubeconfig">
                 <ak-codemirror
                     mode=${CodeMirrorMode.YAML}
-                    value="${YAML.stringify(first(this.instance?.kubeconfig, {}))}"
+                    value="${YAML.stringify(this.instance?.kubeconfig ?? {})}"
                 >
                 </ak-codemirror>
                 <p class="pf-c-form__helper-text">
@@ -87,7 +86,7 @@ export class ServiceConnectionKubernetesForm extends ModelForm<
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.verifySsl, true)}
+                        ?checked=${this.instance?.verifySsl ?? true}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">

--- a/web/src/admin/policies/PolicyBindingForm.ts
+++ b/web/src/admin/policies/PolicyBindingForm.ts
@@ -3,7 +3,7 @@ import {
     PolicyBindingCheckTargetToLabel,
 } from "@goauthentik/admin/policies/utils";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first, groupBy } from "@goauthentik/common/utils";
+import { groupBy } from "@goauthentik/common/utils";
 import "@goauthentik/components/ak-toggle-group";
 import "@goauthentik/elements/forms/HorizontalFormElement";
 import { ModelForm } from "@goauthentik/elements/forms/ModelForm";
@@ -274,7 +274,7 @@ export class PolicyBindingForm extends ModelForm<PolicyBinding, string> {
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.enabled, true)}
+                        ?checked=${this.instance?.enabled ?? true}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">
@@ -289,7 +289,7 @@ export class PolicyBindingForm extends ModelForm<PolicyBinding, string> {
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.negate, false)}
+                        ?checked=${this.instance?.negate ?? false}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">
@@ -305,7 +305,7 @@ export class PolicyBindingForm extends ModelForm<PolicyBinding, string> {
             <ak-form-element-horizontal label=${msg("Order")} ?required=${true} name="order">
                 <input
                     type="number"
-                    value="${first(this.instance?.order, this.defaultOrder)}"
+                    value="${this.instance?.order ?? this.defaultOrder}"
                     class="pf-c-form-control"
                     required
                 />
@@ -313,7 +313,7 @@ export class PolicyBindingForm extends ModelForm<PolicyBinding, string> {
             <ak-form-element-horizontal label=${msg("Timeout")} ?required=${true} name="timeout">
                 <input
                     type="number"
-                    value="${first(this.instance?.timeout, 30)}"
+                    value="${this.instance?.timeout ?? 30}"
                     class="pf-c-form-control"
                     required
                 />

--- a/web/src/admin/policies/PolicyTestForm.ts
+++ b/web/src/admin/policies/PolicyTestForm.ts
@@ -1,5 +1,4 @@
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/components/ak-status-label";
 import "@goauthentik/elements/CodeMirror";
 import { CodeMirrorMode } from "@goauthentik/elements/CodeMirror";
@@ -125,7 +124,7 @@ export class PolicyTestForm extends Form<PolicyTestRequest> {
             <ak-form-element-horizontal label=${msg("Context")} name="context">
                 <ak-codemirror
                     mode=${CodeMirrorMode.YAML}
-                    value=${YAML.stringify(first(this.request?.context, {}))}
+                    value=${YAML.stringify(this.request?.context ?? {})}
                 >
                 </ak-codemirror>
                 <p class="pf-c-form__helper-text">

--- a/web/src/admin/policies/dummy/DummyPolicyForm.ts
+++ b/web/src/admin/policies/dummy/DummyPolicyForm.ts
@@ -1,6 +1,5 @@
 import { BasePolicyForm } from "@goauthentik/admin/policies/BasePolicyForm";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/forms/FormGroup";
 import "@goauthentik/elements/forms/HorizontalFormElement";
 
@@ -51,7 +50,7 @@ export class DummyPolicyForm extends BasePolicyForm<DummyPolicy> {
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.executionLogging, false)}
+                        ?checked=${this.instance?.executionLogging ?? false}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">
@@ -74,7 +73,7 @@ export class DummyPolicyForm extends BasePolicyForm<DummyPolicy> {
                             <input
                                 class="pf-c-switch__input"
                                 type="checkbox"
-                                ?checked=${first(this.instance?.result, false)}
+                                ?checked=${this.instance?.result ?? false}
                             />
                             <span class="pf-c-switch__toggle">
                                 <span class="pf-c-switch__toggle-icon">
@@ -91,7 +90,7 @@ export class DummyPolicyForm extends BasePolicyForm<DummyPolicy> {
                     >
                         <input
                             type="number"
-                            value="${first(this.instance?.waitMin, 1)}"
+                            value="${this.instance?.waitMin ?? 1}"
                             class="pf-c-form-control"
                             required
                         />
@@ -108,7 +107,7 @@ export class DummyPolicyForm extends BasePolicyForm<DummyPolicy> {
                     >
                         <input
                             type="number"
-                            value="${first(this.instance?.waitMax, 5)}"
+                            value="${this.instance?.waitMax ?? 5}"
                             class="pf-c-form-control"
                             required
                         />

--- a/web/src/admin/policies/event_matcher/EventMatcherPolicyForm.ts
+++ b/web/src/admin/policies/event_matcher/EventMatcherPolicyForm.ts
@@ -1,6 +1,5 @@
 import { BasePolicyForm } from "@goauthentik/admin/policies/BasePolicyForm";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/forms/FormGroup";
 import "@goauthentik/elements/forms/HorizontalFormElement";
 import "@goauthentik/elements/forms/SearchSelect";
@@ -63,7 +62,7 @@ export class EventMatcherPolicyForm extends BasePolicyForm<EventMatcherPolicy> {
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.executionLogging, false)}
+                        ?checked=${this.instance?.executionLogging ?? false}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">

--- a/web/src/admin/policies/expiry/ExpiryPolicyForm.ts
+++ b/web/src/admin/policies/expiry/ExpiryPolicyForm.ts
@@ -1,6 +1,5 @@
 import { BasePolicyForm } from "@goauthentik/admin/policies/BasePolicyForm";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/forms/FormGroup";
 import "@goauthentik/elements/forms/HorizontalFormElement";
 
@@ -51,7 +50,7 @@ export class PasswordExpiryPolicyForm extends BasePolicyForm<PasswordExpiryPolic
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.executionLogging, false)}
+                        ?checked=${this.instance?.executionLogging ?? false}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">
@@ -86,7 +85,7 @@ export class PasswordExpiryPolicyForm extends BasePolicyForm<PasswordExpiryPolic
                             <input
                                 class="pf-c-switch__input"
                                 type="checkbox"
-                                ?checked=${first(this.instance?.denyOnly, false)}
+                                ?checked=${this.instance?.denyOnly ?? false}
                             />
                             <span class="pf-c-switch__toggle">
                                 <span class="pf-c-switch__toggle-icon">

--- a/web/src/admin/policies/expression/ExpressionPolicyForm.ts
+++ b/web/src/admin/policies/expression/ExpressionPolicyForm.ts
@@ -1,7 +1,6 @@
 import { BasePolicyForm } from "@goauthentik/admin/policies/BasePolicyForm";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
 import { docLink } from "@goauthentik/common/global";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/CodeMirror";
 import { CodeMirrorMode } from "@goauthentik/elements/CodeMirror";
 import "@goauthentik/elements/forms/FormGroup";
@@ -54,7 +53,7 @@ export class ExpressionPolicyForm extends BasePolicyForm<ExpressionPolicy> {
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.executionLogging, false)}
+                        ?checked=${this.instance?.executionLogging ?? false}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">

--- a/web/src/admin/policies/geoip/GeoIPPolicyForm.ts
+++ b/web/src/admin/policies/geoip/GeoIPPolicyForm.ts
@@ -1,6 +1,5 @@
 import { BasePolicyForm } from "@goauthentik/admin/policies/BasePolicyForm";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/ak-dual-select";
 import { DataProvision, DualSelectPair } from "@goauthentik/elements/ak-dual-select/types";
 import "@goauthentik/elements/forms/FormGroup";
@@ -112,7 +111,7 @@ export class GeoIPPolicyForm extends BasePolicyForm<GeoIPPolicy> {
                         <input
                             type="number"
                             min="1"
-                            value="${first(this.instance?.historyMaxDistanceKm, 100)}"
+                            value="${this.instance?.historyMaxDistanceKm ?? 100}"
                             class="pf-c-form-control"
                         />
                         <p class="pf-c-form__helper-text">
@@ -128,7 +127,7 @@ export class GeoIPPolicyForm extends BasePolicyForm<GeoIPPolicy> {
                         <input
                             type="number"
                             min="1"
-                            value="${first(this.instance?.distanceToleranceKm, 50)}"
+                            value="${this.instance?.distanceToleranceKm ?? 50}"
                             class="pf-c-form-control"
                         />
                         <p class="pf-c-form__helper-text">
@@ -142,7 +141,7 @@ export class GeoIPPolicyForm extends BasePolicyForm<GeoIPPolicy> {
                         <input
                             type="number"
                             min="1"
-                            value="${first(this.instance?.historyLoginCount, 5)}"
+                            value="${this.instance?.historyLoginCount ?? 5}"
                             class="pf-c-form-control"
                         />
                         <p class="pf-c-form__helper-text">
@@ -178,7 +177,7 @@ export class GeoIPPolicyForm extends BasePolicyForm<GeoIPPolicy> {
                         <input
                             type="number"
                             min="1"
-                            value="${first(this.instance?.impossibleToleranceKm, 50)}"
+                            value="${this.instance?.impossibleToleranceKm ?? 50}"
                             class="pf-c-form-control"
                         />
                         <p class="pf-c-form__helper-text">

--- a/web/src/admin/policies/password/PasswordPolicyForm.ts
+++ b/web/src/admin/policies/password/PasswordPolicyForm.ts
@@ -1,6 +1,5 @@
 import { BasePolicyForm } from "@goauthentik/admin/policies/BasePolicyForm";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/forms/FormGroup";
 import "@goauthentik/elements/forms/HorizontalFormElement";
 
@@ -56,7 +55,7 @@ export class PasswordPolicyForm extends BasePolicyForm<PasswordPolicy> {
                 >
                     <input
                         type="number"
-                        value="${first(this.instance?.lengthMin, 10)}"
+                        value="${this.instance?.lengthMin ?? 10}"
                         class="pf-c-form-control"
                         required
                     />
@@ -68,7 +67,7 @@ export class PasswordPolicyForm extends BasePolicyForm<PasswordPolicy> {
                 >
                     <input
                         type="number"
-                        value="${first(this.instance?.amountUppercase, 2)}"
+                        value="${this.instance?.amountUppercase ?? 2}"
                         class="pf-c-form-control"
                         required
                     />
@@ -80,7 +79,7 @@ export class PasswordPolicyForm extends BasePolicyForm<PasswordPolicy> {
                 >
                     <input
                         type="number"
-                        value="${first(this.instance?.amountLowercase, 2)}"
+                        value="${this.instance?.amountLowercase ?? 2}"
                         class="pf-c-form-control"
                         required
                     />
@@ -92,7 +91,7 @@ export class PasswordPolicyForm extends BasePolicyForm<PasswordPolicy> {
                 >
                     <input
                         type="number"
-                        value="${first(this.instance?.amountDigits, 2)}"
+                        value="${this.instance?.amountDigits ?? 2}"
                         class="pf-c-form-control"
                         required
                     />
@@ -104,7 +103,7 @@ export class PasswordPolicyForm extends BasePolicyForm<PasswordPolicy> {
                 >
                     <input
                         type="number"
-                        value="${first(this.instance?.amountSymbols, 2)}"
+                        value="${this.instance?.amountSymbols ?? 2}"
                         class="pf-c-form-control"
                         required
                     />
@@ -154,7 +153,7 @@ export class PasswordPolicyForm extends BasePolicyForm<PasswordPolicy> {
                     >
                         <input
                             type="number"
-                            value="${first(this.instance?.hibpAllowedCount, 0)}"
+                            value="${this.instance?.hibpAllowedCount ?? 0}"
                             class="pf-c-form-control"
                             required
                         />
@@ -179,7 +178,7 @@ export class PasswordPolicyForm extends BasePolicyForm<PasswordPolicy> {
                     >
                         <input
                             type="number"
-                            value="${first(this.instance?.zxcvbnScoreThreshold, 0)}"
+                            value="${this.instance?.zxcvbnScoreThreshold ?? 0}"
                             class="pf-c-form-control"
                             required
                         />
@@ -236,7 +235,7 @@ export class PasswordPolicyForm extends BasePolicyForm<PasswordPolicy> {
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.executionLogging, false)}
+                        ?checked=${this.instance?.executionLogging ?? false}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">
@@ -272,7 +271,7 @@ export class PasswordPolicyForm extends BasePolicyForm<PasswordPolicy> {
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.checkStaticRules, true)}
+                        ?checked=${this.instance?.checkStaticRules ?? true}
                         @change=${(ev: Event) => {
                             const el = ev.target as HTMLInputElement;
                             this.showStatic = el.checked;
@@ -291,7 +290,7 @@ export class PasswordPolicyForm extends BasePolicyForm<PasswordPolicy> {
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.checkHaveIBeenPwned, true)}
+                        ?checked=${this.instance?.checkHaveIBeenPwned ?? true}
                         @change=${(ev: Event) => {
                             const el = ev.target as HTMLInputElement;
                             this.showHIBP = el.checked;
@@ -316,7 +315,7 @@ export class PasswordPolicyForm extends BasePolicyForm<PasswordPolicy> {
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.checkZxcvbn, true)}
+                        ?checked=${this.instance?.checkZxcvbn ?? true}
                         @change=${(ev: Event) => {
                             const el = ev.target as HTMLInputElement;
                             this.showZxcvbn = el.checked;

--- a/web/src/admin/policies/reputation/ReputationPolicyForm.ts
+++ b/web/src/admin/policies/reputation/ReputationPolicyForm.ts
@@ -1,6 +1,5 @@
 import { BasePolicyForm } from "@goauthentik/admin/policies/BasePolicyForm";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/forms/FormGroup";
 import "@goauthentik/elements/forms/HorizontalFormElement";
 
@@ -61,7 +60,7 @@ doesn't pass when either or both of the selected options are equal or above the 
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.executionLogging, false)}
+                        ?checked=${this.instance?.executionLogging ?? false}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">
@@ -84,7 +83,7 @@ doesn't pass when either or both of the selected options are equal or above the 
                             <input
                                 class="pf-c-switch__input"
                                 type="checkbox"
-                                ?checked=${first(this.instance?.checkIp, true)}
+                                ?checked=${this.instance?.checkIp ?? true}
                             />
                             <span class="pf-c-switch__toggle">
                                 <span class="pf-c-switch__toggle-icon">
@@ -99,7 +98,7 @@ doesn't pass when either or both of the selected options are equal or above the 
                             <input
                                 class="pf-c-switch__input"
                                 type="checkbox"
-                                ?checked=${first(this.instance?.checkUsername, false)}
+                                ?checked=${this.instance?.checkUsername ?? false}
                             />
                             <span class="pf-c-switch__toggle">
                                 <span class="pf-c-switch__toggle-icon">

--- a/web/src/admin/policies/unique_password/UniquePasswordPolicyForm.ts
+++ b/web/src/admin/policies/unique_password/UniquePasswordPolicyForm.ts
@@ -1,6 +1,5 @@
 import { BasePolicyForm } from "@goauthentik/admin/policies/BasePolicyForm";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/forms/FormGroup";
 import "@goauthentik/elements/forms/HorizontalFormElement";
 
@@ -51,7 +50,7 @@ export class UniquePasswordPolicyForm extends BasePolicyForm<UniquePasswordPolic
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.executionLogging, false)}
+                        ?checked=${this.instance?.executionLogging ?? false}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">
@@ -88,7 +87,7 @@ export class UniquePasswordPolicyForm extends BasePolicyForm<UniquePasswordPolic
             >
                 <input
                     type="number"
-                    value="${first(this.instance?.numHistoricalPasswords, 1)}"
+                    value="${this.instance?.numHistoricalPasswords ?? 1}"
                     class="pf-c-form-control"
                     required
                 />

--- a/web/src/admin/property-mappings/PropertyMappingTestForm.ts
+++ b/web/src/admin/property-mappings/PropertyMappingTestForm.ts
@@ -1,5 +1,4 @@
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/CodeMirror";
 import { CodeMirrorMode } from "@goauthentik/elements/CodeMirror";
 import { Form } from "@goauthentik/elements/forms/Form";
@@ -181,7 +180,7 @@ export class PolicyTestForm extends Form<PropertyMappingTestRequest> {
             <ak-form-element-horizontal label=${msg("Context")} name="context">
                 <ak-codemirror
                     mode=${CodeMirrorMode.YAML}
-                    value=${YAML.stringify(first(this.request?.context, {}))}
+                    value=${YAML.stringify(this.request?.context ?? {})}
                 >
                 </ak-codemirror>
                 <p class="pf-c-form__helper-text">${this.renderExampleButtons()}</p>

--- a/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderForm.ts
+++ b/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderForm.ts
@@ -4,7 +4,6 @@ import {
     propertyMappingsSelector,
 } from "@goauthentik/admin/providers/google_workspace/GoogleWorkspaceProviderFormHelpers.js";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/CodeMirror";
 import { CodeMirrorMode } from "@goauthentik/elements/CodeMirror";
 import "@goauthentik/elements/ak-dual-select/ak-dual-select-dynamic-selected-provider.js";
@@ -68,7 +67,7 @@ export class GoogleWorkspaceProviderFormPage extends BaseProviderForm<GoogleWork
                     >
                         <ak-codemirror
                             mode=${CodeMirrorMode.JavaScript}
-                            .value="${first(this.instance?.credentials, {})}"
+                            .value="${this.instance?.credentials ?? {}}"
                         ></ak-codemirror>
                         <p class="pf-c-form__helper-text">
                             ${msg("Google Cloud credentials file.")}
@@ -81,7 +80,7 @@ export class GoogleWorkspaceProviderFormPage extends BaseProviderForm<GoogleWork
                     >
                         <input
                             type="email"
-                            value="${first(this.instance?.delegatedSubject, "")}"
+                            value="${this.instance?.delegatedSubject ?? ""}"
                             class="pf-c-form-control pf-m-monospace"
                             required
                         />
@@ -98,7 +97,7 @@ export class GoogleWorkspaceProviderFormPage extends BaseProviderForm<GoogleWork
                     >
                         <input
                             type="text"
-                            value="${first(this.instance?.defaultGroupEmailDomain, "")}"
+                            value="${this.instance?.defaultGroupEmailDomain ?? ""}"
                             class="pf-c-form-control pf-m-monospace"
                             required
                         />
@@ -166,7 +165,7 @@ export class GoogleWorkspaceProviderFormPage extends BaseProviderForm<GoogleWork
                             <input
                                 class="pf-c-switch__input"
                                 type="checkbox"
-                                ?checked=${first(this.instance?.dryRun, false)}
+                                ?checked=${this.instance?.dryRun ?? false}
                             />
                             <span class="pf-c-switch__toggle">
                                 <span class="pf-c-switch__toggle-icon">
@@ -191,7 +190,7 @@ export class GoogleWorkspaceProviderFormPage extends BaseProviderForm<GoogleWork
                             <input
                                 class="pf-c-switch__input"
                                 type="checkbox"
-                                ?checked=${first(this.instance?.excludeUsersServiceAccount, true)}
+                                ?checked=${this.instance?.excludeUsersServiceAccount ?? true}
                             />
                             <span class="pf-c-switch__toggle">
                                 <span class="pf-c-switch__toggle-icon">

--- a/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderForm.ts
+++ b/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderForm.ts
@@ -4,7 +4,6 @@ import {
     propertyMappingsSelector,
 } from "@goauthentik/admin/providers/microsoft_entra/MicrosoftEntraProviderFormHelpers.js";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/ak-dual-select/ak-dual-select-dynamic-selected-provider.js";
 import "@goauthentik/elements/ak-dual-select/ak-dual-select-provider.js";
 import "@goauthentik/elements/forms/FormGroup";
@@ -66,7 +65,7 @@ export class MicrosoftEntraProviderFormPage extends BaseProviderForm<MicrosoftEn
                     >
                         <input
                             type="text"
-                            value="${first(this.instance?.clientId, "")}"
+                            value="${this.instance?.clientId ?? ""}"
                             class="pf-c-form-control pf-m-monospace"
                             required
                         />
@@ -81,7 +80,7 @@ export class MicrosoftEntraProviderFormPage extends BaseProviderForm<MicrosoftEn
                     >
                         <input
                             type="text"
-                            value="${first(this.instance?.clientSecret, "")}"
+                            value="${this.instance?.clientSecret ?? ""}"
                             class="pf-c-form-control pf-m-monospace"
                             required
                         />
@@ -96,7 +95,7 @@ export class MicrosoftEntraProviderFormPage extends BaseProviderForm<MicrosoftEn
                     >
                         <input
                             type="text"
-                            value="${first(this.instance?.tenantId, "")}"
+                            value="${this.instance?.tenantId ?? ""}"
                             class="pf-c-form-control pf-m-monospace"
                             required
                         />
@@ -155,7 +154,7 @@ export class MicrosoftEntraProviderFormPage extends BaseProviderForm<MicrosoftEn
                             <input
                                 class="pf-c-switch__input"
                                 type="checkbox"
-                                ?checked=${first(this.instance?.dryRun, false)}
+                                ?checked=${this.instance?.dryRun ?? false}
                             />
                             <span class="pf-c-switch__toggle">
                                 <span class="pf-c-switch__toggle-icon">
@@ -180,7 +179,7 @@ export class MicrosoftEntraProviderFormPage extends BaseProviderForm<MicrosoftEn
                             <input
                                 class="pf-c-switch__input"
                                 type="checkbox"
-                                ?checked=${first(this.instance?.excludeUsersServiceAccount, true)}
+                                ?checked=${this.instance?.excludeUsersServiceAccount ?? true}
                             />
                             <span class="pf-c-switch__toggle">
                                 <span class="pf-c-switch__toggle-icon">

--- a/web/src/admin/providers/oauth2/OAuth2ProviderFormForm.ts
+++ b/web/src/admin/providers/oauth2/OAuth2ProviderFormForm.ts
@@ -4,7 +4,7 @@ import {
     IRedirectURIInput,
     akOAuthRedirectURIInput,
 } from "@goauthentik/admin/providers/oauth2/OAuth2ProviderRedirectURI";
-import { ascii_letters, digits, first, randomString } from "@goauthentik/common/utils";
+import { ascii_letters, digits, randomString } from "@goauthentik/common/utils";
 import "@goauthentik/components/ak-radio-input";
 import "@goauthentik/components/ak-text-input";
 import "@goauthentik/components/ak-textarea-input";
@@ -161,7 +161,7 @@ export function renderForm(
                 <ak-text-input
                     name="clientId"
                     label=${msg("Client ID")}
-                    value="${first(provider?.clientId, randomString(40, ascii_letters + digits))}"
+                    value="${provider?.clientId ?? randomString(40, ascii_letters + digits)}"
                     required
                     inputHint="code"
                 >
@@ -169,10 +169,7 @@ export function renderForm(
                 <ak-text-input
                     name="clientSecret"
                     label=${msg("Client Secret")}
-                    value="${first(
-                        provider?.clientSecret,
-                        randomString(128, ascii_letters + digits),
-                    )}"
+                    value="${provider?.clientSecret ?? randomString(128, ascii_letters + digits)}"
                     inputHint="code"
                     ?hidden=${!showClientSecret}
                 >
@@ -257,7 +254,7 @@ export function renderForm(
                     label=${msg("Access code validity")}
                     inputHint="code"
                     required
-                    value="${first(provider?.accessCodeValidity, "minutes=1")}"
+                    value="${provider?.accessCodeValidity ?? "minutes=1"}"
                     .bighelp=${html`<p class="pf-c-form__helper-text">
                             ${msg("Configure how long access codes are valid for.")}
                         </p>
@@ -267,7 +264,7 @@ export function renderForm(
                 <ak-text-input
                     name="accessTokenValidity"
                     label=${msg("Access Token validity")}
-                    value="${first(provider?.accessTokenValidity, "minutes=5")}"
+                    value="${provider?.accessTokenValidity ?? "minutes=5"}"
                     inputHint="code"
                     required
                     .bighelp=${html` <p class="pf-c-form__helper-text">
@@ -280,7 +277,7 @@ export function renderForm(
                 <ak-text-input
                     name="refreshTokenValidity"
                     label=${msg("Refresh Token validity")}
-                    value="${first(provider?.refreshTokenValidity, "days=30")}"
+                    value="${provider?.refreshTokenValidity ?? "days=30"}"
                     inputHint="code"
                     ?required=${true}
                     .bighelp=${html` <p class="pf-c-form__helper-text">
@@ -317,7 +314,7 @@ export function renderForm(
                 <ak-switch-input
                     name="includeClaimsInIdToken"
                     label=${msg("Include claims in id_token")}
-                    ?checked=${first(provider?.includeClaimsInIdToken, true)}
+                    ?checked=${provider?.includeClaimsInIdToken ?? true}
                     help=${msg(
                         "Include User claims from scopes in the id_token, for applications that don't access the userinfo endpoint.",
                     )}

--- a/web/src/admin/providers/proxy/ProxyProviderViewPage.ts
+++ b/web/src/admin/providers/proxy/ProxyProviderViewPage.ts
@@ -3,7 +3,6 @@ import "@goauthentik/admin/providers/proxy/ProxyProviderForm";
 import "@goauthentik/admin/rbac/ObjectPermissionsPage";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
 import { EVENT_REFRESH } from "@goauthentik/common/constants";
-import { convertToSlug } from "@goauthentik/common/utils";
 import "@goauthentik/components/ak-status-label";
 import "@goauthentik/components/events/ObjectChangelog";
 import MDCaddyStandalone from "@goauthentik/docs/add-secure-apps/providers/proxy/_caddy_standalone.md";
@@ -22,6 +21,7 @@ import type { Replacer } from "@goauthentik/elements/ak-mdx";
 import "@goauthentik/elements/buttons/ModalButton";
 import "@goauthentik/elements/buttons/SpinnerButton";
 import { getURLParam } from "@goauthentik/elements/router/RouteMatch";
+import { formatSlug } from "@goauthentik/elements/router/utils.js";
 
 import { msg } from "@lit/localize";
 import { CSSResult, PropertyValues, TemplateResult, css, html } from "lit";
@@ -183,7 +183,7 @@ export class ProxyProviderViewPage extends AKElement {
         return html`<ak-tabs pageIdentifier="proxy-setup">
             ${servers.map((server) => {
                 return html`<section
-                    slot="page-${convertToSlug(server.label)}"
+                    slot="page-${formatSlug(server.label)}"
                     data-tab-title="${server.label}"
                     class="pf-c-page__main-section pf-m-no-padding-mobile ak-markdown-section"
                 >

--- a/web/src/admin/providers/rac/EndpointForm.ts
+++ b/web/src/admin/providers/rac/EndpointForm.ts
@@ -1,5 +1,4 @@
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/components/ak-radio-input";
 import "@goauthentik/elements/CodeMirror";
 import "@goauthentik/elements/ak-dual-select/ak-dual-select-dynamic-selected-provider.js";
@@ -99,7 +98,7 @@ export class EndpointForm extends ModelForm<Endpoint, string> {
             >
                 <input
                     type="number"
-                    value="${first(this.instance?.maximumConnections, 1)}"
+                    value="${this.instance?.maximumConnections ?? 1}"
                     class="pf-c-form-control"
                     required
                 />
@@ -123,7 +122,7 @@ export class EndpointForm extends ModelForm<Endpoint, string> {
                     <ak-form-element-horizontal label=${msg("Settings")} name="settings">
                         <ak-codemirror
                             mode="yaml"
-                            value="${YAML.stringify(first(this.instance?.settings, {}))}"
+                            value="${YAML.stringify(this.instance?.settings ?? {})}"
                         >
                         </ak-codemirror>
                         <p class="pf-c-form__helper-text">${msg("Connection settings.")}</p>

--- a/web/src/admin/providers/rac/RACProviderForm.ts
+++ b/web/src/admin/providers/rac/RACProviderForm.ts
@@ -1,7 +1,6 @@
 import "@goauthentik/admin/common/ak-crypto-certificate-search";
 import "@goauthentik/admin/common/ak-flow-search/ak-branded-flow-search";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/CodeMirror";
 import "@goauthentik/elements/ak-dual-select/ak-dual-select-dynamic-selected-provider.js";
 import "@goauthentik/elements/forms/FormGroup";
@@ -82,7 +81,7 @@ export class RACProviderFormPage extends ModelForm<RACProvider, number> {
             >
                 <input
                     type="text"
-                    value="${first(this.instance?.connectionExpiry, "hours=8")}"
+                    value="${this.instance?.connectionExpiry ?? "hours=8"}"
                     class="pf-c-form-control pf-m-monospace"
                     autocomplete="off"
                     spellcheck="false"
@@ -100,7 +99,7 @@ export class RACProviderFormPage extends ModelForm<RACProvider, number> {
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.deleteTokenOnDisconnect, false)}
+                        ?checked=${this.instance?.deleteTokenOnDisconnect ?? false}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">
@@ -135,7 +134,7 @@ export class RACProviderFormPage extends ModelForm<RACProvider, number> {
                     <ak-form-element-horizontal label=${msg("Settings")} name="settings">
                         <ak-codemirror
                             mode="yaml"
-                            value="${YAML.stringify(first(this.instance?.settings, {}))}"
+                            value="${YAML.stringify(this.instance?.settings ?? {})}"
                         >
                         </ak-codemirror>
                         <p class="pf-c-form__helper-text">${msg("Connection settings.")}</p>

--- a/web/src/admin/providers/radius/RadiusProviderFormForm.ts
+++ b/web/src/admin/providers/radius/RadiusProviderFormForm.ts
@@ -1,6 +1,6 @@
 import "@goauthentik/admin/common/ak-flow-search/ak-branded-flow-search";
 import "@goauthentik/admin/common/ak-flow-search/ak-flow-search";
-import { ascii_letters, digits, first, randomString } from "@goauthentik/common/utils";
+import { ascii_letters, digits, randomString } from "@goauthentik/common/utils";
 import "@goauthentik/elements/forms/FormGroup";
 import "@goauthentik/elements/forms/HorizontalFormElement";
 import "@goauthentik/elements/forms/SearchSelect";
@@ -78,17 +78,14 @@ export function renderForm(
                     name="sharedSecret"
                     label=${msg("Shared secret")}
                     .errorMessages=${errors?.sharedSecret ?? []}
-                    value=${first(
-                        provider?.sharedSecret,
-                        randomString(128, ascii_letters + digits),
-                    )}
+                    value=${provider?.sharedSecret ?? randomString(128, ascii_letters + digits)}
                     required
                     inputHint="code"
                 ></ak-text-input>
                 <ak-text-input
                     name="clientNetworks"
                     label=${msg("Client Networks")}
-                    value=${first(provider?.clientNetworks, "0.0.0.0/0, ::/0")}
+                    value=${provider?.clientNetworks ?? "0.0.0.0/0, ::/0"}
                     .errorMessages=${errors?.clientNetworks ?? []}
                     required
                     help=${clientNetworksHelp}

--- a/web/src/admin/providers/scim/SCIMProviderFormForm.ts
+++ b/web/src/admin/providers/scim/SCIMProviderFormForm.ts
@@ -1,5 +1,4 @@
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/ak-dual-select/ak-dual-select-dynamic-selected-provider.js";
 import "@goauthentik/elements/forms/FormGroup";
 import "@goauthentik/elements/forms/HorizontalFormElement";
@@ -37,7 +36,7 @@ export function renderForm(provider?: Partial<SCIMProvider>, errors: ValidationE
                 <ak-text-input
                     name="url"
                     label=${msg("URL")}
-                    value="${first(provider?.url, "")}"
+                    value="${provider?.url ?? ""}"
                     .errorMessages=${errors?.url ?? []}
                     required
                     help=${msg("SCIM base url, usually ends in /v2.")}
@@ -96,7 +95,7 @@ export function renderForm(provider?: Partial<SCIMProvider>, errors: ValidationE
                         <input
                             class="pf-c-switch__input"
                             type="checkbox"
-                            ?checked=${first(provider?.dryRun, false)}
+                            ?checked=${provider?.dryRun ?? false}
                         />
                         <span class="pf-c-switch__toggle">
                             <span class="pf-c-switch__toggle-icon">
@@ -119,7 +118,7 @@ export function renderForm(provider?: Partial<SCIMProvider>, errors: ValidationE
                 <ak-switch-input
                     name="excludeUsersServiceAccount"
                     label=${msg("Exclude service accounts")}
-                    ?checked=${first(provider?.excludeUsersServiceAccount, true)}
+                    ?checked=${provider?.excludeUsersServiceAccount ?? true}
                 >
                 </ak-switch-input>
 

--- a/web/src/admin/providers/ssf/SSFProviderFormPage.ts
+++ b/web/src/admin/providers/ssf/SSFProviderFormPage.ts
@@ -5,7 +5,6 @@ import {
     oauth2ProvidersSelector,
 } from "@goauthentik/admin/providers/oauth2/OAuth2ProvidersProvider";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/components/ak-text-input";
 import "@goauthentik/elements/ak-dual-select/ak-dual-select-dynamic-selected-provider.js";
 import "@goauthentik/elements/ak-dual-select/ak-dual-select-provider.js";
@@ -81,7 +80,7 @@ export class SSFProviderFormPage extends BaseProviderForm<SSFProvider> {
                     >
                         <input
                             type="text"
-                            value="${first(provider?.eventRetention, "days=30")}"
+                            value="${provider?.eventRetention ?? "days=30"}"
                             class="pf-c-form-control"
                             required
                         />

--- a/web/src/admin/sources/kerberos/KerberosSourceForm.ts
+++ b/web/src/admin/sources/kerberos/KerberosSourceForm.ts
@@ -6,7 +6,6 @@ import {
     UserMatchingModeToLabel,
 } from "@goauthentik/admin/sources/oauth/utils";
 import { DEFAULT_CONFIG, config } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/components/ak-switch-input";
 import "@goauthentik/components/ak-text-input";
 import "@goauthentik/components/ak-textarea-input";
@@ -97,12 +96,12 @@ export class KerberosSourceForm extends WithCapabilitiesConfig(BaseSourceForm<Ke
             ></ak-text-input>
             <ak-switch-input
                 name="enabled"
-                ?checked=${first(this.instance?.enabled, true)}
+                ?checked=${this.instance?.enabled ?? true}
                 label=${msg("Enabled")}
             ></ak-switch-input>
             <ak-switch-input
                 name="passwordLoginUpdateInternalPassword"
-                ?checked=${first(this.instance?.passwordLoginUpdateInternalPassword, false)}
+                ?checked=${this.instance?.passwordLoginUpdateInternalPassword ?? false}
                 label=${msg("Update internal password on login")}
                 help=${msg(
                     "When the user logs in to authentik using this source password backend, update their credentials in authentik.",
@@ -110,12 +109,12 @@ export class KerberosSourceForm extends WithCapabilitiesConfig(BaseSourceForm<Ke
             ></ak-switch-input>
             <ak-switch-input
                 name="syncUsers"
-                ?checked=${first(this.instance?.syncUsers, true)}
+                ?checked=${this.instance?.syncUsers ?? true}
                 label=${msg("Sync users")}
             ></ak-switch-input>
             <ak-switch-input
                 name="syncUsersPassword"
-                ?checked=${first(this.instance?.syncUsersPassword, true)}
+                ?checked=${this.instance?.syncUsersPassword ?? true}
                 label=${msg("User password writeback")}
                 help=${msg(
                     "Enable this option to write password changes made in authentik back to Kerberos. Ignored if sync is disabled.",
@@ -395,10 +394,8 @@ export class KerberosSourceForm extends WithCapabilitiesConfig(BaseSourceForm<Ke
                     <ak-text-input
                         name="userPathTemplate"
                         label=${msg("User path")}
-                        value=${first(
-                            this.instance?.userPathTemplate,
-                            "goauthentik.io/sources/%(slug)s",
-                        )}
+                        value=${this.instance?.userPathTemplate ??
+                        "goauthentik.io/sources/%(slug)s"}
                         help=${placeholderHelperText}
                     ></ak-text-input>
                 </div>
@@ -443,7 +440,7 @@ export class KerberosSourceForm extends WithCapabilitiesConfig(BaseSourceForm<Ke
                     : html`<ak-form-element-horizontal label=${msg("Icon")} name="icon">
                           <input
                               type="text"
-                              value="${first(this.instance?.icon, "")}"
+                              value="${this.instance?.icon ?? ""}"
                               class="pf-c-form-control"
                           />
                           <p class="pf-c-form__helper-text">${iconHelperText}</p>

--- a/web/src/admin/sources/ldap/LDAPSourceForm.ts
+++ b/web/src/admin/sources/ldap/LDAPSourceForm.ts
@@ -2,7 +2,6 @@ import "@goauthentik/admin/common/ak-crypto-certificate-search";
 import { placeholderHelperText } from "@goauthentik/admin/helperText";
 import { BaseSourceForm } from "@goauthentik/admin/sources/BaseSourceForm";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/ak-dual-select/ak-dual-select-dynamic-selected-provider.js";
 import "@goauthentik/elements/forms/FormGroup";
 import "@goauthentik/elements/forms/HorizontalFormElement";
@@ -67,7 +66,7 @@ export class LDAPSourceForm extends BaseSourceForm<LDAPSource> {
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.enabled, true)}
+                        ?checked=${this.instance?.enabled ?? true}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">
@@ -82,7 +81,7 @@ export class LDAPSourceForm extends BaseSourceForm<LDAPSource> {
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.passwordLoginUpdateInternalPassword, false)}
+                        ?checked=${this.instance?.passwordLoginUpdateInternalPassword ?? false}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">
@@ -104,7 +103,7 @@ export class LDAPSourceForm extends BaseSourceForm<LDAPSource> {
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.syncUsers, true)}
+                        ?checked=${this.instance?.syncUsers ?? true}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">
@@ -119,7 +118,7 @@ export class LDAPSourceForm extends BaseSourceForm<LDAPSource> {
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.syncUsersPassword, true)}
+                        ?checked=${this.instance?.syncUsersPassword ?? true}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">
@@ -139,7 +138,7 @@ export class LDAPSourceForm extends BaseSourceForm<LDAPSource> {
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.syncGroups, true)}
+                        ?checked=${this.instance?.syncGroups ?? true}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">
@@ -173,7 +172,7 @@ export class LDAPSourceForm extends BaseSourceForm<LDAPSource> {
                             <input
                                 class="pf-c-switch__input"
                                 type="checkbox"
-                                ?checked=${first(this.instance?.startTls, true)}
+                                ?checked=${this.instance?.startTls ?? true}
                             />
                             <span class="pf-c-switch__toggle">
                                 <span class="pf-c-switch__toggle-icon">
@@ -191,7 +190,7 @@ export class LDAPSourceForm extends BaseSourceForm<LDAPSource> {
                             <input
                                 class="pf-c-switch__input"
                                 type="checkbox"
-                                ?checked=${first(this.instance?.sni, false)}
+                                ?checked=${this.instance?.sni ?? false}
                             />
                             <span class="pf-c-switch__toggle">
                                 <span class="pf-c-switch__toggle-icon">
@@ -335,10 +334,8 @@ export class LDAPSourceForm extends BaseSourceForm<LDAPSource> {
                     <ak-form-element-horizontal label=${msg("User path")} name="userPathTemplate">
                         <input
                             type="text"
-                            value="${first(
-                                this.instance?.userPathTemplate,
-                                "goauthentik.io/sources/%(slug)s",
-                            )}"
+                            value="${this.instance?.userPathTemplate ??
+                            "goauthentik.io/sources/%(slug)s"}"
                             class="pf-c-form-control"
                         />
                         <p class="pf-c-form__helper-text">${placeholderHelperText}</p>
@@ -421,7 +418,7 @@ export class LDAPSourceForm extends BaseSourceForm<LDAPSource> {
                             <input
                                 class="pf-c-switch__input"
                                 type="checkbox"
-                                ?checked=${first(this.instance?.lookupGroupsFromUser, false)}
+                                ?checked=${this.instance?.lookupGroupsFromUser ?? false}
                             />
                             <span class="pf-c-switch__toggle">
                                 <span class="pf-c-switch__toggle-icon">

--- a/web/src/admin/sources/oauth/OAuthSourceForm.ts
+++ b/web/src/admin/sources/oauth/OAuthSourceForm.ts
@@ -6,7 +6,6 @@ import {
     UserMatchingModeToLabel,
 } from "@goauthentik/admin/sources/oauth/utils";
 import { DEFAULT_CONFIG, config } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/components/ak-radio-input";
 import "@goauthentik/elements/CodeMirror";
 import { CodeMirrorMode } from "@goauthentik/elements/CodeMirror";
@@ -136,11 +135,9 @@ export class OAuthSourceForm extends WithCapabilitiesConfig(BaseSourceForm<OAuth
                 >
                     <input
                         type="text"
-                        value="${first(
-                            this.instance?.authorizationUrl,
-                            this.providerType.authorizationUrl,
-                            "",
-                        )}"
+                        value="${this.instance?.authorizationUrl ??
+                        this.providerType.authorizationUrl ??
+                        ""}"
                         class="pf-c-form-control pf-m-monospace"
                         autocomplete="off"
                         spellcheck="false"
@@ -152,11 +149,9 @@ export class OAuthSourceForm extends WithCapabilitiesConfig(BaseSourceForm<OAuth
                 <ak-form-element-horizontal label=${msg("Access token URL")} name="accessTokenUrl">
                     <input
                         type="url"
-                        value="${first(
-                            this.instance?.accessTokenUrl,
-                            this.providerType.accessTokenUrl,
-                            "",
-                        )}"
+                        value="${this.instance?.accessTokenUrl ??
+                        this.providerType.accessTokenUrl ??
+                        ""}"
                         class="pf-c-form-control pf-m-monospace"
                         autocomplete="off"
                         spellcheck="false"
@@ -168,11 +163,7 @@ export class OAuthSourceForm extends WithCapabilitiesConfig(BaseSourceForm<OAuth
                 <ak-form-element-horizontal label=${msg("Profile URL")} name="profileUrl">
                     <input
                         type="url"
-                        value="${first(
-                            this.instance?.profileUrl,
-                            this.providerType.profileUrl,
-                            "",
-                        )}"
+                        value="${this.instance?.profileUrl ?? this.providerType.profileUrl ?? ""}"
                         class="pf-c-form-control pf-m-monospace"
                         autocomplete="off"
                         spellcheck="false"
@@ -188,7 +179,7 @@ export class OAuthSourceForm extends WithCapabilitiesConfig(BaseSourceForm<OAuth
                       >
                           <input
                               type="url"
-                              value="${first(this.instance?.requestTokenUrl, "")}"
+                              value="${this.instance?.requestTokenUrl ?? ""}"
                               class="pf-c-form-control pf-m-monospace"
                               autocomplete="off"
                           />
@@ -207,11 +198,9 @@ export class OAuthSourceForm extends WithCapabilitiesConfig(BaseSourceForm<OAuth
                       >
                           <input
                               type="url"
-                              value="${first(
-                                  this.instance?.oidcWellKnownUrl,
-                                  this.providerType.oidcWellKnownUrl,
-                                  "",
-                              )}"
+                              value="${this.instance?.oidcWellKnownUrl ??
+                              this.providerType.oidcWellKnownUrl ??
+                              ""}"
                               class="pf-c-form-control pf-m-monospace"
                               autocomplete="off"
                               spellcheck="false"
@@ -231,11 +220,9 @@ export class OAuthSourceForm extends WithCapabilitiesConfig(BaseSourceForm<OAuth
                           >
                               <input
                                   type="url"
-                                  value="${first(
-                                      this.instance?.oidcJwksUrl,
-                                      this.providerType.oidcJwksUrl,
-                                      "",
-                                  )}"
+                                  value="${this.instance?.oidcJwksUrl ??
+                                  this.providerType.oidcJwksUrl ??
+                                  ""}"
                                   class="pf-c-form-control pf-m-monospace"
                                   autocomplete="off"
                                   spellcheck="false"
@@ -249,7 +236,7 @@ export class OAuthSourceForm extends WithCapabilitiesConfig(BaseSourceForm<OAuth
                           <ak-form-element-horizontal label=${msg("OIDC JWKS")} name="oidcJwks">
                               <ak-codemirror
                                   mode=${CodeMirrorMode.JavaScript}
-                                  value="${JSON.stringify(first(this.instance?.oidcJwks, {}))}"
+                                  value="${JSON.stringify(this.instance?.oidcJwks ?? {})}"
                               >
                               </ak-codemirror>
                               <p class="pf-c-form__helper-text">${msg("Raw JWKS data.")}</p>
@@ -296,7 +283,7 @@ export class OAuthSourceForm extends WithCapabilitiesConfig(BaseSourceForm<OAuth
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.enabled, true)}
+                        ?checked=${this.instance?.enabled ?? true}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">
@@ -381,10 +368,7 @@ export class OAuthSourceForm extends WithCapabilitiesConfig(BaseSourceForm<OAuth
             <ak-form-element-horizontal label=${msg("User path")} name="userPathTemplate">
                 <input
                     type="text"
-                    value="${first(
-                        this.instance?.userPathTemplate,
-                        "goauthentik.io/sources/%(slug)s",
-                    )}"
+                    value="${this.instance?.userPathTemplate ?? "goauthentik.io/sources/%(slug)s"}"
                     class="pf-c-form-control pf-m-monospace"
                     autocomplete="off"
                     spellcheck="false"
@@ -432,7 +416,7 @@ export class OAuthSourceForm extends WithCapabilitiesConfig(BaseSourceForm<OAuth
                 : html`<ak-form-element-horizontal label=${msg("Icon")} name="icon">
                       <input
                           type="text"
-                          value="${first(this.instance?.icon, "")}"
+                          value="${this.instance?.icon ?? ""}"
                           class="pf-c-form-control pf-m-monospace"
                           autocomplete="off"
                           spellcheck="false"
@@ -474,7 +458,7 @@ export class OAuthSourceForm extends WithCapabilitiesConfig(BaseSourceForm<OAuth
                     <ak-form-element-horizontal label=${msg("Scopes")} name="additionalScopes">
                         <input
                             type="text"
-                            value="${first(this.instance?.additionalScopes, "")}"
+                            value="${this.instance?.additionalScopes ?? ""}"
                             class="pf-c-form-control pf-m-monospace"
                             autocomplete="off"
                             spellcheck="false"

--- a/web/src/admin/sources/plex/PlexSourceForm.ts
+++ b/web/src/admin/sources/plex/PlexSourceForm.ts
@@ -7,7 +7,7 @@ import {
 } from "@goauthentik/admin/sources/oauth/utils";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
 import { PlexAPIClient, PlexResource, popupCenterScreen } from "@goauthentik/common/helpers/plex";
-import { ascii_letters, digits, first, randomString } from "@goauthentik/common/utils";
+import { ascii_letters, digits, randomString } from "@goauthentik/common/utils";
 import {
     CapabilitiesEnum,
     WithCapabilitiesConfig,
@@ -137,7 +137,7 @@ export class PlexSourceForm extends WithCapabilitiesConfig(BaseSourceForm<PlexSo
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.allowFriends, true)}
+                        ?checked=${this.instance?.allowFriends ?? true}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">
@@ -198,7 +198,7 @@ export class PlexSourceForm extends WithCapabilitiesConfig(BaseSourceForm<PlexSo
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.enabled, true)}
+                        ?checked=${this.instance?.enabled ?? true}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">
@@ -283,10 +283,7 @@ export class PlexSourceForm extends WithCapabilitiesConfig(BaseSourceForm<PlexSo
             <ak-form-element-horizontal label=${msg("User path")} name="userPathTemplate">
                 <input
                     type="text"
-                    value="${first(
-                        this.instance?.userPathTemplate,
-                        "goauthentik.io/sources/%(slug)s",
-                    )}"
+                    value="${this.instance?.userPathTemplate ?? "goauthentik.io/sources/%(slug)s"}"
                     class="pf-c-form-control"
                 />
                 <p class="pf-c-form__helper-text">${placeholderHelperText}</p>
@@ -332,7 +329,7 @@ export class PlexSourceForm extends WithCapabilitiesConfig(BaseSourceForm<PlexSo
                 : html`<ak-form-element-horizontal label=${msg("Icon")} name="icon">
                       <input
                           type="text"
-                          value="${first(this.instance?.icon, "")}"
+                          value="${this.instance?.icon ?? ""}"
                           class="pf-c-form-control"
                       />
                       <p class="pf-c-form__helper-text">${iconHelperText}</p>
@@ -347,7 +344,7 @@ export class PlexSourceForm extends WithCapabilitiesConfig(BaseSourceForm<PlexSo
                     >
                         <input
                             type="text"
-                            value="${first(this.instance?.clientId, "")}"
+                            value="${this.instance?.clientId ?? ""}"
                             class="pf-c-form-control"
                             required
                         />

--- a/web/src/admin/sources/saml/SAMLSourceForm.ts
+++ b/web/src/admin/sources/saml/SAMLSourceForm.ts
@@ -7,7 +7,6 @@ import {
     UserMatchingModeToLabel,
 } from "@goauthentik/admin/sources/oauth/utils";
 import { DEFAULT_CONFIG, config } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import {
     CapabilitiesEnum,
     WithCapabilitiesConfig,
@@ -105,7 +104,7 @@ export class SAMLSourceForm extends WithCapabilitiesConfig(BaseSourceForm<SAMLSo
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.enabled, true)}
+                        ?checked=${this.instance?.enabled ?? true}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">
@@ -228,7 +227,7 @@ export class SAMLSourceForm extends WithCapabilitiesConfig(BaseSourceForm<SAMLSo
                 : html`<ak-form-element-horizontal label=${msg("Icon")} name="icon">
                       <input
                           type="text"
-                          value="${first(this.instance?.icon, "")}"
+                          value="${this.instance?.icon ?? ""}"
                           class="pf-c-form-control"
                       />
                       <p class="pf-c-form__helper-text">${iconHelperText}</p>
@@ -334,7 +333,7 @@ export class SAMLSourceForm extends WithCapabilitiesConfig(BaseSourceForm<SAMLSo
                             <input
                                 class="pf-c-switch__input"
                                 type="checkbox"
-                                ?checked=${first(this.instance?.allowIdpInitiated, false)}
+                                ?checked=${this.instance?.allowIdpInitiated ?? false}
                             />
                             <span class="pf-c-switch__toggle">
                                 <span class="pf-c-switch__toggle-icon">
@@ -397,10 +396,8 @@ export class SAMLSourceForm extends WithCapabilitiesConfig(BaseSourceForm<SAMLSo
                     <ak-form-element-horizontal label=${msg("User path")} name="userPathTemplate">
                         <input
                             type="text"
-                            value="${first(
-                                this.instance?.userPathTemplate,
-                                "goauthentik.io/sources/%(slug)s",
-                            )}"
+                            value="${this.instance?.userPathTemplate ??
+                            "goauthentik.io/sources/%(slug)s"}"
                             class="pf-c-form-control"
                         />
                         <p class="pf-c-form__helper-text">${placeholderHelperText}</p>

--- a/web/src/admin/sources/scim/SCIMSourceForm.ts
+++ b/web/src/admin/sources/scim/SCIMSourceForm.ts
@@ -1,7 +1,6 @@
 import { placeholderHelperText } from "@goauthentik/admin/helperText";
 import { BaseSourceForm } from "@goauthentik/admin/sources/BaseSourceForm";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/ak-dual-select/ak-dual-select-dynamic-selected-provider.js";
 import "@goauthentik/elements/forms/FormGroup";
 import "@goauthentik/elements/forms/HorizontalFormElement";
@@ -63,7 +62,7 @@ export class SCIMSourceForm extends BaseSourceForm<SCIMSource> {
                     <input
                         type="checkbox"
                         class="pf-c-check__input"
-                        ?checked=${first(this.instance?.enabled, true)}
+                        ?checked=${this.instance?.enabled ?? true}
                     />
                     <label class="pf-c-check__label"> ${msg("Enabled")} </label>
                 </div>
@@ -111,10 +110,8 @@ export class SCIMSourceForm extends BaseSourceForm<SCIMSource> {
                     <ak-form-element-horizontal label=${msg("User path")} name="userPathTemplate">
                         <input
                             type="text"
-                            value="${first(
-                                this.instance?.userPathTemplate,
-                                "goauthentik.io/sources/%(slug)s",
-                            )}"
+                            value="${this.instance?.userPathTemplate ??
+                            "goauthentik.io/sources/%(slug)s"}"
                             class="pf-c-form-control"
                         />
                         <p class="pf-c-form__helper-text">${placeholderHelperText}</p>

--- a/web/src/admin/stages/authenticator_duo/AuthenticatorDuoStageForm.ts
+++ b/web/src/admin/stages/authenticator_duo/AuthenticatorDuoStageForm.ts
@@ -1,7 +1,6 @@
 import { RenderFlowOption } from "@goauthentik/admin/flows/utils";
 import { BaseStageForm } from "@goauthentik/admin/stages/BaseStageForm";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/forms/FormGroup";
 import "@goauthentik/elements/forms/HorizontalFormElement";
 import "@goauthentik/elements/forms/SearchSelect";
@@ -50,7 +49,7 @@ export class AuthenticatorDuoStageForm extends BaseStageForm<AuthenticatorDuoSta
             <ak-form-element-horizontal label=${msg("Name")} ?required=${true} name="name">
                 <input
                     type="text"
-                    value="${first(this.instance?.name, "")}"
+                    value="${this.instance?.name ?? ""}"
                     class="pf-c-form-control"
                     required
                 />
@@ -62,7 +61,7 @@ export class AuthenticatorDuoStageForm extends BaseStageForm<AuthenticatorDuoSta
             >
                 <input
                     type="text"
-                    value="${first(this.instance?.friendlyName, "")}"
+                    value="${this.instance?.friendlyName ?? ""}"
                     class="pf-c-form-control"
                 />
                 <p class="pf-c-form__helper-text">
@@ -78,7 +77,7 @@ export class AuthenticatorDuoStageForm extends BaseStageForm<AuthenticatorDuoSta
             >
                 <input
                     type="text"
-                    value="${first(this.instance?.apiHostname, "")}"
+                    value="${this.instance?.apiHostname ?? ""}"
                     class="pf-c-form-control pf-m-monospace"
                     autocomplete="off"
                     spellcheck="false"
@@ -95,7 +94,7 @@ export class AuthenticatorDuoStageForm extends BaseStageForm<AuthenticatorDuoSta
                     >
                         <input
                             type="text"
-                            value="${first(this.instance?.clientId, "")}"
+                            value="${this.instance?.clientId ?? ""}"
                             class="pf-c-form-control"
                             required
                         />
@@ -132,7 +131,7 @@ export class AuthenticatorDuoStageForm extends BaseStageForm<AuthenticatorDuoSta
                     >
                         <input
                             type="text"
-                            value="${first(this.instance?.adminIntegrationKey, "")}"
+                            value="${this.instance?.adminIntegrationKey ?? ""}"
                             class="pf-c-form-control pf-m-monospace"
                             autocomplete="off"
                             spellcheck="false"

--- a/web/src/admin/stages/authenticator_email/AuthenticatorEmailStageForm.ts
+++ b/web/src/admin/stages/authenticator_email/AuthenticatorEmailStageForm.ts
@@ -1,7 +1,6 @@
 import { RenderFlowOption } from "@goauthentik/admin/flows/utils";
 import { BaseStageForm } from "@goauthentik/admin/stages/BaseStageForm";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/forms/FormGroup";
 import "@goauthentik/elements/forms/HorizontalFormElement";
 import "@goauthentik/elements/forms/Radio";
@@ -65,7 +64,7 @@ export class AuthenticatorEmailStageForm extends BaseStageForm<AuthenticatorEmai
                 <ak-form-element-horizontal label=${msg("SMTP Port")} ?required=${true} name="port">
                     <input
                         type="number"
-                        value="${first(this.instance?.port, 25)}"
+                        value="${this.instance?.port ?? 25}"
                         class="pf-c-form-control"
                         required
                     />
@@ -89,7 +88,7 @@ export class AuthenticatorEmailStageForm extends BaseStageForm<AuthenticatorEmai
                         <input
                             class="pf-c-switch__input"
                             type="checkbox"
-                            ?checked=${first(this.instance?.useTls, true)}
+                            ?checked=${this.instance?.useTls ?? true}
                         />
                         <span class="pf-c-switch__toggle">
                             <span class="pf-c-switch__toggle-icon">
@@ -104,7 +103,7 @@ export class AuthenticatorEmailStageForm extends BaseStageForm<AuthenticatorEmai
                         <input
                             class="pf-c-switch__input"
                             type="checkbox"
-                            ?checked=${first(this.instance?.useSsl, false)}
+                            ?checked=${this.instance?.useSsl ?? false}
                         />
                         <span class="pf-c-switch__toggle">
                             <span class="pf-c-switch__toggle-icon">
@@ -121,7 +120,7 @@ export class AuthenticatorEmailStageForm extends BaseStageForm<AuthenticatorEmai
                 >
                     <input
                         type="number"
-                        value="${first(this.instance?.timeout, 30)}"
+                        value="${this.instance?.timeout ?? 30}"
                         class="pf-c-form-control"
                         required
                     />
@@ -150,7 +149,7 @@ export class AuthenticatorEmailStageForm extends BaseStageForm<AuthenticatorEmai
             <ak-form-element-horizontal label=${msg("Name")} ?required=${true} name="name">
                 <input
                     type="text"
-                    value="${first(this.instance?.name, "")}"
+                    value="${this.instance?.name ?? ""}"
                     class="pf-c-form-control"
                     required
                 />
@@ -162,7 +161,7 @@ export class AuthenticatorEmailStageForm extends BaseStageForm<AuthenticatorEmai
             >
                 <input
                     type="text"
-                    value="${first(this.instance?.friendlyName, "")}"
+                    value="${this.instance?.friendlyName ?? ""}"
                     class="pf-c-form-control"
                 />
                 <p class="pf-c-form__helper-text">
@@ -176,7 +175,7 @@ export class AuthenticatorEmailStageForm extends BaseStageForm<AuthenticatorEmai
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.useGlobalSettings, true)}
+                        ?checked=${this.instance?.useGlobalSettings ?? true}
                         @change=${(ev: Event) => {
                             const target = ev.target as HTMLInputElement;
                             this.showConnectionSettings = !target.checked;
@@ -206,7 +205,7 @@ export class AuthenticatorEmailStageForm extends BaseStageForm<AuthenticatorEmai
                     >
                         <input
                             type="text"
-                            value="${first(this.instance?.subject, "authentik Sign-in code")}"
+                            value="${this.instance?.subject ?? "authentik Sign-in code"}"
                             class="pf-c-form-control"
                             required
                         />
@@ -221,7 +220,7 @@ export class AuthenticatorEmailStageForm extends BaseStageForm<AuthenticatorEmai
                     >
                         <input
                             type="text"
-                            value="${first(this.instance?.tokenExpiry, "minutes=15")}"
+                            value="${this.instance?.tokenExpiry ?? "minutes=15"}"
                             class="pf-c-form-control"
                             required
                         />

--- a/web/src/admin/stages/authenticator_endpoint_gdtc/AuthenticatorEndpointGDTCStageForm.ts
+++ b/web/src/admin/stages/authenticator_endpoint_gdtc/AuthenticatorEndpointGDTCStageForm.ts
@@ -1,6 +1,5 @@
 import { BaseStageForm } from "@goauthentik/admin/stages/BaseStageForm";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/CodeMirror";
 import { CodeMirrorMode } from "@goauthentik/elements/CodeMirror";
 import "@goauthentik/elements/forms/FormGroup";
@@ -52,7 +51,7 @@ export class AuthenticatorEndpointGDTCStageForm extends BaseStageForm<Authentica
             <ak-form-element-horizontal label=${msg("Name")} required name="name">
                 <input
                     type="text"
-                    value="${first(this.instance?.name, "")}"
+                    value="${this.instance?.name ?? ""}"
                     class="pf-c-form-control"
                     required
                 />
@@ -67,7 +66,7 @@ export class AuthenticatorEndpointGDTCStageForm extends BaseStageForm<Authentica
                     >
                         <ak-codemirror
                             mode=${CodeMirrorMode.JavaScript}
-                            .value="${first(this.instance?.credentials, {})}"
+                            .value="${this.instance?.credentials ?? {}}"
                         ></ak-codemirror>
                         <p class="pf-c-form__helper-text">
                             ${msg("Google Cloud credentials file.")}

--- a/web/src/admin/stages/authenticator_sms/AuthenticatorSMSStageForm.ts
+++ b/web/src/admin/stages/authenticator_sms/AuthenticatorSMSStageForm.ts
@@ -1,7 +1,6 @@
 import { RenderFlowOption } from "@goauthentik/admin/flows/utils";
 import { BaseStageForm } from "@goauthentik/admin/stages/BaseStageForm";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/forms/FormGroup";
 import "@goauthentik/elements/forms/HorizontalFormElement";
 import "@goauthentik/elements/forms/Radio";
@@ -66,7 +65,7 @@ export class AuthenticatorSMSStageForm extends BaseStageForm<AuthenticatorSMSSta
             >
                 <input
                     type="text"
-                    value="${first(this.instance?.accountSid, "")}"
+                    value="${this.instance?.accountSid ?? ""}"
                     class="pf-c-form-control pf-m-monospace"
                     autocomplete="off"
                     spellcheck="false"
@@ -83,7 +82,7 @@ export class AuthenticatorSMSStageForm extends BaseStageForm<AuthenticatorSMSSta
             >
                 <input
                     type="text"
-                    value="${first(this.instance?.auth, "")}"
+                    value="${this.instance?.auth ?? ""}"
                     class="pf-c-form-control pf-m-monospace"
                     autocomplete="off"
                     spellcheck="false"
@@ -129,7 +128,7 @@ export class AuthenticatorSMSStageForm extends BaseStageForm<AuthenticatorSMSSta
             >
                 <input
                     type="text"
-                    value="${first(this.instance?.accountSid, "")}"
+                    value="${this.instance?.accountSid ?? ""}"
                     class="pf-c-form-control pf-m-monospace"
                     autocomplete="off"
                     spellcheck="false"
@@ -146,7 +145,7 @@ export class AuthenticatorSMSStageForm extends BaseStageForm<AuthenticatorSMSSta
             >
                 <input
                     type="text"
-                    value="${first(this.instance?.auth, "")}"
+                    value="${this.instance?.auth ?? ""}"
                     class="pf-c-form-control pf-m-monospace"
                     autocomplete="off"
                     spellcheck="false"
@@ -164,7 +163,7 @@ export class AuthenticatorSMSStageForm extends BaseStageForm<AuthenticatorSMSSta
             >
                 <input
                     type="text"
-                    value="${first(this.instance?.authPassword, "")}"
+                    value="${this.instance?.authPassword ?? ""}"
                     class="pf-c-form-control pf-m-monospace"
                     autocomplete="off"
                     spellcheck="false"
@@ -215,7 +214,7 @@ export class AuthenticatorSMSStageForm extends BaseStageForm<AuthenticatorSMSSta
             <ak-form-element-horizontal label=${msg("Name")} ?required=${true} name="name">
                 <input
                     type="text"
-                    value="${first(this.instance?.name, "")}"
+                    value="${this.instance?.name ?? ""}"
                     class="pf-c-form-control"
                     required
                 />
@@ -227,7 +226,7 @@ export class AuthenticatorSMSStageForm extends BaseStageForm<AuthenticatorSMSSta
             >
                 <input
                     type="text"
-                    value="${first(this.instance?.friendlyName, "")}"
+                    value="${this.instance?.friendlyName ?? ""}"
                     class="pf-c-form-control"
                 />
                 <p class="pf-c-form__helper-text">
@@ -272,7 +271,7 @@ export class AuthenticatorSMSStageForm extends BaseStageForm<AuthenticatorSMSSta
                     >
                         <input
                             type="text"
-                            value="${first(this.instance?.fromNumber, "")}"
+                            value="${this.instance?.fromNumber ?? ""}"
                             class="pf-c-form-control pf-m-monospace"
                             autocomplete="off"
                             spellcheck="false"
@@ -290,7 +289,7 @@ export class AuthenticatorSMSStageForm extends BaseStageForm<AuthenticatorSMSSta
                             <input
                                 class="pf-c-switch__input"
                                 type="checkbox"
-                                ?checked=${first(this.instance?.verifyOnly, false)}
+                                ?checked=${this.instance?.verifyOnly ?? false}
                             />
                             <span class="pf-c-switch__toggle">
                                 <span class="pf-c-switch__toggle-icon">

--- a/web/src/admin/stages/authenticator_static/AuthenticatorStaticStageForm.ts
+++ b/web/src/admin/stages/authenticator_static/AuthenticatorStaticStageForm.ts
@@ -1,7 +1,6 @@
 import { RenderFlowOption } from "@goauthentik/admin/flows/utils";
 import { BaseStageForm } from "@goauthentik/admin/stages/BaseStageForm";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/forms/HorizontalFormElement";
 import "@goauthentik/elements/forms/SearchSelect";
 
@@ -48,7 +47,7 @@ export class AuthenticatorStaticStageForm extends BaseStageForm<AuthenticatorSta
             <ak-form-element-horizontal label=${msg("Name")} ?required=${true} name="name">
                 <input
                     type="text"
-                    value="${first(this.instance?.name, "")}"
+                    value="${this.instance?.name ?? ""}"
                     class="pf-c-form-control"
                     required
                 />
@@ -60,7 +59,7 @@ export class AuthenticatorStaticStageForm extends BaseStageForm<AuthenticatorSta
             >
                 <input
                     type="text"
-                    value="${first(this.instance?.friendlyName, "")}"
+                    value="${this.instance?.friendlyName ?? ""}"
                     class="pf-c-form-control"
                 />
                 <p class="pf-c-form__helper-text">
@@ -79,7 +78,7 @@ export class AuthenticatorStaticStageForm extends BaseStageForm<AuthenticatorSta
                     >
                         <input
                             type="text"
-                            value="${first(this.instance?.tokenCount, 6)}"
+                            value="${this.instance?.tokenCount ?? 6}"
                             class="pf-c-form-control"
                             required
                         />
@@ -96,7 +95,7 @@ export class AuthenticatorStaticStageForm extends BaseStageForm<AuthenticatorSta
                     >
                         <input
                             type="text"
-                            value="${first(this.instance?.tokenLength, 12)}"
+                            value="${this.instance?.tokenLength ?? 12}"
                             class="pf-c-form-control"
                             required
                         />

--- a/web/src/admin/stages/authenticator_totp/AuthenticatorTOTPStageForm.ts
+++ b/web/src/admin/stages/authenticator_totp/AuthenticatorTOTPStageForm.ts
@@ -1,7 +1,6 @@
 import { RenderFlowOption } from "@goauthentik/admin/flows/utils";
 import { BaseStageForm } from "@goauthentik/admin/stages/BaseStageForm";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/forms/FormGroup";
 import "@goauthentik/elements/forms/HorizontalFormElement";
 import "@goauthentik/elements/forms/SearchSelect";
@@ -50,7 +49,7 @@ export class AuthenticatorTOTPStageForm extends BaseStageForm<AuthenticatorTOTPS
             <ak-form-element-horizontal label=${msg("Name")} ?required=${true} name="name">
                 <input
                     type="text"
-                    value="${first(this.instance?.name, "")}"
+                    value="${this.instance?.name ?? ""}"
                     class="pf-c-form-control"
                     required
                 />
@@ -62,7 +61,7 @@ export class AuthenticatorTOTPStageForm extends BaseStageForm<AuthenticatorTOTPS
             >
                 <input
                     type="text"
-                    value="${first(this.instance?.friendlyName, "")}"
+                    value="${this.instance?.friendlyName ?? ""}"
                     class="pf-c-form-control"
                 />
                 <p class="pf-c-form__helper-text">

--- a/web/src/admin/stages/authenticator_webauthn/AuthenticatorWebAuthnStageForm.ts
+++ b/web/src/admin/stages/authenticator_webauthn/AuthenticatorWebAuthnStageForm.ts
@@ -2,7 +2,6 @@ import { RenderFlowOption } from "@goauthentik/admin/flows/utils";
 import { BaseStageForm } from "@goauthentik/admin/stages/BaseStageForm";
 import { deviceTypeRestrictionPair } from "@goauthentik/admin/stages/authenticator_webauthn/utils";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/ak-dual-select/ak-dual-select-provider";
 import { DataProvision } from "@goauthentik/elements/ak-dual-select/types";
 import "@goauthentik/elements/forms/HorizontalFormElement";
@@ -58,7 +57,7 @@ export class AuthenticatorWebAuthnStageForm extends BaseStageForm<AuthenticatorW
             <ak-form-element-horizontal label=${msg("Name")} ?required=${true} name="name">
                 <input
                     type="text"
-                    value="${first(this.instance?.name, "")}"
+                    value="${this.instance?.name ?? ""}"
                     class="pf-c-form-control"
                     required
                 />
@@ -70,7 +69,7 @@ export class AuthenticatorWebAuthnStageForm extends BaseStageForm<AuthenticatorW
             >
                 <input
                     type="text"
-                    value="${first(this.instance?.friendlyName, "")}"
+                    value="${this.instance?.friendlyName ?? ""}"
                     class="pf-c-form-control"
                 />
                 <p class="pf-c-form__helper-text">

--- a/web/src/admin/stages/captcha/CaptchaStageForm.ts
+++ b/web/src/admin/stages/captcha/CaptchaStageForm.ts
@@ -1,6 +1,5 @@
 import { BaseStageForm } from "@goauthentik/admin/stages/BaseStageForm";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/components/ak-number-input";
 import "@goauthentik/components/ak-switch-input";
 import "@goauthentik/elements/forms/FormGroup";
@@ -118,7 +117,7 @@ export class CaptchaStageForm extends BaseStageForm<CaptchaStage> {
                             <input
                                 class="pf-c-switch__input"
                                 type="checkbox"
-                                ?checked=${first(this.instance?.errorOnInvalidScore, true)}
+                                ?checked=${this.instance?.errorOnInvalidScore ?? true}
                             />
                             <span class="pf-c-switch__toggle">
                                 <span class="pf-c-switch__toggle-icon">

--- a/web/src/admin/stages/dummy/DummyStageForm.ts
+++ b/web/src/admin/stages/dummy/DummyStageForm.ts
@@ -1,6 +1,5 @@
 import { BaseStageForm } from "@goauthentik/admin/stages/BaseStageForm";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/forms/HorizontalFormElement";
 
 import { msg } from "@lit/localize";
@@ -50,7 +49,7 @@ export class DummyStageForm extends BaseStageForm<DummyStage> {
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.throwError, false)}
+                        ?checked=${this.instance?.throwError ?? false}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">

--- a/web/src/admin/stages/email/EmailStageForm.ts
+++ b/web/src/admin/stages/email/EmailStageForm.ts
@@ -1,6 +1,5 @@
 import { BaseStageForm } from "@goauthentik/admin/stages/BaseStageForm";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/forms/FormGroup";
 import "@goauthentik/elements/forms/HorizontalFormElement";
 import "@goauthentik/elements/utils/TimeDeltaHelp";
@@ -62,7 +61,7 @@ export class EmailStageForm extends BaseStageForm<EmailStage> {
                 <ak-form-element-horizontal label=${msg("SMTP Port")} ?required=${true} name="port">
                     <input
                         type="number"
-                        value="${first(this.instance?.port, 25)}"
+                        value="${this.instance?.port ?? 25}"
                         class="pf-c-form-control"
                         required
                     />
@@ -86,7 +85,7 @@ export class EmailStageForm extends BaseStageForm<EmailStage> {
                         <input
                             class="pf-c-switch__input"
                             type="checkbox"
-                            ?checked=${first(this.instance?.useTls, true)}
+                            ?checked=${this.instance?.useTls ?? true}
                         />
                         <span class="pf-c-switch__toggle">
                             <span class="pf-c-switch__toggle-icon">
@@ -101,7 +100,7 @@ export class EmailStageForm extends BaseStageForm<EmailStage> {
                         <input
                             class="pf-c-switch__input"
                             type="checkbox"
-                            ?checked=${first(this.instance?.useSsl, false)}
+                            ?checked=${this.instance?.useSsl ?? false}
                         />
                         <span class="pf-c-switch__toggle">
                             <span class="pf-c-switch__toggle-icon">
@@ -118,7 +117,7 @@ export class EmailStageForm extends BaseStageForm<EmailStage> {
                 >
                     <input
                         type="number"
-                        value="${first(this.instance?.timeout, 30)}"
+                        value="${this.instance?.timeout ?? 30}"
                         class="pf-c-form-control"
                         required
                     />
@@ -161,7 +160,7 @@ export class EmailStageForm extends BaseStageForm<EmailStage> {
                             <input
                                 class="pf-c-switch__input"
                                 type="checkbox"
-                                ?checked=${first(this.instance?.activateUserOnSuccess, true)}
+                                ?checked=${this.instance?.activateUserOnSuccess ?? true}
                             />
                             <span class="pf-c-switch__toggle">
                                 <span class="pf-c-switch__toggle-icon">
@@ -183,7 +182,7 @@ export class EmailStageForm extends BaseStageForm<EmailStage> {
                             <input
                                 class="pf-c-switch__input"
                                 type="checkbox"
-                                ?checked=${first(this.instance?.useGlobalSettings, true)}
+                                ?checked=${this.instance?.useGlobalSettings ?? true}
                                 @change=${(ev: Event) => {
                                     const target = ev.target as HTMLInputElement;
                                     this.showConnectionSettings = !target.checked;
@@ -209,7 +208,7 @@ export class EmailStageForm extends BaseStageForm<EmailStage> {
                     >
                         <input
                             type="text"
-                            value="${first(this.instance?.tokenExpiry, "minutes=30")}"
+                            value="${this.instance?.tokenExpiry ?? "minutes=30"}"
                             class="pf-c-form-control"
                             required
                         />
@@ -225,7 +224,7 @@ export class EmailStageForm extends BaseStageForm<EmailStage> {
                     >
                         <input
                             type="text"
-                            value="${first(this.instance?.subject, "authentik")}"
+                            value="${this.instance?.subject ?? "authentik"}"
                             class="pf-c-form-control"
                             required
                         />

--- a/web/src/admin/stages/identification/IdentificationStageForm.ts
+++ b/web/src/admin/stages/identification/IdentificationStageForm.ts
@@ -1,7 +1,7 @@
 import "@goauthentik/admin/common/ak-flow-search/ak-flow-search";
 import { BaseStageForm } from "@goauthentik/admin/stages/BaseStageForm";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first, groupBy } from "@goauthentik/common/utils";
+import { groupBy } from "@goauthentik/common/utils";
 import "@goauthentik/components/ak-switch-input.js";
 import "@goauthentik/elements/ak-checkbox-group/ak-checkbox-group.js";
 import "@goauthentik/elements/ak-dual-select/ak-dual-select-dynamic-selected-provider.js";
@@ -162,7 +162,7 @@ export class IdentificationStageForm extends BaseStageForm<IdentificationStage> 
                     <ak-switch-input
                         name="caseInsensitiveMatching"
                         label=${msg("Case insensitive matching")}
-                        ?checked=${first(this.instance?.caseInsensitiveMatching, true)}
+                        ?checked=${this.instance?.caseInsensitiveMatching ?? true}
                         help=${msg(
                             "When enabled, user fields are matched regardless of their casing.",
                         )}
@@ -170,7 +170,7 @@ export class IdentificationStageForm extends BaseStageForm<IdentificationStage> 
                     <ak-switch-input
                         name="pretendUserExists"
                         label=${msg("Pretend user exists")}
-                        ?checked=${first(this.instance?.pretendUserExists, true)}
+                        ?checked=${this.instance?.pretendUserExists ?? true}
                         help=${msg(
                             "When enabled, the stage will always accept the given user identifier and continue.",
                         )}
@@ -178,7 +178,7 @@ export class IdentificationStageForm extends BaseStageForm<IdentificationStage> 
                     <ak-switch-input
                         name="showMatchedUser"
                         label=${msg("Show matched user")}
-                        ?checked=${first(this.instance?.showMatchedUser, true)}
+                        ?checked=${this.instance?.showMatchedUser ?? true}
                         help=${msg(
                             "When a valid username/email has been entered, and this option is enabled, the user's username and avatar will be shown. Otherwise, the text that the user entered will be shown.",
                         )}
@@ -218,7 +218,7 @@ export class IdentificationStageForm extends BaseStageForm<IdentificationStage> 
                             <input
                                 class="pf-c-switch__input"
                                 type="checkbox"
-                                ?checked=${first(this.instance?.showSourceLabels, false)}
+                                ?checked=${this.instance?.showSourceLabels ?? false}
                             />
                             <span class="pf-c-switch__toggle">
                                 <span class="pf-c-switch__toggle-icon">

--- a/web/src/admin/stages/invitation/InvitationForm.ts
+++ b/web/src/admin/stages/invitation/InvitationForm.ts
@@ -1,7 +1,6 @@
 import "@goauthentik/admin/common/ak-flow-search/ak-flow-search";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
 import { dateTimeLocal } from "@goauthentik/common/temporal";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/CodeMirror";
 import { CodeMirrorMode } from "@goauthentik/elements/CodeMirror";
 import "@goauthentik/elements/forms/HorizontalFormElement";
@@ -63,7 +62,7 @@ export class InvitationForm extends ModelForm<Invitation, string> {
                     data-type="datetime-local"
                     class="pf-c-form-control"
                     required
-                    value="${dateTimeLocal(first(this.instance?.expires, new Date()))}"
+                    value="${dateTimeLocal(this.instance?.expires ?? new Date())}"
                 />
             </ak-form-element-horizontal>
             <ak-form-element-horizontal label=${msg("Flow")} name="flow">
@@ -80,7 +79,7 @@ export class InvitationForm extends ModelForm<Invitation, string> {
             <ak-form-element-horizontal label=${msg("Custom attributes")} name="fixedData">
                 <ak-codemirror
                     mode=${CodeMirrorMode.YAML}
-                    value="${YAML.stringify(first(this.instance?.fixedData, {}))}"
+                    value="${YAML.stringify(this.instance?.fixedData ?? {})}"
                 >
                 </ak-codemirror>
                 <p class="pf-c-form__helper-text">
@@ -94,7 +93,7 @@ export class InvitationForm extends ModelForm<Invitation, string> {
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.singleUse, true)}
+                        ?checked=${this.instance?.singleUse ?? true}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">

--- a/web/src/admin/stages/invitation/InvitationStageForm.ts
+++ b/web/src/admin/stages/invitation/InvitationStageForm.ts
@@ -1,6 +1,5 @@
 import { BaseStageForm } from "@goauthentik/admin/stages/BaseStageForm";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/forms/FormGroup";
 import "@goauthentik/elements/forms/HorizontalFormElement";
 
@@ -51,10 +50,7 @@ export class InvitationStageForm extends BaseStageForm<InvitationStage> {
                             <input
                                 class="pf-c-switch__input"
                                 type="checkbox"
-                                ?checked=${first(
-                                    this.instance?.continueFlowWithoutInvitation,
-                                    false,
-                                )}
+                                ?checked=${this.instance?.continueFlowWithoutInvitation ?? false}
                             />
                             <span class="pf-c-switch__toggle">
                                 <span class="pf-c-switch__toggle-icon">

--- a/web/src/admin/stages/prompt/PromptForm.ts
+++ b/web/src/admin/stages/prompt/PromptForm.ts
@@ -1,6 +1,5 @@
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
 import { parseAPIResponseError, pluckErrorDetail } from "@goauthentik/common/errors/network";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/CodeMirror";
 import { CodeMirrorMode } from "@goauthentik/elements/CodeMirror";
 import "@goauthentik/elements/forms/HorizontalFormElement";
@@ -269,7 +268,7 @@ export class PromptForm extends ModelForm<Prompt, string> {
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.required, false)}
+                        ?checked=${this.instance?.required ?? false}
                         @change=${() => {
                             this._shouldRefresh = true;
                         }}
@@ -287,7 +286,7 @@ export class PromptForm extends ModelForm<Prompt, string> {
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.placeholderExpression, false)}
+                        ?checked=${this.instance?.placeholderExpression ?? false}
                         @change=${() => {
                             this._shouldRefresh = true;
                         }}
@@ -330,7 +329,7 @@ export class PromptForm extends ModelForm<Prompt, string> {
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.initialValueExpression, false)}
+                        ?checked=${this.instance?.initialValueExpression ?? false}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">
@@ -376,7 +375,7 @@ export class PromptForm extends ModelForm<Prompt, string> {
             <ak-form-element-horizontal label=${msg("Order")} ?required=${true} name="order">
                 <input
                     type="number"
-                    value="${first(this.instance?.order, 0)}"
+                    value="${this.instance?.order ?? 0}"
                     class="pf-c-form-control"
                     required
                 />

--- a/web/src/admin/stages/user_login/UserLoginStageForm.ts
+++ b/web/src/admin/stages/user_login/UserLoginStageForm.ts
@@ -1,6 +1,5 @@
 import { BaseStageForm } from "@goauthentik/admin/stages/BaseStageForm";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/Alert";
 import "@goauthentik/elements/forms/FormGroup";
 import "@goauthentik/elements/forms/HorizontalFormElement";
@@ -38,7 +37,7 @@ export class UserLoginStageForm extends BaseStageForm<UserLoginStage> {
             <ak-form-element-horizontal label=${msg("Name")} ?required=${true} name="name">
                 <input
                     type="text"
-                    value="${first(this.instance?.name, "")}"
+                    value="${this.instance?.name ?? ""}"
                     class="pf-c-form-control"
                     required
                 />
@@ -53,7 +52,7 @@ export class UserLoginStageForm extends BaseStageForm<UserLoginStage> {
                     >
                         <input
                             type="text"
-                            value="${first(this.instance?.sessionDuration, "seconds=0")}"
+                            value="${this.instance?.sessionDuration ?? "seconds=0"}"
                             class="pf-c-form-control pf-m-monospace"
                             autocomplete="off"
                             spellcheck="false"
@@ -84,7 +83,7 @@ export class UserLoginStageForm extends BaseStageForm<UserLoginStage> {
                     >
                         <input
                             type="text"
-                            value="${first(this.instance?.rememberMeOffset, "seconds=0")}"
+                            value="${this.instance?.rememberMeOffset ?? "seconds=0"}"
                             class="pf-c-form-control pf-m-monospace"
                             autocomplete="off"
                             spellcheck="false"
@@ -170,7 +169,7 @@ export class UserLoginStageForm extends BaseStageForm<UserLoginStage> {
                             <input
                                 class="pf-c-switch__input"
                                 type="checkbox"
-                                ?checked=${first(this.instance?.terminateOtherSessions, false)}
+                                ?checked=${this.instance?.terminateOtherSessions ?? false}
                             />
                             <span class="pf-c-switch__toggle">
                                 <span class="pf-c-switch__toggle-icon">

--- a/web/src/admin/stages/user_write/UserWriteStageForm.ts
+++ b/web/src/admin/stages/user_write/UserWriteStageForm.ts
@@ -1,7 +1,6 @@
 import { BaseStageForm } from "@goauthentik/admin/stages/BaseStageForm";
 import { UserCreationModeEnum } from "@goauthentik/api/dist/models/UserCreationModeEnum";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/forms/FormGroup";
 import "@goauthentik/elements/forms/HorizontalFormElement";
 import "@goauthentik/elements/forms/Radio";
@@ -95,7 +94,7 @@ export class UserWriteStageForm extends BaseStageForm<UserWriteStage> {
                             <input
                                 class="pf-c-switch__input"
                                 type="checkbox"
-                                ?checked=${first(this.instance?.createUsersAsInactive, true)}
+                                ?checked=${this.instance?.createUsersAsInactive ?? true}
                             />
                             <span class="pf-c-switch__toggle">
                                 <span class="pf-c-switch__toggle-icon">
@@ -149,7 +148,7 @@ export class UserWriteStageForm extends BaseStageForm<UserWriteStage> {
                     >
                         <input
                             type="text"
-                            value="${first(this.instance?.userPathTemplate, "")}"
+                            value="${this.instance?.userPathTemplate ?? ""}"
                             class="pf-c-form-control pf-m-monospace"
                             autocomplete="off"
                             spellcheck="false"

--- a/web/src/admin/tokens/TokenForm.ts
+++ b/web/src/admin/tokens/TokenForm.ts
@@ -1,6 +1,5 @@
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
 import { dateTimeLocal } from "@goauthentik/common/temporal";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/forms/FormGroup";
 import "@goauthentik/elements/forms/HorizontalFormElement";
 import { ModelForm } from "@goauthentik/elements/forms/ModelForm";
@@ -50,7 +49,7 @@ export class TokenForm extends ModelForm<Token, string> {
             <input
                 type="datetime-local"
                 data-type="datetime-local"
-                value="${dateTimeLocal(first(this.instance?.expires, new Date()))}"
+                value="${dateTimeLocal(this.instance?.expires ?? new Date())}"
                 class="pf-c-form-control"
             />
         </ak-form-element-horizontal>`;
@@ -64,7 +63,7 @@ export class TokenForm extends ModelForm<Token, string> {
             >
                 <input
                     type="text"
-                    value="${first(this.instance?.identifier, "")}"
+                    value="${this.instance?.identifier ?? ""}"
                     class="pf-c-form-control pf-m-monospace"
                     autocomplete="off"
                     spellcheck="false"
@@ -123,7 +122,7 @@ export class TokenForm extends ModelForm<Token, string> {
             <ak-form-element-horizontal label=${msg("Description")} name="description">
                 <input
                     type="text"
-                    value="${first(this.instance?.description, "")}"
+                    value="${this.instance?.description ?? ""}"
                     class="pf-c-form-control"
                 />
             </ak-form-element-horizontal>
@@ -132,7 +131,7 @@ export class TokenForm extends ModelForm<Token, string> {
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.expiring, true)}
+                        ?checked=${this.instance?.expiring ?? true}
                         @change=${(ev: Event) => {
                             const el = ev.target as HTMLInputElement;
                             this.showExpiry = el.checked;

--- a/web/src/admin/users/UserForm.ts
+++ b/web/src/admin/users/UserForm.ts
@@ -1,6 +1,5 @@
 import "@goauthentik/admin/users/GroupSelectModal";
 import { DEFAULT_CONFIG } from "@goauthentik/common/api/config";
-import { first } from "@goauthentik/common/utils";
 import "@goauthentik/elements/CodeMirror";
 import { CodeMirrorMode } from "@goauthentik/elements/CodeMirror";
 import "@goauthentik/elements/forms/HorizontalFormElement";
@@ -159,7 +158,7 @@ export class UserForm extends ModelForm<User, number> {
                     <input
                         class="pf-c-switch__input"
                         type="checkbox"
-                        ?checked=${first(this.instance?.isActive, true)}
+                        ?checked=${this.instance?.isActive ?? true}
                     />
                     <span class="pf-c-switch__toggle">
                         <span class="pf-c-switch__toggle-icon">
@@ -177,7 +176,7 @@ export class UserForm extends ModelForm<User, number> {
             <ak-form-element-horizontal label=${msg("Path")} ?required=${true} name="path">
                 <input
                     type="text"
-                    value="${first(this.instance?.path, this.defaultPath)}"
+                    value="${this.instance?.path ?? this.defaultPath}"
                     class="pf-c-form-control"
                     required
                 />
@@ -190,7 +189,7 @@ export class UserForm extends ModelForm<User, number> {
                 <ak-codemirror
                     mode=${CodeMirrorMode.YAML}
                     value="${YAML.stringify(
-                        first(this.instance?.attributes, UserForm.defaultUserAttributes),
+                        this.instance?.attributes ?? UserForm.defaultUserAttributes,
                     )}"
                 >
                 </ak-codemirror>

--- a/web/src/common/utils.ts
+++ b/web/src/common/utils.ts
@@ -1,5 +1,3 @@
-import { kebabCase } from "change-case";
-
 import { CSSResult, css } from "lit";
 
 export function getCookie(name: string): string {
@@ -16,14 +14,6 @@ export function getCookie(name: string): string {
         }
     }
     return cookieValue;
-}
-
-export function convertToSlug(text: string): string {
-    return kebabCase(text);
-}
-
-export function isSlug(input: string): boolean {
-    return kebabCase(input) === input;
 }
 
 /**

--- a/web/src/common/utils.ts
+++ b/web/src/common/utils.ts
@@ -1,4 +1,4 @@
-import { SentryIgnoredError } from "@goauthentik/common/sentry";
+import { kebabCase } from "change-case";
 
 import { CSSResult, css } from "lit";
 
@@ -19,16 +19,11 @@ export function getCookie(name: string): string {
 }
 
 export function convertToSlug(text: string): string {
-    return text
-        .toLowerCase()
-        .replace(/ /g, "-")
-        .replace(/[^\w-]+/g, "");
+    return kebabCase(text);
 }
 
-export function isSlug(text: string): boolean {
-    const lowered = text.toLowerCase();
-    const forbidden = /([^\w-]|\s)/.test(lowered);
-    return lowered === text && !forbidden;
+export function isSlug(input: string): boolean {
+    return kebabCase(input) === input;
 }
 
 /**
@@ -74,16 +69,6 @@ export function groupBy<T>(objects: T[], callback: (obj: T) => string): Array<[s
     return Array.from(m).sort();
 }
 
-export function first<T>(...args: Array<T | undefined | null>): T {
-    for (let index = 0; index < args.length; index++) {
-        const element = args[index];
-        if (element !== undefined && element !== null) {
-            return element;
-        }
-    }
-    throw new SentryIgnoredError(`No compatible arg given: ${args}`);
-}
-
 // Taken from python's string module
 export const ascii_lowercase = "abcdefghijklmnopqrstuvwxyz";
 export const ascii_uppercase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -96,7 +81,9 @@ export const punctuation = "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~";
 export function randomString(len: number, charset: string): string {
     const chars = [];
     const array = new Uint8Array(len);
-    self.crypto.getRandomValues(array);
+
+    crypto.getRandomValues(array);
+
     for (let index = 0; index < len; index++) {
         chars.push(charset[Math.floor(charset.length * (array[index] / Math.pow(2, 8)))]);
     }

--- a/web/src/components/DescriptionList.ts
+++ b/web/src/components/DescriptionList.ts
@@ -1,5 +1,3 @@
-import { first } from "@goauthentik/common/utils";
-
 import { TemplateResult, html, nothing } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { map } from "lit/directives/map.js";
@@ -80,10 +78,10 @@ export function renderDescriptionList(
 ) {
     const checkedTerms = alignTermType(terms);
     const classes = classMap({
-        "pf-m-horizontal": first(config.horizontal, false),
-        "pf-m-compact": first(config.compact, false),
-        "pf-m-2-col-on-lg": first(config.twocolumn, false),
-        "pf-m-3-col-on-lg": first(config.threecolumn, false),
+        "pf-m-horizontal": config.horizontal ?? false,
+        "pf-m-compact": config.compact ?? false,
+        "pf-m-2-col-on-lg": config.twocolumn ?? false,
+        "pf-m-3-col-on-lg": config.threecolumn ?? false,
     });
 
     return html`

--- a/web/src/components/ak-slug-input.ts
+++ b/web/src/components/ak-slug-input.ts
@@ -1,4 +1,4 @@
-import { convertToSlug } from "@goauthentik/common/utils";
+import { formatSlug } from "@goauthentik/elements/router/utils.js";
 
 import { html } from "lit";
 import { customElement, property, query } from "lit/decorators.js";
@@ -34,7 +34,7 @@ export class AkSlugInput extends HorizontalLightComponent<string> {
     // Do not stop propagation of this event; it must be sent up the tree so that a parent
     // component, such as a custom forms manager, may receive it.
     handleTouch(ev: Event) {
-        this.input.value = convertToSlug(this.input.value);
+        this.input.value = formatSlug(this.input.value);
         this.value = this.input.value;
 
         if (this.origin && this.origin.value === "" && this.input.value === "") {
@@ -67,7 +67,7 @@ export class AkSlugInput extends HorizontalLightComponent<string> {
         // "any event which adds or removes a character but leaves the rest of the slug looking like
         // the previous iteration, set it to the current iteration."
 
-        const newSlug = convertToSlug(ev.target.value);
+        const newSlug = formatSlug(ev.target.value);
         const oldSlug = this.input.value;
         const [shorter, longer] =
             newSlug.length < oldSlug.length ? [newSlug, oldSlug] : [oldSlug, newSlug];

--- a/web/src/elements/forms/Form.ts
+++ b/web/src/elements/forms/Form.ts
@@ -2,11 +2,12 @@ import { EVENT_REFRESH } from "@goauthentik/common/constants";
 import { parseAPIResponseError, pluckErrorDetail } from "@goauthentik/common/errors/network";
 import { MessageLevel } from "@goauthentik/common/messages";
 import { dateToUTC } from "@goauthentik/common/temporal";
-import { camelToSnake, convertToSlug } from "@goauthentik/common/utils";
+import { camelToSnake } from "@goauthentik/common/utils";
 import { AKElement } from "@goauthentik/elements/Base";
 import { HorizontalFormElement } from "@goauthentik/elements/forms/HorizontalFormElement";
 import { PreventFormSubmit } from "@goauthentik/elements/forms/helpers";
 import { showMessage } from "@goauthentik/elements/messages/MessageContainer";
+import { formatSlug } from "@goauthentik/elements/router/utils.js";
 
 import { msg } from "@lit/localize";
 import { CSSResult, TemplateResult, css, html } from "lit";
@@ -218,11 +219,11 @@ export abstract class Form<T> extends AKElement {
                 // Only attach handler if the slug is already equal to the name
                 // if not, they are probably completely different and shouldn't update
                 // each other
-                if (convertToSlug(input.value) !== slugField.value) {
+                if (formatSlug(input.value) !== slugField.value) {
                     return;
                 }
                 nameInput.addEventListener("input", () => {
-                    slugField.value = convertToSlug(input.value);
+                    slugField.value = formatSlug(input.value);
                 });
             });
     }

--- a/web/src/elements/forms/HorizontalFormElement.ts
+++ b/web/src/elements/forms/HorizontalFormElement.ts
@@ -1,6 +1,6 @@
-import { convertToSlug } from "@goauthentik/common/utils";
 import { AKElement } from "@goauthentik/elements/Base";
 import { FormGroup } from "@goauthentik/elements/forms/FormGroup";
+import { formatSlug } from "@goauthentik/elements/router/utils.js";
 
 import { msg, str } from "@lit/localize";
 import { CSSResult, css } from "lit";
@@ -123,7 +123,7 @@ export class HorizontalFormElement extends AKElement {
         if (this.name === "slug" || this.slugMode) {
             this.querySelectorAll<HTMLInputElement>("input[type='text']").forEach((input) => {
                 input.addEventListener("keyup", () => {
-                    input.value = convertToSlug(input.value);
+                    input.value = formatSlug(input.value);
                 });
             });
         }

--- a/web/src/elements/router/utils.ts
+++ b/web/src/elements/router/utils.ts
@@ -1,9 +1,12 @@
 /**
  * @file Utilities for working with the client-side page router.
  */
+import { kebabCase } from "change-case";
 
 /**
  * The name identifier for the current interface.
+ *
+ * @category Routing
  */
 export type RouteInterfaceName = "user" | "admin" | "flow" | "unknown";
 
@@ -11,7 +14,9 @@ export type RouteInterfaceName = "user" | "admin" | "flow" | "unknown";
  * Read the current interface route parameter from the URL.
  *
  * @param location - The location object to read the pathname from. Defaults to `window.location`.
- * * @returns The name of the current interface, or "unknown" if not found.
+ * @returns The name of the current interface, or "unknown" if not found.
+ *
+ * @category Routing
  */
 export function readInterfaceRouteParam(
     location: Pick<URL, "pathname"> = window.location,
@@ -23,6 +28,8 @@ export function readInterfaceRouteParam(
 
 /**
  * Predicate to determine if the current route is for the admin interface.
+ *
+ * @category Routing
  */
 export function isAdminRoute(location: Pick<URL, "pathname"> = window.location): boolean {
     return readInterfaceRouteParam(location) === "admin";
@@ -30,7 +37,38 @@ export function isAdminRoute(location: Pick<URL, "pathname"> = window.location):
 
 /**
  * Predicate to determine if the current route is for the user interface.
+ *
+ * @category Routing
  */
 export function isUserRoute(location: Pick<URL, "pathname"> = window.location): boolean {
     return readInterfaceRouteParam(location) === "user";
+}
+
+/**
+ * Format a string to a URL-safe route slug.
+ *
+ * The input is converted to lowercase and non-alphanumeric characters are
+ * replaced with a hyphen. Trailing whitespace and hyphens are removed.
+ *
+ * @param input - The input string to format.
+ *
+ * @category Routing
+ *
+ * ```ts
+ * formatSlug("My Application"); // "my-application"
+ * formatSlug(" 123ABC "); // "123-ABC"
+ * formatSlug("-action-Name-"); // "action-name"
+ * ```
+ */
+export function formatSlug(input: string): string {
+    return kebabCase(input);
+}
+
+/**
+ * Predicate to determine if the input is a valid route slug.
+ *
+ * @param input - The input string to check.
+ */
+export function isSlug(input: string): boolean {
+    return kebabCase(input) === input;
 }

--- a/web/src/flow/FlowExecutor.ts
+++ b/web/src/flow/FlowExecutor.ts
@@ -7,7 +7,6 @@ import {
 import { globalAK } from "@goauthentik/common/global";
 import { configureSentry } from "@goauthentik/common/sentry";
 import { DefaultBrand } from "@goauthentik/common/ui/config";
-import { first } from "@goauthentik/common/utils";
 import { WebsocketClient } from "@goauthentik/common/ws";
 import { Interface } from "@goauthentik/elements/Interface";
 import "@goauthentik/elements/LoadingOverlay";
@@ -521,11 +520,9 @@ export class FlowExecutor extends Interface implements StageHost {
                                             >
                                                 <img
                                                     src="${themeImage(
-                                                        first(
-                                                            this.brand?.brandingLogo,
-                                                            globalAK()?.brand.brandingLogo,
+                                                        this.brand?.brandingLogo ??
+                                                            globalAK()?.brand.brandingLogo ??
                                                             DefaultBrand.brandingLogo,
-                                                        ),
                                                     )}"
                                                     alt="${msg("authentik Logo")}"
                                                 />

--- a/web/src/standalone/api-browser/index.entrypoint.ts
+++ b/web/src/standalone/api-browser/index.entrypoint.ts
@@ -3,7 +3,7 @@ import "rapidoc";
 
 import { CSRFHeaderName } from "@goauthentik/common/api/config";
 import { EVENT_THEME_CHANGE } from "@goauthentik/common/constants";
-import { first, getCookie } from "@goauthentik/common/utils";
+import { getCookie } from "@goauthentik/common/utils";
 import { Interface } from "@goauthentik/elements/Interface";
 import "@goauthentik/elements/ak-locale-context";
 import { DefaultBrand } from "@goauthentik/common/ui/config";
@@ -103,7 +103,7 @@ export class APIBrowser extends Interface {
                             alt="${msg("authentik Logo")}"
                             class="logo"
                             src="${themeImage(
-                                first(this.brand?.brandingLogo, DefaultBrand.brandingLogo),
+                                this.brand?.brandingLogo ?? DefaultBrand.brandingLogo,
                             )}"
                         />
                     </div>

--- a/web/tests/utils/index.ts
+++ b/web/tests/utils/index.ts
@@ -25,10 +25,3 @@ export function randomId() {
         return (c == "x" ? r : (r & 0x3) | 0x8).toString(16);
     });
 }
-
-export function convertToSlug(text: string) {
-    return text
-        .toLowerCase()
-        .replace(/ /g, "-")
-        .replace(/[^\w-]+/g, "");
-}


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

This PR separates a small part of an issue in #14292 -- where our E2E test suite bundles in our browser-only `globalAK` context, as well as removing code paths which can inadvertently lead back to it.

The changes in this PR touch a lot of files but are limited to removing the `first` utility in favor of JavaScript's `??` [nullish-coalescing](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing syntax).  

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
