### PR TITLE
website/docs: use Universal Device Trust for GDTC instead of Okta

### DIFF
--- a/website/docs/add-secure-apps/flows-stages/stages/authenticator_endpoint_gdtc/index.md
+++ b/website/docs/add-secure-apps/flows-stages/stages/authenticator_endpoint_gdtc/index.md
@@ -53,7 +53,7 @@ For detailed instructions, refer to Google documentation.
 4. On the service account page, click the **Details** tab, and expand the **Advanced settings** area.
 5. Log in to the Admin Console, and then navigate to **Chrome browser -> Connectors**.
 6. Click on **New Provider Configuration**.
-7. Under Okta, click "Set up".
+7. Under Universal Device Trust, click "Set up".
 8. Enter a name.
 9. Enter the URL: https://authentik.company/endpoint/gdtc/chrome/
 10. Under Service accounts, enter the full name of the service account created above, for example `authentik-gdtc-docs@authentik-enterprise-dev.iam.gserviceaccount.com`.


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

They work exactly the same but it's a bit nicer to not have to tell people to use a competitor

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
