### PR TITLE
ci: use dependabot for docker-compose files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -118,3 +118,15 @@ updates:
       prefix: "core:"
     labels:
       - dependencies
+  - package-ecosystem: docker-compose
+    directories:
+      # - scripts/docker-compose.yml # Maybe
+      - tests/e2e/docker-compose.yml
+    schedule:
+      interval: daily
+      time: "04:00"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "core:"
+    labels:
+      - dependencies


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

This purposefully excludes `scripts/docker-compose.yml` for now, not sure if we want to keep bumping that automatically or manually bump it cc @rissson 

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
