### PR TITLE
website/docs: remove support badge

### DIFF
--- a/website/docs/customize/policies/unique_password.md
+++ b/website/docs/customize/policies/unique_password.md
@@ -1,7 +1,6 @@
 ---
 title: Password Uniqueness Policy
 sidebar_label: Password Uniqueness Policy
-support_level: authentik
 tags:
     - policy
     - password


### PR DESCRIPTION
This PR removes the support level badge (only needed on Integration guides).

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
