### PR TITLE
website/docs: add one more reference and link about `can view Admin interface`

### DIFF
--- a/website/docs/users-sources/access-control/manage_permissions.md
+++ b/website/docs/users-sources/access-control/manage_permissions.md
@@ -23,7 +23,7 @@ To view _object_ permissions for a specific user or role:
 
 ### View flow permissions
 
-\_These instructions apply to all objects that have a detail page, which can be accessed by clicking on the name in the list page.\_\_
+_These instructions apply to all objects that have a detail page, which can be accessed by clicking on the name in the list page._
 
 1. Go to the Admin interface and navigate to **Flows and Stages -> Flows**.
 2. Click the name of the flow (this opens the details page).

--- a/website/docs/users-sources/access-control/permissions.md
+++ b/website/docs/users-sources/access-control/permissions.md
@@ -26,6 +26,8 @@ Global permissions define who can do what on a global level across the entire sy
 
 You can assign _global permissions_ to individual [users](../user/index.mdx) or to [roles](../roles/index.md). The most common and best practice is to assign permissions to roles.
 
+An example of a global permission is []`Can view admin panel`](./manage_permissions.md), which an administrator can assign to a non-administrator user or role to provide view access to the Admin interface.
+
 ### Object permissions
 
 Object permissions have two categories:

--- a/website/docs/users-sources/access-control/permissions.md
+++ b/website/docs/users-sources/access-control/permissions.md
@@ -26,7 +26,7 @@ Global permissions define who can do what on a global level across the entire sy
 
 You can assign _global permissions_ to individual [users](../user/index.mdx) or to [roles](../roles/index.md). The most common and best practice is to assign permissions to roles.
 
-An example of a global permission is []`Can view admin panel`](./manage_permissions.md), which an administrator can assign to a non-administrator user or role to provide view access to the Admin interface.
+An example of a global permission is [`Can view admin interface`](./manage_permissions#assign-can-view-admin-interface-permissions), which an administrator can assign to a non-administrator user or role to provide view access to the Admin interface.
 
 ### Object permissions
 


### PR DESCRIPTION
This PR adds another reference and another link to the top-level page "About Permissions" page with info about `can view Admin interface` perm.

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
