### PR TITLE
website/integrations: fixes indentation paperless ngx

### DIFF
--- a/website/integrations/services/paperless-ngx/index.mdx
+++ b/website/integrations/services/paperless-ngx/index.mdx
@@ -30,14 +30,14 @@ To support the integration of Paperless-ngx with authentik, you need to create a
 1. Log in to authentik as an admin, and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
-    - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
-    - **Choose a Provider type**: select **OAuth2/OpenID Connect** as the provider type.
-    - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
-        - Note the **Client ID**,**Client Secret**, and **slug** values because they will be required later.
-        - Set a `Strict` redirect URI to <kbd>https://<em>paperless.company</em>/accounts/oidc/authentik/login/callback/</kbd>.
-    - **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/flows-stages/bindings/) (policy, group, or user) to manage the listing and access to applications on a user's **My applications** page.
-    - **Advanced protocol settings**:
-        - **Selected Scopes**: Additionally select the `authentik default OAuth Mapping: OpenID 'openid'` scope.
+- **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
+- **Choose a Provider type**: select **OAuth2/OpenID Connect** as the provider type.
+- **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
+    - Note the **Client ID**,**Client Secret**, and **slug** values because they will be required later.
+    - Set a `Strict` redirect URI to <kbd>https://<em>paperless.company</em>/accounts/oidc/authentik/login/callback/</kbd>.
+- **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/flows-stages/bindings/) (policy, group, or user) to manage the listing and access to applications on a user's **My applications** page.
+- **Advanced protocol settings**:
+    - **Selected Scopes**: Additionally select the `authentik default OAuth Mapping: OpenID 'openid'` scope.
 
 3. Click **Submit** to save the new application and provider.
 


### PR DESCRIPTION
## Details

Fixes the indentation on a text block in the doc.

---

## Checklist

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
