### PR TITLE
website/integrations: fix sonarqube badge

### DIFF
--- a/website/integrations/services/sonar-qube/index.mdx
+++ b/website/integrations/services/sonar-qube/index.mdx
@@ -1,9 +1,8 @@
 ---
 title: Integrate with SonarQube
 sidebar_label: SonarQube
+support_level: community
 ---
-
-<span className="badge badge--primary">Support level: Community</span>
 
 ## What is SonarQube
 


### PR DESCRIPTION
## Details

Page currently not loading because the support level badge isn't definted in the frontmatter, this pr moves the badge to the frontmatter.

https://docs.goauthentik.io/integrations/services/sonar-qube/

Closes #14433

---

## Checklist

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
