### PR TITLE
root: temporarily deactivate database pool option

### DIFF
--- a/authentik/lib/config.py
+++ b/authentik/lib/config.py
@@ -363,6 +363,9 @@ def django_db_config(config: ConfigLoader | None = None) -> dict:
         pool_options = config.get_dict_from_b64_json("postgresql.pool_options", True)
         if not pool_options:
             pool_options = True
+    # FIXME: Temporarily force pool to be deactivated.
+    # See https://github.com/goauthentik/authentik/issues/14320
+    pool_options = False
 
     db = {
         "default": {

--- a/authentik/lib/tests/test_config.py
+++ b/authentik/lib/tests/test_config.py
@@ -494,86 +494,88 @@ class TestConfig(TestCase):
             },
         )
 
-    def test_db_pool(self):
-        """Test DB Config with pool"""
-        config = ConfigLoader()
-        config.set("postgresql.host", "foo")
-        config.set("postgresql.name", "foo")
-        config.set("postgresql.user", "foo")
-        config.set("postgresql.password", "foo")
-        config.set("postgresql.port", "foo")
-        config.set("postgresql.test.name", "foo")
-        config.set("postgresql.use_pool", True)
-        conf = django_db_config(config)
-        self.assertEqual(
-            conf,
-            {
-                "default": {
-                    "ENGINE": "authentik.root.db",
-                    "HOST": "foo",
-                    "NAME": "foo",
-                    "OPTIONS": {
-                        "pool": True,
-                        "sslcert": None,
-                        "sslkey": None,
-                        "sslmode": None,
-                        "sslrootcert": None,
-                    },
-                    "PASSWORD": "foo",
-                    "PORT": "foo",
-                    "TEST": {"NAME": "foo"},
-                    "USER": "foo",
-                    "CONN_MAX_AGE": 0,
-                    "CONN_HEALTH_CHECKS": False,
-                    "DISABLE_SERVER_SIDE_CURSORS": False,
-                }
-            },
-        )
+    # FIXME: Temporarily force pool to be deactivated.
+    # See https://github.com/goauthentik/authentik/issues/14320
+    # def test_db_pool(self):
+    #     """Test DB Config with pool"""
+    #     config = ConfigLoader()
+    #     config.set("postgresql.host", "foo")
+    #     config.set("postgresql.name", "foo")
+    #     config.set("postgresql.user", "foo")
+    #     config.set("postgresql.password", "foo")
+    #     config.set("postgresql.port", "foo")
+    #     config.set("postgresql.test.name", "foo")
+    #     config.set("postgresql.use_pool", True)
+    #     conf = django_db_config(config)
+    #     self.assertEqual(
+    #         conf,
+    #         {
+    #             "default": {
+    #                 "ENGINE": "authentik.root.db",
+    #                 "HOST": "foo",
+    #                 "NAME": "foo",
+    #                 "OPTIONS": {
+    #                     "pool": True,
+    #                     "sslcert": None,
+    #                     "sslkey": None,
+    #                     "sslmode": None,
+    #                     "sslrootcert": None,
+    #                 },
+    #                 "PASSWORD": "foo",
+    #                 "PORT": "foo",
+    #                 "TEST": {"NAME": "foo"},
+    #                 "USER": "foo",
+    #                 "CONN_MAX_AGE": 0,
+    #                 "CONN_HEALTH_CHECKS": False,
+    #                 "DISABLE_SERVER_SIDE_CURSORS": False,
+    #             }
+    #         },
+    #     )
 
-    def test_db_pool_options(self):
-        """Test DB Config with pool"""
-        config = ConfigLoader()
-        config.set("postgresql.host", "foo")
-        config.set("postgresql.name", "foo")
-        config.set("postgresql.user", "foo")
-        config.set("postgresql.password", "foo")
-        config.set("postgresql.port", "foo")
-        config.set("postgresql.test.name", "foo")
-        config.set("postgresql.use_pool", True)
-        config.set(
-            "postgresql.pool_options",
-            base64.b64encode(
-                dumps(
-                    {
-                        "max_size": 15,
-                    }
-                ).encode()
-            ).decode(),
-        )
-        conf = django_db_config(config)
-        self.assertEqual(
-            conf,
-            {
-                "default": {
-                    "ENGINE": "authentik.root.db",
-                    "HOST": "foo",
-                    "NAME": "foo",
-                    "OPTIONS": {
-                        "pool": {
-                            "max_size": 15,
-                        },
-                        "sslcert": None,
-                        "sslkey": None,
-                        "sslmode": None,
-                        "sslrootcert": None,
-                    },
-                    "PASSWORD": "foo",
-                    "PORT": "foo",
-                    "TEST": {"NAME": "foo"},
-                    "USER": "foo",
-                    "CONN_MAX_AGE": 0,
-                    "CONN_HEALTH_CHECKS": False,
-                    "DISABLE_SERVER_SIDE_CURSORS": False,
-                }
-            },
-        )
+    # def test_db_pool_options(self):
+    #     """Test DB Config with pool"""
+    #     config = ConfigLoader()
+    #     config.set("postgresql.host", "foo")
+    #     config.set("postgresql.name", "foo")
+    #     config.set("postgresql.user", "foo")
+    #     config.set("postgresql.password", "foo")
+    #     config.set("postgresql.port", "foo")
+    #     config.set("postgresql.test.name", "foo")
+    #     config.set("postgresql.use_pool", True)
+    #     config.set(
+    #         "postgresql.pool_options",
+    #         base64.b64encode(
+    #             dumps(
+    #                 {
+    #                     "max_size": 15,
+    #                 }
+    #             ).encode()
+    #         ).decode(),
+    #     )
+    #     conf = django_db_config(config)
+    #     self.assertEqual(
+    #         conf,
+    #         {
+    #             "default": {
+    #                 "ENGINE": "authentik.root.db",
+    #                 "HOST": "foo",
+    #                 "NAME": "foo",
+    #                 "OPTIONS": {
+    #                     "pool": {
+    #                         "max_size": 15,
+    #                     },
+    #                     "sslcert": None,
+    #                     "sslkey": None,
+    #                     "sslmode": None,
+    #                     "sslrootcert": None,
+    #                 },
+    #                 "PASSWORD": "foo",
+    #                 "PORT": "foo",
+    #                 "TEST": {"NAME": "foo"},
+    #                 "USER": "foo",
+    #                 "CONN_MAX_AGE": 0,
+    #                 "CONN_HEALTH_CHECKS": False,
+    #                 "DISABLE_SERVER_SIDE_CURSORS": False,
+    #             }
+    #         },
+    #     )

--- a/website/docs/install-config/configuration/configuration.mdx
+++ b/website/docs/install-config/configuration/configuration.mdx
@@ -70,7 +70,8 @@ To check if your config has been applied correctly, you can run the following co
 - `AUTHENTIK_POSTGRESQL__USER`: Database user
 - `AUTHENTIK_POSTGRESQL__PORT`: Database port, defaults to 5432
 - `AUTHENTIK_POSTGRESQL__PASSWORD`: Database password, defaults to the environment variable `POSTGRES_PASSWORD`
-- `AUTHENTIK_POSTGRESQL__USE_POOL`: Use a [connection pool](https://docs.djangoproject.com/en/stable/ref/databases/#connection-pool) for PostgreSQL connections. Defaults to `false`. :ak-version[2025.4]
+{/* TODO: Temporarily deactivated feature, see https://github.com/goauthentik/authentik/issues/14320 */}
+{/* - `AUTHENTIK_POSTGRESQL__USE_POOL`: Use a [connection pool](https://docs.djangoproject.com/en/stable/ref/databases/#connection-pool) for PostgreSQL connections. Defaults to `false`. :ak-version[2025.4] */}
 - `AUTHENTIK_POSTGRESQL__POOL_OPTIONS`: Extra configuration to pass to the [ConnectionPool object](https://www.psycopg.org/psycopg3/docs/api/pool.html#psycopg_pool.ConnectionPool) when it is created. Must be a base64-encoded JSON dictionary. Ignored when `USE_POOL` is set to `false`. :ak-version[2025.4]
 - `AUTHENTIK_POSTGRESQL__USE_PGBOUNCER`: Adjust configuration to support connection to PgBouncer. Deprecated, see below
 - `AUTHENTIK_POSTGRESQL__USE_PGPOOL`: Adjust configuration to support connection to Pgpool. Deprecated, see below

--- a/website/docs/install-config/configuration/configuration.mdx
+++ b/website/docs/install-config/configuration/configuration.mdx
@@ -70,8 +70,8 @@ To check if your config has been applied correctly, you can run the following co
 - `AUTHENTIK_POSTGRESQL__USER`: Database user
 - `AUTHENTIK_POSTGRESQL__PORT`: Database port, defaults to 5432
 - `AUTHENTIK_POSTGRESQL__PASSWORD`: Database password, defaults to the environment variable `POSTGRES_PASSWORD`
-{/* TODO: Temporarily deactivated feature, see https://github.com/goauthentik/authentik/issues/14320 */}
-{/* - `AUTHENTIK_POSTGRESQL__USE_POOL`: Use a [connection pool](https://docs.djangoproject.com/en/stable/ref/databases/#connection-pool) for PostgreSQL connections. Defaults to `false`. :ak-version[2025.4] */}
+  {/* TODO: Temporarily deactivated feature, see https://github.com/goauthentik/authentik/issues/14320 */}
+  {/* - `AUTHENTIK_POSTGRESQL__USE_POOL`: Use a [connection pool](https://docs.djangoproject.com/en/stable/ref/databases/#connection-pool) for PostgreSQL connections. Defaults to `false`. :ak-version[2025.4] */}
 - `AUTHENTIK_POSTGRESQL__POOL_OPTIONS`: Extra configuration to pass to the [ConnectionPool object](https://www.psycopg.org/psycopg3/docs/api/pool.html#psycopg_pool.ConnectionPool) when it is created. Must be a base64-encoded JSON dictionary. Ignored when `USE_POOL` is set to `false`. :ak-version[2025.4]
 - `AUTHENTIK_POSTGRESQL__USE_PGBOUNCER`: Adjust configuration to support connection to PgBouncer. Deprecated, see below
 - `AUTHENTIK_POSTGRESQL__USE_PGPOOL`: Adjust configuration to support connection to Pgpool. Deprecated, see below

--- a/website/docs/releases/2025/v2025.4.md
+++ b/website/docs/releases/2025/v2025.4.md
@@ -7,7 +7,8 @@ slug: "/releases/2025.4"
 
 - **Improve membership resolution for the LDAP Source** Allow lookups of LDAP group memberships from user attributes as an alternative to lookups from group attributes. This also allows for nested group lookups in Active Directory.
 
-- **Support for PostgreSQL Connection Pools** PostgreSQL Connection Pools provides a set of open connections in order to reduce latency.
+<!-- TODO: Temporarily deactivated feature, see https://github.com/goauthentik/authentik/issues/14320 -->
+<!-- - **Support for PostgreSQL Connection Pools** PostgreSQL Connection Pools provides a set of open connections in order to reduce latency. -->
 
 - **RBAC: Initial Permissions** :ak-preview Provides more flexible access control by assigning permissions to the user/role creating a new object in authentik. Use **Initial Permissions** as a pragmatic way to implement the principle of least privilege.
 
@@ -64,7 +65,7 @@ Previously, sessions were stored by default in the cache. Now, they are stored i
 
     Reputation scores now have a configurable numerical limit in addition to the [already existing temporal limit](https://docs.goauthentik.io/docs/install-config/configuration/#authentik_reputation_expiry).
 
-- **Support for PostgreSQL Connection Pools**: See [description](#highlights) under Highlights. Refer to our [documentation](../../install-config/configuration/configuration.mdx).
+<!-- - **Support for PostgreSQL Connection Pools**: See [description](#highlights) under Highlights. Refer to our [documentation](../../install-config/configuration/configuration.mdx). -->
 
 - **Password History Policy**: See [description](#highlights) under Highlights. Refer to our [documentation](../../customize/policies/unique_password.md).
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

See https://github.com/goauthentik/authentik/issues/14320

> Since this issue seems to happen due to something multithreading related, either due to the multithreading happening with uvicorn or multithreading in authentik and we're not yet able to find a solution for this, we'll deactivate this option temporarily with 2025.4.1 and re-enable the option when we've found a solution.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
