### PR TITLE
Revert "web/admin: fix enterprise menu display"

### DIFF
--- a/web/src/admin/AdminInterface/index.entrypoint.ts
+++ b/web/src/admin/AdminInterface/index.entrypoint.ts
@@ -10,7 +10,6 @@ import { configureSentry } from "@goauthentik/common/sentry";
 import { me } from "@goauthentik/common/users";
 import { WebsocketClient } from "@goauthentik/common/ws";
 import { AuthenticatedInterface } from "@goauthentik/elements/Interface";
-import { WithCapabilitiesConfig } from "@goauthentik/elements/Interface/capabilitiesProvider";
 import { WithLicenseSummary } from "@goauthentik/elements/Interface/licenseSummaryProvider.js";
 import "@goauthentik/elements/ak-locale-context";
 import "@goauthentik/elements/banner/EnterpriseStatusBanner";
@@ -36,7 +35,7 @@ import PFNav from "@patternfly/patternfly/components/Nav/nav.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
-import { CapabilitiesEnum, SessionUser, UiThemeEnum } from "@goauthentik/api";
+import { LicenseSummaryStatusEnum, SessionUser, UiThemeEnum } from "@goauthentik/api";
 
 import {
     AdminSidebarEnterpriseEntries,
@@ -49,9 +48,7 @@ if (process.env.NODE_ENV === "development") {
 }
 
 @customElement("ak-interface-admin")
-export class AdminInterface extends WithCapabilitiesConfig(
-    WithLicenseSummary(AuthenticatedInterface),
-) {
+export class AdminInterface extends WithLicenseSummary(AuthenticatedInterface) {
     //#region Properties
 
     @property({ type: Boolean })
@@ -207,7 +204,7 @@ export class AdminInterface extends WithCapabilitiesConfig(
 
                 <ak-sidebar class="${classMap(sidebarClasses)}">
                     ${renderSidebarItems(AdminSidebarEntries)}
-                    ${this.can(CapabilitiesEnum.IsEnterprise)
+                    ${this.licenseSummary?.status !== LicenseSummaryStatusEnum.Unlicensed
                         ? renderSidebarItems(AdminSidebarEnterpriseEntries)
                         : nothing}
                 </ak-sidebar>


### PR DESCRIPTION
Reverts goauthentik/authentik#14447

Breaks the admin interface due to `WithCapabilitiesConfig` not being initialised yet for the first render