### PR TITLE
website/integrations: fix missing closing brace for semaphore

### DIFF
--- a/website/integrations/services/semaphore/index.mdx
+++ b/website/integrations/services/semaphore/index.mdx
@@ -61,6 +61,7 @@ Add the `oidc_providers` configuration:
       "name_claim": "name",
       "email_claim": "email",
       "scopes": ["openid", "profile", "email"]
+    }
   },
   ...
 }


### PR DESCRIPTION
Added missing closing bracket to the oidc_provide JSON example

