### PR TITLE
website/integrations: update paperless ngx instructions to include additional scopes

### DIFF
--- a/website/integrations/services/paperless-ngx/index.mdx
+++ b/website/integrations/services/paperless-ngx/index.mdx
@@ -37,7 +37,10 @@ To support the integration of Paperless-ngx with authentik, you need to create a
         - Set a `Strict` redirect URI to <kbd>https://<em>paperless.company</em>/accounts/oidc/authentik/login/callback/</kbd>.
     - **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/flows-stages/bindings/) (policy, group, or user) to manage the listing and access to applications on a user's **My applications** page.
     - **Advanced protocol settings**:
-        - **Selected Scopes**: Additionally select the `authentik default OAuth Mapping: OpenID 'openid'` scope.
+        - **Selected Scopes**: Add the following
+            - `authentik default OAuth Mapping: OpenID 'openid'`
+            - `authentik default OAuth Mapping: OpenID 'email'`
+            - `authentik default OAuth Mapping: OpenID 'profile'`
 
 3. Click **Submit** to save the new application and provider.
 


### PR DESCRIPTION
I found I needed 2 additional scopes to work properly with full  logout and login workflows

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
When implementing authentik as a full replacement for the Paperless NGX authentication, I found I needed 2 additional scopes to allow logout and log back in.

```
PAPERLESS_SOCIAL_AUTO_SIGNUP=true
PAPERLESS_DISABLE_REGULAR_LOGIN=true
PAPERLESS_LOGOUT_REDIRECT_URL=https://authentik.company/application/o/paperless-ngx/end-session/
PAPERLESS_ACCOUNT_EMAIL_VERIFICATION=none
```

---

## Checklist

~~-  [ ] Local tests pass (`ak test authentik/`)~~
~~-   [ ] The code has been formatted (`make lint-fix`)~~

If an API change has been made

~~-   [ ] The API schema has been updated (`make gen-build`)~~

If changes to the frontend have been made

~~-   [ ] The code has been formatted (`make web`)~~

If applicable

-   [x] The documentation has been updated
~~-   [ ] The documentation has been formatted (`make website`)~~
