### PR TITLE
core: fix unable to create group if no enable_group_superuser permission is given

### DIFF
--- a/authentik/core/api/groups.py
+++ b/authentik/core/api/groups.py
@@ -99,18 +99,17 @@ class GroupSerializer(ModelSerializer):
             if superuser
             else "authentik_core.disable_group_superuser"
         )
-        has_perm = user.has_perm(perm)
-        if self.instance and not has_perm:
-            has_perm = user.has_perm(perm, self.instance)
-        if not has_perm:
-            raise ValidationError(
-                _(
-                    (
-                        "User does not have permission to set "
-                        "superuser status to {superuser_status}."
-                    ).format_map({"superuser_status": superuser})
+        if self.instance or superuser:
+            has_perm = user.has_perm(perm) or user.has_perm(perm, self.instance)
+            if not has_perm:
+                raise ValidationError(
+                    _(
+                        (
+                            "User does not have permission to set "
+                            "superuser status to {superuser_status}."
+                        ).format_map({"superuser_status": superuser})
+                    )
                 )
-            )
         return superuser
 
     class Meta:

--- a/authentik/core/tests/test_groups_api.py
+++ b/authentik/core/tests/test_groups_api.py
@@ -124,6 +124,16 @@ class TestGroupsAPI(APITestCase):
             {"is_superuser": ["User does not have permission to set superuser status to True."]},
         )
 
+    def test_superuser_no_perm_no_superuser(self):
+        """Test creating a group without permission and without superuser flag"""
+        assign_perm("authentik_core.add_group", self.login_user)
+        self.client.force_login(self.login_user)
+        res = self.client.post(
+            reverse("authentik_api:group-list"),
+            data={"name": generate_id(), "is_superuser": False},
+        )
+        self.assertEqual(res.status_code, 201)
+
     def test_superuser_update_no_perm(self):
         """Test updating a superuser group without permission"""
         group = Group.objects.create(name=generate_id(), is_superuser=True)


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

A restricted user should be able create a permission without having the permission to the enable/disable superuser flag. The permission needs to be checked when a group is updated or the superuser flag is set

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
