### PR TITLE
policies: buffered policy access view for concurrent authorization attempts when unauthenticated 2025.4

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -228,7 +228,6 @@ jobs:
     needs:
       - lint
       - test-migrations
-      - test-migrations-from-stable
       - test-unittest
       - test-integration
       - test-e2e

--- a/authentik/flows/views/executor.py
+++ b/authentik/flows/views/executor.py
@@ -69,6 +69,7 @@ SESSION_KEY_APPLICATION_PRE = "authentik/flows/application_pre"
 SESSION_KEY_GET = "authentik/flows/get"
 SESSION_KEY_POST = "authentik/flows/post"
 SESSION_KEY_HISTORY = "authentik/flows/history"
+SESSION_KEY_AUTH_STARTED = "authentik/flows/auth_started"
 QS_KEY_TOKEN = "flow_token"  # nosec
 QS_QUERY = "query"
 
@@ -453,6 +454,7 @@ class FlowExecutorView(APIView):
             SESSION_KEY_APPLICATION_PRE,
             SESSION_KEY_PLAN,
             SESSION_KEY_GET,
+            SESSION_KEY_AUTH_STARTED,
             # We might need the initial POST payloads for later requests
             # SESSION_KEY_POST,
             # We don't delete the history on purpose, as a user might

--- a/authentik/policies/apps.py
+++ b/authentik/policies/apps.py
@@ -39,3 +39,4 @@ class AuthentikPoliciesConfig(ManagedAppConfig):
     label = "authentik_policies"
     verbose_name = "authentik Policies"
     default = True
+    mountpoint = "policy/"

--- a/authentik/policies/templates/policies/buffer.html
+++ b/authentik/policies/templates/policies/buffer.html
@@ -1,0 +1,89 @@
+{% extends 'login/base_full.html' %}
+
+{% load static %}
+{% load i18n %}
+
+{% block head %}
+{{ block.super }}
+<script>
+  let redirecting = false;
+  const checkAuth = async () => {
+    if (redirecting) return true;
+    const url = "{{ check_auth_url }}";
+    console.debug("authentik/policies/buffer: Checking authentication...");
+    try {
+      const result = await fetch(url, {
+        method: "HEAD",
+      });
+      if (result.status >= 400) {
+        return false
+      }
+      console.debug("authentik/policies/buffer: Continuing");
+      redirecting = true;
+      if ("{{ auth_req_method }}" === "post") {
+        document.querySelector("form").submit();
+      } else {
+        window.location.assign("{{ continue_url|escapejs }}");
+      }
+    } catch {
+      return false;
+    }
+  };
+  let timeout = 100;
+  let offset = 20;
+  let attempt = 0;
+  const main = async () => {
+    attempt += 1;
+    await checkAuth();
+    console.debug(`authentik/policies/buffer: Waiting ${timeout}ms...`);
+    setTimeout(main, timeout);
+    timeout += (offset * attempt);
+    if (timeout >= 2000) {
+      timeout = 2000;
+    }
+  }
+  document.addEventListener("visibilitychange", async () => {
+    if (document.hidden) return;
+    console.debug("authentik/policies/buffer: Checking authentication on tab activate...");
+    await checkAuth();
+  });
+  main();
+</script>
+{% endblock %}
+
+{% block title %}
+{% trans 'Waiting for authentication...' %} - {{ brand.branding_title }}
+{% endblock %}
+
+{% block card_title %}
+{% trans 'Waiting for authentication...' %}
+{% endblock %}
+
+{% block card %}
+<form class="pf-c-form" method="{{ auth_req_method }}" action="{{ continue_url }}">
+  {% if auth_req_method == "post" %}
+    {% for key, value in auth_req_body.items %}
+      <input type="hidden" name="{{ key }}" value="{{ value }}" />
+    {% endfor %}
+  {% endif %}
+  <div class="pf-c-empty-state">
+    <div class="pf-c-empty-state__content">
+      <div class="pf-c-empty-state__icon">
+        <span class="pf-c-spinner pf-m-xl" role="progressbar">
+          <span class="pf-c-spinner__clipper"></span>
+          <span class="pf-c-spinner__lead-ball"></span>
+          <span class="pf-c-spinner__tail-ball"></span>
+        </span>
+      </div>
+      <h1 class="pf-c-title pf-m-lg">
+        {% trans "You're already authenticating in another tab. This page will refresh once authentication is completed." %}
+      </h1>
+    </div>
+  </div>
+  <div class="pf-c-form__group pf-m-action">
+    <a href="{{ auth_req_url }}" class="pf-c-button pf-m-primary pf-m-block">
+      {% trans "Authenticate in this tab" %}
+    </a>
+  </div>
+</form>
+{% endblock %}

--- a/authentik/policies/tests/test_views.py
+++ b/authentik/policies/tests/test_views.py
@@ -1,0 +1,121 @@
+from django.contrib.auth.models import AnonymousUser
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.http import HttpResponse
+from django.test import RequestFactory, TestCase
+from django.urls import reverse
+
+from authentik.core.models import Application, Provider
+from authentik.core.tests.utils import create_test_flow, create_test_user
+from authentik.flows.models import FlowDesignation
+from authentik.flows.planner import FlowPlan
+from authentik.flows.views.executor import SESSION_KEY_PLAN
+from authentik.lib.generators import generate_id
+from authentik.lib.tests.utils import dummy_get_response
+from authentik.policies.views import (
+    QS_BUFFER_ID,
+    SESSION_KEY_BUFFER,
+    BufferedPolicyAccessView,
+    BufferView,
+    PolicyAccessView,
+)
+
+
+class TestPolicyViews(TestCase):
+    """Test PolicyAccessView"""
+
+    def setUp(self):
+        super().setUp()
+        self.factory = RequestFactory()
+        self.user = create_test_user()
+
+    def test_pav(self):
+        """Test simple policy access view"""
+        provider = Provider.objects.create(
+            name=generate_id(),
+        )
+        app = Application.objects.create(name=generate_id(), slug=generate_id(), provider=provider)
+
+        class TestView(PolicyAccessView):
+            def resolve_provider_application(self):
+                self.provider = provider
+                self.application = app
+
+            def get(self, *args, **kwargs):
+                return HttpResponse("foo")
+
+        req = self.factory.get("/")
+        req.user = self.user
+        res = TestView.as_view()(req)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.content, b"foo")
+
+    def test_pav_buffer(self):
+        """Test simple policy access view"""
+        provider = Provider.objects.create(
+            name=generate_id(),
+        )
+        app = Application.objects.create(name=generate_id(), slug=generate_id(), provider=provider)
+        flow = create_test_flow(FlowDesignation.AUTHENTICATION)
+
+        class TestView(BufferedPolicyAccessView):
+            def resolve_provider_application(self):
+                self.provider = provider
+                self.application = app
+
+            def get(self, *args, **kwargs):
+                return HttpResponse("foo")
+
+        req = self.factory.get("/")
+        req.user = AnonymousUser()
+        middleware = SessionMiddleware(dummy_get_response)
+        middleware.process_request(req)
+        req.session[SESSION_KEY_PLAN] = FlowPlan(flow.pk)
+        req.session.save()
+        res = TestView.as_view()(req)
+        self.assertEqual(res.status_code, 302)
+        self.assertTrue(res.url.startswith(reverse("authentik_policies:buffer")))
+
+    def test_pav_buffer_skip(self):
+        """Test simple policy access view (skip buffer)"""
+        provider = Provider.objects.create(
+            name=generate_id(),
+        )
+        app = Application.objects.create(name=generate_id(), slug=generate_id(), provider=provider)
+        flow = create_test_flow(FlowDesignation.AUTHENTICATION)
+
+        class TestView(BufferedPolicyAccessView):
+            def resolve_provider_application(self):
+                self.provider = provider
+                self.application = app
+
+            def get(self, *args, **kwargs):
+                return HttpResponse("foo")
+
+        req = self.factory.get("/?skip_buffer=true")
+        req.user = AnonymousUser()
+        middleware = SessionMiddleware(dummy_get_response)
+        middleware.process_request(req)
+        req.session[SESSION_KEY_PLAN] = FlowPlan(flow.pk)
+        req.session.save()
+        res = TestView.as_view()(req)
+        self.assertEqual(res.status_code, 302)
+        self.assertTrue(res.url.startswith(reverse("authentik_flows:default-authentication")))
+
+    def test_buffer(self):
+        """Test buffer view"""
+        uid = generate_id()
+        req = self.factory.get(f"/?{QS_BUFFER_ID}={uid}")
+        req.user = AnonymousUser()
+        middleware = SessionMiddleware(dummy_get_response)
+        middleware.process_request(req)
+        ts = generate_id()
+        req.session[SESSION_KEY_BUFFER % uid] = {
+            "method": "get",
+            "body": {},
+            "url": f"/{ts}",
+        }
+        req.session.save()
+
+        res = BufferView.as_view()(req)
+        self.assertEqual(res.status_code, 200)
+        self.assertIn(ts, res.render().content.decode())

--- a/authentik/policies/urls.py
+++ b/authentik/policies/urls.py
@@ -1,7 +1,14 @@
 """API URLs"""
 
+from django.urls import path
+
 from authentik.policies.api.bindings import PolicyBindingViewSet
 from authentik.policies.api.policies import PolicyViewSet
+from authentik.policies.views import BufferView
+
+urlpatterns = [
+    path("buffer", BufferView.as_view(), name="buffer"),
+]
 
 api_urlpatterns = [
     ("policies/all", PolicyViewSet),

--- a/authentik/providers/oauth2/views/authorize.py
+++ b/authentik/providers/oauth2/views/authorize.py
@@ -30,7 +30,7 @@ from authentik.flows.stage import StageView
 from authentik.lib.utils.time import timedelta_from_string
 from authentik.lib.views import bad_request_message
 from authentik.policies.types import PolicyRequest
-from authentik.policies.views import PolicyAccessView, RequestValidationError
+from authentik.policies.views import BufferedPolicyAccessView, RequestValidationError
 from authentik.providers.oauth2.constants import (
     PKCE_METHOD_PLAIN,
     PKCE_METHOD_S256,
@@ -326,7 +326,7 @@ class OAuthAuthorizationParams:
         return code
 
 
-class AuthorizationFlowInitView(PolicyAccessView):
+class AuthorizationFlowInitView(BufferedPolicyAccessView):
     """OAuth2 Flow initializer, checks access to application and starts flow"""
 
     params: OAuthAuthorizationParams

--- a/authentik/providers/rac/views.py
+++ b/authentik/providers/rac/views.py
@@ -18,11 +18,11 @@ from authentik.flows.planner import PLAN_CONTEXT_APPLICATION, FlowPlanner
 from authentik.flows.stage import RedirectStage
 from authentik.lib.utils.time import timedelta_from_string
 from authentik.policies.engine import PolicyEngine
-from authentik.policies.views import PolicyAccessView
+from authentik.policies.views import BufferedPolicyAccessView
 from authentik.providers.rac.models import ConnectionToken, Endpoint, RACProvider
 
 
-class RACStartView(PolicyAccessView):
+class RACStartView(BufferedPolicyAccessView):
     """Start a RAC connection by checking access and creating a connection token"""
 
     endpoint: Endpoint

--- a/authentik/providers/saml/views/slo.py
+++ b/authentik/providers/saml/views/slo.py
@@ -19,9 +19,9 @@ from authentik.providers.saml.exceptions import CannotHandleAssertion
 from authentik.providers.saml.models import SAMLProvider
 from authentik.providers.saml.processors.logout_request_parser import LogoutRequestParser
 from authentik.providers.saml.views.flows import (
+    PLAN_CONTEXT_SAML_LOGOUT_REQUEST,
     REQUEST_KEY_RELAY_STATE,
     REQUEST_KEY_SAML_REQUEST,
-    SESSION_KEY_LOGOUT_REQUEST,
 )
 
 LOGGER = get_logger()
@@ -32,6 +32,10 @@ class SAMLSLOView(PolicyAccessView):
     Calls get/post handler."""
 
     flow: Flow
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.plan_context = {}
 
     def resolve_provider_application(self):
         self.application = get_object_or_404(Application, slug=self.kwargs["application_slug"])
@@ -59,6 +63,7 @@ class SAMLSLOView(PolicyAccessView):
             request,
             {
                 PLAN_CONTEXT_APPLICATION: self.application,
+                **self.plan_context,
             },
         )
         plan.append_stage(in_memory_stage(SessionEndStage))
@@ -83,7 +88,7 @@ class SAMLSLOBindingRedirectView(SAMLSLOView):
                 self.request.GET[REQUEST_KEY_SAML_REQUEST],
                 relay_state=self.request.GET.get(REQUEST_KEY_RELAY_STATE, None),
             )
-            self.request.session[SESSION_KEY_LOGOUT_REQUEST] = logout_request
+            self.plan_context[PLAN_CONTEXT_SAML_LOGOUT_REQUEST] = logout_request
         except CannotHandleAssertion as exc:
             Event.new(
                 EventAction.CONFIGURATION_ERROR,
@@ -111,7 +116,7 @@ class SAMLSLOBindingPOSTView(SAMLSLOView):
                 payload[REQUEST_KEY_SAML_REQUEST],
                 relay_state=payload.get(REQUEST_KEY_RELAY_STATE, None),
             )
-            self.request.session[SESSION_KEY_LOGOUT_REQUEST] = logout_request
+            self.plan_context[PLAN_CONTEXT_SAML_LOGOUT_REQUEST] = logout_request
         except CannotHandleAssertion as exc:
             LOGGER.info(str(exc))
             return bad_request_message(self.request, str(exc))

--- a/authentik/providers/saml/views/sso.py
+++ b/authentik/providers/saml/views/sso.py
@@ -15,7 +15,7 @@ from authentik.flows.models import in_memory_stage
 from authentik.flows.planner import PLAN_CONTEXT_APPLICATION, PLAN_CONTEXT_SSO, FlowPlanner
 from authentik.flows.views.executor import SESSION_KEY_POST
 from authentik.lib.views import bad_request_message
-from authentik.policies.views import PolicyAccessView
+from authentik.policies.views import BufferedPolicyAccessView
 from authentik.providers.saml.exceptions import CannotHandleAssertion
 from authentik.providers.saml.models import SAMLBindings, SAMLProvider
 from authentik.providers.saml.processors.authn_request_parser import AuthNRequestParser
@@ -35,7 +35,7 @@ from authentik.stages.consent.stage import (
 LOGGER = get_logger()
 
 
-class SAMLSSOView(PolicyAccessView):
+class SAMLSSOView(BufferedPolicyAccessView):
     """SAML SSO Base View, which plans a flow and injects our final stage.
     Calls get/post handler."""
 
@@ -83,7 +83,7 @@ class SAMLSSOView(PolicyAccessView):
 
     def post(self, request: HttpRequest, application_slug: str) -> HttpResponse:
         """GET and POST use the same handler, but we can't
-        override .dispatch easily because PolicyAccessView's dispatch"""
+        override .dispatch easily because BufferedPolicyAccessView's dispatch"""
         return self.get(request, application_slug)
 
 

--- a/tests/e2e/test_provider_saml.py
+++ b/tests/e2e/test_provider_saml.py
@@ -20,7 +20,7 @@ from tests.e2e.utils import SeleniumTestCase, retry
 class TestProviderSAML(SeleniumTestCase):
     """test SAML Provider flow"""
 
-    def setup_client(self, provider: SAMLProvider, force_post: bool = False):
+    def setup_client(self, provider: SAMLProvider, force_post: bool = False, **kwargs):
         """Setup client saml-sp container which we test SAML against"""
         metadata_url = (
             self.url(
@@ -40,6 +40,7 @@ class TestProviderSAML(SeleniumTestCase):
                 "SP_ENTITY_ID": provider.issuer,
                 "SP_SSO_BINDING": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
                 "SP_METADATA_URL": metadata_url,
+                **kwargs,
             },
         )
 
@@ -78,6 +79,74 @@ class TestProviderSAML(SeleniumTestCase):
             provider=provider,
         )
         self.setup_client(provider)
+        self.driver.get("http://localhost:9009")
+        self.login()
+        self.wait_for_url("http://localhost:9009/")
+
+        body = loads(self.driver.find_element(By.CSS_SELECTOR, "pre").text)
+
+        self.assertEqual(
+            body["attr"]["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"],
+            [self.user.name],
+        )
+        self.assertEqual(
+            body["attr"][
+                "http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"
+            ],
+            [self.user.username],
+        )
+        self.assertEqual(
+            body["attr"]["http://schemas.goauthentik.io/2021/02/saml/username"],
+            [self.user.username],
+        )
+        self.assertEqual(
+            body["attr"]["http://schemas.goauthentik.io/2021/02/saml/uid"],
+            [str(self.user.pk)],
+        )
+        self.assertEqual(
+            body["attr"]["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"],
+            [self.user.email],
+        )
+        self.assertEqual(
+            body["attr"]["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn"],
+            [self.user.email],
+        )
+
+    @retry()
+    @apply_blueprint(
+        "default/flow-default-authentication-flow.yaml",
+        "default/flow-default-invalidation-flow.yaml",
+    )
+    @apply_blueprint(
+        "default/flow-default-provider-authorization-implicit-consent.yaml",
+    )
+    @apply_blueprint(
+        "system/providers-saml.yaml",
+    )
+    @reconcile_app("authentik_crypto")
+    def test_sp_initiated_implicit_post(self):
+        """test SAML Provider flow SP-initiated flow (implicit consent)"""
+        # Bootstrap all needed objects
+        authorization_flow = Flow.objects.get(
+            slug="default-provider-authorization-implicit-consent"
+        )
+        provider: SAMLProvider = SAMLProvider.objects.create(
+            name="saml-test",
+            acs_url="http://localhost:9009/saml/acs",
+            audience="authentik-e2e",
+            issuer="authentik-e2e",
+            sp_binding=SAMLBindings.POST,
+            authorization_flow=authorization_flow,
+            signing_kp=create_test_cert(),
+        )
+        provider.property_mappings.set(SAMLPropertyMapping.objects.all())
+        provider.save()
+        Application.objects.create(
+            name="SAML",
+            slug="authentik-saml",
+            provider=provider,
+        )
+        self.setup_client(provider, True)
         self.driver.get("http://localhost:9009")
         self.login()
         self.wait_for_url("http://localhost:9009/")
@@ -449,4 +518,82 @@ class TestProviderSAML(SeleniumTestCase):
         self.wait.until(
             lambda driver: driver.current_url.startswith(should_url),
             f"URL {self.driver.current_url} doesn't match expected URL {should_url}",
+        )
+
+    @retry()
+    @apply_blueprint(
+        "default/flow-default-authentication-flow.yaml",
+        "default/flow-default-invalidation-flow.yaml",
+    )
+    @apply_blueprint(
+        "default/flow-default-provider-authorization-implicit-consent.yaml",
+    )
+    @apply_blueprint(
+        "system/providers-saml.yaml",
+    )
+    @reconcile_app("authentik_crypto")
+    def test_sp_initiated_implicit_post_buffer(self):
+        """test SAML Provider flow SP-initiated flow (implicit consent)"""
+        # Bootstrap all needed objects
+        authorization_flow = Flow.objects.get(
+            slug="default-provider-authorization-implicit-consent"
+        )
+        provider: SAMLProvider = SAMLProvider.objects.create(
+            name="saml-test",
+            acs_url=f"http://{self.host}:9009/saml/acs",
+            audience="authentik-e2e",
+            issuer="authentik-e2e",
+            sp_binding=SAMLBindings.POST,
+            authorization_flow=authorization_flow,
+            signing_kp=create_test_cert(),
+        )
+        provider.property_mappings.set(SAMLPropertyMapping.objects.all())
+        provider.save()
+        Application.objects.create(
+            name="SAML",
+            slug="authentik-saml",
+            provider=provider,
+        )
+        self.setup_client(provider, True, SP_ROOT_URL=f"http://{self.host}:9009")
+
+        self.driver.get(self.live_server_url)
+        login_window = self.driver.current_window_handle
+        self.driver.switch_to.new_window("tab")
+        client_window = self.driver.current_window_handle
+        # We need to access the SP on the same host as the IdP for SameSite cookies
+        self.driver.get(f"http://{self.host}:9009")
+
+        self.driver.switch_to.window(login_window)
+        self.login()
+        self.driver.switch_to.window(client_window)
+
+        self.wait_for_url(f"http://{self.host}:9009/")
+
+        body = loads(self.driver.find_element(By.CSS_SELECTOR, "pre").text)
+
+        self.assertEqual(
+            body["attr"]["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"],
+            [self.user.name],
+        )
+        self.assertEqual(
+            body["attr"][
+                "http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"
+            ],
+            [self.user.username],
+        )
+        self.assertEqual(
+            body["attr"]["http://schemas.goauthentik.io/2021/02/saml/username"],
+            [self.user.username],
+        )
+        self.assertEqual(
+            body["attr"]["http://schemas.goauthentik.io/2021/02/saml/uid"],
+            [str(self.user.pk)],
+        )
+        self.assertEqual(
+            body["attr"]["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"],
+            [self.user.email],
+        )
+        self.assertEqual(
+            body["attr"]["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn"],
+            [self.user.email],
         )


### PR DESCRIPTION
see #13629 and #14180)

This reverts commit 6aaec08496b5851927d6da70455a2d3d39a3a29b.

Signed-off-by: Jens Langhammer <jens@goauthentik.io>

# Conflicts:
#	authentik/flows/views/interface.py

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
