### PR TITLE
website/docs: Re-introduce Websockets for nginx proxy manager

### DIFF
--- a/website/docs/add-secure-apps/providers/proxy/_nginx_proxy_manager.md
+++ b/website/docs/add-secure-apps/providers/proxy/_nginx_proxy_manager.md
@@ -14,6 +14,10 @@ location / {
     # Set any other headers your application might need
     # proxy_set_header Host $host;
     # proxy_set_header ...
+    # Support for websocket
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $http_connection;
+    proxy_http_version 1.1;
 
     ##############################
     # authentik-specific config


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
PR #11621 fixed a crash from the configuration file provided for use by nginx proxy manager by removing Websocket functionality altogether, instead of fixing the feature.

In order to bring feature-parity with the already existing configuration file for use by nginx, websocket support is reintroduced in this PR.

This has been extensively tested, and works perfectly fine. nginx proxy manager does not need the `map` directive that the regular nginx uses, so no additional changes are needed to someone's setup. This new configuration is all it takes to re-introduce feature-parity with other nginx-based configurations, and strictly matches what NPM would be doing internally, for vhosts without an advanced configuration.

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
