### PR TITLE
web: fix description for signing responses in SAML provider

### DIFF
--- a/web/src/admin/providers/saml/SAMLProviderFormForm.ts
+++ b/web/src/admin/providers/saml/SAMLProviderFormForm.ts
@@ -50,7 +50,7 @@ function renderHasSigningKp(provider?: Partial<SAMLProvider>) {
             name="signResponse"
             label=${msg("Sign responses")}
             ?checked=${provider?.signResponse ?? false}
-            help=${msg("When enabled, the assertion element of the SAML response will be signed.")}
+            help=${msg("When enabled, the SAML response will be signed.")}
         >
         </ak-switch-input>`;
 }


### PR DESCRIPTION
## Details

Changes the description for signing responses in the SAML provider creation/edit UI 

Closes #14559


---

## Checklist

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)
