### PR TITLE
providers/proxy: kubernetes outpost: fix reconcile when ingress class name changed

### DIFF
--- a/authentik/providers/proxy/controllers/k8s/ingress.py
+++ b/authentik/providers/proxy/controllers/k8s/ingress.py
@@ -47,6 +47,8 @@ class IngressReconciler(KubernetesObjectReconciler[V1Ingress]):
     def reconcile(self, current: V1Ingress, reference: V1Ingress):
         super().reconcile(current, reference)
         self._check_annotations(current, reference)
+        if current.spec.ingress_class_name != reference.spec.ingress_class_name:
+            raise NeedsUpdate()
         # Create a list of all expected host and tls hosts
         expected_hosts = []
         expected_hosts_tls = []


### PR DESCRIPTION

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Closes #14603

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
