### PR TITLE
website: Fix issue where OpenAPI docs template generates semi-synthet…

### DIFF
--- a/website/src/theme/DocItem/Content/index.tsx
+++ b/website/src/theme/DocItem/Content/index.tsx
@@ -29,12 +29,14 @@ class MarkdownLintError extends Error {
 const DocItemContent: React.FC<Props> = ({ children }) => {
     const syntheticTitle = useSyntheticTitle();
     const { frontMatter, metadata, contentTitle } = useDoc();
+    const { id } = metadata;
     const {
         // ---
         support_level,
         authentik_version,
         authentik_enterprise,
         authentik_preview,
+        hide_title,
     } = frontMatter;
 
     const badges: JSX.Element[] = [];
@@ -57,32 +59,31 @@ const DocItemContent: React.FC<Props> = ({ children }) => {
 
     if (badges.length && !syntheticTitle) {
         throw new MarkdownLintError(
-            `${metadata.id}: ${badges.length} Badge(s) found with a missing synthetic title. Remove the page heading and set it via the frontmatter.`,
+            `${id}: ${badges.length} Badge(s) found with a missing synthetic title. Remove the page heading and set it via the frontmatter.`,
         );
     }
 
     if (frontMatter.title && contentTitle && frontMatter.title === contentTitle) {
         throw new MarkdownLintError(
-            `${metadata.id}: Synthetic title "${frontMatter.title}" and content title "${contentTitle}" are the same. Remove the first heading and let the frontmatter set the title.`,
+            `${id}: Synthetic title "${frontMatter.title}" and content title "${contentTitle}" are the same. Remove the first heading and let the frontmatter set the title.`,
         );
     }
 
     useEffect(() => {
+        if (hide_title) return;
+
         const invalidBadges = document.querySelectorAll(`.theme-doc-markdown > header + .badge,
             .theme-doc-markdown .markdown > .badge
             `);
 
         if (!invalidBadges.length) return;
 
-        console.error(
-            `Found ${invalidBadges.length} invalid badges on ${metadata.id}`,
-            invalidBadges,
-        );
+        console.error(`Found ${invalidBadges.length} invalid badges on ${id}`, invalidBadges);
 
         throw new MarkdownLintError(
-            `${metadata.id}: ${invalidBadges.length} Badge(s) defined in markdown content instead of the frontmatter.`,
+            `${id}: ${invalidBadges.length} Badge(s) defined in markdown content instead of the frontmatter.`,
         );
-    }, [metadata.id]);
+    }, [hide_title, id]);
 
     return (
         <div className={clsx(ThemeClassNames.docs.docMarkdown, "markdown")}>


### PR DESCRIPTION
…ic title.

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
This PR fixes an issue stemming from a change introduced in the latest OpenAPI doc generator. Generated markdown files which apply `hide_title` should be exempt from the linter check for incorrectly placed badges.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
