### PR TITLE
website/integrations: minio: notice about sso deprecation on CE

### DIFF
--- a/website/integrations/services/minio/index.md
+++ b/website/integrations/services/minio/index.md
@@ -18,7 +18,7 @@ The following placeholders are used in this guide:
 - `authentik.company` is the FQDN of the authentik installation.
 
 :::warning
-MinIO has recently limited SSO support to its [Enterprise offering (AIStor)](https://min.io/pricing). We recommend reverting to a version **before `RELEASE.2025-04-22T22-12-26Z`** to continue using SSO for free.
+MinIO has recently limited SSO support to its [Enterprise offering (AIStor)](https://min.io/pricing). The last version to include free SSO support is **`RELEASE.2025-04-22T22-12-26Z`**. While it's technically possible to use an earlier version to retain this functionality, we do **not** recommend reverting due to potential security and stability concerns.
 :::
 
 :::note

--- a/website/integrations/services/minio/index.md
+++ b/website/integrations/services/minio/index.md
@@ -17,6 +17,10 @@ The following placeholders are used in this guide:
 - `minio.company` is the FQDN of the MinIO installation.
 - `authentik.company` is the FQDN of the authentik installation.
 
+:::warning
+MinIO has recently limited SSO support to its [Enterprise offering (AIStor)](https://min.io/pricing). We recommend reverting to a version **before `RELEASE.2025-04-22T22-12-26Z`** to continue using SSO for free.
+:::
+
 :::note
 This documentation lists only the settings that you need to change from their default values. Be aware that any changes other than those explicitly mentioned in this guide could cause issues accessing your application.
 :::

--- a/website/integrations/services/minio/index.md
+++ b/website/integrations/services/minio/index.md
@@ -18,7 +18,7 @@ The following placeholders are used in this guide:
 - `authentik.company` is the FQDN of the authentik installation.
 
 :::warning
-MinIO has recently limited SSO support to its [Enterprise offering (AIStor)](https://min.io/pricing). The last version to include free SSO support is **`RELEASE.2025-04-22T22-12-26Z`**. While it's technically possible to use an earlier version to retain this functionality, we do **not** recommend reverting due to potential security and stability concerns.
+MinIO has recently limited SSO to its [Enterprise offering (AIStor)](https://min.io/pricing). **`RELEASE.2025-04-22T22-12-26Z`** is the last version where this feature is available for free. While it’s technically possible to continue using that release, we **do not** recommend reverting due to potential security and stability risks.
 :::
 
 :::note


### PR DESCRIPTION
Starting with RELEASE.2025-05-24T17-08-30Z, MinIO has limited SSO support to their enterprise edition. This pr adds a warning to inform users and recommends sticking with earlier versions to retain SSO functionality. (wow)

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)