### PR TITLE
tests/e2e: fix flaky SAML Source test

### DIFF
--- a/authentik/root/test_runner.py
+++ b/authentik/root/test_runner.py
@@ -31,6 +31,8 @@ class PytestTestRunner(DiscoverRunner):  # pragma: no cover
 
         if kwargs.get("randomly_seed", None):
             self.args.append(f"--randomly-seed={kwargs['randomly_seed']}")
+        if kwargs.get("no_capture", False):
+            self.args.append("--capture=no")
 
         settings.TEST = True
         settings.CELERY["task_always_eager"] = True
@@ -63,6 +65,11 @@ class PytestTestRunner(DiscoverRunner):  # pragma: no cover
             "to reuse the seed from the previous run."
             "Default behaviour: use random.Random().getrandbits(32), so the seed is"
             "different on each run.",
+        )
+        parser.add_argument(
+            "--no-capture",
+            action="store_true",
+            help="Disable any capturing of stdout/stderr during tests."
         )
 
     def run_tests(self, test_labels, extra_tests=None, **kwargs):

--- a/authentik/root/test_runner.py
+++ b/authentik/root/test_runner.py
@@ -69,7 +69,7 @@ class PytestTestRunner(DiscoverRunner):  # pragma: no cover
         parser.add_argument(
             "--no-capture",
             action="store_true",
-            help="Disable any capturing of stdout/stderr during tests."
+            help="Disable any capturing of stdout/stderr during tests.",
         )
 
     def run_tests(self, test_labels, extra_tests=None, **kwargs):

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   chrome:
+    platform: linux/x86_64
     image: docker.io/selenium/standalone-chrome:136.0
     volumes:
       - /dev/shm:/dev/shm

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -177,17 +177,17 @@ class SeleniumTestCase(DockerTestCase, StaticLiveServerTestCase):
         count = 0
         opts = webdriver.ChromeOptions()
         opts.add_argument("--disable-search-engine-choice-screen")
-        opts.set_capability("goog:loggingPrefs", {"browser": "ALL"})
+        # opts.set_capability("goog:loggingPrefs", {"browser": "ALL"})
         opts.add_experimental_option(
             "prefs",
             {
                 "profile.password_manager_leak_detection": False,
             },
         )
-        try:
-            return webdriver.Chrome(options=opts)
-        except WebDriverException:
-            pass
+        # try:
+        #     return webdriver.Chrome(options=opts)
+        # except WebDriverException:
+        #     pass
         while count < RETRIES:
             # try:
             driver = webdriver.Remote(

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -177,6 +177,7 @@ class SeleniumTestCase(DockerTestCase, StaticLiveServerTestCase):
         count = 0
         opts = webdriver.ChromeOptions()
         opts.add_argument("--disable-search-engine-choice-screen")
+        # This breaks selenium when running remotely...?
         # opts.set_capability("goog:loggingPrefs", {"browser": "ALL"})
         opts.add_experimental_option(
             "prefs",
@@ -184,21 +185,17 @@ class SeleniumTestCase(DockerTestCase, StaticLiveServerTestCase):
                 "profile.password_manager_leak_detection": False,
             },
         )
-        # try:
-        #     return webdriver.Chrome(options=opts)
-        # except WebDriverException:
-        #     pass
         while count < RETRIES:
-            # try:
-            driver = webdriver.Remote(
-                command_executor="http://localhost:4444/wd/hub",
-                options=opts,
-            )
-            driver.maximize_window()
-            return driver
-            # except WebDriverException as exc:
-            #     self.logger.warning("Failed to setup webdriver", exc=exc)
-            #     count += 1
+            try:
+                driver = webdriver.Remote(
+                    command_executor="http://localhost:4444/wd/hub",
+                    options=opts,
+                )
+                driver.maximize_window()
+                return driver
+            except WebDriverException as exc:
+                self.logger.warning("Failed to setup webdriver", exc=exc)
+                count += 1
         raise ValueError(f"Webdriver failed after {RETRIES}.")
 
     def tearDown(self):

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -166,10 +166,10 @@ class SeleniumTestCase(DockerTestCase, StaticLiveServerTestCase):
             print("::group::authentik Logs", file=stderr)
         apps.get_app_config("authentik_tenants").ready()
         self.wait_timeout = 60
+        self.logger = get_logger()
         self.driver = self._get_driver()
         self.driver.implicitly_wait(30)
         self.wait = WebDriverWait(self.driver, self.wait_timeout)
-        self.logger = get_logger()
         self.user = create_test_admin_user()
         super().setUp()
 
@@ -181,7 +181,7 @@ class SeleniumTestCase(DockerTestCase, StaticLiveServerTestCase):
         opts.add_experimental_option(
             "prefs",
             {
-            "profile.password_manager_leak_detection": False,
+                "profile.password_manager_leak_detection": False,
             },
         )
         try:
@@ -196,7 +196,8 @@ class SeleniumTestCase(DockerTestCase, StaticLiveServerTestCase):
                 )
                 driver.maximize_window()
                 return driver
-            except WebDriverException:
+            except WebDriverException as exc:
+                self.logger.warning("Failed to setup webdriver", exc=exc)
                 count += 1
         raise ValueError(f"Webdriver failed after {RETRIES}.")
 

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -175,9 +175,10 @@ class SeleniumTestCase(DockerTestCase, StaticLiveServerTestCase):
 
     def _get_driver(self) -> WebDriver:
         count = 0
+        opts = webdriver.ChromeOptions()
+        opts.add_argument("--disable-search-engine-choice-screen")
+        opts.set_capability("goog:loggingPrefs", {"browser": "ALL"})
         try:
-            opts = webdriver.ChromeOptions()
-            opts.add_argument("--disable-search-engine-choice-screen")
             return webdriver.Chrome(options=opts)
         except WebDriverException:
             pass
@@ -185,7 +186,7 @@ class SeleniumTestCase(DockerTestCase, StaticLiveServerTestCase):
             try:
                 driver = webdriver.Remote(
                     command_executor="http://localhost:4444/wd/hub",
-                    options=webdriver.ChromeOptions(),
+                    options=opts,
                 )
                 driver.maximize_window()
                 return driver

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -178,6 +178,9 @@ class SeleniumTestCase(DockerTestCase, StaticLiveServerTestCase):
         opts = webdriver.ChromeOptions()
         opts.add_argument("--disable-search-engine-choice-screen")
         opts.set_capability("goog:loggingPrefs", {"browser": "ALL"})
+        opts.add_experimental_option("prefs", {
+            "profile.password_manager_leak_detection": False,
+        })
         try:
             return webdriver.Chrome(options=opts)
         except WebDriverException:

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -178,9 +178,12 @@ class SeleniumTestCase(DockerTestCase, StaticLiveServerTestCase):
         opts = webdriver.ChromeOptions()
         opts.add_argument("--disable-search-engine-choice-screen")
         opts.set_capability("goog:loggingPrefs", {"browser": "ALL"})
-        opts.add_experimental_option("prefs", {
+        opts.add_experimental_option(
+            "prefs",
+            {
             "profile.password_manager_leak_detection": False,
-        })
+            },
+        )
         try:
             return webdriver.Chrome(options=opts)
         except WebDriverException:

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -189,16 +189,16 @@ class SeleniumTestCase(DockerTestCase, StaticLiveServerTestCase):
         except WebDriverException:
             pass
         while count < RETRIES:
-            try:
-                driver = webdriver.Remote(
-                    command_executor="http://localhost:4444/wd/hub",
-                    options=opts,
-                )
-                driver.maximize_window()
-                return driver
-            except WebDriverException as exc:
-                self.logger.warning("Failed to setup webdriver", exc=exc)
-                count += 1
+            # try:
+            driver = webdriver.Remote(
+                command_executor="http://localhost:4444/wd/hub",
+                options=opts,
+            )
+            driver.maximize_window()
+            return driver
+            # except WebDriverException as exc:
+            #     self.logger.warning("Failed to setup webdriver", exc=exc)
+            #     count += 1
         raise ValueError(f"Webdriver failed after {RETRIES}.")
 
     def tearDown(self):


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

From testing, the main thing that causes this test to break is the chrome password leak thingy; it seems to block all interactions from selenium until dismissed and is obviously not helpful while testing locally. Sometimes selenium is fast enoug/chrome is slow enough for us to send the signal to click on the button before the warning pops up and we succeed.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
