### PR TITLE
providers/ldap: retain binder and update users instead of re-creating

### DIFF
--- a/internal/outpost/ldap/refresh.go
+++ b/internal/outpost/ldap/refresh.go
@@ -16,6 +16,7 @@ import (
 	memorybind "goauthentik.io/internal/outpost/ldap/bind/memory"
 	"goauthentik.io/internal/outpost/ldap/constants"
 	"goauthentik.io/internal/outpost/ldap/flags"
+	"goauthentik.io/internal/outpost/ldap/search"
 	directsearch "goauthentik.io/internal/outpost/ldap/search/direct"
 	memorysearch "goauthentik.io/internal/outpost/ldap/search/memory"
 )
@@ -85,7 +86,11 @@ func (ls *LDAPServer) Refresh() error {
 			providers[idx].certUUID = *kp
 		}
 		if *provider.SearchMode.Ptr() == api.LDAPAPIACCESSMODE_CACHED {
-			providers[idx].searcher = memorysearch.NewMemorySearcher(providers[idx])
+			var oldSearcher search.Searcher
+			if existing != nil {
+				oldSearcher = existing.searcher
+			}
+			providers[idx].searcher = memorysearch.NewMemorySearcher(providers[idx], oldSearcher)
 		} else if *provider.SearchMode.Ptr() == api.LDAPAPIACCESSMODE_DIRECT {
 			providers[idx].searcher = directsearch.NewDirectSearcher(providers[idx])
 		}

--- a/internal/outpost/ldap/search/memory/memory.go
+++ b/internal/outpost/ldap/search/memory/memory.go
@@ -31,13 +31,26 @@ type MemorySearcher struct {
 	groups []api.Group
 }
 
-func NewMemorySearcher(si server.LDAPServerInstance) *MemorySearcher {
+func NewMemorySearcher(si server.LDAPServerInstance, existing search.Searcher) *MemorySearcher {
 	ms := &MemorySearcher{
 		si:  si,
 		log: log.WithField("logger", "authentik.outpost.ldap.searcher.memory"),
 		ds:  direct.NewDirectSearcher(si),
 	}
+	if existing != nil {
+		if ems, ok := existing.(*MemorySearcher); ok {
+			ems.si = si
+			ems.fetch()
+			ems.log.Debug("re-initialised memory searcher")
+			return ems
+		}
+	}
+	ms.fetch()
 	ms.log.Debug("initialised memory searcher")
+	return ms
+}
+
+func (ms *MemorySearcher) fetch() {
 	// Error is not handled here, we get an empty/truncated list and the error is logged
 	users, _ := ak.Paginator(ms.si.GetAPIClient().CoreApi.CoreUsersList(context.TODO()).IncludeGroups(true), ak.PaginatorOptions{
 		PageSize: 100,
@@ -49,7 +62,6 @@ func NewMemorySearcher(si server.LDAPServerInstance) *MemorySearcher {
 		Logger:   ms.log,
 	})
 	ms.groups = groups
-	return ms
 }
 
 func (ms *MemorySearcher) SearchBase(req *search.Request) (ldap.ServerSearchResult, error) {


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Fixes growing memory usage everytime the outpost gets an update trigger

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
