### PR TITLE
website/docs: spell out administrator in service template

### DIFF
--- a/website/integrations/template/service.md
+++ b/website/integrations/template/service.md
@@ -29,7 +29,7 @@ _Any specific info about this integration can go here._
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
     - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/template/service.md
+++ b/website/integrations/template/service.md
@@ -43,7 +43,7 @@ _Any specific info about this integration can go here._
 
 ## Service configuration
 
-Insert Service configuration
+Insert service configuration
 
 1. Write first step here...
 


### PR DESCRIPTION
This PR makes a minor fix to our template for service guides.

If applicable

-   [X] The documentation has been updated
-   [X] The documentation has been formatted (`make website`)
