### PR TITLE
website: use "administrator" instead of "admin" for Admin interface

### DIFF
--- a/website/docs/add-secure-apps/applications/manage_apps.mdx
+++ b/website/docs/add-secure-apps/applications/manage_apps.mdx
@@ -8,7 +8,7 @@ Managing the applications that your team uses involves several tasks, from initi
 
 To add an application to authentik and have it display on users' **My applications** page, follow these steps:
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 
 2. Navigate to **Applications -> Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can create only an application, without a provider, by clicking **Create.)**
 

--- a/website/docs/add-secure-apps/providers/oauth2/create-oauth2-provider.md
+++ b/website/docs/add-secure-apps/providers/oauth2/create-oauth2-provider.md
@@ -4,7 +4,7 @@ title: Create an OAuth2 provider
 
 To add a provider (and the application that uses the provider for authentication) use the ** Create with provider** option, which creates both the new application and the required provider at the same time. For typical scenarios, authentik recommends that you create both the application and the provider together. (Alternatively, use our legacy process: navigate to **Applications --> Providers**, and then click **Create**.)
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 
 2. Navigate to **Applications -> Applications** and click **Create with provider** to create an application and provider pair. (Alternatively you can create only an application, without a provider, by clicking **Create**.)
 

--- a/website/docs/add-secure-apps/providers/oauth2/device_code.md
+++ b/website/docs/add-secure-apps/providers/oauth2/device_code.md
@@ -52,7 +52,7 @@ If the user _has_ finished the authentication and authorization, the response wi
 
 ### Create and apply a device code flow
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Flows and Stages** > **Flows** and click **Create**.
 3. Set the following required configurations:
     - **Name**: provide a name (e.g. `default-device-code-flow`)

--- a/website/docs/add-secure-apps/providers/rac/how-to-rac.md
+++ b/website/docs/add-secure-apps/providers/rac/how-to-rac.md
@@ -26,7 +26,7 @@ Depending on whether you are connecting using RDP, SSH, or VNC, the exact config
 
 The first step is to create the RAC application and provider pair.
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with provider**.
 3. Follow these [instructions](../../applications/manage_apps.mdx#instructions) to create your RAC application and provider.
 
@@ -34,7 +34,7 @@ The first step is to create the RAC application and provider pair.
 
 Next, you need to add property mappings for each remote machine you want to access. Property mappings allow you to pass information to external applications, and with RAC they are used to pass the host name, IP address, and access credentials of the remote machine.
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Customization > Property Mappings** and click **Create**.
 
     - **Select Type**: RAC Property Mappings
@@ -57,7 +57,7 @@ Next, you need to add property mappings for each remote machine you want to acce
 
 Finally, you need to create an endpoint for each remote machine. Endpoints are defined within providers; connections between the remote machine and authentik are enabled through communication between the provider's endpoint and the remote machine.
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications > Providers**.
 3. Click the **Edit** button on the RAC provider that you previously created.
 4. On the Provider page, under **Endpoints**, click **Create**, and provide the following settings:

--- a/website/docs/add-secure-apps/providers/ssf/create-ssf-provider.md
+++ b/website/docs/add-secure-apps/providers/ssf/create-ssf-provider.md
@@ -16,7 +16,7 @@ The workflow to implement an SSF provider as a [backchannel provider](../../appl
 
 ## Create the SSF provider
 
-1. Log in to authentik as an admin, and in the Admin interface navigate to **Applications -> Providers**.
+1. Log in to authentik as an administrator and in the Admin interface navigate to **Applications -> Providers**.
 
 2. Click **Create**.
 
@@ -28,7 +28,7 @@ The workflow to implement an SSF provider as a [backchannel provider](../../appl
 
 ## Create the OIDC provider
 
-1. Log in to authentik as an admin, and in the Admin interface navigate to **Applications -> Providers**.
+1. Log in to authentik as an administrator and in the Admin interface navigate to **Applications -> Providers**.
 
 2. Click **Create**.
 
@@ -38,7 +38,7 @@ The workflow to implement an SSF provider as a [backchannel provider](../../appl
 
 ## Create the application
 
-1. Log in to authentik as an admin, and in the Admin interface navigate to **Applications -> Applications**.
+1. Log in to authentik as an administrator and in the Admin interface navigate to **Applications -> Applications**.
 
 2. Click **Create**.
 

--- a/website/docs/users-sources/sources/directory-sync/active-directory/index.md
+++ b/website/docs/users-sources/sources/directory-sync/active-directory/index.md
@@ -42,7 +42,7 @@ To support the integration of Active Directory with authentik, you need to creat
 
 To support the integration of authentik with Active Directory, you will need to create a new LDAP Source in authentik.
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Directory** > **Federation & Social login**.
 3. Click **Create** and select **LDAP Source** as the type.
 4. Provide a name, slug, and the following required configurations:

--- a/website/docs/users-sources/sources/index.md
+++ b/website/docs/users-sources/sources/index.md
@@ -19,7 +19,7 @@ For instructions to add a specific source, refer to the documentation links in t
 
 To have sources show on the default login screen you will need to add them to the flow. The process below assumes that you have not created or renamed the default stages and flows.
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Flows and Stages** > **Flows**.
 3. Click the **default-authentication-flow**.
 4. Click the **Stage Bindings** tab.

--- a/website/integrations/services/actual-budget/index.mdx
+++ b/website/integrations/services/actual-budget/index.mdx
@@ -30,7 +30,7 @@ To support the integration of Actual Budget with authentik, you need to create a
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/adventurelog/index.mdx
+++ b/website/integrations/services/adventurelog/index.mdx
@@ -27,7 +27,7 @@ To support the integration of AdventureLog with authentik, you need to create an
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/apache-guacamole/index.mdx
+++ b/website/integrations/services/apache-guacamole/index.mdx
@@ -30,7 +30,7 @@ To support the integration of Apache Guacamole with authentik, you need to creat
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/argocd/index.md
+++ b/website/integrations/services/argocd/index.md
@@ -27,7 +27,7 @@ To support the integration of ArgoCD with authentik, you need to create an appli
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/aruba-orchestrator/index.md
+++ b/website/integrations/services/aruba-orchestrator/index.md
@@ -27,7 +27,7 @@ To support the integration of Aruba Orchestrator with authentik, you need to cre
 
 ### Create property mappings
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Customization** > **Property Mappings** and click **Create**. Create a **SAML Provider Property Mapping** with the following settings:
     - **Name**: Set an appropriate name
     - **SAML Attribute Name**: <kbd>sp-roles</kbd>
@@ -41,7 +41,7 @@ To support the integration of Aruba Orchestrator with authentik, you need to cre
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings. Take note of the **slug** as it will be required later.

--- a/website/integrations/services/atlassian/index.mdx
+++ b/website/integrations/services/atlassian/index.mdx
@@ -54,7 +54,7 @@ To support the integration of Atlassian Cloud with authentik, you need to create
 
 ### Download the signing certificate
 
-1. Log into authentik as an admin, and open the authentik Admin interface.
+1. Log into authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Providers** and click on the name of the newly created Atlassian Cloud provider.
 3. Under **Download signing certificate** click the **Download** button. The contents of this certificate will be required in the next section.
 

--- a/website/integrations/services/atlassian/index.mdx
+++ b/website/integrations/services/atlassian/index.mdx
@@ -38,7 +38,7 @@ To support the integration of Atlassian Cloud with authentik, you need to create
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
     - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
@@ -77,7 +77,7 @@ To support the integration of Atlassian Cloud with authentik, you need to create
 
 ## Reconfigure authentik provider
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Providers** and click the **Edit** icon of the newly created Atlassian Cloud provider.
 3. Under **Protocol settgins**, set the following required configurations:
     - **ACS URL**: set the acs url to the copied **Service provider assertion consumer service URL** (e.g. https://auth.atlassian.com/login/callback?connection=saml-example).

--- a/website/integrations/services/aws/index.mdx
+++ b/website/integrations/services/aws/index.mdx
@@ -38,7 +38,7 @@ To support the integration of AWS with authentik using the classic IAM method, y
 
 #### Create property mappings
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Customization** > **Property Mappings** and click **Create**. Create two **SAML Provider Property Mapping**s with the following settings:
 
     - **Role Mapping:**
@@ -79,7 +79,7 @@ To support the integration of AWS with authentik using the classic IAM method, y
 
 #### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name (e.g. "AWS"), an optional group for the type of application, the policy engine mode, and optional UI settings. The **slug** will be used in URLs and should match the `aws-slug` placeholder defined earlier.
@@ -120,7 +120,7 @@ To support the integration of AWS with authentik using IAM Identity Center, you 
 
 #### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name (e.g. "AWS Identity Center"), an optional group for the type of application, the policy engine mode, and optional UI settings. The **slug** will be used in URLs and should match the `aws-slug` placeholder defined earlier.
@@ -161,7 +161,7 @@ To support the integration of AWS with authentik using SCIM, you need to create 
 
 #### Create property mappings
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Customization** > **Property Mappings** and click **Create**. Create a **SCIM Mapping** with the following settings:
     - **Name**: Choose a name lexically lower than `authentik default` (e.g. `AWS SCIM User mapping`)
     - **Expression**:
@@ -175,7 +175,7 @@ To support the integration of AWS with authentik using SCIM, you need to create 
 
 #### Create a SCIM provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Providers** > **Providers** and click **Create**.
 3. Select **SCIM Provider** as the provider type.
 4. Configure the provider with the following settings:

--- a/website/integrations/services/awx-tower/index.md
+++ b/website/integrations/services/awx-tower/index.md
@@ -31,7 +31,7 @@ To support the integration of AWX Tower with authentik, you need to create an ap
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings. Take note of the **slug** as it will be required later.

--- a/website/integrations/services/beszel/index.mdx
+++ b/website/integrations/services/beszel/index.mdx
@@ -29,7 +29,7 @@ This documentation lists only the settings that you need to change from their de
 
 The steps to configure authentik include creating an application and provider pair in authentik, obtaining the Client ID, Client Secret, and slug values, setting the redirect URI, and selecting a signing key.
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name (`Beszel`), a slug (`beszel`), an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/bookstack/index.mdx
+++ b/website/integrations/services/bookstack/index.mdx
@@ -42,7 +42,7 @@ To support the integration of BookStack with authentik, you need to create an ap
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
@@ -81,7 +81,7 @@ To support the integration of BookStack with authentik, you need to create an ap
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings. Take note of the **slug** as it will be required later.

--- a/website/integrations/services/budibase/index.md
+++ b/website/integrations/services/budibase/index.md
@@ -27,7 +27,7 @@ To support the integration of Budibase with authentik, you need to create an app
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/calibre-web/index.md
+++ b/website/integrations/services/calibre-web/index.md
@@ -27,7 +27,7 @@ To support the integration of Calibre-Web with authentik, you need to create an 
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/chronograf/index.mdx
+++ b/website/integrations/services/chronograf/index.mdx
@@ -26,9 +26,9 @@ To support the integration of Chronograf with authentik, you need to create an a
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
-3. Log in to authentik as an admin, and open the authentik Admin interface.
+3. Log in to authentik as an administrator and open the authentik Admin interface.
 4. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can create only an application, without a provider, by clicking **Create**.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/cloudflare-access/index.md
+++ b/website/integrations/services/cloudflare-access/index.md
@@ -29,7 +29,7 @@ To support the integration of Cloudflare Access with authentik, you need to crea
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/coder/index.md
+++ b/website/integrations/services/coder/index.md
@@ -27,7 +27,7 @@ To support the integration of Coder with authentik, you need to create an applic
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/dokuwiki/index.md
+++ b/website/integrations/services/dokuwiki/index.md
@@ -27,7 +27,7 @@ To support the integration of DocuWiki with authentik, you need to create an app
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/drupal/index.md
+++ b/website/integrations/services/drupal/index.md
@@ -32,7 +32,7 @@ To support the integration of Drupal with authentik, you need to create an appli
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings. The **slug** will be used in URLs and should match the `drupal-slug` placeholder defined earlier.

--- a/website/integrations/services/engomo/index.mdx
+++ b/website/integrations/services/engomo/index.mdx
@@ -29,7 +29,7 @@ To support the integration of Engomo with authentik, you need to create an appli
 
 ### Create property mappings
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Customization** > **Property Mappings** and click **Create**. Create a **Scope Mapping** with the following settings:
     - **Name**: Set an appropriate name.
     - **Scope Name**: `profile`
@@ -38,7 +38,7 @@ To support the integration of Engomo with authentik, you need to create an appli
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/espocrm/index.md
+++ b/website/integrations/services/espocrm/index.md
@@ -31,7 +31,7 @@ To support the integration of EspoCRM with authentik, you need to create an appl
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/firezone/index.md
+++ b/website/integrations/services/firezone/index.md
@@ -27,7 +27,7 @@ To support the integration of Firezone with authentik, you need to create an app
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/fortigate-admin/index.md
+++ b/website/integrations/services/fortigate-admin/index.md
@@ -27,7 +27,7 @@ To support the integration of FortiGate with authentik, you need to create an ap
 
 ### Create property mapping
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Customization** > **Property Mappings** and click **Create**. Create a **SAML Provider Property Mapping** with the following settings:
 
 - **Name**: Choose a descriptive name
@@ -37,7 +37,7 @@ To support the integration of FortiGate with authentik, you need to create an ap
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings. Take note of the **slug** as it will be required later.

--- a/website/integrations/services/fortimanager/index.md
+++ b/website/integrations/services/fortimanager/index.md
@@ -27,7 +27,7 @@ To support the integration of FortiManager with authentik, you need to create an
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/frappe/index.md
+++ b/website/integrations/services/frappe/index.md
@@ -32,7 +32,7 @@ To support the integration of Frappe with authentik, you need to create an appli
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/freshrss/index.mdx
+++ b/website/integrations/services/freshrss/index.mdx
@@ -27,7 +27,7 @@ To support the integration of FreshRss with authentik, you need to create an app
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/gatus/index.mdx
+++ b/website/integrations/services/gatus/index.mdx
@@ -27,7 +27,7 @@ To support the integration of Gatus with authentik, you need to create an applic
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/gitea/index.md
+++ b/website/integrations/services/gitea/index.md
@@ -27,7 +27,7 @@ To support the integration of Gitea with authentik, you need to create an applic
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
@@ -89,7 +89,7 @@ You can add users to the groups at any point.
 
 #### Create custom property mapping
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Customization** > **Property Mappings** and click **Create**. Create a **Scope Mapping** with the following configurations:
 
     - **Name**: Choose a descriptive name (.e.g `authentik gitea OAuth Mapping: OpenID 'gitea'`)
@@ -113,7 +113,7 @@ You can add users to the groups at any point.
 
 #### Add the custom property mapping to the Gitea provider
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Providers** and click on the **Edit** icon of the Gitea provider.
 3. Under **Advanced protocol settings** > **Scopes** add the following scopes to **Selected Scopes**:
 

--- a/website/integrations/services/gitea/index.md
+++ b/website/integrations/services/gitea/index.md
@@ -42,7 +42,7 @@ To support the integration of Gitea with authentik, you need to create an applic
 
 ## Gitea configuration
 
-1. Log in to Gitea as an admin, then click on your profile icon at the top right and select **Site Administration**.
+1. Log in to Gitea as an administrator, then click on your profile icon at the top right and select **Site Administration**.
 2. Select the **Authentication Sources** tab and then click on **Add Authentication Source**.
 3. Set the following required configurations:
     - **Authentication Name**: `authentik` (This must match the name used in the **Redirect URI** in the previous section)

--- a/website/integrations/services/github-enterprise-cloud/index.md
+++ b/website/integrations/services/github-enterprise-cloud/index.md
@@ -31,7 +31,7 @@ To support the integration of GitHub Enterprise Cloud with authentik, you need t
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/github-enterprise-emu/index.md
+++ b/website/integrations/services/github-enterprise-emu/index.md
@@ -43,7 +43,7 @@ GitHub will create usenames for your EMU users based on the SAML `NameID` proper
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/github-enterprise-server/index.md
+++ b/website/integrations/services/github-enterprise-server/index.md
@@ -33,7 +33,7 @@ In order to use GitHub Enterprise Server, SCIM must also be set up.
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/github-organization/index.md
+++ b/website/integrations/services/github-organization/index.md
@@ -27,7 +27,7 @@ To support the integration of AWX Tower with authentik, you need to create an ap
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings. Take note of the **slug** as it will be required later.

--- a/website/integrations/services/gitlab/index.mdx
+++ b/website/integrations/services/gitlab/index.mdx
@@ -104,7 +104,7 @@ To support the integration of GitLab with authentik, you need to create an appli
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/glitchtip/index.md
+++ b/website/integrations/services/glitchtip/index.md
@@ -27,7 +27,7 @@ To support the integration of Glitchtip with authentik, you need to create an ap
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/grafana/index.mdx
+++ b/website/integrations/services/grafana/index.mdx
@@ -27,7 +27,7 @@ To support the integration of Grafana with authentik, you need to create an appl
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/gravitee/index.md
+++ b/website/integrations/services/gravitee/index.md
@@ -29,7 +29,7 @@ To support the integration of Gravitee with authentik, you need to create an app
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/gravity/index.md
+++ b/website/integrations/services/gravity/index.md
@@ -31,7 +31,7 @@ To support the integration of Gravity with authentik, you need to create an appl
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: Provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/harbor/index.md
+++ b/website/integrations/services/harbor/index.md
@@ -27,7 +27,7 @@ To support the integration of Harbor with authentik, you need to create an appli
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/hashicorp-vault/index.md
+++ b/website/integrations/services/hashicorp-vault/index.md
@@ -31,7 +31,7 @@ To support the integration of Hashicorp Vault with authentik, you need to create
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/hedgedoc/index.md
+++ b/website/integrations/services/hedgedoc/index.md
@@ -27,7 +27,7 @@ To support the integration of HedgeDoc with authentik, you need to create an app
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/homarr/index.md
+++ b/website/integrations/services/homarr/index.md
@@ -27,7 +27,7 @@ To support the integration of Homarr with authentik, you need to create an appli
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/immich/index.md
+++ b/website/integrations/services/immich/index.md
@@ -27,7 +27,7 @@ To support the integration of Immich with authentik, you need to create an appli
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/jenkins/index.md
+++ b/website/integrations/services/jenkins/index.md
@@ -27,7 +27,7 @@ To support the integration of Jenkins with authentik, you need to create an appl
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/karakeep/index.md
+++ b/website/integrations/services/karakeep/index.md
@@ -27,7 +27,7 @@ To support the integration of Karakeep with authentik, you need to create an app
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/kimai/index.md
+++ b/website/integrations/services/kimai/index.md
@@ -28,7 +28,7 @@ To support the integration of Kimai with authentik, you need to create an applic
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings. Take note of the **slug** as it will be required later.

--- a/website/integrations/services/knocknoc/index.md
+++ b/website/integrations/services/knocknoc/index.md
@@ -27,7 +27,7 @@ To support the integration of Knocknoc with authentik, you need to create an app
 
 ### Create property mappings in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Customization** > **Property Mappings** and click **Create** to create a property mapping.
 
 - **Select type**: Select **SAML Provider Property Mapping** as the type and click **Next**.
@@ -72,7 +72,7 @@ This example will set session duration at 540 minutes. Change the value to match
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/komga/index.md
+++ b/website/integrations/services/komga/index.md
@@ -27,7 +27,7 @@ To support the integration of Komga with authentik, you need to create an applic
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/linkwarden/index.md
+++ b/website/integrations/services/linkwarden/index.md
@@ -27,7 +27,7 @@ To support the integration of Linkwarden with authentik, you need to create an a
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/mailcow/index.md
+++ b/website/integrations/services/mailcow/index.md
@@ -31,7 +31,7 @@ To support the integration of mailcow with authentik, you need to create an appl
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/mastodon/index.md
+++ b/website/integrations/services/mastodon/index.md
@@ -27,7 +27,7 @@ To support the integration of Mastodon with authentik, you need to create an app
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/matrix-synapse/index.md
+++ b/website/integrations/services/matrix-synapse/index.md
@@ -27,7 +27,7 @@ To support the integration of Matrix Synapse with authentik, you need to create 
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/mautic/index.md
+++ b/website/integrations/services/mautic/index.md
@@ -41,7 +41,7 @@ To support the integration of Mautic with authentik, you need to create property
 
 Because Mautic requires a first name and last name attribute, create two [SAML provider property mappings](../../../docs/users-sources/sources/property-mappings):
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Customization** > **Property Mappings** and click **Create**:
     - **Name**: `SAML-FirstName-from-Name`
     - **SAML Attribute Name**: `FirstName`
@@ -64,7 +64,7 @@ Because Mautic requires a first name and last name attribute, create two [SAML p
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
     - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
     - **Choose a Provider**: select **SAML Provider** as the provider type.

--- a/website/integrations/services/mealie/index.md
+++ b/website/integrations/services/mealie/index.md
@@ -27,7 +27,7 @@ To support the integration of Mealie with authentik, you need to create an appli
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/meshcentral/index.md
+++ b/website/integrations/services/meshcentral/index.md
@@ -27,7 +27,7 @@ To support the integration of MeshCentral with authentik, you need to create an 
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/miniflux/index.md
+++ b/website/integrations/services/miniflux/index.md
@@ -27,7 +27,7 @@ To support the integration of Miniflux with authentik, you need to create an app
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name (e.g., `Miniflux`), an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/minio/index.md
+++ b/website/integrations/services/minio/index.md
@@ -31,7 +31,7 @@ To support the integration of MinIO with authentik, you need to create an applic
 
 ### Create property mappings
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Customization** > **Property Mappings** and click **Create**. Create a **Scope Mapping** with the following settings:
 
 - **Name**: Set an appropriate name
@@ -64,7 +64,7 @@ You can assign multiple policies to a user by returning a list, and returning `N
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/mobilizon/index.md
+++ b/website/integrations/services/mobilizon/index.md
@@ -27,7 +27,7 @@ To support the integration of Mobilizon with authentik, you need to create an ap
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/netbird/index.md
+++ b/website/integrations/services/netbird/index.md
@@ -57,7 +57,7 @@ If an access group is created for the Netbird application, the Netbird service a
 
 ### Set up a service account
 
-1. Log into authentik as an admin, and open the authentik Admin interface.
+1. Log into authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Directory** > **Users**, and click **Create a service account**.
 3. Set the **Username** to `NetBird` and disable the **Create group** option. Click **Create** and take note of the **password**.
 
@@ -65,7 +65,7 @@ If an access group is created for the Netbird application, the Netbird service a
 
 NetBird requires the service account to have full administrative access to the authentik instance. Follow these steps to make it an administrator.
 
-1. Log into authentik as an admin, and open the authentik Admin interface.
+1. Log into authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Directory** > **Groups**, and click **`authentik Admins`**.
 3. On the top of the group configuration page, switch to the **Users** tab near the top of the page, then click **Add existing user**, and select the service account you just created.
 

--- a/website/integrations/services/netbird/index.md
+++ b/website/integrations/services/netbird/index.md
@@ -27,7 +27,7 @@ To support the integration of NetBird with authentik, you need to create an appl
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
@@ -71,7 +71,7 @@ NetBird requires the service account to have full administrative access to the a
 
 ### Create and apply a device token authentication flow
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Flows and Stages** > **Flows** and click **Create**.
 3. Set the following required configurations:
     - **Name**: provide a name (e.g. `default-device-code-flow`)

--- a/website/integrations/services/netbox/index.md
+++ b/website/integrations/services/netbox/index.md
@@ -27,7 +27,7 @@ To support the integration of NetBox with authentik, you need to create an appli
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/node-red/index.md
+++ b/website/integrations/services/node-red/index.md
@@ -33,7 +33,7 @@ To support the integration of Node-RED with authentik, you need to create an app
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/observium/index.md
+++ b/website/integrations/services/observium/index.md
@@ -44,7 +44,7 @@ To support the integration of Observium with authentik, you need to create an ap
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/omni/index.md
+++ b/website/integrations/services/omni/index.md
@@ -27,7 +27,7 @@ To support the integration of Omni with authentik, you need to create a property
 
 ### Create a Property Mapping, Application, and Provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Customization** > **Property Mappings** and click **Create** to create a property mapping.
 
 - **Choose a Property Mapping type**: Select SAML Provider Property Mapping as the property mapping type.

--- a/website/integrations/services/open-webui/index.md
+++ b/website/integrations/services/open-webui/index.md
@@ -27,7 +27,7 @@ To support the integration of Open WebUI with authentik, you need to create an a
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/openproject/index.md
+++ b/website/integrations/services/openproject/index.md
@@ -76,7 +76,7 @@ OpenProject requires a first and last name for each user. By default authentik o
 
 To support the integration of authentik with OpenProject, you need to configure authentication in the OpenProject administration interface.
 
-1. Login to OpenProject as an admin, click on your profile icon at the top right and then **Administration**.
+1. Login to OpenProject as an administrator, click on your profile icon at the top right and then **Administration**.
 2. Navigate to **Authentication** > **OpenID providers**.
 3. Provide a display name (e.g. `Authentik`) and click **Save**.
 4. Click on **I have a discover endpoint URL** and enter:

--- a/website/integrations/services/openproject/index.md
+++ b/website/integrations/services/openproject/index.md
@@ -29,7 +29,7 @@ To support the integration of OpenProject with authentik, you need to create a p
 
 OpenProject requires a first and last name for each user. By default authentik only provides a full name, as a single string value. Therefore you need to create a property mapping to provide first and last names to OpenProject.
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Customization** > **Property Mappings** and click **Create**.
 
 - **Select type**: select **Scope Mapping** as the property mapping type.
@@ -53,7 +53,7 @@ OpenProject requires a first and last name for each user. By default authentik o
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/oracle-cloud/index.md
+++ b/website/integrations/services/oracle-cloud/index.md
@@ -27,7 +27,7 @@ To support the integration of Oracle Cloud with authentik, you need to create an
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/outline/index.md
+++ b/website/integrations/services/outline/index.md
@@ -28,7 +28,7 @@ To support the integration of Outline with authentik, you need to create an appl
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/owncloud/index.md
+++ b/website/integrations/services/owncloud/index.md
@@ -29,7 +29,7 @@ The configuration for each application is nearly identical, except for the **Cli
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.) You will need to repeat the process four times: once each for the Desktop application, Web UI, Android application, and iOS application.
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/paperless-ngx/index.mdx
+++ b/website/integrations/services/paperless-ngx/index.mdx
@@ -27,7 +27,7 @@ To support the integration of Paperless-ngx with authentik, you need to create a
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
     - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/pgadmin/index.md
+++ b/website/integrations/services/pgadmin/index.md
@@ -31,7 +31,7 @@ To support the integration of pgAdmin with authentik, you need to create an appl
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/plesk/index.md
+++ b/website/integrations/services/plesk/index.md
@@ -31,7 +31,7 @@ To support the integration of Plesk with authentik, you need to create an applic
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/pocketbase/index.md
+++ b/website/integrations/services/pocketbase/index.md
@@ -34,7 +34,7 @@ To support the integration of Pocketbase with authentik, you need to create an a
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/portainer/index.md
+++ b/website/integrations/services/portainer/index.md
@@ -31,7 +31,7 @@ To support the integration of Portainer with authentik, you need to create an ap
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/proxmox-ve/index.md
+++ b/website/integrations/services/proxmox-ve/index.md
@@ -31,7 +31,7 @@ To support the integration of Proxmox with authentik, you need to create an appl
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/push-security/index.mdx
+++ b/website/integrations/services/push-security/index.mdx
@@ -60,7 +60,7 @@ Push Security requires separate first and last names for each user, but authenti
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
     - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/rocketchat/index.md
+++ b/website/integrations/services/rocketchat/index.md
@@ -31,7 +31,7 @@ To support the integration of Rocket.chat with authentik, you need to create an 
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/roundcube/index.md
+++ b/website/integrations/services/roundcube/index.md
@@ -31,7 +31,7 @@ To support the integration of Roundcube with authentik, you need to create an ap
 
 ### Create property mappings
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Customization** > **Property Mappings** and click **Create**. Create a **Scope Mapping** with the following settings:
     - **Name**: Set an appropriate name.
     - **Scope Name**: `dovecotprofile`
@@ -49,7 +49,7 @@ To support the integration of Roundcube with authentik, you need to create an ap
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/rustdesk-pro/index.mdx
+++ b/website/integrations/services/rustdesk-pro/index.mdx
@@ -31,7 +31,7 @@ To support the integration of Rustdesk Server Pro with authentik, you need to cr
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/semaphore/index.mdx
+++ b/website/integrations/services/semaphore/index.mdx
@@ -29,7 +29,7 @@ To support the integration of Semaphore with authentik, you need to create an ap
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/slack/index.md
+++ b/website/integrations/services/slack/index.md
@@ -27,7 +27,7 @@ To support the integration of Slack with authentik, you need to create an applic
 
 ### Create property mappings
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Customization** > **Property Mappings** and click **Create**. Create two **SAML Provider Property Mapping**s with the following settings:
     - **Name Mapping:**
         - **Name**: Choose a descriptive name
@@ -42,7 +42,7 @@ To support the integration of Slack with authentik, you need to create an applic
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings. Take note of the **slug** as it will be required later.

--- a/website/integrations/services/stripe/index.mdx
+++ b/website/integrations/services/stripe/index.mdx
@@ -36,7 +36,7 @@ To support the integration of Stripe with authentik, you need to create a group,
 
 ### Create a property mapping in authentik
 
-1.  Log in to authentik as an admin, and open the authentik Admin interface.
+1.  Log in to authentik as an administrator and open the authentik Admin interface.
 2.  Navigate to **Customization** > **Property Mappings** and click **Create**. Then, create a **SAML Provider Property Mapping** using the following settings:
 
         - **Name**: `Stripe Role`
@@ -54,7 +54,7 @@ To support the integration of Stripe with authentik, you need to create a group,
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
     - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/synology-dsm/index.md
+++ b/website/integrations/services/synology-dsm/index.md
@@ -31,7 +31,7 @@ To support the integration of Synology DSM with authentik, you need to create an
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/tandoor/index.md
+++ b/website/integrations/services/tandoor/index.md
@@ -27,7 +27,7 @@ To support the integration of Tandoor with authentik, you need to create an appl
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/terrakube/index.md
+++ b/website/integrations/services/terrakube/index.md
@@ -27,7 +27,7 @@ To support the integration of Terrakube with authentik, you need to create an ap
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/truecommand/index.md
+++ b/website/integrations/services/truecommand/index.md
@@ -31,7 +31,7 @@ To support the integration of TrueCommand with authentik, you need to create an 
 
 ### Create property mappings
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Customization** > **Property Mappings** and click **Create**. Create create three or five **SAML Provider Property Mapping**s, depending on your setup, with the following settings:
     - **Username Mapping:**
         - **Name**: Choose a descriptive name
@@ -61,7 +61,7 @@ To support the integration of TrueCommand with authentik, you need to create an 
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings. Take note of the **slug** as it will be required later.

--- a/website/integrations/services/ubuntu-landscape/index.md
+++ b/website/integrations/services/ubuntu-landscape/index.md
@@ -33,7 +33,7 @@ To support the integration of Landscape with authentik, you need to create an ap
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/uptime-kuma/index.md
+++ b/website/integrations/services/uptime-kuma/index.md
@@ -29,7 +29,7 @@ To support the integration of Uptime Kuma with authentik, you need to create an 
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/veeam-enterprise-manager/index.md
+++ b/website/integrations/services/veeam-enterprise-manager/index.md
@@ -35,7 +35,7 @@ To support the integration of Veeam Enterprise Manage with authentik, you need t
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Providers** and click **Create** to create a provider.
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings. Take note of the **slug** as it will be required later.

--- a/website/integrations/services/vikunja/index.md
+++ b/website/integrations/services/vikunja/index.md
@@ -32,7 +32,7 @@ To support the integration of Vikunja with authentik, you need to create an appl
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/vmware-vcenter/index.md
+++ b/website/integrations/services/vmware-vcenter/index.md
@@ -29,7 +29,7 @@ To support the integration of vCenter with authentik, you need to create an appl
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/wazuh/index.mdx
+++ b/website/integrations/services/wazuh/index.mdx
@@ -28,7 +28,7 @@ To support the integration of Wazuh with authentik, you need to create a group, 
 
 ### Create a user group in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Directory** > **Groups** and click **Create**.
 3. Set a name for the group (e.g. `wazuh-administrators`) and click **Create**.
 4. Click the name of the newly created group and navigate to the **Users** tab.
@@ -36,7 +36,7 @@ To support the integration of Wazuh with authentik, you need to create a group, 
 
 ### Create a property mapping in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Customization** > **Property Mappings** and click **Create**. Create a **SAML Provider Property Mapping** with the following settings:
 
     - **Name**: Choose a descriptive name
@@ -53,7 +53,7 @@ To support the integration of Wazuh with authentik, you need to create a group, 
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name (e.g., `Wazuh`), an optional group for the type of application, the policy engine mode, and optional UI settings.
@@ -71,7 +71,7 @@ To support the integration of Wazuh with authentik, you need to create a group, 
 
 ### Download metadata file
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Providers** and click on the name of the provider that you created in the previous section (e.g. `Provider for wazuh`).
 3. Under **Related objects** > **Metadata**, click on **Download**. This downloaded file is your `SAML Metadata` file and it will be required in the next section.
 

--- a/website/integrations/services/weblate/index.md
+++ b/website/integrations/services/weblate/index.md
@@ -28,7 +28,7 @@ To support the integration of Weblate with authentik, you need to create an appl
 
 ### Create property mappings
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Customization** > **Property Mappings** and click **Create**. Create four **SAML Provider Property Mapping**s with the following settings:
     - **Full Name Mapping:**
         - **Name**: Choose a descriptive name
@@ -65,7 +65,7 @@ To support the integration of Weblate with authentik, you need to create an appl
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings. Take note of the **slug** as it will be required later.

--- a/website/integrations/services/wekan/index.mdx
+++ b/website/integrations/services/wekan/index.mdx
@@ -27,7 +27,7 @@ To support the integration of Wekan with authentik, you need to create an applic
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/whats-up-docker/index.md
+++ b/website/integrations/services/whats-up-docker/index.md
@@ -27,7 +27,7 @@ To support the integration of What's Up Docker with authentik, you need to creat
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/wiki-js/index.md
+++ b/website/integrations/services/wiki-js/index.md
@@ -37,7 +37,7 @@ To support the integration of Wiki.js with authentik, you need to create an appl
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/wordpress/index.md
+++ b/website/integrations/services/wordpress/index.md
@@ -31,7 +31,7 @@ To support the integration of WordPress with authentik, you need to create an ap
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/writefreely/index.md
+++ b/website/integrations/services/writefreely/index.md
@@ -31,7 +31,7 @@ To support the integration of Writefreely with authentik, you need to create an 
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/xcreds/index.mdx
+++ b/website/integrations/services/xcreds/index.mdx
@@ -20,7 +20,7 @@ To support the integration of XCreds with authentik, you need to create an appli
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
     - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
@@ -34,7 +34,7 @@ To support the integration of XCreds with authentik, you need to create an appli
 
 ### Copy OpenID configuration URL
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Providers** and click on the name of the newly created XCreds provider.
 3. Copy the **OpenID Configuration URL**. This will be required to configure XCreds in the next section.
 

--- a/website/integrations/services/xen-orchestra/index.md
+++ b/website/integrations/services/xen-orchestra/index.md
@@ -32,7 +32,7 @@ To support the integration of Xen Orchestra with authentik, you need to create a
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/youtrack/index.md
+++ b/website/integrations/services/youtrack/index.md
@@ -27,7 +27,7 @@ To support the integration of YouTrack with authentik, you need to create an app
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
@@ -45,7 +45,7 @@ To support the integration of YouTrack with authentik, you need to create an app
 
 ### Get the certificate's SHA-256 fingerprint
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **System** > **Certificates**, expand the certificate chosen in the previous section, and take note of the **Certificate Fingerprint (SHA256)**.
 
 ## YouTrack configuration
@@ -61,7 +61,7 @@ To support the integration of YouTrack with authentik, you need to create an app
 
 ### Update the authentik provider
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Providers** > **_application name_**, then click **Edit**.
 3. Replace the placeholder value for the **ACS URL** with the value copied from the previous section.
 

--- a/website/integrations/services/zabbix/index.md
+++ b/website/integrations/services/zabbix/index.md
@@ -29,7 +29,7 @@ To support the integration of Zabbix with authentik, you need to create an appli
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings. Take note of the **slug** as it will be required later.

--- a/website/integrations/services/zammad/index.md
+++ b/website/integrations/services/zammad/index.md
@@ -28,7 +28,7 @@ To support the integration of Zammad with authentik, you need to create an appli
 
 ### Create property mappings
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Customization** > **Property Mappings** and click **Create**. Create two **SAML Provider Property Mapping**s with the following settings:
     - **Name Mapping:**
         - **Name**: Choose a descriptive name
@@ -43,7 +43,7 @@ To support the integration of Zammad with authentik, you need to create an appli
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings. Take note of the **slug** as it will be required later.

--- a/website/integrations/services/zipline/index.md
+++ b/website/integrations/services/zipline/index.md
@@ -31,7 +31,7 @@ To support the integration of Zipline with authentik, you need to create an appl
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: Provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.

--- a/website/integrations/services/zulip/index.md
+++ b/website/integrations/services/zulip/index.md
@@ -27,7 +27,7 @@ To support the integration of Zulip with authentik, you need to create an applic
 
 ### Create an application and provider in authentik
 
-1. Log in to authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
 - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings. Take note of the **slug** as it will be required later.


### PR DESCRIPTION
### What

This pull request standardizes the terminology used across our documentation by replacing the term "admin" with "administrator" in contexts related to logging into the Admin interface. This was most often seen in the integration guides, but it also affects the regular user-facing documentation.

### How

Nearly all changes could be made using the following shell command:
```sh
find ~/Developer/authentik/website/docs ~/Developer/authentik/website/integrations -type f -exec perl -pi -e 's/Log in to authentik as an admin, and open the authentik Admin interface\./Log in to authentik as an administrator and open the authentik Admin interface./g' {} +
```

To try to ensure nothing was missed, the following command was also ran to look for the term "as an admin,":
```sh
find ~/Developer/authentik/website/ -type d -name node_modules -prune -o -type f -exec perl -ne 'print "$ARGV:$.: $_" if /as an admin,/' {} +
```

### Updates

Follow up for https://github.com/goauthentik/authentik/pull/14770

### Acceptance Criteria

* [x] CI is green for documentation-related jobs

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
