### PR TITLE
website: fix incorrect usage of "login to" + "log into" vs "log in to"

### DIFF
--- a/website/docs/add-secure-apps/providers/entra/setup-entra.md
+++ b/website/docs/add-secure-apps/providers/entra/setup-entra.md
@@ -9,7 +9,7 @@ For detailed instructions, refer to Microsoft Entra ID documentation.
 
 ## Configure Entra ID
 
-1. Log into the Azure portal and on the Home page, under Azure services, click on or search for **App registrations**.
+1. Log in to the Azure portal and on the Home page, under Azure services, click on or search for **App registrations**.
 2. On the **App registrations** page, click **New registration**.
 3. On the **Register an application** page, define the **Name** of the app, and under **Supported account types** select **Accounts in this organizational directory only**. Leave **Redirect URI** empty.
 4. Click **Register**.

--- a/website/docs/users-sources/sources/directory-sync/freeipa/index.md
+++ b/website/docs/users-sources/sources/directory-sync/freeipa/index.md
@@ -13,7 +13,7 @@ The following placeholders are used in this guide:
 
 ## FreeIPA Setup
 
-1. Log into FreeIPA.
+1. Log in to FreeIPA.
 
 2. Create a user in FreeIPA, matching your naming scheme. Provide a strong password, example generation methods: `pwgen 64 1` or `openssl rand 36 | base64 -w 0`. After you are done click **Add and Edit**.
 

--- a/website/docs/users-sources/sources/protocols/kerberos/browser.md
+++ b/website/docs/users-sources/sources/protocols/kerberos/browser.md
@@ -26,7 +26,7 @@ To automate the deployment of this configuration use a [Group policy](https://su
 
 ## Windows / Internet Explorer
 
-Log into the Windows machine using an account of your Kerberos realm (or administrative domain).
+Log in to the Windows machine using an account of your Kerberos realm (or administrative domain).
 
 Open Internet Explorer, click **Tools** and then click **Internet Options**. You can also find **Internet Options** using the system search.
 

--- a/website/docs/users-sources/sources/social-logins/apple/index.md
+++ b/website/docs/users-sources/sources/social-logins/apple/index.md
@@ -21,7 +21,7 @@ The following placeholders are used in this guide:
 
 ## Apple
 
-1. Log into your Apple developer account, and navigate to **Certificates, IDs & Profiles**, then click **Identifiers** in the sidebar.
+1. Log in to your Apple developer account, and navigate to **Certificates, IDs & Profiles**, then click **Identifiers** in the sidebar.
 2. Register a new Identifier with the type of **App IDs**, and the subtype **App**.
 3. Choose a name that users will recognise for the **Description** field.
 4. For your bundle ID, use the reverse domain of authentik, in this case `company.authentik`.

--- a/website/docs/users-sources/sources/social-logins/facebook/index.md
+++ b/website/docs/users-sources/sources/social-logins/facebook/index.md
@@ -48,7 +48,7 @@ Finally, you need to publish the Facebook app.
 
 ## authentik configuration
 
-1. Log into authentik as admin, and then navigate to **Directory -> Federation & Social login**
+1. Log in to authentik as admin, and then navigate to **Directory -> Federation & Social login**
 2. Click **Create**.
 3. In the **New Source** box, for **Select type** select **Facebook OAuth Source** and then click **Next**.
 4. Define the following fields:

--- a/website/docs/users-sources/sources/social-logins/mailcow/index.md
+++ b/website/docs/users-sources/sources/social-logins/mailcow/index.md
@@ -14,7 +14,7 @@ The following placeholders are used in this guide:
 
 ## Mailcow
 
-1. Log into mailcow as an admin and navigate to the OAuth2 Apps settings
+1. Log in to mailcow as an admin and navigate to the OAuth2 Apps settings
 
 ![OAuth2 Apps menu](./mailcow1.png)
 

--- a/website/integrations/services/atlassian/index.mdx
+++ b/website/integrations/services/atlassian/index.mdx
@@ -54,7 +54,7 @@ To support the integration of Atlassian Cloud with authentik, you need to create
 
 ### Download the signing certificate
 
-1. Log into authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an admin, and open the authentik Admin interface.
 2. Navigate to **Applications** > **Providers** and click on the name of the newly created Atlassian Cloud provider.
 3. Under **Download signing certificate** click the **Download** button. The contents of this certificate will be required in the next section.
 
@@ -88,7 +88,7 @@ To support the integration of Atlassian Cloud with authentik, you need to create
 
 ### Internal users
 
-1. Log into the [Atlassian administrator portal](https://admin.atlassian.com) as an Atlassian Cloud organization admin.
+1. Log in to the [Atlassian administrator portal](https://admin.atlassian.com) as an Atlassian Cloud organization admin.
 2. Navigate to **Security** > **Authentication policies**.
 3. Click **Add policy** at the top right.
 4. Select the `authentik` directory and provide a name for the policy.

--- a/website/integrations/services/harbor/index.md
+++ b/website/integrations/services/harbor/index.md
@@ -49,7 +49,7 @@ To support the integration of Harbor with authentik, you need to create an appli
 
 To support the integration of authentik with Harbor, you need to configure OIDC authentication.
 
-1. Login to the Harbor dashboard as an admin.
+1. Log in to the Harbor dashboard as an admin.
 2. Navigate to **Configuration** and select the **Authentication** tab.
 3. In the **Auth Mode** dropdown, select **OIDC** and provide the following required configurations.
 

--- a/website/integrations/services/netbird/index.md
+++ b/website/integrations/services/netbird/index.md
@@ -57,7 +57,7 @@ If an access group is created for the Netbird application, the Netbird service a
 
 ### Set up a service account
 
-1. Log into authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an admin, and open the authentik Admin interface.
 2. Navigate to **Directory** > **Users**, and click **Create a service account**.
 3. Set the **Username** to `NetBird` and disable the **Create group** option. Click **Create** and take note of the **password**.
 
@@ -65,7 +65,7 @@ If an access group is created for the Netbird application, the Netbird service a
 
 NetBird requires the service account to have full administrative access to the authentik instance. Follow these steps to make it an administrator.
 
-1. Log into authentik as an admin, and open the authentik Admin interface.
+1. Log in to authentik as an admin, and open the authentik Admin interface.
 2. Navigate to **Directory** > **Groups**, and click **`authentik Admins`**.
 3. On the top of the group configuration page, switch to the **Users** tab near the top of the page, then click **Add existing user**, and select the service account you just created.
 

--- a/website/integrations/services/openproject/index.md
+++ b/website/integrations/services/openproject/index.md
@@ -76,7 +76,7 @@ OpenProject requires a first and last name for each user. By default authentik o
 
 To support the integration of authentik with OpenProject, you need to configure authentication in the OpenProject administration interface.
 
-1. Login to OpenProject as an admin, click on your profile icon at the top right and then **Administration**.
+1. Log in to OpenProject as an admin, click on your profile icon at the top right and then **Administration**.
 2. Navigate to **Authentication** > **OpenID providers**.
 3. Provide a display name (e.g. `Authentik`) and click **Save**.
 4. Click on **I have a discover endpoint URL** and enter:

--- a/website/integrations/services/push-security/index.mdx
+++ b/website/integrations/services/push-security/index.mdx
@@ -80,7 +80,7 @@ Push Security requires separate first and last names for each user, but authenti
 
 ### Download the signing certificate
 
-1. Log into authentik as an administrator, and open the authentik Admin interface.
+1. Log in to authentik as an administrator, and open the authentik Admin interface.
 2. Navigate to **Applications** > **Providers** and click on the name of the newly created Push Security provider.
 3. Click **Download** under **Download signing certificate**. The contents of this certificate will be required in the next section.
 

--- a/website/integrations/services/veeam-enterprise-manager/index.md
+++ b/website/integrations/services/veeam-enterprise-manager/index.md
@@ -25,7 +25,7 @@ You will need an existing group or multiple in authentik to assign roles in Veea
 
 ## Veeam Enterprise Manager pre-configuration
 
-Login to your Veeam Enterprise Manager. Navigate to the Configuration in the top-right. On the left sidebar, select Settings. Select the SAML Authentication tab.
+Log in to your Veeam Enterprise Manager. Navigate to the Configuration in the top-right. On the left sidebar, select Settings. Select the SAML Authentication tab.
 
 Check the checkbox called "Enable SAML 2.0". Further down the site, click the "Download" button, to download the metadata.
 


### PR DESCRIPTION
### What

This PR updates several instances of "log into" and "login to" to the grammatically correct "log in to" form across the documentation.

From what I can understand of the English language - Explanation of usage

1) Log in to - Correct verb phrase: "Please log in to the Azure portal." Used when instructing someone to sign into a system. "Log in" is the verb, and "to" is a preposition introducing the destination.
2) Log into - Common but less formal variant of the verb phrase. Can be used conversationally but is less precise. Example: "Log into your account."
3) Login to - Incorrect in this context, because login (one word) is a noun or adjective, not a verb. Example of correct use as a noun: "Enter your login credentials." Incorrect use: "Login to the portal" (should be "log in to").

I've looked over each changed file and it should (?) be fine. Tana, please confirm...

### How

Ran the following shell command:
```sh
find ~/Developer/authentik/website/ -type d -name node_modules -prune -o -type f -print \
  | xargs perl -pi -e 's/\b(?:Login to|Log into)\b/Log in to/g'
```

### Acceptance Criteria

* [x] CI is green for documentation-related jobs

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
