### PR TITLE
docs/troubleshooting: cleanup upgrade instructions for postgres k8s

### DIFF
--- a/website/docs/troubleshooting/postgres/upgrade_kubernetes.md
+++ b/website/docs/troubleshooting/postgres/upgrade_kubernetes.md
@@ -14,7 +14,7 @@ For this guide, we assume the PostgreSQL pod is named `authentik-postgresql-0`, 
 - Your existing `values.yaml` file used for authentik deployment
 - Basic understanding of Kubernetes and Helm commands
 
-## Stopping authentik Services
+## Stopping authentik services
 
 Begin by scaling down authentik services to prevent database access during the migration:
 
@@ -23,7 +23,7 @@ kubectl scale deploy --replicas 0 authentik-server
 kubectl scale deploy --replicas 0 authentik-worker
 ```
 
-## Backing Up the Database
+## Backing up the database
 
 Connect to your PostgreSQL pod:
 
@@ -55,7 +55,7 @@ kubectl cp authentik-postgresql-0:/bitnami/postgresql/dump.sql ./authentik-db-ba
 This ensures you have a backup even if something goes wrong with the pod or storage.
 :::
 
-## Preparing the Data Directory
+## Preparing the data directory
 
 While still connected to the PostgreSQL pod, prepare the data directory for the upgrade:
 
@@ -88,7 +88,7 @@ Apply these changes using Helm to deploy the updated configuration.
 
 This will restart the PostgreSQL pod with the new image. When the pod starts, PostgreSQL will initialize a new, empty data directory since the previous directory was renamed.
 
-## Restoring Database Content
+## Restoring database content
 
 Connect to the PostgreSQL pod again:
 
@@ -112,7 +112,7 @@ export PGPASSWORD=$POSTGRES_POSTGRES_PASSWORD
 psql -U $POSTGRES_USER $POSTGRES_DB < dump.sql
 ```
 
-## Restarting authentik Services
+## Restarting authentik services
 
 After the database restoration completes successfully, restart authentik using Helm with your updated configuration.
 
@@ -129,14 +129,14 @@ If you encounter issues during the upgrade process:
 - Verify the values in your `values.yaml` file match the recommended settings
 - Ensure you have sufficient storage available for both the database dump and the database itself
 
-### Dump File Not Found
+### Dump file not found
 
 If your dump file is missing after upgrading:
 
 - You may need to restore from the external backup if you copied it out of the pod
 - The volume might have been recreated if you're using ephemeral storage
 
-### Restoring the Original Database
+### Restoring the original database
 
 For persistent problems, you can restore from the `data-old` directory if needed:
 

--- a/website/docs/troubleshooting/postgres/upgrade_kubernetes.md
+++ b/website/docs/troubleshooting/postgres/upgrade_kubernetes.md
@@ -41,7 +41,7 @@ Connect to your PostgreSQL pod:
 kubectl exec -it authentik-postgresql-0 -- bash
 ```
 
-Once connected, execute these commands to create a database backup:
+After you are connected, execute these commands to create a database backup:
 
 ```shell
 # Navigate to the PostgreSQL data directory

--- a/website/docs/troubleshooting/postgres/upgrade_kubernetes.md
+++ b/website/docs/troubleshooting/postgres/upgrade_kubernetes.md
@@ -33,7 +33,7 @@ kubectl scale deploy --replicas 0 authentik-server
 kubectl scale deploy --replicas 0 authentik-worker
 ```
 
-## Backing up the database
+## Back up the database
 
 Connect to your PostgreSQL pod:
 

--- a/website/docs/troubleshooting/postgres/upgrade_kubernetes.md
+++ b/website/docs/troubleshooting/postgres/upgrade_kubernetes.md
@@ -122,7 +122,7 @@ export PGPASSWORD=$POSTGRES_POSTGRES_PASSWORD
 psql -U $POSTGRES_USER $POSTGRES_DB < dump.sql
 ```
 
-## Restarting authentik services
+## Restart authentik services
 
 After the database restoration completes successfully, restart authentik using Helm with your updated configuration.
 

--- a/website/docs/troubleshooting/postgres/upgrade_kubernetes.md
+++ b/website/docs/troubleshooting/postgres/upgrade_kubernetes.md
@@ -98,7 +98,7 @@ Apply these changes using Helm to deploy the updated configuration.
 
 This will restart the PostgreSQL pod with the new image. When the pod starts, PostgreSQL will initialize a new, empty data directory since the previous directory was renamed.
 
-## Restoring database content
+## Restore database content
 
 Connect to the PostgreSQL pod again:
 

--- a/website/docs/troubleshooting/postgres/upgrade_kubernetes.md
+++ b/website/docs/troubleshooting/postgres/upgrade_kubernetes.md
@@ -84,7 +84,7 @@ mv data data-old
 Do not delete the old data directory immediately. Keeping it as `data-old` allows for recovery if the upgrade encounters issues.
 :::
 
-## Upgrading PostgreSQL
+## Upgrade PostgreSQL
 
 Now update your `values.yaml` to specify the new PostgreSQL version:
 

--- a/website/docs/troubleshooting/postgres/upgrade_kubernetes.md
+++ b/website/docs/troubleshooting/postgres/upgrade_kubernetes.md
@@ -65,7 +65,7 @@ kubectl cp authentik-postgresql-0:/bitnami/postgresql/dump.sql ./authentik-db-ba
 This ensures you have a backup even if something goes wrong with the pod or storage.
 :::
 
-## Preparing the data directory
+## Prepare the data directory
 
 While still connected to the PostgreSQL pod, prepare the data directory for the upgrade:
 

--- a/website/docs/troubleshooting/postgres/upgrade_kubernetes.md
+++ b/website/docs/troubleshooting/postgres/upgrade_kubernetes.md
@@ -17,6 +17,7 @@ For this guide, we assume the PostgreSQL pod is named `authentik-postgresql-0`, 
 ## Overview of workflow
 
 The basic steps to upgrades PostgreSQL on Kubernetes are:
+
 1. Stop authentik services
 2. Back up the database
 3. Prepare the data directory

--- a/website/docs/troubleshooting/postgres/upgrade_kubernetes.md
+++ b/website/docs/troubleshooting/postgres/upgrade_kubernetes.md
@@ -14,6 +14,16 @@ For this guide, we assume the PostgreSQL pod is named `authentik-postgresql-0`, 
 - Your existing `values.yaml` file used for authentik deployment
 - Basic understanding of Kubernetes and Helm commands
 
+## Overview of workflow
+
+The basic steps to upgrades PostgreSQL on Kubernetes are:
+1. Stop authentik services
+2. Back up the database
+3. Prepare the data directory
+4. Upgrade PostgreSQL
+5. Restore database content
+6. Restart authentik services
+
 ## Stop authentik services
 
 Begin by scaling down authentik services to prevent database access during the migration:

--- a/website/docs/troubleshooting/postgres/upgrade_kubernetes.md
+++ b/website/docs/troubleshooting/postgres/upgrade_kubernetes.md
@@ -14,7 +14,7 @@ For this guide, we assume the PostgreSQL pod is named `authentik-postgresql-0`, 
 - Your existing `values.yaml` file used for authentik deployment
 - Basic understanding of Kubernetes and Helm commands
 
-## Stopping authentik services
+## Stop authentik services
 
 Begin by scaling down authentik services to prevent database access during the migration:
 

--- a/website/docs/troubleshooting/postgres/upgrade_kubernetes.md
+++ b/website/docs/troubleshooting/postgres/upgrade_kubernetes.md
@@ -1,98 +1,150 @@
 ---
-title: Upgrade PostgreSQL on Kubernetes
+title: Upgrading PostgreSQL on Kubernetes
 ---
 
-## Preparation
+This guide walks you through upgrading PostgreSQL in your authentik Kubernetes deployment. The process requires a brief downtime period while the database is migrated.
 
-- `authentik-postgresql-0` is the Kubernetes Pod running PostgreSQL.
+:::note
+For this guide, we assume the PostgreSQL pod is named `authentik-postgresql-0`, which is the default name in the authentik Helm chart.
+:::
 
-### Prerequisites
+## Prerequisites
 
-This migration requires some downtime, during which authentik must be stopped. To do this, run the following command:
+- `kubectl` access with permissions to `scale` deployments and `exec` into pods
+- Your existing `values.yaml` file used for authentik deployment
+- Basic understanding of Kubernetes and Helm commands
+
+## Stopping authentik Services
+
+Begin by scaling down authentik services to prevent database access during the migration:
 
 ```shell
 kubectl scale deploy --replicas 0 authentik-server
 kubectl scale deploy --replicas 0 authentik-worker
 ```
 
-### Dump the current database
+## Backing Up the Database
 
-Run `kubectl exec -it authentik-postgresql-0 -- bash` to get a shell in the PostgreSQL pod.
-
-Run the following commands to dump the current data into a `.sql` file:
+Connect to your PostgreSQL pod:
 
 ```shell
-# This is the path where the PVC is mounted, so we'll place the dump here too
-cd /bitnami/postgresql/
-# Set the postgres password based on the `POSTGRES_POSTGRES_PASSWORD` environment variable
-export PGPASSWORD=$POSTGRES_POSTGRES_PASSWORD
-# Dump the authentik database into an sql file
-pg_dump -U $POSTGRES_USER $POSTGRES_DB > dump-11.sql
+kubectl exec -it authentik-postgresql-0 -- bash
 ```
 
-### Stop PostgreSQL and start the upgrade
+Once connected, execute these commands to create a database backup:
 
-To upgrade, change the following entries in your `values.yaml` used to deploy authentik:
+```shell
+# Navigate to the PostgreSQL data directory
+cd /bitnami/postgresql/
+
+# Set the PostgreSQL password from environment variable
+export PGPASSWORD=$POSTGRES_POSTGRES_PASSWORD
+
+# Create a full database dump
+pg_dump -U $POSTGRES_USER $POSTGRES_DB > /bitnami/postgresql/dump.sql
+```
+
+:::tip
+Consider copying the dump file to a safe location outside the pod:
+
+```shell
+# From a separate terminal
+kubectl cp authentik-postgresql-0:/bitnami/postgresql/dump.sql ./authentik-db-backup.sql
+```
+
+This ensures you have a backup even if something goes wrong with the pod or storage.
+:::
+
+## Preparing the Data Directory
+
+While still connected to the PostgreSQL pod, prepare the data directory for the upgrade:
+
+```shell
+# Ensure you're in the PostgreSQL data directory
+cd /bitnami/postgresql/
+
+# Verify the SQL dump exists and has content
+ls -lh dump.sql
+
+# Preserve the existing data by renaming the directory
+mv data data-old
+```
+
+:::caution
+Do not delete the old data directory immediately. Keeping it as `data-old` allows for recovery if the upgrade encounters issues.
+:::
+
+## Upgrading PostgreSQL
+
+Now update your `values.yaml` to specify the new PostgreSQL version:
 
 ```yaml
 postgresql:
-    diagnosticMode:
-        enabled: true
     image:
-        tag: 15.2.0-debian-11-r26
+        tag: <NEW_VERSION>
 ```
 
-Now run `helm upgrade --install authentik authentik/authentik -f values.yaml` to apply these changes. Depending on your configuration, you might have to repeat the steps from [Prerequisites](#prerequisites).
+Apply these changes using Helm to deploy the updated configuration.
 
-After the upgrade is finished, you should have a new PostgreSQL pod running with the updated image.
+This will restart the PostgreSQL pod with the new image. When the pod starts, PostgreSQL will initialize a new, empty data directory since the previous directory was renamed.
 
-### Remove the old data
+## Restoring Database Content
 
-Because the PVC mounted by the PostgreSQL pod still contains the old data, we need to remove/rename that data, so that PostgreSQL can initialize it with the new version.
-
-Run `kubectl exec -it authentik-postgresql-0 -- bash` to get a shell in the PostgreSQL pod.
-
-Run the following commands to move the old data:
+Connect to the PostgreSQL pod again:
 
 ```shell
-# This is the path where the PVC is mounted
-cd /bitnami/postgresql/
-# Move Postgres' data folder to data-11, which is the version we're upgrading to.
-# The data folder can also be deleted; however it is recommended to rename it first
-# in case the upgrade fails.
-mv data data-11
+kubectl exec -it authentik-postgresql-0 -- bash
 ```
 
-### Restart PostgreSQL
-
-In the step [Stop PostgreSQL and start the upgrade](#stop-postgresql-and-start-the-upgrade), we enabled the _diagnostic mode_, which means the PostgreSQL pod is running, but the actual Postgres process isn't running. Now that we've removed the old data directory, we can disable the diagnostic mode.
-
-Once again, change the following entries in your `values.yaml` used to deploy authentik:
-
-```yaml
-postgresql:
-    image:
-        tag: 15.2.0-debian-11-r26
-```
-
-And once again run `helm upgrade --install authentik authentik/authentik -f values.yaml` to apply these changes. Depending on your configuration, you might have to repeat the steps from [Prerequisites](#prerequisites).
-
-After the PostgreSQL pod is running again, we need to restore the data from the dump we created above.
-
-Run `kubectl exec -it authentik-postgresql-0 -- bash` to get a shell in the PostgreSQL pod.
-
-Run the following commands to restore the data:
+Restore your database from the backup:
 
 ```shell
-# This is the path where the PVC is mounted
+# Navigate to the PostgreSQL directory
 cd /bitnami/postgresql/
-# Set the Postgres password based on the `POSTGRES_POSTGRES_PASSWORD` environment variable.
+
+# Verify your dump file is still there
+ls -lh dump.sql
+
+# Set the PostgreSQL password
 export PGPASSWORD=$POSTGRES_POSTGRES_PASSWORD
-psql -U $POSTGRES_USER $POSTGRES_DB < dump-11.sql
+
+# Import the database dump
+psql -U $POSTGRES_USER $POSTGRES_DB < dump.sql
 ```
 
-After the last command finishes, all of the data is restored, and you can restart authentik.
+## Restarting authentik Services
 
-### Restarting authentik
+After the database restoration completes successfully, restart authentik using Helm with your updated configuration.
 
-Run `helm upgrade --install authentik authentik/authentik -f values.yaml` once again, which will restart your authentik server and worker containers.
+This will scale your authentik server and worker deployments back to their original replica counts.
+
+## Troubleshooting
+
+If you encounter issues during the upgrade process:
+
+- Check PostgreSQL logs:
+    ```shell
+    kubectl logs authentik-postgresql-0
+    ```
+- Verify the values in your `values.yaml` file match the recommended settings
+- Ensure you have sufficient storage available for both the database dump and the database itself
+
+### Dump File Not Found
+
+If your dump file is missing after upgrading:
+
+- You may need to restore from the external backup if you copied it out of the pod
+- The volume might have been recreated if you're using ephemeral storage
+
+### Restoring the Original Database
+
+For persistent problems, you can restore from the `data-old` directory if needed:
+
+```shell
+kubectl exec -it authentik-postgresql-0 -- bash
+cd /bitnami/postgresql/
+mv data data-new-failed
+mv data-old data
+```
+
+Then restart PostgreSQL with the original version in your `values.yaml`.


### PR DESCRIPTION
### What

Revised and expanded the PostgreSQL upgrade documentation for Kubernetes deployments, improved clarity, and added  more detailed steps.

### Problem

The existing PostgreSQL upgrade documentation for Kubernetes was too brief and lacked sufficient guidence on the upgrade process, backup procedures, and common troubleshooting steps. It was also version-specific rather than providing a more "agnostic" approach that would work for the future without needing to update this documentation each time the Helm chart gets updated. Also, it lacked important safety considerations like external backups, verification steps, and recovery procedures in case of upgrade failures.

### Acceptance Criteria

* [x] CI is green
* [x] LGTM from docs
* [ ] LGTM from ops

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
