### PR TITLE
website/docs: update user ref doc with parent group example

### DIFF
--- a/website/docs/users-sources/user/user_ref.mdx
+++ b/website/docs/users-sources/user/user_ref.mdx
@@ -42,7 +42,7 @@ user.ak_groups.filter(name__startswith='test')
 
 ### List a user's group memberships including parent groups
 
-Use the following example to list all groups that a User object is a member of, including parent groups:
+Use the following example to list all groups that a user object is a member of, including parent groups:
 
 ```python
 groups = [group.name for group in request.user.all_groups()]

--- a/website/docs/users-sources/user/user_ref.mdx
+++ b/website/docs/users-sources/user/user_ref.mdx
@@ -25,7 +25,7 @@ These are examples of how User objects can be used within Policies and Property 
 
 ### List a user's group memberships
 
-Use the following example to list all groups that a User object is a direct member of:
+Use the following example to list all groups that a user object is a member of:
 
 ```python
 for group in user.ak_groups.all():
@@ -34,7 +34,7 @@ for group in user.ak_groups.all():
 
 ### List a user's group memberships and filter based on group name
 
-Use the following example to list groups that a User object is a member of, but filter based on group name:
+Use the following example to list groups that a user object is a member of, but filter based on group name:
 
 ```python
 user.ak_groups.filter(name__startswith='test')

--- a/website/docs/users-sources/user/user_ref.mdx
+++ b/website/docs/users-sources/user/user_ref.mdx
@@ -25,7 +25,7 @@ These are examples of how User objects can be used within Policies and Property 
 
 ### List a user's group memberships
 
-Use the following example to list all groups that a User object is a member of:
+Use the following example to list all groups that a User object is a direct member of:
 
 ```python
 for group in user.ak_groups.all():
@@ -38,6 +38,14 @@ Use the following example to list groups that a User object is a member of, but 
 
 ```python
 user.ak_groups.filter(name__startswith='test')
+```
+
+### List a user's group memberships including parent groups
+
+Use the following example to list all groups that a User object is a member of, including parent groups:
+
+```python
+groups = [group.name for group in request.user.all_groups()]
 ```
 
 :::info


### PR DESCRIPTION
## Details

Adds an extra example to the doc. How to obtain user groups and parent groups.

---

## Checklist

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
