### PR TITLE
website/integrations: update cloudflare access callback url

### DIFF
--- a/website/integrations/services/cloudflare-access/index.md
+++ b/website/integrations/services/cloudflare-access/index.md
@@ -36,7 +36,7 @@ To support the integration of Cloudflare Access with authentik, you need to crea
 - **Choose a Provider type**: select **OAuth2/OpenID Connect** as the provider type.
 - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
     - Note the **Client ID**,**Client Secret**, and **slug** values because they will be required later.
-    - Set a `Strict` redirect URI to <kbd>https://<em>company</em>.cloudflareaccess.com/cdn-cgi/access/callback/</kbd>.
+    - Set a `Strict` redirect URI to <kbd>https://<em>company</em>.cloudflareaccess.com/cdn-cgi/access/callback</kbd>.
     - Select any available signing key.
 - **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/flows-stages/bindings/) (policy, group, or user) to manage the listing and access to applications on a user's **My applications** page.
 


### PR DESCRIPTION
Very simple Doc change.

The callback URL example for Cloudflare Access had a trailing / that breaks the callback URL being matched by a strict policy.