### PR TITLE
stages/email: Only attach logo to email if used

### DIFF
--- a/authentik/stages/email/tasks.py
+++ b/authentik/stages/email/tasks.py
@@ -100,9 +100,9 @@ def send_mail(
         # Because we use the Message-ID as UID for the task, manually assign it
         message_object.extra_headers["Message-ID"] = message_id
 
-        # Add the logo if it is used in the email body (we can't add it in the 
+        # Add the logo if it is used in the email body (we can't add it in the
         # previous message since MIMEImage can't be converted to json)
-        body=get_email_body(message_object),
+        body = (get_email_body(message_object),)
         if "cid:logo" in body:
             message_object.attach(logo_data())
 

--- a/authentik/stages/email/tasks.py
+++ b/authentik/stages/email/tasks.py
@@ -102,7 +102,7 @@ def send_mail(
 
         # Add the logo if it is used in the email body (we can't add it in the
         # previous message since MIMEImage can't be converted to json)
-        body = (get_email_body(message_object),)
+        body = get_email_body(message_object)
         if "cid:logo" in body:
             message_object.attach(logo_data())
 

--- a/authentik/stages/email/tasks.py
+++ b/authentik/stages/email/tasks.py
@@ -100,9 +100,11 @@ def send_mail(
         # Because we use the Message-ID as UID for the task, manually assign it
         message_object.extra_headers["Message-ID"] = message_id
 
-        # Add the logo (we can't add it in the previous message since MIMEImage
-        # can't be converted to json)
-        message_object.attach(logo_data())
+        # Add the logo if it is used in the email body (we can't add it in the 
+        # previous message since MIMEImage can't be converted to json)
+        body=get_email_body(message_object),
+        if "cid:logo" in body:
+            message_object.attach(logo_data())
 
         if (
             message_object.to

--- a/authentik/stages/email/templates/email/base.html
+++ b/authentik/stages/email/templates/email/base.html
@@ -96,7 +96,7 @@
                 <table width="100%" style="background-color: #FFFFFF; border-spacing: 0; margin-top: 15px;">
                   <tr height="80">
                     <td align="center" style="padding: 20px 0;">
-                      <img src="{% block logo_url %}cid:logo.png{% endblock %}" border="0=" alt="authentik logo" class="flexibleImage logo">
+                      <img src="{% block logo_url %}cid:logo{% endblock %}" border="0=" alt="authentik logo" class="flexibleImage logo">
                     </td>
                   </tr>
                   {% block content %}

--- a/authentik/stages/email/utils.py
+++ b/authentik/stages/email/utils.py
@@ -19,8 +19,8 @@ def logo_data() -> MIMEImage:
         path = Path("web/dist/assets/icons/icon_left_brand.png")
     with open(path, "rb") as _logo_file:
         logo = MIMEImage(_logo_file.read())
-    logo.add_header('Content-ID', '<logo>')
-    logo.add_header('Content-Disposition', 'inline', filename='logo.png')
+    logo.add_header("Content-ID", "<logo>")
+    logo.add_header("Content-Disposition", "inline", filename="logo.png")
     return logo
 
 

--- a/authentik/stages/email/utils.py
+++ b/authentik/stages/email/utils.py
@@ -19,7 +19,8 @@ def logo_data() -> MIMEImage:
         path = Path("web/dist/assets/icons/icon_left_brand.png")
     with open(path, "rb") as _logo_file:
         logo = MIMEImage(_logo_file.read())
-    logo.add_header("Content-ID", "logo.png")
+    logo.add_header('Content-ID', '<logo>')
+    logo.add_header('Content-Disposition', 'inline', filename='logo.png')
     return logo
 
 

--- a/web/src/components/ak-event-info.ts
+++ b/web/src/components/ak-event-info.ts
@@ -374,7 +374,7 @@ ${JSON.stringify(value.new_value, null, 4)}</pre
 
     renderEmailSent() {
         let body = this.event.context.body as string;
-        body = body.replace("cid:logo.png", "/static/dist/assets/icons/icon_left_brand.png");
+        body = body.replace("cid:logo", "/static/dist/assets/icons/icon_left_brand.png");
         return html`<div class="pf-c-card__title">${msg("Email info:")}</div>
             <div class="pf-c-card__body">${this.getEmailInfo(this.event.context)}</div>
             <ak-expand>


### PR DESCRIPTION
## Details

Address #8397 by only attaching the logo file to an email only when that logo is used in the mailed template via MIME embedded files. 
If user modify the template and do not use the logo (e.g. remove it or reference logos via https://...) the logo is not attached. 

Makes sure that if the logo is used, the MIME attachment conforms to standards:
- content-id is an actual ID and not a file name
- content-disposition is correctly set to inline 

---

## Checklist

-   [X] Local tests pass (`ak test authentik/`)
-   [X] The code has been formatted (`make lint-fix`)
