### PR TITLE
website/releases: order new integrations alphabetically

### DIFF
--- a/website/docs/releases/2025/v2025.6.md
+++ b/website/docs/releases/2025/v2025.6.md
@@ -43,14 +43,14 @@ To try out the release candidate, replace your Docker image tag with the latest 
 
 An integration is how authentik connects to third-party applications, directories, and other identity providers. The following integration guides were recently added.
 
-- [Pangolin](../../../integrations/services/pangolin/)
-- [Stripe](../../../integrations/services/stripe/)
-- [FileRise](../../../integrations/services/filerise/)
-- [Push Security](../../../integrations/services/push-security/)
 - [Atlassian Cloud (Jira, Confluence, etc)](../../../integrations/services/atlassian/)
 - [Coder](../../../integrations/services/coder/)
-- [YouTrack](../../../integrations/services/youtrack/)
+- [FileRise](../../../integrations/services/filerise/)
 - [Komodo](../../../integrations/services/komodo/)
+- [Pangolin](../../../integrations/services/pangolin/)
+- [Push Security](../../../integrations/services/push-security/)
+- [Stripe](../../../integrations/services/stripe/)
+- [YouTrack](../../../integrations/services/youtrack/)
 
 ## Upgrading
 


### PR DESCRIPTION
### What

Orders the 2025.6 release note's new integrations alphabetically. It just bothers me.

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
