### PR TITLE
website/docs: fix note at end of rac credentials prompt

### DIFF
--- a/website/docs/add-secure-apps/providers/rac/rac_credentials_prompt.md
+++ b/website/docs/add-secure-apps/providers/rac/rac_credentials_prompt.md
@@ -87,6 +87,7 @@ Depending on the configuration of the RDP server that's being connected to, it i
 
 :::note
 Other options for the connection security type are: `any`, `nla`, `nla-ext`, `vmconnect`, and `rdp`. For more information see the [Guacamole RDP Authentication and Security Documentation](https://guacamole.apache.org/doc/gug/configuring-guacamole.html#authentication-and-security).
+:::
 
 ## Configuration verification
 

--- a/website/docs/add-secure-apps/providers/rac/rac_credentials_prompt.md
+++ b/website/docs/add-secure-apps/providers/rac/rac_credentials_prompt.md
@@ -91,4 +91,4 @@ Other options for the connection security type are: `any`, `nla`, `nla-ext`, `vm
 
 ## Configuration verification
 
-Log in to authentik with a user account that has the required privileges to access the RAC application. Open the User interface, and on the **My applications** page click the RAC application. You should then be redirected to the prompt stage and prompted for a username and password. Enter the credentials for the RAC endpoint and if the credentials are valid, the RDP/SSH/VNC connection should be established.
+Log in to authentik with a user account that has the required privileges to access the RAC application. Open the User interface, and on the **My applications** page click the RAC application. You should then be redirected to the prompt stage and prompted for a username and password. Enter the credentials for the RAC endpoint and if the credentials are valid the RDP/SSH/VNC connection should be established.


### PR DESCRIPTION
=## Details

Fixes the note section at the end of the document

---

## Checklist

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
