### PR TITLE
website/integrations: fix komodo provider url

### DIFF
--- a/website/integrations/services/komodo/index.mdx
+++ b/website/integrations/services/komodo/index.mdx
@@ -48,7 +48,7 @@ To support the integration of Komodo with authentik, you need to create an appli
 
 ```yaml
 KOMODO_OIDC_ENABLED=true
-KOMODO_OIDC_PROVIDER=https://authentik.company/application/o/authorize
+KOMODO_OIDC_PROVIDER=https://authentik.company/application/o/application-slug/
 KOMODO_OIDC_CLIENT_ID=<authentik_client_ID>
 KOMODO_OIDC_CLIENT_SECRET=<authentik client secret>
 ```

--- a/website/integrations/services/komodo/index.mdx
+++ b/website/integrations/services/komodo/index.mdx
@@ -48,7 +48,7 @@ To support the integration of Komodo with authentik, you need to create an appli
 
 ```yaml
 KOMODO_OIDC_ENABLED=true
-KOMODO_OIDC_PROVIDER=https://authentik.company/application/o/application-slug/
+KOMODO_OIDC_PROVIDER=https://authentik.company/application/o/<application-slug>/
 KOMODO_OIDC_CLIENT_ID=<authentik_client_ID>
 KOMODO_OIDC_CLIENT_SECRET=<authentik client secret>
 ```


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
This PR changes the Komodo integration instructions page on the website. The `KOMODO_OIDC_PROVIDER` value is incorrect. Following the current instructions, Komodo will crash with the following error:

```
thread 'tokio-runtime-worker' panicked at bin/core/src/auth/oidc/client.rs:54:6:
called `Result::unwrap()` on an `Err` value: Failed to initialize OIDC client.

Caused by:
    0: Failed to get OIDC /.well-known/openid-configuration
    1: Server returned invalid response: HTTP status code 404 Not Found at https://authentik.company/application/o/authorize/.well-known/openid-configuration
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Error: task 9 panicked with message "called `Result::unwrap()` on an `Err` value: Failed to initialize OIDC client.\n\nCaused by:\n    0: Failed to get OIDC /.well-known/openid-configuration\n    1: Server returned invalid response: HTTP status code 404 Not Found at https://authentik.company/application/o/authorize/.well-known/openid-configuration"
```

The correct `KOMODO_OIDC_PROVIDER` value is `https://authentik.company/application/o/application-slug/`

This PR updates the website with the new value.

Closes #14913

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
