### PR TITLE
web/elements: Add light mode custom css handling

### DIFF
--- a/web/src/elements/Base.ts
+++ b/web/src/elements/Base.ts
@@ -123,6 +123,9 @@ export class AKElement extends LitElement {
             applyUITheme(nextStyleRoot, UiThemeEnum.Dark, this.#customCSSStyleSheet);
 
             this.activeTheme = UiThemeEnum.Dark;
+        } else if (this.preferredColorScheme === "light") {
+            applyUITheme(nextStyleRoot, UiThemeEnum.Light, this.#customCSSStyleSheet); 
+            this.activeTheme = UiThemeEnum.Light;
         } else if (this.preferredColorScheme === "auto") {
             createUIThemeEffect(
                 (nextUITheme) => {

--- a/web/src/elements/Base.ts
+++ b/web/src/elements/Base.ts
@@ -124,7 +124,7 @@ export class AKElement extends LitElement {
 
             this.activeTheme = UiThemeEnum.Dark;
         } else if (this.preferredColorScheme === "light") {
-            applyUITheme(nextStyleRoot, UiThemeEnum.Light, this.#customCSSStyleSheet); 
+            applyUITheme(nextStyleRoot, UiThemeEnum.Light, this.#customCSSStyleSheet);
             this.activeTheme = UiThemeEnum.Light;
         } else if (this.preferredColorScheme === "auto") {
             createUIThemeEffect(


### PR DESCRIPTION
## Details
This PR fixes an issue where custom CSS was not being applied in light mode theme. The root cause was identified as a missing light mode case in the `styleRoot` setter within the `AKElement` class.

### Changes:
- Added light mode case in `styleRoot` setter to properly handle theme application
- Added `applyUITheme` call with `UiThemeEnum.Light` and custom CSS stylesheet
- Ensured `activeTheme` is properly set for light mode

This change ensures consistent behavior of custom CSS application across all theme modes (dark, light, and auto), improving the user experience particularly for those using light mode themes.

No new requirements or breaking changes are introduced.