### PR TITLE
policies: Optimize policy checking for static bindings

### DIFF
--- a/authentik/core/api/applications.py
+++ b/authentik/core/api/applications.py
@@ -149,10 +149,10 @@ class ApplicationViewSet(UsedByMixin, ModelViewSet):
         return applications
 
     def _filter_applications_with_launch_url(
-        self, pagined_apps: Iterator[Application]
+        self, paginated_apps: Iterator[Application]
     ) -> list[Application]:
         applications = []
-        for app in pagined_apps:
+        for app in paginated_apps:
             if app.get_launch_url():
                 applications.append(app)
         return applications

--- a/authentik/policies/engine.py
+++ b/authentik/policies/engine.py
@@ -106,6 +106,9 @@ class PolicyEngine:
         return True
 
     def compute_static_bindings(self, bindings: QuerySet[PolicyBinding]):
+        if self.request.user.is_anonymous:
+            # If the user is anonymous it cannot be in a group or used as a binding target
+            return
         all_groups = self.request.user.all_groups()
         self.logger.debug("P_ENG: Checking static bindings")
         matched_bindings = bindings.aggregate(

--- a/authentik/policies/tests/test_engine.py
+++ b/authentik/policies/tests/test_engine.py
@@ -170,3 +170,18 @@ class TestPolicyEngine(TestCase):
                     engine.build()
                 self.assertLess(ctx.final_queries, 1000)
                 self.assertEqual(engine.result.passing, case["passing"])
+
+    def test_engine_group_complex(self):
+        """Test more complex group setups"""
+        group_a = Group.objects.create(name=generate_id())
+        group_b = Group.objects.create(name=generate_id(), parent=group_a)
+        user = create_test_user()
+        group_b.users.add(user)
+        pbm = PolicyBindingModel.objects.create()
+        PolicyBinding.objects.create(target=pbm, order=0, group=group_a)
+        engine = PolicyEngine(pbm, user)
+        engine.use_cache = False
+        with CaptureQueriesContext(connections["default"]) as ctx:
+            engine.build()
+        self.assertLess(ctx.final_queries, 1000)
+        self.assertTrue(engine.result.passing)

--- a/authentik/policies/tests/test_process.py
+++ b/authentik/policies/tests/test_process.py
@@ -29,13 +29,12 @@ class TestPolicyProcess(TestCase):
     def setUp(self):
         clear_policy_cache()
         self.factory = RequestFactory()
-        self.user = User.objects.create_user(username="policyuser")
+        self.user = User.objects.create_user(username=generate_id())
 
     def test_group_passing(self):
         """Test binding to group"""
-        group = Group.objects.create(name="test-group")
+        group = Group.objects.create(name=generate_id())
         group.users.add(self.user)
-        group.save()
         binding = PolicyBinding(group=group)
 
         request = PolicyRequest(self.user)
@@ -44,8 +43,7 @@ class TestPolicyProcess(TestCase):
 
     def test_group_negative(self):
         """Test binding to group"""
-        group = Group.objects.create(name="test-group")
-        group.save()
+        group = Group.objects.create(name=generate_id())
         binding = PolicyBinding(group=group)
 
         request = PolicyRequest(self.user)
@@ -115,8 +113,10 @@ class TestPolicyProcess(TestCase):
 
     def test_exception(self):
         """Test policy execution"""
-        policy = Policy.objects.create(name="test-execution")
-        binding = PolicyBinding(policy=policy, target=Application.objects.create(name="test"))
+        policy = Policy.objects.create(name=generate_id())
+        binding = PolicyBinding(
+            policy=policy, target=Application.objects.create(name=generate_id())
+        )
 
         request = PolicyRequest(self.user)
         response = PolicyProcess(binding, request, None).execute()
@@ -125,13 +125,15 @@ class TestPolicyProcess(TestCase):
     def test_execution_logging(self):
         """Test policy execution creates event"""
         policy = DummyPolicy.objects.create(
-            name="test-execution-logging",
+            name=generate_id(),
             result=False,
             wait_min=0,
             wait_max=1,
             execution_logging=True,
         )
-        binding = PolicyBinding(policy=policy, target=Application.objects.create(name="test"))
+        binding = PolicyBinding(
+            policy=policy, target=Application.objects.create(name=generate_id())
+        )
 
         http_request = self.factory.get(reverse("authentik_api:user-impersonate-end"))
         http_request.user = self.user
@@ -186,13 +188,15 @@ class TestPolicyProcess(TestCase):
     def test_execution_logging_anonymous(self):
         """Test policy execution creates event with anonymous user"""
         policy = DummyPolicy.objects.create(
-            name="test-execution-logging-anon",
+            name=generate_id(),
             result=False,
             wait_min=0,
             wait_max=1,
             execution_logging=True,
         )
-        binding = PolicyBinding(policy=policy, target=Application.objects.create(name="test"))
+        binding = PolicyBinding(
+            policy=policy, target=Application.objects.create(name=generate_id())
+        )
 
         user = AnonymousUser()
 
@@ -219,9 +223,9 @@ class TestPolicyProcess(TestCase):
 
     def test_raises(self):
         """Test policy that raises error"""
-        policy_raises = ExpressionPolicy.objects.create(name="raises", expression="{{ 0/0 }}")
+        policy_raises = ExpressionPolicy.objects.create(name=generate_id(), expression="{{ 0/0 }}")
         binding = PolicyBinding(
-            policy=policy_raises, target=Application.objects.create(name="test")
+            policy=policy_raises, target=Application.objects.create(name=generate_id())
         )
 
         request = PolicyRequest(self.user)

--- a/authentik/stages/prompt/stage.py
+++ b/authentik/stages/prompt/stage.py
@@ -1,6 +1,6 @@
 """Prompt Stage Logic"""
 
-from collections.abc import Callable, Iterator
+from collections.abc import Callable
 from email.policy import Policy
 from types import MethodType
 from typing import Any
@@ -190,7 +190,7 @@ class ListPolicyEngine(PolicyEngine):
         self.__list = policies
         self.use_cache = False
 
-    def iterate_bindings(self) -> Iterator[PolicyBinding]:
+    def bindings(self):
         for policy in self.__list:
             yield PolicyBinding(
                 policy=policy,


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Currently we spawn a sub process to check policies for every type of binding, regardless whether it's bound to a user, group or policy. Realistically we only need to do this for bindings bound to policies as user and group bindings are static.

This PR does that, checking any bindings bound to a user or group on a database level, skipping the rest of the policy engine

## Improvements so far:

#### Computing policy result for a PBM with 1000 bindings all bound to groups:

`main`: 3000~ queries
Now: 2 queries

~~TODO: Needs some more test to ensure the behaviour with `Group.parent` is identical to the old behaviour~~

closes #14130

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
