### PR TITLE
core, providers/ldap: add parent/child groups to api and ldap results

### DIFF
--- a/authentik/core/api/groups.py
+++ b/authentik/core/api/groups.py
@@ -61,7 +61,6 @@ class GroupSerializer(ModelSerializer):
         required=False,
     )
     parent_name = CharField(source="parent.name", read_only=True, allow_null=True)
-
     num_pk = IntegerField(read_only=True)
 
     @property
@@ -126,9 +125,14 @@ class GroupSerializer(ModelSerializer):
             "attributes",
             "roles",
             "roles_obj",
+            "children",
         ]
         extra_kwargs = {
             "users": {
+                "default": list,
+            },
+            "children": {
+                "required": False,
                 "default": list,
             },
             # TODO: This field isn't unique on the database which is hard to backport
@@ -194,7 +198,7 @@ class GroupViewSet(UsedByMixin, ModelViewSet):
     ordering = ["name"]
 
     def get_queryset(self):
-        base_qs = Group.objects.all().select_related("parent").prefetch_related("roles")
+        base_qs = Group.objects.all().select_related("parent").prefetch_related("roles", "children")
 
         if self.serializer_class(context={"request": self.request})._should_include_users:
             base_qs = base_qs.prefetch_related("users")

--- a/authentik/core/api/groups.py
+++ b/authentik/core/api/groups.py
@@ -70,6 +70,7 @@ class GroupSerializer(ModelSerializer):
 
     attributes = JSONDictField(required=False)
     users_obj = SerializerMethodField(allow_null=True)
+    children_obj = SerializerMethodField(allow_null=True)
     roles_obj = ListSerializer(
         child=RoleSerializer(),
         read_only=True,
@@ -77,12 +78,6 @@ class GroupSerializer(ModelSerializer):
         required=False,
     )
     parent_name = CharField(source="parent.name", read_only=True, allow_null=True)
-    children_obj = ListSerializer(
-        child=GroupChildSerializer(),
-        read_only=True,
-        source="children",
-        required=False
-    )
     num_pk = IntegerField(read_only=True)
 
     @property
@@ -92,11 +87,24 @@ class GroupSerializer(ModelSerializer):
             return True
         return str(request.query_params.get("include_users", "true")).lower() == "true"
 
+    @property
+    def _should_include_children(self) -> bool:
+        request: Request = self.context.get("request", None)
+        if not request:
+            return True
+        return str(request.query_params.get("include_children", "true")).lower() == "true"
+
     @extend_schema_field(GroupMemberSerializer(many=True))
     def get_users_obj(self, instance: Group) -> list[GroupMemberSerializer] | None:
         if not self._should_include_users:
             return None
         return GroupMemberSerializer(instance.users, many=True).data
+
+    @extend_schema_field(GroupChildSerializer(many=True))
+    def get_children_obj(self, instance: Group) -> list[GroupChildSerializer] | None:
+        if not self._should_include_children:
+            return None
+        return GroupChildSerializer(instance.children, many=True).data
 
     def validate_parent(self, parent: Group | None):
         """Validate group parent (if set), ensuring the parent isn't itself"""
@@ -221,7 +229,7 @@ class GroupViewSet(UsedByMixin, ModelViewSet):
     ordering = ["name"]
 
     def get_queryset(self):
-        base_qs = Group.objects.all().select_related("parent").prefetch_related("roles", "children")
+        base_qs = Group.objects.all().select_related("parent").prefetch_related("roles")
 
         if self.serializer_class(context={"request": self.request})._should_include_users:
             base_qs = base_qs.prefetch_related("users")
@@ -230,11 +238,15 @@ class GroupViewSet(UsedByMixin, ModelViewSet):
                 Prefetch("users", queryset=User.objects.all().only("id"))
             )
 
+        if self.serializer_class(context={"request": self.request})._should_include_children:
+            base_qs = base_qs.prefetch_related("children")
+
         return base_qs
 
     @extend_schema(
         parameters=[
             OpenApiParameter("include_users", bool, default=True),
+            OpenApiParameter("include_children", bool, default=True),
         ]
     )
     def list(self, request, *args, **kwargs):
@@ -243,6 +255,7 @@ class GroupViewSet(UsedByMixin, ModelViewSet):
     @extend_schema(
         parameters=[
             OpenApiParameter("include_users", bool, default=True),
+            OpenApiParameter("include_children", bool, default=True),
         ]
     )
     def retrieve(self, request, *args, **kwargs):

--- a/authentik/core/api/groups.py
+++ b/authentik/core/api/groups.py
@@ -92,7 +92,7 @@ class GroupSerializer(ModelSerializer):
         request: Request = self.context.get("request", None)
         if not request:
             return True
-        return str(request.query_params.get("include_children", "true")).lower() == "true"
+        return str(request.query_params.get("include_children", "false")).lower() == "true"
 
     @extend_schema_field(GroupMemberSerializer(many=True))
     def get_users_obj(self, instance: Group) -> list[GroupMemberSerializer] | None:
@@ -246,7 +246,7 @@ class GroupViewSet(UsedByMixin, ModelViewSet):
     @extend_schema(
         parameters=[
             OpenApiParameter("include_users", bool, default=True),
-            OpenApiParameter("include_children", bool, default=True),
+            OpenApiParameter("include_children", bool, default=False),
         ]
     )
     def list(self, request, *args, **kwargs):
@@ -255,7 +255,7 @@ class GroupViewSet(UsedByMixin, ModelViewSet):
     @extend_schema(
         parameters=[
             OpenApiParameter("include_users", bool, default=True),
-            OpenApiParameter("include_children", bool, default=True),
+            OpenApiParameter("include_children", bool, default=False),
         ]
     )
     def retrieve(self, request, *args, **kwargs):

--- a/authentik/core/api/groups.py
+++ b/authentik/core/api/groups.py
@@ -49,6 +49,22 @@ class GroupMemberSerializer(ModelSerializer):
         ]
 
 
+class GroupChildSerializer(ModelSerializer):
+    """Stripped down group serializer to show relevant children for groups"""
+
+    attributes = JSONDictField(required=False)
+
+    class Meta:
+        model = Group
+        fields = [
+            "pk",
+            "name",
+            "is_superuser",
+            "attributes",
+            "group_uuid",
+        ]
+
+
 class GroupSerializer(ModelSerializer):
     """Group Serializer"""
 
@@ -61,6 +77,12 @@ class GroupSerializer(ModelSerializer):
         required=False,
     )
     parent_name = CharField(source="parent.name", read_only=True, allow_null=True)
+    children_obj = ListSerializer(
+        child=GroupChildSerializer(),
+        read_only=True,
+        source="children",
+        required=False
+    )
     num_pk = IntegerField(read_only=True)
 
     @property
@@ -126,6 +148,7 @@ class GroupSerializer(ModelSerializer):
             "roles",
             "roles_obj",
             "children",
+            "children_obj",
         ]
         extra_kwargs = {
             "users": {

--- a/blueprints/schema.json
+++ b/blueprints/schema.json
@@ -4689,6 +4689,14 @@
                         "format": "uuid"
                     },
                     "title": "Roles"
+                },
+                "children": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "title": "Children"
                 }
             },
             "required": []

--- a/internal/outpost/ldap/group/group.go
+++ b/internal/outpost/ldap/group/group.go
@@ -17,6 +17,7 @@ type LDAPGroup struct {
 	Uid            string
 	GidNumber      string
 	Member         []string
+	MemberOf       []string
 	IsSuperuser    bool
 	IsVirtualGroup bool
 	Attributes     map[string]interface{}
@@ -38,6 +39,7 @@ func (lg *LDAPGroup) Entry() *ldap.Entry {
 		"ak-superuser":   {strconv.FormatBool(lg.IsSuperuser)},
 		"objectClass":    objectClass,
 		"member":         lg.Member,
+		"memberOf":       lg.MemberOf,
 		"cn":             {lg.CN},
 		"uid":            {lg.Uid},
 		"sAMAccountName": {lg.CN},
@@ -53,6 +55,7 @@ func FromAPIGroup(g api.Group, si server.LDAPServerInstance) *LDAPGroup {
 		Uid:            string(g.Pk),
 		GidNumber:      si.GetGroupGidNumber(g),
 		Member:         si.MembersForGroup(g),
+		MemberOf:       si.MemberOfForGroup(g),
 		IsVirtualGroup: false,
 		IsSuperuser:    *g.IsSuperuser,
 		Attributes:     g.Attributes,

--- a/internal/outpost/ldap/group/group.go
+++ b/internal/outpost/ldap/group/group.go
@@ -52,7 +52,7 @@ func FromAPIGroup(g api.Group, si server.LDAPServerInstance) *LDAPGroup {
 		CN:             g.Name,
 		Uid:            string(g.Pk),
 		GidNumber:      si.GetGroupGidNumber(g),
-		Member:         si.UsersForGroup(g),
+		Member:         si.MembersForGroup(g),
 		IsVirtualGroup: false,
 		IsSuperuser:    *g.IsSuperuser,
 		Attributes:     g.Attributes,

--- a/internal/outpost/ldap/search/direct/direct.go
+++ b/internal/outpost/ldap/search/direct/direct.go
@@ -155,7 +155,7 @@ func (ds *DirectSearcher) Search(req *search.Request) (ldap.ServerSearchResult, 
 	if needGroups {
 		errs.Go(func() error {
 			gapisp := sentry.StartSpan(errCtx, "authentik.providers.ldap.search.api_group")
-			searchReq, skip := utils.ParseFilterForGroup(c.CoreApi.CoreGroupsList(gapisp.Context()).IncludeUsers(true), parsedFilter, false)
+			searchReq, skip := utils.ParseFilterForGroup(c.CoreApi.CoreGroupsList(gapisp.Context()).IncludeUsers(true).IncludeChildren(true), parsedFilter, false)
 			if skip {
 				req.Log().Trace("Skip backend request")
 				return nil

--- a/internal/outpost/ldap/search/memory/memory.go
+++ b/internal/outpost/ldap/search/memory/memory.go
@@ -165,7 +165,7 @@ func (ms *MemorySearcher) Search(req *search.Request) (ldap.ServerSearchResult, 
 				for _, u := range g.UsersObj {
 					if flag.UserPk == u.Pk {
 						// TODO: Is there a better way to clone this object?
-						fg := api.NewGroup(g.Pk, g.NumPk, g.Name, g.ParentName, []api.GroupMember{u}, []api.Role{})
+						fg := api.NewGroup(g.Pk, g.NumPk, g.Name, g.ParentName, []api.GroupMember{u}, []api.Role{}, []api.GroupChild{})
 						fg.SetUsers([]int32{flag.UserPk})
 						if g.Parent.IsSet() {
 							if p := g.Parent.Get(); p != nil {

--- a/internal/outpost/ldap/server/base.go
+++ b/internal/outpost/ldap/server/base.go
@@ -32,7 +32,7 @@ type LDAPServerInstance interface {
 	GetUserGidNumber(api.User) string
 	GetGroupGidNumber(api.Group) string
 
-	UsersForGroup(api.Group) []string
+	MembersForGroup(api.Group) []string
 
 	GetFlags(dn string) *flags.UserFlags
 	SetFlags(dn string, flags *flags.UserFlags)

--- a/internal/outpost/ldap/server/base.go
+++ b/internal/outpost/ldap/server/base.go
@@ -33,6 +33,7 @@ type LDAPServerInstance interface {
 	GetGroupGidNumber(api.Group) string
 
 	MembersForGroup(api.Group) []string
+	MemberOfForGroup(api.Group) []string
 
 	GetFlags(dn string) *flags.UserFlags
 	SetFlags(dn string, flags *flags.UserFlags)

--- a/internal/outpost/ldap/utils.go
+++ b/internal/outpost/ldap/utils.go
@@ -27,6 +27,17 @@ func (pi *ProviderInstance) MembersForGroup(group api.Group) []string {
 	return append(users, children...)
 }
 
+func (pi *ProviderInstance) MemberOfForGroup(group api.Group) []string {
+	if group.ParentName.IsSet() {
+		parent := group.ParentName.Get()
+		if parent != nil {
+			return []string{pi.GetGroupDN(*group.ParentName.Get())}
+		}
+	}
+
+	return []string{}
+}
+
 func (pi *ProviderInstance) GetUserDN(user string) string {
 	return fmt.Sprintf("cn=%s,%s", user, pi.UserDN)
 }

--- a/internal/outpost/ldap/utils.go
+++ b/internal/outpost/ldap/utils.go
@@ -15,12 +15,16 @@ func (pi *ProviderInstance) GroupsForUser(user api.User) []string {
 	return groups
 }
 
-func (pi *ProviderInstance) UsersForGroup(group api.Group) []string {
+func (pi *ProviderInstance) MembersForGroup(group api.Group) []string {
 	users := make([]string, len(group.UsersObj))
 	for i, user := range group.UsersObj {
 		users[i] = pi.GetUserDN(user.Username)
 	}
-	return users
+	children := make([]string, len(group.ChildrenObj))
+	for i, child := range group.ChildrenObj {
+		children[i] = pi.GetGroupDN(child.Name)
+	}
+	return append(users, children...)
 }
 
 func (pi *ProviderInstance) GetUserDN(user string) string {

--- a/schema.yml
+++ b/schema.yml
@@ -4722,7 +4722,7 @@ paths:
         name: include_children
         schema:
           type: boolean
-          default: true
+          default: false
       - in: query
         name: include_users
         schema:
@@ -4849,7 +4849,7 @@ paths:
         name: include_children
         schema:
           type: boolean
-          default: true
+          default: false
       - in: query
         name: include_users
         schema:

--- a/schema.yml
+++ b/schema.yml
@@ -46466,6 +46466,11 @@ components:
           items:
             $ref: '#/components/schemas/Role'
           readOnly: true
+        children:
+          type: array
+          items:
+            type: string
+            format: uuid
       required:
       - name
       - num_pk
@@ -46790,6 +46795,11 @@ components:
           type: object
           additionalProperties: {}
         roles:
+          type: array
+          items:
+            type: string
+            format: uuid
+        children:
           type: array
           items:
             type: string
@@ -53681,6 +53691,11 @@ components:
           type: object
           additionalProperties: {}
         roles:
+          type: array
+          items:
+            type: string
+            format: uuid
+        children:
           type: array
           items:
             type: string

--- a/schema.yml
+++ b/schema.yml
@@ -4719,6 +4719,11 @@ paths:
           type: string
         description: Attributes
       - in: query
+        name: include_children
+        schema:
+          type: boolean
+          default: true
+      - in: query
         name: include_users
         schema:
           type: boolean
@@ -4840,6 +4845,11 @@ paths:
           format: uuid
         description: A UUID string identifying this Group.
         required: true
+      - in: query
+        name: include_children
+        schema:
+          type: boolean
+          default: true
       - in: query
         name: include_users
         schema:
@@ -46476,6 +46486,7 @@ components:
           items:
             $ref: '#/components/schemas/GroupChild'
           readOnly: true
+          nullable: true
       required:
       - children_obj
       - name
@@ -46509,21 +46520,6 @@ components:
       - group_uuid
       - name
       - pk
-    GroupChildRequest:
-      type: object
-      description: Stripped down group serializer to show relevant children for groups
-      properties:
-        name:
-          type: string
-          minLength: 1
-        is_superuser:
-          type: boolean
-          description: Users added to this group will be superusers.
-        attributes:
-          type: object
-          additionalProperties: {}
-      required:
-      - name
     GroupKerberosSourceConnection:
       type: object
       description: Group Source Connection

--- a/schema.yml
+++ b/schema.yml
@@ -46471,13 +46471,59 @@ components:
           items:
             type: string
             format: uuid
+        children_obj:
+          type: array
+          items:
+            $ref: '#/components/schemas/GroupChild'
+          readOnly: true
       required:
+      - children_obj
       - name
       - num_pk
       - parent_name
       - pk
       - roles_obj
       - users_obj
+    GroupChild:
+      type: object
+      description: Stripped down group serializer to show relevant children for groups
+      properties:
+        pk:
+          type: string
+          format: uuid
+          readOnly: true
+          title: Group uuid
+        name:
+          type: string
+        is_superuser:
+          type: boolean
+          description: Users added to this group will be superusers.
+        attributes:
+          type: object
+          additionalProperties: {}
+        group_uuid:
+          type: string
+          format: uuid
+          readOnly: true
+      required:
+      - group_uuid
+      - name
+      - pk
+    GroupChildRequest:
+      type: object
+      description: Stripped down group serializer to show relevant children for groups
+      properties:
+        name:
+          type: string
+          minLength: 1
+        is_superuser:
+          type: boolean
+          description: Users added to this group will be superusers.
+        attributes:
+          type: object
+          additionalProperties: {}
+      required:
+      - name
     GroupKerberosSourceConnection:
       type: object
       description: Group Source Connection

--- a/website/docs/add-secure-apps/providers/ldap/index.md
+++ b/website/docs/add-secure-apps/providers/ldap/index.md
@@ -37,12 +37,13 @@ The following fields are currently sent for users:
 - `ak-active`: "true" if the account is active, otherwise "false"
 - `ak-superuser`: "true" if the account is part of a group with superuser permissions, otherwise "false"
 
-The following fields are current set for groups:
+The following fields are currently set for groups:
 
 - `cn`: The group's name
 - `uid`: Unique group identifier
 - `gidNumber`: A unique numeric identifier for the group
-- `member`: A list of all DNs of the groups members
+- `member`: A list of all DNs of the group's members, including groups which have this group as their parent group
+- `memberOf`: The DN of the parent group if this group has a parent group
 - `objectClass`: A list of these strings:
     - "group"
     - "goauthentik.io/ldap/group"


### PR DESCRIPTION
## Details
Closes #2417

This PR adds a `children`/`childrenObj` field to the core groups API and a `memberOf` attribute for LDAP groups. The `member` attribute is also extended to show both users and child groups. An `include_children` parameter is also added to the API, similar to `include_users`/`include_groups`, to control the inclusion of child groups in responses. Finally, serializers and queries are updated to accommodate these changes.

**Breaking changes?** Since this is my first PR I am unsure if these are considered breaking changes. The core API just gets some additional fields/parameters so I would think not. As for the LDAP outpost changes, the results are again just extended with child groups and listing groups as `member` is expected behaviour IMO.

**Background**: #2417 details how the LDAP results currently don't show parent/child groups. We are currently trying to migrate to authentik from FreeIPA, but we have other systems that depend on getting this information from its LDAP server. This PR would solve the issue for us.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [x] The API schema has been updated (`make gen-build`)

~If changes to the frontend have been made~

-   [ ] ~The code has been formatted (`make web`)~

~If applicable~

-   [ ] ~The documentation has been updated~
-   [ ] ~The documentation has been formatted (`make website`)~
