### PR TITLE
outposts/ldap: Handle comma-separated attributes in LDAP search requests

### DIFF
--- a/internal/outpost/ldap/search/request_test.go
+++ b/internal/outpost/ldap/search/request_test.go
@@ -1,0 +1,98 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeAttributes(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          []string
+		expectedOutput []string
+	}{
+		{
+			name:           "Empty input",
+			input:          []string{},
+			expectedOutput: []string{},
+		},
+		{
+			name:           "No commas",
+			input:          []string{"uid", "cn", "sn"},
+			expectedOutput: []string{"uid", "cn", "sn"},
+		},
+		{
+			name:           "Single comma-separated string",
+			input:          []string{"uid,cn,sn"},
+			expectedOutput: []string{"uid", "cn", "sn"},
+		},
+		{
+			name:           "Mixed input",
+			input:          []string{"uid,cn", "sn"},
+			expectedOutput: []string{"uid", "cn", "sn"},
+		},
+		{
+			name:           "With spaces",
+			input:          []string{"uid, cn, sn"},
+			expectedOutput: []string{"uid", "cn", "sn"},
+		},
+		{
+			name:           "Empty parts",
+			input:          []string{"uid,, cn"},
+			expectedOutput: []string{"uid", "cn"},
+		},
+		{
+			name:           "Single element",
+			input:          []string{"uid"},
+			expectedOutput: []string{"uid"},
+		},
+		{
+			name:           "Only commas",
+			input:          []string{",,,"},
+			expectedOutput: []string{},
+		},
+		{
+			name:           "Multiple comma-separated attributes",
+			input:          []string{"uid,cn", "sn,mail", "givenName"},
+			expectedOutput: []string{"uid", "cn", "sn", "mail", "givenName"},
+		},
+		{
+			name:           "Case preservation",
+			input:          []string{"uid,CN,sAMAccountName"},
+			expectedOutput: []string{"uid", "CN", "sAMAccountName"},
+		},
+		{
+			name:           "Leading and trailing spaces",
+			input:          []string{" uid , cn , sn "},
+			expectedOutput: []string{"uid", "cn", "sn"},
+		},
+		{
+			name:           "Real-world LDAP attribute examples",
+			input:          []string{"objectClass,memberOf,mail", "sAMAccountName,userPrincipalName"},
+			expectedOutput: []string{"objectClass", "memberOf", "mail", "sAMAccountName", "userPrincipalName"},
+		},
+		{
+			name:           "Jira-style attribute format",
+			input:          []string{"uid,cn,sn"},
+			expectedOutput: []string{"uid", "cn", "sn"},
+		},
+		{
+			name:           "Single string with single attribute",
+			input:          []string{"cn"},
+			expectedOutput: []string{"cn"},
+		},
+		{
+			name:           "Mix of standard and operational attributes",
+			input:          []string{"uid,+", "createTimestamp"},
+			expectedOutput: []string{"uid", "+", "createTimestamp"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeAttributes(tt.input)
+			assert.Equal(t, tt.expectedOutput, result)
+		})
+	}
+}


### PR DESCRIPTION
Closes https://github.com/goauthentik/authentik/issues/13539

When LDAP clients like Jira submit search requests with comma-separated attributes (e.g., ["uid,cn,sn"] instead of ["uid", "cn", "sn"]), the LDAP outpost would return an "Operations Error". Ths fix adds attribute normalization to properly handle both formats by splitting comma separated attributes into individual entries.

(happy pr 15k hehe)

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
