### PR TITLE
website/docs: correct minor version in release notes

### DIFF
--- a/website/docs/releases/2025/v2025.6.md
+++ b/website/docs/releases/2025/v2025.6.md
@@ -136,7 +136,7 @@ helm upgrade authentik authentik/authentik -f values.yaml --version ^2025.6
 - web/flows: update default flow background (#14769)
 - web/flows/sfe: fix global background image not being loaded (#14442)
 
-## Fixed in 2025.4.1
+## Fixed in 2025.6.1
 
 - providers/proxy: add option to override host header with property mappings (cherry-pick #14927) (#14945)
 - tenants: fix tenant aware celery scheduler (cherry-pick #14921)


### PR DESCRIPTION
## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
Replaces the mentioned major version with the correct one. Major version release notes 2025.6 mentions 2025.4.1

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
