### PR TITLE
blueprints: add section support for organisation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ gen-build:  ## Extract the schema from the database
 	AUTHENTIK_DEBUG=true \
 		AUTHENTIK_TENANTS__ENABLED=true \
 		AUTHENTIK_OUTPOSTS__DISABLE_EMBEDDED_OUTPOST=true \
-		uv run ak make_blueprint_schema > blueprints/schema.json
+		uv run ak make_blueprint_schema --file blueprints/schema.json
 	AUTHENTIK_DEBUG=true \
 		AUTHENTIK_TENANTS__ENABLED=true \
 		AUTHENTIK_OUTPOSTS__DISABLE_EMBEDDED_OUTPOST=true \

--- a/authentik/blueprints/management/commands/make_blueprint_schema.py
+++ b/authentik/blueprints/management/commands/make_blueprint_schema.py
@@ -72,20 +72,33 @@ class Command(BaseCommand):
                     "additionalProperties": True,
                 },
                 "entries": {
-                    "type": "array",
-                    "items": {
-                        "oneOf": [],
-                    },
+                    "anyOf": [
+                        {
+                            "type": "array",
+                            "items": {"$ref": "#/$defs/blueprint_entry"},
+                        },
+                        {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "array",
+                                "items": {"$ref": "#/$defs/blueprint_entry"},
+                            },
+                        },
+                    ],
                 },
             },
-            "$defs": {},
+            "$defs": {"blueprint_entry": {"oneOf": []}},
         }
 
+    def add_arguments(self, parser):
+        parser.add_argument("--file", type=str)
+
     @no_translations
-    def handle(self, *args, **options):
+    def handle(self, *args, file: str, **options):
         """Generate JSON Schema for blueprints"""
         self.build()
-        self.stdout.write(dumps(self.schema, indent=4, default=Command.json_default))
+        with open(file, "w") as _schema:
+            _schema.write(dumps(self.schema, indent=4, default=Command.json_default))
 
     @staticmethod
     def json_default(value: Any) -> Any:
@@ -112,7 +125,7 @@ class Command(BaseCommand):
                 }
             )
             model_path = f"{model._meta.app_label}.{model._meta.model_name}"
-            self.schema["properties"]["entries"]["items"]["oneOf"].append(
+            self.schema["$defs"]["blueprint_entry"]["oneOf"].append(
                 self.template_entry(model_path, model, serializer)
             )
 

--- a/authentik/blueprints/tests/fixtures/state_present.yaml
+++ b/authentik/blueprints/tests/fixtures/state_present.yaml
@@ -1,10 +1,11 @@
 version: 1
 entries:
-    - identifiers:
-          name: "%(id)s"
-          slug: "%(id)s"
-      model: authentik_flows.flow
-      state: present
-      attrs:
-          designation: stage_configuration
-          title: foo
+  foo:
+      - identifiers:
+            name: "%(id)s"
+            slug: "%(id)s"
+        model: authentik_flows.flow
+        state: present
+        attrs:
+            designation: stage_configuration
+            title: foo

--- a/authentik/blueprints/v1/common.py
+++ b/authentik/blueprints/v1/common.py
@@ -191,10 +191,17 @@ class Blueprint:
     """Dataclass used for a full export"""
 
     version: int = field(default=1)
-    entries: list[BlueprintEntry] = field(default_factory=list)
+    entries: list[BlueprintEntry] | dict[str, list[BlueprintEntry]] = field(default_factory=list)
     context: dict = field(default_factory=dict)
 
     metadata: BlueprintMetadata | None = field(default=None)
+
+    def iter_entries(self) -> Iterable[BlueprintEntry]:
+        if isinstance(self.entries, dict):
+            for _section, entries in self.entries.items():
+                yield from entries
+        else:
+            yield from self.entries
 
 
 class YAMLTag:
@@ -226,7 +233,7 @@ class KeyOf(YAMLTag):
         self.id_from = node.value
 
     def resolve(self, entry: BlueprintEntry, blueprint: Blueprint) -> Any:
-        for _entry in blueprint.entries:
+        for _entry in blueprint.iter_entries():
             if _entry.id == self.id_from and _entry._state.instance:
                 # Special handling for PolicyBindingModels, as they'll have a different PK
                 # which is used when creating policy bindings

--- a/authentik/blueprints/v1/importer.py
+++ b/authentik/blueprints/v1/importer.py
@@ -384,7 +384,7 @@ class Importer:
     def _apply_models(self, raise_errors=False) -> bool:
         """Apply (create/update) models yaml"""
         self.__pk_map = {}
-        for entry in self._import.entries:
+        for entry in self._import.iter_entries():
             model_app_label, model_name = entry.get_model(self._import).split(".")
             try:
                 model: type[SerializerModel] = registry.get_model(model_app_label, model_name)

--- a/blueprints/schema.json
+++ b/blueprints/schema.json
@@ -38,4210 +38,4226 @@
             "additionalProperties": true
         },
         "entries": {
-            "type": "array",
-            "items": {
-                "oneOf": [
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_blueprints.blueprintinstance"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_blueprints.blueprintinstance_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_blueprints.blueprintinstance"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_blueprints.blueprintinstance"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_blueprints.metaapplyblueprint"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_blueprints.metaapplyblueprint_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_blueprints.metaapplyblueprint"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_brands.brand"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_brands.brand_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_brands.brand"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_brands.brand"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_core.application"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_core.application_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_core.application"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_core.application"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_core.applicationentitlement"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_core.applicationentitlement_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_core.applicationentitlement"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_core.applicationentitlement"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_core.group"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_core.group_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_core.group"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_core.group"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_core.token"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_core.token_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_core.token"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_core.token"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_core.user"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_core.user_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_core.user"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_core.user"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_crypto.certificatekeypair"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_crypto.certificatekeypair_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_crypto.certificatekeypair"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_crypto.certificatekeypair"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_enterprise.license"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_enterprise.license_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_enterprise.license"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_enterprise.license"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_policies_unique_password.uniquepasswordpolicy"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_policies_unique_password.uniquepasswordpolicy_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_policies_unique_password.uniquepasswordpolicy"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_policies_unique_password.uniquepasswordpolicy"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_providers_google_workspace.googleworkspaceprovider"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_providers_google_workspace.googleworkspaceprovider_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_providers_google_workspace.googleworkspaceprovider"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_providers_google_workspace.googleworkspaceprovider"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_providers_google_workspace.googleworkspaceprovidermapping"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_providers_google_workspace.googleworkspaceprovidermapping_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_providers_google_workspace.googleworkspaceprovidermapping"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_providers_google_workspace.googleworkspaceprovidermapping"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_providers_microsoft_entra.microsoftentraprovider"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_providers_microsoft_entra.microsoftentraprovider_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_providers_microsoft_entra.microsoftentraprovider"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_providers_microsoft_entra.microsoftentraprovider"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_providers_microsoft_entra.microsoftentraprovidermapping"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_providers_microsoft_entra.microsoftentraprovidermapping_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_providers_microsoft_entra.microsoftentraprovidermapping"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_providers_microsoft_entra.microsoftentraprovidermapping"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_providers_ssf.ssfprovider"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_providers_ssf.ssfprovider_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_providers_ssf.ssfprovider"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_providers_ssf.ssfprovider"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_authenticator_endpoint_gdtc.authenticatorendpointgdtcstage"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_endpoint_gdtc.authenticatorendpointgdtcstage_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_endpoint_gdtc.authenticatorendpointgdtcstage"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_endpoint_gdtc.authenticatorendpointgdtcstage"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_mtls.mutualtlsstage"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_mtls.mutualtlsstage_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_mtls.mutualtlsstage"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_mtls.mutualtlsstage"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_source.sourcestage"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_source.sourcestage_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_source.sourcestage"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_source.sourcestage"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_events.event"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_events.event_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_events.event"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_events.event"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_events.notification"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_events.notification_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_events.notification"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_events.notification"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_events.notificationrule"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_events.notificationrule_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_events.notificationrule"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_events.notificationrule"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_events.notificationtransport"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_events.notificationtransport_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_events.notificationtransport"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_events.notificationtransport"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_events.notificationwebhookmapping"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_events.notificationwebhookmapping_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_events.notificationwebhookmapping"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_events.notificationwebhookmapping"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_flows.flow"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_flows.flow_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_flows.flow"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_flows.flow"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_flows.flowstagebinding"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_flows.flowstagebinding_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_flows.flowstagebinding"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_flows.flowstagebinding"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_outposts.dockerserviceconnection"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_outposts.dockerserviceconnection_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_outposts.dockerserviceconnection"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_outposts.dockerserviceconnection"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_outposts.kubernetesserviceconnection"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_outposts.kubernetesserviceconnection_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_outposts.kubernetesserviceconnection"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_outposts.kubernetesserviceconnection"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_outposts.outpost"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_outposts.outpost_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_outposts.outpost"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_outposts.outpost"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_policies_dummy.dummypolicy"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_policies_dummy.dummypolicy_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_policies_dummy.dummypolicy"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_policies_dummy.dummypolicy"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_policies_event_matcher.eventmatcherpolicy"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_policies_event_matcher.eventmatcherpolicy_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_policies_event_matcher.eventmatcherpolicy"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_policies_event_matcher.eventmatcherpolicy"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_policies_expiry.passwordexpirypolicy"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_policies_expiry.passwordexpirypolicy_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_policies_expiry.passwordexpirypolicy"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_policies_expiry.passwordexpirypolicy"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_policies_expression.expressionpolicy"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_policies_expression.expressionpolicy_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_policies_expression.expressionpolicy"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_policies_expression.expressionpolicy"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_policies_geoip.geoippolicy"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_policies_geoip.geoippolicy_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_policies_geoip.geoippolicy"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_policies_geoip.geoippolicy"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_policies.policybinding"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_policies.policybinding_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_policies.policybinding"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_policies.policybinding"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_policies_password.passwordpolicy"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_policies_password.passwordpolicy_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_policies_password.passwordpolicy"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_policies_password.passwordpolicy"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_policies_reputation.reputationpolicy"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_policies_reputation.reputationpolicy_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_policies_reputation.reputationpolicy"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_policies_reputation.reputationpolicy"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_providers_ldap.ldapprovider"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_providers_ldap.ldapprovider_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_providers_ldap.ldapprovider"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_providers_ldap.ldapprovider"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_providers_oauth2.oauth2provider"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_providers_oauth2.oauth2provider_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_providers_oauth2.oauth2provider"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_providers_oauth2.oauth2provider"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_providers_oauth2.scopemapping"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_providers_oauth2.scopemapping_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_providers_oauth2.scopemapping"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_providers_oauth2.scopemapping"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_providers_proxy.proxyprovider"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_providers_proxy.proxyprovider_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_providers_proxy.proxyprovider"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_providers_proxy.proxyprovider"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_providers_rac.endpoint"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_providers_rac.endpoint_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_providers_rac.endpoint"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_providers_rac.endpoint"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_providers_rac.racpropertymapping"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_providers_rac.racpropertymapping_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_providers_rac.racpropertymapping"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_providers_rac.racpropertymapping"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_providers_rac.racprovider"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_providers_rac.racprovider_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_providers_rac.racprovider"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_providers_rac.racprovider"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_providers_radius.radiusprovider"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_providers_radius.radiusprovider_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_providers_radius.radiusprovider"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_providers_radius.radiusprovider"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_providers_radius.radiusproviderpropertymapping"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_providers_radius.radiusproviderpropertymapping_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_providers_radius.radiusproviderpropertymapping"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_providers_radius.radiusproviderpropertymapping"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_providers_saml.samlpropertymapping"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_providers_saml.samlpropertymapping_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_providers_saml.samlpropertymapping"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_providers_saml.samlpropertymapping"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_providers_saml.samlprovider"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_providers_saml.samlprovider_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_providers_saml.samlprovider"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_providers_saml.samlprovider"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_providers_scim.scimmapping"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_providers_scim.scimmapping_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_providers_scim.scimmapping"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_providers_scim.scimmapping"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_providers_scim.scimprovider"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_providers_scim.scimprovider_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_providers_scim.scimprovider"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_providers_scim.scimprovider"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_rbac.initialpermissions"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_rbac.initialpermissions_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_rbac.initialpermissions"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_rbac.initialpermissions"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_rbac.role"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_rbac.role_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_rbac.role"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_rbac.role"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_sources_kerberos.groupkerberossourceconnection"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_sources_kerberos.groupkerberossourceconnection_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_sources_kerberos.groupkerberossourceconnection"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_sources_kerberos.groupkerberossourceconnection"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_sources_kerberos.kerberossource"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_sources_kerberos.kerberossource_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_sources_kerberos.kerberossource"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_sources_kerberos.kerberossource"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_sources_kerberos.kerberossourcepropertymapping"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_sources_kerberos.kerberossourcepropertymapping_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_sources_kerberos.kerberossourcepropertymapping"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_sources_kerberos.kerberossourcepropertymapping"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_sources_kerberos.userkerberossourceconnection"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_sources_kerberos.userkerberossourceconnection_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_sources_kerberos.userkerberossourceconnection"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_sources_kerberos.userkerberossourceconnection"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_sources_ldap.groupldapsourceconnection"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_sources_ldap.groupldapsourceconnection_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_sources_ldap.groupldapsourceconnection"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_sources_ldap.groupldapsourceconnection"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_sources_ldap.ldapsource"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_sources_ldap.ldapsource_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_sources_ldap.ldapsource"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_sources_ldap.ldapsource"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_sources_ldap.ldapsourcepropertymapping"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_sources_ldap.ldapsourcepropertymapping_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_sources_ldap.ldapsourcepropertymapping"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_sources_ldap.ldapsourcepropertymapping"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_sources_ldap.userldapsourceconnection"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_sources_ldap.userldapsourceconnection_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_sources_ldap.userldapsourceconnection"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_sources_ldap.userldapsourceconnection"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_sources_oauth.groupoauthsourceconnection"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_sources_oauth.groupoauthsourceconnection_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_sources_oauth.groupoauthsourceconnection"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_sources_oauth.groupoauthsourceconnection"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_sources_oauth.oauthsource"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_sources_oauth.oauthsource_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_sources_oauth.oauthsource"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_sources_oauth.oauthsource"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_sources_oauth.oauthsourcepropertymapping"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_sources_oauth.oauthsourcepropertymapping_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_sources_oauth.oauthsourcepropertymapping"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_sources_oauth.oauthsourcepropertymapping"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_sources_oauth.useroauthsourceconnection"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_sources_oauth.useroauthsourceconnection_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_sources_oauth.useroauthsourceconnection"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_sources_oauth.useroauthsourceconnection"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_sources_plex.groupplexsourceconnection"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_sources_plex.groupplexsourceconnection_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_sources_plex.groupplexsourceconnection"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_sources_plex.groupplexsourceconnection"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_sources_plex.plexsource"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_sources_plex.plexsource_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_sources_plex.plexsource"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_sources_plex.plexsource"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_sources_plex.plexsourcepropertymapping"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_sources_plex.plexsourcepropertymapping_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_sources_plex.plexsourcepropertymapping"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_sources_plex.plexsourcepropertymapping"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_sources_plex.userplexsourceconnection"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_sources_plex.userplexsourceconnection_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_sources_plex.userplexsourceconnection"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_sources_plex.userplexsourceconnection"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_sources_saml.groupsamlsourceconnection"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_sources_saml.groupsamlsourceconnection_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_sources_saml.groupsamlsourceconnection"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_sources_saml.groupsamlsourceconnection"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_sources_saml.samlsource"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_sources_saml.samlsource_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_sources_saml.samlsource"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_sources_saml.samlsource"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_sources_saml.samlsourcepropertymapping"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_sources_saml.samlsourcepropertymapping_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_sources_saml.samlsourcepropertymapping"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_sources_saml.samlsourcepropertymapping"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_sources_saml.usersamlsourceconnection"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_sources_saml.usersamlsourceconnection_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_sources_saml.usersamlsourceconnection"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_sources_saml.usersamlsourceconnection"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_sources_scim.scimsource"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_sources_scim.scimsource_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_sources_scim.scimsource"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_sources_scim.scimsource"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_sources_scim.scimsourcepropertymapping"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_sources_scim.scimsourcepropertymapping_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_sources_scim.scimsourcepropertymapping"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_sources_scim.scimsourcepropertymapping"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_authenticator_duo.authenticatorduostage"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_duo.authenticatorduostage_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_duo.authenticatorduostage"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_duo.authenticatorduostage"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_authenticator_duo.duodevice"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_duo.duodevice_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_duo.duodevice"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_duo.duodevice"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_authenticator_email.authenticatoremailstage"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_email.authenticatoremailstage_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_email.authenticatoremailstage"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_email.authenticatoremailstage"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_authenticator_email.emaildevice"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_email.emaildevice_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_email.emaildevice"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_email.emaildevice"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_authenticator_sms.authenticatorsmsstage"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_sms.authenticatorsmsstage_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_sms.authenticatorsmsstage"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_sms.authenticatorsmsstage"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_authenticator_sms.smsdevice"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_sms.smsdevice_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_sms.smsdevice"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_sms.smsdevice"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_authenticator_static.authenticatorstaticstage"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_static.authenticatorstaticstage_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_static.authenticatorstaticstage"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_static.authenticatorstaticstage"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_authenticator_static.staticdevice"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_static.staticdevice_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_static.staticdevice"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_static.staticdevice"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_authenticator_totp.authenticatortotpstage"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_totp.authenticatortotpstage_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_totp.authenticatortotpstage"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_totp.authenticatortotpstage"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_authenticator_totp.totpdevice"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_totp.totpdevice_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_totp.totpdevice"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_totp.totpdevice"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_authenticator_validate.authenticatorvalidatestage"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_validate.authenticatorvalidatestage_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_validate.authenticatorvalidatestage"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_validate.authenticatorvalidatestage"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_authenticator_webauthn.authenticatorwebauthnstage"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_webauthn.authenticatorwebauthnstage_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_webauthn.authenticatorwebauthnstage"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_webauthn.authenticatorwebauthnstage"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_authenticator_webauthn.webauthndevice"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_webauthn.webauthndevice_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_webauthn.webauthndevice"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_authenticator_webauthn.webauthndevice"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_captcha.captchastage"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_captcha.captchastage_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_captcha.captchastage"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_captcha.captchastage"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_consent.consentstage"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_consent.consentstage_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_consent.consentstage"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_consent.consentstage"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_consent.userconsent"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_consent.userconsent_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_consent.userconsent"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_consent.userconsent"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_deny.denystage"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_deny.denystage_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_deny.denystage"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_deny.denystage"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_dummy.dummystage"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_dummy.dummystage_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_dummy.dummystage"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_dummy.dummystage"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_email.emailstage"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_email.emailstage_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_email.emailstage"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_email.emailstage"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_identification.identificationstage"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_identification.identificationstage_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_identification.identificationstage"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_identification.identificationstage"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_invitation.invitation"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_invitation.invitation_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_invitation.invitation"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_invitation.invitation"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_invitation.invitationstage"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_invitation.invitationstage_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_invitation.invitationstage"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_invitation.invitationstage"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_password.passwordstage"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_password.passwordstage_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_password.passwordstage"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_password.passwordstage"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_prompt.prompt"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_prompt.prompt_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_prompt.prompt"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_prompt.prompt"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_prompt.promptstage"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_prompt.promptstage_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_prompt.promptstage"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_prompt.promptstage"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_redirect.redirectstage"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_redirect.redirectstage_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_redirect.redirectstage"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_redirect.redirectstage"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_user_delete.userdeletestage"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_user_delete.userdeletestage_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_user_delete.userdeletestage"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_user_delete.userdeletestage"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_user_login.userloginstage"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_user_login.userloginstage_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_user_login.userloginstage"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_user_login.userloginstage"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_user_logout.userlogoutstage"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_user_logout.userlogoutstage_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_user_logout.userlogoutstage"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_user_logout.userlogoutstage"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_stages_user_write.userwritestage"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_stages_user_write.userwritestage_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_stages_user_write.userwritestage"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_stages_user_write.userwritestage"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "model",
-                            "identifiers"
-                        ],
-                        "properties": {
-                            "model": {
-                                "const": "authentik_tenants.domain"
-                            },
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "enum": [
-                                    "absent",
-                                    "created",
-                                    "must_created",
-                                    "present"
-                                ],
-                                "default": "present"
-                            },
-                            "conditions": {
-                                "type": "array",
-                                "items": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "permissions": {
-                                "$ref": "#/$defs/model_authentik_tenants.domain_permissions"
-                            },
-                            "attrs": {
-                                "$ref": "#/$defs/model_authentik_tenants.domain"
-                            },
-                            "identifiers": {
-                                "$ref": "#/$defs/model_authentik_tenants.domain"
-                            }
+            "anyOf": [
+                {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/blueprint_entry"
+                    }
+                },
+                {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/$defs/blueprint_entry"
                         }
                     }
-                ]
-            }
+                }
+            ]
         }
     },
     "$defs": {
+        "blueprint_entry": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_blueprints.blueprintinstance"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_blueprints.blueprintinstance_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_blueprints.blueprintinstance"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_blueprints.blueprintinstance"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_blueprints.metaapplyblueprint"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_blueprints.metaapplyblueprint_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_blueprints.metaapplyblueprint"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_brands.brand"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_brands.brand_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_brands.brand"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_brands.brand"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_core.application"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_core.application_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_core.application"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_core.application"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_core.applicationentitlement"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_core.applicationentitlement_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_core.applicationentitlement"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_core.applicationentitlement"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_core.group"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_core.group_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_core.group"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_core.group"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_core.token"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_core.token_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_core.token"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_core.token"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_core.user"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_core.user_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_core.user"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_core.user"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_crypto.certificatekeypair"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_crypto.certificatekeypair_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_crypto.certificatekeypair"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_crypto.certificatekeypair"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_enterprise.license"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_enterprise.license_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_enterprise.license"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_enterprise.license"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_policies_unique_password.uniquepasswordpolicy"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_policies_unique_password.uniquepasswordpolicy_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_policies_unique_password.uniquepasswordpolicy"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_policies_unique_password.uniquepasswordpolicy"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_providers_google_workspace.googleworkspaceprovider"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_providers_google_workspace.googleworkspaceprovider_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_providers_google_workspace.googleworkspaceprovider"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_providers_google_workspace.googleworkspaceprovider"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_providers_google_workspace.googleworkspaceprovidermapping"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_providers_google_workspace.googleworkspaceprovidermapping_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_providers_google_workspace.googleworkspaceprovidermapping"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_providers_google_workspace.googleworkspaceprovidermapping"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_providers_microsoft_entra.microsoftentraprovider"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_providers_microsoft_entra.microsoftentraprovider_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_providers_microsoft_entra.microsoftentraprovider"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_providers_microsoft_entra.microsoftentraprovider"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_providers_microsoft_entra.microsoftentraprovidermapping"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_providers_microsoft_entra.microsoftentraprovidermapping_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_providers_microsoft_entra.microsoftentraprovidermapping"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_providers_microsoft_entra.microsoftentraprovidermapping"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_providers_ssf.ssfprovider"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_providers_ssf.ssfprovider_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_providers_ssf.ssfprovider"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_providers_ssf.ssfprovider"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_authenticator_endpoint_gdtc.authenticatorendpointgdtcstage"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_endpoint_gdtc.authenticatorendpointgdtcstage_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_endpoint_gdtc.authenticatorendpointgdtcstage"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_endpoint_gdtc.authenticatorendpointgdtcstage"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_mtls.mutualtlsstage"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_mtls.mutualtlsstage_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_mtls.mutualtlsstage"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_mtls.mutualtlsstage"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_source.sourcestage"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_source.sourcestage_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_source.sourcestage"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_source.sourcestage"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_events.event"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_events.event_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_events.event"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_events.event"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_events.notification"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_events.notification_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_events.notification"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_events.notification"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_events.notificationrule"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_events.notificationrule_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_events.notificationrule"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_events.notificationrule"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_events.notificationtransport"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_events.notificationtransport_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_events.notificationtransport"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_events.notificationtransport"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_events.notificationwebhookmapping"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_events.notificationwebhookmapping_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_events.notificationwebhookmapping"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_events.notificationwebhookmapping"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_flows.flow"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_flows.flow_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_flows.flow"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_flows.flow"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_flows.flowstagebinding"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_flows.flowstagebinding_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_flows.flowstagebinding"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_flows.flowstagebinding"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_outposts.dockerserviceconnection"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_outposts.dockerserviceconnection_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_outposts.dockerserviceconnection"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_outposts.dockerserviceconnection"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_outposts.kubernetesserviceconnection"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_outposts.kubernetesserviceconnection_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_outposts.kubernetesserviceconnection"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_outposts.kubernetesserviceconnection"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_outposts.outpost"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_outposts.outpost_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_outposts.outpost"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_outposts.outpost"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_policies_dummy.dummypolicy"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_policies_dummy.dummypolicy_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_policies_dummy.dummypolicy"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_policies_dummy.dummypolicy"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_policies_event_matcher.eventmatcherpolicy"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_policies_event_matcher.eventmatcherpolicy_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_policies_event_matcher.eventmatcherpolicy"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_policies_event_matcher.eventmatcherpolicy"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_policies_expiry.passwordexpirypolicy"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_policies_expiry.passwordexpirypolicy_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_policies_expiry.passwordexpirypolicy"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_policies_expiry.passwordexpirypolicy"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_policies_expression.expressionpolicy"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_policies_expression.expressionpolicy_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_policies_expression.expressionpolicy"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_policies_expression.expressionpolicy"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_policies_geoip.geoippolicy"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_policies_geoip.geoippolicy_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_policies_geoip.geoippolicy"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_policies_geoip.geoippolicy"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_policies.policybinding"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_policies.policybinding_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_policies.policybinding"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_policies.policybinding"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_policies_password.passwordpolicy"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_policies_password.passwordpolicy_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_policies_password.passwordpolicy"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_policies_password.passwordpolicy"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_policies_reputation.reputationpolicy"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_policies_reputation.reputationpolicy_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_policies_reputation.reputationpolicy"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_policies_reputation.reputationpolicy"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_providers_ldap.ldapprovider"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_providers_ldap.ldapprovider_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_providers_ldap.ldapprovider"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_providers_ldap.ldapprovider"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_providers_oauth2.oauth2provider"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_providers_oauth2.oauth2provider_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_providers_oauth2.oauth2provider"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_providers_oauth2.oauth2provider"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_providers_oauth2.scopemapping"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_providers_oauth2.scopemapping_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_providers_oauth2.scopemapping"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_providers_oauth2.scopemapping"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_providers_proxy.proxyprovider"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_providers_proxy.proxyprovider_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_providers_proxy.proxyprovider"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_providers_proxy.proxyprovider"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_providers_rac.endpoint"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_providers_rac.endpoint_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_providers_rac.endpoint"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_providers_rac.endpoint"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_providers_rac.racpropertymapping"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_providers_rac.racpropertymapping_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_providers_rac.racpropertymapping"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_providers_rac.racpropertymapping"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_providers_rac.racprovider"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_providers_rac.racprovider_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_providers_rac.racprovider"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_providers_rac.racprovider"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_providers_radius.radiusprovider"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_providers_radius.radiusprovider_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_providers_radius.radiusprovider"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_providers_radius.radiusprovider"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_providers_radius.radiusproviderpropertymapping"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_providers_radius.radiusproviderpropertymapping_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_providers_radius.radiusproviderpropertymapping"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_providers_radius.radiusproviderpropertymapping"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_providers_saml.samlpropertymapping"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_providers_saml.samlpropertymapping_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_providers_saml.samlpropertymapping"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_providers_saml.samlpropertymapping"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_providers_saml.samlprovider"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_providers_saml.samlprovider_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_providers_saml.samlprovider"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_providers_saml.samlprovider"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_providers_scim.scimmapping"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_providers_scim.scimmapping_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_providers_scim.scimmapping"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_providers_scim.scimmapping"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_providers_scim.scimprovider"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_providers_scim.scimprovider_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_providers_scim.scimprovider"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_providers_scim.scimprovider"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_rbac.initialpermissions"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_rbac.initialpermissions_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_rbac.initialpermissions"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_rbac.initialpermissions"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_rbac.role"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_rbac.role_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_rbac.role"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_rbac.role"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_sources_kerberos.groupkerberossourceconnection"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_sources_kerberos.groupkerberossourceconnection_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_sources_kerberos.groupkerberossourceconnection"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_sources_kerberos.groupkerberossourceconnection"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_sources_kerberos.kerberossource"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_sources_kerberos.kerberossource_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_sources_kerberos.kerberossource"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_sources_kerberos.kerberossource"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_sources_kerberos.kerberossourcepropertymapping"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_sources_kerberos.kerberossourcepropertymapping_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_sources_kerberos.kerberossourcepropertymapping"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_sources_kerberos.kerberossourcepropertymapping"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_sources_kerberos.userkerberossourceconnection"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_sources_kerberos.userkerberossourceconnection_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_sources_kerberos.userkerberossourceconnection"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_sources_kerberos.userkerberossourceconnection"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_sources_ldap.groupldapsourceconnection"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_sources_ldap.groupldapsourceconnection_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_sources_ldap.groupldapsourceconnection"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_sources_ldap.groupldapsourceconnection"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_sources_ldap.ldapsource"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_sources_ldap.ldapsource_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_sources_ldap.ldapsource"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_sources_ldap.ldapsource"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_sources_ldap.ldapsourcepropertymapping"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_sources_ldap.ldapsourcepropertymapping_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_sources_ldap.ldapsourcepropertymapping"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_sources_ldap.ldapsourcepropertymapping"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_sources_ldap.userldapsourceconnection"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_sources_ldap.userldapsourceconnection_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_sources_ldap.userldapsourceconnection"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_sources_ldap.userldapsourceconnection"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_sources_oauth.groupoauthsourceconnection"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_sources_oauth.groupoauthsourceconnection_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_sources_oauth.groupoauthsourceconnection"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_sources_oauth.groupoauthsourceconnection"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_sources_oauth.oauthsource"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_sources_oauth.oauthsource_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_sources_oauth.oauthsource"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_sources_oauth.oauthsource"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_sources_oauth.oauthsourcepropertymapping"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_sources_oauth.oauthsourcepropertymapping_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_sources_oauth.oauthsourcepropertymapping"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_sources_oauth.oauthsourcepropertymapping"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_sources_oauth.useroauthsourceconnection"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_sources_oauth.useroauthsourceconnection_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_sources_oauth.useroauthsourceconnection"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_sources_oauth.useroauthsourceconnection"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_sources_plex.groupplexsourceconnection"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_sources_plex.groupplexsourceconnection_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_sources_plex.groupplexsourceconnection"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_sources_plex.groupplexsourceconnection"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_sources_plex.plexsource"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_sources_plex.plexsource_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_sources_plex.plexsource"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_sources_plex.plexsource"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_sources_plex.plexsourcepropertymapping"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_sources_plex.plexsourcepropertymapping_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_sources_plex.plexsourcepropertymapping"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_sources_plex.plexsourcepropertymapping"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_sources_plex.userplexsourceconnection"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_sources_plex.userplexsourceconnection_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_sources_plex.userplexsourceconnection"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_sources_plex.userplexsourceconnection"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_sources_saml.groupsamlsourceconnection"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_sources_saml.groupsamlsourceconnection_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_sources_saml.groupsamlsourceconnection"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_sources_saml.groupsamlsourceconnection"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_sources_saml.samlsource"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_sources_saml.samlsource_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_sources_saml.samlsource"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_sources_saml.samlsource"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_sources_saml.samlsourcepropertymapping"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_sources_saml.samlsourcepropertymapping_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_sources_saml.samlsourcepropertymapping"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_sources_saml.samlsourcepropertymapping"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_sources_saml.usersamlsourceconnection"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_sources_saml.usersamlsourceconnection_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_sources_saml.usersamlsourceconnection"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_sources_saml.usersamlsourceconnection"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_sources_scim.scimsource"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_sources_scim.scimsource_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_sources_scim.scimsource"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_sources_scim.scimsource"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_sources_scim.scimsourcepropertymapping"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_sources_scim.scimsourcepropertymapping_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_sources_scim.scimsourcepropertymapping"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_sources_scim.scimsourcepropertymapping"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_authenticator_duo.authenticatorduostage"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_duo.authenticatorduostage_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_duo.authenticatorduostage"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_duo.authenticatorduostage"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_authenticator_duo.duodevice"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_duo.duodevice_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_duo.duodevice"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_duo.duodevice"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_authenticator_email.authenticatoremailstage"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_email.authenticatoremailstage_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_email.authenticatoremailstage"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_email.authenticatoremailstage"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_authenticator_email.emaildevice"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_email.emaildevice_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_email.emaildevice"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_email.emaildevice"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_authenticator_sms.authenticatorsmsstage"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_sms.authenticatorsmsstage_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_sms.authenticatorsmsstage"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_sms.authenticatorsmsstage"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_authenticator_sms.smsdevice"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_sms.smsdevice_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_sms.smsdevice"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_sms.smsdevice"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_authenticator_static.authenticatorstaticstage"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_static.authenticatorstaticstage_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_static.authenticatorstaticstage"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_static.authenticatorstaticstage"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_authenticator_static.staticdevice"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_static.staticdevice_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_static.staticdevice"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_static.staticdevice"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_authenticator_totp.authenticatortotpstage"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_totp.authenticatortotpstage_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_totp.authenticatortotpstage"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_totp.authenticatortotpstage"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_authenticator_totp.totpdevice"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_totp.totpdevice_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_totp.totpdevice"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_totp.totpdevice"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_authenticator_validate.authenticatorvalidatestage"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_validate.authenticatorvalidatestage_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_validate.authenticatorvalidatestage"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_validate.authenticatorvalidatestage"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_authenticator_webauthn.authenticatorwebauthnstage"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_webauthn.authenticatorwebauthnstage_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_webauthn.authenticatorwebauthnstage"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_webauthn.authenticatorwebauthnstage"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_authenticator_webauthn.webauthndevice"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_webauthn.webauthndevice_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_webauthn.webauthndevice"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_authenticator_webauthn.webauthndevice"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_captcha.captchastage"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_captcha.captchastage_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_captcha.captchastage"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_captcha.captchastage"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_consent.consentstage"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_consent.consentstage_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_consent.consentstage"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_consent.consentstage"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_consent.userconsent"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_consent.userconsent_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_consent.userconsent"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_consent.userconsent"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_deny.denystage"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_deny.denystage_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_deny.denystage"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_deny.denystage"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_dummy.dummystage"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_dummy.dummystage_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_dummy.dummystage"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_dummy.dummystage"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_email.emailstage"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_email.emailstage_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_email.emailstage"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_email.emailstage"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_identification.identificationstage"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_identification.identificationstage_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_identification.identificationstage"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_identification.identificationstage"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_invitation.invitation"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_invitation.invitation_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_invitation.invitation"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_invitation.invitation"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_invitation.invitationstage"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_invitation.invitationstage_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_invitation.invitationstage"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_invitation.invitationstage"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_password.passwordstage"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_password.passwordstage_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_password.passwordstage"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_password.passwordstage"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_prompt.prompt"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_prompt.prompt_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_prompt.prompt"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_prompt.prompt"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_prompt.promptstage"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_prompt.promptstage_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_prompt.promptstage"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_prompt.promptstage"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_redirect.redirectstage"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_redirect.redirectstage_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_redirect.redirectstage"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_redirect.redirectstage"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_user_delete.userdeletestage"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_user_delete.userdeletestage_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_user_delete.userdeletestage"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_user_delete.userdeletestage"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_user_login.userloginstage"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_user_login.userloginstage_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_user_login.userloginstage"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_user_login.userloginstage"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_user_logout.userlogoutstage"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_user_logout.userlogoutstage_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_user_logout.userlogoutstage"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_user_logout.userlogoutstage"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_stages_user_write.userwritestage"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_stages_user_write.userwritestage_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_stages_user_write.userwritestage"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_stages_user_write.userwritestage"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "model",
+                        "identifiers"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_tenants.domain"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_tenants.domain_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_tenants.domain"
+                        },
+                        "identifiers": {
+                            "$ref": "#/$defs/model_authentik_tenants.domain"
+                        }
+                    }
+                }
+            ]
+        },
         "model_authentik_blueprints.blueprintinstance": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Make writing long blueprints a bit more comfortable

Instead of writing

```yaml
entries:
  - foo
  - bar
  - baz
  - [repeat 5000 times]
```

this allows for

```yaml
entries:
  part1:
    - foo
    - bar
    - baz
  part2:
    - foo
    - bar
```

Which makes collapsing sections of the blueprint in the editor much easier.

The section names have no semantic effect on anything and are basically discarded when a blueprint is executed

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
