### PR TITLE
website/integrations: change nextcloud scope name to avoid confusion

### DIFF
--- a/website/integrations/services/nextcloud/index.mdx
+++ b/website/integrations/services/nextcloud/index.mdx
@@ -81,7 +81,7 @@ If you want to control user storage and designate Nextcloud administrators, you 
     - **Create Scope Mapping**:
 
         - **Name**: `Nextcloud Profile`
-        - **Scope name**: `profile`
+        - **Scope name**: `nextcloud`
         - **Expression**:
 
             ```python
@@ -146,7 +146,7 @@ Depending on your Nextcloud configuration, you may need to use `https://nextclou
     - **Client ID**: Client ID from authentik
     - **Client secret**: Client secret from authentik
     - **Discovery endpoint**: `https://authentik.company/application/o/<application_slug>/.well-known/openid-configuration`
-    - **Scope**: `email profile openid`
+    - **Scope**: `email nextcloud openid`
     - Under **Attribute mappings**:
 
         - **User ID mapping**: `sub` (or `user_id` for existing users)


### PR DESCRIPTION
This PR changes the Nextcloud Docs by replacing the proposed scope name 'profile' to 'nextcloud'. The reason for this is, that the name 'profile' is very close to the default scope 'profiles', which had lead me (and probably many others) to hours of debugging even though the issue is very simple and can easily be avoided by renaming the scope, which eliminates this confusion.


## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)


If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
