### PR TITLE
web/common: fix uiConfig not merged correctly

### DIFF
--- a/web/src/common/ui/config.ts
+++ b/web/src/common/ui/config.ts
@@ -1,5 +1,6 @@
 import { me } from "@goauthentik/common/users.js";
 import { isUserRoute } from "@goauthentik/elements/router/utils.js";
+import { deepmerge, deepmergeInto } from "deepmerge-ts";
 
 import { UiThemeEnum, UserSelf } from "@goauthentik/api";
 import { CurrentBrand } from "@goauthentik/api";
@@ -96,13 +97,12 @@ export class DefaultUIConfig implements UIConfig {
 let globalUiConfig: Promise<UIConfig>;
 
 export function getConfigForUser(user: UserSelf): UIConfig {
-    const settings = user.settings;
-    let config = new DefaultUIConfig();
+    const settings = user.settings as UIConfig;
+    const config = new DefaultUIConfig();
     if (!settings) {
         return config;
     }
-    config = Object.assign(new DefaultUIConfig(), settings);
-    return config;
+    return deepmerge({ ...config }, settings);
 }
 
 export function uiConfig(): Promise<UIConfig> {


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Currently when setting `enabledFeatures.notificationDrawer` to `false` it will also override the defaults of `true` for the other features, which is not the intended behaviour 

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
