### PR TITLE
web: Add identifier change handling for forms to fix navigation after slug updates

### DIFF
--- a/web/src/admin/applications/ApplicationForm.ts
+++ b/web/src/admin/applications/ApplicationForm.ts
@@ -93,7 +93,7 @@ export class ApplicationForm extends WithCapabilitiesConfig(ModelForm<Applicatio
             });
         }
         this.dispatchEvent(
-            new CustomEvent("ak-form-success", {
+            new CustomEvent("ak-form-successful-submit", {
                 detail: { slug: app.slug },
                 bubbles: true,
                 composed: true,

--- a/web/src/admin/applications/ApplicationForm.ts
+++ b/web/src/admin/applications/ApplicationForm.ts
@@ -92,6 +92,13 @@ export class ApplicationForm extends WithCapabilitiesConfig(ModelForm<Applicatio
                 },
             });
         }
+        this.dispatchEvent(
+            new CustomEvent("ak-form-success", {
+                detail: { slug: app.slug },
+                bubbles: true,
+                composed: true,
+            }),
+        );
         return app;
     }
 

--- a/web/src/admin/applications/ApplicationViewPage.ts
+++ b/web/src/admin/applications/ApplicationViewPage.ts
@@ -13,6 +13,7 @@ import { AKElement } from "#elements/Base";
 import "#elements/EmptyState";
 import "#elements/Tabs";
 import "#elements/buttons/SpinnerButton/ak-spinner-button";
+import { ModelForm } from "@goauthentik/elements/forms/ModelForm";
 
 import { msg } from "@lit/localize";
 import { CSSResult, PropertyValues, TemplateResult, html } from "lit";
@@ -114,6 +115,7 @@ export class ApplicationViewPage extends AKElement {
         if (!this.application) {
             return html`<ak-empty-state default-label></ak-empty-state>`;
         }
+        const currentSlug = this.application.slug;
         return html`<ak-tabs>
             ${this.missingOutpost
                 ? html`<div slot="header" class="pf-c-banner pf-m-warning">
@@ -201,7 +203,16 @@ export class ApplicationViewPage extends AKElement {
                                     </dt>
                                     <dd class="pf-c-description-list__description">
                                         <div class="pf-c-description-list__text">
-                                            <ak-forms-modal>
+                                            <ak-forms-modal
+                                                @ak-form-successful-submit=${(e: CustomEvent) => {
+                                                    const app = e.detail as Application;
+                                                    ModelForm.handleIdentifierChange(
+                                                        this.applicationSlug || "",
+                                                        app.slug,
+                                                        "/core/applications/",
+                                                    );
+                                                }}
+                                            >
                                                 <span slot="submit"> ${msg("Update")} </span>
                                                 <span slot="header">
                                                     ${msg("Update Application")}

--- a/web/src/admin/flows/FlowForm.ts
+++ b/web/src/admin/flows/FlowForm.ts
@@ -72,7 +72,7 @@ export class FlowForm extends WithCapabilitiesConfig(ModelForm<Flow, string>) {
             });
         }
         this.dispatchEvent(
-            new CustomEvent("ak-form-success", {
+            new CustomEvent("ak-form-successful-submit", {
                 detail: { slug: flow.slug },
                 bubbles: true,
                 composed: true,

--- a/web/src/admin/flows/FlowForm.ts
+++ b/web/src/admin/flows/FlowForm.ts
@@ -71,6 +71,13 @@ export class FlowForm extends WithCapabilitiesConfig(ModelForm<Flow, string>) {
                 },
             });
         }
+        this.dispatchEvent(
+            new CustomEvent("ak-form-success", {
+                detail: { slug: flow.slug },
+                bubbles: true,
+                composed: true,
+            }),
+        );
         return flow;
     }
 

--- a/web/src/admin/flows/FlowViewPage.ts
+++ b/web/src/admin/flows/FlowViewPage.ts
@@ -11,6 +11,7 @@ import "#components/events/ObjectChangelog";
 import { AKElement } from "#elements/Base";
 import "#elements/Tabs";
 import "#elements/buttons/SpinnerButton/ak-spinner-button";
+import { ModelForm } from "@goauthentik/elements/forms/ModelForm";
 
 import { msg } from "@lit/localize";
 import { CSSResult, PropertyValues, TemplateResult, css, html } from "lit";
@@ -126,6 +127,21 @@ export class FlowViewPage extends AKElement {
                                                     <ak-flow-form
                                                         slot="form"
                                                         .instancePk=${this.flow.slug}
+                                                        @ak-form-successful-submit=${(
+                                                            e: CustomEvent,
+                                                        ) => {
+                                                            const flow = e.detail as Flow;
+                                                            if (!this.flowSlug) {
+                                                                console.warn(
+                                                                    "Old identifier (flowSlug) is undefined or empty. Ensure this is intentional.",
+                                                                );
+                                                            }
+                                                            ModelForm.handleIdentifierChange(
+                                                                this.flowSlug || "",
+                                                                flow.slug,
+                                                                "/flow/flows/",
+                                                            );
+                                                        }}
                                                     >
                                                     </ak-flow-form>
                                                     <button

--- a/web/src/admin/sources/SourceViewPage.ts
+++ b/web/src/admin/sources/SourceViewPage.ts
@@ -9,6 +9,7 @@ import "#components/ak-page-header";
 import { AKElement } from "#elements/Base";
 import "#elements/EmptyState";
 import "#elements/buttons/SpinnerButton/ak-spinner-button";
+import { ModelForm } from "@goauthentik/elements/forms/ModelForm";
 
 import { TemplateResult, html } from "lit";
 import { customElement, property } from "lit/decorators.js";
@@ -31,6 +32,15 @@ export class SourceViewPage extends AKElement {
 
     @property({ attribute: false })
     source?: Source;
+
+    connectedCallback() {
+        super.connectedCallback();
+        this.addEventListener("ak-form-successful-submit", (e: Event) => {
+            const customEvent = e as CustomEvent;
+            const source = customEvent.detail as Source;
+            ModelForm.handleIdentifierChange(this.sourceSlug || "", source.slug, "/core/sources/");
+        });
+    }
 
     renderSource(): TemplateResult {
         if (!this.source) {
@@ -74,6 +84,11 @@ export class SourceViewPage extends AKElement {
             >
             </ak-page-header>
             ${this.renderSource()}`;
+    }
+
+    handleFormSubmit(e: CustomEvent) {
+        const source = e.detail as Source;
+        ModelForm.handleIdentifierChange(this.sourceSlug || "", source.slug, "/core/sources/");
     }
 }
 

--- a/web/src/admin/sources/kerberos/KerberosSourceForm.ts
+++ b/web/src/admin/sources/kerberos/KerberosSourceForm.ts
@@ -79,7 +79,7 @@ export class KerberosSourceForm extends WithCapabilitiesConfig(BaseSourceForm<Ke
             });
         }
         this.dispatchEvent(
-            new CustomEvent("ak-form-success", {
+            new CustomEvent("ak-form-successful-submit", {
                 detail: { slug: source.slug },
                 bubbles: true,
                 composed: true,

--- a/web/src/admin/sources/kerberos/KerberosSourceForm.ts
+++ b/web/src/admin/sources/kerberos/KerberosSourceForm.ts
@@ -78,6 +78,13 @@ export class KerberosSourceForm extends WithCapabilitiesConfig(BaseSourceForm<Ke
                 },
             });
         }
+        this.dispatchEvent(
+            new CustomEvent("ak-form-success", {
+                detail: { slug: source.slug },
+                bubbles: true,
+                composed: true,
+            }),
+        );
         return source;
     }
 

--- a/web/src/admin/sources/ldap/LDAPSourceForm.ts
+++ b/web/src/admin/sources/ldap/LDAPSourceForm.ts
@@ -46,7 +46,7 @@ export class LDAPSourceForm extends BaseSourceForm<LDAPSource> {
             });
         }
         this.dispatchEvent(
-            new CustomEvent("ak-form-success", {
+            new CustomEvent("ak-form-successful-submit", {
                 detail: { slug: source.slug },
                 bubbles: true,
                 composed: true,

--- a/web/src/admin/sources/ldap/LDAPSourceForm.ts
+++ b/web/src/admin/sources/ldap/LDAPSourceForm.ts
@@ -34,16 +34,25 @@ export class LDAPSourceForm extends BaseSourceForm<LDAPSource> {
     }
 
     async send(data: LDAPSource): Promise<LDAPSource> {
+        let source: LDAPSource;
         if (this.instance) {
-            return new SourcesApi(DEFAULT_CONFIG).sourcesLdapPartialUpdate({
+            source = await new SourcesApi(DEFAULT_CONFIG).sourcesLdapPartialUpdate({
                 slug: this.instance.slug,
                 patchedLDAPSourceRequest: data,
             });
+        } else {
+            source = await new SourcesApi(DEFAULT_CONFIG).sourcesLdapCreate({
+                lDAPSourceRequest: data as unknown as LDAPSourceRequest,
+            });
         }
-
-        return new SourcesApi(DEFAULT_CONFIG).sourcesLdapCreate({
-            lDAPSourceRequest: data as unknown as LDAPSourceRequest,
-        });
+        this.dispatchEvent(
+            new CustomEvent("ak-form-success", {
+                detail: { slug: source.slug },
+                bubbles: true,
+                composed: true,
+            }),
+        );
+        return source;
     }
 
     renderForm(): TemplateResult {

--- a/web/src/admin/sources/oauth/OAuthSourceForm.ts
+++ b/web/src/admin/sources/oauth/OAuthSourceForm.ts
@@ -103,6 +103,13 @@ export class OAuthSourceForm extends WithCapabilitiesConfig(BaseSourceForm<OAuth
                 },
             });
         }
+        this.dispatchEvent(
+            new CustomEvent("ak-form-success", {
+                detail: { slug: source.slug },
+                bubbles: true,
+                composed: true,
+            }),
+        );
         return source;
     }
 

--- a/web/src/admin/sources/oauth/OAuthSourceForm.ts
+++ b/web/src/admin/sources/oauth/OAuthSourceForm.ts
@@ -104,7 +104,7 @@ export class OAuthSourceForm extends WithCapabilitiesConfig(BaseSourceForm<OAuth
             });
         }
         this.dispatchEvent(
-            new CustomEvent("ak-form-success", {
+            new CustomEvent("ak-form-successful-submit", {
                 detail: { slug: source.slug },
                 bubbles: true,
                 composed: true,

--- a/web/src/admin/sources/plex/PlexSourceForm.ts
+++ b/web/src/admin/sources/plex/PlexSourceForm.ts
@@ -91,7 +91,7 @@ export class PlexSourceForm extends WithCapabilitiesConfig(BaseSourceForm<PlexSo
             });
         }
         this.dispatchEvent(
-            new CustomEvent("ak-form-success", {
+            new CustomEvent("ak-form-successful-submit", {
                 detail: { slug: source.slug },
                 bubbles: true,
                 composed: true,

--- a/web/src/admin/sources/plex/PlexSourceForm.ts
+++ b/web/src/admin/sources/plex/PlexSourceForm.ts
@@ -90,6 +90,13 @@ export class PlexSourceForm extends WithCapabilitiesConfig(BaseSourceForm<PlexSo
                 },
             });
         }
+        this.dispatchEvent(
+            new CustomEvent("ak-form-success", {
+                detail: { slug: source.slug },
+                bubbles: true,
+                composed: true,
+            }),
+        );
         return source;
     }
 

--- a/web/src/admin/sources/saml/SAMLSourceForm.ts
+++ b/web/src/admin/sources/saml/SAMLSourceForm.ts
@@ -79,7 +79,7 @@ export class SAMLSourceForm extends WithCapabilitiesConfig(BaseSourceForm<SAMLSo
             });
         }
         this.dispatchEvent(
-            new CustomEvent("ak-form-success", {
+            new CustomEvent("ak-form-successful-submit", {
                 detail: { slug: source.slug },
                 bubbles: true,
                 composed: true,

--- a/web/src/admin/sources/saml/SAMLSourceForm.ts
+++ b/web/src/admin/sources/saml/SAMLSourceForm.ts
@@ -78,6 +78,13 @@ export class SAMLSourceForm extends WithCapabilitiesConfig(BaseSourceForm<SAMLSo
                 },
             });
         }
+        this.dispatchEvent(
+            new CustomEvent("ak-form-success", {
+                detail: { slug: source.slug },
+                bubbles: true,
+                composed: true,
+            }),
+        );
         return source;
     }
 

--- a/web/src/elements/forms/Form.ts
+++ b/web/src/elements/forms/Form.ts
@@ -269,6 +269,14 @@ export abstract class Form<T> extends AKElement {
                     }),
                 );
 
+                this.dispatchEvent(
+                    new CustomEvent("ak-form-successful-submit", {
+                        bubbles: true,
+                        composed: true,
+                        detail: response,
+                    }),
+                );
+
                 return response;
             })
             .catch(async (error: unknown) => {

--- a/web/src/elements/forms/ModelForm.ts
+++ b/web/src/elements/forms/ModelForm.ts
@@ -95,4 +95,34 @@ export abstract class ModelForm<T, PKT extends string | number> extends Form<T> 
         }
         return super.render();
     }
+
+    /**
+     * Handle identifier change after form submission
+     *
+     * Call this method from the parent component's successful submit handler
+     * to handle redirection when an object's identifier (slug, pk, etc.) changes
+     *
+     * @param oldIdentifier Original identifier before update
+     * @param newIdentifier New identifier after update
+     * @param basePath Base path for the object (e.g., "/core/applications/")
+     * @returns True if redirect was performed, false otherwise
+     */
+    static handleIdentifierChange(
+        oldIdentifier: string,
+        newIdentifier: string,
+        basePath: string,
+    ): boolean {
+        if (!oldIdentifier) {
+            console.warn("Old identifier is undefined or empty. Ensure this is intentional.");
+        }
+        if (!newIdentifier) {
+            console.warn("New identifier is undefined or empty. Navigation may fail.");
+        }
+
+        if (oldIdentifier !== newIdentifier) {
+            window.location.href = `/if/admin/#${basePath}${newIdentifier}`;
+            return true;
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
I'm probably missing at least 10 other places where this bug occurs, I'll try to find more as I go.

So, this MR adds functionality to handle slug changes after form submission. When a user edits an object and changes its identifier, authentik now properly redirects to the new URL path.

Closes https://github.com/goauthentik/authentik/pull/11981 Closes https://github.com/goauthentik/authentik/issues/11973

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
