### PR TITLE
fix(blueprints-examples): token_expiry wrong in the email recovery

### DIFF
--- a/blueprints/example/flows-recovery-email-verification.yaml
+++ b/blueprints/example/flows-recovery-email-verification.yaml
@@ -57,7 +57,7 @@ entries:
       use_ssl: false
       timeout: 10
       from_address: system@authentik.local
-      token_expiry: minutes=30
+      token_expiry: 30
       subject: authentik
       template: email/password_reset.html
       activate_user_on_success: true


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
This blueprint won’t apply in its current stage
`token_expiry: minutes=30 `needs to be `token_expiry: 30`

Thanks in advance! :)
---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
