### PR TITLE
events: disable computation of autocomplete structure for event context

### DIFF
--- a/authentik/enterprise/search/fields.py
+++ b/authentik/enterprise/search/fields.py
@@ -14,9 +14,10 @@ class JSONSearchField(StrField):
 
     model: Model
 
-    def __init__(self, model=None, name=None, nullable=None):
+    def __init__(self, model=None, name=None, nullable=None, suggest_nested=True):
         # Set this in the constructor to not clobber the type variable
         self.type = "relation"
+        self.suggest_nested = suggest_nested
         super().__init__(model, name, nullable)
 
     def get_lookup(self, path, operator, value):
@@ -58,6 +59,8 @@ class JSONSearchField(StrField):
 
     def get_nested_options(self) -> OrderedDict:
         """Get keys of all nested objects to show autocomplete"""
+        if not self.suggest_nested:
+            return OrderedDict()
         base_model_name = f"{self.model._meta.app_label}.{self.model._meta.model_name}_{self.name}"
 
         def recursive_function(parts: list[str], parent_parts: list[str] | None = None):

--- a/authentik/events/api/events.py
+++ b/authentik/events/api/events.py
@@ -144,7 +144,7 @@ class EventViewSet(ModelViewSet):
             JSONSearchField(Event, "user"),
             JSONSearchField(Event, "brand"),
             ChoiceSearchField(Event, "action"),
-            JSONSearchField(Event, "context"),
+            JSONSearchField(Event, "context", suggest_nested=False),
             DateTimeField(Event, "created", suggest_options=True),
         ]
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Turns out computing the autocomplete for context with 800k events takes about 90 seconds...needs some caching/pre-computing

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
