### PR TITLE
web/elements: typing error when variables are not converted to string

### DIFF
--- a/web/src/elements/ak-dual-select/ak-dual-select.ts
+++ b/web/src/elements/ak-dual-select/ak-dual-select.ts
@@ -32,8 +32,8 @@ import {
 } from "./types.js";
 
 function localeComparator(a: DualSelectPair, b: DualSelectPair) {
-    const aSortBy = a[2] || a[0];
-    const bSortBy = b[2] || b[0];
+    const aSortBy = String(a[2] || a[0]);
+    const bSortBy = String(b[2] || b[0]);
 
     return aSortBy.localeCompare(bSortBy);
 }


### PR DESCRIPTION
This PR fixes a really small UI error.

Closes #15168 