### PR TITLE
website/docs: fix egregious maintenance fail

### DIFF
--- a/website/docs/sys-mgmt/events/notifications.md
+++ b/website/docs/sys-mgmt/events/notifications.md
@@ -8,9 +8,7 @@ To prevent infinite loops (events created by policies which are attached to a No
 
 ## Filtering Events
 
-Starting with authentik 0.15, you can create notification rules, which can alert you based on the creation of certain events.
-
-Filtering is done by using the Policy Engine. You can do simple filtering using the "Event Matcher Policy" type.
+An authentik administrator can create notification rules based on the creation of specified events. Filtering is done by using the Policy Engine. You can do simple filtering using the "Event Matcher Policy" type.
 
 ![](./event_matcher.png)
 


### PR DESCRIPTION
This PR removes a refernece to umm version 0.15. Yep.

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
