### PR TITLE
website/docs: enterprise: fix link for customer portal

### DIFF
--- a/website/docs/enterprise/get-started.md
+++ b/website/docs/enterprise/get-started.md
@@ -19,7 +19,7 @@ Access your Enterprise features by first [purchasing a license](./manage-enterpr
 
 To open the Customer Portal and buy a license, go to the Admin interface and in the left pane, navigate to **Enterprise -> Licenses**, and then click **Go to Customer Portal**.
 
-Alternatively you can open a new browser window and go directly to the [Customer Portal](https://customers.goauthentik.io/). If you do not yet have an authentik account, there is a [Sign up link](https://id.customers.goauthentik.io/signup) on the Customer Portal login page.
+Alternatively you can open a new browser window and go directly to the [Customer Portal](https://customers.goauthentik.io/). If you do not yet have an authentik account, there is a [Sign up link](https://customers.goauthentik.io/signup) on the Customer Portal login page.
 
 In the Customer Portal you [define your organization](./manage-enterprise.mdx#create-an-organization) and its members, manage your [licenses](./manage-enterprise.mdx#license-management) and [billing](./manage-enterprise.mdx#manage-billing), and access our [Support center](./entsupport.md).
 

--- a/website/docs/enterprise/manage-enterprise.mdx
+++ b/website/docs/enterprise/manage-enterprise.mdx
@@ -50,7 +50,7 @@ Note that a license is associated with a specific Organization in the Customer P
 
 1. To get a license key, log in to your authentik account with your administrator credentials, and then click **Admin interface** in the upper right.
 
-2. On the **Admin interface**, navigate to **Enterprise → Licenses** in the left menu, and then click **Go to Customer Portal** under the **Get a license** section. Alternatively you can open a new browser window and go directly to the [Customer Portal](https://id.customers.goauthentik.io).
+2. On the **Admin interface**, navigate to **Enterprise → Licenses** in the left menu, and then click **Go to Customer Portal** under the **Get a license** section. Alternatively you can open a new browser window and go directly to the [Customer Portal](https://customers.goauthentik.io).
 
 3. Log in to the Customer Portal.
 

--- a/website/docs/enterprise/manage-enterprise.mdx
+++ b/website/docs/enterprise/manage-enterprise.mdx
@@ -138,7 +138,7 @@ Once a subscription is canceled, the associated license will still be valid unti
 
 Billing is based on each individual organization.
 
-1. To manage your billing, go to the [Customer Portal](https://customers.goauthentik.io) and click "My organizations" in the top menu bar.
+1. To manage your billing, go to the [Customer Portal](https://customers.goauthentik.io) and navigate to **Organizations > My organizations**.
 
 2. Select the organization for which you want to manage billing.
 

--- a/website/docs/enterprise/manage-enterprise.mdx
+++ b/website/docs/enterprise/manage-enterprise.mdx
@@ -138,7 +138,7 @@ Once a subscription is canceled, the associated license will still be valid unti
 
 Billing is based on each individual organization.
 
-1. To manage your billing, go to the [Customer Portal](https://id.customers.goauthentik.io) and click "My organizations" in the top menu bar.
+1. To manage your billing, go to the [Customer Portal](https://customers.goauthentik.io) and click "My organizations" in the top menu bar.
 
 2. Select the organization for which you want to manage billing.
 


### PR DESCRIPTION
From 15223.diff:
<img width="1306" alt="image" src="https://github.com/user-attachments/assets/a5d66036-4c0b-41ad-a1c7-3ec555cd179d" />

The correct portal url is customers.g.i, id.customers.g.i is just the authentication layer  and not passing by authentik gives a direct link (which forces auth and adds an oidc callback to the customer portal if you're logged out anyways)

and

<img width="1697" alt="image" src="https://github.com/user-attachments/assets/f66a5f68-213f-4f07-8e56-a10cc165f0f2" />

/signup is on customers.g.i which redirects you to enrolment on id.customers.g.i, the other link returns a 404 anyways.

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
