### PR TITLE
website/docs: Fix documentation for external group write commands in hashicorp-vault integrations

### DIFF
--- a/website/integrations/services/hashicorp-vault/index.md
+++ b/website/integrations/services/hashicorp-vault/index.md
@@ -96,15 +96,15 @@ vault write auth/oidc/role/reader \
       user_claim="sub" \
       policies="reader" \
       groups_claim="groups" \
-      oidc_scopes=[ "openid profile email" ]
+      oidc_scopes="openid,profile,email"
 ```
 
 Add a group.
 
 ```
-vault write identity/group/reader \
+vault write identity/group \
     name="reader" \
-    policies=["reader"] \
+    policies="reader" \
     type="external"
 ```
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
Updated the vault write commands for the external group write commands.  
The parameteers `oidc_scopes=` for the `auth/oidc/role` write command,  
and `policies=` for the `identity/group` write command should be comma separated.  

Using the current documentation, `oidc_scopes=["openid profile email"]` results in this: `oidc_scopes [[openid profile email]]`, instead of the proper `oidc_scopes [openid profile email]`
```
bash-5.2$ vault write auth/oidc/role/test_role_placeholder \
  bound_audiences="audiences_placeholder_string" \
  allowed_redirect_uris="https://fqdn.vault.ext:8200/ui/vault/auth/oidc/oidc/callback" \
  user_claim="sub" \
  policies="test_policy_placeholder" \
  groups_claim="groups" \
  oidc_scopes=["openid profile email"]
Success! Data written to: auth/oidc/role/test_role_placeholder
bash-5.2$ vault read auth/oidc/role/test_role_placeholder
Key                        Value
---                        -----
allowed_redirect_uris      [https://fqdn.vault.ext/ui/vault/auth/oidc/oidc/callback]
bound_audiences            [audiences_placeholder_string]
bound_claims               <nil>
bound_claims_type          string
bound_subject              n/a
claim_mappings             <nil>
clock_skew_leeway          0
expiration_leeway          0
groups_claim               groups
max_age                    0
not_before_leeway          0
oidc_scopes                [[openid profile email]]
policies                   [test_policy_placeholder]
role_type                  oidc
token_bound_cidrs          []
token_explicit_max_ttl     0s
token_max_ttl              0s
token_no_default_policy    false
token_num_uses             0
token_period               0s
token_policies             [test_policy_placeholder]
token_ttl                  0s
token_type                 default
user_claim                 sub
user_claim_json_pointer    false
verbose_oidc_logging       false
```
So in the command it should be `oidc_scopes="openid,profile,email"`.

Same thing with policies in the `vault write identity` command.  
Which also shouldn't have the group name in the path, because it throws an error.
```
bash-5.2$ vault write identity/group/test_group_placeholder \
  name="test_group_placeholder" \
  policies="test_policy_placeholder" \
  type="external"
Error writing data to identity/group/test_group_placeholder: Error making API request.

URL: PUT https://fqdn.vault.ext/v1/identity/group/test_group_placeholder
Code: 404. Errors:

* 1 error occurred:
        * unsupported path
```
It does work if the path is just `identity/group`:  
```
bash-5.2$ vault write identity/group \
  name="test_group_placeholder" \
  policies="test_policy_placeholder" \
  type="external"
Key     Value
---     -----
id      95664140-c7e4-c9d6-ad3d-fb57ed611861
name    test_group_placeholder
bash-5.2$
```
---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
