### PR TITLE
website/docs: add hint that flows need cookies

### DIFF
--- a/website/docs/developer-docs/api/flow-executor.md
+++ b/website/docs/developer-docs/api/flow-executor.md
@@ -11,7 +11,7 @@ Because the flow executor stores its state in the HTTP Session, so you need to e
 :::
 
 :::info
-Note that the HTTP Session must be obtained as cookie before GET /api/v3/flows/executor/:slug can be called. If you are using a JWT for authentication, you first have to obtain a session cookie via GET /api/v3/flows/instances/:slug/execute/ before requesting GET /api/v3/flows/executor/:slug.
+Note that the HTTP session must be obtained as a cookie before `GET /api/v3/flows/executor/:slug` can be called. If you are using a JWT for authentication, you first have to obtain a session cookie via `GET /api/v3/flows/instances/:slug/execute/` before requesting `GET /api/v3/flows/executor/:slug`.
 :::
 
 The main endpoint for flow execution is `/api/v3/flows/executor/:slug`.

--- a/website/docs/developer-docs/api/flow-executor.md
+++ b/website/docs/developer-docs/api/flow-executor.md
@@ -10,6 +10,10 @@ However, any flow can be executed via an API from anywhere, in fact that is what
 Because the flow executor stores its state in the HTTP Session, so you need to ensure that cookies between flow executor requests are persisted.
 :::
 
+:::info
+Note that the HTTP Session must be obtained as cookie before GET /api/v3/flows/executor/:slug can be called. If you are using a JWT for authentication, you first have to obtain a session cookie via GET /api/v3/flows/instances/:slug/execute/ before requesting GET /api/v3/flows/executor/:slug.
+:::
+
 The main endpoint for flow execution is `/api/v3/flows/executor/:slug`.
 
 This endpoint accepts a query parameter called `query`, in which the flow executor sends the full query-string.


### PR DESCRIPTION
The executor itself does not set a session cookie, but requires one to be set before it works. This took me days to figure out, so maybe this will be helpful to somebody in the future.

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
