### PR TITLE
website/integrations: change issuer in zulip integration documentation

### DIFF
--- a/website/integrations/services/zulip/index.md
+++ b/website/integrations/services/zulip/index.md
@@ -34,7 +34,7 @@ To support the integration of Zulip with authentik, you need to create an applic
 - **Choose a Provider type**: select **SAML Provider** as the provider type.
 - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
     - Set the **ACS URL** to `https://zulip.company/complete/saml/`.
-    - Set the **Issuer** to `https://zulip.company`.
+    - Set the **Issuer** to `https://authentik.company`.
     - Set the **Service Provider Binding** to `Post`.
     - Under **Advanced protocol settings**, select an available signing certificate.
 - **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/flows-stages/bindings/) (policy, group, or user) to manage the listing and access to applications on a user's **My applications** page.


### PR DESCRIPTION
I tried to follow this documentation. My zulip instance (running docker-zulip 10.3-0)  did not recognize the IdP when a user returned from authentik to zulip, until I changed the issuer in the authentik settings from `zulip.company` to `authentik.company`.
