### PR TITLE
stages/email: remove superflous <td> from account_confirmation template

### DIFF
--- a/authentik/stages/email/templates/email/account_confirmation.html
+++ b/authentik/stages/email/templates/email/account_confirmation.html
@@ -27,7 +27,6 @@
     </table>
   </td>
 </tr>
-<td>
 {% endblock %}
 
 {% block sub_content %}


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
While studying the email templates, I found this `<td>` tag which opens at the end of the `content` block and does not get closed anywhere.

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [X] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
