### PR TITLE
web/elements: fix table search not resetting page when query changes

### DIFF
--- a/web/src/elements/table/Table.ts
+++ b/web/src/elements/table/Table.ts
@@ -478,8 +478,10 @@ export abstract class Table<T> extends WithLicenseSummary(AKElement) implements 
     renderSearch(): TemplateResult {
         const runSearch = (value: string) => {
             this.search = value;
+            this.page = 1;
             updateURLParams({
                 search: value,
+                tablePage: 1,
             });
             this.fetch();
         };

--- a/web/src/elements/table/TablePage.ts
+++ b/web/src/elements/table/TablePage.ts
@@ -3,7 +3,7 @@ import { updateURLParams } from "#elements/router/RouteMatch";
 import { Table } from "#elements/table/Table";
 
 import { msg } from "@lit/localize";
-import { CSSResult } from "lit";
+import { CSSResult, nothing } from "lit";
 import { TemplateResult, html } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
 
@@ -45,7 +45,7 @@ export abstract class TablePage<T> extends Table<T> {
                 : html`<ak-empty-state icon=${this.pageIcon()}
                       ><span>${msg("No objects found.")}</span>
                       <div slot="body">
-                          ${this.searchEnabled() ? this.renderEmptyClearSearch() : html``}
+                          ${this.searchEnabled() ? this.renderEmptyClearSearch() : nothing}
                       </div>
                       <div slot="primary">${this.renderObjectCreate()}</div>
                   </ak-empty-state>`}
@@ -61,8 +61,10 @@ export abstract class TablePage<T> extends Table<T> {
                 this.search = "";
                 this.requestUpdate();
                 this.fetch();
+                this.page = 1;
                 updateURLParams({
                     search: "",
+                    tablePage: 1,
                 });
             }}
             class="pf-c-button pf-m-link"


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

When changing search queries, the pagination page is supposed to reset

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
