### PR TITLE
stages/authenticator_validate: fix WebAuthn in android during google account addition (2025.4)

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -228,7 +228,6 @@ jobs:
     needs:
       - lint
       - test-migrations
-      - test-migrations-from-stable
       - test-unittest
       - test-integration
       - test-e2e


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

https://github.com/goauthentik/authentik/pull/15351 but 2025.4

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
