### PR TITLE
website/integrations: fix kanboard doc prettier

### DIFF
--- a/website/integrations/services/kanboard/index.md
+++ b/website/integrations/services/kanboard/index.md
@@ -29,7 +29,6 @@ To support the integration of Kanboard with authentik, you need to create an app
 
 1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
-
     - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
     - **Choose a Provider type**: select **OAuth2/OpenID Connect** as the provider type.
     - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.


### PR DESCRIPTION
## Details

Removes a linebreak. Required by prettier

---

## Checklist

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
