### PR TITLE
web: Fix lack of error when setting recovery password

### DIFF
--- a/web/src/common/errors/network.ts
+++ b/web/src/common/errors/network.ts
@@ -144,6 +144,9 @@ export function composeResponseErrorDescriptor(descriptor: ResponseErrorDescript
     return `${descriptor.headline}: ${descriptor.reason}`;
 }
 
+export const ErrorFieldFallbackKeys = ["detail", "message", "non_field_errors"] as const;
+export type FallbackError = Record<(typeof ErrorFieldFallbackKeys)[number], string | undefined>;
+
 /**
  * Attempts to pluck a human readable error message from a {@linkcode ValidationError}.
  */
@@ -172,12 +175,14 @@ export function pluckErrorDetail(errorLike: unknown, fallback?: string): string 
         return fallback;
     }
 
-    if ("detail" in errorLike && typeof errorLike.detail === "string") {
-        return errorLike.detail;
-    }
+    for (const fieldKey of ErrorFieldFallbackKeys) {
+        if (!(fieldKey in errorLike)) continue;
 
-    if ("message" in errorLike && typeof errorLike.message === "string") {
-        return errorLike.message;
+        const value = (errorLike as FallbackError)[fieldKey];
+
+        if (typeof value === "string" && value) {
+            return value;
+        }
     }
 
     return fallback;


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
<img width="908" alt="Screenshot 2025-07-04 at 15 00 27" src="https://github.com/user-attachments/assets/08fc65f2-6fc9-4e9a-96a1-8bd2da981332" />


---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
