### PR TITLE
root: add npm install to set up authentik Typescript API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ gen-client-ts: gen-clean-ts  ## Build and install the authentik API for Typescri
 		--git-repo-id authentik \
 		--git-user-id goauthentik
 
-	cd ${PWD}/${GEN_API_TS} && npm link
+	cd ${PWD}/${GEN_API_TS} && npm install && npm link
 	cd ${PWD}/web && npm link @goauthentik/api
 
 gen-client-py: gen-clean-py ## Build and install the authentik API for Python


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
When following through [the steps to set up local development](https://docs.goauthentik.io/docs/developer-docs/setup/full-dev-environment), the developer is asked to run:

```sh
make install
make gen-dev-config
make migrate
make gen
```

`make gen` tries to run `npm link`, but the `make install` step never handles running `npm install` in the root of the directory, so `npm link` does not work.

This PR adds `npm install` to the `core-install` step ran by `make install`, fixing the issue

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
