### PR TITLE
website/docs: fix typo and update wordpress plugin name in wordpress integration guide

### DIFF
--- a/website/integrations/services/wordpress/index.md
+++ b/website/integrations/services/wordpress/index.md
@@ -11,7 +11,7 @@ support_level: community
 > -- https://en.wikipedia.org/wiki/WordPress
 
 :::note
-There are many different plugins for WordPress that allow you to setup SSO using different authentication methods. The plugin that is explained in this tutorial is "OpenID Connect Generic" version 3.8.5 by daggerhart. This plugin uses OpenID/OAUTH2 and is free without paywalls or subscriptions at the time of writing this. The plugin is available for free in the WordPress Plugin gallery.
+There are many different plugins for WordPress that allow you to setup SSO using different authentication methods. The plugin that is explained in this tutorial is "OpenID Connect Generic Client" version 3.8.5 by Jonathan Daggerhart. This plugin uses OpenID/OAUTH2 and is free without paywalls or subscriptions at the time of writing this. The plugin is available for free in the WordPress Plugin gallery.
 :::
 
 ## Preparation
@@ -40,7 +40,7 @@ To support the integration of WordPress with authentik, you need to create an ap
     - Note the **Client ID**,**Client Secret**, and **slug** values because they will be required later.
     - Set a `Strict` redirect URI to `https://wp.company/wp-admin/admin-ajax.php\?action=openid-connect-authorize`.
     - Select any available signing key.
-    - Under **Advanced Protocol Settings**, add `offline_access` to the list of available scopes.
+    - Under **Advanced Protocol Settings**, add `offline_access` to the list of selected scopes.
 - **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/flows-stages/bindings/) (policy, group, or user) to manage the listing and access to applications on a user's **My applications** page.
 
 3. Click **Submit** to save the new application and provider.
@@ -48,7 +48,7 @@ To support the integration of WordPress with authentik, you need to create an ap
 ## WordPress configuration
 
 :::note
-Assumption is being made that you have successfully downloaded and activated the required plugin "OpenID Connect Generic" by daggerhart
+Assumption is being made that you have successfully downloaded and activated the required plugin "OpenID Connect Generic Client" by Jonathan Daggerhart
 :::
 
 In WordPress, under _Settings_, Select _OpenID Connect Client_


### PR DESCRIPTION

## Details
Edited plugin name and plugin author's name - it seems they have changed slightly since this guide was written (see the plugin's [current wordpress page](https://wordpress.org/plugins/daggerhart-openid-connect-generic/#description). Changed **available scopes** to **selected scopes** - `offline_access` is already present in **available scopes**, and you are adding it to **selected scopes**, not to **available scopes**. This is probably a mistake/typo in the documentation page.

## Checklist

-   [ ] Local tests pass (`ak test authentik/`) - not applicable
-   [ ] The code has been formatted (`make lint-fix`) - not applicable

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`) - not applicable

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`) - not applicable

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
