### PR TITLE
events: fix ak_client_ip not set in notification rule policy context

### DIFF
--- a/authentik/events/tasks.py
+++ b/authentik/events/tasks.py
@@ -62,6 +62,7 @@ def event_trigger_handler(event_uuid: str, trigger_name: str):
     policy_engine.mode = PolicyEngineMode.MODE_ANY
     policy_engine.empty_result = False
     policy_engine.use_cache = False
+    policy_engine.request.obj = event
     policy_engine.request.context["event"] = event
     policy_engine.build()
     result = policy_engine.result

--- a/authentik/policies/expression/evaluator.py
+++ b/authentik/policies/expression/evaluator.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Optional
 from django.http import HttpRequest
 from structlog.stdlib import get_logger
 
+from authentik.events.models import Event
 from authentik.flows.planner import PLAN_CONTEXT_SSO
 from authentik.lib.expression.evaluator import BaseEvaluator
 from authentik.policies.exceptions import PolicyException
@@ -45,6 +46,10 @@ class PolicyEvaluator(BaseEvaluator):
             self.set_http_request(request.http_request)
         self._context["request"] = request
         self._context["context"] = request.context
+        if request.obj and isinstance(request.obj, Event):
+            self._context["ak_client_ip"] = ip_address(
+                request.obj.client_ip or ClientIPMiddleware.default_ip
+            )
 
     def set_http_request(self, request: HttpRequest):
         """Update context based on http request"""


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

closes https://github.com/goauthentik/authentik/issues/15161

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
