### PR TITLE
website/docs: add use case, move diagram, link to ABM

### DIFF
--- a/authentik/enterprise/stages/authenticator_endpoint_gdtc/models.py
+++ b/authentik/enterprise/stages/authenticator_endpoint_gdtc/models.py
@@ -16,7 +16,7 @@ from authentik.stages.authenticator.models import Device
 
 
 class AuthenticatorEndpointGDTCStage(ConfigurableStage, FriendlyNamedStage, Stage):
-    """Setup Google Chrome Device-trust connection"""
+    """Setup Google Chrome Device Trust connection"""
 
     credentials = models.JSONField()
 

--- a/website/docs/add-secure-apps/flows-stages/stages/authenticator_endpoint_gdtc/index.md
+++ b/website/docs/add-secure-apps/flows-stages/stages/authenticator_endpoint_gdtc/index.md
@@ -1,5 +1,5 @@
 ---
-title: Chrome Enterprise Device Trust connector endpoint
+title: Google Chrome Device Trust Authenticator Stage
 authentik_version: "2024.10"
 authentik_preview: true
 authentik_enterprise: true

--- a/website/docs/add-secure-apps/flows-stages/stages/authenticator_endpoint_gdtc/index.md
+++ b/website/docs/add-secure-apps/flows-stages/stages/authenticator_endpoint_gdtc/index.md
@@ -1,11 +1,17 @@
 ---
-title: Endpoint Authenticator Google Device Trust Connector Stage
+title: Chrome Enterprise Device Trust connector endpoint
 authentik_version: "2024.10"
 authentik_preview: true
 authentik_enterprise: true
 ---
 
 With this stage, authentik can validate users' Chrome browsers and ensure that users' devices are compliant and up-to-date.
+
+Support for the Chrome Enterprise Device Trust connector allows organizations to integrate Chrome browsers and ChromeOS devices with authentik as the Identity Provider (IdP), to strengthen their overall security posture.
+
+Device Trust is particularly important in environments with many different device types that are used by a large, remote workforce that might have a BYOD (Bring Your Own Device) policy, or have large teams of of contractors, temporary workers, or volunteers.
+
+With Device Trust you can enable "context-aware" access policies; for example a policy might require that a device has all security patches installed.
 
 :::info
 This stage only works with Google Chrome, as it relies on the [Chrome Verified Access API](https://developers.google.com/chrome/verified-access).

--- a/website/docs/add-secure-apps/flows-stages/stages/source/index.md
+++ b/website/docs/add-secure-apps/flows-stages/stages/source/index.md
@@ -4,7 +4,7 @@ authentik_version: "2024.4"
 authentik_enterprise: true
 ---
 
-The source stage injects an [OAuth](../../../../users-sources/sources/protocols/oauth/index.mdx) or [SAML](../../../../users-sources/sources/protocols/saml/index.md) Source into the flow execution. This allows for additional user verification, or to dynamically access different sources for different user identifiers (username, email address, etc).
+The source stage embeds an [OAuth](../../../../users-sources/sources/protocols/oauth/index.mdx) or [SAML](../../../../users-sources/sources/protocols/saml/index.md) source into the flow execution. This allows for additional user verification, or to dynamically access different sources for different user identifiers (username, email address, etc).
 
 ### Example use case
 

--- a/website/docs/add-secure-apps/flows-stages/stages/source/index.md
+++ b/website/docs/add-secure-apps/flows-stages/stages/source/index.md
@@ -6,6 +6,22 @@ authentik_enterprise: true
 
 The source stage injects an [OAuth](../../../../users-sources/sources/protocols/oauth/index.mdx) or [SAML](../../../../users-sources/sources/protocols/saml/index.md) Source into the flow execution. This allows for additional user verification, or to dynamically access different sources for different user identifiers (username, email address, etc).
 
+### Example use case
+
+This stage can be used to leverage an external OAuth/SAML identity provider.
+
+For example, you can authenticate users by routing them through a custom device-health solution.
+
+Another use case is to route users to authenticate with your legacy (Okta, etc) IdP and then use the returned identity and attributes within authentik as part of an authorization flow, for example as part of an IdP migration. For authentication/enrollment this is also possible with an [OAuth](../../../../users-sources/sources/protocols/oauth/index.mdx)/[SAML](../../../../users-sources/sources/protocols/saml/index.md) source by itself.
+
+### Considerations
+
+It is very important that the configured source's authentication and enrollment flows (when set; they can be left unselected to prevent authentication or enrollment with the source) do **not** have a [User login stage](../user_login/index.md) bound to them.
+
+This is because the Source stage works by appending a [dynamic in-memory](../../../../core/terminology.md#dynamic-in-memory-stage) stage to the source's flow, so having a [User login stage](../user_login/index.md) bound will cause the source's flow to not resume the original flow it was started from, and instead directly authenticating the pending user.
+
+## Source stage workflow
+
 ```mermaid
 sequenceDiagram
     participant u as User
@@ -28,20 +44,6 @@ sequenceDiagram
 
     ak->>u: Execution of the previous flow is resumed
 ```
-
-### Considerations
-
-It is very important that the configured source's authentication and enrollment flows (when set; they can be left unselected to prevent authentication or enrollment with the source) do **not** have a [User login stage](../user_login/index.md) bound to them.
-
-This is because the Source stage works by appending a [dynamic in-memory](../../../../core/terminology.md#dynamic-in-memory-stage) stage to the source's flow, so having a [User login stage](../user_login/index.md) bound will cause the source's flow to not resume the original flow it was started from, and instead directly authenticating the pending user.
-
-### Example use case
-
-This stage can be used to leverage an external OAuth/SAML identity provider.
-
-For example, you can authenticate users by routing them through a custom device-health solution.
-
-Another use case is to route users to authenticate with your legacy (Okta, etc) IdP and then use the returned identity and attributes within authentik as part of an authorization flow, for example as part of an IdP migration. For authentication/enrollment this is also possible with an [OAuth](../../../../users-sources/sources/protocols/oauth/index.mdx)/[SAML](../../../../users-sources/sources/protocols/saml/index.md) source by itself.
 
 ### Options
 

--- a/website/docs/add-secure-apps/providers/ssf/index.md
+++ b/website/docs/add-secure-apps/providers/ssf/index.md
@@ -16,7 +16,9 @@ Events in authentik that are tracked via SSF include when an MFA device is added
 
 ## Example use cases
 
-A common use case for SSF is when an Admin wants to know if a user logs out of authentik, so that the user is then also automaticlaly logged out of all other work-focused applications.
+One important use case for SFF is to [integrate Apple Business Manager](https://integrations.goauthentik.io/device-management/apple/) or any of the Apple device management platforms with authentik, so that users can enroll their Apple devices using their authentik credentials. When a user signs in with their email address, Apple redirects them to authentik for authentication. Once authenticated, Apple enrolls the user's device and grants access to Apple services.
+
+Another use case for SSF is when an Admin wants to know if a user logs out of authentik, so that the user is then also automaticlaly logged out of all other work-focused applications.
 
 Another example use case is when an application uses SSF to subscribe to authorization events because the application needs to know if a user changed their password in authentik. If a user did change their password, then the application receives a POST request to write the fact that the password was changed.
 


### PR DESCRIPTION
This PR improves the docs that are linked to from the Pricing page.
- Change title from "Endpoint Authenticator Google Device Trust Connector Stage" to "Chrome Enterprise Device Trust connector endpoint" so they match between Pricing page and doc
- Source stage doc, move use case section higher and digram down lower
--SSF doc, added mention of ABM use case and link to our ABM Integration Guide.

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
