### PR TITLE
stages/email: only update is_active on user to not overwrite external changes

### DIFF
--- a/authentik/enterprise/audit/tests.py
+++ b/authentik/enterprise/audit/tests.py
@@ -7,6 +7,7 @@ from rest_framework.test import APITestCase
 
 from authentik.core.models import Group, User
 from authentik.core.tests.utils import create_test_admin_user
+from authentik.enterprise.audit.middleware import EnterpriseAuditMiddleware
 from authentik.events.models import Event, EventAction
 from authentik.events.utils import sanitize_item
 from authentik.lib.generators import generate_id
@@ -208,3 +209,14 @@ class TestEnterpriseAudit(APITestCase):
             diff,
             {"users": {"remove": [user.pk]}},
         )
+
+    @patch(
+        "authentik.enterprise.audit.middleware.EnterpriseAuditMiddleware.enabled",
+        PropertyMock(return_value=True),
+    )
+    def test_serialize_fields(self):
+        """Test update audit log"""
+        self.client.force_login(self.user)
+        user = create_test_admin_user()
+        state = EnterpriseAuditMiddleware(None).serialize_simple(user, update_fields=["is_active"])
+        self.assertEqual(state, {"is_active": True})

--- a/authentik/stages/email/stage.py
+++ b/authentik/stages/email/stage.py
@@ -145,7 +145,7 @@ class EmailStageView(ChallengeStageView):
             messages.success(request, _("Successfully verified Email."))
             if self.executor.current_stage.activate_user_on_success:
                 user.is_active = True
-                user.save()
+                user.save(update_fields=["is_active"])
             return self.executor.stage_ok()
         if PLAN_CONTEXT_PENDING_USER not in self.executor.plan.context:
             self.logger.debug("No pending user")


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Due to the entire user object being stored in the flow context, when it is modified externally during a flow execution, data such as attributes can be lost

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
