### PR TITLE
web: Consistent use of static styles

### DIFF
--- a/packages/prettier-config/lib/imports.js
+++ b/packages/prettier-config/lib/imports.js
@@ -124,12 +124,13 @@ const useLegacyCleanup = process.env.AK_FIX_LEGACY_IMPORTS === "true";
  * @param {ParserOptions} options
  */
 const preprocess = (input, { filepath, printWidth }) => {
+    if (input?.includes("ts-import-sorter: disable")) {
+        return input;
+    }
+
     let output = input;
 
-    console.log("Looking for JSDoc...");
     if (output.startsWith("/**\n")) {
-        console.log("JSDoc detected. Adding double newline if not present");
-
         output = output.replace(/(^\s\*\/\n)(import)/m, "$1\n$2");
     }
 
@@ -144,6 +145,7 @@ const preprocess = (input, { filepath, printWidth }) => {
         wrappingStyle: "prettier",
         groupRules: [
             "^node:",
+            "^[./]",
             ...webSubmodules.map((submodule) => `^(@goauthentik/|#)${submodule}.+`),
 
             "^#.+",
@@ -154,7 +156,6 @@ const preprocess = (input, { filepath, printWidth }) => {
             "^(@?)lit(.*)$",
             "\\.css$",
             "^@goauthentik/api$",
-            "^[./]",
         ],
     });
 

--- a/packages/prettier-config/package-lock.json
+++ b/packages/prettier-config/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@goauthentik/prettier-config",
-    "version": "3.0.1",
+    "version": "3.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@goauthentik/prettier-config",
-            "version": "3.0.1",
+            "version": "3.1.0",
             "license": "MIT",
             "dependencies": {
                 "format-imports": "^4.0.7"

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@goauthentik/prettier-config",
-    "version": "3.0.1",
+    "version": "3.1.0",
     "description": "authentik's Prettier config",
     "license": "MIT",
     "scripts": {

--- a/web/src/admin/AdminInterface/AboutModal.ts
+++ b/web/src/admin/AdminInterface/AboutModal.ts
@@ -16,16 +16,15 @@ import { AdminApi, CapabilitiesEnum, LicenseSummaryStatusEnum } from "@goauthent
 
 @customElement("ak-about-modal")
 export class AboutModal extends WithLicenseSummary(WithBrandConfig(ModalButton)) {
-    static get styles() {
-        return ModalButton.styles.concat(
-            PFAbout,
-            css`
-                .pf-c-about-modal-box__hero {
-                    background-image: url("/static/dist/assets/images/flow_background.jpg");
-                }
-            `,
-        );
-    }
+    static styles = [
+        ...ModalButton.styles,
+        PFAbout,
+        css`
+            .pf-c-about-modal-box__hero {
+                background-image: url("/static/dist/assets/images/flow_background.jpg");
+            }
+        `,
+    ];
 
     async getAboutEntries(): Promise<[string, string | TemplateResult][]> {
         const status = await new AdminApi(DEFAULT_CONFIG).adminSystemRetrieve();

--- a/web/src/admin/DebugPage.ts
+++ b/web/src/admin/DebugPage.ts
@@ -19,9 +19,7 @@ import { AdminApi } from "@goauthentik/api";
 
 @customElement("ak-admin-debug-page")
 export class DebugPage extends AKElement {
-    static get styles(): CSSResult[] {
-        return [PFBase, PFCard, PFPage, PFGrid, PFButton];
-    }
+    static styles: CSSResult[] = [PFBase, PFCard, PFPage, PFGrid, PFButton];
 
     render(): TemplateResult {
         return html`

--- a/web/src/admin/admin-overview/AdminOverviewPage.ts
+++ b/web/src/admin/admin-overview/AdminOverviewPage.ts
@@ -35,33 +35,31 @@ const AdminOverviewBase = WithLicenseSummary(AKElement);
 
 @customElement("ak-admin-overview")
 export class AdminOverviewPage extends AdminOverviewBase {
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFGrid,
-            PFPage,
-            PFContent,
-            PFDivider,
-            css`
-                .pf-l-grid__item {
-                    height: 100%;
-                }
-                .pf-l-grid__item.big-graph-container {
-                    height: 35em;
-                }
-                .card-container {
-                    max-height: 10em;
-                }
-                .ak-external-link {
-                    display: inline-block;
-                    margin-left: 0.175rem;
-                    vertical-align: super;
-                    line-height: normal;
-                    font-size: var(--pf-global--icon--FontSize--sm);
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFGrid,
+        PFPage,
+        PFContent,
+        PFDivider,
+        css`
+            .pf-l-grid__item {
+                height: 100%;
+            }
+            .pf-l-grid__item.big-graph-container {
+                height: 35em;
+            }
+            .card-container {
+                max-height: 10em;
+            }
+            .ak-external-link {
+                display: inline-block;
+                margin-left: 0.175rem;
+                vertical-align: super;
+                line-height: normal;
+                font-size: var(--pf-global--icon--FontSize--sm);
+            }
+        `,
+    ];
 
     quickActions: QuickAction[] = [
         [msg("Create a new application"), paramURL("/core/applications", { createWizard: true })],

--- a/web/src/admin/admin-overview/DashboardUserPage.ts
+++ b/web/src/admin/admin-overview/DashboardUserPage.ts
@@ -17,23 +17,21 @@ import { EventActions, EventsEventsVolumeListRequest } from "@goauthentik/api";
 
 @customElement("ak-admin-dashboard-users")
 export class DashboardUserPage extends AKElement {
-    static get styles(): CSSResult[] {
-        return [
-            PFGrid,
-            PFPage,
-            PFContent,
-            PFList,
-            PFDivider,
-            css`
-                .big-graph-container {
-                    height: 35em;
-                }
-                .card-container {
-                    max-height: 10em;
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFGrid,
+        PFPage,
+        PFContent,
+        PFList,
+        PFDivider,
+        css`
+            .big-graph-container {
+                height: 35em;
+            }
+            .card-container {
+                max-height: 10em;
+            }
+        `,
+    ];
 
     render(): TemplateResult {
         return html`<ak-page-header icon="pf-icon pf-icon-user" header=${msg("User Statistics")}>

--- a/web/src/admin/admin-overview/TopApplicationsTable.ts
+++ b/web/src/admin/admin-overview/TopApplicationsTable.ts
@@ -15,9 +15,7 @@ export class TopApplicationsTable extends AKElement {
     @property({ attribute: false })
     topN?: EventTopPerUser[];
 
-    static get styles(): CSSResult[] {
-        return [PFTable];
-    }
+    static styles: CSSResult[] = [PFTable];
 
     firstUpdated(): void {
         new EventsApi(DEFAULT_CONFIG)

--- a/web/src/admin/admin-overview/cards/RecentEventsCard.ts
+++ b/web/src/admin/admin-overview/cards/RecentEventsCard.ts
@@ -35,23 +35,20 @@ export class RecentEventsCard extends Table<Event> {
         });
     }
 
-    static get styles(): CSSResult[] {
-        return super.styles.concat(
-            PFCard,
-            css`
-                .pf-c-card__title {
-                    --pf-c-card__title--FontFamily: var(
-                        --pf-global--FontFamily--heading--sans-serif
-                    );
-                    --pf-c-card__title--FontSize: var(--pf-global--FontSize--md);
-                    --pf-c-card__title--FontWeight: var(--pf-global--FontWeight--bold);
-                }
-                * {
-                    word-break: break-all;
-                }
-            `,
-        );
-    }
+    static styles: CSSResult[] = [
+        ...super.styles,
+        PFCard,
+        css`
+            .pf-c-card__title {
+                --pf-c-card__title--FontFamily: var(--pf-global--FontFamily--heading--sans-serif);
+                --pf-c-card__title--FontSize: var(--pf-global--FontSize--md);
+                --pf-c-card__title--FontWeight: var(--pf-global--FontWeight--bold);
+            }
+            * {
+                word-break: break-all;
+            }
+        `,
+    ];
 
     columns(): TableColumn[] {
         return [

--- a/web/src/admin/admin-settings/AdminSettingsFooterLinks.ts
+++ b/web/src/admin/admin-settings/AdminSettingsFooterLinks.ts
@@ -23,19 +23,17 @@ const hasLegalScheme = (url: string) =>
 
 @customElement("ak-admin-settings-footer-link")
 export class FooterLinkInput extends AkControlElement<FooterLink> {
-    static get styles() {
-        return [
-            PFBase,
-            PFInputGroup,
-            PFFormControl,
-            css`
-                .pf-c-input-group input#linkname {
-                    flex-grow: 1;
-                    width: 8rem;
-                }
-            `,
-        ];
-    }
+    static styles = [
+        PFBase,
+        PFInputGroup,
+        PFFormControl,
+        css`
+            .pf-c-input-group input#linkname {
+                flex-grow: 1;
+                width: 8rem;
+            }
+        `,
+    ];
 
     @property({ type: Object, attribute: false })
     footerLink: FooterLink = {

--- a/web/src/admin/admin-settings/AdminSettingsForm.ts
+++ b/web/src/admin/admin-settings/AdminSettingsForm.ts
@@ -43,16 +43,15 @@ export class AdminSettingsForm extends Form<SettingsRequest> {
 
     private _settings?: Settings;
 
-    static get styles(): CSSResult[] {
-        return super.styles.concat(
-            PFList,
-            css`
-                ak-array-input {
-                    width: 100%;
-                }
-            `,
-        );
-    }
+    static styles: CSSResult[] = [
+        ...super.styles,
+        PFList,
+        css`
+            ak-array-input {
+                width: 100%;
+            }
+        `,
+    ];
 
     getSuccessMessage(): string {
         return msg("Successfully updated settings.");

--- a/web/src/admin/admin-settings/AdminSettingsPage.ts
+++ b/web/src/admin/admin-settings/AdminSettingsPage.ts
@@ -30,20 +30,18 @@ import { AdminApi, Settings } from "@goauthentik/api";
 
 @customElement("ak-admin-settings")
 export class AdminSettingsPage extends AKElement {
-    static get styles() {
-        return [
-            PFBase,
-            PFButton,
-            PFPage,
-            PFGrid,
-            PFContent,
-            PFCard,
-            PFDescriptionList,
-            PFForm,
-            PFFormControl,
-            PFBanner,
-        ];
-    }
+    static styles = [
+        PFBase,
+        PFButton,
+        PFPage,
+        PFGrid,
+        PFContent,
+        PFCard,
+        PFDescriptionList,
+        PFForm,
+        PFFormControl,
+        PFBanner,
+    ];
 
     @query("ak-admin-settings-form#form")
     form?: AdminSettingsForm;

--- a/web/src/admin/applications/ApplicationCheckAccessForm.ts
+++ b/web/src/admin/applications/ApplicationCheckAccessForm.ts
@@ -48,9 +48,7 @@ export class ApplicationCheckAccessForm extends Form<{ forUser: number }> {
         this.result = undefined;
     }
 
-    static get styles(): CSSResult[] {
-        return super.styles.concat(PFDescriptionList);
-    }
+    static styles: CSSResult[] = [...super.styles, PFDescriptionList];
 
     renderResult(): TemplateResult {
         return html`

--- a/web/src/admin/applications/ApplicationListPage.ts
+++ b/web/src/admin/applications/ApplicationListPage.ts
@@ -70,9 +70,7 @@ export class ApplicationListPage extends WithBrandConfig(TablePage<Application>)
         });
     }
 
-    static get styles(): CSSResult[] {
-        return TablePage.styles.concat(PFCard, applicationListStyle);
-    }
+    static styles: CSSResult[] = [...TablePage.styles, PFCard, applicationListStyle];
 
     columns(): TableColumn[] {
         return [

--- a/web/src/admin/applications/ApplicationViewPage.ts
+++ b/web/src/admin/applications/ApplicationViewPage.ts
@@ -47,19 +47,17 @@ export class ApplicationViewPage extends AKElement {
     @state()
     missingOutpost = false;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFList,
-            PFBanner,
-            PFPage,
-            PFContent,
-            PFButton,
-            PFDescriptionList,
-            PFGrid,
-            PFCard,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFList,
+        PFBanner,
+        PFPage,
+        PFContent,
+        PFButton,
+        PFDescriptionList,
+        PFGrid,
+        PFCard,
+    ];
 
     fetchIsMissingOutpost(providersByPk: Array<number>) {
         new OutpostsApi(DEFAULT_CONFIG)

--- a/web/src/admin/applications/ApplicationWizardHint.ts
+++ b/web/src/admin/applications/ApplicationWizardHint.ts
@@ -36,22 +36,20 @@ const closeButtonIcon = html`<svg
 
 @customElement("ak-application-wizard-hint")
 export class AkApplicationWizardHint extends AKElement implements ShowHintControllerHost {
-    static get styles() {
-        return [
-            PFBase,
-            PFButton,
-            PFPage,
-            PFLabel,
-            css`
-                .pf-c-page__main-section {
-                    padding-bottom: 0;
-                }
-                .ak-hint-text {
-                    padding-bottom: var(--pf-global--spacer--md);
-                }
-            `,
-        ];
-    }
+    static styles = [
+        PFBase,
+        PFButton,
+        PFPage,
+        PFLabel,
+        css`
+            .pf-c-page__main-section {
+                padding-bottom: 0;
+            }
+            .ak-hint-text {
+                padding-bottom: var(--pf-global--spacer--md);
+            }
+        `,
+    ];
 
     @property({ type: Boolean, attribute: "show-hint" })
     forceHint: boolean = false;

--- a/web/src/admin/applications/entitlements/ApplicationEntitlementForm.ts
+++ b/web/src/admin/applications/entitlements/ApplicationEntitlementForm.ts
@@ -34,9 +34,7 @@ export class ApplicationEntitlementForm extends ModelForm<ApplicationEntitlement
         return msg("Successfully created entitlement.");
     }
 
-    static get styles(): CSSResult[] {
-        return [...super.styles, PFContent];
-    }
+    static styles: CSSResult[] = [...super.styles, PFContent];
 
     send(data: ApplicationEntitlement): Promise<unknown> {
         if (this.targetPk) {

--- a/web/src/admin/applications/wizard/ApplicationWizardStep.ts
+++ b/web/src/admin/applications/wizard/ApplicationWizardStep.ts
@@ -20,9 +20,7 @@ import {
 } from "./types";
 
 export class ApplicationWizardStep extends WizardStep {
-    static get styles() {
-        return [...WizardStep.styles, ...styles];
-    }
+    static styles = [...WizardStep.styles, ...styles];
 
     @property({ type: Object, attribute: false })
     wizard!: ApplicationWizardState;

--- a/web/src/admin/applications/wizard/ak-wizard-title.ts
+++ b/web/src/admin/applications/wizard/ak-wizard-title.ts
@@ -8,17 +8,15 @@ import PFTitle from "@patternfly/patternfly/components/Title/title.css";
 
 @customElement("ak-wizard-title")
 export class AkWizardTitle extends AKElement {
-    static get styles() {
-        return [
-            PFContent,
-            PFTitle,
-            css`
-                .ak-bottom-spacing {
-                    padding-bottom: var(--pf-global--spacer--lg);
-                }
-            `,
-        ];
-    }
+    static styles = [
+        PFContent,
+        PFTitle,
+        css`
+            .ak-bottom-spacing {
+                padding-bottom: var(--pf-global--spacer--lg);
+            }
+        `,
+    ];
 
     render() {
         return html`<div class="ak-bottom-spacing pf-c-content">

--- a/web/src/admin/applications/wizard/steps/ak-application-wizard-bindings-step.ts
+++ b/web/src/admin/applications/wizard/steps/ak-application-wizard-bindings-step.ts
@@ -44,16 +44,15 @@ export class ApplicationWizardBindingsStep extends ApplicationWizardStep {
     @query("ak-select-table")
     selectTable!: SelectTable;
 
-    static get styles() {
-        return super.styles.concat(
-            PFCard,
-            css`
-                .pf-c-card {
-                    margin-top: 1em;
-                }
-            `,
-        );
-    }
+    static styles = [
+        ...super.styles,
+        PFCard,
+        css`
+            .pf-c-card {
+                margin-top: 1em;
+            }
+        `,
+    ];
 
     get bindingsAsColumns() {
         return this.wizard.bindings.map((binding, index) => {

--- a/web/src/admin/applications/wizard/steps/ak-application-wizard-submit-step.ts
+++ b/web/src/admin/applications/wizard/steps/ak-application-wizard-submit-step.ts
@@ -76,22 +76,20 @@ const cleanBinding = (binding: PolicyBinding): TransactionPolicyBindingRequest =
 
 @customElement("ak-application-wizard-submit-step")
 export class ApplicationWizardSubmitStep extends CustomEmitterElement(ApplicationWizardStep) {
-    static get styles() {
-        return [
-            ...ApplicationWizardStep.styles,
-            PFBullseye,
-            PFEmptyState,
-            PFTitle,
-            PFProgressStepper,
-            PFDescriptionList,
-            css`
-                .ak-wizard-main-content .pf-c-title {
-                    padding-bottom: var(--pf-global--spacer--md);
-                    padding-top: var(--pf-global--spacer--md);
-                }
-            `,
-        ];
-    }
+    static styles = [
+        ...ApplicationWizardStep.styles,
+        PFBullseye,
+        PFEmptyState,
+        PFTitle,
+        PFProgressStepper,
+        PFDescriptionList,
+        css`
+            .ak-wizard-main-content .pf-c-title {
+                padding-bottom: var(--pf-global--spacer--md);
+                padding-top: var(--pf-global--spacer--md);
+            }
+        `,
+    ];
 
     label = msg("Review and Submit Application");
 

--- a/web/src/admin/applications/wizard/steps/bindings/ak-application-wizard-bindings-edit-button.ts
+++ b/web/src/admin/applications/wizard/steps/bindings/ak-application-wizard-bindings-edit-button.ts
@@ -9,9 +9,7 @@ import PFButton from "@patternfly/patternfly/components/Button/button.css";
 
 @customElement("ak-application-wizard-binding-step-edit-button")
 export class ApplicationWizardBindingStepEditButton extends AKElement {
-    static get styles() {
-        return [PFButton];
-    }
+    static styles = [PFButton];
 
     @property({ type: Number })
     value = -1;

--- a/web/src/admin/applications/wizard/steps/bindings/ak-application-wizard-bindings-toolbar.ts
+++ b/web/src/admin/applications/wizard/steps/bindings/ak-application-wizard-bindings-toolbar.ts
@@ -10,9 +10,7 @@ import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-application-wizard-bindings-toolbar")
 export class ApplicationWizardBindingsToolbar extends AKElement {
-    static get styles() {
-        return [PFBase, PFButton, PFToolbar];
-    }
+    static styles = [PFBase, PFButton, PFToolbar];
 
     @property({ type: Boolean, attribute: "can-delete", reflect: true })
     canDelete = false;

--- a/web/src/admin/applications/wizard/steps/providers/ApplicationWizardProviderForm.ts
+++ b/web/src/admin/applications/wizard/steps/providers/ApplicationWizardProviderForm.ts
@@ -9,15 +9,14 @@ import "@goauthentik/elements/forms/FormGroup";
 import "@goauthentik/elements/forms/HorizontalFormElement";
 import { HorizontalFormElement } from "@goauthentik/elements/forms/HorizontalFormElement";
 
+import { CSSResult } from "lit";
 import { property, query } from "lit/decorators.js";
 
 import { styles as AwadStyles } from "../../ApplicationWizardFormStepStyles.css.js";
 import { type ApplicationWizardState, type OneOfProvider } from "../../types";
 
 export class ApplicationWizardProviderForm<T extends OneOfProvider> extends AKElement {
-    static get styles() {
-        return AwadStyles;
-    }
+    static styles: CSSResult[] = [...AwadStyles];
 
     label = "";
 

--- a/web/src/admin/blueprints/BlueprintForm.ts
+++ b/web/src/admin/blueprints/BlueprintForm.ts
@@ -48,9 +48,7 @@ export class BlueprintForm extends ModelForm<BlueprintInstance, string> {
             : msg("Successfully created instance.");
     }
 
-    static get styles(): CSSResult[] {
-        return [...super.styles, PFContent];
-    }
+    static styles: CSSResult[] = [...super.styles, PFContent];
 
     async send(data: BlueprintInstance): Promise<BlueprintInstance> {
         if (this.instance?.pk) {

--- a/web/src/admin/blueprints/BlueprintListPage.ts
+++ b/web/src/admin/blueprints/BlueprintListPage.ts
@@ -63,9 +63,7 @@ export class BlueprintListPage extends TablePage<BlueprintInstance> {
     @property()
     order = "name";
 
-    static get styles(): CSSResult[] {
-        return super.styles.concat(PFDescriptionList);
-    }
+    static styles: CSSResult[] = [...super.styles, PFDescriptionList];
 
     async apiEndpoint(): Promise<PaginatedResponse<BlueprintInstance>> {
         return new ManagedApi(DEFAULT_CONFIG).managedBlueprintsList(

--- a/web/src/admin/crypto/CertificateKeyPairListPage.ts
+++ b/web/src/admin/crypto/CertificateKeyPairListPage.ts
@@ -48,9 +48,7 @@ export class CertificateKeyPairListPage extends TablePage<CertificateKeyPair> {
     @property()
     order = "name";
 
-    static get styles(): CSSResult[] {
-        return super.styles.concat(PFDescriptionList);
-    }
+    static styles: CSSResult[] = [...super.styles, PFDescriptionList];
 
     async apiEndpoint(): Promise<PaginatedResponse<CertificateKeyPair>> {
         return new CryptoApi(DEFAULT_CONFIG).cryptoCertificatekeypairsList(

--- a/web/src/admin/enterprise/EnterpriseLicenseListPage.ts
+++ b/web/src/admin/enterprise/EnterpriseLicenseListPage.ts
@@ -63,23 +63,22 @@ export class EnterpriseLicenseListPage extends TablePage<License> {
     @state()
     installID?: string;
 
-    static get styles(): CSSResult[] {
-        return super.styles.concat(
-            PFGrid,
-            PFBanner,
-            PFFormControl,
-            PFButton,
-            PFCard,
-            css`
-                .pf-m-no-padding-bottom {
-                    padding-bottom: 0;
-                }
-                .install-id {
-                    word-break: break-all;
-                }
-            `,
-        );
-    }
+    static styles: CSSResult[] = [
+        ...super.styles,
+        PFGrid,
+        PFBanner,
+        PFFormControl,
+        PFButton,
+        PFCard,
+        css`
+            .pf-m-no-padding-bottom {
+                padding-bottom: 0;
+            }
+            .install-id {
+                word-break: break-all;
+            }
+        `,
+    ];
 
     async apiEndpoint(): Promise<PaginatedResponse<License>> {
         this.forecast = await new EnterpriseApi(DEFAULT_CONFIG).enterpriseLicenseForecastRetrieve();

--- a/web/src/admin/enterprise/EnterpriseStatusCard.ts
+++ b/web/src/admin/enterprise/EnterpriseStatusCard.ts
@@ -21,9 +21,7 @@ export class EnterpriseStatusCard extends AKElement {
     @state()
     summary?: LicenseSummary;
 
-    static get styles(): CSSResult[] {
-        return [PFBase, PFDescriptionList, PFCard, PFSplit, PFProgress];
-    }
+    static styles: CSSResult[] = [PFBase, PFDescriptionList, PFCard, PFSplit, PFProgress];
 
     renderSummaryBadge() {
         switch (this.summary?.status) {

--- a/web/src/admin/events/EventListPage.ts
+++ b/web/src/admin/events/EventListPage.ts
@@ -43,17 +43,15 @@ export class EventListPage extends WithLicenseSummary(TablePage<Event>) {
     @property()
     order = "-created";
 
-    static get styles(): CSSResult[] {
-        // @ts-expect-error
-        return super.styles.concat(
-            PFGrid,
-            css`
-                .pf-m-no-padding-bottom {
-                    padding-bottom: 0;
-                }
-            `,
-        );
-    }
+    static styles: CSSResult[] = [
+        ...TablePage.styles,
+        PFGrid,
+        css`
+            .pf-m-no-padding-bottom {
+                padding-bottom: 0;
+            }
+        `,
+    ];
 
     async apiEndpoint(): Promise<PaginatedResponse<Event>> {
         return new EventsApi(DEFAULT_CONFIG).eventsEventsList(await this.defaultEndpointConfig());

--- a/web/src/admin/events/EventMap.ts
+++ b/web/src/admin/events/EventMap.ts
@@ -65,21 +65,19 @@ export class EventMap extends AKElement {
     @property({ type: Number })
     zoomPaddingPx = 100;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFCard,
-            css`
-                .pf-c-card,
-                ol-map {
-                    height: 24rem;
-                }
-                :host([theme="dark"]) ol-map {
-                    filter: invert(100%) hue-rotate(180deg);
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFCard,
+        css`
+            .pf-c-card,
+            ol-map {
+                height: 24rem;
+            }
+            :host([theme="dark"]) ol-map {
+                filter: invert(100%) hue-rotate(180deg);
+            }
+        `,
+    ];
 
     updated(_changedProperties: PropertyValues<this>): void {
         if (!_changedProperties.has("events")) {

--- a/web/src/admin/events/EventViewPage.ts
+++ b/web/src/admin/events/EventViewPage.ts
@@ -28,9 +28,7 @@ export class EventViewPage extends AKElement {
     @state()
     event!: EventWithContext;
 
-    static get styles(): CSSResult[] {
-        return [PFBase, PFGrid, PFDescriptionList, PFPage, PFContent, PFCard];
-    }
+    static styles: CSSResult[] = [PFBase, PFGrid, PFDescriptionList, PFPage, PFContent, PFCard];
 
     fetchEvent(eventUuid: string) {
         new EventsApi(DEFAULT_CONFIG).eventsEventsRetrieve({ eventUuid }).then((ev) => {

--- a/web/src/admin/events/EventVolumeChart.ts
+++ b/web/src/admin/events/EventVolumeChart.ts
@@ -23,19 +23,18 @@ export class EventVolumeChart extends EventChart {
         this.refreshHandler();
     }
 
-    static get styles(): CSSResult[] {
-        return super.styles.concat(
-            PFCard,
-            css`
-                :host([with-map]) .pf-c-card {
-                    height: 24rem;
-                }
-                .pf-c-card {
-                    height: 20rem;
-                }
-            `,
-        );
-    }
+    static styles: CSSResult[] = [
+        ...super.styles,
+        PFCard,
+        css`
+            :host([with-map]) .pf-c-card {
+                height: 24rem;
+            }
+            .pf-c-card {
+                height: 20rem;
+            }
+        `,
+    ];
 
     apiRequest(): Promise<EventVolume[]> {
         return new EventsApi(DEFAULT_CONFIG).eventsEventsVolumeList({

--- a/web/src/admin/flows/FlowImportForm.ts
+++ b/web/src/admin/flows/FlowImportForm.ts
@@ -22,9 +22,7 @@ export class FlowImportForm extends Form<Flow> {
         return msg("Successfully imported flow.");
     }
 
-    static get styles(): CSSResult[] {
-        return super.styles.concat(PFDescriptionList);
-    }
+    static styles: CSSResult[] = [...super.styles, PFDescriptionList];
 
     async send(): Promise<FlowImportResult> {
         const file = this.getFormFiles().flow;

--- a/web/src/admin/flows/FlowViewPage.ts
+++ b/web/src/admin/flows/FlowViewPage.ts
@@ -34,16 +34,23 @@ export class FlowViewPage extends AKElement {
     @state()
     flow!: Flow;
 
-    static get styles(): CSSResult[] {
-        return [PFBase, PFPage, PFDescriptionList, PFButton, PFCard, PFContent, PFGrid].concat(css`
+    static styles: CSSResult[] = [
+        PFBase,
+        PFPage,
+        PFDescriptionList,
+        PFButton,
+        PFCard,
+        PFContent,
+        PFGrid,
+        css`
             img.pf-icon {
                 max-height: 24px;
             }
             ak-tabs {
                 height: 100%;
             }
-        `);
-    }
+        `,
+    ];
 
     fetchFlow(slug: string) {
         new FlowsApi(DEFAULT_CONFIG).flowsInstancesRetrieve({ slug }).then((flow) => {

--- a/web/src/admin/groups/GroupForm.ts
+++ b/web/src/admin/groups/GroupForm.ts
@@ -24,16 +24,17 @@ export function rbacRolePair(item: Role): DualSelectPair {
 
 @customElement("ak-group-form")
 export class GroupForm extends ModelForm<Group, string> {
-    static get styles(): CSSResult[] {
-        return super.styles.concat(css`
+    static styles: CSSResult[] = [
+        ...super.styles,
+        css`
             .pf-c-button.pf-m-control {
                 height: 100%;
             }
             .pf-c-form-control {
                 height: auto !important;
             }
-        `);
-    }
+        `,
+    ];
 
     loadInstance(pk: string): Promise<Group> {
         return new CoreApi(DEFAULT_CONFIG).coreGroupsRetrieve({

--- a/web/src/admin/groups/GroupViewPage.ts
+++ b/web/src/admin/groups/GroupViewPage.ts
@@ -47,20 +47,18 @@ export class GroupViewPage extends AKElement {
     @property({ attribute: false })
     group?: Group;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFPage,
-            PFButton,
-            PFDisplay,
-            PFGrid,
-            PFList,
-            PFContent,
-            PFCard,
-            PFDescriptionList,
-            PFSizing,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFPage,
+        PFButton,
+        PFDisplay,
+        PFGrid,
+        PFList,
+        PFContent,
+        PFCard,
+        PFDescriptionList,
+        PFSizing,
+    ];
 
     constructor() {
         super();

--- a/web/src/admin/groups/MemberSelectModal.ts
+++ b/web/src/admin/groups/MemberSelectModal.ts
@@ -20,16 +20,14 @@ type UserListRequestFilter = Partial<Pick<CoreUsersListRequest, "isActive">>;
 
 @customElement("ak-group-member-select-table")
 export class MemberSelectTable extends TableModal<User> {
-    static get styles() {
-        return [
-            ...super.styles,
-            css`
-                .show-disabled-toggle-group {
-                    margin-inline-start: 0.5rem;
-                }
-            `,
-        ];
-    }
+    static styles = [
+        ...super.styles,
+        css`
+            .show-disabled-toggle-group {
+                margin-inline-start: 0.5rem;
+            }
+        `,
+    ];
 
     checkbox = true;
     checkboxChip = true;

--- a/web/src/admin/groups/RelatedUserList.ts
+++ b/web/src/admin/groups/RelatedUserList.ts
@@ -123,9 +123,7 @@ export class RelatedUserList extends WithBrandConfig(WithCapabilitiesConfig(Tabl
     @state()
     me?: SessionUser;
 
-    static get styles(): CSSResult[] {
-        return Table.styles.concat(PFDescriptionList, PFAlert, PFBanner);
-    }
+    static styles: CSSResult[] = [...Table.styles, PFDescriptionList, PFAlert, PFBanner];
 
     async apiEndpoint(): Promise<PaginatedResponse<User>> {
         const users = await new CoreApi(DEFAULT_CONFIG).coreUsersList({

--- a/web/src/admin/outposts/OutpostHealth.ts
+++ b/web/src/admin/outposts/OutpostHealth.ts
@@ -17,17 +17,15 @@ export class OutpostHealthElement extends AKElement {
     @property({ attribute: false })
     outpostHealth?: OutpostHealth;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFDescriptionList,
-            css`
-                li {
-                    margin: 5px 0;
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFDescriptionList,
+        css`
+            li {
+                margin: 5px 0;
+            }
+        `,
+    ];
 
     render(): TemplateResult {
         if (!this.outpostHealth) {

--- a/web/src/admin/outposts/OutpostHealthSimple.ts
+++ b/web/src/admin/outposts/OutpostHealthSimple.ts
@@ -27,9 +27,7 @@ export class OutpostHealthSimpleElement extends AKElement {
     @property({ attribute: false })
     showVersion = true;
 
-    static get styles(): CSSResult[] {
-        return [PFBase];
-    }
+    static styles: CSSResult[] = [PFBase];
 
     constructor() {
         super();

--- a/web/src/admin/outposts/OutpostListPage.ts
+++ b/web/src/admin/outposts/OutpostListPage.ts
@@ -98,9 +98,7 @@ export class OutpostListPage extends TablePage<Outpost> {
         ];
     }
 
-    static get styles(): CSSResult[] {
-        return super.styles.concat(PFDescriptionList);
-    }
+    static styles: CSSResult[] = [...super.styles, PFDescriptionList];
 
     checkbox = true;
     clearOnRefresh = true;

--- a/web/src/admin/outposts/ServiceConnectionWizard.ts
+++ b/web/src/admin/outposts/ServiceConnectionWizard.ts
@@ -20,9 +20,7 @@ import { OutpostsApi, TypeCreate } from "@goauthentik/api";
 
 @customElement("ak-service-connection-wizard")
 export class ServiceConnectionWizard extends AKElement {
-    static get styles(): CSSResult[] {
-        return [PFBase, PFButton];
-    }
+    static styles: CSSResult[] = [PFBase, PFButton];
 
     @property()
     createText = msg("Create");

--- a/web/src/admin/policies/PolicyBindingForm.ts
+++ b/web/src/admin/policies/PolicyBindingForm.ts
@@ -76,9 +76,7 @@ export class PolicyBindingForm extends ModelForm<PolicyBinding, string> {
         return msg("Successfully created binding.");
     }
 
-    static get styles(): CSSResult[] {
-        return [...super.styles, PFContent];
-    }
+    static styles: CSSResult[] = [...super.styles, PFContent];
 
     async load(): Promise<void> {
         // Overwrite the default for policyGroupUser with the first allowed type,

--- a/web/src/admin/policies/PolicyTestForm.ts
+++ b/web/src/admin/policies/PolicyTestForm.ts
@@ -48,9 +48,7 @@ export class PolicyTestForm extends Form<PolicyTestRequest> {
         return (this.result = result);
     }
 
-    static get styles(): CSSResult[] {
-        return super.styles.concat(PFDescriptionList);
-    }
+    static styles: CSSResult[] = [...super.styles, PFDescriptionList];
 
     renderResult(): TemplateResult {
         return html`

--- a/web/src/admin/policies/PolicyWizard.ts
+++ b/web/src/admin/policies/PolicyWizard.ts
@@ -28,9 +28,7 @@ import { PoliciesApi, Policy, PolicyBinding, TypeCreate } from "@goauthentik/api
 
 @customElement("ak-policy-wizard")
 export class PolicyWizard extends AKElement {
-    static get styles(): CSSResult[] {
-        return [PFBase, PFButton];
-    }
+    static styles: CSSResult[] = [PFBase, PFButton];
 
     @property()
     createText = msg("Create");

--- a/web/src/admin/property-mappings/PropertyMappingWizard.ts
+++ b/web/src/admin/property-mappings/PropertyMappingWizard.ts
@@ -33,9 +33,7 @@ import { PropertymappingsApi, TypeCreate } from "@goauthentik/api";
 
 @customElement("ak-property-mapping-wizard")
 export class PropertyMappingWizard extends AKElement {
-    static get styles() {
-        return [PFBase, PFButton];
-    }
+    static styles = [PFBase, PFButton];
 
     @property({ attribute: false })
     mappingTypes: TypeCreate[] = [];

--- a/web/src/admin/providers/ProviderViewPage.ts
+++ b/web/src/admin/providers/ProviderViewPage.ts
@@ -36,9 +36,7 @@ export class ProviderViewPage extends AKElement {
     @property({ attribute: false })
     provider?: Provider;
 
-    static get styles(): CSSResult[] {
-        return [PFPage];
-    }
+    static styles: CSSResult[] = [PFPage];
 
     renderProvider(): TemplateResult {
         if (!this.provider) {

--- a/web/src/admin/providers/ProviderWizard.ts
+++ b/web/src/admin/providers/ProviderWizard.ts
@@ -25,9 +25,7 @@ import { ProvidersApi, TypeCreate } from "@goauthentik/api";
 
 @customElement("ak-provider-wizard")
 export class ProviderWizard extends AKElement {
-    static get styles(): CSSResult[] {
-        return [PFBase, PFButton];
-    }
+    static styles: CSSResult[] = [PFBase, PFButton];
 
     @property()
     createText = msg("Create");

--- a/web/src/admin/providers/RelatedApplicationButton.ts
+++ b/web/src/admin/providers/RelatedApplicationButton.ts
@@ -14,9 +14,7 @@ import { Provider } from "@goauthentik/api";
 
 @customElement("ak-provider-related-application")
 export class RelatedApplicationButton extends AKElement {
-    static get styles(): CSSResult[] {
-        return [PFBase, PFButton];
-    }
+    static styles: CSSResult[] = [PFBase, PFButton];
 
     @property({ attribute: false })
     provider?: Provider;

--- a/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderViewPage.ts
+++ b/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderViewPage.ts
@@ -46,21 +46,19 @@ export class GoogleWorkspaceProviderViewPage extends AKElement {
     @state()
     syncState?: SyncStatus;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFButton,
-            PFForm,
-            PFFormControl,
-            PFStack,
-            PFList,
-            PFGrid,
-            PFPage,
-            PFContent,
-            PFCard,
-            PFDescriptionList,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFButton,
+        PFForm,
+        PFFormControl,
+        PFStack,
+        PFList,
+        PFGrid,
+        PFPage,
+        PFContent,
+        PFCard,
+        PFDescriptionList,
+    ];
 
     constructor() {
         super();

--- a/web/src/admin/providers/ldap/LDAPProviderViewPage.ts
+++ b/web/src/admin/providers/ldap/LDAPProviderViewPage.ts
@@ -46,21 +46,19 @@ export class LDAPProviderViewPage extends AKElement {
     @state()
     me?: SessionUser;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFButton,
-            PFBanner,
-            PFForm,
-            PFFormControl,
-            PFList,
-            PFGrid,
-            PFPage,
-            PFContent,
-            PFCard,
-            PFDescriptionList,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFButton,
+        PFBanner,
+        PFForm,
+        PFFormControl,
+        PFList,
+        PFGrid,
+        PFPage,
+        PFContent,
+        PFCard,
+        PFDescriptionList,
+    ];
 
     constructor() {
         super();

--- a/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderViewPage.ts
+++ b/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderViewPage.ts
@@ -45,21 +45,19 @@ export class MicrosoftEntraProviderViewPage extends AKElement {
     @state()
     syncState?: SyncStatus;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFButton,
-            PFForm,
-            PFFormControl,
-            PFStack,
-            PFList,
-            PFGrid,
-            PFPage,
-            PFContent,
-            PFCard,
-            PFDescriptionList,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFButton,
+        PFForm,
+        PFFormControl,
+        PFStack,
+        PFList,
+        PFGrid,
+        PFPage,
+        PFContent,
+        PFCard,
+        PFDescriptionList,
+    ];
 
     constructor() {
         super();

--- a/web/src/admin/providers/oauth2/OAuth2ProviderForm.ts
+++ b/web/src/admin/providers/oauth2/OAuth2ProviderForm.ts
@@ -60,13 +60,14 @@ export class OAuth2ProviderFormPage extends BaseProviderForm<OAuth2Provider> {
     @state()
     showClientSecret = true;
 
-    static get styles() {
-        return super.styles.concat(css`
+    static styles = [
+        ...super.styles,
+        css`
             ak-array-input {
                 width: 100%;
             }
-        `);
-    }
+        `,
+    ];
 
     async loadInstance(pk: number): Promise<OAuth2Provider> {
         const provider = await new ProvidersApi(DEFAULT_CONFIG).providersOauth2Retrieve({

--- a/web/src/admin/providers/oauth2/OAuth2ProviderRedirectURI.ts
+++ b/web/src/admin/providers/oauth2/OAuth2ProviderRedirectURI.ts
@@ -20,18 +20,16 @@ export interface IRedirectURIInput {
 
 @customElement("ak-provider-oauth2-redirect-uri")
 export class OAuth2ProviderRedirectURI extends AkControlElement<RedirectURI> {
-    static get styles() {
-        return [
-            PFBase,
-            PFInputGroup,
-            PFFormControl,
-            css`
-                .pf-c-input-group select {
-                    width: 10em;
-                }
-            `,
-        ];
-    }
+    static styles = [
+        PFBase,
+        PFInputGroup,
+        PFFormControl,
+        css`
+            .pf-c-input-group select {
+                width: 10em;
+            }
+        `,
+    ];
 
     @property({ type: Object, attribute: false })
     redirectURI: RedirectURI = {

--- a/web/src/admin/providers/oauth2/OAuth2ProviderViewPage.ts
+++ b/web/src/admin/providers/oauth2/OAuth2ProviderViewPage.ts
@@ -78,21 +78,19 @@ export class OAuth2ProviderViewPage extends AKElement {
     @state()
     previewUser?: User;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFButton,
-            PFPage,
-            PFGrid,
-            PFContent,
-            PFCard,
-            PFDescriptionList,
-            PFForm,
-            PFFormControl,
-            PFBanner,
-            PFDivider,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFButton,
+        PFPage,
+        PFGrid,
+        PFContent,
+        PFCard,
+        PFDescriptionList,
+        PFForm,
+        PFFormControl,
+        PFBanner,
+        PFDivider,
+    ];
 
     constructor() {
         super();

--- a/web/src/admin/providers/proxy/ProxyProviderForm.ts
+++ b/web/src/admin/providers/proxy/ProxyProviderForm.ts
@@ -16,9 +16,7 @@ import { SetMode, SetShowHttpBasic, renderForm } from "./ProxyProviderFormForm.j
 
 @customElement("ak-provider-proxy-form")
 export class ProxyProviderFormPage extends BaseProviderForm<ProxyProvider> {
-    static get styles(): CSSResult[] {
-        return [...super.styles, PFContent, PFList, PFSpacing];
-    }
+    static styles: CSSResult[] = [...super.styles, PFContent, PFList, PFSpacing];
 
     async loadInstance(pk: number): Promise<ProxyProvider> {
         const provider = await new ProvidersApi(DEFAULT_CONFIG).providersProxyRetrieve({

--- a/web/src/admin/providers/proxy/ProxyProviderViewPage.ts
+++ b/web/src/admin/providers/proxy/ProxyProviderViewPage.ts
@@ -80,26 +80,24 @@ export class ProxyProviderViewPage extends AKElement {
     @state()
     provider?: ProxyProvider;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFButton,
-            PFPage,
-            PFGrid,
-            PFContent,
-            PFList,
-            PFForm,
-            PFFormControl,
-            PFCard,
-            PFDescriptionList,
-            PFBanner,
-            css`
-                :host(:not([theme="dark"])) .ak-markdown-section {
-                    background-color: var(--pf-c-card--BackgroundColor);
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFButton,
+        PFPage,
+        PFGrid,
+        PFContent,
+        PFList,
+        PFForm,
+        PFFormControl,
+        PFCard,
+        PFDescriptionList,
+        PFBanner,
+        css`
+            :host(:not([theme="dark"])) .ak-markdown-section {
+                background-color: var(--pf-c-card--BackgroundColor);
+            }
+        `,
+    ];
 
     constructor() {
         super();

--- a/web/src/admin/providers/rac/ConnectionTokenList.ts
+++ b/web/src/admin/providers/rac/ConnectionTokenList.ts
@@ -32,9 +32,7 @@ export class ConnectionTokenListPage extends Table<ConnectionToken> {
     @property({ type: Number })
     userId?: number;
 
-    static get styles(): CSSResult[] {
-        return super.styles.concat(PFDescriptionList);
-    }
+    static styles: CSSResult[] = [...super.styles, PFDescriptionList];
 
     async apiEndpoint(): Promise<PaginatedResponse<ConnectionToken>> {
         return new RacApi(DEFAULT_CONFIG).racConnectionTokensList({

--- a/web/src/admin/providers/rac/EndpointList.ts
+++ b/web/src/admin/providers/rac/EndpointList.ts
@@ -38,9 +38,7 @@ export class EndpointListPage extends Table<Endpoint> {
     @property({ attribute: false })
     provider?: RACProvider;
 
-    static get styles(): CSSResult[] {
-        return super.styles.concat(PFDescriptionList);
-    }
+    static styles: CSSResult[] = [...super.styles, PFDescriptionList];
 
     async apiEndpoint(): Promise<PaginatedResponse<Endpoint>> {
         return new RacApi(DEFAULT_CONFIG).racEndpointsList({

--- a/web/src/admin/providers/rac/RACProviderViewPage.ts
+++ b/web/src/admin/providers/rac/RACProviderViewPage.ts
@@ -44,21 +44,19 @@ export class RACProviderViewPage extends AKElement {
     @state()
     provider?: RACProvider;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFButton,
-            PFPage,
-            PFGrid,
-            PFContent,
-            PFList,
-            PFForm,
-            PFFormControl,
-            PFCard,
-            PFDescriptionList,
-            PFBanner,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFButton,
+        PFPage,
+        PFGrid,
+        PFContent,
+        PFList,
+        PFForm,
+        PFFormControl,
+        PFCard,
+        PFDescriptionList,
+        PFBanner,
+    ];
 
     constructor() {
         super();

--- a/web/src/admin/providers/radius/RadiusProviderViewPage.ts
+++ b/web/src/admin/providers/radius/RadiusProviderViewPage.ts
@@ -38,19 +38,17 @@ export class RadiusProviderViewPage extends AKElement {
     @state()
     provider?: RadiusProvider;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFButton,
-            PFPage,
-            PFDisplay,
-            PFGallery,
-            PFContent,
-            PFCard,
-            PFDescriptionList,
-            PFSizing,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFButton,
+        PFPage,
+        PFDisplay,
+        PFGallery,
+        PFContent,
+        PFCard,
+        PFDescriptionList,
+        PFSizing,
+    ];
 
     constructor() {
         super();

--- a/web/src/admin/providers/saml/SAMLProviderViewPage.ts
+++ b/web/src/admin/providers/saml/SAMLProviderViewPage.ts
@@ -76,21 +76,19 @@ export class SAMLProviderViewPage extends AKElement {
     @state()
     previewUser?: User;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFButton,
-            PFPage,
-            PFGrid,
-            PFContent,
-            PFCard,
-            PFList,
-            PFDescriptionList,
-            PFForm,
-            PFFormControl,
-            PFBanner,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFButton,
+        PFPage,
+        PFGrid,
+        PFContent,
+        PFCard,
+        PFList,
+        PFDescriptionList,
+        PFForm,
+        PFFormControl,
+        PFBanner,
+    ];
 
     constructor() {
         super();

--- a/web/src/admin/providers/scim/SCIMProviderViewPage.ts
+++ b/web/src/admin/providers/scim/SCIMProviderViewPage.ts
@@ -46,22 +46,20 @@ export class SCIMProviderViewPage extends AKElement {
     @state()
     provider?: SCIMProvider;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFButton,
-            PFBanner,
-            PFForm,
-            PFFormControl,
-            PFStack,
-            PFList,
-            PFGrid,
-            PFPage,
-            PFContent,
-            PFCard,
-            PFDescriptionList,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFButton,
+        PFBanner,
+        PFForm,
+        PFFormControl,
+        PFStack,
+        PFList,
+        PFGrid,
+        PFPage,
+        PFContent,
+        PFCard,
+        PFDescriptionList,
+    ];
 
     constructor() {
         super();

--- a/web/src/admin/providers/ssf/SSFProviderViewPage.ts
+++ b/web/src/admin/providers/ssf/SSFProviderViewPage.ts
@@ -49,21 +49,19 @@ export class SSFProviderViewPage extends AKElement {
     @property({ attribute: false })
     provider?: SSFProvider;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFButton,
-            PFPage,
-            PFGrid,
-            PFContent,
-            PFCard,
-            PFDescriptionList,
-            PFForm,
-            PFFormControl,
-            PFBanner,
-            PFDivider,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFButton,
+        PFPage,
+        PFGrid,
+        PFContent,
+        PFCard,
+        PFDescriptionList,
+        PFForm,
+        PFFormControl,
+        PFBanner,
+        PFDivider,
+    ];
 
     constructor() {
         super();

--- a/web/src/admin/rbac/ObjectPermissionModal.ts
+++ b/web/src/admin/rbac/ObjectPermissionModal.ts
@@ -50,9 +50,7 @@ export class ObjectPermissionModal extends AKElement {
     @property()
     objectPk?: string | number;
 
-    static get styles(): CSSResult[] {
-        return [PFBase, PFButton];
-    }
+    static styles: CSSResult[] = [PFBase, PFButton];
 
     render(): TemplateResult {
         return html`

--- a/web/src/admin/rbac/ObjectPermissionsPage.ts
+++ b/web/src/admin/rbac/ObjectPermissionsPage.ts
@@ -29,9 +29,7 @@ export class ObjectPermissionPage extends AKElement {
     @property({ type: Boolean })
     embedded = false;
 
-    static get styles() {
-        return [PFBase, PFGrid, PFPage, PFCard];
-    }
+    static styles = [PFBase, PFGrid, PFPage, PFCard];
 
     render() {
         return html` <ak-tabs pageIdentifier="permissionPage" ?vertical=${!this.embedded}>

--- a/web/src/admin/rbac/PermissionSelectModal.ts
+++ b/web/src/admin/rbac/PermissionSelectModal.ts
@@ -27,9 +27,7 @@ export class PermissionSelectModal extends TableModal<Permission> {
 
     order = "content_type__app_label,content_type__model";
 
-    static get styles(): CSSResult[] {
-        return super.styles.concat(PFBanner);
-    }
+    static styles: CSSResult[] = [...super.styles, PFBanner];
 
     async apiEndpoint(): Promise<PaginatedResponse<Permission>> {
         return new RbacApi(DEFAULT_CONFIG).rbacPermissionsList(await this.defaultEndpointConfig());

--- a/web/src/admin/roles/RoleViewPage.ts
+++ b/web/src/admin/roles/RoleViewPage.ts
@@ -42,27 +42,25 @@ export class RoleViewPage extends AKElement {
     @state()
     _role?: Role;
 
-    static get styles() {
-        return [
-            PFBase,
-            PFPage,
-            PFButton,
-            PFDisplay,
-            PFGrid,
-            PFContent,
-            PFCard,
-            PFDescriptionList,
-            css`
-                .pf-c-description-list__description ak-action-button {
-                    margin-right: 6px;
-                    margin-bottom: 6px;
-                }
-                .ak-button-collection {
-                    max-width: 12em;
-                }
-            `,
-        ];
-    }
+    static styles = [
+        PFBase,
+        PFPage,
+        PFButton,
+        PFDisplay,
+        PFGrid,
+        PFContent,
+        PFCard,
+        PFDescriptionList,
+        css`
+            .pf-c-description-list__description ak-action-button {
+                margin-right: 6px;
+                margin-bottom: 6px;
+            }
+            .ak-button-collection {
+                max-width: 12em;
+            }
+        `,
+    ];
 
     constructor() {
         super();

--- a/web/src/admin/sources/SourceWizard.ts
+++ b/web/src/admin/sources/SourceWizard.ts
@@ -24,9 +24,7 @@ import { SourcesApi, TypeCreate } from "@goauthentik/api";
 
 @customElement("ak-source-wizard")
 export class SourceWizard extends AKElement {
-    static get styles(): CSSResult[] {
-        return [PFBase, PFButton];
-    }
+    static styles: CSSResult[] = [PFBase, PFButton];
 
     @property({ attribute: false })
     sourceTypes: TypeCreate[] = [];

--- a/web/src/admin/sources/kerberos/KerberosSourceConnectivity.ts
+++ b/web/src/admin/sources/kerberos/KerberosSourceConnectivity.ts
@@ -16,9 +16,7 @@ export class KerberosSourceConnectivity extends AKElement {
         };
     };
 
-    static get styles(): CSSResult[] {
-        return [PFBase, PFList];
-    }
+    static styles: CSSResult[] = [PFBase, PFList];
 
     render(): TemplateResult {
         if (!this.connectivity) {

--- a/web/src/admin/sources/kerberos/KerberosSourceViewPage.ts
+++ b/web/src/admin/sources/kerberos/KerberosSourceViewPage.ts
@@ -54,19 +54,17 @@ export class KerberosSourceViewPage extends AKElement {
     @state()
     syncState?: SyncStatus;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFPage,
-            PFButton,
-            PFGrid,
-            PFContent,
-            PFCard,
-            PFDescriptionList,
-            PFBanner,
-            PFList,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFPage,
+        PFButton,
+        PFGrid,
+        PFContent,
+        PFCard,
+        PFDescriptionList,
+        PFBanner,
+        PFList,
+    ];
 
     constructor() {
         super();

--- a/web/src/admin/sources/ldap/LDAPSourceConnectivity.ts
+++ b/web/src/admin/sources/ldap/LDAPSourceConnectivity.ts
@@ -17,9 +17,7 @@ export class LDAPSourceConnectivity extends AKElement {
         };
     };
 
-    static get styles(): CSSResult[] {
-        return [PFBase, PFList];
-    }
+    static styles: CSSResult[] = [PFBase, PFList];
 
     render(): TemplateResult {
         if (!this.connectivity) {

--- a/web/src/admin/sources/ldap/LDAPSourceViewPage.ts
+++ b/web/src/admin/sources/ldap/LDAPSourceViewPage.ts
@@ -51,9 +51,16 @@ export class LDAPSourceViewPage extends AKElement {
     @state()
     syncState?: SyncStatus;
 
-    static get styles(): CSSResult[] {
-        return [PFBase, PFPage, PFButton, PFGrid, PFContent, PFCard, PFDescriptionList, PFList];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFPage,
+        PFButton,
+        PFGrid,
+        PFContent,
+        PFCard,
+        PFDescriptionList,
+        PFList,
+    ];
 
     constructor() {
         super();

--- a/web/src/admin/sources/oauth/OAuthSourceViewPage.ts
+++ b/web/src/admin/sources/oauth/OAuthSourceViewPage.ts
@@ -84,9 +84,15 @@ export class OAuthSourceViewPage extends AKElement {
     @property({ attribute: false })
     source?: OAuthSource;
 
-    static get styles(): CSSResult[] {
-        return [PFBase, PFPage, PFButton, PFGrid, PFContent, PFCard, PFDescriptionList];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFPage,
+        PFButton,
+        PFGrid,
+        PFContent,
+        PFCard,
+        PFDescriptionList,
+    ];
 
     constructor() {
         super();

--- a/web/src/admin/sources/plex/PlexSourceViewPage.ts
+++ b/web/src/admin/sources/plex/PlexSourceViewPage.ts
@@ -45,9 +45,15 @@ export class PlexSourceViewPage extends AKElement {
     @property({ attribute: false })
     source?: PlexSource;
 
-    static get styles(): CSSResult[] {
-        return [PFBase, PFPage, PFButton, PFGrid, PFContent, PFCard, PFDescriptionList];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFPage,
+        PFButton,
+        PFGrid,
+        PFContent,
+        PFCard,
+        PFDescriptionList,
+    ];
 
     constructor() {
         super();

--- a/web/src/admin/sources/saml/SAMLSourceViewPage.ts
+++ b/web/src/admin/sources/saml/SAMLSourceViewPage.ts
@@ -51,9 +51,15 @@ export class SAMLSourceViewPage extends AKElement {
     @state()
     metadata?: SAMLMetadata;
 
-    static get styles(): CSSResult[] {
-        return [PFBase, PFPage, PFGrid, PFButton, PFContent, PFCard, PFDescriptionList];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFPage,
+        PFGrid,
+        PFButton,
+        PFContent,
+        PFCard,
+        PFDescriptionList,
+    ];
 
     constructor() {
         super();

--- a/web/src/admin/sources/scim/SCIMSourceViewPage.ts
+++ b/web/src/admin/sources/scim/SCIMSourceViewPage.ts
@@ -48,19 +48,17 @@ export class SCIMSourceViewPage extends AKElement {
     @property({ attribute: false })
     source?: SCIMSource;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFPage,
-            PFButton,
-            PFForm,
-            PFFormControl,
-            PFGrid,
-            PFContent,
-            PFCard,
-            PFDescriptionList,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFPage,
+        PFButton,
+        PFForm,
+        PFFormControl,
+        PFGrid,
+        PFContent,
+        PFCard,
+        PFDescriptionList,
+    ];
 
     constructor() {
         super();

--- a/web/src/admin/stages/StageWizard.ts
+++ b/web/src/admin/stages/StageWizard.ts
@@ -44,9 +44,7 @@ import { FlowStageBinding, Stage, StagesApi, TypeCreate } from "@goauthentik/api
 
 @customElement("ak-stage-wizard")
 export class StageWizard extends AKElement {
-    static get styles(): CSSResult[] {
-        return [PFBase, PFButton];
-    }
+    static styles: CSSResult[] = [PFBase, PFButton];
 
     @property()
     createText = msg("Create");

--- a/web/src/admin/stages/authenticator_endpoint_gdtc/AuthenticatorEndpointGDTCStageForm.ts
+++ b/web/src/admin/stages/authenticator_endpoint_gdtc/AuthenticatorEndpointGDTCStageForm.ts
@@ -33,9 +33,7 @@ export class AuthenticatorEndpointGDTCStageForm extends BaseStageForm<Authentica
         });
     }
 
-    static get styles() {
-        return super.styles.concat(PFBanner);
-    }
+    static styles = [...super.styles, PFBanner];
 
     renderForm(): TemplateResult {
         return html`<div class="pf-c-banner pf-m-info">

--- a/web/src/admin/stages/identification/IdentificationStageForm.ts
+++ b/web/src/admin/stages/identification/IdentificationStageForm.ts
@@ -28,16 +28,14 @@ import { sourcesProvider, sourcesSelector } from "./IdentificationStageFormHelpe
 
 @customElement("ak-stage-identification-form")
 export class IdentificationStageForm extends BaseStageForm<IdentificationStage> {
-    static get styles() {
-        return [
-            ...super.styles,
-            css`
-                ak-checkbox-group::part(checkbox-group) {
-                    padding-top: var(--pf-c-form--m-horizontal__group-label--md--PaddingTop);
-                }
-            `,
-        ];
-    }
+    static styles = [
+        ...super.styles,
+        css`
+            ak-checkbox-group::part(checkbox-group) {
+                padding-top: var(--pf-c-form--m-horizontal__group-label--md--PaddingTop);
+            }
+        `,
+    ];
 
     loadInstance(pk: string): Promise<IdentificationStage> {
         return new StagesApi(DEFAULT_CONFIG).stagesIdentificationRetrieve({

--- a/web/src/admin/stages/invitation/InvitationListLink.ts
+++ b/web/src/admin/stages/invitation/InvitationListLink.ts
@@ -21,9 +21,7 @@ export class InvitationListLink extends AKElement {
     @property()
     selectedFlow?: string;
 
-    static get styles(): CSSResult[] {
-        return [PFBase, PFForm, PFFormControl, PFDescriptionList];
-    }
+    static styles: CSSResult[] = [PFBase, PFForm, PFFormControl, PFDescriptionList];
 
     renderLink(): string {
         if (this.invitation?.flowObj) {

--- a/web/src/admin/stages/invitation/InvitationListPage.ts
+++ b/web/src/admin/stages/invitation/InvitationListPage.ts
@@ -45,9 +45,7 @@ export class InvitationListPage extends TablePage<Invitation> {
         return "pf-icon pf-icon-migration";
     }
 
-    static get styles(): CSSResult[] {
-        return super.styles.concat(PFBanner);
-    }
+    static styles: CSSResult[] = [...super.styles, PFBanner];
 
     checkbox = true;
     clearOnRefresh = true;

--- a/web/src/admin/stages/prompt/PromptForm.ts
+++ b/web/src/admin/stages/prompt/PromptForm.ts
@@ -99,9 +99,7 @@ export class PromptForm extends ModelForm<Prompt, string> {
             : msg("Successfully created prompt.");
     }
 
-    static get styles(): CSSResult[] {
-        return super.styles.concat(PFGrid, PFTitle);
-    }
+    static styles: CSSResult[] = [...super.styles, PFGrid, PFTitle];
 
     _shouldRefresh = false;
     _timer = 0;

--- a/web/src/admin/system-tasks/SystemTaskListPage.ts
+++ b/web/src/admin/system-tasks/SystemTaskListPage.ts
@@ -39,9 +39,7 @@ export class SystemTaskListPage extends TablePage<SystemTask> {
     @property()
     order = "name";
 
-    static get styles(): CSSResult[] {
-        return super.styles.concat(PFDescriptionList);
-    }
+    static styles: CSSResult[] = [...super.styles, PFDescriptionList];
 
     async apiEndpoint(): Promise<PaginatedResponse<SystemTask>> {
         return new EventsApi(DEFAULT_CONFIG).eventsSystemTasksList(

--- a/web/src/admin/users/GroupSelectModal.ts
+++ b/web/src/admin/users/GroupSelectModal.ts
@@ -27,9 +27,7 @@ export class GroupSelectModal extends TableModal<Group> {
 
     order = "name";
 
-    static get styles(): CSSResult[] {
-        return super.styles.concat(PFBanner);
-    }
+    static styles: CSSResult[] = [...super.styles, PFBanner];
 
     async apiEndpoint(): Promise<PaginatedResponse<Group>> {
         return new CoreApi(DEFAULT_CONFIG).coreGroupsList({

--- a/web/src/admin/users/UserApplicationTable.ts
+++ b/web/src/admin/users/UserApplicationTable.ts
@@ -16,9 +16,7 @@ export class UserApplicationTable extends Table<Application> {
     @property({ attribute: false })
     user?: User;
 
-    static get styles(): CSSResult[] {
-        return super.styles.concat(applicationListStyle);
-    }
+    static styles: CSSResult[] = [...super.styles, applicationListStyle];
 
     async apiEndpoint(): Promise<PaginatedResponse<Application>> {
         return new CoreApi(DEFAULT_CONFIG).coreApplicationsList({

--- a/web/src/admin/users/UserForm.ts
+++ b/web/src/admin/users/UserForm.ts
@@ -26,16 +26,17 @@ export class UserForm extends ModelForm<User, number> {
         return {};
     }
 
-    static get styles(): CSSResult[] {
-        return super.styles.concat(css`
+    static styles: CSSResult[] = [
+        ...super.styles,
+        css`
             .pf-c-button.pf-m-control {
                 height: 100%;
             }
             .pf-c-form-control {
                 height: auto !important;
             }
-        `);
-    }
+        `,
+    ];
 
     loadInstance(pk: number): Promise<User> {
         return new CoreApi(DEFAULT_CONFIG).coreUsersRetrieve({

--- a/web/src/admin/users/UserListPage.ts
+++ b/web/src/admin/users/UserListPage.ts
@@ -115,9 +115,13 @@ export class UserListPage extends WithBrandConfig(WithCapabilitiesConfig(TablePa
     @state()
     me?: SessionUser;
 
-    static get styles(): CSSResult[] {
-        return [...TablePage.styles, PFDescriptionList, PFCard, PFAlert, recoveryButtonStyles];
-    }
+    static styles: CSSResult[] = [
+        ...TablePage.styles,
+        PFDescriptionList,
+        PFCard,
+        PFAlert,
+        recoveryButtonStyles,
+    ];
 
     constructor() {
         super();

--- a/web/src/admin/users/UserViewPage.ts
+++ b/web/src/admin/users/UserViewPage.ts
@@ -82,41 +82,39 @@ export class UserViewPage extends WithCapabilitiesConfig(AKElement) {
     @state()
     me?: SessionUser;
 
-    static get styles() {
-        return [
-            PFBase,
-            PFPage,
-            PFButton,
-            PFDisplay,
-            PFGrid,
-            PFContent,
-            PFCard,
-            PFDescriptionList,
-            PFSizing,
-            PFBanner,
-            css`
-                .ak-button-collection {
-                    display: flex;
-                    flex-direction: column;
-                    gap: 0.375rem;
-                    max-width: 12rem;
-                }
-                .ak-button-collection > * {
-                    flex: 1 0 100%;
-                }
-                #reset-password-button {
-                    margin-right: 0;
-                }
+    static styles = [
+        PFBase,
+        PFPage,
+        PFButton,
+        PFDisplay,
+        PFGrid,
+        PFContent,
+        PFCard,
+        PFDescriptionList,
+        PFSizing,
+        PFBanner,
+        css`
+            .ak-button-collection {
+                display: flex;
+                flex-direction: column;
+                gap: 0.375rem;
+                max-width: 12rem;
+            }
+            .ak-button-collection > * {
+                flex: 1 0 100%;
+            }
+            #reset-password-button {
+                margin-right: 0;
+            }
 
-                #ak-email-recovery-request,
-                #update-password-request .pf-c-button,
-                #ak-email-recovery-request .pf-c-button {
-                    margin: 0;
-                    width: 100%;
-                }
-            `,
-        ];
-    }
+            #ak-email-recovery-request,
+            #update-password-request .pf-c-button,
+            #ak-email-recovery-request .pf-c-button {
+                margin: 0;
+                width: 100%;
+            }
+        `,
+    ];
 
     constructor() {
         super();

--- a/web/src/components/ak-event-info.ts
+++ b/web/src/components/ak-event-info.ts
@@ -87,35 +87,33 @@ export class EventInfo extends AKElement {
     @property({ attribute: false })
     event!: EventWithContext;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFButton,
-            PFFlex,
-            PFCard,
-            PFTable,
-            PFList,
-            PFSplit,
-            PFDescriptionList,
-            css`
-                code {
-                    display: block;
-                    white-space: pre-wrap;
-                    word-break: break-all;
-                }
-                .pf-l-flex {
-                    justify-content: space-between;
-                }
-                .pf-l-flex__item {
-                    min-width: 25%;
-                }
-                iframe {
-                    width: 100%;
-                    height: 50rem;
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFButton,
+        PFFlex,
+        PFCard,
+        PFTable,
+        PFList,
+        PFSplit,
+        PFDescriptionList,
+        css`
+            code {
+                display: block;
+                white-space: pre-wrap;
+                word-break: break-all;
+            }
+            .pf-l-flex {
+                justify-content: space-between;
+            }
+            .pf-l-flex__item {
+                min-width: 25%;
+            }
+            iframe {
+                width: 100%;
+                height: 50rem;
+            }
+        `,
+    ];
 
     renderDescriptionGroup([term, description]: FieldLabelTuple) {
         return html` <div class="pf-c-description-list__group">

--- a/web/src/components/ak-hidden-text-input.ts
+++ b/web/src/components/ak-hidden-text-input.ts
@@ -40,15 +40,13 @@ export class AkHiddenTextInput<T extends InputLike = HTMLInputElement>
     extends HorizontalLightComponent<string>
     implements AkHiddenTextInputProps
 {
-    public static get styles() {
-        return [
-            css`
-                main {
-                    display: flex;
-                }
-            `,
-        ];
-    }
+    public static styles = [
+        css`
+            main {
+                display: flex;
+            }
+        `,
+    ];
 
     /**
      * @property

--- a/web/src/components/ak-hint/ak-hint-actions.ts
+++ b/web/src/components/ak-hint/ak-hint-actions.ts
@@ -20,9 +20,7 @@ const style = css`
 
 @customElement("ak-hint-actions")
 export class AkHintActions extends AKElement {
-    static get styles() {
-        return [style];
-    }
+    static styles = [style];
 
     render() {
         return html`<div part="ak-hint-actions"><slot></slot></div>`;

--- a/web/src/components/ak-hint/ak-hint-body.ts
+++ b/web/src/components/ak-hint/ak-hint-body.ts
@@ -12,9 +12,7 @@ const style = css`
 
 @customElement("ak-hint-body")
 export class AkHintBody extends AKElement {
-    static get styles() {
-        return [style];
-    }
+    static styles = [style];
 
     render() {
         return html`<div part="ak-hint-body"><slot></slot></div>`;

--- a/web/src/components/ak-hint/ak-hint-footer.ts
+++ b/web/src/components/ak-hint/ak-hint-footer.ts
@@ -14,9 +14,7 @@ const style = css`
 
 @customElement("ak-hint-footer")
 export class AkHintFooter extends AKElement {
-    static get styles() {
-        return [style];
-    }
+    static styles = [style];
 
     render() {
         return html`<div id="host" part="ak-hint-footer"><slot></slot></div>`;

--- a/web/src/components/ak-hint/ak-hint-title.ts
+++ b/web/src/components/ak-hint/ak-hint-title.ts
@@ -11,9 +11,7 @@ const style = css`
 
 @customElement("ak-hint-title")
 export class AkHintTitle extends AKElement {
-    static get styles() {
-        return [style];
-    }
+    static styles = [style];
 
     render() {
         return html`<div id="host" part="ak-hint-title"><slot></slot></div>`;

--- a/web/src/components/ak-hint/ak-hint.ts
+++ b/web/src/components/ak-hint/ak-hint.ts
@@ -60,9 +60,7 @@ const styles = css`
 
 @customElement("ak-hint")
 export class AkHint extends AKElement {
-    static get styles() {
-        return [styles];
-    }
+    static styles = [styles];
 
     render() {
         return html`<div part="ak-hint" id="host"><slot></slot></div>`;

--- a/web/src/components/ak-multi-select.ts
+++ b/web/src/components/ak-multi-select.ts
@@ -26,9 +26,7 @@ const selectStyles = css`
  */
 @customElement("ak-multi-select")
 export class AkMultiSelect extends AkControlElement {
-    static get styles() {
-        return [PFBase, PFForm, PFFormControl, selectStyles];
-    }
+    static styles = [PFBase, PFForm, PFFormControl, selectStyles];
 
     /**
      * The [name] attribute, which is also distributed to the layout manager and the input control.

--- a/web/src/components/ak-nav-buttons.ts
+++ b/web/src/components/ak-nav-buttons.ts
@@ -44,32 +44,30 @@ export class NavigationButtons extends AKElement {
     @property({ type: Number })
     notificationsCount = 0;
 
-    static get styles() {
-        return [
-            PFBase,
-            PFDisplay,
-            PFBrand,
-            PFPage,
-            PFAvatar,
-            PFButton,
-            PFDrawer,
-            PFDropdown,
-            PFNotificationBadge,
-            css`
-                .pf-c-page__header-tools {
-                    display: flex;
-                }
-                :host([theme="dark"]) .pf-c-page__header-tools {
-                    color: var(--ak-dark-foreground) !important;
-                }
-                :host([theme="light"]) .pf-c-page__header-tools-item .fas,
-                :host([theme="light"]) .pf-c-notification-badge__count,
-                :host([theme="light"]) .pf-c-page__header-tools-group .pf-c-button {
-                    color: var(--ak-global--Color--100) !important;
-                }
-            `,
-        ];
-    }
+    static styles = [
+        PFBase,
+        PFDisplay,
+        PFBrand,
+        PFPage,
+        PFAvatar,
+        PFButton,
+        PFDrawer,
+        PFDropdown,
+        PFNotificationBadge,
+        css`
+            .pf-c-page__header-tools {
+                display: flex;
+            }
+            :host([theme="dark"]) .pf-c-page__header-tools {
+                color: var(--ak-dark-foreground) !important;
+            }
+            :host([theme="light"]) .pf-c-page__header-tools-item .fas,
+            :host([theme="light"]) .pf-c-notification-badge__count,
+            :host([theme="light"]) .pf-c-page__header-tools-group .pf-c-button {
+                color: var(--ak-global--Color--100) !important;
+            }
+        `,
+    ];
 
     async firstUpdated() {
         this.me = await me();

--- a/web/src/components/ak-page-header.ts
+++ b/web/src/components/ak-page-header.ts
@@ -44,15 +44,13 @@ export class AKPageHeader extends LitElement implements PageHeaderInit {
     @property({ type: Boolean })
     iconImage = false;
 
-    static get styles(): CSSResult[] {
-        return [
-            css`
-                :host {
-                    display: none;
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        css`
+            :host {
+                display: none;
+            }
+        `,
+    ];
 
     connectedCallback(): void {
         super.connectedCallback();

--- a/web/src/components/ak-page-navbar.ts
+++ b/web/src/components/ak-page-navbar.ts
@@ -58,185 +58,106 @@ export class AKPageNavbar
         elementRef.hasIcon = !!icon;
     };
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFButton,
-            PFPage,
-            PFDrawer,
+    static styles: CSSResult[] = [
+        PFBase,
+        PFButton,
+        PFPage,
+        PFDrawer,
 
-            PFNotificationBadge,
-            PFContent,
-            PFAvatar,
-            PFDropdown,
-            css`
-                :host {
-                    position: sticky;
-                    top: 0;
-                    z-index: var(--pf-global--ZIndex--lg);
-                    --pf-c-page__header-tools--MarginRight: 0;
-                    --ak-brand-logo-height: var(--pf-global--FontSize--4xl, 2.25rem);
-                    --ak-brand-background-color: var(
-                        --pf-c-page__sidebar--m-light--BackgroundColor
-                    );
-                    --host-navbar-height: var(--ak-c-page-header--height, 7.5rem);
+        PFNotificationBadge,
+        PFContent,
+        PFAvatar,
+        PFDropdown,
+        css`
+            :host {
+                position: sticky;
+                top: 0;
+                z-index: var(--pf-global--ZIndex--lg);
+                --pf-c-page__header-tools--MarginRight: 0;
+                --ak-brand-logo-height: var(--pf-global--FontSize--4xl, 2.25rem);
+                --ak-brand-background-color: var(--pf-c-page__sidebar--m-light--BackgroundColor);
+                --host-navbar-height: var(--ak-c-page-header--height, 7.5rem);
+            }
+
+            :host([theme="dark"]) {
+                --ak-brand-background-color: var(--pf-c-page__sidebar--BackgroundColor);
+                --pf-c-page__sidebar--BackgroundColor: var(--ak-dark-background-light);
+                color: var(--ak-dark-foreground);
+            }
+
+            navbar {
+                border-bottom: var(--pf-global--BorderWidth--sm);
+                border-bottom-style: solid;
+                border-bottom-color: var(--pf-global--BorderColor--100);
+                background-color: var(--pf-c-page--BackgroundColor);
+
+                display: flex;
+                flex-direction: row;
+
+                display: grid;
+                column-gap: var(--pf-global--spacer--sm);
+                grid-template-columns: [brand] auto [toggle] auto [primary] 1fr [secondary] auto;
+                grid-template-rows: auto auto;
+                grid-template-areas:
+                    "brand toggle primary secondary"
+                    "brand toggle description secondary";
+
+                @media (min-width: 769px) {
+                    height: var(--host-navbar-height);
                 }
 
-                :host([theme="dark"]) {
-                    --ak-brand-background-color: var(--pf-c-page__sidebar--BackgroundColor);
-                    --pf-c-page__sidebar--BackgroundColor: var(--ak-dark-background-light);
-                    color: var(--ak-dark-foreground);
-                }
+                @media (max-width: 768px) {
+                    row-gap: var(--pf-global--spacer--xs);
 
-                navbar {
-                    border-bottom: var(--pf-global--BorderWidth--sm);
-                    border-bottom-style: solid;
-                    border-bottom-color: var(--pf-global--BorderColor--100);
-                    background-color: var(--pf-c-page--BackgroundColor);
-
-                    display: flex;
-                    flex-direction: row;
-
-                    display: grid;
-                    column-gap: var(--pf-global--spacer--sm);
-                    grid-template-columns: [brand] auto [toggle] auto [primary] 1fr [secondary] auto;
-                    grid-template-rows: auto auto;
+                    align-items: center;
                     grid-template-areas:
-                        "brand toggle primary secondary"
-                        "brand toggle description secondary";
+                        "toggle primary secondary"
+                        "toggle description description";
+                    justify-content: space-between;
+                    width: 100%;
+                }
+            }
 
-                    @media (min-width: 769px) {
-                        height: var(--host-navbar-height);
-                    }
+            .items {
+                display: block;
+
+                &.primary {
+                    grid-column: primary;
+                    grid-row: primary / description;
+
+                    align-self: center;
+                    padding-block: var(--pf-global--spacer--md);
 
                     @media (max-width: 768px) {
-                        row-gap: var(--pf-global--spacer--xs);
-
-                        align-items: center;
-                        grid-template-areas:
-                            "toggle primary secondary"
-                            "toggle description description";
-                        justify-content: space-between;
-                        width: 100%;
+                        padding-block: var(--pf-global--spacer--sm);
                     }
-                }
 
-                .items {
-                    display: block;
+                    &.block-sibling {
+                        align-self: end;
+                    }
 
-                    &.primary {
-                        grid-column: primary;
-                        grid-row: primary / description;
+                    @media (min-width: 426px) {
+                        &.block-sibling {
+                            padding-block-end: 0;
+                            grid-row: primary;
+                        }
+                    }
 
-                        align-self: center;
-                        padding-block: var(--pf-global--spacer--md);
+                    .accent-icon {
+                        height: 1.2em;
+                        width: 1em;
 
                         @media (max-width: 768px) {
-                            padding-block: var(--pf-global--spacer--sm);
-                        }
-
-                        &.block-sibling {
-                            align-self: end;
-                        }
-
-                        @media (min-width: 426px) {
-                            &.block-sibling {
-                                padding-block-end: 0;
-                                grid-row: primary;
-                            }
-                        }
-
-                        .accent-icon {
-                            height: 1.2em;
-                            width: 1em;
-
-                            @media (max-width: 768px) {
-                                display: none;
-                            }
-                        }
-                    }
-
-                    &.page-description {
-                        padding-top: 0.3em;
-                        grid-area: description;
-                        margin-block-end: var(--pf-global--spacer--md);
-
-                        display: box;
-                        display: -webkit-box;
-                        line-clamp: 2;
-                        -webkit-line-clamp: 2;
-                        box-orient: vertical;
-                        -webkit-box-orient: vertical;
-                        overflow: hidden;
-
-                        @media (max-width: 425px) {
                             display: none;
                         }
-
-                        @media (min-width: 769px) {
-                            text-wrap: balance;
-                        }
-                    }
-
-                    &.secondary {
-                        grid-area: secondary;
-                        flex: 0 0 auto;
-                        justify-self: end;
-                        padding-block: var(--pf-global--spacer--sm);
-                        padding-inline-end: var(--pf-global--spacer--sm);
-
-                        @media (min-width: 769px) {
-                            align-content: center;
-                            padding-block: var(--pf-global--spacer--md);
-                            padding-inline-end: var(--pf-global--spacer--xl);
-                        }
                     }
                 }
 
-                .brand {
-                    grid-area: brand;
-                    background-color: var(--ak-brand-background-color);
-                    height: 100%;
-                    width: var(--pf-c-page__sidebar--Width);
-                    align-items: center;
-                    padding-inline: var(--pf-global--spacer--sm);
+                &.page-description {
+                    padding-top: 0.3em;
+                    grid-area: description;
+                    margin-block-end: var(--pf-global--spacer--md);
 
-                    display: flex;
-                    justify-content: center;
-
-                    &.pf-m-collapsed {
-                        display: none;
-                    }
-
-                    @media (max-width: 1199px) {
-                        display: none;
-                    }
-                }
-
-                .sidebar-trigger {
-                    grid-area: toggle;
-                    height: 100%;
-                }
-
-                .logo {
-                    flex: 0 0 auto;
-                    height: var(--ak-brand-logo-height);
-
-                    & img {
-                        height: 100%;
-                    }
-                }
-
-                .sidebar-trigger,
-                .notification-trigger {
-                    font-size: 1.5rem;
-                }
-
-                .notification-trigger.has-notifications {
-                    color: var(--pf-global--active-color--100);
-                }
-
-                .pf-c-content .page-title {
                     display: box;
                     display: -webkit-box;
                     line-clamp: 2;
@@ -244,16 +165,91 @@ export class AKPageNavbar
                     box-orient: vertical;
                     -webkit-box-orient: vertical;
                     overflow: hidden;
+
+                    @media (max-width: 425px) {
+                        display: none;
+                    }
+
+                    @media (min-width: 769px) {
+                        text-wrap: balance;
+                    }
                 }
 
-                h1 {
-                    display: flex;
-                    flex-direction: row;
-                    align-items: center !important;
+                &.secondary {
+                    grid-area: secondary;
+                    flex: 0 0 auto;
+                    justify-self: end;
+                    padding-block: var(--pf-global--spacer--sm);
+                    padding-inline-end: var(--pf-global--spacer--sm);
+
+                    @media (min-width: 769px) {
+                        align-content: center;
+                        padding-block: var(--pf-global--spacer--md);
+                        padding-inline-end: var(--pf-global--spacer--xl);
+                    }
                 }
-            `,
-        ];
-    }
+            }
+
+            .brand {
+                grid-area: brand;
+                background-color: var(--ak-brand-background-color);
+                height: 100%;
+                width: var(--pf-c-page__sidebar--Width);
+                align-items: center;
+                padding-inline: var(--pf-global--spacer--sm);
+
+                display: flex;
+                justify-content: center;
+
+                &.pf-m-collapsed {
+                    display: none;
+                }
+
+                @media (max-width: 1199px) {
+                    display: none;
+                }
+            }
+
+            .sidebar-trigger {
+                grid-area: toggle;
+                height: 100%;
+            }
+
+            .logo {
+                flex: 0 0 auto;
+                height: var(--ak-brand-logo-height);
+
+                & img {
+                    height: 100%;
+                }
+            }
+
+            .sidebar-trigger,
+            .notification-trigger {
+                font-size: 1.5rem;
+            }
+
+            .notification-trigger.has-notifications {
+                color: var(--pf-global--active-color--100);
+            }
+
+            .pf-c-content .page-title {
+                display: box;
+                display: -webkit-box;
+                line-clamp: 2;
+                -webkit-line-clamp: 2;
+                box-orient: vertical;
+                -webkit-box-orient: vertical;
+                overflow: hidden;
+            }
+
+            h1 {
+                display: flex;
+                flex-direction: row;
+                align-items: center !important;
+            }
+        `,
+    ];
 
     //#endregion
 

--- a/web/src/components/ak-search-ql/index.ts
+++ b/web/src/components/ak-search-ql/index.ts
@@ -56,50 +56,46 @@ export class QLSearch extends AKElement {
         this.ql.loadIntrospections(value.autocomplete as unknown as Introspections);
     }
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFFormControl,
-            PFSearchInput,
-            css`
-                ::-webkit-search-cancel-button {
-                    display: none;
-                }
-                .ql.pf-c-form-control {
-                    font-family: monospace;
-                    resize: vertical;
-                    height: 2.25em;
-                }
-                .selected {
-                    background-color: var(--pf-c-search-input__menu-item--hover--BackgroundColor);
-                }
-                :host([theme="dark"]) .pf-c-search-input__menu {
-                    --pf-c-search-input__menu--BackgroundColor: var(--ak-dark-background-light-ish);
-                    color: var(--ak-dark-foreground);
-                }
-                :host([theme="dark"]) .pf-c-search-input__menu-item {
-                    --pf-c-search-input__menu-item--Color: var(--ak-dark-foreground);
-                }
-                :host([theme="dark"]) .pf-c-search-input__menu-item:hover {
-                    --pf-c-search-input__menu-item--BackgroundColor: var(
-                        --ak-dark-background-lighter
-                    );
-                }
-                :host([theme="dark"]) .pf-c-search-input__menu-list-item.selected {
-                    --pf-c-search-input__menu-item--hover--BackgroundColor: var(
-                        --ak-dark-background-light
-                    );
-                }
-                :host([theme="dark"]) .pf-c-search-input__text::before {
-                    border: 0;
-                }
-                .pf-c-search-input__menu {
-                    position: fixed;
-                    min-width: 0;
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFFormControl,
+        PFSearchInput,
+        css`
+            ::-webkit-search-cancel-button {
+                display: none;
+            }
+            .ql.pf-c-form-control {
+                font-family: monospace;
+                resize: vertical;
+                height: 2.25em;
+            }
+            .selected {
+                background-color: var(--pf-c-search-input__menu-item--hover--BackgroundColor);
+            }
+            :host([theme="dark"]) .pf-c-search-input__menu {
+                --pf-c-search-input__menu--BackgroundColor: var(--ak-dark-background-light-ish);
+                color: var(--ak-dark-foreground);
+            }
+            :host([theme="dark"]) .pf-c-search-input__menu-item {
+                --pf-c-search-input__menu-item--Color: var(--ak-dark-foreground);
+            }
+            :host([theme="dark"]) .pf-c-search-input__menu-item:hover {
+                --pf-c-search-input__menu-item--BackgroundColor: var(--ak-dark-background-lighter);
+            }
+            :host([theme="dark"]) .pf-c-search-input__menu-list-item.selected {
+                --pf-c-search-input__menu-item--hover--BackgroundColor: var(
+                    --ak-dark-background-light
+                );
+            }
+            :host([theme="dark"]) .pf-c-search-input__text::before {
+                border: 0;
+            }
+            .pf-c-search-input__menu {
+                position: fixed;
+                min-width: 0;
+            }
+        `,
+    ];
 
     firstUpdated() {
         if (!this.searchElement) {

--- a/web/src/components/ak-status-label.ts
+++ b/web/src/components/ak-status-label.ts
@@ -71,9 +71,7 @@ const styles = css`
 
 @customElement("ak-status-label")
 export class AkStatusLabel extends AKElement {
-    static get styles() {
-        return [PFBase, PFLabel, styles];
-    }
+    static styles = [PFBase, PFLabel, styles];
 
     @property({ type: Boolean })
     good = false;

--- a/web/src/components/ak-toggle-group.ts
+++ b/web/src/components/ak-toggle-group.ts
@@ -25,17 +25,15 @@ type Pair = [string, string];
 
 @customElement("ak-toggle-group")
 export class AkToggleGroup extends CustomEmitterElement(AKElement) {
-    static get styles() {
-        return [
-            PFBase,
-            PFToggleGroup,
-            css`
-                .pf-c-toggle-group {
-                    justify-content: center;
-                }
-            `,
-        ];
-    }
+    static styles = [
+        PFBase,
+        PFToggleGroup,
+        css`
+            .pf-c-toggle-group {
+                justify-content: center;
+            }
+        `,
+    ];
 
     /*
      * The value (causes highlighting, value is returned)

--- a/web/src/components/ak-visibility-toggle.ts
+++ b/web/src/components/ak-visibility-toggle.ts
@@ -27,9 +27,7 @@ export interface VisibilityToggleProps {
  */
 @customElement("ak-visibility-toggle")
 export class VisibilityToggle extends AKElement implements VisibilityToggleProps {
-    static get styles() {
-        return [PFBase, PFButton];
-    }
+    static styles = [PFBase, PFButton];
 
     /**
      * @property

--- a/web/src/components/ak-wizard/WizardStep.ts
+++ b/web/src/components/ak-wizard/WizardStep.ts
@@ -57,23 +57,21 @@ const BUTTON_KIND_TO_LABEL: Record<ButtonKind, string> = {
 export class WizardStep extends AKElement {
     // These additions are necessary because we don't want to inherit *all* of the modal box
     // modifiers, just the ones related to managing the height of the display box.
-    static get styles() {
-        return [
-            PFWizard,
-            PFContent,
-            PFTitle,
-            css`
-                .ak-wizard-box {
-                    height: 75%;
-                    height: 75vh;
-                    display: flex;
-                    flex-direction: column;
-                    position: relative;
-                    z-index: 500;
-                }
-            `,
-        ];
-    }
+    static styles = [
+        PFWizard,
+        PFContent,
+        PFTitle,
+        css`
+            .ak-wizard-box {
+                height: 75%;
+                height: 75vh;
+                display: flex;
+                flex-direction: column;
+                position: relative;
+                z-index: 500;
+            }
+        `,
+    ];
 
     @property({ type: Boolean, attribute: true, reflect: true })
     enabled = false;

--- a/web/src/elements/Alert.ts
+++ b/web/src/elements/Alert.ts
@@ -63,17 +63,15 @@ export class Alert extends AKElement implements IAlert {
     @property()
     icon = "fa-exclamation-circle";
 
-    static get styles() {
-        return [
-            PFBase,
-            PFAlert,
-            css`
-                p {
-                    margin: 0;
-                }
-            `,
-        ];
-    }
+    static styles = [
+        PFBase,
+        PFAlert,
+        css`
+            p {
+                margin: 0;
+            }
+        `,
+    ];
 
     get classmap() {
         const level = levelNames.includes(this.level)

--- a/web/src/elements/AppIcon.ts
+++ b/web/src/elements/AppIcon.ts
@@ -26,53 +26,51 @@ export class AppIcon extends AKElement implements IAppIcon {
     @property({ reflect: true })
     size: PFSize = PFSize.Medium;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFFAIcons,
-            PFAvatar,
-            css`
-                :host {
-                    max-height: calc(var(--icon-height) + var(--icon-border) + var(--icon-border));
-                }
-                :host([size="pf-m-lg"]) {
-                    --icon-height: 4rem;
-                    --icon-border: 0.25rem;
-                }
-                :host([size="pf-m-md"]) {
-                    --icon-height: 2rem;
-                    --icon-border: 0.125rem;
-                }
-                :host([size="pf-m-sm"]) {
-                    --icon-height: 1rem;
-                    --icon-border: 0.125rem;
-                }
-                :host([size="pf-m-xl"]) {
-                    --icon-height: 6rem;
-                    --icon-border: 0.25rem;
-                }
-                .pf-c-avatar {
-                    --pf-c-avatar--BorderRadius: 0;
-                    --pf-c-avatar--Height: calc(
-                        var(--icon-height) + var(--icon-border) + var(--icon-border)
-                    );
-                    --pf-c-avatar--Width: calc(
-                        var(--icon-height) + var(--icon-border) + var(--icon-border)
-                    );
-                }
-                .icon {
-                    font-size: var(--icon-height);
-                    color: var(--ak-global--Color--100);
-                    padding: var(--icon-border);
-                    max-height: calc(var(--icon-height) + var(--icon-border) + var(--icon-border));
-                    line-height: calc(var(--icon-height) + var(--icon-border) + var(--icon-border));
-                    filter: drop-shadow(5px 5px 5px rgba(128, 128, 128, 0.25));
-                }
-                div {
-                    height: calc(var(--icon-height) + var(--icon-border) + var(--icon-border));
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFFAIcons,
+        PFAvatar,
+        css`
+            :host {
+                max-height: calc(var(--icon-height) + var(--icon-border) + var(--icon-border));
+            }
+            :host([size="pf-m-lg"]) {
+                --icon-height: 4rem;
+                --icon-border: 0.25rem;
+            }
+            :host([size="pf-m-md"]) {
+                --icon-height: 2rem;
+                --icon-border: 0.125rem;
+            }
+            :host([size="pf-m-sm"]) {
+                --icon-height: 1rem;
+                --icon-border: 0.125rem;
+            }
+            :host([size="pf-m-xl"]) {
+                --icon-height: 6rem;
+                --icon-border: 0.25rem;
+            }
+            .pf-c-avatar {
+                --pf-c-avatar--BorderRadius: 0;
+                --pf-c-avatar--Height: calc(
+                    var(--icon-height) + var(--icon-border) + var(--icon-border)
+                );
+                --pf-c-avatar--Width: calc(
+                    var(--icon-height) + var(--icon-border) + var(--icon-border)
+                );
+            }
+            .icon {
+                font-size: var(--icon-height);
+                color: var(--ak-global--Color--100);
+                padding: var(--icon-border);
+                max-height: calc(var(--icon-height) + var(--icon-border) + var(--icon-border));
+                line-height: calc(var(--icon-height) + var(--icon-border) + var(--icon-border));
+                filter: drop-shadow(5px 5px 5px rgba(128, 128, 128, 0.25));
+            }
+            div {
+                height: calc(var(--icon-height) + var(--icon-border) + var(--icon-border));
+            }
+        `,
+    ];
 
     render(): TemplateResult {
         // prettier-ignore

--- a/web/src/elements/CodeMirror.ts
+++ b/web/src/elements/CodeMirror.ts
@@ -66,23 +66,21 @@ export class CodeMirrorTextarea<T> extends AKElement {
     syntaxHighlightingLight = syntaxHighlighting(defaultHighlightStyle);
     syntaxHighlightingDark = syntaxHighlighting(oneDarkHighlightStyle);
 
-    static get styles(): CSSResult[] {
-        return [
-            // Better alignment with patternfly components
-            css`
-                .cm-editor {
-                    padding-top: calc(
-                        var(--pf-global--spacer--form-element) - var(--pf-global--BorderWidth--sm)
-                    );
-                    padding-bottom: calc(
-                        var(--pf-global--spacer--form-element) - var(--pf-global--BorderWidth--sm)
-                    );
-                    padding-right: var(--pf-c-form-control--inset--base);
-                    padding-left: var(--pf-c-form-control--inset--base);
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        // Better alignment with patternfly components
+        css`
+            .cm-editor {
+                padding-top: calc(
+                    var(--pf-global--spacer--form-element) - var(--pf-global--BorderWidth--sm)
+                );
+                padding-bottom: calc(
+                    var(--pf-global--spacer--form-element) - var(--pf-global--BorderWidth--sm)
+                );
+                padding-right: var(--pf-c-form-control--inset--base);
+                padding-left: var(--pf-c-form-control--inset--base);
+            }
+        `,
+    ];
 
     @property()
     set value(v: T | string) {

--- a/web/src/elements/Diagram.ts
+++ b/web/src/elements/Diagram.ts
@@ -23,16 +23,14 @@ export class Diagram extends AKElement {
 
     handlerBound = false;
 
-    static get styles(): CSSResult[] {
-        return [
-            css`
-                :host {
-                    display: flex;
-                    justify-content: center;
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        css`
+            :host {
+                display: flex;
+                justify-content: center;
+            }
+        `,
+    ];
 
     config: MermaidConfig;
 

--- a/web/src/elements/Divider.ts
+++ b/web/src/elements/Divider.ts
@@ -8,33 +8,31 @@ import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-divider")
 export class Divider extends AKElement {
-    static get styles() {
-        return [
-            PFBase,
-            css`
-                .separator {
-                    display: flex;
-                    align-items: center;
-                    text-align: center;
-                }
+    static styles = [
+        PFBase,
+        css`
+            .separator {
+                display: flex;
+                align-items: center;
+                text-align: center;
+            }
 
-                .separator::before,
-                .separator::after {
-                    content: "";
-                    flex: 1;
-                    border-bottom: 1px solid var(--pf-global--Color--100);
-                }
+            .separator::before,
+            .separator::after {
+                content: "";
+                flex: 1;
+                border-bottom: 1px solid var(--pf-global--Color--100);
+            }
 
-                .separator:not(:empty)::before {
-                    margin-right: 0.25em;
-                }
+            .separator:not(:empty)::before {
+                margin-right: 0.25em;
+            }
 
-                .separator:not(:empty)::after {
-                    margin-left: 0.25em;
-                }
-            `,
-        ];
-    }
+            .separator:not(:empty)::after {
+                margin-left: 0.25em;
+            }
+        `,
+    ];
 
     render() {
         return html`<div class="separator">

--- a/web/src/elements/EmptyState.ts
+++ b/web/src/elements/EmptyState.ts
@@ -61,19 +61,17 @@ export class EmptyState extends AKElement implements IEmptyState {
     @property({ type: Boolean, attribute: "full-height" })
     public fullHeight = false;
 
-    static get styles() {
-        return [
-            PFBase,
-            PFEmptyState,
-            PFTitle,
-            css`
-                i.pf-c-empty-state__icon {
-                    height: var(--pf-global--icon--FontSize--2xl);
-                    line-height: var(--pf-global--icon--FontSize--2xl);
-                }
-            `,
-        ];
-    }
+    static styles = [
+        PFBase,
+        PFEmptyState,
+        PFTitle,
+        css`
+            i.pf-c-empty-state__icon {
+                height: var(--pf-global--icon--FontSize--2xl);
+                line-height: var(--pf-global--icon--FontSize--2xl);
+            }
+        `,
+    ];
 
     willUpdate() {
         if (this.defaultLabel && this.querySelector("span:not([slot])") === null) {

--- a/web/src/elements/Expand.ts
+++ b/web/src/elements/Expand.ts
@@ -26,17 +26,15 @@ export class Expand extends AKElement implements IExpand {
     @property({ type: String, attribute: "text-closed" })
     textClosed = msg("Show more");
 
-    static get styles() {
-        return [
-            PFBase,
-            PFExpandableSection,
-            css`
-                .pf-c-expandable-section.pf-m-display-lg {
-                    background-color: var(--pf-global--BackgroundColor--100);
-                }
-            `,
-        ];
-    }
+    static styles = [
+        PFBase,
+        PFExpandableSection,
+        css`
+            .pf-c-expandable-section.pf-m-display-lg {
+                background-color: var(--pf-global--BackgroundColor--100);
+            }
+        `,
+    ];
 
     render() {
         return html`<div

--- a/web/src/elements/LoadingOverlay.ts
+++ b/web/src/elements/LoadingOverlay.ts
@@ -51,28 +51,26 @@ export class LoadingOverlay extends AKElement implements ILoadingOverlay {
     @property({ type: String })
     icon?: string;
 
-    static get styles() {
-        return [
-            PFBase,
-            css`
-                :host {
-                    top: 0;
-                    left: 0;
-                    display: flex;
-                    height: 100%;
-                    width: 100%;
-                    justify-content: center;
-                    align-items: center;
-                    position: absolute;
-                    background-color: var(--pf-global--BackgroundColor--dark-transparent-200);
-                    z-index: 1;
-                }
-                :host([topmost]) {
-                    z-index: 999;
-                }
-            `,
-        ];
-    }
+    static styles = [
+        PFBase,
+        css`
+            :host {
+                top: 0;
+                left: 0;
+                display: flex;
+                height: 100%;
+                width: 100%;
+                justify-content: center;
+                align-items: center;
+                position: absolute;
+                background-color: var(--pf-global--BackgroundColor--dark-transparent-200);
+                z-index: 1;
+            }
+            :host([topmost]) {
+                z-index: 999;
+            }
+        `,
+    ];
 
     render() {
         // Nested slots. Can get a little cognitively heavy, so be careful if you're editing here...

--- a/web/src/elements/Spinner.ts
+++ b/web/src/elements/Spinner.ts
@@ -12,9 +12,7 @@ export class Spinner extends AKElement {
     @property()
     size: PFSize = PFSize.Medium;
 
-    static get styles(): CSSResult[] {
-        return [PFSpinner];
-    }
+    static styles: CSSResult[] = [PFSpinner];
 
     render(): TemplateResult {
         return html`<span

--- a/web/src/elements/Tabs.ts
+++ b/web/src/elements/Tabs.ts
@@ -21,29 +21,27 @@ export class Tabs extends AKElement {
     @property({ type: Boolean })
     vertical = false;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFGlobal,
-            PFTabs,
-            css`
-                ::slotted(*) {
-                    flex-grow: 2;
-                }
-                :host([vertical]) {
-                    display: flex;
-                }
-                :host([vertical]) .pf-c-tabs {
-                    width: auto !important;
-                }
-                :host([vertical]) .pf-c-tabs__list {
-                    height: 100%;
-                }
-                :host([vertical]) .pf-c-tabs .pf-c-tabs__list::before {
-                    border-color: transparent;
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFGlobal,
+        PFTabs,
+        css`
+            ::slotted(*) {
+                flex-grow: 2;
+            }
+            :host([vertical]) {
+                display: flex;
+            }
+            :host([vertical]) .pf-c-tabs {
+                width: auto !important;
+            }
+            :host([vertical]) .pf-c-tabs__list {
+                height: 100%;
+            }
+            :host([vertical]) .pf-c-tabs .pf-c-tabs__list::before {
+                border-color: transparent;
+            }
+        `,
+    ];
 
     observer: MutationObserver;
 

--- a/web/src/elements/TreeView.ts
+++ b/web/src/elements/TreeView.ts
@@ -139,9 +139,7 @@ export class TreeViewNode extends AKElement {
 
 @customElement("ak-treeview")
 export class TreeView extends AKElement {
-    static get styles(): CSSResult[] {
-        return [PFBase, PFTreeView];
-    }
+    static styles: CSSResult[] = [PFBase, PFTreeView];
 
     @property({ type: Array })
     items: string[] = [];

--- a/web/src/elements/ak-array-input.ts
+++ b/web/src/elements/ak-array-input.ts
@@ -28,32 +28,30 @@ type Keyed<T> = { key: string; item: T };
 
 @customElement("ak-array-input")
 export class ArrayInput<T> extends AkControlElement<T[]> implements IArrayInput<T> {
-    static get styles() {
-        return [
-            PFBase,
-            PFButton,
-            PFInputGroup,
-            PFFormControl,
-            css`
-                select.pf-c-form-control {
-                    width: 100px;
-                }
-                .pf-c-input-group {
-                    padding-bottom: 0;
-                }
-                .ak-plus-button {
-                    display: flex;
-                    justify-content: flex-end;
-                    flex-direction: row;
-                }
-                .ak-input-group {
-                    display: flex;
-                    flex-direction: row;
-                    flex-wrap: nowrap;
-                }
-            `,
-        ];
-    }
+    static styles = [
+        PFBase,
+        PFButton,
+        PFInputGroup,
+        PFFormControl,
+        css`
+            select.pf-c-form-control {
+                width: 100px;
+            }
+            .pf-c-input-group {
+                padding-bottom: 0;
+            }
+            .ak-plus-button {
+                display: flex;
+                justify-content: flex-end;
+                flex-direction: row;
+            }
+            .ak-input-group {
+                display: flex;
+                flex-direction: row;
+                flex-wrap: nowrap;
+            }
+        `,
+    ];
 
     @property({ type: Boolean })
     validate = false;

--- a/web/src/elements/ak-checkbox-group/ak-checkbox-group.ts
+++ b/web/src/elements/ak-checkbox-group/ak-checkbox-group.ts
@@ -79,20 +79,18 @@ const AkElementWithCustomEvents = CustomEmitterElement(AkControlElement);
 
 @customElement("ak-checkbox-group")
 export class CheckboxGroup extends AkElementWithCustomEvents {
-    static get styles() {
-        return [
-            PFBase,
-            PFForm,
-            PFCheck,
-            css`
-                .pf-c-form__group-control {
-                    padding-top: calc(
-                        var(--pf-c-form--m-horizontal__group-label--md--PaddingTop) * 1.3
-                    );
-                }
-            `,
-        ];
-    }
+    static styles = [
+        PFBase,
+        PFForm,
+        PFCheck,
+        css`
+            .pf-c-form__group-control {
+                padding-top: calc(
+                    var(--pf-c-form--m-horizontal__group-label--md--PaddingTop) * 1.3
+                );
+            }
+        `,
+    ];
 
     static get formAssociated() {
         return true;

--- a/web/src/elements/ak-list-select/ak-list-select.ts
+++ b/web/src/elements/ak-list-select/ak-list-select.ts
@@ -50,29 +50,27 @@ export interface IListSelect {
  */
 @customElement("ak-list-select")
 export class ListSelect extends AKElement implements IListSelect {
-    static get styles() {
-        return [
-            PFBase,
-            PFDropdown,
-            PFSelect,
-            css`
-                :host {
-                    overflow: visible;
-                    z-index: 9999;
-                }
+    static styles = [
+        PFBase,
+        PFDropdown,
+        PFSelect,
+        css`
+            :host {
+                overflow: visible;
+                z-index: 9999;
+            }
 
-                :host([hidden]) {
-                    display: none;
-                }
+            :host([hidden]) {
+                display: none;
+            }
 
-                .pf-c-dropdown__menu {
-                    max-height: 50vh;
-                    overflow-y: auto;
-                    width: 100%;
-                }
-            `,
-        ];
-    }
+            .pf-c-dropdown__menu {
+                max-height: 50vh;
+                overflow-y: auto;
+                width: 100%;
+            }
+        `,
+    ];
 
     /**
      * See the search options type, described in the `./types` file, for the relevant types.

--- a/web/src/elements/ak-table/ak-simple-table.ts
+++ b/web/src/elements/ak-table/ak-simple-table.ts
@@ -74,26 +74,24 @@ export interface ISimpleTable {
 
 @customElement("ak-simple-table")
 export class SimpleTable extends AKElement implements ISimpleTable {
-    static get styles() {
-        return [
-            PFBase,
-            PFTable,
-            css`
-                .pf-c-table thead .pf-c-table__check {
-                    min-width: 3rem;
-                }
-                .pf-c-table tbody .pf-c-table__check input {
-                    margin-top: calc(var(--pf-c-table__check--input--MarginTop) + 1px);
-                }
-                .pf-c-toolbar__content {
-                    row-gap: var(--pf-global--spacer--sm);
-                }
-                .pf-c-toolbar__item .pf-c-input-group {
-                    padding: 0 var(--pf-global--spacer--sm);
-                }
-            `,
-        ];
-    }
+    static styles = [
+        PFBase,
+        PFTable,
+        css`
+            .pf-c-table thead .pf-c-table__check {
+                min-width: 3rem;
+            }
+            .pf-c-table tbody .pf-c-table__check input {
+                margin-top: calc(var(--pf-c-table__check--input--MarginTop) + 1px);
+            }
+            .pf-c-toolbar__content {
+                row-gap: var(--pf-global--spacer--sm);
+            }
+            .pf-c-toolbar__item .pf-c-input-group {
+                padding: 0 var(--pf-global--spacer--sm);
+            }
+        `,
+    ];
 
     @property({ type: String, attribute: true, reflect: true })
     order?: string;

--- a/web/src/elements/banner/EnterpriseStatusBanner.ts
+++ b/web/src/elements/banner/EnterpriseStatusBanner.ts
@@ -15,9 +15,7 @@ export class EnterpriseStatusBanner extends WithLicenseSummary(AKElement) {
     @property()
     interface: "admin" | "user" | "flow" | "" = "";
 
-    static get styles() {
-        return [PFBanner];
-    }
+    static styles = [PFBanner];
 
     renderStatusBanner() {
         // Check if we're in the correct interface to render a banner

--- a/web/src/elements/buttons/ModalButton.ts
+++ b/web/src/elements/buttons/ModalButton.ts
@@ -48,30 +48,28 @@ export class ModalButton extends AKElement {
 
     handlerBound = false;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFButton,
-            PFModalBox,
-            PFForm,
-            PFTitle,
-            PFFormControl,
-            PFBullseye,
-            PFBackdrop,
-            PFPage,
-            PFCard,
-            PFContent,
-            MODAL_BUTTON_STYLES,
-            css`
-                .locked {
-                    overflow-y: hidden !important;
-                }
-                .pf-c-modal-box.pf-m-xl {
-                    --pf-c-modal-box--Width: calc(1.5 * var(--pf-c-modal-box--m-lg--lg--MaxWidth));
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFButton,
+        PFModalBox,
+        PFForm,
+        PFTitle,
+        PFFormControl,
+        PFBullseye,
+        PFBackdrop,
+        PFPage,
+        PFCard,
+        PFContent,
+        MODAL_BUTTON_STYLES,
+        css`
+            .locked {
+                overflow-y: hidden !important;
+            }
+            .pf-c-modal-box.pf-m-xl {
+                --pf-c-modal-box--Width: calc(1.5 * var(--pf-c-modal-box--m-lg--lg--MaxWidth));
+            }
+        `,
+    ];
 
     closeModal() {
         this.resetForms();

--- a/web/src/elements/buttons/SpinnerButton/BaseTaskButton.ts
+++ b/web/src/elements/buttons/SpinnerButton/BaseTaskButton.ts
@@ -50,9 +50,7 @@ const SPINNER_TIMEOUT = 1000 * 1.5; // milliseconds
 export abstract class BaseTaskButton extends CustomEmitterElement(AKElement) {
     eventPrefix = "ak-button";
 
-    static get styles() {
-        return buttonStyles;
-    }
+    static styles = [...buttonStyles];
 
     callAction!: () => Promise<unknown>;
 

--- a/web/src/elements/cards/AggregateCard.ts
+++ b/web/src/elements/cards/AggregateCard.ts
@@ -68,37 +68,38 @@ export class AggregateCard extends AKElement implements IAggregateCard {
     @property({ type: Boolean, attribute: "left-justified" })
     leftJustified = false;
 
-    static get styles(): CSSResult[] {
-        return [PFBase, PFCard, PFFlex].concat([
-            css`
-                .pf-c-card.pf-c-card-aggregate {
-                    height: 100%;
-                }
-                .pf-c-card__header {
-                    flex-wrap: nowrap;
-                }
-                .center-value {
-                    font-size: var(--pf-global--icon--FontSize--lg);
-                    text-align: center;
-                }
-                .subtext {
-                    margin-top: var(--pf-global--spacer--sm);
-                    font-size: var(--pf-global--FontSize--sm);
-                }
-                .pf-c-card__body {
-                    overflow-x: auto;
-                    padding-left: calc(var(--pf-c-card--child--PaddingLeft) / 2);
-                    padding-right: calc(var(--pf-c-card--child--PaddingRight) / 2);
-                }
-                .pf-c-card__header,
-                .pf-c-card__title,
-                .pf-c-card__body,
-                .pf-c-card__footer {
-                    padding-bottom: 0;
-                }
-            `,
-        ]);
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFCard,
+        PFFlex,
+        css`
+            .pf-c-card.pf-c-card-aggregate {
+                height: 100%;
+            }
+            .pf-c-card__header {
+                flex-wrap: nowrap;
+            }
+            .center-value {
+                font-size: var(--pf-global--icon--FontSize--lg);
+                text-align: center;
+            }
+            .subtext {
+                margin-top: var(--pf-global--spacer--sm);
+                font-size: var(--pf-global--FontSize--sm);
+            }
+            .pf-c-card__body {
+                overflow-x: auto;
+                padding-left: calc(var(--pf-c-card--child--PaddingLeft) / 2);
+                padding-right: calc(var(--pf-c-card--child--PaddingRight) / 2);
+            }
+            .pf-c-card__header,
+            .pf-c-card__title,
+            .pf-c-card__body,
+            .pf-c-card__footer {
+                padding-bottom: 0;
+            }
+        `,
+    ];
 
     renderInner(): TemplateResult {
         return html`<slot></slot>`;

--- a/web/src/elements/cards/QuickActionsCard.ts
+++ b/web/src/elements/cards/QuickActionsCard.ts
@@ -24,9 +24,7 @@ export interface IQuickActionsCard {
  */
 @customElement("ak-quick-actions-card")
 export class QuickActionsCard extends AKElement implements IQuickActionsCard {
-    static get styles() {
-        return [PFBase, PFList];
-    }
+    static styles = [PFBase, PFList];
 
     /**
      * Card title

--- a/web/src/elements/charts/Chart.ts
+++ b/web/src/elements/charts/Chart.ts
@@ -53,31 +53,29 @@ export abstract class AKChart<T> extends AKElement {
 
     fontColour = FONT_COLOUR_LIGHT_MODE;
 
-    static get styles(): CSSResult[] {
-        return [
-            css`
-                .container {
-                    height: 100%;
-                    width: 100%;
+    static styles: CSSResult[] = [
+        css`
+            .container {
+                height: 100%;
+                width: 100%;
 
-                    display: flex;
-                    justify-content: center;
-                    align-items: center;
-                    position: relative;
-                }
-                .container > span {
-                    position: absolute;
-                    font-size: 2.5rem;
-                }
-                canvas {
-                    width: 100px;
-                    height: 100px;
-                    z-index: 1;
-                    cursor: crosshair;
-                }
-            `,
-        ];
-    }
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                position: relative;
+            }
+            .container > span {
+                position: absolute;
+                font-size: 2.5rem;
+            }
+            canvas {
+                width: 100px;
+                height: 100px;
+                z-index: 1;
+                cursor: crosshair;
+            }
+        `,
+    ];
 
     connectedCallback(): void {
         super.connectedCallback();

--- a/web/src/elements/chips/Chip.ts
+++ b/web/src/elements/chips/Chip.ts
@@ -17,9 +17,7 @@ export class Chip extends AKElement {
     @property({ type: Boolean })
     removable = false;
 
-    static get styles(): CSSResult[] {
-        return [PFBase, PFButton, PFChip];
-    }
+    static styles: CSSResult[] = [PFBase, PFButton, PFChip];
 
     render(): TemplateResult {
         return html`<li class="pf-c-chip-group__list-item">

--- a/web/src/elements/chips/ChipGroup.ts
+++ b/web/src/elements/chips/ChipGroup.ts
@@ -11,22 +11,20 @@ import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-chip-group")
 export class ChipGroup extends AKElement {
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFChip,
-            PFChipGroup,
-            PFButton,
-            css`
-                ::slotted(*) {
-                    margin: 0 2px;
-                }
-                .pf-c-chip-group {
-                    margin-bottom: 8px;
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFChip,
+        PFChipGroup,
+        PFButton,
+        css`
+            ::slotted(*) {
+                margin: 0 2px;
+            }
+            .pf-c-chip-group {
+                margin-bottom: 8px;
+            }
+        `,
+    ];
 
     @property()
     name?: string;

--- a/web/src/elements/events/LogViewer.ts
+++ b/web/src/elements/events/LogViewer.ts
@@ -19,9 +19,7 @@ export class LogViewer extends Table<LogEvent> {
     expandable = true;
     paginated = false;
 
-    static get styles(): CSSResult[] {
-        return super.styles.concat(PFDescriptionList);
-    }
+    static styles: CSSResult[] = [...super.styles, PFDescriptionList];
 
     async apiEndpoint(): Promise<PaginatedResponse<LogEvent>> {
         return {

--- a/web/src/elements/forms/DeleteBulkForm.ts
+++ b/web/src/elements/forms/DeleteBulkForm.ts
@@ -34,9 +34,7 @@ export class DeleteObjectsTable<T> extends Table<T> {
     @state()
     usedByData: Map<T, UsedBy[]> = new Map();
 
-    static get styles(): CSSResult[] {
-        return super.styles.concat(PFList);
-    }
+    static styles: CSSResult[] = [...super.styles, PFList];
 
     async apiEndpoint(): Promise<PaginatedResponse<T>> {
         return Promise.resolve({

--- a/web/src/elements/forms/DeleteForm.ts
+++ b/web/src/elements/forms/DeleteForm.ts
@@ -16,9 +16,7 @@ import { UsedBy, UsedByActionEnum } from "@goauthentik/api";
 
 @customElement("ak-forms-delete")
 export class DeleteForm extends ModalButton {
-    static get styles(): CSSResult[] {
-        return super.styles.concat(PFList);
-    }
+    static styles: CSSResult[] = [...super.styles, PFList];
 
     @property({ attribute: false })
     obj?: Record<string, unknown>;

--- a/web/src/elements/forms/Form.ts
+++ b/web/src/elements/forms/Form.ts
@@ -165,23 +165,21 @@ export abstract class Form<T> extends AKElement {
     @state()
     nonFieldErrors?: string[];
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFCard,
-            PFButton,
-            PFForm,
-            PFAlert,
-            PFInputGroup,
-            PFFormControl,
-            PFSwitch,
-            css`
-                select[multiple] {
-                    height: 15em;
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFCard,
+        PFButton,
+        PFForm,
+        PFAlert,
+        PFInputGroup,
+        PFFormControl,
+        PFSwitch,
+        css`
+            select[multiple] {
+                height: 15em;
+            }
+        `,
+    ];
 
     /**
      * Called by the render function. Blocks rendering the form if the form is not within the

--- a/web/src/elements/forms/FormElement.ts
+++ b/web/src/elements/forms/FormElement.ts
@@ -18,9 +18,7 @@ import { ErrorDetail } from "@goauthentik/api";
 
 @customElement("ak-form-element")
 export class FormElement extends AKElement {
-    static get styles(): CSSResult[] {
-        return [PFBase, PFForm, PFFormControl];
-    }
+    static styles: CSSResult[] = [PFBase, PFForm, PFFormControl];
 
     @property()
     label?: string;

--- a/web/src/elements/forms/FormGroup.ts
+++ b/web/src/elements/forms/FormGroup.ts
@@ -26,52 +26,50 @@ export class FormGroup extends AKElement {
     @property({ type: String, attribute: "aria-label", reflect: true })
     ariaLabel = msg("Details");
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFForm,
-            PFButton,
-            PFFormControl,
-            css`
-                /**
+    static styles: CSSResult[] = [
+        PFBase,
+        PFForm,
+        PFButton,
+        PFFormControl,
+        css`
+            /**
                  * Workaround to trigger the hover effect on the button when the header is hovered.
                  *
                  * Alternatively, we group the expander button and header, but the grid would have to be
                  * restructured to allow for this.
                  */
-                .pf-c-form__field-group:has(.pf-c-form__field-group-header:hover) .pf-c-button {
-                    color: var(--pf-c-button--m-plain--hover--Color) !important;
-                }
+            .pf-c-form__field-group:has(.pf-c-form__field-group-header:hover) .pf-c-button {
+                color: var(--pf-c-button--m-plain--hover--Color) !important;
+            }
 
-                /**
+            /**
                  * Transition ensuring a smooth animation when the body is expanded/collapsed.
                  */
+            slot[name="body"] {
+                transition-behavior: allow-discrete;
+                transition-property: opacity, display, transform;
+                transition-duration: var(--pf-global--TransitionDuration);
+                transition-timing-function: var(--pf-global--TimingFunction);
+                display: block;
+                opacity: 1;
+                transform: scaleY(1);
+                transform-origin: top left;
+                will-change: opacity, display, transform;
+            }
+
+            slot[name="body"][hidden] {
+                opacity: 0 !important;
+                display: none !important;
+                transform: scaleY(0) !important;
+            }
+
+            @media (prefers-reduced-motion) {
                 slot[name="body"] {
-                    transition-behavior: allow-discrete;
-                    transition-property: opacity, display, transform;
-                    transition-duration: var(--pf-global--TransitionDuration);
-                    transition-timing-function: var(--pf-global--TimingFunction);
-                    display: block;
-                    opacity: 1;
-                    transform: scaleY(1);
-                    transform-origin: top left;
-                    will-change: opacity, display, transform;
+                    transition-duration: 0s;
                 }
-
-                slot[name="body"][hidden] {
-                    opacity: 0 !important;
-                    display: none !important;
-                    transform: scaleY(0) !important;
-                }
-
-                @media (prefers-reduced-motion) {
-                    slot[name="body"] {
-                        transition-duration: 0s;
-                    }
-                }
-            `,
-        ];
-    }
+            }
+        `,
+    ];
 
     formRef = createRef<HTMLFormElement>();
 

--- a/web/src/elements/forms/HorizontalFormElement.ts
+++ b/web/src/elements/forms/HorizontalFormElement.ts
@@ -49,24 +49,22 @@ const nameables = new Set([
 
 @customElement("ak-form-element-horizontal")
 export class HorizontalFormElement extends AKElement {
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFForm,
-            PFFormControl,
-            css`
-                .pf-c-form__group {
-                    display: grid;
-                    grid-template-columns:
-                        var(--pf-c-form--m-horizontal__group-label--md--GridColumnWidth)
-                        var(--pf-c-form--m-horizontal__group-control--md--GridColumnWidth);
-                }
-                .pf-c-form__group-label {
-                    padding-top: var(--pf-c-form--m-horizontal__group-label--md--PaddingTop);
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFForm,
+        PFFormControl,
+        css`
+            .pf-c-form__group {
+                display: grid;
+                grid-template-columns:
+                    var(--pf-c-form--m-horizontal__group-label--md--GridColumnWidth)
+                    var(--pf-c-form--m-horizontal__group-control--md--GridColumnWidth);
+            }
+            .pf-c-form__group-label {
+                padding-top: var(--pf-c-form--m-horizontal__group-label--md--PaddingTop);
+            }
+        `,
+    ];
 
     @property()
     label = "";

--- a/web/src/elements/forms/Radio.ts
+++ b/web/src/elements/forms/Radio.ts
@@ -32,24 +32,22 @@ export class Radio<T> extends CustomEmitterElement(AKElement) {
 
     internalId: string;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFRadio,
-            PFForm,
-            css`
-                .pf-c-form__group-control {
-                    padding-top: calc(
-                        var(--pf-c-form--m-horizontal__group-label--md--PaddingTop) * 1.3
-                    );
-                }
-                .pf-c-radio label,
-                .pf-c-radio span {
-                    user-select: none;
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFRadio,
+        PFForm,
+        css`
+            .pf-c-form__group-control {
+                padding-top: calc(
+                    var(--pf-c-form--m-horizontal__group-label--md--PaddingTop) * 1.3
+                );
+            }
+            .pf-c-radio label,
+            .pf-c-radio span {
+                user-select: none;
+            }
+        `,
+    ];
 
     constructor() {
         super();

--- a/web/src/elements/forms/SearchSelect/SearchSelect.ts
+++ b/web/src/elements/forms/SearchSelect/SearchSelect.ts
@@ -34,9 +34,7 @@ export interface ISearchSelectBase<T> {
 }
 
 export class SearchSelectBase<T> extends AkControlElement<string> implements ISearchSelectBase<T> {
-    static get styles() {
-        return [PFBase];
-    }
+    static styles = [PFBase];
 
     // A function which takes the query state object (accepting that it may be empty) and returns a
     // new collection of objects.

--- a/web/src/elements/forms/SearchSelect/ak-search-select-ez.ts
+++ b/web/src/elements/forms/SearchSelect/ak-search-select-ez.ts
@@ -45,9 +45,7 @@ export interface ISearchSelectEz<T> extends ISearchSelectBase<T> {
 
 @customElement("ak-search-select-ez")
 export class SearchSelectEz<T> extends SearchSelectBase<T> implements ISearchSelectEz<T> {
-    static get styles() {
-        return [...SearchSelectBase.styles];
-    }
+    static styles = [...SearchSelectBase.styles];
 
     @property({ type: Object, attribute: false })
     config!: ISearchSelectApi<T>;

--- a/web/src/elements/forms/SearchSelect/ak-search-select-loading-indicator.ts
+++ b/web/src/elements/forms/SearchSelect/ak-search-select-loading-indicator.ts
@@ -25,9 +25,7 @@ import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-search-select-loading-indicator")
 export class SearchSelectLoadingIndicator extends AKElement {
-    static get styles() {
-        return [PFBase, PFFormControl, PFSelect];
-    }
+    static styles = [PFBase, PFFormControl, PFSelect];
 
     connectedCallback() {
         super.connectedCallback();

--- a/web/src/elements/forms/SearchSelect/ak-search-select-view.ts
+++ b/web/src/elements/forms/SearchSelect/ak-search-select-view.ts
@@ -69,9 +69,7 @@ export interface ISearchSelectView {
  */
 @customElement("ak-search-select-view")
 export class SearchSelectView extends AKElement implements ISearchSelectView {
-    static get styles() {
-        return [PFBase, PFForm, PFFormControl, PFSelect];
-    }
+    static styles = [PFBase, PFForm, PFFormControl, PFSelect];
 
     /**
      * The options collection. The simplest variant is just [key, label, optional<description>]. See

--- a/web/src/elements/forms/SearchSelect/ak-search-select.ts
+++ b/web/src/elements/forms/SearchSelect/ak-search-select.ts
@@ -47,9 +47,7 @@ export interface ISearchSelect<T> extends ISearchSelectBase<T> {
 
 @customElement("ak-search-select")
 export class SearchSelect<T> extends SearchSelectBase<T> implements ISearchSelect<T> {
-    static get styles() {
-        return [...SearchSelectBase.styles];
-    }
+    static styles = [...SearchSelectBase.styles];
 
     // A function which takes the query state object (accepting that it may be empty) and returns a
     // new collection of objects.

--- a/web/src/elements/messages/Message.ts
+++ b/web/src/elements/messages/Message.ts
@@ -33,9 +33,7 @@ export class Message extends AKElement {
     @property({ attribute: false })
     onRemove?: (m: APIMessage) => void;
 
-    static get styles(): CSSResult[] {
-        return [PFBase, PFButton, PFAlert, PFAlertGroup];
-    }
+    static styles: CSSResult[] = [PFBase, PFButton, PFAlert, PFAlertGroup];
 
     firstUpdated(): void {
         setTimeout(() => {

--- a/web/src/elements/messages/MessageContainer.ts
+++ b/web/src/elements/messages/MessageContainer.ts
@@ -83,22 +83,20 @@ export class MessageContainer extends AKElement {
     @property()
     alignment: "top" | "bottom" = "top";
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFAlertGroup,
-            css`
-                /* Fix spacing between messages */
-                ak-message {
-                    display: block;
-                }
-                :host([alignment="bottom"]) .pf-c-alert-group.pf-m-toast {
-                    bottom: var(--pf-c-alert-group--m-toast--Top);
-                    top: unset;
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFAlertGroup,
+        css`
+            /* Fix spacing between messages */
+            ak-message {
+                display: block;
+            }
+            :host([alignment="bottom"]) .pf-c-alert-group.pf-m-toast {
+                bottom: var(--pf-c-alert-group--m-toast--Top);
+                top: unset;
+            }
+        `,
+    ];
 
     constructor() {
         super();

--- a/web/src/elements/notifications/APIDrawer.ts
+++ b/web/src/elements/notifications/APIDrawer.ts
@@ -19,39 +19,37 @@ export class APIDrawer extends AKElement {
     @property({ attribute: false })
     requests: RequestInfo[] = [];
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFNotificationDrawer,
-            PFButton,
-            PFContent,
-            PFDropdown,
-            css`
-                :host {
-                    --header-height: 114px;
-                }
-                .pf-c-notification-drawer__header {
-                    height: var(--header-height);
-                    align-items: center;
-                }
-                .pf-c-notification-drawer__header-action,
-                .pf-c-notification-drawer__header-action-close,
-                .pf-c-notification-drawer__header-action-close > .pf-c-button.pf-m-plain {
-                    height: 100%;
-                }
-                .pf-c-notification-drawer__list-item-description {
-                    white-space: pre-wrap;
-                    font-family: monospace;
-                }
-                .pf-c-notification-drawer__body {
-                    overflow-x: hidden;
-                }
-                .pf-c-notification-drawer__list {
-                    max-height: calc(100vh - var(--header-height));
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFNotificationDrawer,
+        PFButton,
+        PFContent,
+        PFDropdown,
+        css`
+            :host {
+                --header-height: 114px;
+            }
+            .pf-c-notification-drawer__header {
+                height: var(--header-height);
+                align-items: center;
+            }
+            .pf-c-notification-drawer__header-action,
+            .pf-c-notification-drawer__header-action-close,
+            .pf-c-notification-drawer__header-action-close > .pf-c-button.pf-m-plain {
+                height: 100%;
+            }
+            .pf-c-notification-drawer__list-item-description {
+                white-space: pre-wrap;
+                font-family: monospace;
+            }
+            .pf-c-notification-drawer__body {
+                overflow-x: hidden;
+            }
+            .pf-c-notification-drawer__list {
+                max-height: calc(100vh - var(--header-height));
+            }
+        `,
+    ];
 
     constructor() {
         super();

--- a/web/src/elements/notifications/NotificationDrawer.ts
+++ b/web/src/elements/notifications/NotificationDrawer.ts
@@ -31,8 +31,13 @@ export class NotificationDrawer extends AKElement {
     @property({ type: Number })
     unread = 0;
 
-    static get styles(): CSSResult[] {
-        return [PFBase, PFButton, PFNotificationDrawer, PFContent, PFDropdown].concat(css`
+    static styles: CSSResult[] = [
+        PFBase,
+        PFButton,
+        PFNotificationDrawer,
+        PFContent,
+        PFDropdown,
+        css`
             .pf-c-drawer__body {
                 height: 100%;
             }
@@ -52,8 +57,8 @@ export class NotificationDrawer extends AKElement {
             .pf-c-notification-drawer__list-item-description {
                 white-space: pre-wrap;
             }
-        `);
-    }
+        `,
+    ];
 
     firstUpdated(): void {
         me().then((user) => {

--- a/web/src/elements/oauth/UserAccessTokenList.ts
+++ b/web/src/elements/oauth/UserAccessTokenList.ts
@@ -22,9 +22,7 @@ export class UserOAuthAccessTokenList extends Table<TokenModel> {
     @property({ type: Number })
     userId?: number;
 
-    static get styles(): CSSResult[] {
-        return super.styles.concat(PFFlex);
-    }
+    static styles: CSSResult[] = [...super.styles, PFFlex];
 
     async apiEndpoint(): Promise<PaginatedResponse<TokenModel>> {
         return new Oauth2Api(DEFAULT_CONFIG).oauth2AccessTokensList({

--- a/web/src/elements/oauth/UserRefreshTokenList.ts
+++ b/web/src/elements/oauth/UserRefreshTokenList.ts
@@ -22,9 +22,7 @@ export class UserOAuthRefreshTokenList extends Table<TokenModel> {
     @property({ type: Number })
     userId?: number;
 
-    static get styles(): CSSResult[] {
-        return super.styles.concat(PFFlex);
-    }
+    static styles: CSSResult[] = [...super.styles, PFFlex];
 
     async apiEndpoint(): Promise<PaginatedResponse<TokenModel>> {
         return new Oauth2Api(DEFAULT_CONFIG).oauth2RefreshTokensList({

--- a/web/src/elements/router/Router404.ts
+++ b/web/src/elements/router/Router404.ts
@@ -13,9 +13,7 @@ export class Router404 extends AKElement {
     @property()
     url = "";
 
-    static get styles(): CSSResult[] {
-        return [PFBase, PFEmptyState, PFTitle];
-    }
+    static styles: CSSResult[] = [PFBase, PFEmptyState, PFTitle];
 
     render(): TemplateResult {
         return html`<div class="pf-c-empty-state pf-m-full-height">

--- a/web/src/elements/router/RouterOutlet.ts
+++ b/web/src/elements/router/RouterOutlet.ts
@@ -64,18 +64,16 @@ export class RouterOutlet extends AKElement {
     private sentryClient?: BrowserClient;
     private pageLoadSpan?: Span;
 
-    static get styles(): CSSResult[] {
-        return [
-            css`
-                :host {
-                    background-color: transparent !important;
-                }
-                *:first-child {
-                    flex-direction: column;
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        css`
+            :host {
+                background-color: transparent !important;
+            }
+            *:first-child {
+                flex-direction: column;
+            }
+        `,
+    ];
 
     constructor() {
         super();

--- a/web/src/elements/sidebar/Sidebar.ts
+++ b/web/src/elements/sidebar/Sidebar.ts
@@ -13,54 +13,52 @@ import { UiThemeEnum } from "@goauthentik/api";
 
 @customElement("ak-sidebar")
 export class Sidebar extends AKElement {
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFPage,
-            PFNav,
-            css`
-                :host {
-                    z-index: 100;
-                    --pf-c-page__sidebar--Transition: 0 !important;
-                }
-                .pf-c-nav__link.pf-m-current::after,
-                .pf-c-nav__link.pf-m-current:hover::after,
-                .pf-c-nav__item.pf-m-current:not(.pf-m-expanded) .pf-c-nav__link::after {
-                    --pf-c-nav__link--m-current--after--BorderColor: #fd4b2d;
-                }
-                :host([theme="light"]) {
-                    border-right-color: transparent !important;
-                }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFPage,
+        PFNav,
+        css`
+            :host {
+                z-index: 100;
+                --pf-c-page__sidebar--Transition: 0 !important;
+            }
+            .pf-c-nav__link.pf-m-current::after,
+            .pf-c-nav__link.pf-m-current:hover::after,
+            .pf-c-nav__item.pf-m-current:not(.pf-m-expanded) .pf-c-nav__link::after {
+                --pf-c-nav__link--m-current--after--BorderColor: #fd4b2d;
+            }
+            :host([theme="light"]) {
+                border-right-color: transparent !important;
+            }
 
-                .pf-c-nav__section + .pf-c-nav__section {
-                    --pf-c-nav__section--section--MarginTop: var(--pf-global--spacer--sm);
-                }
+            .pf-c-nav__section + .pf-c-nav__section {
+                --pf-c-nav__section--section--MarginTop: var(--pf-global--spacer--sm);
+            }
 
-                nav {
-                    display: flex;
-                    flex-direction: column;
-                    height: 100%;
-                    overflow-y: hidden;
-                }
-                .pf-c-nav__list {
-                    flex-grow: 1;
-                    overflow-y: auto;
-                }
+            nav {
+                display: flex;
+                flex-direction: column;
+                height: 100%;
+                overflow-y: hidden;
+            }
+            .pf-c-nav__list {
+                flex-grow: 1;
+                overflow-y: auto;
+            }
 
-                .pf-c-nav__link {
-                    --pf-c-nav__link--PaddingTop: 0.5rem;
-                    --pf-c-nav__link--PaddingRight: 0.5rem;
-                    --pf-c-nav__link--PaddingBottom: 0.5rem;
-                }
-                .pf-c-nav__section-title {
-                    font-size: 12px;
-                }
-                .pf-c-nav__item {
-                    --pf-c-nav__item--MarginTop: 0px;
-                }
-            `,
-        ];
-    }
+            .pf-c-nav__link {
+                --pf-c-nav__link--PaddingTop: 0.5rem;
+                --pf-c-nav__link--PaddingRight: 0.5rem;
+                --pf-c-nav__link--PaddingBottom: 0.5rem;
+            }
+            .pf-c-nav__section-title {
+                font-size: 12px;
+            }
+            .pf-c-nav__item {
+                --pf-c-nav__item--MarginTop: 0px;
+            }
+        `,
+    ];
 
     render(): TemplateResult {
         return html`<nav

--- a/web/src/elements/sidebar/SidebarItem.ts
+++ b/web/src/elements/sidebar/SidebarItem.ts
@@ -11,62 +11,60 @@ import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-sidebar-item")
 export class SidebarItem extends AKElement {
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFPage,
-            PFNav,
-            css`
-                :host {
-                    z-index: 100;
-                    box-shadow: none !important;
-                }
-                :host([highlight]) .pf-c-nav__item {
-                    background-color: var(--ak-accent);
-                    margin: 16px;
-                }
-                :host([highlight]) .pf-c-nav__item .pf-c-nav__link {
-                    padding-left: 0.5rem;
-                }
-                .pf-c-nav__link.pf-m-current::after,
-                .pf-c-nav__link.pf-m-current:hover::after,
-                .pf-c-nav__item.pf-m-current:not(.pf-m-expanded) .pf-c-nav__link::after {
-                    --pf-c-nav__link--m-current--after--BorderColor: #fd4b2d;
-                }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFPage,
+        PFNav,
+        css`
+            :host {
+                z-index: 100;
+                box-shadow: none !important;
+            }
+            :host([highlight]) .pf-c-nav__item {
+                background-color: var(--ak-accent);
+                margin: 16px;
+            }
+            :host([highlight]) .pf-c-nav__item .pf-c-nav__link {
+                padding-left: 0.5rem;
+            }
+            .pf-c-nav__link.pf-m-current::after,
+            .pf-c-nav__link.pf-m-current:hover::after,
+            .pf-c-nav__item.pf-m-current:not(.pf-m-expanded) .pf-c-nav__link::after {
+                --pf-c-nav__link--m-current--after--BorderColor: #fd4b2d;
+            }
 
-                .pf-c-nav__section + .pf-c-nav__section {
-                    --pf-c-nav__section--section--MarginTop: var(--pf-global--spacer--sm);
-                }
-                .pf-c-nav__list .sidebar-brand {
-                    max-height: 82px;
-                    margin-bottom: -0.5rem;
-                }
-                nav {
-                    display: flex;
-                    flex-direction: column;
-                    max-height: 100vh;
-                    height: 100%;
-                    overflow-y: hidden;
-                }
-                .pf-c-nav__list {
-                    flex-grow: 1;
-                    overflow-y: auto;
-                }
+            .pf-c-nav__section + .pf-c-nav__section {
+                --pf-c-nav__section--section--MarginTop: var(--pf-global--spacer--sm);
+            }
+            .pf-c-nav__list .sidebar-brand {
+                max-height: 82px;
+                margin-bottom: -0.5rem;
+            }
+            nav {
+                display: flex;
+                flex-direction: column;
+                max-height: 100vh;
+                height: 100%;
+                overflow-y: hidden;
+            }
+            .pf-c-nav__list {
+                flex-grow: 1;
+                overflow-y: auto;
+            }
 
-                .pf-c-nav__link {
-                    --pf-c-nav__link--PaddingTop: 0.5rem;
-                    --pf-c-nav__link--PaddingRight: 0.5rem;
-                    --pf-c-nav__link--PaddingBottom: 0.5rem;
-                }
-                .pf-c-nav__section-title {
-                    font-size: 12px;
-                }
-                .pf-c-nav__item {
-                    --pf-c-nav__item--MarginTop: 0px;
-                }
-            `,
-        ];
-    }
+            .pf-c-nav__link {
+                --pf-c-nav__link--PaddingTop: 0.5rem;
+                --pf-c-nav__link--PaddingRight: 0.5rem;
+                --pf-c-nav__link--PaddingBottom: 0.5rem;
+            }
+            .pf-c-nav__section-title {
+                font-size: 12px;
+            }
+            .pf-c-nav__item {
+                --pf-c-nav__item--MarginTop: 0px;
+            }
+        `,
+    ];
 
     @property()
     path?: string;

--- a/web/src/elements/sidebar/SidebarVersion.ts
+++ b/web/src/elements/sidebar/SidebarVersion.ts
@@ -19,28 +19,26 @@ import { LicenseSummaryStatusEnum } from "@goauthentik/api";
 
 @customElement("ak-sidebar-version")
 export class SidebarVersion extends WithLicenseSummary(WithVersion(AKElement)) {
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFNav,
-            PFAvatar,
-            PFButton,
-            css`
-                :host {
-                    display: flex;
-                    width: 100%;
-                    flex-direction: column;
-                    justify-content: space-between;
-                    padding: 1rem !important;
-                }
-                p {
-                    text-align: center;
-                    width: 100%;
-                    font-size: var(--pf-global--FontSize--xs);
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFNav,
+        PFAvatar,
+        PFButton,
+        css`
+            :host {
+                display: flex;
+                width: 100%;
+                flex-direction: column;
+                justify-content: space-between;
+                padding: 1rem !important;
+            }
+            p {
+                text-align: center;
+                width: 100%;
+                font-size: var(--pf-global--FontSize--xs);
+            }
+        `,
+    ];
 
     render() {
         if (!this.version || !this.licenseSummary) {

--- a/web/src/elements/sync/SyncStatusCard.ts
+++ b/web/src/elements/sync/SyncStatusCard.ts
@@ -25,14 +25,15 @@ export class SyncStatusTable extends Table<SystemTask> {
 
     expandable = true;
 
-    static get styles() {
-        return super.styles.concat(css`
+    static styles = [
+        ...super.styles,
+        css`
             code:not(:last-of-type)::after {
                 content: "-";
                 margin: 0 0.25rem;
             }
-        `);
-    }
+        `,
+    ];
 
     async apiEndpoint(): Promise<PaginatedResponse<SystemTask>> {
         if (this.tasks.length === 1) {
@@ -107,9 +108,7 @@ export class SyncStatusCard extends AKElement {
     @property({ attribute: false })
     triggerSync!: () => Promise<unknown>;
 
-    static get styles(): CSSResult[] {
-        return [PFBase, PFButton, PFCard, PFTable];
-    }
+    static styles: CSSResult[] = [PFBase, PFButton, PFCard, PFTable];
 
     firstUpdated() {
         this.loading = true;

--- a/web/src/elements/table/Table.ts
+++ b/web/src/elements/table/Table.ts
@@ -178,44 +178,42 @@ export abstract class Table<T> extends WithLicenseSummary(AKElement) implements 
     @state()
     error?: APIError;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFTable,
-            PFBullseye,
-            PFButton,
-            PFSwitch,
-            PFToolbar,
-            PFDropdown,
-            PFPagination,
-            css`
-                .pf-c-toolbar__group.pf-m-search-filter.ql {
-                    flex-grow: 1;
-                }
-                ak-table-search.ql {
-                    width: 100% !important;
-                }
-                .pf-c-table thead .pf-c-table__check {
-                    min-width: 3rem;
-                }
-                .pf-c-table tbody .pf-c-table__check input {
-                    margin-top: calc(var(--pf-c-table__check--input--MarginTop) + 1px);
-                }
-                .pf-c-toolbar__content {
-                    row-gap: var(--pf-global--spacer--sm);
-                }
-                .pf-c-toolbar__item .pf-c-input-group {
-                    padding: 0 var(--pf-global--spacer--sm);
-                }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFTable,
+        PFBullseye,
+        PFButton,
+        PFSwitch,
+        PFToolbar,
+        PFDropdown,
+        PFPagination,
+        css`
+            .pf-c-toolbar__group.pf-m-search-filter.ql {
+                flex-grow: 1;
+            }
+            ak-table-search.ql {
+                width: 100% !important;
+            }
+            .pf-c-table thead .pf-c-table__check {
+                min-width: 3rem;
+            }
+            .pf-c-table tbody .pf-c-table__check input {
+                margin-top: calc(var(--pf-c-table__check--input--MarginTop) + 1px);
+            }
+            .pf-c-toolbar__content {
+                row-gap: var(--pf-global--spacer--sm);
+            }
+            .pf-c-toolbar__item .pf-c-input-group {
+                padding: 0 var(--pf-global--spacer--sm);
+            }
 
-                .pf-c-table {
-                    --pf-c-table--m-striped__tr--BackgroundColor: var(
-                        --pf-global--BackgroundColor--dark-300
-                    );
-                }
-            `,
-        ];
-    }
+            .pf-c-table {
+                --pf-c-table--m-striped__tr--BackgroundColor: var(
+                    --pf-global--BackgroundColor--dark-300
+                );
+            }
+        `,
+    ];
 
     constructor() {
         super();

--- a/web/src/elements/table/TableModal.ts
+++ b/web/src/elements/table/TableModal.ts
@@ -34,17 +34,16 @@ export abstract class TableModal<T> extends Table<T> {
 
     _open = false;
 
-    static get styles(): CSSResult[] {
-        return super.styles.concat(
-            PFModalBox,
-            PFBullseye,
-            PFContent,
-            PFBackdrop,
-            PFPage,
-            PFStack,
-            MODAL_BUTTON_STYLES,
-        );
-    }
+    static styles: CSSResult[] = [
+        ...super.styles,
+        PFModalBox,
+        PFBullseye,
+        PFContent,
+        PFBackdrop,
+        PFPage,
+        PFStack,
+        MODAL_BUTTON_STYLES,
+    ];
 
     public async fetch(): Promise<void> {
         if (!this.open) {

--- a/web/src/elements/table/TablePage.ts
+++ b/web/src/elements/table/TablePage.ts
@@ -16,9 +16,7 @@ export abstract class TablePage<T> extends Table<T> {
     abstract pageDescription(): string | undefined;
     abstract pageIcon(): string;
 
-    static get styles(): CSSResult[] {
-        return super.styles.concat(PFPage, PFContent, PFSidebar);
-    }
+    static styles: CSSResult[] = [...super.styles, PFPage, PFContent, PFSidebar];
 
     renderSidebarBefore(): TemplateResult {
         return html``;

--- a/web/src/elements/table/TablePagination.ts
+++ b/web/src/elements/table/TablePagination.ts
@@ -20,22 +20,20 @@ export class TablePagination extends AKElement {
         return;
     };
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFButton,
-            PFPagination,
-            css`
-                :host([theme="dark"]) .pf-c-pagination__nav-control .pf-c-button {
-                    color: var(--pf-c-button--m-plain--disabled--Color);
-                    --pf-c-button--disabled--Color: var(--pf-c-button--m-plain--Color);
-                }
-                :host([theme="dark"]) .pf-c-pagination__nav-control .pf-c-button:disabled {
-                    color: var(--pf-c-button--disabled--Color);
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFButton,
+        PFPagination,
+        css`
+            :host([theme="dark"]) .pf-c-pagination__nav-control .pf-c-button {
+                color: var(--pf-c-button--m-plain--disabled--Color);
+                --pf-c-button--disabled--Color: var(--pf-c-button--m-plain--Color);
+            }
+            :host([theme="dark"]) .pf-c-pagination__nav-control .pf-c-button:disabled {
+                color: var(--pf-c-button--disabled--Color);
+            }
+        `,
+    ];
 
     render(): TemplateResult {
         if (!this.pages) {

--- a/web/src/elements/table/TableSearch.ts
+++ b/web/src/elements/table/TableSearch.ts
@@ -30,23 +30,21 @@ export class TableSearch extends WithLicenseSummary(AKElement) {
     @property()
     onSearch?: (value: string) => void;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFButton,
-            PFToolbar,
-            PFInputGroup,
-            PFFormControl,
-            css`
-                ::-webkit-search-cancel-button {
-                    display: none;
-                }
-                ak-search-ql {
-                    width: 100%;
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFButton,
+        PFToolbar,
+        PFInputGroup,
+        PFFormControl,
+        css`
+            ::-webkit-search-cancel-button {
+                display: none;
+            }
+            ak-search-ql {
+                width: 100%;
+            }
+        `,
+    ];
 
     renderInput(): TemplateResult {
         if (

--- a/web/src/elements/user/sources/BaseUserSettings.ts
+++ b/web/src/elements/user/sources/BaseUserSettings.ts
@@ -15,7 +15,5 @@ export abstract class BaseUserSettings extends AKElement {
     @property()
     configureUrl?: string;
 
-    static get styles(): CSSResult[] {
-        return [PFBase, PFButton, PFForm, PFFormControl];
-    }
+    static styles: CSSResult[] = [PFBase, PFButton, PFForm, PFFormControl];
 }

--- a/web/src/elements/user/sources/SourceSettings.ts
+++ b/web/src/elements/user/sources/SourceSettings.ts
@@ -29,28 +29,26 @@ export class UserSourceSettingsPage extends AKElement {
     @property({ type: Boolean })
     canConnect = true;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFDataList,
-            css`
-                .pf-c-data-list__cell {
-                    display: flex;
-                    align-items: center;
-                }
-                .pf-c-data-list__cell img {
-                    max-width: 48px;
-                    width: 48px;
-                    margin-right: 16px;
-                }
-                :host([theme="dark"]) .pf-c-data-list__cell img {
-                    filter: invert(1);
-                }
-                .pf-c-data-list__item {
-                    background-color: transparent;
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFDataList,
+        css`
+            .pf-c-data-list__cell {
+                display: flex;
+                align-items: center;
+            }
+            .pf-c-data-list__cell img {
+                max-width: 48px;
+                width: 48px;
+                margin-right: 16px;
+            }
+            :host([theme="dark"]) .pf-c-data-list__cell img {
+                filter: invert(1);
+            }
+            .pf-c-data-list__item {
+                background-color: transparent;
+            }
+        `,
+    ];
 
     constructor() {
         super();

--- a/web/src/elements/utils/TimeDeltaHelp.ts
+++ b/web/src/elements/utils/TimeDeltaHelp.ts
@@ -14,9 +14,7 @@ export class TimeDeltaHelp extends AKElement {
     @property({ type: Boolean })
     negative = false;
 
-    static get styles(): CSSResult[] {
-        return [PFBase, PFForm, PFList];
-    }
+    static styles: CSSResult[] = [PFBase, PFForm, PFList];
 
     render(): TemplateResult {
         return html`<div class="pf-c-form__helper-text">

--- a/web/src/elements/wizard/ActionWizardPage.ts
+++ b/web/src/elements/wizard/ActionWizardPage.ts
@@ -29,9 +29,7 @@ export interface ActionStateBundle {
 
 @customElement("ak-wizard-page-action")
 export class ActionWizardPage extends WizardPage {
-    static get styles(): CSSResult[] {
-        return [PFBase, PFBullseye, PFEmptyState, PFTitle, PFProgressStepper];
-    }
+    static styles: CSSResult[] = [PFBase, PFBullseye, PFEmptyState, PFTitle, PFProgressStepper];
 
     @property({ attribute: false })
     states: ActionStateBundle[] = [];

--- a/web/src/elements/wizard/TypeCreateWizardPage.ts
+++ b/web/src/elements/wizard/TypeCreateWizardPage.ts
@@ -35,24 +35,22 @@ export class TypeCreateWizardPage extends WithLicenseSummary(WizardPage) {
 
     //#endregion
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFForm,
-            PFGrid,
-            PFRadio,
-            PFCard,
-            css`
-                .pf-c-card__header-main img {
-                    max-height: 2em;
-                    min-height: 2em;
-                }
-                :host([theme="dark"]) .pf-c-card__header-main img {
-                    filter: invert(1);
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFForm,
+        PFGrid,
+        PFRadio,
+        PFCard,
+        css`
+            .pf-c-card__header-main img {
+                max-height: 2em;
+                min-height: 2em;
+            }
+            :host([theme="dark"]) .pf-c-card__header-main img {
+                filter: invert(1);
+            }
+        `,
+    ];
 
     //#region Refs
 

--- a/web/src/elements/wizard/Wizard.ts
+++ b/web/src/elements/wizard/Wizard.ts
@@ -21,16 +21,15 @@ export const ApplyActionsSlot = "apply-actions";
 
 @customElement("ak-wizard")
 export class Wizard extends ModalButton {
-    static get styles(): CSSResult[] {
-        return super.styles.concat(
-            PFWizard,
-            css`
-                .pf-c-modal-box {
-                    height: 75%;
-                }
-            `,
-        );
-    }
+    static styles: CSSResult[] = [
+        ...super.styles,
+        PFWizard,
+        css`
+            .pf-c-modal-box {
+                height: 75%;
+            }
+        `,
+    ];
 
     //#region Properties
 

--- a/web/src/elements/wizard/WizardFormPage.ts
+++ b/web/src/elements/wizard/WizardFormPage.ts
@@ -33,9 +33,15 @@ export abstract class WizardForm extends Form<KeyUnknown> {
 }
 
 export class WizardFormPage extends WizardPage {
-    static get styles(): CSSResult[] {
-        return [PFBase, PFCard, PFButton, PFForm, PFAlert, PFInputGroup, PFFormControl];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFCard,
+        PFButton,
+        PFForm,
+        PFAlert,
+        PFInputGroup,
+        PFFormControl,
+    ];
 
     inputCallback(): void {
         const form = this.shadowRoot?.querySelector<HTMLFormElement>("form");

--- a/web/src/elements/wizard/WizardPage.ts
+++ b/web/src/elements/wizard/WizardPage.ts
@@ -20,9 +20,7 @@ export type WizardPageNextCallback = () => boolean | Promise<boolean>;
 
 @customElement("ak-wizard-page")
 export class WizardPage extends AKElement {
-    static get styles(): CSSResult[] {
-        return [PFBase];
-    }
+    static styles: CSSResult[] = [PFBase];
 
     /**
      * The label to display in the sidebar for this page.

--- a/web/src/flow/FlowExecutor.ts
+++ b/web/src/flow/FlowExecutor.ts
@@ -88,8 +88,15 @@ export class FlowExecutor
 
     ws: WebsocketClient;
 
-    static get styles(): CSSResult[] {
-        return [PFBase, PFLogin, PFDrawer, PFButton, PFTitle, PFList, PFBackgroundImage].concat(css`
+    static styles: CSSResult[] = [
+        PFBase,
+        PFLogin,
+        PFDrawer,
+        PFButton,
+        PFTitle,
+        PFList,
+        PFBackgroundImage,
+        css`
             :host {
                 --pf-c-login__main-body--PaddingBottom: var(--pf-global--spacer--2xl);
             }
@@ -172,8 +179,8 @@ export class FlowExecutor
                 right: 1rem;
                 z-index: 100;
             }
-        `);
-    }
+        `,
+    ];
 
     constructor() {
         configureSentry();

--- a/web/src/flow/FlowInspector.ts
+++ b/web/src/flow/FlowInspector.ts
@@ -34,31 +34,29 @@ export class FlowInspector extends AKElement {
     @property({ attribute: false })
     error?: APIError;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFButton,
-            PFStack,
-            PFCard,
-            PFNotificationDrawer,
-            PFDescriptionList,
-            PFProgressStepper,
-            css`
-                .pf-c-drawer__body {
-                    min-height: 100vh;
-                    max-height: 100vh;
-                }
-                code.break {
-                    word-break: break-all;
-                }
-                pre {
-                    word-break: break-all;
-                    overflow-x: hidden;
-                    white-space: break-spaces;
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFButton,
+        PFStack,
+        PFCard,
+        PFNotificationDrawer,
+        PFDescriptionList,
+        PFProgressStepper,
+        css`
+            .pf-c-drawer__body {
+                min-height: 100vh;
+                max-height: 100vh;
+            }
+            code.break {
+                word-break: break-all;
+            }
+            pre {
+                word-break: break-all;
+                overflow-x: hidden;
+                white-space: break-spaces;
+            }
+        `,
+    ];
 
     constructor() {
         super();

--- a/web/src/flow/FormStatic.ts
+++ b/web/src/flow/FormStatic.ts
@@ -15,32 +15,30 @@ export class FormStatic extends AKElement {
     @property()
     user?: string;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFAvatar,
-            css`
-                /* Form with user */
-                .form-control-static {
-                    margin-top: var(--pf-global--spacer--sm);
-                    display: flex;
-                    align-items: center;
-                    justify-content: space-between;
-                }
-                .form-control-static .avatar {
-                    display: flex;
-                    align-items: center;
-                }
-                .form-control-static img {
-                    margin-right: var(--pf-global--spacer--xs);
-                }
-                .form-control-static a {
-                    padding-top: var(--pf-global--spacer--xs);
-                    padding-bottom: var(--pf-global--spacer--xs);
-                    line-height: var(--pf-global--spacer--xl);
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFAvatar,
+        css`
+            /* Form with user */
+            .form-control-static {
+                margin-top: var(--pf-global--spacer--sm);
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+            }
+            .form-control-static .avatar {
+                display: flex;
+                align-items: center;
+            }
+            .form-control-static img {
+                margin-right: var(--pf-global--spacer--xs);
+            }
+            .form-control-static a {
+                padding-top: var(--pf-global--spacer--xs);
+                padding-bottom: var(--pf-global--spacer--xs);
+                line-height: var(--pf-global--spacer--xl);
+            }
+        `,
+    ];
 
     render() {
         if (!this.user) {

--- a/web/src/flow/components/ak-brand-footer.ts
+++ b/web/src/flow/components/ak-brand-footer.ts
@@ -23,9 +23,7 @@ const styles = css`
 
 @customElement("ak-brand-links")
 export class BrandLinks extends AKElement {
-    static get styles() {
-        return [PFBase, PFList, styles];
-    }
+    static styles = [PFBase, PFList, styles];
 
     @property({ type: Array, attribute: false })
     links: FooterLink[] = [];

--- a/web/src/flow/components/ak-flow-card.ts
+++ b/web/src/flow/components/ak-flow-card.ts
@@ -27,31 +27,29 @@ export class FlowCard extends AKElement {
     @property({ type: Boolean })
     loading = false;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFLogin,
-            PFTitle,
-            css`
-                slot[name="footer"],
-                slot[name="footer-band"] {
-                    display: flex;
-                    flex-wrap: wrap;
-                    justify-content: center;
-                    flex-basis: 100%;
-                }
-                slot[name="footer-band"] {
-                    text-align: center;
-                    background-color: var(--pf-c-login__main-footer-band--BackgroundColor);
-                    padding: 0;
-                    margin-top: 1em;
-                }
-                .pf-c-login__main-body:last-child {
-                    padding-bottom: calc(var(--pf-c-login__main-header--PaddingTop) * 1.2);
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFLogin,
+        PFTitle,
+        css`
+            slot[name="footer"],
+            slot[name="footer-band"] {
+                display: flex;
+                flex-wrap: wrap;
+                justify-content: center;
+                flex-basis: 100%;
+            }
+            slot[name="footer-band"] {
+                text-align: center;
+                background-color: var(--pf-c-login__main-footer-band--BackgroundColor);
+                padding: 0;
+                margin-top: 1em;
+            }
+            .pf-c-login__main-body:last-child {
+                padding-bottom: calc(var(--pf-c-login__main-header--PaddingTop) * 1.2);
+            }
+        `,
+    ];
 
     render() {
         let inner = html`<slot></slot>`;

--- a/web/src/flow/components/ak-flow-password-input.ts
+++ b/web/src/flow/components/ak-flow-password-input.ts
@@ -39,9 +39,7 @@ const Visibility = {
 
 @customElement("ak-flow-input-password")
 export class InputPassword extends AKElement {
-    static get styles() {
-        return [PFBase, PFInputGroup, PFFormControl, PFButton];
-    }
+    static styles = [PFBase, PFInputGroup, PFFormControl, PFButton];
 
     //#region Properties
 

--- a/web/src/flow/providers/SessionEnd.ts
+++ b/web/src/flow/providers/SessionEnd.ts
@@ -19,9 +19,7 @@ import { SessionEndChallenge } from "@goauthentik/api";
 
 @customElement("ak-stage-session-end")
 export class SessionEnd extends BaseStage<SessionEndChallenge, unknown> {
-    static get styles(): CSSResult[] {
-        return [PFBase, PFLogin, PFForm, PFFormControl, PFTitle, PFButton];
-    }
+    static styles: CSSResult[] = [PFBase, PFLogin, PFForm, PFFormControl, PFTitle, PFButton];
 
     render(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>

--- a/web/src/flow/providers/oauth2/DeviceCode.ts
+++ b/web/src/flow/providers/oauth2/DeviceCode.ts
@@ -24,9 +24,7 @@ export class OAuth2DeviceCode extends BaseStage<
     OAuthDeviceCodeChallenge,
     OAuthDeviceCodeChallengeResponseRequest
 > {
-    static get styles(): CSSResult[] {
-        return [PFBase, PFLogin, PFForm, PFFormControl, PFTitle, PFButton];
-    }
+    static styles: CSSResult[] = [PFBase, PFLogin, PFForm, PFFormControl, PFTitle, PFButton];
 
     render(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>

--- a/web/src/flow/sources/apple/AppleLoginInit.ts
+++ b/web/src/flow/sources/apple/AppleLoginInit.ts
@@ -19,9 +19,7 @@ export class AppleLoginInit extends BaseStage<AppleLoginChallenge, AppleChalleng
     @property({ type: Boolean })
     isModalShown = false;
 
-    static get styles(): CSSResult[] {
-        return [PFBase, PFLogin, PFForm, PFFormControl, PFButton, PFTitle];
-    }
+    static styles: CSSResult[] = [PFBase, PFLogin, PFForm, PFFormControl, PFButton, PFTitle];
 
     firstUpdated(): void {
         const appleAuth = document.createElement("script");

--- a/web/src/flow/sources/plex/PlexLoginInit.ts
+++ b/web/src/flow/sources/plex/PlexLoginInit.ts
@@ -33,9 +33,15 @@ export class PlexLoginInit extends BaseStage<
     @state()
     authUrl?: string;
 
-    static get styles(): CSSResult[] {
-        return [PFBase, PFLogin, PFForm, PFFormControl, PFButton, PFTitle, PFDivider];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFLogin,
+        PFForm,
+        PFFormControl,
+        PFButton,
+        PFTitle,
+        PFDivider,
+    ];
 
     async firstUpdated(): Promise<void> {
         const authInfo = await PlexAPIClient.getPin(this.challenge?.clientId || "");

--- a/web/src/flow/stages/FlowErrorStage.ts
+++ b/web/src/flow/stages/FlowErrorStage.ts
@@ -17,25 +17,23 @@ import { FlowChallengeResponseRequest, FlowErrorChallenge } from "@goauthentik/a
 
 @customElement("ak-stage-flow-error")
 export class FlowErrorStage extends BaseStage<FlowErrorChallenge, FlowChallengeResponseRequest> {
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFLogin,
-            PFForm,
-            PFFormControl,
-            PFTitle,
-            css`
-                pre {
-                    overflow-x: scroll;
-                    max-width: calc(
-                        35rem - var(--pf-c-login__main-body--PaddingRight) - var(
-                                --pf-c-login__main-body--PaddingRight
-                            )
-                    );
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFLogin,
+        PFForm,
+        PFFormControl,
+        PFTitle,
+        css`
+            pre {
+                overflow-x: scroll;
+                max-width: calc(
+                    35rem - var(--pf-c-login__main-body--PaddingRight) - var(
+                            --pf-c-login__main-body--PaddingRight
+                        )
+                );
+            }
+        `,
+    ];
 
     render(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>

--- a/web/src/flow/stages/FlowFrameStage.ts
+++ b/web/src/flow/stages/FlowFrameStage.ts
@@ -16,9 +16,7 @@ import { FrameChallenge, FrameChallengeResponseRequest } from "@goauthentik/api"
 
 @customElement("xak-flow-frame")
 export class FlowFrameStage extends BaseStage<FrameChallenge, FrameChallengeResponseRequest> {
-    static get styles(): CSSResult[] {
-        return [PFBase, PFLogin, PFForm, PFFormControl, PFTitle, css``];
-    }
+    static styles: CSSResult[] = [PFBase, PFLogin, PFForm, PFFormControl, PFTitle, css``];
 
     render(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>

--- a/web/src/flow/stages/RedirectStage.ts
+++ b/web/src/flow/stages/RedirectStage.ts
@@ -22,21 +22,19 @@ export class RedirectStage extends BaseStage<RedirectChallenge, FlowChallengeRes
     @state()
     startedRedirect = false;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFLogin,
-            PFForm,
-            PFButton,
-            PFFormControl,
-            PFTitle,
-            css`
-                code {
-                    word-break: break-all;
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFLogin,
+        PFForm,
+        PFButton,
+        PFFormControl,
+        PFTitle,
+        css`
+            code {
+                word-break: break-all;
+            }
+        `,
+    ];
 
     getURL(): string {
         return new URL(this.challenge.to, document.baseURI).toString();

--- a/web/src/flow/stages/access_denied/AccessDeniedStage.ts
+++ b/web/src/flow/stages/access_denied/AccessDeniedStage.ts
@@ -20,9 +20,7 @@ export class AccessDeniedStage extends BaseStage<
     AccessDeniedChallenge,
     FlowChallengeResponseRequest
 > {
-    static get styles(): CSSResult[] {
-        return [PFBase, PFLogin, PFForm, PFTitle, PFFormControl];
-    }
+    static styles: CSSResult[] = [PFBase, PFLogin, PFForm, PFTitle, PFFormControl];
 
     render(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>

--- a/web/src/flow/stages/authenticator_duo/AuthenticatorDuoStage.ts
+++ b/web/src/flow/stages/authenticator_duo/AuthenticatorDuoStage.ts
@@ -28,9 +28,7 @@ export class AuthenticatorDuoStage extends BaseStage<
     AuthenticatorDuoChallenge,
     AuthenticatorDuoChallengeResponseRequest
 > {
-    static get styles(): CSSResult[] {
-        return [PFBase, PFLogin, PFForm, PFFormControl, PFTitle, PFButton];
-    }
+    static styles: CSSResult[] = [PFBase, PFLogin, PFForm, PFFormControl, PFTitle, PFButton];
 
     updated(changedProperties: PropertyValues<this>) {
         if (changedProperties.has("challenge") && this.challenge !== undefined) {

--- a/web/src/flow/stages/authenticator_email/AuthenticatorEmailStage.ts
+++ b/web/src/flow/stages/authenticator_email/AuthenticatorEmailStage.ts
@@ -26,9 +26,15 @@ export class AuthenticatorEmailStage extends BaseStage<
     AuthenticatorEmailChallenge,
     AuthenticatorEmailChallengeResponseRequest
 > {
-    static get styles(): CSSResult[] {
-        return [PFBase, PFAlert, PFLogin, PFForm, PFFormControl, PFTitle, PFButton];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFAlert,
+        PFLogin,
+        PFForm,
+        PFFormControl,
+        PFTitle,
+        PFButton,
+    ];
 
     renderEmailInput(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>

--- a/web/src/flow/stages/authenticator_sms/AuthenticatorSMSStage.ts
+++ b/web/src/flow/stages/authenticator_sms/AuthenticatorSMSStage.ts
@@ -26,9 +26,15 @@ export class AuthenticatorSMSStage extends BaseStage<
     AuthenticatorSMSChallenge,
     AuthenticatorSMSChallengeResponseRequest
 > {
-    static get styles(): CSSResult[] {
-        return [PFBase, PFAlert, PFLogin, PFForm, PFFormControl, PFTitle, PFButton];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFAlert,
+        PFLogin,
+        PFForm,
+        PFFormControl,
+        PFTitle,
+        PFButton,
+    ];
 
     renderPhoneNumber(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>

--- a/web/src/flow/stages/authenticator_static/AuthenticatorStaticStage.ts
+++ b/web/src/flow/stages/authenticator_static/AuthenticatorStaticStage.ts
@@ -25,31 +25,29 @@ export class AuthenticatorStaticStage extends BaseStage<
     AuthenticatorStaticChallenge,
     AuthenticatorStaticChallengeResponseRequest
 > {
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFLogin,
-            PFForm,
-            PFFormControl,
-            PFTitle,
-            PFButton,
-            css`
-                /* Static OTP Tokens */
-                ul {
-                    list-style: circle;
-                    columns: 2;
-                    -webkit-columns: 2;
-                    -moz-columns: 2;
-                    column-width: 1em;
-                    margin-left: var(--pf-global--spacer--xs);
-                }
-                ul li {
-                    font-size: var(--pf-global--FontSize--2xl);
-                    margin: 0 2rem;
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFLogin,
+        PFForm,
+        PFFormControl,
+        PFTitle,
+        PFButton,
+        css`
+            /* Static OTP Tokens */
+            ul {
+                list-style: circle;
+                columns: 2;
+                -webkit-columns: 2;
+                -moz-columns: 2;
+                column-width: 1em;
+                margin-left: var(--pf-global--spacer--xs);
+            }
+            ul li {
+                font-size: var(--pf-global--FontSize--2xl);
+                margin: 0 2rem;
+            }
+        `,
+    ];
 
     render(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>

--- a/web/src/flow/stages/authenticator_totp/AuthenticatorTOTPStage.ts
+++ b/web/src/flow/stages/authenticator_totp/AuthenticatorTOTPStage.ts
@@ -28,23 +28,21 @@ export class AuthenticatorTOTPStage extends BaseStage<
     AuthenticatorTOTPChallenge,
     AuthenticatorTOTPChallengeResponseRequest
 > {
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFLogin,
-            PFForm,
-            PFFormControl,
-            PFTitle,
-            PFButton,
-            css`
-                .qr-container {
-                    display: flex;
-                    flex-direction: column;
-                    place-items: center;
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFLogin,
+        PFForm,
+        PFFormControl,
+        PFTitle,
+        PFButton,
+        css`
+            .qr-container {
+                display: flex;
+                flex-direction: column;
+                place-items: center;
+            }
+        `,
+    ];
 
     render(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>

--- a/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStage.ts
+++ b/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStage.ts
@@ -65,9 +65,15 @@ export class AuthenticatorValidateStage
     >
     implements StageHost
 {
-    static get styles(): CSSResult[] {
-        return [PFBase, PFLogin, PFForm, PFFormControl, PFTitle, PFButton, customCSS];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFLogin,
+        PFForm,
+        PFFormControl,
+        PFTitle,
+        PFButton,
+        customCSS,
+    ];
 
     flowSlug = "";
 

--- a/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStageCode.ts
+++ b/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStageCode.ts
@@ -18,8 +18,9 @@ export class AuthenticatorValidateStageWebCode extends BaseDeviceStage<
     AuthenticatorValidationChallenge,
     AuthenticatorValidationChallengeResponseRequest
 > {
-    static get styles(): CSSResult[] {
-        return super.styles.concat(css`
+    static styles: CSSResult[] = [
+        ...super.styles,
+        css`
             .icon-description {
                 display: flex;
             }
@@ -28,8 +29,8 @@ export class AuthenticatorValidateStageWebCode extends BaseDeviceStage<
                 padding: 0.25em;
                 padding-right: 0.5em;
             }
-        `);
-    }
+        `,
+    ];
 
     deviceMessage(): string {
         switch (this.deviceChallenge?.deviceClass) {

--- a/web/src/flow/stages/authenticator_validate/base.ts
+++ b/web/src/flow/stages/authenticator_validate/base.ts
@@ -24,25 +24,23 @@ export class BaseDeviceStage<
     @property({ type: Boolean })
     showBackButton = false;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFLogin,
-            PFForm,
-            PFFormControl,
-            PFTitle,
-            PFButton,
-            css`
-                .pf-c-form__group.pf-m-action {
-                    display: flex;
-                    gap: 16px;
-                    margin-top: 0;
-                    margin-bottom: calc(var(--pf-c-form__group--m-action--MarginTop) / 2);
-                    flex-direction: column;
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFLogin,
+        PFForm,
+        PFFormControl,
+        PFTitle,
+        PFButton,
+        css`
+            .pf-c-form__group.pf-m-action {
+                display: flex;
+                gap: 16px;
+                margin-top: 0;
+                margin-bottom: calc(var(--pf-c-form__group--m-action--MarginTop) / 2);
+                flex-direction: column;
+            }
+        `,
+    ];
 
     submit(payload: Tin): Promise<boolean> {
         return this.host?.submit(payload) || Promise.resolve();

--- a/web/src/flow/stages/authenticator_webauthn/WebAuthnAuthenticatorRegisterStage.ts
+++ b/web/src/flow/stages/authenticator_webauthn/WebAuthnAuthenticatorRegisterStage.ts
@@ -42,26 +42,24 @@ export class WebAuthnAuthenticatorRegisterStage extends BaseStage<
 
     publicKeyCredentialCreateOptions?: PublicKeyCredentialCreationOptions;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFLogin,
-            PFFormControl,
-            PFForm,
-            PFTitle,
-            PFButton,
-            // FIXME: this is technically duplicate with ../authenticator_validate/base.ts
-            css`
-                .pf-c-form__group.pf-m-action {
-                    display: flex;
-                    gap: 16px;
-                    margin-top: 0;
-                    margin-bottom: calc(var(--pf-c-form__group--m-action--MarginTop) / 2);
-                    flex-direction: column;
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFLogin,
+        PFFormControl,
+        PFForm,
+        PFTitle,
+        PFButton,
+        // FIXME: this is technically duplicate with ../authenticator_validate/base.ts
+        css`
+            .pf-c-form__group.pf-m-action {
+                display: flex;
+                gap: 16px;
+                margin-top: 0;
+                margin-bottom: calc(var(--pf-c-form__group--m-action--MarginTop) / 2);
+                flex-direction: column;
+            }
+        `,
+    ];
 
     async register(): Promise<void> {
         if (!this.challenge) {

--- a/web/src/flow/stages/autosubmit/AutosubmitStage.ts
+++ b/web/src/flow/stages/autosubmit/AutosubmitStage.ts
@@ -23,9 +23,7 @@ export class AutosubmitStage extends BaseStage<
     @query("form")
     private form?: HTMLFormElement;
 
-    static get styles(): CSSResult[] {
-        return [PFBase, PFLogin, PFForm, PFFormControl, PFButton, PFTitle];
-    }
+    static styles: CSSResult[] = [PFBase, PFLogin, PFForm, PFFormControl, PFButton, PFTitle];
 
     updated(): void {
         if (this.challenge.url !== undefined) {

--- a/web/src/flow/stages/captcha/CaptchaStage.ts
+++ b/web/src/flow/stages/captcha/CaptchaStage.ts
@@ -90,21 +90,19 @@ function iframeTemplate(children: TemplateResult, challengeURL: string): Templat
 
 @customElement("ak-stage-captcha")
 export class CaptchaStage extends BaseStage<CaptchaChallenge, CaptchaChallengeResponseRequest> {
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFLogin,
-            PFForm,
-            PFFormControl,
-            PFTitle,
-            css`
-                iframe {
-                    width: 100%;
-                    height: 0;
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFLogin,
+        PFForm,
+        PFFormControl,
+        PFTitle,
+        css`
+            iframe {
+                width: 100%;
+                height: 0;
+            }
+        `,
+    ];
 
     @property({ type: Boolean })
     embedded = false;

--- a/web/src/flow/stages/consent/ConsentStage.ts
+++ b/web/src/flow/stages/consent/ConsentStage.ts
@@ -25,19 +25,17 @@ import {
 
 @customElement("ak-stage-consent")
 export class ConsentStage extends BaseStage<ConsentChallenge, ConsentChallengeResponseRequest> {
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFLogin,
-            PFList,
-            PFForm,
-            PFSpacing,
-            PFFormControl,
-            PFTitle,
-            PFButton,
-            PFText,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFLogin,
+        PFList,
+        PFForm,
+        PFSpacing,
+        PFFormControl,
+        PFTitle,
+        PFButton,
+        PFText,
+    ];
 
     renderPermissions(perms: ConsentPermission[]): TemplateResult {
         return html`${perms.map((permission) => {

--- a/web/src/flow/stages/dummy/DummyStage.ts
+++ b/web/src/flow/stages/dummy/DummyStage.ts
@@ -17,9 +17,7 @@ import { DummyChallenge, DummyChallengeResponseRequest } from "@goauthentik/api"
 
 @customElement("ak-stage-dummy")
 export class DummyStage extends BaseStage<DummyChallenge, DummyChallengeResponseRequest> {
-    static get styles(): CSSResult[] {
-        return [PFBase, PFLogin, PFForm, PFFormControl, PFTitle, PFButton];
-    }
+    static styles: CSSResult[] = [PFBase, PFLogin, PFForm, PFFormControl, PFTitle, PFButton];
 
     render(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>

--- a/web/src/flow/stages/email/EmailStage.ts
+++ b/web/src/flow/stages/email/EmailStage.ts
@@ -16,9 +16,7 @@ import { EmailChallenge, EmailChallengeResponseRequest } from "@goauthentik/api"
 
 @customElement("ak-stage-email")
 export class EmailStage extends BaseStage<EmailChallenge, EmailChallengeResponseRequest> {
-    static get styles(): CSSResult[] {
-        return [PFBase, PFLogin, PFForm, PFFormControl, PFButton, PFTitle];
-    }
+    static styles: CSSResult[] = [PFBase, PFLogin, PFForm, PFFormControl, PFButton, PFTitle];
 
     render(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>

--- a/web/src/flow/stages/identification/IdentificationStage.ts
+++ b/web/src/flow/stages/identification/IdentificationStage.ts
@@ -56,35 +56,33 @@ export class IdentificationStage extends BaseStage<
     @state()
     captchaRefreshedAt = new Date();
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFAlert,
-            PFInputGroup,
-            PFLogin,
-            PFForm,
-            PFFormControl,
-            PFTitle,
-            PFButton,
-            AkRememberMeController.styles,
-            css`
-                /* login page's icons */
-                .pf-c-login__main-footer-links-item button {
-                    background-color: transparent;
-                    border: 0;
-                    display: flex;
-                    align-items: stretch;
-                }
-                .pf-c-login__main-footer-links-item img {
-                    fill: var(--pf-c-login__main-footer-links-item-link-svg--Fill);
-                    width: 100px;
-                    max-width: var(--pf-c-login__main-footer-links-item-link-svg--Width);
-                    height: 100%;
-                    max-height: var(--pf-c-login__main-footer-links-item-link-svg--Height);
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFAlert,
+        PFInputGroup,
+        PFLogin,
+        PFForm,
+        PFFormControl,
+        PFTitle,
+        PFButton,
+        ...AkRememberMeController.styles,
+        css`
+            /* login page's icons */
+            .pf-c-login__main-footer-links-item button {
+                background-color: transparent;
+                border: 0;
+                display: flex;
+                align-items: stretch;
+            }
+            .pf-c-login__main-footer-links-item img {
+                fill: var(--pf-c-login__main-footer-links-item-link-svg--Fill);
+                width: 100px;
+                max-width: var(--pf-c-login__main-footer-links-item-link-svg--Width);
+                height: 100%;
+                max-height: var(--pf-c-login__main-footer-links-item-link-svg--Height);
+            }
+        `,
+    ];
 
     constructor() {
         super();

--- a/web/src/flow/stages/identification/RememberMeController.ts
+++ b/web/src/flow/stages/identification/RememberMeController.ts
@@ -9,14 +9,14 @@ import type { IdentificationStage } from "./IdentificationStage.js";
 type RememberMeHost = ReactiveControllerHost & IdentificationStage;
 
 export class AkRememberMeController implements ReactiveController {
-    static get styles() {
-        return css`
+    static styles = [
+        css`
             .remember-me-switch {
                 display: inline-block;
                 padding-top: 0.25rem;
             }
-        `;
-    }
+        `,
+    ];
 
     username?: string;
 

--- a/web/src/flow/stages/password/PasswordStage.ts
+++ b/web/src/flow/stages/password/PasswordStage.ts
@@ -22,9 +22,15 @@ import { PasswordChallenge, PasswordChallengeResponseRequest } from "@goauthenti
 
 @customElement("ak-stage-password")
 export class PasswordStage extends BaseStage<PasswordChallenge, PasswordChallengeResponseRequest> {
-    static get styles(): CSSResult[] {
-        return [PFBase, PFLogin, PFInputGroup, PFForm, PFFormControl, PFButton, PFTitle];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFLogin,
+        PFInputGroup,
+        PFForm,
+        PFFormControl,
+        PFButton,
+        PFTitle,
+    ];
 
     hasError(field: string): boolean {
         const errors = (this.challenge?.responseErrors || {})[field];

--- a/web/src/flow/stages/prompt/PromptStage.ts
+++ b/web/src/flow/stages/prompt/PromptStage.ts
@@ -30,25 +30,23 @@ import {
 export class PromptStage extends WithCapabilitiesConfig(
     BaseStage<PromptChallenge, PromptChallengeResponseRequest>,
 ) {
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFLogin,
-            PFAlert,
-            PFForm,
-            PFFormControl,
-            PFTitle,
-            PFButton,
-            PFCheck,
-            css`
-                textarea {
-                    min-height: 4em;
-                    max-height: 15em;
-                    resize: vertical;
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFLogin,
+        PFAlert,
+        PFForm,
+        PFFormControl,
+        PFTitle,
+        PFButton,
+        PFCheck,
+        css`
+            textarea {
+                min-height: 4em;
+                max-height: 15em;
+                resize: vertical;
+            }
+        `,
+    ];
 
     renderPromptInner(prompt: StagePrompt): TemplateResult {
         switch (prompt.type) {

--- a/web/src/flow/stages/user_login/UserLoginStage.ts
+++ b/web/src/flow/stages/user_login/UserLoginStage.ts
@@ -23,9 +23,15 @@ export class PasswordStage extends BaseStage<
     UserLoginChallenge,
     UserLoginChallengeResponseRequest
 > {
-    static get styles(): CSSResult[] {
-        return [PFBase, PFLogin, PFForm, PFFormControl, PFSpacing, PFButton, PFTitle];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFLogin,
+        PFForm,
+        PFFormControl,
+        PFSpacing,
+        PFButton,
+        PFTitle,
+    ];
 
     render(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>

--- a/web/src/rac/index.entrypoint.ts
+++ b/web/src/rac/index.entrypoint.ts
@@ -44,33 +44,31 @@ const RECONNECT_ATTEMPTS = 5;
 
 @customElement("ak-rac")
 export class RacInterface extends WithBrandConfig(Interface) {
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFPage,
-            PFContent,
-            AKGlobal,
-            css`
-                :host {
-                    cursor: none;
-                }
-                canvas {
-                    z-index: unset !important;
-                }
-                .container {
-                    overflow: hidden;
-                    height: 100vh;
-                    background-color: black;
-                    display: flex;
-                    justify-content: center;
-                    align-items: center;
-                }
-                ak-loading-overlay {
-                    z-index: 5;
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        PFBase,
+        PFPage,
+        PFContent,
+        AKGlobal,
+        css`
+            :host {
+                cursor: none;
+            }
+            canvas {
+                z-index: unset !important;
+            }
+            .container {
+                overflow: hidden;
+                height: 100vh;
+                background-color: black;
+                display: flex;
+                justify-content: center;
+                align-items: center;
+            }
+            ak-loading-overlay {
+                z-index: 5;
+            }
+        `,
+    ];
 
     client?: Guacamole.Client;
     tunnel?: Guacamole.Tunnel;

--- a/web/src/standalone/api-browser/index.entrypoint.ts
+++ b/web/src/standalone/api-browser/index.entrypoint.ts
@@ -21,17 +21,15 @@ export class APIBrowser extends WithBrandConfig(Interface) {
     @property()
     schemaPath?: string;
 
-    static get styles(): CSSResult[] {
-        return [
-            css`
-                img.logo {
-                    width: 100%;
-                    padding: 1rem 0.5rem 1.5rem 0.5rem;
-                    min-height: 48px;
-                }
-            `,
-        ];
-    }
+    static styles: CSSResult[] = [
+        css`
+            img.logo {
+                width: 100%;
+                padding: 1rem 0.5rem 1.5rem 0.5rem;
+                min-height: 48px;
+            }
+        `,
+    ];
 
     @state()
     bgColor = "#000000";

--- a/web/src/user/LibraryApplication/index.ts
+++ b/web/src/user/LibraryApplication/index.ts
@@ -36,40 +36,38 @@ export class LibraryApplication extends AKElement {
     @query("ak-library-rac-endpoint-launch")
     racEndpointLaunch?: RACLaunchEndpointModal;
 
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFCard,
-            PFButton,
-            css`
-                .pf-c-card {
-                    --pf-c-card--BoxShadow: var(--pf-global--BoxShadow--md);
-                }
-                .pf-c-card__header {
-                    justify-content: space-between;
-                    flex-direction: column;
-                }
-                .pf-c-card__header a {
-                    display: flex;
-                    flex-direction: column;
-                    justify-content: center;
-                }
-                a:hover {
-                    text-decoration: none;
-                }
-                .expander {
-                    flex-grow: 1;
-                }
-                .pf-c-card__title {
-                    text-align: center;
-                    /* This is not ideal as it hard limits us to 2 lines of text for the title
+    static styles: CSSResult[] = [
+        PFBase,
+        PFCard,
+        PFButton,
+        css`
+            .pf-c-card {
+                --pf-c-card--BoxShadow: var(--pf-global--BoxShadow--md);
+            }
+            .pf-c-card__header {
+                justify-content: space-between;
+                flex-direction: column;
+            }
+            .pf-c-card__header a {
+                display: flex;
+                flex-direction: column;
+                justify-content: center;
+            }
+            a:hover {
+                text-decoration: none;
+            }
+            .expander {
+                flex-grow: 1;
+            }
+            .pf-c-card__title {
+                text-align: center;
+                /* This is not ideal as it hard limits us to 2 lines of text for the title
                     of the application. In theory that should be fine for most cases, but ideally
                     we don't do this */
-                    height: 48px;
-                }
-            `,
-        ];
-    }
+                height: 48px;
+            }
+        `,
+    ];
 
     renderExpansion(application: Application) {
         const { me, uiConfig } = rootInterface<UserInterface>();

--- a/web/src/user/LibraryPage/LibraryPageImpl.css.ts
+++ b/web/src/user/LibraryPage/LibraryPageImpl.css.ts
@@ -6,34 +6,41 @@ import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFBase from "@patternfly/patternfly/patternfly-base.css";
 import PFDisplay from "@patternfly/patternfly/utilities/Display/display.css";
 
-export const styles = [PFBase, PFDisplay, PFEmptyState, PFPage, PFContent].concat(css`
-    :host {
-        display: block;
-        padding: 3% 5%;
-    }
-    .header {
-        display: flex;
-        flex-direction: row;
-        justify-content: space-between;
-    }
-    .header input {
-        width: 30ch;
-        box-sizing: border-box;
-        border: 0;
-        border-bottom: 1px solid;
-        border-bottom-color: #fd4b2d;
-        background-color: transparent;
-        font-size: 1.5rem;
-    }
-    .header input:focus {
-        outline: 0;
-    }
-    .pf-c-page__main {
-        overflow: hidden;
-    }
-    .pf-c-page__main-section {
-        background-color: transparent;
-    }
-`);
+export const styles = [
+    PFBase,
+    PFDisplay,
+    PFEmptyState,
+    PFPage,
+    PFContent,
+    css`
+        :host {
+            display: block;
+            padding: 3% 5%;
+        }
+        .header {
+            display: flex;
+            flex-direction: row;
+            justify-content: space-between;
+        }
+        .header input {
+            width: 30ch;
+            box-sizing: border-box;
+            border: 0;
+            border-bottom: 1px solid;
+            border-bottom-color: #fd4b2d;
+            background-color: transparent;
+            font-size: 1.5rem;
+        }
+        .header input:focus {
+            outline: 0;
+        }
+        .pf-c-page__main {
+            overflow: hidden;
+        }
+        .pf-c-page__main-section {
+            background-color: transparent;
+        }
+    `,
+];
 
 export default styles;

--- a/web/src/user/LibraryPage/ak-library-application-empty-list.ts
+++ b/web/src/user/LibraryPage/ak-library-application-empty-list.ts
@@ -21,21 +21,19 @@ import PFSpacing from "@patternfly/patternfly/utilities/Spacing/spacing.css";
 
 @customElement("ak-library-application-empty-list")
 export class LibraryPageApplicationEmptyList extends AKElement {
-    static get styles() {
-        return [
-            PFBase,
-            PFEmptyState,
-            PFButton,
-            PFContent,
-            PFSpacing,
-            css`
-                .cta {
-                    display: inline-block;
-                    font-weight: bold;
-                }
-            `,
-        ];
-    }
+    static styles = [
+        PFBase,
+        PFEmptyState,
+        PFButton,
+        PFContent,
+        PFSpacing,
+        css`
+            .cta {
+                display: inline-block;
+                font-weight: bold;
+            }
+        `,
+    ];
 
     @property({ attribute: "isadmin", type: Boolean })
     isAdmin = false;

--- a/web/src/user/LibraryPage/ak-library-application-list.ts
+++ b/web/src/user/LibraryPage/ak-library-application-list.ts
@@ -40,20 +40,18 @@ const LAYOUTS = new Map<string, [string, string]>([
  */
 @customElement("ak-library-application-list")
 export class LibraryPageApplicationList extends AKElement {
-    static get styles() {
-        return [
-            PFBase,
-            PFEmptyState,
-            PFContent,
-            PFGrid,
-            css`
-                .app-group-header {
-                    margin-bottom: 1em;
-                    margin-top: 1.2em;
-                }
-            `,
-        ];
-    }
+    static styles = [
+        PFBase,
+        PFEmptyState,
+        PFContent,
+        PFGrid,
+        css`
+            .app-group-header {
+                margin-bottom: 1em;
+                margin-top: 1.2em;
+            }
+        `,
+    ];
 
     @property({ attribute: true })
     layout = "row" as LayoutType;

--- a/web/src/user/LibraryPage/ak-library-application-search-empty.ts
+++ b/web/src/user/LibraryPage/ak-library-application-search-empty.ts
@@ -18,9 +18,7 @@ import PFSpacing from "@patternfly/patternfly/utilities/Spacing/spacing.css";
 
 @customElement("ak-library-application-search-empty")
 export class LibraryPageApplicationSearchEmpty extends AKElement {
-    static get styles() {
-        return [PFBase, PFEmptyState, PFContent, PFSpacing];
-    }
+    static styles = [PFBase, PFEmptyState, PFContent, PFSpacing];
 
     render() {
         return html` <div class="pf-c-empty-state pf-m-full-height">

--- a/web/src/user/LibraryPage/ak-library-application-search.ts
+++ b/web/src/user/LibraryPage/ak-library-application-search.ts
@@ -37,29 +37,27 @@ import {
  */
 @customElement("ak-library-application-search")
 export class LibraryPageApplicationSearch extends AKElement {
-    static get styles() {
-        return [
-            PFBase,
-            PFDisplay,
-            css`
-                input {
-                    width: 30ch;
-                    box-sizing: border-box;
-                    border: 0;
-                    border-bottom: 1px solid;
-                    border-bottom-color: var(--ak-accent);
-                    background-color: transparent;
-                    font-size: 1.5rem;
-                }
-                input:focus {
-                    outline: 0;
-                }
-                :host([theme="dark"]) input {
-                    color: var(--ak-dark-foreground) !important;
-                }
-            `,
-        ];
-    }
+    static styles = [
+        PFBase,
+        PFDisplay,
+        css`
+            input {
+                width: 30ch;
+                box-sizing: border-box;
+                border: 0;
+                border-bottom: 1px solid;
+                border-bottom-color: var(--ak-accent);
+                background-color: transparent;
+                font-size: 1.5rem;
+            }
+            input:focus {
+                outline: 0;
+            }
+            :host([theme="dark"]) input {
+                color: var(--ak-dark-foreground) !important;
+            }
+        `,
+    ];
 
     @property({ attribute: false })
     set apps(value: Application[]) {

--- a/web/src/user/LibraryPage/ak-library-impl.ts
+++ b/web/src/user/LibraryPage/ak-library-impl.ts
@@ -40,9 +40,7 @@ import type { PageUIConfig } from "./types.js";
 
 @customElement("ak-library-impl")
 export class LibraryPage extends AKElement {
-    static get styles() {
-        return styles;
-    }
+    static styles = styles;
 
     /**
      * Controls showing the "Switch to Admin" button.

--- a/web/src/user/user-settings/UserSettingsPage.ts
+++ b/web/src/user/user-settings/UserSettingsPage.ts
@@ -34,46 +34,44 @@ import { StagesApi, UserSetting } from "@goauthentik/api";
 @localized()
 @customElement("ak-user-settings")
 export class UserSettingsPage extends AKElement {
-    static get styles(): CSSResult[] {
-        return [
-            PFBase,
-            PFPage,
-            PFDisplay,
-            PFGallery,
-            PFContent,
-            PFCard,
-            PFDescriptionList,
-            PFSizing,
-            PFForm,
-            PFFormControl,
-            PFStack,
-            css`
-                .pf-c-page {
-                    --pf-c-page--BackgroundColor: transparent;
+    static styles: CSSResult[] = [
+        PFBase,
+        PFPage,
+        PFDisplay,
+        PFGallery,
+        PFContent,
+        PFCard,
+        PFDescriptionList,
+        PFSizing,
+        PFForm,
+        PFFormControl,
+        PFStack,
+        css`
+            .pf-c-page {
+                --pf-c-page--BackgroundColor: transparent;
+            }
+            .pf-c-page__main-section {
+                --pf-c-page__main-section--BackgroundColor: transparent;
+            }
+            :host([theme="dark"]) .pf-c-page {
+                --pf-c-page--BackgroundColor: transparent;
+            }
+            :host([theme="dark"]) .pf-c-page__main-section {
+                --pf-c-page__main-section--BackgroundColor: transparent;
+            }
+            .pf-c-page__main {
+                min-height: 100vh;
+                overflow-y: auto;
+            }
+            @media screen and (min-width: 1200px) {
+                :host {
+                    width: 90rem;
+                    margin-left: auto;
+                    margin-right: auto;
                 }
-                .pf-c-page__main-section {
-                    --pf-c-page__main-section--BackgroundColor: transparent;
-                }
-                :host([theme="dark"]) .pf-c-page {
-                    --pf-c-page--BackgroundColor: transparent;
-                }
-                :host([theme="dark"]) .pf-c-page__main-section {
-                    --pf-c-page__main-section--BackgroundColor: transparent;
-                }
-                .pf-c-page__main {
-                    min-height: 100vh;
-                    overflow-y: auto;
-                }
-                @media screen and (min-width: 1200px) {
-                    :host {
-                        width: 90rem;
-                        margin-left: auto;
-                        margin-right: auto;
-                    }
-                }
-            `,
-        ];
-    }
+            }
+        `,
+    ];
 
     @state()
     userSettings?: UserSetting[];

--- a/web/src/user/user-settings/details/UserPassword.ts
+++ b/web/src/user/user-settings/details/UserPassword.ts
@@ -20,9 +20,7 @@ export class UserSettingsPassword extends AKElement {
     @property()
     configureUrl?: string;
 
-    static get styles(): CSSResult[] {
-        return [PFBase, PFCard, PFButton, PFForm, PFFormControl];
-    }
+    static styles: CSSResult[] = [PFBase, PFCard, PFButton, PFForm, PFFormControl];
 
     render(): TemplateResult {
         // For this stage we don't need to check for a configureFlow,

--- a/web/src/user/user-settings/details/UserSettingsFlowExecutor.ts
+++ b/web/src/user/user-settings/details/UserSettingsFlowExecutor.ts
@@ -53,9 +53,7 @@ export class UserSettingsFlowExecutor
     @property({ type: Boolean })
     loading = false;
 
-    static get styles(): CSSResult[] {
-        return [PFBase, PFCard, PFPage, PFButton, PFContent];
-    }
+    static styles: CSSResult[] = [PFBase, PFCard, PFPage, PFButton, PFContent];
 
     submit(payload?: FlowChallengeResponseRequest): Promise<boolean> {
         if (!payload) return Promise.reject();

--- a/web/src/user/user-settings/tokens/UserTokenList.ts
+++ b/web/src/user/user-settings/tokens/UserTokenList.ts
@@ -48,9 +48,7 @@ export class UserTokenList extends Table<Token> {
         return [new TableColumn(msg("Identifier"), "identifier"), new TableColumn("")];
     }
 
-    static get styles(): CSSResult[] {
-        return super.styles.concat(PFDescriptionList);
-    }
+    static styles: CSSResult[] = [...super.styles, PFDescriptionList];
 
     renderToolbar(): TemplateResult {
         return html`


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

This PR formats all instances of Lit's `static styles`. The formatting is grouped into three categories across 3 commits:

### Category 1

Unusually formatted, combinations of functions and concatenation.

### Category 2

Similar to Category 1, but with TypeScript errors.

### Category 3

Styles which can be formatted with the following regexes:

```
# Single line
find src -name '*.ts' -exec perl -0777 -i -pe 's/return\s+([a-zA-Z0-9_\.]+)\.concat\(([^\n]*?)\);/return [ ...$1, $2 ]/g' {} \;

# Multiline
find src -name '*.ts' -exec perl -0777 -i -pe 's{
    return\s+([^\s;]+)\.concat\(\s*
    ([\s\S]*? ^[\W]{8})\);
}{return [ ...$1, $2 ]}gmx' {} \;


## Final
find src -name '*.ts' -exec perl -0777 -i -pe 's/static get styles\(\)(\s*:\s*[\w\[\]<>, ]+)?\s*\{\s*return\s*\[([\s\S]*?)\](?:\.concat\([\s\S]*?\))?;?\s*\}\n?/static styles$1 = [\n$2\n]\n/g' {} \;
```

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
