### PR TITLE
stages/prompt: fix list policy for prompt validation failing with multiple policies

### DIFF
--- a/authentik/stages/prompt/stage.py
+++ b/authentik/stages/prompt/stage.py
@@ -191,9 +191,10 @@ class ListPolicyEngine(PolicyEngine):
         self.use_cache = False
 
     def bindings(self):
-        for policy in self.__list:
+        for idx, policy in enumerate(self.__list):
             yield PolicyBinding(
                 policy=policy,
+                order=idx,
             )
 
 

--- a/authentik/stages/prompt/tests.py
+++ b/authentik/stages/prompt/tests.py
@@ -214,8 +214,20 @@ class TestPromptStage(FlowTestCase):
         """Test challenge_response validation"""
         plan = FlowPlan(flow_pk=self.flow.pk.hex, bindings=[self.binding], markers=[StageMarker()])
         expr = "False"
-        expr_policy = ExpressionPolicy.objects.create(name="validate-form", expression=expr)
+        expr_policy = ExpressionPolicy.objects.create(name=generate_id(), expression=expr)
         self.stage.validation_policies.set([expr_policy])
+        self.stage.save()
+        challenge_response = PromptChallengeResponse(
+            None, stage_instance=self.stage, plan=plan, data=self.prompt_data, stage=self.stage_view
+        )
+        self.assertEqual(challenge_response.is_valid(), False)
+
+    def test_invalid_challenge_multiple(self):
+        """Test challenge_response validation (multiple policies)"""
+        plan = FlowPlan(flow_pk=self.flow.pk.hex, bindings=[self.binding], markers=[StageMarker()])
+        expr_policy1 = ExpressionPolicy.objects.create(name=generate_id(), expression="False")
+        expr_policy2 = ExpressionPolicy.objects.create(name=generate_id(), expression="False")
+        self.stage.validation_policies.set([expr_policy1, expr_policy2])
         self.stage.save()
         challenge_response = PromptChallengeResponse(
             None, stage_instance=self.stage, plan=plan, data=self.prompt_data, stage=self.stage_view
@@ -234,7 +246,7 @@ class TestPromptStage(FlowTestCase):
             "return request.context['prompt_data']['password_prompt'] "
             "== request.context['prompt_data']['password2_prompt']"
         )
-        expr_policy = ExpressionPolicy.objects.create(name="validate-form", expression=expr)
+        expr_policy = ExpressionPolicy.objects.create(name=generate_id(), expression=expr)
         self.stage.validation_policies.set([expr_policy])
         self.stage.save()
         challenge_response = PromptChallengeResponse(


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Introduced by #14957

Apparently python has different behaviour for `list.sort(key=lambda ...)` where when the list has one item it calls the lambda but doesn't care about the return value but when there are >1 items it does care...which we were missing a test for

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
