### PR TITLE
website/docs: Use Django case insensitive filter for unique emails

### DIFF
--- a/website/docs/customize/policies/expression/unique_email.md
+++ b/website/docs/customize/policies/expression/unique_email.md
@@ -7,12 +7,10 @@ Due to the database design of authentik, email addresses are by default not requ
 The snippet below can be used as the expression in policies both with enrollment flows, where the policy should be bound to any stage before the [User write](../../../add-secure-apps/flows-stages/stages/user_write.md) stage, or with the [Prompt stage](../../../add-secure-apps/flows-stages/stages/prompt/index.md).
 
 ```python
-from authentik.core.models import User
-
 # Ensure this matches the *Field Key* value of the prompt
 field_name = "email"
 email = request.context["prompt_data"][field_name]
-if User.objects.filter(email__iexact=email).exists():
+if ak_user_by(email__iexact=email):
   ak_message("Email address in use")
   return False
 return True

--- a/website/docs/customize/policies/expression/unique_email.md
+++ b/website/docs/customize/policies/expression/unique_email.md
@@ -12,7 +12,7 @@ from authentik.core.models import User
 # Ensure this matches the *Field Key* value of the prompt
 field_name = "email"
 email = request.context["prompt_data"][field_name]
-if User.objects.filter(email=email).exists():
+if User.objects.filter(email__iexact=email).exists():
   ak_message("Email address in use")
   return False
 return True


### PR DESCRIPTION
## Details

Use the Django [__iexact](https://docs.djangoproject.com/en/dev/ref/models/querysets/#std-fieldlookup-iexact) filter method for case insensitive email matching.

closes #14208

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
