### PR TITLE
web: Fix intermediate wizard steps propagating refresh events to parent

### DIFF
--- a/web/src/elements/wizard/Wizard.ts
+++ b/web/src/elements/wizard/Wizard.ts
@@ -1,5 +1,7 @@
 import "#elements/wizard/ActionWizardPage";
 
+import { EVENT_REFRESH } from "#common/constants";
+
 import { ModalButton } from "#elements/buttons/ModalButton";
 import { WizardPage } from "#elements/wizard/WizardPage";
 
@@ -50,13 +52,13 @@ export class Wizard extends ModalButton {
      * Header title of the wizard.
      */
     @property()
-    header?: string;
+    public header?: string;
 
     /**
      * Description of the wizard.
      */
     @property()
-    description?: string;
+    public description?: string;
 
     /**
      * Whether the wizard is valid and can proceed to the next step.
@@ -68,15 +70,13 @@ export class Wizard extends ModalButton {
      * Actions to display at the end of the wizard.
      */
     @property({ attribute: false })
-    actions: WizardAction[] = [];
+    public actions: WizardAction[] = [];
 
     @property({ attribute: false })
-    finalHandler = () => {
-        return Promise.resolve();
-    };
+    public finalHandler?: () => Promise<void>;
 
     @property({ attribute: false })
-    state: { [key: string]: unknown } = {};
+    public state: { [key: string]: unknown } = {};
 
     //#endregion
 
@@ -86,7 +86,7 @@ export class Wizard extends ModalButton {
      * Memoized step tag names.
      */
     @state()
-    _steps: string[] = [];
+    protected _steps: string[] = [];
 
     /**
      * Step tag names present in the wizard.
@@ -123,25 +123,25 @@ export class Wizard extends ModalButton {
     /**
      * Initial steps to reset to.
      */
-    _initialSteps: string[] = [];
+    #initialSteps: string[] = [];
 
     @state()
-    _activeStep?: WizardPage;
+    protected activeStep: WizardPage | null = null;
 
-    set activeStepElement(nextActiveStepElement: WizardPage | undefined) {
-        this._activeStep = nextActiveStepElement;
+    set activeStepElement(nextActiveStepElement: WizardPage | null) {
+        this.activeStep = nextActiveStepElement;
 
-        if (!this._activeStep) return;
+        if (!this.activeStep) return;
 
-        this._activeStep.activeCallback();
-        this._activeStep.requestUpdate();
+        this.activeStep.activeCallback();
+        this.activeStep.requestUpdate();
     }
 
     /**
      * The active step element being displayed.
      */
-    get activeStepElement(): WizardPage | undefined {
-        return this._activeStep;
+    get activeStepElement(): WizardPage | null {
+        return this.activeStep;
     }
 
     getStepElementByIndex(stepIndex: number): WizardPage | null {
@@ -154,69 +154,7 @@ export class Wizard extends ModalButton {
         return this.querySelector<WizardPage>(`[slot=${stepName}]`);
     }
 
-    //#endregion
-
-    //#region Lifecycle
-
-    firstUpdated(): void {
-        this._initialSteps = this._steps;
-    }
-
-    /**
-     * Add action to the beginning of the list.
-     */
-    addActionBefore(displayName: string, run: () => Promise<boolean>): void {
-        this.actions.unshift({
-            displayName,
-            run,
-        });
-    }
-
-    /**
-     * Add action at the end of the list.
-     *
-     * @todo: Is this used?
-     */
-    addActionAfter(displayName: string, run: () => Promise<boolean>): void {
-        this.actions.push({
-            displayName,
-            run,
-        });
-    }
-
-    /**
-     * Reset the wizard to it's initial state.
-     */
-    reset = (ev?: Event) => {
-        if (ev) {
-            ev.preventDefault();
-            ev.stopPropagation();
-        }
-        this.open = false;
-
-        this.querySelectorAll("[data-wizardmanaged=true]").forEach((el) => {
-            el.remove();
-        });
-
-        for (const step of this.steps) {
-            const stepElement = this.getStepElementByName(step);
-
-            stepElement?.reset?.();
-        }
-
-        this.steps = this._initialSteps;
-        this.actions = [];
-        this.state = {};
-        this.activeStepElement = undefined;
-        this.canBack = true;
-        this.canCancel = true;
-    };
-
-    //#endregion
-
-    //#region Rendering
-
-    renderModalInner(): TemplateResult {
+    #gatherSteps() {
         const firstPage = this.getStepElementByIndex(0);
 
         if (!this.activeStepElement && firstPage) {
@@ -234,7 +172,78 @@ export class Wizard extends ModalButton {
             lastPage = activeStepIndex === this.steps.length - 1;
         }
 
-        const navigateToPreviousStep = () => {
+        return {
+            firstPage,
+            activeStepIndex,
+            lastPage,
+        };
+    }
+
+    //#endregion
+
+    //#region Lifecycle
+
+    public firstUpdated(): void {
+        this.#initialSteps = this._steps;
+    }
+
+    public connectedCallback(): void {
+        super.connectedCallback();
+        this.addEventListener(EVENT_REFRESH, this.#refreshListener);
+    }
+
+    public disconnectedCallback(): void {
+        super.disconnectedCallback();
+        this.removeEventListener(EVENT_REFRESH, this.#refreshListener);
+    }
+
+    //#endregion
+
+    //#region Event Listeners
+
+    /**
+     * Reset the wizard to it's initial state.
+     */
+    #resetListener = (event?: Event) => {
+        event?.preventDefault();
+        event?.stopPropagation();
+
+        this.open = false;
+
+        for (const element of this.querySelectorAll("[data-wizardmanaged=true]")) {
+            element.remove();
+        }
+
+        for (const step of this.steps) {
+            const stepElement = this.getStepElementByName(step);
+
+            stepElement?.reset?.();
+        }
+
+        this.steps = this.#initialSteps;
+        this.actions = [];
+        this.state = {};
+        this.canBack = true;
+        this.canCancel = true;
+        this.activeStepElement = null;
+    };
+
+    #refreshListener = (event: Event) => {
+        const { lastPage } = this.#gatherSteps();
+
+        if (!lastPage) {
+            event.stopImmediatePropagation();
+        }
+    };
+
+    //#endregion
+
+    //#region Rendering
+
+    public renderModalInner(): TemplateResult {
+        const { activeStepIndex, lastPage } = this.#gatherSteps();
+
+        const navigatePreviousListener = () => {
             const prevPage = this.getStepElementByIndex(activeStepIndex - 1);
 
             if (prevPage) {
@@ -242,6 +251,28 @@ export class Wizard extends ModalButton {
             }
         };
 
+        const navigateNextListener = async (): Promise<void> => {
+            if (!this.activeStepElement) return;
+
+            if (this.activeStepElement.nextCallback) {
+                const completedStep = await this.activeStepElement.nextCallback();
+
+                if (!completedStep) return;
+
+                if (lastPage) {
+                    await this.finalHandler?.();
+                    this.#resetListener();
+
+                    return;
+                }
+            }
+
+            const nextPage = this.getStepElementByIndex(activeStepIndex + 1);
+
+            if (nextPage) {
+                this.activeStepElement = nextPage;
+            }
+        };
         return html`<div class="pf-c-wizard">
             <div class="pf-c-wizard__header">
                 ${this.canCancel
@@ -249,7 +280,7 @@ export class Wizard extends ModalButton {
                           class="pf-c-button pf-m-plain pf-c-wizard__close"
                           type="button"
                           aria-label="${msg("Close")}"
-                          @click=${(ev: Event) => this.reset(ev)}
+                          @click=${this.#resetListener}
                       >
                           <i class="fas fa-times" aria-hidden="true"></i>
                       </button>`
@@ -275,6 +306,7 @@ export class Wizard extends ModalButton {
                                                 "pf-c-wizard__nav-link": true,
                                                 "pf-m-current": idx === activeStepIndex,
                                             })}
+                                            type="button"
                                             ?disabled=${activeStepIndex < idx}
                                             @click=${() => {
                                                 this.activeStepElement = stepEl;
@@ -296,25 +328,9 @@ export class Wizard extends ModalButton {
                 <footer class="pf-c-wizard__footer">
                     <button
                         class="pf-c-button pf-m-primary"
-                        type="submit"
                         ?disabled=${!this.isValid}
-                        @click=${async () => {
-                            const completedStep = await this.activeStepElement?.nextCallback();
-                            if (!completedStep) return;
-
-                            if (lastPage) {
-                                await this.finalHandler();
-                                this.reset();
-
-                                return;
-                            }
-
-                            const nextPage = this.getStepElementByIndex(activeStepIndex + 1);
-
-                            if (nextPage) {
-                                this.activeStepElement = nextPage;
-                            }
-                        }}
+                        type="button"
+                        @click=${navigateNextListener}
                     >
                         ${lastPage ? msg("Finish") : msg("Next")}
                     </button>
@@ -325,7 +341,7 @@ export class Wizard extends ModalButton {
                               <button
                                   class="pf-c-button pf-m-secondary"
                                   type="button"
-                                  @click=${navigateToPreviousStep}
+                                  @click=${navigatePreviousListener}
                               >
                                   ${msg("Back")}
                               </button>
@@ -336,7 +352,7 @@ export class Wizard extends ModalButton {
                               <button
                                   class="pf-c-button pf-m-link"
                                   type="button"
-                                  @click=${(ev: Event) => this.reset(ev)}
+                                  @click=${(ev: Event) => this.#resetListener(ev)}
                               >
                                   ${msg("Cancel")}
                               </button>

--- a/web/src/elements/wizard/Wizard.ts
+++ b/web/src/elements/wizard/Wizard.ts
@@ -202,9 +202,9 @@ export class Wizard extends ModalButton {
     //#region Event Listeners
 
     /**
-     * Reset the wizard to it's initial state.
+     * Reset the wizard to its initial state.
      */
-    #resetListener = (event?: Event) => {
+    #reset = (event?: Event) => {
         event?.preventDefault();
         event?.stopPropagation();
 
@@ -243,7 +243,7 @@ export class Wizard extends ModalButton {
     public renderModalInner(): TemplateResult {
         const { activeStepIndex, lastPage } = this.#gatherSteps();
 
-        const navigatePreviousListener = () => {
+        const navigatePrevious = () => {
             const prevPage = this.getStepElementByIndex(activeStepIndex - 1);
 
             if (prevPage) {
@@ -251,7 +251,7 @@ export class Wizard extends ModalButton {
             }
         };
 
-        const navigateNextListener = async (): Promise<void> => {
+        const navigateNext = async (): Promise<void> => {
             if (!this.activeStepElement) return;
 
             if (this.activeStepElement.nextCallback) {
@@ -261,7 +261,7 @@ export class Wizard extends ModalButton {
 
                 if (lastPage) {
                     await this.finalHandler?.();
-                    this.#resetListener();
+                    this.#reset();
 
                     return;
                 }
@@ -280,7 +280,7 @@ export class Wizard extends ModalButton {
                           class="pf-c-button pf-m-plain pf-c-wizard__close"
                           type="button"
                           aria-label="${msg("Close")}"
-                          @click=${this.#resetListener}
+                          @click=${this.#reset}
                       >
                           <i class="fas fa-times" aria-hidden="true"></i>
                       </button>`
@@ -330,7 +330,7 @@ export class Wizard extends ModalButton {
                         class="pf-c-button pf-m-primary"
                         ?disabled=${!this.isValid}
                         type="button"
-                        @click=${navigateNextListener}
+                        @click=${navigateNext}
                     >
                         ${lastPage ? msg("Finish") : msg("Next")}
                     </button>
@@ -341,7 +341,7 @@ export class Wizard extends ModalButton {
                               <button
                                   class="pf-c-button pf-m-secondary"
                                   type="button"
-                                  @click=${navigatePreviousListener}
+                                  @click=${navigatePrevious}
                               >
                                   ${msg("Back")}
                               </button>
@@ -352,7 +352,7 @@ export class Wizard extends ModalButton {
                               <button
                                   class="pf-c-button pf-m-link"
                                   type="button"
-                                  @click=${(ev: Event) => this.#resetListener(ev)}
+                                  @click=${this.#reset}
                               >
                                   ${msg("Cancel")}
                               </button>


### PR DESCRIPTION
…rerenders.

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

1. User clicks modal button within an element which subscribes to refresh.
2. Opens modal form
3. User navigates to a step which contains a form submission, that also isn’t the last step
4. Refresh triggers, causing the whole modal button to reload
---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make website`)
