### PR TITLE
stages/authenticator_sms: allow custom message for twilio provider, pass request

### DIFF
--- a/authentik/stages/authenticator_sms/models.py
+++ b/authentik/stages/authenticator_sms/models.py
@@ -4,7 +4,7 @@ from hashlib import sha256
 
 from django.contrib.auth import get_user_model
 from django.db import models
-from django.http import HttpResponseBadRequest
+from django.http import HttpRequest, HttpResponseBadRequest
 from django.utils.translation import gettext_lazy as _
 from django.views import View
 from requests.exceptions import RequestException
@@ -68,32 +68,44 @@ class AuthenticatorSMSStage(ConfigurableStage, FriendlyNamedStage, Stage):
         help_text=_("Optionally modify the payload being sent to custom providers."),
     )
 
-    def send(self, token: str, device: "SMSDevice"):
+    def send(self, request: HttpRequest, token: str, device: "SMSDevice"):
         """Send message via selected provider"""
         if self.provider == SMSProviders.TWILIO:
-            return self.send_twilio(token, device)
+            return self.send_twilio(request, token, device)
         if self.provider == SMSProviders.GENERIC:
-            return self.send_generic(token, device)
+            return self.send_generic(request, token, device)
         raise ValueError(f"invalid provider {self.provider}")
 
     def get_message(self, token: str) -> str:
         """Get SMS message"""
         return _("Use this code to authenticate in authentik: {token}".format_map({"token": token}))
 
-    def send_twilio(self, token: str, device: "SMSDevice"):
+    def send_twilio(self, request: HttpRequest, token: str, device: "SMSDevice"):
         """send sms via twilio provider"""
         client = Client(self.account_sid, self.auth)
+        message_body = str(self.get_message(token))
+        if self.mapping:
+            payload = sanitize_item(
+                self.mapping.evaluate(
+                    user=device.user,
+                    request=request,
+                    device=device,
+                    token=token,
+                    stage=self,
+                )
+            )
+            message_body = payload.get("message", message_body)
 
         try:
             message = client.messages.create(
-                to=device.phone_number, from_=self.from_number, body=str(self.get_message(token))
+                to=device.phone_number, from_=self.from_number, body=message_body
             )
             LOGGER.debug("Sent SMS", to=device, message=message.sid)
         except TwilioRestException as exc:
             LOGGER.warning("Error sending token by Twilio SMS", exc=exc, msg=exc.msg)
             raise ValidationError(exc.msg) from None
 
-    def send_generic(self, token: str, device: "SMSDevice"):
+    def send_generic(self, request: HttpRequest, token: str, device: "SMSDevice"):
         """Send SMS via outside API"""
         payload = {
             "From": self.from_number,
@@ -106,7 +118,7 @@ class AuthenticatorSMSStage(ConfigurableStage, FriendlyNamedStage, Stage):
             payload = sanitize_item(
                 self.mapping.evaluate(
                     user=device.user,
-                    request=None,
+                    request=request,
                     device=device,
                     token=token,
                     stage=self,

--- a/authentik/stages/authenticator_sms/stage.py
+++ b/authentik/stages/authenticator_sms/stage.py
@@ -71,7 +71,7 @@ class AuthenticatorSMSStageView(ChallengeStageView):
             raise ValidationError(_("Invalid phone number"))
         # No code yet, but we have a phone number, so send a verification message
         device: SMSDevice = self.request.session[SESSION_KEY_SMS_DEVICE]
-        stage.send(device.token, device)
+        stage.send(self.request, device.token, device)
 
     def _has_phone_number(self) -> str | None:
         context = self.executor.plan.context

--- a/authentik/stages/authenticator_validate/challenge.py
+++ b/authentik/stages/authenticator_validate/challenge.py
@@ -124,7 +124,7 @@ def select_challenge(request: HttpRequest, device: Device):
 def select_challenge_sms(request: HttpRequest, device: SMSDevice):
     """Send SMS"""
     device.generate_token()
-    device.stage.send(device.token, device)
+    device.stage.send(request, device.token, device)
 
 
 def select_challenge_email(request: HttpRequest, device: EmailDevice):

--- a/web/src/admin/stages/authenticator_sms/AuthenticatorSMSStageForm.ts
+++ b/web/src/admin/stages/authenticator_sms/AuthenticatorSMSStageForm.ts
@@ -245,7 +245,7 @@ export class AuthenticatorSMSStageForm extends BaseStageForm<AuthenticatorSMSSta
                                 const args: PropertymappingsNotificationListRequest = {
                                     ordering: "name",
                                 };
-                                if (query !== undefined) {
+                                if (query) {
                                     args.search = query;
                                 }
                                 const items = await new PropertymappingsApi(

--- a/web/src/admin/stages/authenticator_sms/AuthenticatorSMSStageForm.ts
+++ b/web/src/admin/stages/authenticator_sms/AuthenticatorSMSStageForm.ts
@@ -256,9 +256,7 @@ export class AuthenticatorSMSStageForm extends BaseStageForm<AuthenticatorSMSSta
                             .renderElement=${(item: NotificationWebhookMapping): string => {
                                 return item.name;
                             }}
-                            .value=${(
-                                item: NotificationWebhookMapping | undefined,
-                            ): string | undefined => {
+                            .value=${(item?: NotificationWebhookMapping) => {
                                 return item?.pk;
                             }}
                             .selected=${(item: NotificationWebhookMapping): boolean => {

--- a/web/src/admin/stages/authenticator_sms/AuthenticatorSMSStageForm.ts
+++ b/web/src/admin/stages/authenticator_sms/AuthenticatorSMSStageForm.ts
@@ -161,38 +161,6 @@ export class AuthenticatorSMSStageForm extends BaseStageForm<AuthenticatorSMSSta
                     ${msg("This is the password to be used with basic auth")}
                 </p>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal label=${msg("Mapping")} name="mapping">
-                <ak-search-select
-                    .fetchObjects=${async (
-                        query?: string,
-                    ): Promise<NotificationWebhookMapping[]> => {
-                        const args: PropertymappingsNotificationListRequest = {
-                            ordering: "saml_name",
-                        };
-                        if (query !== undefined) {
-                            args.search = query;
-                        }
-                        const items = await new PropertymappingsApi(
-                            DEFAULT_CONFIG,
-                        ).propertymappingsNotificationList(args);
-                        return items.results;
-                    }}
-                    .renderElement=${(item: NotificationWebhookMapping): string => {
-                        return item.name;
-                    }}
-                    .value=${(item: NotificationWebhookMapping | undefined): string | undefined => {
-                        return item?.pk;
-                    }}
-                    .selected=${(item: NotificationWebhookMapping): boolean => {
-                        return this.instance?.mapping === item.pk;
-                    }}
-                    blankable
-                >
-                </ak-search-select>
-                <p class="pf-c-form__helper-text">
-                    ${msg("Modify the payload sent to the custom provider.")}
-                </p>
-            </ak-form-element-horizontal>
         `;
     }
 
@@ -269,6 +237,40 @@ export class AuthenticatorSMSStageForm extends BaseStageForm<AuthenticatorSMSSta
                     ${this.provider === ProviderEnum.Generic
                         ? this.renderProviderGeneric()
                         : this.renderProviderTwillio()}
+                    <ak-form-element-horizontal label=${msg("Mapping")} name="mapping">
+                        <ak-search-select
+                            .fetchObjects=${async (
+                                query?: string,
+                            ): Promise<NotificationWebhookMapping[]> => {
+                                const args: PropertymappingsNotificationListRequest = {
+                                    ordering: "name",
+                                };
+                                if (query !== undefined) {
+                                    args.search = query;
+                                }
+                                const items = await new PropertymappingsApi(
+                                    DEFAULT_CONFIG,
+                                ).propertymappingsNotificationList(args);
+                                return items.results;
+                            }}
+                            .renderElement=${(item: NotificationWebhookMapping): string => {
+                                return item.name;
+                            }}
+                            .value=${(
+                                item: NotificationWebhookMapping | undefined,
+                            ): string | undefined => {
+                                return item?.pk;
+                            }}
+                            .selected=${(item: NotificationWebhookMapping): boolean => {
+                                return this.instance?.mapping === item.pk;
+                            }}
+                            blankable
+                        >
+                        </ak-search-select>
+                        <p class="pf-c-form__helper-text">
+                            ${msg("Modify the payload sent to the provider.")}
+                        </p>
+                    </ak-form-element-horizontal>
                     <ak-form-element-horizontal name="verifyOnly">
                         <label class="pf-c-switch">
                             <input

--- a/website/docs/add-secure-apps/flows-stages/stages/authenticator_sms/index.mdx
+++ b/website/docs/add-secure-apps/flows-stages/stages/authenticator_sms/index.mdx
@@ -22,18 +22,21 @@ The other two steps can be skipped using the _Skip setup_ button.
 
 Navigate back to the root of your Twilio console, and copy the Auth token. This is the value for the _Twilio Auth Token_ field in authentik. Copy the value of **Account SID**. This is the value for the _Twilio Account SID_ field in authentik.
 
-#### Custom message :ak-version[2025.8]
+#### Custom SMS message :ak-version[2025.8]
 
-It is also possible to customize the text message when using Twilio by using a mapping. The mapping should return a dictionary with the `message` key, which will be sent to the user. For example:
+Using a property mapping, it is possible to customize the SMS message sent via Twilio. The mapping should return a dictionary with the `message` key, which will be sent to the user. For example:
 
 ```python
-# You also have access to the device, for example `device.phone_number`
-# and the stage sending the message, for example `stage.from_number`
-# and the request this code is being sent from, for example `request.http_request.brand`
 return {
     "message": f"This is a custom message for {request.http_request.brand.branding_title} SMS authentication. The code is {token}".
 }
 ```
+
+Variables related to different objects can be used within the message:
+
+    - The end user device, for example: `device.phone_number`
+    - The stage sending the message, for example: `stage.from_number`
+    - The request this verification code is being sent from, for example: `request.http_request.brand`
 
 ### Generic
 
@@ -49,7 +52,7 @@ For the generic provider, a POST request will be sent to the URL you have specif
 
 Authentication can either be done as HTTP Basic, or via a Bearer Token. Any response with status 400 or above is counted as failed, and will prevent the user from proceeding.
 
-#### Custom message
+#### Custom SMS message
 
 A custom webhook mapping can be used to customize the SMS message sent to users. For example:
 

--- a/website/docs/add-secure-apps/flows-stages/stages/authenticator_sms/index.mdx
+++ b/website/docs/add-secure-apps/flows-stages/stages/authenticator_sms/index.mdx
@@ -22,6 +22,19 @@ The other two steps can be skipped using the _Skip setup_ button.
 
 Navigate back to the root of your Twilio console, and copy the Auth token. This is the value for the _Twilio Auth Token_ field in authentik. Copy the value of **Account SID**. This is the value for the _Twilio Account SID_ field in authentik.
 
+##### Custom message :ak-version[2025.8]
+
+It is also possible to customize the text message when using Twilio by using a mapping. The mapping should return a dictionary with the `message` key, which will be sent to the user. For example:
+
+```python
+# You also have access to the device, for example `device.phone_number`
+# and the stage sending the message, for example `stage.from_number`
+# and the request this code is being sent from, for example `request.http_request.brand`
+return {
+    "message": f"This is a custom message for {request.http_request.brand.branding_title} SMS authentication. The code is {token}".
+}
+```
+
 #### Generic
 
 For the generic provider, a POST request will be sent to the URL you have specified in the _External API URL_ field. The request payload looks like this
@@ -36,7 +49,9 @@ For the generic provider, a POST request will be sent to the URL you have specif
 
 Authentication can either be done as HTTP Basic, or via a Bearer Token. Any response with status 400 or above is counted as failed, and will prevent the user from proceeding.
 
-Starting with authentik 2022.10, a custom webhook mapping can be specified to freely customize the payload of the request. For example:
+##### Custom message :ak-version[2022.10]
+
+A custom webhook mapping can be specified to freely customize the payload of the request. For example:
 
 ```python
 return {

--- a/website/docs/add-secure-apps/flows-stages/stages/authenticator_sms/index.mdx
+++ b/website/docs/add-secure-apps/flows-stages/stages/authenticator_sms/index.mdx
@@ -51,7 +51,7 @@ Authentication can either be done as HTTP Basic, or via a Bearer Token. Any resp
 
 #### Custom message
 
-A custom webhook mapping can be specified to freely customize the payload of the request. For example:
+A custom webhook mapping can be used to customize the SMS message sent to users. For example:
 
 ```python
 return {

--- a/website/docs/add-secure-apps/flows-stages/stages/authenticator_sms/index.mdx
+++ b/website/docs/add-secure-apps/flows-stages/stages/authenticator_sms/index.mdx
@@ -49,7 +49,7 @@ For the generic provider, a POST request will be sent to the URL you have specif
 
 Authentication can either be done as HTTP Basic, or via a Bearer Token. Any response with status 400 or above is counted as failed, and will prevent the user from proceeding.
 
-##### Custom message :ak-version[2022.10]
+##### Custom message
 
 A custom webhook mapping can be specified to freely customize the payload of the request. For example:
 

--- a/website/docs/add-secure-apps/flows-stages/stages/authenticator_sms/index.mdx
+++ b/website/docs/add-secure-apps/flows-stages/stages/authenticator_sms/index.mdx
@@ -6,7 +6,7 @@ This stage configures an SMS-based authenticator using either Twilio, or a gener
 
 ## Providers
 
-#### Twilio
+### Twilio
 
 Navigate to https://console.twilio.com/, and log in to your existing account, or create a new one.
 
@@ -22,7 +22,7 @@ The other two steps can be skipped using the _Skip setup_ button.
 
 Navigate back to the root of your Twilio console, and copy the Auth token. This is the value for the _Twilio Auth Token_ field in authentik. Copy the value of **Account SID**. This is the value for the _Twilio Account SID_ field in authentik.
 
-##### Custom message :ak-version[2025.8]
+#### Custom message :ak-version[2025.8]
 
 It is also possible to customize the text message when using Twilio by using a mapping. The mapping should return a dictionary with the `message` key, which will be sent to the user. For example:
 
@@ -35,7 +35,7 @@ return {
 }
 ```
 
-#### Generic
+### Generic
 
 For the generic provider, a POST request will be sent to the URL you have specified in the _External API URL_ field. The request payload looks like this
 
@@ -49,7 +49,7 @@ For the generic provider, a POST request will be sent to the URL you have specif
 
 Authentication can either be done as HTTP Basic, or via a Bearer Token. Any response with status 400 or above is counted as failed, and will prevent the user from proceeding.
 
-##### Custom message
+#### Custom message
 
 A custom webhook mapping can be specified to freely customize the payload of the request. For example:
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Allow for specifying a mapping to modify the message sent when using twilio
In addition, pass the request to do text based on brand

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [x] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
