### PR TITLE
website/docs: fix user ref typos

### DIFF
--- a/website/docs/users-sources/user/user_ref.mdx
+++ b/website/docs/users-sources/user/user_ref.mdx
@@ -16,7 +16,7 @@ The User object has the following properties:
 - `password_change_date`: Date password was last changed. Read-only.
 - `path`: User's path, see [Path](#path)
 - `attributes`: Dynamic attributes, see [Attributes](#attributes)
-- `group_attributes()`: Merged attributes of all groups the user is member of and the user's own attributes. Ready-only.
+- `group_attributes()`: Merged attributes of all groups the user is a member of and the user's own attributes. Read-only.
 - `ak_groups`: This is a queryset of all the user's groups.
 
 ## Examples


### PR DESCRIPTION
## Details

Fixes two small typos.

---

## Checklist

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make website`)
