### PR TITLE
website/docs: add force password reset guide

### DIFF
--- a/website/docs/sidebar.mjs
+++ b/website/docs/sidebar.mjs
@@ -3,12 +3,14 @@
  *
  * @import { SidebarItemConfig } from "@docusaurus/plugin-content-docs/src/sidebars/types.js"
  */
+
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
 import {
     collectReleaseFiles,
     createReleaseSidebarEntries,
 } from "@goauthentik/docusaurus-theme/releases/utils";
-import * as path from "node:path";
-import { fileURLToPath } from "node:url";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 

--- a/website/docs/sidebar.mjs
+++ b/website/docs/sidebar.mjs
@@ -3,14 +3,12 @@
  *
  * @import { SidebarItemConfig } from "@docusaurus/plugin-content-docs/src/sidebars/types.js"
  */
-
-import * as path from "node:path";
-import { fileURLToPath } from "node:url";
-
 import {
     collectReleaseFiles,
     createReleaseSidebarEntries,
 } from "@goauthentik/docusaurus-theme/releases/utils";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
@@ -450,6 +448,7 @@ const items = [
                     "users-sources/user/user_basic_operations",
                     "users-sources/user/user_ref",
                     "users-sources/user/invitations",
+                    "users-sources/user/password_reset_on_login",
                 ],
             },
             {

--- a/website/docs/troubleshooting/force_password_reset.mdx
+++ b/website/docs/troubleshooting/force_password_reset.mdx
@@ -1,0 +1,104 @@
+---
+title: Force password reset on next login
+---
+
+It's possible to utilize expression policies, custom stages, and a custom user attribute to force users to reset their password on next login. This guide describes how to configure this in conjunction with the `default-authentication-flow`, however the same process can be used with any authentication flow.
+
+## Create expression policies
+
+You will need to create two expression policies; a policy that checks the value of a custom user attribute on whichever user account is attempting to login, and a policy that resets the value of the custom user attribute.
+
+1. Log in to authentik as an administrator and open the authentik Admin interface.
+2. Navigate to **Customization** > **Policies** and click **Create** to create the first policy.
+3. Select **Expression Policy** as the policy type, click **Next**, and configure the following settings:
+    - **Name**: Provide a descriptive name for the policy (e.g. `reset_password_check`).
+    - **Expression**:
+
+        ```python
+        # Check if user has the "reset_password" attribute set to true
+        if (request.context["pending_user"].attributes.get("reset_password") == True):
+            return True
+
+        return False
+        ```
+
+4. Click **Finish** to create the policy and repeat the process to create the second policy with the following settings:
+    - **Name**: Provide a descriptive name for the policy (e.g. `reset_password_update`).
+    - **Expression**:
+
+        ```python
+        # Check if user has the "reset_password" attribute set to true
+        if (request.context["pending_user"].attributes.get("reset_password") == True):
+            # Sets the user's "reset_password" attribute set to false so that they're not forced to reset their password upon next login
+            request.context["pending_user"].attributes["reset_password"] = False
+            return True
+
+        return False
+        ```
+
+5. Click **Finish**.
+
+## Create stages
+
+You will need to create two stages; a prompt stage to prompt the user for a new password, and a user write stage to write the new password to the user's account. Both of these stages will need to be bound to the authentication flow that's in use, usually the `default-authentication-flow`.
+
+1. Log in to authentik as an administrator and open the authentik Admin interface.
+2. Navigate to **Flows and Stages** > **Flows** and click on the name of the authentication policy that's in use (e.g. `default-authentication-flow`).
+3. Select the **Stage Bindings** tab and click **Create and bind stage**.
+4. Select **Prompt Stage** as the stage type, click **Next**, and configure the following settings for the stage:
+    - **Name**: Provide a descriptive name for the stage (e.g. `Force Password Reset Prompt Stage`).
+    - Under **Fields**:
+        - Click the `x` icon between **Available Fields** and **Selected Fields** to clear the selections.
+        - Select `default-password-change-field-password` and `default-password-change-field-password-repeat`.
+    - Under **Validation Policies**:
+        - Click the `x` icon between **Available Policies** and **Selected Policies** to clear the selections.
+        - _(Optional but recommended)_ Select `default-password-change-policy`.
+
+:::tip
+Optionally, create a text field that explains to the user that they're being forced to reset their password. This text field can be added to the prompt stage. See the [Prompt Stage documentation](../add-secure-apps/flows-stages/stages/prompt/index.md#Prompt) for more information.
+:::
+
+5. Click **Next** to creat the stage and then configure the following settings for the binding:
+    - **Order**: `25` or any number higher than the `default-authentication-password` stage order and lower than the `default-authentication-mfa-validation` stage order.
+    - Leave the other settings as their default values.
+
+6. Click **Finish** to create the binding and repeat the process for the second stage using the following settings:
+    - **Stage type**: Select **User Write Stage** as the type.
+    - **Name**: Provide a descriptive name for the stage (e.g. `Force Password Reset User Write Stage`).
+    - Leave the other settings as their default values.
+
+7. Click **Next** to create the stage and then configure the following settings for the binding:
+    - **Order**: `26` or any number higher than the `Force Password Reset Prompt Stage` stage order and lower than the `default-authentication-mfa-validation` stage order.
+    - Leave the other settings as their default values.
+
+8. Click **Finish** to create the binding
+
+## Bind policies to stages
+
+You will need to bind the previously created policies to the newly created stages. Specifically:
+
+    - The `reset_password_check` policy needs to be bound to the `Force Password Reset Prompt Stage`.
+    - The `reset_password_update` policy needs to be bound to the `Force Password Reset User Write Stage`.
+
+1. Log in to authentik as an administrator and open the authentik Admin interface.
+2. Navigate to **Flows and Stages** > **Flows** and click on the name of the authentication policy that's in use (e.g. `default-authentication-flow`).
+3. Select the **Stage Bindings** tab and click the arrow next to the newly created `Force Password Reset Prompt Stage` to expand it.
+4. Click **Bind existing Policy / Group / User**.
+5. Set **Policy** to `reset_password_check` and click **Create**.
+6. Click the arrow next to the newly created `Force Password Reset User Write Stage` to expand it.
+7. Click **Bind existing Policy / Group / User**.
+8. Set **Policy** to `reset_password_update` and click **Create**.
+
+## Set custom user attribute
+
+To force a user to reset their password on next login, you will need to set a custom user attribute on their account.
+
+1. Log in to authentik as an administrator and open the authentik Admin interface.
+2. Navigate to **Directory** > **Users** and click the **Edit** icon of the user in question.
+3. Add the following values to the user's attribute field:
+    ```python
+    reset_password: True
+    ```
+4. Click **Update**.
+
+The next time the user logs in, they will be forced to reset their password.

--- a/website/docs/troubleshooting/force_password_reset.mdx
+++ b/website/docs/troubleshooting/force_password_reset.mdx
@@ -43,7 +43,7 @@ You will need to create two expression policies; a policy that checks the value 
 You will need to create two stages; a prompt stage to prompt the user for a new password, and a user write stage to write the new password to the user's account. Both of these stages will need to be bound to the authentication flow that's in use, usually the `default-authentication-flow`.
 
 1. Log in to authentik as an administrator and open the authentik Admin interface.
-2. Navigate to **Flows and Stages** > **Flows** and click on the name of the authentication policy that's in use (e.g. `default-authentication-flow`).
+2. Navigate to **Flows and Stages** > **Flows** and click on the name of the authentication flow that's in use (e.g. `default-authentication-flow`).
 3. Select the **Stage Bindings** tab and click **Create and bind stage**.
 4. Select **Prompt Stage** as the stage type, click **Next**, and configure the following settings for the stage:
     - **Name**: Provide a descriptive name for the stage (e.g. `Force Password Reset Prompt Stage`).

--- a/website/docs/troubleshooting/force_password_reset.mdx
+++ b/website/docs/troubleshooting/force_password_reset.mdx
@@ -16,7 +16,7 @@ You will need to create two expression policies; a policy that checks the value 
 
         ```python
         # Check if user has the "reset_password" attribute set to true
-        if (request.context["pending_user"].attributes.get("reset_password") == True):
+        if request.context["pending_user"].attributes.get("reset_password") == True:
             return True
 
         return False
@@ -28,7 +28,7 @@ You will need to create two expression policies; a policy that checks the value 
 
         ```python
         # Check if user has the "reset_password" attribute set to true
-        if (request.context["pending_user"].attributes.get("reset_password") == True):
+        if request.context["pending_user"].attributes.get("reset_password") == True:
             # Sets the user's "reset_password" attribute set to false so that they're not forced to reset their password upon next login
             request.context["pending_user"].attributes["reset_password"] = False
             return True

--- a/website/docs/users-sources/user/password_reset_on_login.mdx
+++ b/website/docs/users-sources/user/password_reset_on_login.mdx
@@ -4,6 +4,13 @@ title: Force password reset on next login
 
 You can require users to reset their password on their next login, using expression policies, custom stages, and a custom user attribute. This guide explains how to configure this with the `default-authentication-flow`; however, the same steps apply to any authentication flow.
 
+Configuring forced password reset on next login involves the following steps:
+
+    1. Creating two expression policicies.
+    2. Creating and binding two stages to the active authentication flow.
+    3. Binding the expression policies to the stages.
+    4. Setting a custom user attribute which tiggers the password prompt.
+
 ## Create expression policies
 
 You'll need to create two expression policies; one that checks the value of a custom user attribute on the user account attempting to log in, and another that resets the value of the custom user attribute.

--- a/website/docs/users-sources/user/password_reset_on_login.mdx
+++ b/website/docs/users-sources/user/password_reset_on_login.mdx
@@ -2,34 +2,34 @@
 title: Force password reset on next login
 ---
 
-It's possible to utilize expression policies, custom stages, and a custom user attribute to force users to reset their password on next login. This guide describes how to configure this in conjunction with the `default-authentication-flow`, however the same process can be used with any authentication flow.
+You can use expression policies, custom stages, and a custom user attribute to require users to reset their password on their next login. This guide explains how to set this up with the `default-authentication-flow`, however the same steps apply to any authentication flow.
 
 ## Create expression policies
 
-You will need to create two expression policies; a policy that checks the value of a custom user attribute on whichever user account is attempting to login, and a policy that resets the value of the custom user attribute.
+You'll' need to create two expression policies; one that checks the value of a custom user attribute on the user account attempting to log in, and another that resets the value of the custom user attribute.
 
 1. Log in to authentik as an administrator and open the authentik Admin interface.
-2. Navigate to **Customization** > **Policies** and click **Create** to create the first policy.
+2. Navigate to **Customization** > **Policies** and click **Create** to set up the first policy.
 3. Select **Expression Policy** as the policy type, click **Next**, and configure the following settings:
     - **Name**: Provide a descriptive name for the policy (e.g. `reset_password_check`).
     - **Expression**:
 
         ```python
-        # Check if user has the "reset_password" attribute set to true
+        # Check if the "reset_password" attribute set to true for the pending user
         if request.context["pending_user"].attributes.get("reset_password") == True:
             return True
 
         return False
         ```
 
-4. Click **Finish** to create the policy and repeat the process to create the second policy with the following settings:
+4. Click **Finish** to save the first policy, then repeat the steps to create the second policy using the following settings:
     - **Name**: Provide a descriptive name for the policy (e.g. `reset_password_update`).
     - **Expression**:
 
         ```python
-        # Check if user has the "reset_password" attribute set to true
+        # Check if the "reset_password" attribute is set to true for the pending user
         if request.context["pending_user"].attributes.get("reset_password") == True:
-            # Sets the user's "reset_password" attribute set to false so that they're not forced to reset their password upon next login
+            # Resest the "reset_password" attribute to false to prevent forcing a password reset on next login
             request.context["pending_user"].attributes["reset_password"] = False
             return True
 
@@ -40,7 +40,7 @@ You will need to create two expression policies; a policy that checks the value 
 
 ## Create stages
 
-You will need to create two stages; a prompt stage to prompt the user for a new password, and a user write stage to write the new password to the user's account. Both of these stages will need to be bound to the authentication flow that's in use, usually the `default-authentication-flow`.
+You'll need to create two stages; a _Prompt stage_ to prompt the user to enter a new password, and a _User Write stage_ to update the user's account with the new password. Both stages will need to be bound to the active authentication flow, typically the `default-authentication-flow`.
 
 1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Flows and Stages** > **Flows** and click on the name of the authentication flow that's in use (e.g. `default-authentication-flow`).

--- a/website/docs/users-sources/user/password_reset_on_login.mdx
+++ b/website/docs/users-sources/user/password_reset_on_login.mdx
@@ -9,7 +9,7 @@ Configuring forced password reset on next login involves the following steps:
     1. Creating two expression policicies.
     2. Creating and binding two stages to the active authentication flow.
     3. Binding the expression policies to the stages.
-    4. Setting a custom user attribute which tiggers the password prompt.
+    4. Setting a custom user attribute which triggers the password prompt.
 
 ## Create expression policies
 

--- a/website/docs/users-sources/user/password_reset_on_login.mdx
+++ b/website/docs/users-sources/user/password_reset_on_login.mdx
@@ -62,7 +62,7 @@ You'll need to create two stages; a _Prompt stage_ to prompt the user to enter a
         - _(Optional but recommended)_ Select `default-password-change-policy`.
 
 :::tip
-Optionally, you can create and add a text field to the prompt stage to inform users that they are required to reset their password. For more details on configuring this, refer to the [Prompt Stage documentation](../add-secure-apps/flows-stages/stages/prompt/index.md#Prompt).
+Optionally, you can create and add a text field to the prompt stage to inform users that they are required to reset their password. For more details on configuring this, refer to the [Prompt Stage documentation](../../add-secure-apps/flows-stages/stages/prompt/index.md#Prompt).
 :::
 
 5. Click **Next** to create the stage and then configure the following settings for the binding:

--- a/website/docs/users-sources/user/password_reset_on_login.mdx
+++ b/website/docs/users-sources/user/password_reset_on_login.mdx
@@ -62,7 +62,7 @@ You'll need to create two stages; a _Prompt stage_ to prompt the user to enter a
         - _(Optional but recommended)_ Select `default-password-change-policy`.
 
 :::tip
-Optionally, you can create and add a text field to the prompt stage to inform users that they are required to reset their password. For more details on configuring this, refer to the [Prompt Stage documentation](../../add-secure-apps/flows-stages/stages/prompt/index.md#Prompt).
+Optionally, you can create and add a text field to the prompt stage to inform users that they are required to reset their password. For more details on configuring this, refer to the [Prompt Stage documentation](../../add-secure-apps/flows-stages/stages/prompt/index.md).
 :::
 
 5. Click **Next** to create the stage and then configure the following settings for the binding:

--- a/website/docs/users-sources/user/password_reset_on_login.mdx
+++ b/website/docs/users-sources/user/password_reset_on_login.mdx
@@ -71,7 +71,7 @@ Optionally, create a text field that explains to the user that they're being for
     - **Order**: `26` or any number higher than the `Force Password Reset Prompt Stage` stage order and lower than the `default-authentication-mfa-validation` stage order.
     - Leave the other settings as their default values.
 
-8. Click **Finish** to create the binding
+8. Click **Finish** to create the binding.
 
 ## Bind policies to stages
 
@@ -81,7 +81,7 @@ You will need to bind the previously created policies to the newly created stage
     - The `reset_password_update` policy needs to be bound to the `Force Password Reset User Write Stage`.
 
 1. Log in to authentik as an administrator and open the authentik Admin interface.
-2. Navigate to **Flows and Stages** > **Flows** and click on the name of the authentication policy that's in use (e.g. `default-authentication-flow`).
+2. Navigate to **Flows and Stages** > **Flows** and click on the name of the active authentication flow, typically `default-authentication-flow`.
 3. Select the **Stage Bindings** tab and click the arrow next to the newly created `Force Password Reset Prompt Stage` to expand it.
 4. Click **Bind existing Policy / Group / User**.
 5. Set **Policy** to `reset_password_check` and click **Create**.
@@ -91,7 +91,7 @@ You will need to bind the previously created policies to the newly created stage
 
 ## Set custom user attribute
 
-To force a user to reset their password on next login, you will need to set a custom user attribute on their account.
+To require a user to reset their password on next login, you will need to set a custom user attribute on their account.
 
 1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Directory** > **Users** and click the **Edit** icon of the user in question.
@@ -101,4 +101,4 @@ To force a user to reset their password on next login, you will need to set a cu
     ```
 4. Click **Update**.
 
-The next time the user logs in, they will be forced to reset their password.
+The next time the user logs in, they will be required to reset their password, and the `reset_password` attribute on their account will be set to `False`.

--- a/website/docs/users-sources/user/password_reset_on_login.mdx
+++ b/website/docs/users-sources/user/password_reset_on_login.mdx
@@ -6,7 +6,7 @@ You can use expression policies, custom stages, and a custom user attribute to r
 
 ## Create expression policies
 
-You'll' need to create two expression policies; one that checks the value of a custom user attribute on the user account attempting to log in, and another that resets the value of the custom user attribute.
+You'll need to create two expression policies; one that checks the value of a custom user attribute on the user account attempting to log in, and another that resets the value of the custom user attribute.
 
 1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Customization** > **Policies** and click **Create** to set up the first policy.
@@ -29,7 +29,7 @@ You'll' need to create two expression policies; one that checks the value of a c
         ```python
         # Check if the "reset_password" attribute is set to true for the pending user
         if request.context["pending_user"].attributes.get("reset_password") == True:
-            # Resest the "reset_password" attribute to false to prevent forcing a password reset on next login
+            # Reset the "reset_password" attribute to false to prevent forcing a password reset on next login
             request.context["pending_user"].attributes["reset_password"] = False
             return True
 

--- a/website/docs/users-sources/user/password_reset_on_login.mdx
+++ b/website/docs/users-sources/user/password_reset_on_login.mdx
@@ -58,7 +58,7 @@ You'll need to create two stages; a _Prompt stage_ to prompt the user to enter a
 Optionally, create a text field that explains to the user that they're being forced to reset their password. This text field can be added to the prompt stage. See the [Prompt Stage documentation](../add-secure-apps/flows-stages/stages/prompt/index.md#Prompt) for more information.
 :::
 
-5. Click **Next** to creat the stage and then configure the following settings for the binding:
+5. Click **Next** to create the stage and then configure the following settings for the binding:
     - **Order**: `25` or any number higher than the `default-authentication-password` stage order and lower than the `default-authentication-mfa-validation` stage order.
     - Leave the other settings as their default values.
 

--- a/website/docs/users-sources/user/password_reset_on_login.mdx
+++ b/website/docs/users-sources/user/password_reset_on_login.mdx
@@ -2,7 +2,7 @@
 title: Force password reset on next login
 ---
 
-You can use expression policies, custom stages, and a custom user attribute to require users to reset their password on their next login. This guide explains how to set this up with the `default-authentication-flow`, however the same steps apply to any authentication flow.
+You can require users to reset their password on their next login, using expression policies, custom stages, and a custom user attribute. This guide explains how to configure this with the `default-authentication-flow`; however, the same steps apply to any authentication flow.
 
 ## Create expression policies
 
@@ -55,7 +55,7 @@ You'll need to create two stages; a _Prompt stage_ to prompt the user to enter a
         - _(Optional but recommended)_ Select `default-password-change-policy`.
 
 :::tip
-Optionally, create a text field that explains to the user that they're being forced to reset their password. This text field can be added to the prompt stage. See the [Prompt Stage documentation](../add-secure-apps/flows-stages/stages/prompt/index.md#Prompt) for more information.
+Optionally, you can create and add a text field to the prompt stage to inform users that they are required to reset their password. For more details on configuring this, refer to the [Prompt Stage documentation](../add-secure-apps/flows-stages/stages/prompt/index.md#Prompt).
 :::
 
 5. Click **Next** to create the stage and then configure the following settings for the binding:

--- a/website/docs/users-sources/user/password_reset_on_login.mdx
+++ b/website/docs/users-sources/user/password_reset_on_login.mdx
@@ -43,7 +43,7 @@ You'll need to create two expression policies; one that checks the value of a cu
 You'll need to create two stages; a _Prompt stage_ to prompt the user to enter a new password, and a _User Write stage_ to update the user's account with the new password. Both stages will need to be bound to the active authentication flow, typically the `default-authentication-flow`.
 
 1. Log in to authentik as an administrator and open the authentik Admin interface.
-2. Navigate to **Flows and Stages** > **Flows** and click on the name of the authentication flow that's in use (e.g. `default-authentication-flow`).
+2. Navigate to **Flows and Stages** > **Flows** and click on the name of the active authentication flow, typically the `default-authentication-flow`.
 3. Select the **Stage Bindings** tab and click **Create and bind stage**.
 4. Select **Prompt Stage** as the stage type, click **Next**, and configure the following settings for the stage:
     - **Name**: Provide a descriptive name for the stage (e.g. `Force Password Reset Prompt Stage`).

--- a/website/docs/users-sources/user/password_reset_on_login.mdx
+++ b/website/docs/users-sources/user/password_reset_on_login.mdx
@@ -1,5 +1,6 @@
 ---
 title: Force password reset on next login
+sidebar_label: Password reset on login
 ---
 
 You can require users to reset their password on their next login, using expression policies, custom stages, and a custom user attribute. This guide explains how to configure this with the `default-authentication-flow`; however, the same steps apply to any authentication flow.


### PR DESCRIPTION
## Details

Adds a guide explaining how to force a user to reset their password on next login.

Current location in troubleshooting is temporary

---

## Checklist

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
