### PR TITLE
website/dev docs: FDE e2e: fix useless markdown lini

### DIFF
--- a/website/docs/developer-docs/setup/full-dev-environment.mdx
+++ b/website/docs/developer-docs/setup/full-dev-environment.mdx
@@ -151,7 +151,7 @@ In case of issues in this process, feel free to use `make dev-reset` which drops
 
 To run E2E tests, navigate to the `/tests/e2e` directory in your local copy of the authentik git repo, and start the services by running `docker compose up -d`.
 
-You can then view the Selenium Chrome browser via [http://localhost:7900/](http://localhost:7900) using the password: `secret`.
+You can then view the Selenium Chrome browser via http://localhost:7900/ using the password: `secret`.
 
 Alternatively, you can connect directly via VNC on port `5900` using the password: `secret`.
 


### PR DESCRIPTION
It renders the same and was a mishap on my part when I copied the link in a previous pr

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
