### PR TITLE
providers/oauth2: fix clean_expired_models failing

### DIFF
--- a/authentik/providers/oauth2/signals.py
+++ b/authentik/providers/oauth2/signals.py
@@ -10,7 +10,7 @@ def user_session_deleted_oauth_tokens_removal(sender, instance: AuthenticatedSes
     """Revoke tokens upon user logout"""
     AccessToken.objects.filter(
         user=instance.user,
-        session__session__session_key=instance.session.session_key,
+        session__session__session_key=instance.pk,
     ).delete()
 
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

In this signal we were accessing the relation which at that point might've been deleted already, but we can use the PK

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
