### PR TITLE
Bitwarden integration requires a bitwarden subscription

### DIFF
--- a/website/integrations/security/bitwarden/index.mdx
+++ b/website/integrations/security/bitwarden/index.mdx
@@ -24,6 +24,10 @@ The following placeholders are used in this guide:
 This documentation lists only the settings that you need to change from their default values. Be aware that any changes other than those explicitly mentioned in this guide could cause issues accessing your application.
 :::
 
+:::note
+Setting up Single Sign On with bitwarden requires [an enterprise subscription](https://bitwarden.com/help/password-manager-plans/#compare-business-plans)
+:::
+
 ## Configuration methods
 
 You can configure Bitwarden to use either OIDC or SAML; this guide explains both options.


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
This PR updates the documentation to clarify that an bitwarden enterprise subscription is required to integrate with authentik

---

## Checklist

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
