### PR TITLE
web/a11y: Wizards & Forms

### DIFF
--- a/web/src/components/ak-wizard/WizardStep.ts
+++ b/web/src/components/ak-wizard/WizardStep.ts
@@ -80,7 +80,7 @@ export abstract class WizardStep extends AKElement {
     ];
 
     @property({ type: Boolean, attribute: true, reflect: true })
-    enabled = false;
+    public enabled?: boolean;
 
     /**
      * The name. Should match the slot. Reflected if not present.
@@ -89,7 +89,7 @@ export abstract class WizardStep extends AKElement {
     name?: string;
 
     @consume({ context: wizardStepContext, subscribe: true })
-    wizardStepState: WizardStepState = { currentStep: undefined, stepLabels: [] };
+    protected wizardStepState: WizardStepState = { currentStep: undefined, stepLabels: [] };
 
     /**
      * What appears in the titlebar of the Wizard. Usually, but not necessarily, the same for all
@@ -263,7 +263,7 @@ export abstract class WizardStep extends AKElement {
             });
     }
 
-    renderHeaderCancelIcon() {
+    protected renderHeaderCancelIcon() {
         return html`<button
             class="pf-c-button pf-m-plain pf-c-wizard__close"
             type="button"

--- a/web/src/elements/wizard/Wizard.ts
+++ b/web/src/elements/wizard/Wizard.ts
@@ -40,13 +40,13 @@ export class Wizard extends ModalButton {
      * Whether the wizard can be cancelled.
      */
     @property({ type: Boolean })
-    canCancel = true;
+    public canCancel = true;
 
     /**
      * Whether the wizard can go back to the previous step.
      */
     @property({ type: Boolean })
-    canBack = true;
+    public canBack = true;
 
     /**
      * Header title of the wizard.
@@ -64,7 +64,7 @@ export class Wizard extends ModalButton {
      * Whether the wizard is valid and can proceed to the next step.
      */
     @property({ type: Boolean })
-    isValid = false;
+    public isValid?: boolean;
 
     /**
      * Actions to display at the end of the wizard.


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Depends on

- #15877 
- #15878 

## Details

This PR continues the a11y-ification of the UI, adding additional labels for wizards, tables, inputs, navigations -- Pretty much everything the test suite needs to traverse the DOM.


<img width="1144" height="581" alt="Screenshot 2025-07-21 at 22 24 44" src="https://github.com/user-attachments/assets/9e1b692a-f237-4a98-be4b-ceb6598fd0bb" />


<img width="1042" height="752" alt="Screenshot 2025-07-21 at 22 33 55" src="https://github.com/user-attachments/assets/e9408979-1360-4458-93e7-2501626a8cec" />

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)

## See also

- #15876 