### PR TITLE
web/a11y: ak-form-group part 2: type clean up, Chrome warnings

### DIFF
--- a/web/src/admin/applications/wizard/steps/providers/ak-application-wizard-provider-for-rac.ts
+++ b/web/src/admin/applications/wizard/steps/providers/ak-application-wizard-provider-for-rac.ts
@@ -61,7 +61,7 @@ export class ApplicationWizardRACProviderForm extends ApplicationWizardProviderF
                     input-hint="code"
                 ></ak-text-input>
 
-                <ak-form-group open label=" ${msg("Protocol settings")} ">
+                <ak-form-group open label="${msg("Protocol settings")}">
                     <div class="pf-c-form">
                         <ak-form-element-horizontal
                             label=${msg("Property mappings")}

--- a/web/src/admin/providers/oauth2/OAuth2ProviderFormForm.ts
+++ b/web/src/admin/providers/oauth2/OAuth2ProviderFormForm.ts
@@ -178,6 +178,7 @@ export function renderForm(
                 >
                 </ak-hidden-text-input>
                 <ak-form-element-horizontal
+                    flow-direction="row"
                     label=${msg("Redirect URIs/Origins (RegEx)")}
                     name="redirectUris"
                 >

--- a/web/src/admin/providers/oauth2/OAuth2ProviderFormForm.ts
+++ b/web/src/admin/providers/oauth2/OAuth2ProviderFormForm.ts
@@ -12,17 +12,13 @@ import "#elements/forms/HorizontalFormElement";
 import "#elements/forms/Radio";
 import "#elements/forms/SearchSelect/index";
 import "#elements/utils/TimeDeltaHelp";
+import "#admin/providers/oauth2/OAuth2ProviderRedirectURI";
 
 import { propertyMappingsProvider, propertyMappingsSelector } from "./OAuth2ProviderFormHelpers.js";
 import { oauth2ProvidersProvider, oauth2ProvidersSelector } from "./OAuth2ProvidersProvider.js";
 import { oauth2SourcesProvider, oauth2SourcesSelector } from "./OAuth2Sources.js";
 
 import { ascii_letters, digits, randomString } from "#common/utils";
-
-import {
-    akOAuthRedirectURIInput,
-    IRedirectURIInput,
-} from "#admin/providers/oauth2/OAuth2ProviderRedirectURI";
 
 import {
     ClientTypeEnum,
@@ -185,12 +181,14 @@ export function renderForm(
                     <ak-array-input
                         .items=${provider?.redirectUris ?? []}
                         .newItem=${() => ({ matchingMode: MatchingModeEnum.Strict, url: "" })}
-                        .row=${(f?: RedirectURI) =>
-                            akOAuthRedirectURIInput({
-                                ".redirectURI": f,
-                                "style": "width: 100%",
-                                "name": "oauth2-redirect-uri",
-                            } as unknown as IRedirectURIInput)}
+                        .row=${(redirectURI: RedirectURI, idx: number) => {
+                            return html`<ak-provider-oauth2-redirect-uri
+                                .redirectURI=${redirectURI}
+                                name="oauth2-redirect-uri"
+                                style="width: 100%"
+                                inputID="redirect-uri-${idx}"
+                            ></ak-provider-oauth2-redirect-uri>`;
+                        }}
                     >
                     </ak-array-input>
                     ${redirectUriHelp}

--- a/web/src/admin/providers/oauth2/OAuth2ProviderRedirectURI.ts
+++ b/web/src/admin/providers/oauth2/OAuth2ProviderRedirectURI.ts
@@ -1,11 +1,9 @@
 import "#admin/providers/oauth2/OAuth2ProviderRedirectURI";
 
 import { AkControlElement } from "#elements/AkControlElement";
-import { type Spread } from "#elements/types";
+import { LitPropertyRecord } from "#elements/types";
 
 import { MatchingModeEnum, RedirectURI } from "@goauthentik/api";
-
-import { spread } from "@open-wc/lit-helpers";
 
 import { msg } from "@lit/localize";
 import { css, html } from "lit";
@@ -16,9 +14,12 @@ import PFFormControl from "@patternfly/patternfly/components/FormControl/form-co
 import PFInputGroup from "@patternfly/patternfly/components/InputGroup/input-group.css";
 import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
-export interface IRedirectURIInput {
+export type RedirectURIProperties = LitPropertyRecord<{
     redirectURI: RedirectURI;
-}
+}> & {
+    style?: string;
+    name: string;
+};
 
 @customElement("ak-provider-oauth2-redirect-uri")
 export class OAuth2ProviderRedirectURI extends AkControlElement<RedirectURI> {
@@ -34,10 +35,13 @@ export class OAuth2ProviderRedirectURI extends AkControlElement<RedirectURI> {
     ];
 
     @property({ type: Object, attribute: false })
-    redirectURI: RedirectURI = {
+    public redirectURI: RedirectURI = {
         matchingMode: MatchingModeEnum.Strict,
         url: "",
     };
+
+    @property({ type: String })
+    public inputID?: string;
 
     @queryAll(".ak-form-control")
     controls?: HTMLInputElement[];
@@ -84,19 +88,13 @@ export class OAuth2ProviderRedirectURI extends AkControlElement<RedirectURI> {
                 spellcheck="false"
                 autocomplete="off"
                 required
-                id="url"
+                id=${ifDefined(this.inputID)}
                 placeholder=${msg("URL")}
                 name="url"
                 tabindex="1"
             />
         </div>`;
     }
-}
-
-export function akOAuthRedirectURIInput(properties: IRedirectURIInput) {
-    return html`<ak-provider-oauth2-redirect-uri
-        ${spread(properties as unknown as Spread)}
-    ></ak-provider-oauth2-redirect-uri>`;
 }
 
 declare global {

--- a/web/src/admin/providers/radius/RadiusProviderFormForm.ts
+++ b/web/src/admin/providers/radius/RadiusProviderFormForm.ts
@@ -76,12 +76,14 @@ export function renderForm(
 
         <ak-form-group open label="${msg("Protocol settings")}">
             <div class="pf-c-form">
-                <ak-hidden-text-input>
-                    name="sharedSecret" label=${msg("Shared secret")}
+                <ak-hidden-text-input
+                    name="sharedSecret"
+                    label=${msg("Shared secret")}
                     .errorMessages=${errors?.sharedSecret ?? []}
                     value=${provider?.sharedSecret ?? randomString(128, ascii_letters + digits)}
-                    required input-hint="code" ></ak-hidden-text-input
-                >
+                    required
+                    input-hint="code"
+                ></ak-hidden-text-input>
                 <ak-text-input
                     name="clientNetworks"
                     label=${msg("Client Networks")}

--- a/web/src/common/styles/authentik.css
+++ b/web/src/common/styles/authentik.css
@@ -35,6 +35,11 @@
     --ak-navbar--height: 7rem;
 }
 
+.pf-c-form__group {
+    --pf-c-form--m-horizontal__group-label--md--GridColumnWidth: minmax(max-content, 9.375rem);
+    column-gap: var(--pf-global--spacer--md);
+}
+
 @supports selector(::-webkit-scrollbar) {
     ::-webkit-scrollbar {
         width: 5px;

--- a/web/src/elements/ak-array-input.ts
+++ b/web/src/elements/ak-array-input.ts
@@ -15,7 +15,7 @@ import PFFormControl from "@patternfly/patternfly/components/FormControl/form-co
 import PFInputGroup from "@patternfly/patternfly/components/InputGroup/input-group.css";
 import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
-type InputCell<T> = (el: T) => TemplateResult | typeof nothing;
+export type InputCell<T> = (el: T, idx: number) => TemplateResult | typeof nothing;
 
 export interface IArrayInput<T> {
     row: InputCell<T>;
@@ -151,7 +151,7 @@ export class ArrayInput<T> extends AkControlElement<T[]> implements IArrayInput<
                 (item: Keyed<T>) => item.key,
                 (item: Keyed<T>, idx) =>
                     html` <div class="ak-input-group" @change=${() => this.onChange()}>
-                        ${this.row(item.item)}${this.renderDeleteButton(idx)}
+                        ${this.row(item.item, idx)}${this.renderDeleteButton(idx)}
                     </div>`,
             )}
             <button class="pf-c-button pf-m-link" type="button" @click=${this.addNewGroup}>

--- a/web/src/elements/forms/HorizontalFormElement.ts
+++ b/web/src/elements/forms/HorizontalFormElement.ts
@@ -58,6 +58,10 @@ export class HorizontalFormElement extends AKElement {
                 grid-template-columns:
                     var(--pf-c-form--m-horizontal__group-label--md--GridColumnWidth)
                     var(--pf-c-form--m-horizontal__group-control--md--GridColumnWidth);
+
+                &[data-flow-direction="row"] {
+                    grid-template-columns: 1fr;
+                }
             }
 
             .pf-c-form__group-label {
@@ -75,16 +79,16 @@ export class HorizontalFormElement extends AKElement {
     ];
 
     @property({ type: String, reflect: false })
-    fieldID?: string;
+    public fieldID?: string;
 
-    @property()
-    label = "";
+    @property({ type: String })
+    public label = "";
 
     @property({ type: Boolean })
-    required = false;
+    public required = false;
 
     @property({ attribute: false })
-    errorMessages: string[] | string[][] = [];
+    public errorMessages: string[] | string[][] = [];
 
     _invalid = false;
 
@@ -105,8 +109,14 @@ export class HorizontalFormElement extends AKElement {
         return this._invalid;
     }
 
-    @property()
-    name = "";
+    @property({ type: String })
+    public name = "";
+
+    @property({
+        type: String,
+        attribute: "flow-direction",
+    })
+    public flowDirection: "row" | "column" = "column";
 
     firstUpdated(): void {
         this.updated();
@@ -132,7 +142,12 @@ export class HorizontalFormElement extends AKElement {
 
     render(): TemplateResult {
         this.updated();
-        return html`<div class="pf-c-form__group" role="group" aria-label="${this.label}">
+        return html`<div
+            class="pf-c-form__group"
+            role="group"
+            aria-label="${this.label}"
+            data-flow-direction="${this.flowDirection}"
+        >
             <div class="pf-c-form__group-label">
                 <label
                     id="group-label"

--- a/web/src/elements/types.ts
+++ b/web/src/elements/types.ts
@@ -44,7 +44,7 @@ export type TemplatedProperties<
  * ```
  */
 export type LitPropertyRecord<T extends object> = {
-    [K in keyof T as K extends string ? LitPropertyKey<K> : never]: T[K];
+    [K in keyof T as K extends string ? LitPropertyKey<K> : never]?: T[K];
 };
 
 /**


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

This PR is follow-up to #15688. Some enhancements include...

- Fix Chrome warnings surrounding `ak-array-input` having duplicate IDs
- Fix typo in template
- Add more type checking around OAuth provider properties
- Fix issue where extra-wide field names compete for field width

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
