### PR TITLE
outpost/proxyv2: add session cleanup for filesystem session store

### DIFF
--- a/internal/outpost/proxyv2/filesystemstore/filesystemstore.go
+++ b/internal/outpost/proxyv2/filesystemstore/filesystemstore.go
@@ -1,0 +1,226 @@
+package filesystemstore
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/gorilla/sessions"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	SessionCleanupInterval     = 5 * time.Minute
+	SessionCleanupLockFileName = "session-cleanup.lock"
+	SessionFilePrefix          = "session_"
+	SessionTestFile            = SessionFilePrefix + "write_test"
+)
+
+var (
+	ErrSessionCleanupAlreadyRunning = errors.New("session cleanup is already running by another instance")
+	ErrSessionStoreNoPermission     = errors.New("path is not writable")
+	ErrSessionStorePathNotExist     = errors.New("path does not exist")
+)
+
+type Store struct {
+	*sessions.FilesystemStore
+	storePath string
+	log       *log.Entry
+}
+
+// NewStore checks if the specified store path exists, is writable and creates a new filesystem session store.
+func NewStore(storePath string, keyPairs ...[]byte) (*Store, error) {
+	if storePath == "" {
+		storePath = os.TempDir()
+	}
+
+	// check if path exists
+	_, err := os.ReadDir(storePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, ErrSessionStorePathNotExist
+		}
+		return nil, err
+	}
+
+	// check if path is writable
+	testPath := path.Join(storePath, SessionTestFile)
+	testFile, err := os.OpenFile(testPath, os.O_CREATE, 0600)
+	if err != nil {
+		if errors.Is(err, os.ErrPermission) {
+			return nil, ErrSessionStoreNoPermission
+		}
+		return nil, err
+	}
+	if err = testFile.Close(); err != nil {
+		return nil, err
+	}
+	if err = os.Remove(testPath); err != nil {
+		return nil, err
+	}
+
+	return &Store{
+		FilesystemStore: sessions.NewFilesystemStore(storePath, keyPairs...),
+		storePath:       storePath,
+		log:             log.WithField("logger", "authentik.outpost.proxyv2.filesystemstore"),
+	}, nil
+}
+
+// SessionCleanup acquires a file lock to ensure only one instance runs at a time,
+// then checks and deletes expired session files from the filesystem session store.
+// It supports context-based cancellation to allow graceful shutdowns or timeouts.
+func (s *Store) SessionCleanup(ctx context.Context) error {
+	s.log.Info("Starting session cleanup")
+	lockPath := path.Join(s.storePath, SessionCleanupLockFileName)
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := lockFile.Close(); closeErr != nil {
+			s.log.WithError(closeErr).Warn("failed to close lock file")
+		}
+	}()
+
+	err = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err != nil {
+		if errno, ok := err.(syscall.Errno); ok && errno == syscall.EWOULDBLOCK {
+			return ErrSessionCleanupAlreadyRunning
+		}
+		return err
+	}
+	defer func() {
+		if flockErr := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN); flockErr != nil {
+			s.log.WithError(flockErr).Warn("failed to unlock file")
+		}
+
+		if removeErr := os.Remove(lockPath); removeErr != nil {
+			s.log.WithError(removeErr).Warn("failed to remove lock file")
+		}
+	}()
+
+	return s.sessionCleanup(ctx)
+}
+
+// sessionCleanup checks the modification time of all session files and removes them
+// when they reach the configured maximum age in the session store.
+// Since the FilesystemStore from Gorilla does not have a session cleanup function,
+// it is only necessary for the filesystem session store.
+func (s *Store) sessionCleanup(ctx context.Context) error {
+	files, err := os.ReadDir(s.storePath)
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+	for _, file := range files {
+		select {
+		case <-ctx.Done():
+			s.log.Warn("session cleanup interrupted during file processing")
+			return ctx.Err()
+		default:
+		}
+
+		if !strings.HasPrefix(file.Name(), SessionFilePrefix) {
+			continue
+		}
+
+		fullPath := path.Join(s.storePath, file.Name())
+		stat, err := os.Lstat(fullPath)
+		if err != nil {
+			s.log.WithError(err).WithField("path", fullPath).Warning("failed to read stats from file")
+			errs = append(errs, err)
+			continue
+		}
+
+		modTime := stat.ModTime()
+		if time.Since(modTime) <= time.Duration(s.Options.MaxAge)*time.Second {
+			s.log.WithField("max-age", s.Options.MaxAge).WithField("modified", modTime.String()).Debug("session still valid")
+			continue
+		}
+
+		s.log.WithField("path", fullPath).WithField("modified", modTime.String()).Info("cleanup expired session")
+		if err = os.Remove(fullPath); err != nil {
+			s.log.WithError(err).WithField("path", fullPath).Warn("failed to delete session")
+			errs = append(errs, err)
+			continue
+		}
+	}
+	return errors.Join(errs...)
+}
+
+var (
+	cancelCleanup context.CancelFunc
+	doneCleanup   chan struct{}
+	globalStore   *Store
+	mu            sync.Mutex
+)
+
+// GetPersistentStore creates a new filesystem store if it is the first time the function has been called,
+// or if the path string has changed. It then stores this in the globalStore variable.
+// If the function is called multiple times, the store from the variable is returned to ensure that only one instance is running.
+func GetPersistentStore(path string) (*Store, error) {
+	mu.Lock()
+	defer mu.Unlock()
+	if globalStore == nil || globalStore.storePath != path {
+		if cancelCleanup != nil {
+			cancelCleanup()
+			if doneCleanup != nil {
+				<-doneCleanup
+			}
+		}
+		store, err := NewStore(path)
+		if err != nil {
+			return nil, err
+		}
+		globalStore = store
+		ctx, cancel := context.WithCancel(context.Background())
+		cancelCleanup = cancel
+		doneCleanup = make(chan struct{})
+
+		go func() {
+			defer close(doneCleanup)
+			globalStore.log.Info("Scheduling session cleanup job")
+			ticker := time.NewTicker(SessionCleanupInterval)
+			defer ticker.Stop()
+
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					err := globalStore.SessionCleanup(ctx)
+					if err == nil {
+						continue
+					}
+					if errors.Is(err, ErrSessionCleanupAlreadyRunning) {
+						globalStore.log.WithError(err).Warn("Session cleanup is locked by another job")
+						continue
+					}
+					globalStore.log.WithError(err).Warn("Session cleanup returned error")
+				}
+			}
+		}()
+	}
+	return globalStore, nil
+}
+
+// StopPersistentStore stops the cleanup background job and clears the globalStore variable.
+func StopPersistentStore() {
+	mu.Lock()
+	defer mu.Unlock()
+	if cancelCleanup != nil {
+		cancelCleanup()
+		if doneCleanup != nil {
+			<-doneCleanup
+		}
+	}
+	cancelCleanup = nil
+	doneCleanup = nil
+	globalStore = nil
+}

--- a/internal/outpost/proxyv2/filesystemstore/filesystemstore_test.go
+++ b/internal/outpost/proxyv2/filesystemstore/filesystemstore_test.go
@@ -1,0 +1,146 @@
+package filesystemstore
+
+import (
+	"context"
+	"os"
+	"path"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createTempSessionFile(t *testing.T, dir string, modTime time.Time) string {
+	t.Helper()
+	path := filepath.Join(dir, "session_test")
+	err := os.WriteFile(path, []byte("session data"), 0600)
+	require.NoError(t, err)
+	err = os.Chtimes(path, modTime, modTime)
+	require.NoError(t, err)
+	return path
+}
+
+func TestNewStore_PathNotExist(t *testing.T) {
+	_, err := NewStore("/invalid_path")
+	assert.ErrorIs(t, err, ErrSessionStorePathNotExist)
+}
+
+func TestNewStore_PathNotWritable(t *testing.T) {
+	storePath := path.Join(os.TempDir(), "test")
+	err := os.Mkdir(storePath, 0400)
+	require.NoError(t, err)
+
+	_, err = NewStore(storePath)
+	assert.ErrorIs(t, err, ErrSessionStoreNoPermission)
+
+	_ = os.RemoveAll(storePath)
+}
+
+func TestNewStore(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := NewStore(tmpDir)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, store)
+}
+
+func TestSessionCleanup_RemovesExpired(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := NewStore(tmpDir)
+	require.NoError(t, err)
+	store.Options.MaxAge = 1 // 1 second
+
+	// Create an expired session file
+	oldTime := time.Now().Add(-10 * time.Second)
+	createTempSessionFile(t, tmpDir, oldTime)
+
+	ctx := context.Background()
+	err = store.SessionCleanup(ctx)
+	assert.NoError(t, err)
+
+	// File should be deleted
+	files, _ := os.ReadDir(tmpDir)
+	assert.Empty(t, files)
+}
+
+func TestSessionCleanup_PreservesValid(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := NewStore(tmpDir)
+	require.NoError(t, err)
+	store.Options.MaxAge = 3600 // 1 hour
+
+	// Create a valid (non-expired) session file
+	modTime := time.Now().Add(-10 * time.Second)
+	createTempSessionFile(t, tmpDir, modTime)
+
+	ctx := context.Background()
+	err = store.SessionCleanup(ctx)
+	assert.NoError(t, err)
+
+	// File should still exist
+	files, _ := os.ReadDir(tmpDir)
+	assert.Len(t, files, 1)
+}
+
+func TestSessionCleanup_ContextCancel(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := NewStore(tmpDir)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	err = store.SessionCleanup(ctx)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestSessionCleanup_AlreadyRunning(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := NewStore(tmpDir)
+	require.NoError(t, err)
+
+	// Manually acquire the lock before calling SessionCleanup
+	lockPath := path.Join(tmpDir, SessionCleanupLockFileName)
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600)
+	require.NoError(t, err, "failed to create lock file")
+
+	err = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	require.NoError(t, err, "failed to acquire lock for test")
+
+	// Run SessionCleanup while lock is held
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	err = store.SessionCleanup(ctx)
+	assert.ErrorIs(t, err, ErrSessionCleanupAlreadyRunning)
+
+	// Unlock and clean up
+	_ = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+	_ = lockFile.Close()
+	_ = os.Remove(lockPath)
+}
+
+func TestPersistentStore_ReusesStore(t *testing.T) {
+	tmpDir := t.TempDir()
+	store1, err := GetPersistentStore(tmpDir)
+	require.NoError(t, err)
+	assert.NotNil(t, store1)
+
+	store2, err := GetPersistentStore(tmpDir)
+	require.NoError(t, err)
+	assert.Equal(t, store1, store2)
+
+	StopPersistentStore()
+}
+
+func TestStopPersistentStore(t *testing.T) {
+	tmpDir := t.TempDir()
+	_, err := GetPersistentStore(tmpDir)
+	require.NoError(t, err)
+	StopPersistentStore()
+
+	// call again should not panic
+	StopPersistentStore()
+}


### PR DESCRIPTION
## Details

The package used for the file system sessions `github.com/gorilla/sessions` does not seem to have a session cleanup.
This PR contains a wrapper for the session store with a session cleanup job. With the current implementation, this job will run every five minutes.
With these changes the issue #12230 should hopefully be solved.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
