### PR TITLE
packages/django-dramatiq-postgres: broker: avoid exception on consumer final close

### DIFF
--- a/packages/django-dramatiq-postgres/django_dramatiq_postgres/broker.py
+++ b/packages/django-dramatiq-postgres/django_dramatiq_postgres/broker.py
@@ -447,6 +447,8 @@ class _PostgresConsumer(Consumer):
         finally:
             try:
                 self.connection.close()
+            except DatabaseError:
+                pass
             finally:
                 if self._listen_connection is not None:
                     conn = self._listen_connection


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Consumer may be closed from a different thread than the one where the db connection was created. This happens either when the worker shuts down or when the consumer gets restarted. In either case, we don't care.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
