### PR TITLE
website/integrations: change redirect uri for mealie

### DIFF
--- a/website/integrations/documentation/mealie/index.md
+++ b/website/integrations/documentation/mealie/index.md
@@ -34,7 +34,7 @@ To support the integration of Mealie with authentik, you need to create an appli
 - **Choose a Provider type**: select **OAuth2/OpenID Connect** as the provider type.
 - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
     - Note the **Client ID**, **Client Secret**, , and **slug** values because they will be required later.
-    - Create two `Strict` redirect URIs and set to `https://mealie.company/login` and `https://mealie.company/login?direct=1`.
+    - Create two `Strict` redirect URIs and set to `https://mealie.company/login` and `https://mealie.company/login/?direct=1`.
 - **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/flows-stages/bindings/) (policy, group, or user) to manage the listing and access to applications on a user's **My applications** page.
 
 3. Click **Submit** to save the new application and provider.


### PR DESCRIPTION
Corrected an error in redirect URL from /login?direct=1 to /login/?direct=1

Due to a small misspelling, the whole authentication stopped working.

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
Misspelled the URL / was missing and due to this documentation error the whole authentication did not work 

---

## Checklist

-   [X] Local tests pass (`ak test authentik/`)
-   [X] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [X] The documentation has been updated
-   [X] The documentation has been formatted (`make docs`)
