### PR TITLE
website/integrations: add profile scope to nextcloud oidc

### DIFF
--- a/website/integrations/chat-communication-collaboration/nextcloud/index.mdx
+++ b/website/integrations/chat-communication-collaboration/nextcloud/index.mdx
@@ -142,7 +142,7 @@ Depending on your Nextcloud configuration, you may need to use `https://nextclou
     - **Client ID**: Client ID from authentik
     - **Client secret**: Client secret from authentik
     - **Discovery endpoint**: `https://authentik.company/application/o/<application_slug>/.well-known/openid-configuration`
-    - **Scope**: `email nextcloud openid`
+    - **Scope**: `email profile nextcloud openid`
     - Under **Attribute mappings**:
         - **User ID mapping**: `sub` (or `user_id` for existing users)
         - **Display name mapping**: `name`


### PR DESCRIPTION
When configuring the OpenID Connect user backend app, the  scope profile is missing. Without that, auto-provisioned users will have the display name set to the account name - which is not easily human readable.