### PR TITLE
web/a11y: Flow Search

### DIFF
--- a/web/e2e/fixtures/FormFixture.ts
+++ b/web/e2e/fixtures/FormFixture.ts
@@ -31,8 +31,7 @@ export class FormFixture extends PageFixture {
                 parent.getByRole("spinbutton", {
                     name: fieldName,
                 }),
-            )
-            .first();
+            );
 
         await expect(control, `Field (${fieldName}) should be visible`).toBeVisible();
 
@@ -80,14 +79,12 @@ export class FormFixture extends PageFixture {
         fieldName: string,
         parent: LocatorContext = this.page,
     ): Promise<void> => {
-        const group = parent.getByRole("group", { name: groupName });
+        const group = parent.getByRole("radiogroup", { name: groupName });
 
         await expect(group, `Field "${groupName}" should be visible`).toBeVisible();
         const control = parent.getByRole("radio", { name: fieldName });
 
-        await control.setChecked(true, {
-            force: true,
-        });
+        await control.setChecked(true);
     };
 
     /**

--- a/web/e2e/fixtures/SessionFixture.ts
+++ b/web/e2e/fixtures/SessionFixture.ts
@@ -91,7 +91,11 @@ export class SessionFixture extends PageFixture {
 
         const expectedPathname = typeof to === "string" ? to : to.pathname;
 
-        await this.page.waitForURL(`**${expectedPathname}`);
+        this.logger.info(`Waiting for URL to change to ${expectedPathname}`);
+
+        await this.page.waitForURL(`**${expectedPathname}**`);
+
+        this.logger.info(`URL changed to ${this.page.url()}`);
     }
 
     //#endregion

--- a/web/playwright.config.js
+++ b/web/playwright.config.js
@@ -84,8 +84,12 @@ export default defineConfig({
     /* Configure projects for major browsers */
     projects: [
         {
+            name: "prerequisites",
+            testMatch: /prerequisites\.setup\.ts/,
+        },
+        {
             name: "chromium",
-
+            dependencies: ["prerequisites"],
             use: {
                 ...devices["Desktop Chrome"],
             },

--- a/web/src/admin/admin-overview/SystemTasksPage.ts
+++ b/web/src/admin/admin-overview/SystemTasksPage.ts
@@ -48,9 +48,12 @@ export class SystemTasksPage extends AKElement {
                 )}
             ></ak-page-header>
             <ak-tabs>
-                <section
+                <div
+                    role="tabpanel"
+                    tabindex="0"
                     slot="page-schedules"
-                    data-tab-title="${msg("Schedules")}"
+                    id="page-schedules"
+                    aria-label="${msg("Schedules")}"
                     class="pf-c-page__main-section pf-m-no-padding-mobile"
                 >
                     <div class="pf-l-grid pf-m-gutter">
@@ -60,10 +63,13 @@ export class SystemTasksPage extends AKElement {
                             <ak-schedule-list></ak-schedule-list>
                         </div>
                     </div>
-                </section>
-                <section
+                </div>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
                     slot="page-tasks"
-                    data-tab-title="${msg("Tasks")}"
+                    id="page-tasks"
+                    aria-label="${msg("Tasks")}"
                     class="pf-c-page__main-section pf-m-no-padding-mobile"
                 >
                     <div class="pf-l-grid pf-m-gutter">
@@ -73,7 +79,7 @@ export class SystemTasksPage extends AKElement {
                             <ak-task-list></ak-task-list>
                         </div>
                     </div>
-                </section>
+                </div>
             </ak-tabs>`;
     }
 }

--- a/web/src/admin/admin-overview/SystemTasksPage.ts
+++ b/web/src/admin/admin-overview/SystemTasksPage.ts
@@ -47,40 +47,42 @@ export class SystemTasksPage extends AKElement {
                     "Long-running operations which authentik executes in the background.",
                 )}
             ></ak-page-header>
-            <ak-tabs>
-                <div
-                    role="tabpanel"
-                    tabindex="0"
-                    slot="page-schedules"
-                    id="page-schedules"
-                    aria-label="${msg("Schedules")}"
-                    class="pf-c-page__main-section pf-m-no-padding-mobile"
-                >
-                    <div class="pf-l-grid pf-m-gutter">
-                        <div
-                            class="pf-l-grid__item pf-m-12-col pf-m-12-col-on-xl pf-m-12-col-on-2xl"
-                        >
-                            <ak-schedule-list></ak-schedule-list>
+            <main>
+                <ak-tabs>
+                    <div
+                        role="tabpanel"
+                        tabindex="0"
+                        slot="page-schedules"
+                        id="page-schedules"
+                        aria-label="${msg("Schedules")}"
+                        class="pf-c-page__main-section pf-m-no-padding-mobile"
+                    >
+                        <div class="pf-l-grid pf-m-gutter">
+                            <div
+                                class="pf-l-grid__item pf-m-12-col pf-m-12-col-on-xl pf-m-12-col-on-2xl"
+                            >
+                                <ak-schedule-list></ak-schedule-list>
+                            </div>
                         </div>
                     </div>
-                </div>
-                <div
-                    role="tabpanel"
-                    tabindex="0"
-                    slot="page-tasks"
-                    id="page-tasks"
-                    aria-label="${msg("Tasks")}"
-                    class="pf-c-page__main-section pf-m-no-padding-mobile"
-                >
-                    <div class="pf-l-grid pf-m-gutter">
-                        <div
-                            class="pf-l-grid__item pf-m-12-col pf-m-12-col-on-xl pf-m-12-col-on-2xl"
-                        >
-                            <ak-task-list></ak-task-list>
+                    <div
+                        role="tabpanel"
+                        tabindex="0"
+                        slot="page-tasks"
+                        id="page-tasks"
+                        aria-label="${msg("Tasks")}"
+                        class="pf-c-page__main-section pf-m-no-padding-mobile"
+                    >
+                        <div class="pf-l-grid pf-m-gutter">
+                            <div
+                                class="pf-l-grid__item pf-m-12-col pf-m-12-col-on-xl pf-m-12-col-on-2xl"
+                            >
+                                <ak-task-list></ak-task-list>
+                            </div>
                         </div>
                     </div>
-                </div>
-            </ak-tabs>`;
+                </ak-tabs>
+            </main>`;
     }
 }
 

--- a/web/src/admin/admin-settings/AdminSettingsFooterLinks.ts
+++ b/web/src/admin/admin-settings/AdminSettingsFooterLinks.ts
@@ -1,5 +1,6 @@
 import { AkControlElement } from "#elements/AkControlElement";
 import { type Spread } from "#elements/types";
+import { ifPresent } from "#elements/utils/attributes";
 
 import { FooterLink } from "@goauthentik/api";
 
@@ -8,7 +9,6 @@ import { spread } from "@open-wc/lit-helpers";
 import { msg } from "@lit/localize";
 import { css, html } from "lit";
 import { customElement, property, queryAll } from "lit/decorators.js";
-import { ifDefined } from "lit/directives/if-defined.js";
 
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFInputGroup from "@patternfly/patternfly/components/InputGroup/input-group.css";
@@ -75,7 +75,7 @@ export class FooterLinkInput extends AkControlElement<FooterLink> {
             <input
                 type="url"
                 @change=${onChange}
-                value="${ifDefined(this.footerLink.href ?? undefined)}"
+                value="${ifPresent(this.footerLink.href)}"
                 class="pf-c-form-control ak-form-control pf-m-monospace"
                 autocomplete="off"
                 required

--- a/web/src/admin/applications/ApplicationForm.ts
+++ b/web/src/admin/applications/ApplicationForm.ts
@@ -21,6 +21,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { ModelForm } from "#elements/forms/ModelForm";
 import { CapabilitiesEnum, WithCapabilitiesConfig } from "#elements/mixins/capabilities";
 import { navigate } from "#elements/router/RouterOutlet";
+import { ifPresent } from "#elements/utils/attributes";
 
 import { iconHelperText } from "#admin/helperText";
 import { policyEngineModes } from "#admin/policies/PolicyEngineModes";
@@ -165,7 +166,7 @@ export class ApplicationForm extends WithCapabilitiesConfig(ModelForm<Applicatio
             <ak-provider-search-input
                 name="provider"
                 label=${msg("Provider")}
-                value=${ifDefined(this.instance?.provider ?? undefined)}
+                value=${ifPresent(this.instance?.provider)}
                 help=${msg("Select a provider that this application should use.")}
                 blankable
             ></ak-provider-search-input>
@@ -216,7 +217,7 @@ export class ApplicationForm extends WithCapabilitiesConfig(ModelForm<Applicatio
                         ? html`<ak-file-input
                                   label="${msg("Icon")}"
                                   name="metaIcon"
-                                  value=${ifDefined(this.instance?.metaIcon ?? undefined)}
+                                  value=${ifPresent(this.instance?.metaIcon)}
                                   current=${msg("Currently set to:")}
                               ></ak-file-input>
                               ${this.instance?.metaIcon

--- a/web/src/admin/applications/ApplicationListPage.ts
+++ b/web/src/admin/applications/ApplicationListPage.ts
@@ -14,6 +14,7 @@ import { getURLParam } from "#elements/router/RouteMatch";
 import { PaginatedResponse, TableColumn } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
 import { SlottedTemplateResult } from "#elements/types";
+import { ifPresent } from "#elements/utils/attributes";
 
 import { Application, CoreApi, PoliciesApi } from "@goauthentik/api";
 
@@ -22,7 +23,6 @@ import MDApplication from "~docs/add-secure-apps/applications/index.md";
 import { msg, str } from "@lit/localize";
 import { css, CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
-import { ifDefined } from "lit/directives/if-defined.js";
 
 import PFCard from "@patternfly/patternfly/components/Card/card.css";
 
@@ -117,7 +117,7 @@ export class ApplicationListPage extends WithBrandConfig(TablePage<Application>)
             html`<ak-app-icon
                 aria-label=${msg(str`Application icon for "${item.name}"`)}
                 name=${item.name}
-                icon=${ifDefined(item.metaIcon || undefined)}
+                icon=${ifPresent(item.metaIcon)}
             ></ak-app-icon>`,
             html`<a href="#/core/applications/${item.slug}">
                 <div>${item.name}</div>

--- a/web/src/admin/applications/ApplicationViewPage.ts
+++ b/web/src/admin/applications/ApplicationViewPage.ts
@@ -149,8 +149,11 @@ export class ApplicationViewPage extends AKElement {
                   </div>`
                 : nothing}
             <section
+                role="tabpanel"
+                tabindex="0"
                 slot="page-overview"
-                data-tab-title="${msg("Overview")}"
+                id="page-overview"
+                aria-label="${msg("Overview")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-l-grid pf-m-gutter">
@@ -329,8 +332,11 @@ export class ApplicationViewPage extends AKElement {
                 </div>
             </section>
             <section
+                role="tabpanel"
+                tabindex="0"
                 slot="page-app-entitlements"
-                data-tab-title="${msg("Application entitlements")}"
+                id="page-app-entitlements"
+                aria-label="${msg("Application entitlements")}"
             >
                 <div slot="header" class="pf-c-banner pf-m-info">
                     ${msg("Application entitlements are in preview.")}
@@ -351,8 +357,11 @@ export class ApplicationViewPage extends AKElement {
                 </div>
             </section>
             <section
+                role="tabpanel"
+                tabindex="0"
                 slot="page-policy-bindings"
-                data-tab-title="${msg("Policy / Group / User Bindings")}"
+                id="page-policy-bindings"
+                aria-label="${msg("Policy / Group / User Bindings")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-c-card">
@@ -367,8 +376,11 @@ export class ApplicationViewPage extends AKElement {
                 </div>
             </section>
             <ak-rbac-object-permission-page
+                role="tabpanel"
+                tabindex="0"
                 slot="page-permissions"
-                data-tab-title="${msg("Permissions")}"
+                id="page-permissions"
+                aria-label="${msg("Permissions")}"
                 model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikCoreApplication}
                 objectPk=${this.application.pk}
             ></ak-rbac-object-permission-page>

--- a/web/src/admin/applications/ApplicationViewPage.ts
+++ b/web/src/admin/applications/ApplicationViewPage.ts
@@ -16,6 +16,7 @@ import { PFSize } from "#common/enums";
 import { APIError, parseAPIResponseError, pluckErrorDetail } from "#common/errors/network";
 
 import { AKElement } from "#elements/Base";
+import { ifPresent } from "#elements/utils/attributes";
 
 import {
     Application,
@@ -27,7 +28,6 @@ import {
 import { msg, str } from "@lit/localize";
 import { CSSResult, html, nothing, PropertyValues, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import { ifDefined } from "lit/directives/if-defined.js";
 
 import PFBanner from "@patternfly/patternfly/components/Banner/banner.css";
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
@@ -118,12 +118,12 @@ export class ApplicationViewPage extends AKElement {
     render(): TemplateResult {
         return html`<ak-page-header
                 header=${this.application?.name || msg("Loading")}
-                description=${ifDefined(this.application?.metaPublisher)}
+                description=${ifPresent(this.application?.metaPublisher)}
             >
                 <ak-app-icon
                     size=${PFSize.Medium}
-                    name=${ifDefined(this.application?.name || undefined)}
-                    icon=${ifDefined(this.application?.metaIcon || undefined)}
+                    name=${ifPresent(this.application?.name)}
+                    icon=${ifPresent(this.application?.metaIcon)}
                     slot="icon"
                 ></ak-app-icon>
             </ak-page-header>

--- a/web/src/admin/applications/ApplicationViewPage.ts
+++ b/web/src/admin/applications/ApplicationViewPage.ts
@@ -142,249 +142,256 @@ export class ApplicationViewPage extends AKElement {
             return html`<ak-empty-state default-label></ak-empty-state>`;
         }
 
-        return html`<ak-tabs>
-            ${this.missingOutpost
-                ? html`<div slot="header" class="pf-c-banner pf-m-warning">
-                      ${msg("Warning: Application is not used by any Outpost.")}
-                  </div>`
-                : nothing}
-            <section
-                role="tabpanel"
-                tabindex="0"
-                slot="page-overview"
-                id="page-overview"
-                aria-label="${msg("Overview")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-l-grid pf-m-gutter">
-                    <div
-                        class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-2-col-on-xl pf-m-2-col-on-2xl"
-                    >
-                        <div class="pf-c-card__title">${msg("Related")}</div>
-                        <div class="pf-c-card__body">
-                            <dl class="pf-c-description-list">
-                                ${this.application.providerObj
-                                    ? html`<div class="pf-c-description-list__group">
-                                          <dt class="pf-c-description-list__term">
-                                              <span class="pf-c-description-list__text"
-                                                  >${msg("Provider")}</span
-                                              >
-                                          </dt>
-                                          <dd class="pf-c-description-list__description">
-                                              <div class="pf-c-description-list__text">
-                                                  <a
-                                                      href="#/core/providers/${this.application
-                                                          .providerObj?.pk}"
+        return html`<main>
+            <ak-tabs>
+                ${this.missingOutpost
+                    ? html`<div slot="header" class="pf-c-banner pf-m-warning">
+                          ${msg("Warning: Application is not used by any Outpost.")}
+                      </div>`
+                    : nothing}
+                <section
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-overview"
+                    id="page-overview"
+                    aria-label="${msg("Overview")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-l-grid pf-m-gutter">
+                        <div
+                            class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-2-col-on-xl pf-m-2-col-on-2xl"
+                        >
+                            <div class="pf-c-card__title">${msg("Related")}</div>
+                            <div class="pf-c-card__body">
+                                <dl class="pf-c-description-list">
+                                    ${this.application.providerObj
+                                        ? html`<div class="pf-c-description-list__group">
+                                              <dt class="pf-c-description-list__term">
+                                                  <span class="pf-c-description-list__text"
+                                                      >${msg("Provider")}</span
                                                   >
-                                                      ${this.application.providerObj?.name}
-                                                      (${this.application.providerObj?.verboseName})
-                                                  </a>
-                                              </div>
-                                          </dd>
-                                      </div>`
-                                    : nothing}
-                                ${(this.application.backchannelProvidersObj || []).length > 0
-                                    ? html`<div class="pf-c-description-list__group">
-                                          <dt class="pf-c-description-list__term">
-                                              <span class="pf-c-description-list__text"
-                                                  >${msg("Backchannel Providers")}</span
-                                              >
-                                          </dt>
-                                          <dd class="pf-c-description-list__description">
-                                              <div class="pf-c-description-list__text">
-                                                  <ul class="pf-c-list">
-                                                      ${this.application.backchannelProvidersObj.map(
-                                                          (provider) => {
-                                                              return html`
-                                                                  <li>
-                                                                      <a
-                                                                          href="#/core/providers/${provider.pk}"
-                                                                      >
-                                                                          ${provider.name}
-                                                                          (${provider.verboseName})
-                                                                      </a>
-                                                                  </li>
-                                                              `;
-                                                          },
-                                                      )}
-                                                  </ul>
-                                              </div>
-                                          </dd>
-                                      </div>`
-                                    : nothing}
-                                <div class="pf-c-description-list__group">
-                                    <dt class="pf-c-description-list__term">
-                                        <span class="pf-c-description-list__text"
-                                            >${msg("Policy engine mode")}</span
-                                        >
-                                    </dt>
-                                    <dd class="pf-c-description-list__description">
-                                        <div class="pf-c-description-list__text pf-m-monospace">
-                                            ${this.application.policyEngineMode?.toUpperCase()}
-                                        </div>
-                                    </dd>
-                                </div>
-                                <div class="pf-c-description-list__group">
-                                    <dt class="pf-c-description-list__term">
-                                        <span class="pf-c-description-list__text"
-                                            >${msg("Edit")}</span
-                                        >
-                                    </dt>
-                                    <dd class="pf-c-description-list__description">
-                                        <div class="pf-c-description-list__text">
-                                            <ak-forms-modal>
-                                                <span slot="submit"> ${msg("Update")} </span>
-                                                <span slot="header">
-                                                    ${msg("Update Application")}
-                                                </span>
-                                                <ak-application-form
-                                                    slot="form"
-                                                    .instancePk=${this.application.slug}
-                                                >
-                                                </ak-application-form>
-                                                <button
-                                                    slot="trigger"
-                                                    class="pf-c-button pf-m-secondary"
-                                                >
-                                                    ${msg("Edit")}
-                                                </button>
-                                            </ak-forms-modal>
-                                        </div>
-                                    </dd>
-                                </div>
-                                <div class="pf-c-description-list__group">
-                                    <dt class="pf-c-description-list__term">
-                                        <span class="pf-c-description-list__text"
-                                            >${msg("Check access")}</span
-                                        >
-                                    </dt>
-                                    <dd class="pf-c-description-list__description">
-                                        <div class="pf-c-description-list__text">
-                                            <ak-forms-modal .closeAfterSuccessfulSubmit=${false}>
-                                                <span slot="submit"> ${msg("Check")} </span>
-                                                <span slot="header">
-                                                    ${msg("Check Application access")}
-                                                </span>
-                                                <ak-application-check-access-form
-                                                    slot="form"
-                                                    .application=${this.application}
-                                                >
-                                                </ak-application-check-access-form>
-                                                <button
-                                                    slot="trigger"
-                                                    class="pf-c-button pf-m-secondary"
-                                                >
-                                                    ${msg("Test")}
-                                                </button>
-                                            </ak-forms-modal>
-                                        </div>
-                                    </dd>
-                                </div>
-                                ${this.application.launchUrl
-                                    ? html`<div class="pf-c-description-list__group">
-                                          <dt class="pf-c-description-list__term">
-                                              <span class="pf-c-description-list__text"
-                                                  >${msg("Launch")}</span
-                                              >
-                                          </dt>
-                                          <dd class="pf-c-description-list__description">
-                                              <div class="pf-c-description-list__text">
-                                                  <a
-                                                      target="_blank"
-                                                      href=${this.application.launchUrl}
-                                                      slot="trigger"
-                                                      class="pf-c-button pf-m-secondary"
+                                              </dt>
+                                              <dd class="pf-c-description-list__description">
+                                                  <div class="pf-c-description-list__text">
+                                                      <a
+                                                          href="#/core/providers/${this.application
+                                                              .providerObj?.pk}"
+                                                      >
+                                                          ${this.application.providerObj?.name}
+                                                          (${this.application.providerObj
+                                                              ?.verboseName})
+                                                      </a>
+                                                  </div>
+                                              </dd>
+                                          </div>`
+                                        : nothing}
+                                    ${(this.application.backchannelProvidersObj || []).length > 0
+                                        ? html`<div class="pf-c-description-list__group">
+                                              <dt class="pf-c-description-list__term">
+                                                  <span class="pf-c-description-list__text"
+                                                      >${msg("Backchannel Providers")}</span
                                                   >
-                                                      ${msg("Launch")}
-                                                  </a>
-                                              </div>
-                                          </dd>
-                                      </div>`
-                                    : nothing}
-                            </dl>
+                                              </dt>
+                                              <dd class="pf-c-description-list__description">
+                                                  <div class="pf-c-description-list__text">
+                                                      <ul class="pf-c-list">
+                                                          ${this.application.backchannelProvidersObj.map(
+                                                              (provider) => {
+                                                                  return html`
+                                                                      <li>
+                                                                          <a
+                                                                              href="#/core/providers/${provider.pk}"
+                                                                          >
+                                                                              ${provider.name}
+                                                                              (${provider.verboseName})
+                                                                          </a>
+                                                                      </li>
+                                                                  `;
+                                                              },
+                                                          )}
+                                                      </ul>
+                                                  </div>
+                                              </dd>
+                                          </div>`
+                                        : nothing}
+                                    <div class="pf-c-description-list__group">
+                                        <dt class="pf-c-description-list__term">
+                                            <span class="pf-c-description-list__text"
+                                                >${msg("Policy engine mode")}</span
+                                            >
+                                        </dt>
+                                        <dd class="pf-c-description-list__description">
+                                            <div class="pf-c-description-list__text pf-m-monospace">
+                                                ${this.application.policyEngineMode?.toUpperCase()}
+                                            </div>
+                                        </dd>
+                                    </div>
+                                    <div class="pf-c-description-list__group">
+                                        <dt class="pf-c-description-list__term">
+                                            <span class="pf-c-description-list__text"
+                                                >${msg("Edit")}</span
+                                            >
+                                        </dt>
+                                        <dd class="pf-c-description-list__description">
+                                            <div class="pf-c-description-list__text">
+                                                <ak-forms-modal>
+                                                    <span slot="submit"> ${msg("Update")} </span>
+                                                    <span slot="header">
+                                                        ${msg("Update Application")}
+                                                    </span>
+                                                    <ak-application-form
+                                                        slot="form"
+                                                        .instancePk=${this.application.slug}
+                                                    >
+                                                    </ak-application-form>
+                                                    <button
+                                                        slot="trigger"
+                                                        class="pf-c-button pf-m-secondary"
+                                                    >
+                                                        ${msg("Edit")}
+                                                    </button>
+                                                </ak-forms-modal>
+                                            </div>
+                                        </dd>
+                                    </div>
+                                    <div class="pf-c-description-list__group">
+                                        <dt class="pf-c-description-list__term">
+                                            <span class="pf-c-description-list__text"
+                                                >${msg("Check access")}</span
+                                            >
+                                        </dt>
+                                        <dd class="pf-c-description-list__description">
+                                            <div class="pf-c-description-list__text">
+                                                <ak-forms-modal
+                                                    .closeAfterSuccessfulSubmit=${false}
+                                                >
+                                                    <span slot="submit"> ${msg("Check")} </span>
+                                                    <span slot="header">
+                                                        ${msg("Check Application access")}
+                                                    </span>
+                                                    <ak-application-check-access-form
+                                                        slot="form"
+                                                        .application=${this.application}
+                                                    >
+                                                    </ak-application-check-access-form>
+                                                    <button
+                                                        slot="trigger"
+                                                        class="pf-c-button pf-m-secondary"
+                                                    >
+                                                        ${msg("Test")}
+                                                    </button>
+                                                </ak-forms-modal>
+                                            </div>
+                                        </dd>
+                                    </div>
+                                    ${this.application.launchUrl
+                                        ? html`<div class="pf-c-description-list__group">
+                                              <dt class="pf-c-description-list__term">
+                                                  <span class="pf-c-description-list__text"
+                                                      >${msg("Launch")}</span
+                                                  >
+                                              </dt>
+                                              <dd class="pf-c-description-list__description">
+                                                  <div class="pf-c-description-list__text">
+                                                      <a
+                                                          target="_blank"
+                                                          href=${this.application.launchUrl}
+                                                          slot="trigger"
+                                                          class="pf-c-button pf-m-secondary"
+                                                      >
+                                                          ${msg("Launch")}
+                                                      </a>
+                                                  </div>
+                                              </dd>
+                                          </div>`
+                                        : nothing}
+                                </dl>
+                            </div>
+                        </div>
+                        <div
+                            class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-10-col-on-xl pf-m-10-col-on-2xl"
+                        >
+                            <div class="pf-c-card__title">
+                                ${msg("Logins over the last week (per 8 hours)")}
+                            </div>
+                            <div class="pf-c-card__body">
+                                ${this.application &&
+                                html` <ak-charts-application-authorize
+                                    application-id=${this.application.pk}
+                                >
+                                </ak-charts-application-authorize>`}
+                            </div>
+                        </div>
+                        <div class="pf-c-card pf-l-grid__item pf-m-12-col">
+                            <div class="pf-c-card__title">${msg("Changelog")}</div>
+                            <div class="pf-c-card__body">
+                                <ak-object-changelog
+                                    targetModelPk=${this.application.pk || ""}
+                                    targetModelApp="authentik_core"
+                                    targetModelName="application"
+                                >
+                                </ak-object-changelog>
+                            </div>
                         </div>
                     </div>
-                    <div
-                        class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-10-col-on-xl pf-m-10-col-on-2xl"
-                    >
-                        <div class="pf-c-card__title">
-                            ${msg("Logins over the last week (per 8 hours)")}
-                        </div>
-                        <div class="pf-c-card__body">
-                            ${this.application &&
-                            html` <ak-charts-application-authorize
-                                application-id=${this.application.pk}
-                            >
-                            </ak-charts-application-authorize>`}
+                </section>
+                <section
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-app-entitlements"
+                    id="page-app-entitlements"
+                    aria-label="${msg("Application entitlements")}"
+                >
+                    <div slot="header" class="pf-c-banner pf-m-info">
+                        ${msg("Application entitlements are in preview.")}
+                        <a href="mailto:hello+feature/app-ent@goauthentik.io"
+                            >${msg("Send us feedback!")}</a
+                        >
+                    </div>
+                    <div class="pf-c-page__main-section pf-m-no-padding-mobile">
+                        <div class="pf-c-card">
+                            <div class="pf-c-card__title">
+                                ${msg(
+                                    "These entitlements can be used to configure user access in this application.",
+                                )}
+                            </div>
+                            <ak-application-entitlements-list .app=${this.application.pk}>
+                            </ak-application-entitlements-list>
                         </div>
                     </div>
-                    <div class="pf-c-card pf-l-grid__item pf-m-12-col">
-                        <div class="pf-c-card__title">${msg("Changelog")}</div>
-                        <div class="pf-c-card__body">
-                            <ak-object-changelog
-                                targetModelPk=${this.application.pk || ""}
-                                targetModelApp="authentik_core"
-                                targetModelName="application"
-                            >
-                            </ak-object-changelog>
-                        </div>
-                    </div>
-                </div>
-            </section>
-            <section
-                role="tabpanel"
-                tabindex="0"
-                slot="page-app-entitlements"
-                id="page-app-entitlements"
-                aria-label="${msg("Application entitlements")}"
-            >
-                <div slot="header" class="pf-c-banner pf-m-info">
-                    ${msg("Application entitlements are in preview.")}
-                    <a href="mailto:hello+feature/app-ent@goauthentik.io"
-                        >${msg("Send us feedback!")}</a
-                    >
-                </div>
-                <div class="pf-c-page__main-section pf-m-no-padding-mobile">
+                </section>
+                <section
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-policy-bindings"
+                    id="page-policy-bindings"
+                    aria-label="${msg("Policy / Group / User Bindings")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
                     <div class="pf-c-card">
                         <div class="pf-c-card__title">
                             ${msg(
-                                "These entitlements can be used to configure user access in this application.",
+                                "These policies control which users can access this application.",
                             )}
                         </div>
-                        <ak-application-entitlements-list .app=${this.application.pk}>
-                        </ak-application-entitlements-list>
+                        <ak-bound-policies-list
+                            .target=${this.application.pk}
+                            .policyEngineMode=${this.application.policyEngineMode}
+                        >
+                        </ak-bound-policies-list>
                     </div>
-                </div>
-            </section>
-            <section
-                role="tabpanel"
-                tabindex="0"
-                slot="page-policy-bindings"
-                id="page-policy-bindings"
-                aria-label="${msg("Policy / Group / User Bindings")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-c-card">
-                    <div class="pf-c-card__title">
-                        ${msg("These policies control which users can access this application.")}
-                    </div>
-                    <ak-bound-policies-list
-                        .target=${this.application.pk}
-                        .policyEngineMode=${this.application.policyEngineMode}
-                    >
-                    </ak-bound-policies-list>
-                </div>
-            </section>
-            <ak-rbac-object-permission-page
-                role="tabpanel"
-                tabindex="0"
-                slot="page-permissions"
-                id="page-permissions"
-                aria-label="${msg("Permissions")}"
-                model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikCoreApplication}
-                objectPk=${this.application.pk}
-            ></ak-rbac-object-permission-page>
-        </ak-tabs>`;
+                </section>
+                <ak-rbac-object-permission-page
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-permissions"
+                    id="page-permissions"
+                    aria-label="${msg("Permissions")}"
+                    model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikCoreApplication}
+                    objectPk=${this.application.pk}
+                ></ak-rbac-object-permission-page>
+            </ak-tabs>
+        </main>`;
     }
 }
 

--- a/web/src/admin/applications/components/ak-provider-search-input.ts
+++ b/web/src/admin/applications/components/ak-provider-search-input.ts
@@ -54,18 +54,14 @@ export class AkProviderInput extends AKElement {
     value?: number;
 
     @property({ type: Boolean })
-    required = false;
+    required?: boolean;
 
     @property({ type: Boolean })
-    blankable = false;
+    blankable?: boolean;
 
     @property({ type: String })
-    help = "";
+    help?: string;
 
-    constructor() {
-        super();
-        this.selected = this.selected.bind(this);
-    }
     /**
      * A unique ID to associate with the input and label.
      * @property
@@ -73,10 +69,11 @@ export class AkProviderInput extends AKElement {
     @property({ type: String, reflect: false })
     public fieldID?: string = IDGenerator.elementID().toString();
 
-    selected(item: Provider) {
-        return this.value !== undefined && this.value === item.pk;
-    }
     //#endregion
+
+    #selected = (item: Provider) => {
+        return typeof this.value === "number" && this.value === item.pk;
+    };
 
     render() {
         return html` <ak-form-element-horizontal name=${this.name}>
@@ -86,12 +83,12 @@ export class AkProviderInput extends AKElement {
 
             <ak-search-select
                 .fieldID=${this.fieldID}
-                .selected=${this.selected}
+                .selected=${this.#selected}
                 .fetchObjects=${fetch}
                 .renderElement=${renderElement}
                 .value=${renderValue}
                 .groupBy=${doGroupBy}
-                ?blankable=${this.blankable}
+                ?blankable=${!!this.blankable}
             >
             </ak-search-select>
             ${this.help ? html`<p class="pf-c-form__helper-text">${this.help}</p>` : nothing}

--- a/web/src/admin/applications/components/ak-provider-search-input.ts
+++ b/web/src/admin/applications/components/ak-provider-search-input.ts
@@ -48,7 +48,7 @@ export class AkProviderInput extends AKElement {
     name!: string;
 
     @property({ type: String })
-    label?: string;
+    label: string | null = null;
 
     @property({ type: Number })
     value?: number;
@@ -60,7 +60,7 @@ export class AkProviderInput extends AKElement {
     blankable = false;
 
     @property({ type: String })
-    help?: string;
+    help: string | null = null;
 
     /**
      * A unique ID to associate with the input and label.

--- a/web/src/admin/applications/components/ak-provider-search-input.ts
+++ b/web/src/admin/applications/components/ak-provider-search-input.ts
@@ -54,10 +54,10 @@ export class AkProviderInput extends AKElement {
     value?: number;
 
     @property({ type: Boolean })
-    required?: boolean;
+    required = false;
 
     @property({ type: Boolean })
-    blankable?: boolean;
+    blankable = false;
 
     @property({ type: String })
     help?: string;

--- a/web/src/admin/common/ak-core-group-search.ts
+++ b/web/src/admin/common/ak-core-group-search.ts
@@ -50,13 +50,12 @@ export class CoreGroupSearch extends CustomListenerElement(AKElement) {
     search!: SearchSelect<Group>;
 
     @property({ type: String })
-    name: string | null | undefined;
+    public name?: string | null;
 
     selectedGroup?: Group;
 
     constructor() {
         super();
-        this.selected = this.selected.bind(this);
         this.handleSearchUpdate = this.handleSearchUpdate.bind(this);
     }
 
@@ -83,9 +82,9 @@ export class CoreGroupSearch extends CustomListenerElement(AKElement) {
         this.dispatchEvent(new InputEvent("input", { bubbles: true, composed: true }));
     }
 
-    selected(group: Group) {
+    selected = (group: Group) => {
         return this.group === group.pk;
-    }
+    };
 
     render() {
         return html`

--- a/web/src/admin/common/ak-crypto-certificate-search.ts
+++ b/web/src/admin/common/ak-crypto-certificate-search.ts
@@ -40,7 +40,13 @@ export class AkCryptoCertificateSearch extends CustomListenerElement(AKElement) 
     search!: SearchSelect<CertificateKeyPair>;
 
     @property({ type: String })
-    name: string | null | undefined;
+    public name?: string | null;
+
+    @property({ type: String })
+    public label?: string | undefined;
+
+    @property({ type: String })
+    public placeholder?: string | undefined;
 
     /**
      * Set to `true` to allow certificates without private key to show up. When set to `false`,
@@ -48,7 +54,7 @@ export class AkCryptoCertificateSearch extends CustomListenerElement(AKElement) 
      * @attr
      */
     @property({ type: Boolean, attribute: "nokey" })
-    noKey = false;
+    public noKey = false;
 
     /**
      * Set this to true if, should there be only one certificate available, you want the system to
@@ -57,16 +63,12 @@ export class AkCryptoCertificateSearch extends CustomListenerElement(AKElement) 
      * @attr
      */
     @property({ type: Boolean, attribute: "singleton" })
-    singleton = false;
+    public singleton = false;
 
-    selectedKeypair?: CertificateKeyPair;
-
-    constructor() {
-        super();
-        this.selected = this.selected.bind(this);
-        this.fetchObjects = this.fetchObjects.bind(this);
-        this.handleSearchUpdate = this.handleSearchUpdate.bind(this);
-    }
+    /**
+     * @todo Document this.
+     */
+    public selectedKeypair?: CertificateKeyPair;
 
     get value() {
         return this.selectedKeypair ? renderValue(this.selectedKeypair) : null;
@@ -85,13 +87,13 @@ export class AkCryptoCertificateSearch extends CustomListenerElement(AKElement) 
         }
     }
 
-    handleSearchUpdate(ev: CustomEvent) {
+    handleSearchUpdate = (ev: CustomEvent) => {
         ev.stopPropagation();
         this.selectedKeypair = ev.detail.value;
         this.dispatchEvent(new InputEvent("input", { bubbles: true, composed: true }));
-    }
+    };
 
-    async fetchObjects(query?: string): Promise<CertificateKeyPair[]> {
+    fetchObjects = async (query?: string): Promise<CertificateKeyPair[]> => {
         const args: CryptoCertificatekeypairsListRequest = {
             ordering: "name",
             hasKey: !this.noKey,
@@ -104,19 +106,21 @@ export class AkCryptoCertificateSearch extends CustomListenerElement(AKElement) 
             args,
         );
         return certificates.results;
-    }
+    };
 
-    selected(item: CertificateKeyPair, items: CertificateKeyPair[]) {
+    selected = (item: CertificateKeyPair, items: CertificateKeyPair[]) => {
         return (
             (this.singleton && !this.certificate && items.length === 1) ||
             (!!this.certificate && this.certificate === item.pk)
         );
-    }
+    };
 
     render() {
         return html`
             <ak-search-select
                 name=${ifDefined(this.name ?? undefined)}
+                label=${ifDefined(this.label ?? undefined)}
+                placeholder=${ifDefined(this.placeholder)}
                 .fetchObjects=${this.fetchObjects}
                 .renderElement=${renderElement}
                 .value=${renderValue}

--- a/web/src/admin/common/ak-crypto-certificate-search.ts
+++ b/web/src/admin/common/ak-crypto-certificate-search.ts
@@ -4,6 +4,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { AKElement } from "#elements/Base";
 import { SearchSelect } from "#elements/forms/SearchSelect/index";
+import { ifPresent } from "#elements/utils/attributes";
 import { CustomListenerElement } from "#elements/utils/eventEmitter";
 
 import {
@@ -14,7 +15,6 @@ import {
 
 import { html } from "lit";
 import { customElement, property, query } from "lit/decorators.js";
-import { ifDefined } from "lit/directives/if-defined.js";
 
 const renderElement = (item: CertificateKeyPair): string => item.name;
 
@@ -43,10 +43,10 @@ export class AkCryptoCertificateSearch extends CustomListenerElement(AKElement) 
     public name?: string | null;
 
     @property({ type: String })
-    public label?: string | undefined;
+    public label: string | null = null;
 
     @property({ type: String })
-    public placeholder?: string | undefined;
+    public placeholder: string | null = null;
 
     /**
      * Set to `true` to allow certificates without private key to show up. When set to `false`,
@@ -118,9 +118,9 @@ export class AkCryptoCertificateSearch extends CustomListenerElement(AKElement) 
     render() {
         return html`
             <ak-search-select
-                name=${ifDefined(this.name ?? undefined)}
-                label=${ifDefined(this.label ?? undefined)}
-                placeholder=${ifDefined(this.placeholder)}
+                name=${ifPresent(this.name)}
+                label=${ifPresent(this.label)}
+                placeholder=${ifPresent(this.placeholder)}
                 .fetchObjects=${this.fetchObjects}
                 .renderElement=${renderElement}
                 .value=${renderValue}

--- a/web/src/admin/common/ak-flow-search/FlowSearch.ts
+++ b/web/src/admin/common/ak-flow-search/FlowSearch.ts
@@ -3,7 +3,7 @@ import "#elements/forms/SearchSelect/index";
 import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { AKElement } from "#elements/Base";
-import { SearchSelect } from "#elements/forms/SearchSelect/index";
+import type { HorizontalFormElement } from "#elements/forms/HorizontalFormElement";
 import { CustomListenerElement } from "#elements/utils/eventEmitter";
 
 import { RenderFlowOption } from "#admin/flows/utils";
@@ -11,8 +11,9 @@ import { RenderFlowOption } from "#admin/flows/utils";
 import type { Flow, FlowsInstancesListRequest } from "@goauthentik/api";
 import { FlowsApi, FlowsInstancesListDesignationEnum } from "@goauthentik/api";
 
+import { msg } from "@lit/localize";
 import { html } from "lit";
-import { property, query } from "lit/decorators.js";
+import { property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
 export function renderElement(flow: Flow) {
@@ -33,17 +34,17 @@ export function getFlowValue(flow: Flow | undefined): string | undefined {
  * A wrapper around SearchSelect that understands the basic semantics of querying about Flows. This
  * code eliminates the long blocks of unreadable invocation that were embedded in every provider, as well as in
  * sources, brands, and applications.
- *
  */
+export abstract class FlowSearch<T extends Flow> extends CustomListenerElement(AKElement) {
+    //#region Properties
 
-export class FlowSearch<T extends Flow> extends CustomListenerElement(AKElement) {
     /**
      * The type of flow we're looking for.
      *
      * @attr
      */
     @property({ type: String })
-    flowType?: FlowsInstancesListDesignationEnum;
+    public flowType?: FlowsInstancesListDesignationEnum;
 
     /**
      * The id of the current flow, if any. For stages where the flow is already defined.
@@ -51,7 +52,7 @@ export class FlowSearch<T extends Flow> extends CustomListenerElement(AKElement)
      * @attr
      */
     @property({ type: String })
-    currentFlow?: string | undefined;
+    public currentFlow?: string;
 
     /**
      * If true, it is not valid to leave the flow blank.
@@ -59,10 +60,7 @@ export class FlowSearch<T extends Flow> extends CustomListenerElement(AKElement)
      * @attr
      */
     @property({ type: Boolean })
-    required?: boolean = false;
-
-    @query("ak-search-select")
-    search!: SearchSelect<T>;
+    public required?: boolean;
 
     /**
      * When specified and the object instance does not have a flow selected, auto-select the flow with the given slug.
@@ -70,66 +68,115 @@ export class FlowSearch<T extends Flow> extends CustomListenerElement(AKElement)
      * @attr
      */
     @property()
-    defaultFlowSlug?: string;
+    public defaultFlowSlug?: string;
 
     @property({ type: String })
-    name: string | null | undefined;
+    public name?: string;
 
-    selectedFlow?: T;
+    /**
+     * The label of the input, for forms.
+     *
+     * @attr
+     */
+    @property({ type: String })
+    public label?: string;
+
+    /**
+     * The textual placeholder for the search's <input> object, if currently empty. Used as the
+     * native <input> object's `placeholder` field.
+     *
+     * @attr
+     */
+    @property({ type: String })
+    public placeholder = msg("Select a flow...");
+
+    protected selectedFlow?: T;
 
     get value() {
         return this.selectedFlow ? getFlowValue(this.selectedFlow) : null;
     }
 
-    constructor() {
-        super();
-        this.fetchObjects = this.fetchObjects.bind(this);
-        this.selected = this.selected.bind(this);
-        this.handleSearchUpdate = this.handleSearchUpdate.bind(this);
-    }
+    //#endregion
 
-    handleSearchUpdate(ev: CustomEvent) {
-        ev.stopPropagation();
-        this.selectedFlow = ev.detail.value;
+    //#region Event Listeners
+
+    protected searchUpdateListener = (event: CustomEvent) => {
+        event.stopPropagation();
+
+        this.selectedFlow = event.detail.value;
+
         this.dispatchEvent(new InputEvent("input", { bubbles: true, composed: true }));
-    }
+    };
 
-    async fetchObjects(query?: string): Promise<Flow[]> {
+    //#endregion
+
+    //#region Lifecycle
+
+    /**
+     * Fetch the objects from the API.
+     *
+     * @param query The search query, if any.
+     */
+    protected fetchObjects = (query?: string): Promise<Flow[]> => {
         const args: FlowsInstancesListRequest = {
             ordering: "slug",
             designation: this.flowType,
-            ...(query !== undefined ? { search: query } : {}),
+            ...(query ? { search: query } : {}),
         };
-        const flows = await new FlowsApi(DEFAULT_CONFIG).flowsInstancesList(args);
-        return flows.results;
-    }
 
-    /* This is the most commonly overridden method of this class. About half of the Flow Searches
-     * use this method, but several have more complex needs, such as relating to the brand, or just
-     * returning false.
+        return new FlowsApi(DEFAULT_CONFIG).flowsInstancesList(args).then((flows) => flows.results);
+    };
+
+    /**
+     * Determine if the flow matches the current state of the search.
+     *
+     * @param flow The flow to compare against.
      */
-    selected(flow: Flow): boolean {
-        let selected = this.currentFlow === flow.pk;
-        if (!this.currentFlow && this.defaultFlowSlug && flow.slug === this.defaultFlowSlug) {
-            selected = true;
+    protected match = (flow: Flow): boolean => {
+        if (this.currentFlow) {
+            return this.currentFlow === flow.pk;
         }
-        return selected;
-    }
 
-    connectedCallback() {
+        return !!(this.defaultFlowSlug && flow.slug === this.defaultFlowSlug);
+    };
+
+    /**
+     * This is the most commonly overridden method of this class.
+     *
+     *  About half of the Flow Searches use this method, but several have more complex needs,
+     * such as relating to the brand, or just returning false.
+     *
+     * @param flow The flow to compare against.
+     * @abstract
+     */
+    protected selected = (flow: Flow): boolean => {
+        return this.match(flow);
+    };
+
+    public override connectedCallback() {
         super.connectedCallback();
-        const horizontalContainer = this.closest("ak-form-element-horizontal[name]");
+
+        const horizontalContainer = this.closest<HorizontalFormElement>(
+            "ak-form-element-horizontal[name]",
+        );
+
         if (!horizontalContainer) {
             throw new Error("This search can only be used in a named ak-form-element-horizontal");
         }
+
         const name = horizontalContainer.getAttribute("name");
         const myName = this.getAttribute("name");
+
         if (name !== null && name !== myName) {
             this.setAttribute("name", name);
         }
     }
 
-    render() {
+    //#endregion
+
+    //#region Render
+
+    public override render() {
         return html`
             <ak-search-select
                 .fetchObjects=${this.fetchObjects}
@@ -137,13 +184,15 @@ export class FlowSearch<T extends Flow> extends CustomListenerElement(AKElement)
                 .renderElement=${renderElement}
                 .renderDescription=${renderDescription}
                 .value=${getFlowValue}
-                name=${ifDefined(this.name ?? undefined)}
-                @ak-change=${this.handleSearchUpdate}
+                placeholder=${ifDefined(this.placeholder)}
+                label=${ifDefined(this.label)}
+                name=${ifDefined(this.name)}
+                @ak-change=${this.searchUpdateListener}
                 ?blankable=${!this.required}
             >
             </ak-search-select>
         `;
     }
-}
 
-export default FlowSearch;
+    //#endregion
+}

--- a/web/src/admin/common/ak-flow-search/FlowSearch.ts
+++ b/web/src/admin/common/ak-flow-search/FlowSearch.ts
@@ -60,7 +60,7 @@ export abstract class FlowSearch<T extends Flow> extends CustomListenerElement(A
      * @attr
      */
     @property({ type: Boolean })
-    public required?: boolean;
+    required = false;
 
     /**
      * When specified and the object instance does not have a flow selected, auto-select the flow with the given slug.

--- a/web/src/admin/common/ak-flow-search/ak-branded-flow-search.ts
+++ b/web/src/admin/common/ak-flow-search/ak-branded-flow-search.ts
@@ -1,4 +1,4 @@
-import FlowSearch from "./FlowSearch.js";
+import { FlowSearch } from "./FlowSearch.js";
 
 import type { Flow } from "@goauthentik/api";
 
@@ -19,16 +19,11 @@ export class AkBrandedFlowSearch<T extends Flow> extends FlowSearch<T> {
      * @attr
      */
     @property({ attribute: false, type: String })
-    brandFlow?: string;
+    public brandFlow?: string;
 
-    constructor() {
-        super();
-        this.selected = this.selected.bind(this);
-    }
-
-    selected(flow: Flow): boolean {
-        return super.selected(flow) || flow.pk === this.brandFlow;
-    }
+    protected override selected = (flow: Flow): boolean => {
+        return this.match(flow) || flow.pk === this.brandFlow;
+    };
 }
 
 declare global {

--- a/web/src/admin/common/ak-flow-search/ak-flow-search-no-default.ts
+++ b/web/src/admin/common/ak-flow-search/ak-flow-search-no-default.ts
@@ -24,7 +24,7 @@ export class AkFlowSearchNoDefault<T extends Flow> extends FlowSearch<T> {
                 .renderElement=${renderElement}
                 .renderDescription=${renderDescription}
                 .value=${getFlowValue}
-                @ak-change=${this.handleSearchUpdate}
+                @ak-change=${this.searchUpdateListener}
                 ?blankable=${!this.required}
             >
             </ak-search-select>

--- a/web/src/admin/common/ak-flow-search/ak-flow-search.ts
+++ b/web/src/admin/common/ak-flow-search/ak-flow-search.ts
@@ -1,4 +1,4 @@
-import FlowSearch from "./FlowSearch.js";
+import { FlowSearch } from "./FlowSearch.js";
 
 import type { Flow } from "@goauthentik/api";
 
@@ -18,5 +18,3 @@ declare global {
         "ak-flow-search": AkFlowSearch<Flow>;
     }
 }
-
-export default AkFlowSearch;

--- a/web/src/admin/common/ak-flow-search/ak-source-flow-search.ts
+++ b/web/src/admin/common/ak-flow-search/ak-source-flow-search.ts
@@ -1,4 +1,4 @@
-import FlowSearch from "./FlowSearch.js";
+import { FlowSearch } from "./FlowSearch.js";
 
 import type { Flow } from "@goauthentik/api";
 
@@ -18,9 +18,8 @@ export class AkSourceFlowSearch<T extends Flow> extends FlowSearch<T> {
      *
      * @attr
      */
-
     @property({ type: String })
-    fallback: string | undefined;
+    public fallback?: string;
 
     /**
      * The primary key of the Source (not the Flow). Mostly the instancePk itself, used to affirm
@@ -29,21 +28,16 @@ export class AkSourceFlowSearch<T extends Flow> extends FlowSearch<T> {
      * @attr
      */
     @property({ type: String })
-    instanceId: string | undefined;
-
-    constructor() {
-        super();
-        this.selected = this.selected.bind(this);
-    }
+    public instanceId?: string;
 
     // If there's no instance or no currentFlowId for it and the flow resembles the fallback,
     // otherwise defer to the parent class.
-    selected(flow: Flow): boolean {
+    protected override selected = (flow: Flow): boolean => {
         return (
             (!this.instanceId && !this.currentFlow && flow.slug === this.fallback) ||
-            super.selected(flow)
+            this.match(flow)
         );
-    }
+    };
 }
 
 declare global {

--- a/web/src/admin/flows/FlowViewPage.ts
+++ b/web/src/admin/flows/FlowViewPage.ts
@@ -78,236 +78,243 @@ export class FlowViewPage extends AKElement {
                 description=${this.flow.title}
             >
             </ak-page-header>
-            <ak-tabs>
-                <div
-                    role="tabpanel"
-                    tabindex="0"
-                    slot="page-overview"
-                    id="page-overview"
-                    aria-label="${msg("Flow Overview")}"
-                    class="pf-c-page__main-section pf-m-no-padding-mobile"
-                >
-                    <div class="pf-l-grid pf-m-gutter">
-                        <div
-                            class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-2-col-on-xl pf-m-2-col-on-2xl"
-                        >
-                            <div class="pf-c-card__title">${msg("Flow Info")}</div>
-                            <div class="pf-c-card__body">
-                                <dl class="pf-c-description-list">
-                                    <div class="pf-c-description-list__group">
-                                        <dt class="pf-c-description-list__term">
-                                            <span class="pf-c-description-list__text"
-                                                >${msg("Name")}</span
-                                            >
-                                        </dt>
-                                        <dd class="pf-c-description-list__description">
-                                            <div class="pf-c-description-list__text">
-                                                ${this.flow.name}
-                                            </div>
-                                        </dd>
-                                        <dt class="pf-c-description-list__term">
-                                            <span class="pf-c-description-list__text"
-                                                >${msg("Slug")}</span
-                                            >
-                                        </dt>
-                                        <dd class="pf-c-description-list__description">
-                                            <div class="pf-c-description-list__text">
-                                                <code>${this.flow.slug}</code>
-                                            </div>
-                                        </dd>
-                                        <dt class="pf-c-description-list__term">
-                                            <span class="pf-c-description-list__text"
-                                                >${msg("Designation")}</span
-                                            >
-                                        </dt>
-                                        <dd class="pf-c-description-list__description">
-                                            <div class="pf-c-description-list__text">
-                                                ${DesignationToLabel(this.flow.designation)}
-                                            </div>
-                                        </dd>
-                                        <dt class="pf-c-description-list__term">
-                                            <span class="pf-c-description-list__text"
-                                                >${msg("Related actions")}</span
-                                            >
-                                        </dt>
-                                        <dd class="pf-c-description-list__description">
-                                            <div class="pf-c-description-list__text">
-                                                <ak-forms-modal>
-                                                    <span slot="submit"> ${msg("Update")} </span>
-                                                    <span slot="header">
-                                                        ${msg("Update Flow")}
-                                                    </span>
-                                                    <ak-flow-form
-                                                        slot="form"
-                                                        .instancePk=${this.flow.slug}
-                                                    >
-                                                    </ak-flow-form>
-                                                    <button
-                                                        slot="trigger"
-                                                        class="pf-c-button pf-m-block pf-m-secondary"
-                                                    >
-                                                        ${msg("Edit")}
-                                                    </button>
-                                                </ak-forms-modal>
-                                            </div>
-                                        </dd>
-                                        <dt class="pf-c-description-list__term">
-                                            <span class="pf-c-description-list__text"
-                                                >${msg("Execute flow")}</span
-                                            >
-                                        </dt>
-                                        <dd class="pf-c-description-list__description">
-                                            <div class="pf-c-description-list__text">
-                                                <button
-                                                    class="pf-c-button pf-m-block pf-m-primary"
-                                                    @click=${() => {
-                                                        const finalURL = `${
-                                                            window.location.origin
-                                                        }/if/flow/${this.flow.slug}/${AndNext(
-                                                            `${window.location.pathname}#${window.location.hash}`,
-                                                        )}`;
-                                                        window.open(finalURL, "_blank");
-                                                    }}
-                                                >
-                                                    ${msg("Normal")}
-                                                </button>
-                                                <button
-                                                    class="pf-c-button pf-m-block pf-m-secondary"
-                                                    @click=${() => {
-                                                        new FlowsApi(DEFAULT_CONFIG)
-                                                            .flowsInstancesExecuteRetrieve({
-                                                                slug: this.flow.slug,
-                                                            })
-                                                            .then((link) => {
-                                                                const finalURL = `${
-                                                                    link.link
-                                                                }${AndNext(
-                                                                    `${window.location.pathname}#${window.location.hash}`,
-                                                                )}`;
-                                                                window.open(finalURL, "_blank");
-                                                            });
-                                                    }}
-                                                >
-                                                    ${msg("with current user")}
-                                                </button>
-                                                <button
-                                                    class="pf-c-button pf-m-block pf-m-secondary"
-                                                    @click=${() => {
-                                                        new FlowsApi(DEFAULT_CONFIG)
-                                                            .flowsInstancesExecuteRetrieve({
-                                                                slug: this.flow.slug,
-                                                            })
-                                                            .then((link) => {
-                                                                const finalURL = `${
-                                                                    link.link
-                                                                }?${encodeURI(
-                                                                    `inspector=open&next=/#${window.location.hash}`,
-                                                                )}`;
-                                                                window.open(finalURL, "_blank");
-                                                            })
-                                                            .catch(async (error: unknown) => {
-                                                                if (isResponseErrorLike(error)) {
-                                                                    // This request can return a HTTP 400 when a flow
-                                                                    // is not applicable.
-                                                                    window.open(
-                                                                        error.response.url,
-                                                                        "_blank",
-                                                                    );
-                                                                }
-                                                            });
-                                                    }}
-                                                >
-                                                    ${msg("with inspector")}
-                                                </button>
-                                            </div>
-                                        </dd>
-                                        <dt class="pf-c-description-list__term">
-                                            <span class="pf-c-description-list__text"
-                                                >${msg("Export flow")}</span
-                                            >
-                                        </dt>
-                                        <dd class="pf-c-description-list__description">
-                                            <div class="pf-c-description-list__text">
-                                                <a
-                                                    class="pf-c-button pf-m-block pf-m-secondary"
-                                                    href=${this.flow.exportUrl}
-                                                >
-                                                    ${msg("Export")}
-                                                </a>
-                                            </div>
-                                        </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </div>
-                        <div
-                            class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-10-col-on-xl pf-m-10-col-on-2xl"
-                        >
-                            <div class="pf-c-card__title">${msg("Diagram")}</div>
-                            <div class="pf-c-card__body">
-                                <ak-flow-diagram flowSlug=${this.flow.slug}> </ak-flow-diagram>
-                            </div>
-                        </div>
-                        <div
-                            class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-12-col-on-xl pf-m-12-col-on-2xl"
-                        >
-                            <div class="pf-c-card__title">${msg("Changelog")}</div>
-                            <div class="pf-c-card__body">
-                                <ak-object-changelog
-                                    targetModelPk=${this.flow.pk || ""}
-                                    targetModelApp="authentik_flows"
-                                    targetModelName="flow"
-                                >
-                                </ak-object-changelog>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div
-                    role="tabpanel"
-                    tabindex="0"
-                    slot="page-stage-bindings"
-                    id="page-stage-bindings"
-                    aria-label="${msg("Stage Bindings")}"
-                    class="pf-c-page__main-section pf-m-no-padding-mobile"
-                >
-                    <div class="pf-c-card">
-                        <div class="pf-c-card__body">
-                            <ak-bound-stages-list .target=${this.flow.pk}> </ak-bound-stages-list>
-                        </div>
-                    </div>
-                </div>
-                <div
-                    role="tabpanel"
-                    tabindex="0"
-                    slot="page-policy-bindings"
-                    id="page-policy-bindings"
-                    aria-label="${msg("Policy / Group / User Bindings")}"
-                    class="pf-c-page__main-section pf-m-no-padding-mobile"
-                >
-                    <div class="pf-c-card">
-                        <div class="pf-c-card__title">
-                            ${msg("These bindings control which users can access this flow.")}
-                        </div>
-                        <div class="pf-c-card__body">
-                            <ak-bound-policies-list
-                                .target=${this.flow.policybindingmodelPtrId}
-                                .policyEngineMode=${this.flow.policyEngineMode}
+            <main>
+                <ak-tabs>
+                    <div
+                        role="tabpanel"
+                        tabindex="0"
+                        slot="page-overview"
+                        id="page-overview"
+                        aria-label="${msg("Flow Overview")}"
+                        class="pf-c-page__main-section pf-m-no-padding-mobile"
+                    >
+                        <div class="pf-l-grid pf-m-gutter">
+                            <div
+                                class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-2-col-on-xl pf-m-2-col-on-2xl"
                             >
-                            </ak-bound-policies-list>
+                                <div class="pf-c-card__title">${msg("Flow Info")}</div>
+                                <div class="pf-c-card__body">
+                                    <dl class="pf-c-description-list">
+                                        <div class="pf-c-description-list__group">
+                                            <dt class="pf-c-description-list__term">
+                                                <span class="pf-c-description-list__text"
+                                                    >${msg("Name")}</span
+                                                >
+                                            </dt>
+                                            <dd class="pf-c-description-list__description">
+                                                <div class="pf-c-description-list__text">
+                                                    ${this.flow.name}
+                                                </div>
+                                            </dd>
+                                            <dt class="pf-c-description-list__term">
+                                                <span class="pf-c-description-list__text"
+                                                    >${msg("Slug")}</span
+                                                >
+                                            </dt>
+                                            <dd class="pf-c-description-list__description">
+                                                <div class="pf-c-description-list__text">
+                                                    <code>${this.flow.slug}</code>
+                                                </div>
+                                            </dd>
+                                            <dt class="pf-c-description-list__term">
+                                                <span class="pf-c-description-list__text"
+                                                    >${msg("Designation")}</span
+                                                >
+                                            </dt>
+                                            <dd class="pf-c-description-list__description">
+                                                <div class="pf-c-description-list__text">
+                                                    ${DesignationToLabel(this.flow.designation)}
+                                                </div>
+                                            </dd>
+                                            <dt class="pf-c-description-list__term">
+                                                <span class="pf-c-description-list__text"
+                                                    >${msg("Related actions")}</span
+                                                >
+                                            </dt>
+                                            <dd class="pf-c-description-list__description">
+                                                <div class="pf-c-description-list__text">
+                                                    <ak-forms-modal>
+                                                        <span slot="submit">
+                                                            ${msg("Update")}
+                                                        </span>
+                                                        <span slot="header">
+                                                            ${msg("Update Flow")}
+                                                        </span>
+                                                        <ak-flow-form
+                                                            slot="form"
+                                                            .instancePk=${this.flow.slug}
+                                                        >
+                                                        </ak-flow-form>
+                                                        <button
+                                                            slot="trigger"
+                                                            class="pf-c-button pf-m-block pf-m-secondary"
+                                                        >
+                                                            ${msg("Edit")}
+                                                        </button>
+                                                    </ak-forms-modal>
+                                                </div>
+                                            </dd>
+                                            <dt class="pf-c-description-list__term">
+                                                <span class="pf-c-description-list__text"
+                                                    >${msg("Execute flow")}</span
+                                                >
+                                            </dt>
+                                            <dd class="pf-c-description-list__description">
+                                                <div class="pf-c-description-list__text">
+                                                    <button
+                                                        class="pf-c-button pf-m-block pf-m-primary"
+                                                        @click=${() => {
+                                                            const finalURL = `${
+                                                                window.location.origin
+                                                            }/if/flow/${this.flow.slug}/${AndNext(
+                                                                `${window.location.pathname}#${window.location.hash}`,
+                                                            )}`;
+                                                            window.open(finalURL, "_blank");
+                                                        }}
+                                                    >
+                                                        ${msg("Normal")}
+                                                    </button>
+                                                    <button
+                                                        class="pf-c-button pf-m-block pf-m-secondary"
+                                                        @click=${() => {
+                                                            new FlowsApi(DEFAULT_CONFIG)
+                                                                .flowsInstancesExecuteRetrieve({
+                                                                    slug: this.flow.slug,
+                                                                })
+                                                                .then((link) => {
+                                                                    const finalURL = `${
+                                                                        link.link
+                                                                    }${AndNext(
+                                                                        `${window.location.pathname}#${window.location.hash}`,
+                                                                    )}`;
+                                                                    window.open(finalURL, "_blank");
+                                                                });
+                                                        }}
+                                                    >
+                                                        ${msg("with current user")}
+                                                    </button>
+                                                    <button
+                                                        class="pf-c-button pf-m-block pf-m-secondary"
+                                                        @click=${() => {
+                                                            new FlowsApi(DEFAULT_CONFIG)
+                                                                .flowsInstancesExecuteRetrieve({
+                                                                    slug: this.flow.slug,
+                                                                })
+                                                                .then((link) => {
+                                                                    const finalURL = `${
+                                                                        link.link
+                                                                    }?${encodeURI(
+                                                                        `inspector=open&next=/#${window.location.hash}`,
+                                                                    )}`;
+                                                                    window.open(finalURL, "_blank");
+                                                                })
+                                                                .catch(async (error: unknown) => {
+                                                                    if (
+                                                                        isResponseErrorLike(error)
+                                                                    ) {
+                                                                        // This request can return a HTTP 400 when a flow
+                                                                        // is not applicable.
+                                                                        window.open(
+                                                                            error.response.url,
+                                                                            "_blank",
+                                                                        );
+                                                                    }
+                                                                });
+                                                        }}
+                                                    >
+                                                        ${msg("with inspector")}
+                                                    </button>
+                                                </div>
+                                            </dd>
+                                            <dt class="pf-c-description-list__term">
+                                                <span class="pf-c-description-list__text"
+                                                    >${msg("Export flow")}</span
+                                                >
+                                            </dt>
+                                            <dd class="pf-c-description-list__description">
+                                                <div class="pf-c-description-list__text">
+                                                    <a
+                                                        class="pf-c-button pf-m-block pf-m-secondary"
+                                                        href=${this.flow.exportUrl}
+                                                    >
+                                                        ${msg("Export")}
+                                                    </a>
+                                                </div>
+                                            </dd>
+                                        </div>
+                                    </dl>
+                                </div>
+                            </div>
+                            <div
+                                class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-10-col-on-xl pf-m-10-col-on-2xl"
+                            >
+                                <div class="pf-c-card__title">${msg("Diagram")}</div>
+                                <div class="pf-c-card__body">
+                                    <ak-flow-diagram flowSlug=${this.flow.slug}> </ak-flow-diagram>
+                                </div>
+                            </div>
+                            <div
+                                class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-12-col-on-xl pf-m-12-col-on-2xl"
+                            >
+                                <div class="pf-c-card__title">${msg("Changelog")}</div>
+                                <div class="pf-c-card__body">
+                                    <ak-object-changelog
+                                        targetModelPk=${this.flow.pk || ""}
+                                        targetModelApp="authentik_flows"
+                                        targetModelName="flow"
+                                    >
+                                    </ak-object-changelog>
+                                </div>
+                            </div>
                         </div>
                     </div>
-                </div>
-                <ak-rbac-object-permission-page
-                    role="tabpanel"
-                    tabindex="0"
-                    slot="page-permissions"
-                    id="page-permissions"
-                    aria-label="${msg("Permissions")}"
-                    model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikFlowsFlow}
-                    objectPk=${this.flow.pk}
-                ></ak-rbac-object-permission-page>
-            </ak-tabs>`;
+                    <div
+                        role="tabpanel"
+                        tabindex="0"
+                        slot="page-stage-bindings"
+                        id="page-stage-bindings"
+                        aria-label="${msg("Stage Bindings")}"
+                        class="pf-c-page__main-section pf-m-no-padding-mobile"
+                    >
+                        <div class="pf-c-card">
+                            <div class="pf-c-card__body">
+                                <ak-bound-stages-list .target=${this.flow.pk}>
+                                </ak-bound-stages-list>
+                            </div>
+                        </div>
+                    </div>
+                    <div
+                        role="tabpanel"
+                        tabindex="0"
+                        slot="page-policy-bindings"
+                        id="page-policy-bindings"
+                        aria-label="${msg("Policy / Group / User Bindings")}"
+                        class="pf-c-page__main-section pf-m-no-padding-mobile"
+                    >
+                        <div class="pf-c-card">
+                            <div class="pf-c-card__title">
+                                ${msg("These bindings control which users can access this flow.")}
+                            </div>
+                            <div class="pf-c-card__body">
+                                <ak-bound-policies-list
+                                    .target=${this.flow.policybindingmodelPtrId}
+                                    .policyEngineMode=${this.flow.policyEngineMode}
+                                >
+                                </ak-bound-policies-list>
+                            </div>
+                        </div>
+                    </div>
+                    <ak-rbac-object-permission-page
+                        role="tabpanel"
+                        tabindex="0"
+                        slot="page-permissions"
+                        id="page-permissions"
+                        aria-label="${msg("Permissions")}"
+                        model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikFlowsFlow}
+                        objectPk=${this.flow.pk}
+                    ></ak-rbac-object-permission-page>
+                </ak-tabs>
+            </main>`;
     }
 }
 

--- a/web/src/admin/flows/FlowViewPage.ts
+++ b/web/src/admin/flows/FlowViewPage.ts
@@ -80,8 +80,11 @@ export class FlowViewPage extends AKElement {
             </ak-page-header>
             <ak-tabs>
                 <div
+                    role="tabpanel"
+                    tabindex="0"
                     slot="page-overview"
-                    data-tab-title="${msg("Flow Overview")}"
+                    id="page-overview"
+                    aria-label="${msg("Flow Overview")}"
                     class="pf-c-page__main-section pf-m-no-padding-mobile"
                 >
                     <div class="pf-l-grid pf-m-gutter">
@@ -261,8 +264,11 @@ export class FlowViewPage extends AKElement {
                     </div>
                 </div>
                 <div
+                    role="tabpanel"
+                    tabindex="0"
                     slot="page-stage-bindings"
-                    data-tab-title="${msg("Stage Bindings")}"
+                    id="page-stage-bindings"
+                    aria-label="${msg("Stage Bindings")}"
                     class="pf-c-page__main-section pf-m-no-padding-mobile"
                 >
                     <div class="pf-c-card">
@@ -272,8 +278,11 @@ export class FlowViewPage extends AKElement {
                     </div>
                 </div>
                 <div
+                    role="tabpanel"
+                    tabindex="0"
                     slot="page-policy-bindings"
-                    data-tab-title="${msg("Policy / Group / User Bindings")}"
+                    id="page-policy-bindings"
+                    aria-label="${msg("Policy / Group / User Bindings")}"
                     class="pf-c-page__main-section pf-m-no-padding-mobile"
                 >
                     <div class="pf-c-card">
@@ -290,8 +299,11 @@ export class FlowViewPage extends AKElement {
                     </div>
                 </div>
                 <ak-rbac-object-permission-page
+                    role="tabpanel"
+                    tabindex="0"
                     slot="page-permissions"
-                    data-tab-title="${msg("Permissions")}"
+                    id="page-permissions"
+                    aria-label="${msg("Permissions")}"
                     model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikFlowsFlow}
                     objectPk=${this.flow.pk}
                 ></ak-rbac-object-permission-page>

--- a/web/src/admin/groups/GroupViewPage.ts
+++ b/web/src/admin/groups/GroupViewPage.ts
@@ -87,8 +87,11 @@ export class GroupViewPage extends AKElement {
         }
         return html`<ak-tabs>
             <section
+                role="tabpanel"
+                tabindex="0"
                 slot="page-overview"
-                data-tab-title="${msg("Overview")}"
+                id="page-overview"
+                aria-label="${msg("Overview")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-l-grid pf-m-gutter">
@@ -191,8 +194,11 @@ export class GroupViewPage extends AKElement {
                 </div>
             </section>
             <section
+                role="tabpanel"
+                tabindex="0"
                 slot="page-users"
-                data-tab-title="${msg("Users")}"
+                id="page-users"
+                aria-label="${msg("Users")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-c-card">
@@ -202,8 +208,11 @@ export class GroupViewPage extends AKElement {
                 </div>
             </section>
             <ak-rbac-object-permission-page
+                role="tabpanel"
+                tabindex="0"
                 slot="page-permissions"
-                data-tab-title="${msg("Permissions")}"
+                id="page-permissions"
+                aria-label="${msg("Permissions")}"
                 model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikCoreGroup}
                 objectPk=${this.group.pk}
             ></ak-rbac-object-permission-page>

--- a/web/src/admin/groups/GroupViewPage.ts
+++ b/web/src/admin/groups/GroupViewPage.ts
@@ -85,138 +85,141 @@ export class GroupViewPage extends AKElement {
         if (!this.group) {
             return nothing;
         }
-        return html`<ak-tabs>
-            <section
-                role="tabpanel"
-                tabindex="0"
-                slot="page-overview"
-                id="page-overview"
-                aria-label="${msg("Overview")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-l-grid pf-m-gutter">
-                    <div
-                        class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-3-col-on-xl pf-m-3-col-on-2xl"
-                    >
-                        <div class="pf-c-card__title">${msg("Group Info")}</div>
+        return html`<main>
+            <ak-tabs>
+                <section
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-overview"
+                    id="page-overview"
+                    aria-label="${msg("Overview")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-l-grid pf-m-gutter">
+                        <div
+                            class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-3-col-on-xl pf-m-3-col-on-2xl"
+                        >
+                            <div class="pf-c-card__title">${msg("Group Info")}</div>
+                            <div class="pf-c-card__body">
+                                <dl class="pf-c-description-list">
+                                    <div class="pf-c-description-list__group">
+                                        <dt class="pf-c-description-list__term">
+                                            <span class="pf-c-description-list__text"
+                                                >${msg("Name")}</span
+                                            >
+                                        </dt>
+                                        <dd class="pf-c-description-list__description">
+                                            <div class="pf-c-description-list__text">
+                                                ${this.group.name}
+                                            </div>
+                                        </dd>
+                                    </div>
+                                    <div class="pf-c-description-list__group">
+                                        <dt class="pf-c-description-list__term">
+                                            <span class="pf-c-description-list__text"
+                                                >${msg("Superuser")}</span
+                                            >
+                                        </dt>
+                                        <dd class="pf-c-description-list__description">
+                                            <div class="pf-c-description-list__text">
+                                                <ak-status-label
+                                                    type="neutral"
+                                                    ?good=${this.group.isSuperuser}
+                                                ></ak-status-label>
+                                            </div>
+                                        </dd>
+                                    </div>
+                                    <div class="pf-c-description-list__group">
+                                        <dt class="pf-c-description-list__term">
+                                            <span class="pf-c-description-list__text"
+                                                >${msg("Roles")}</span
+                                            >
+                                        </dt>
+                                        <dd class="pf-c-description-list__description">
+                                            <div class="pf-c-description-list__text">
+                                                <ul class="pf-c-list">
+                                                    ${this.group.rolesObj.map((role) => {
+                                                        return html`<li>
+                                                            <a href=${`#/identity/roles/${role.pk}`}
+                                                                >${role.name}
+                                                            </a>
+                                                        </li>`;
+                                                    })}
+                                                </ul>
+                                            </div>
+                                        </dd>
+                                    </div>
+                                </dl>
+                            </div>
+                            <div class="pf-c-card__footer">
+                                <ak-forms-modal>
+                                    <span slot="submit"> ${msg("Update")} </span>
+                                    <span slot="header"> ${msg("Update Group")} </span>
+                                    <ak-group-form slot="form" .instancePk=${this.group.pk}>
+                                    </ak-group-form>
+                                    <button slot="trigger" class="pf-m-primary pf-c-button">
+                                        ${msg("Edit")}
+                                    </button>
+                                </ak-forms-modal>
+                            </div>
+                        </div>
+                        <div
+                            class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-9-col-on-xl pf-m-9-col-on-2xl"
+                        >
+                            <div class="pf-c-card__title">${msg("Notes")}</div>
+                            <div class="pf-c-card__body">
+                                ${Object.hasOwn(this.group?.attributes || {}, "notes")
+                                    ? html`${this.group.attributes?.notes}`
+                                    : html`
+                                          <p>
+                                              ${msg(
+                                                  "Edit the notes attribute of this group to add notes here.",
+                                              )}
+                                          </p>
+                                      `}
+                            </div>
+                        </div>
+                        <div
+                            class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-12-col-on-xl pf-m-12-col-on-2xl"
+                        >
+                            <div class="pf-c-card__title">${msg("Changelog")}</div>
+                            <div class="pf-c-card__body">
+                                <ak-object-changelog
+                                    targetModelPk=${this.group.pk}
+                                    targetModelApp="authentik_core"
+                                    targetModelName="group"
+                                >
+                                </ak-object-changelog>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+                <section
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-users"
+                    id="page-users"
+                    aria-label="${msg("Users")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-c-card">
                         <div class="pf-c-card__body">
-                            <dl class="pf-c-description-list">
-                                <div class="pf-c-description-list__group">
-                                    <dt class="pf-c-description-list__term">
-                                        <span class="pf-c-description-list__text"
-                                            >${msg("Name")}</span
-                                        >
-                                    </dt>
-                                    <dd class="pf-c-description-list__description">
-                                        <div class="pf-c-description-list__text">
-                                            ${this.group.name}
-                                        </div>
-                                    </dd>
-                                </div>
-                                <div class="pf-c-description-list__group">
-                                    <dt class="pf-c-description-list__term">
-                                        <span class="pf-c-description-list__text"
-                                            >${msg("Superuser")}</span
-                                        >
-                                    </dt>
-                                    <dd class="pf-c-description-list__description">
-                                        <div class="pf-c-description-list__text">
-                                            <ak-status-label
-                                                type="neutral"
-                                                ?good=${this.group.isSuperuser}
-                                            ></ak-status-label>
-                                        </div>
-                                    </dd>
-                                </div>
-                                <div class="pf-c-description-list__group">
-                                    <dt class="pf-c-description-list__term">
-                                        <span class="pf-c-description-list__text"
-                                            >${msg("Roles")}</span
-                                        >
-                                    </dt>
-                                    <dd class="pf-c-description-list__description">
-                                        <div class="pf-c-description-list__text">
-                                            <ul class="pf-c-list">
-                                                ${this.group.rolesObj.map((role) => {
-                                                    return html`<li>
-                                                        <a href=${`#/identity/roles/${role.pk}`}
-                                                            >${role.name}
-                                                        </a>
-                                                    </li>`;
-                                                })}
-                                            </ul>
-                                        </div>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
-                        <div class="pf-c-card__footer">
-                            <ak-forms-modal>
-                                <span slot="submit"> ${msg("Update")} </span>
-                                <span slot="header"> ${msg("Update Group")} </span>
-                                <ak-group-form slot="form" .instancePk=${this.group.pk}>
-                                </ak-group-form>
-                                <button slot="trigger" class="pf-m-primary pf-c-button">
-                                    ${msg("Edit")}
-                                </button>
-                            </ak-forms-modal>
+                            <ak-user-related-list .targetGroup=${this.group}>
+                            </ak-user-related-list>
                         </div>
                     </div>
-                    <div
-                        class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-9-col-on-xl pf-m-9-col-on-2xl"
-                    >
-                        <div class="pf-c-card__title">${msg("Notes")}</div>
-                        <div class="pf-c-card__body">
-                            ${Object.hasOwn(this.group?.attributes || {}, "notes")
-                                ? html`${this.group.attributes?.notes}`
-                                : html`
-                                      <p>
-                                          ${msg(
-                                              "Edit the notes attribute of this group to add notes here.",
-                                          )}
-                                      </p>
-                                  `}
-                        </div>
-                    </div>
-                    <div
-                        class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-12-col-on-xl pf-m-12-col-on-2xl"
-                    >
-                        <div class="pf-c-card__title">${msg("Changelog")}</div>
-                        <div class="pf-c-card__body">
-                            <ak-object-changelog
-                                targetModelPk=${this.group.pk}
-                                targetModelApp="authentik_core"
-                                targetModelName="group"
-                            >
-                            </ak-object-changelog>
-                        </div>
-                    </div>
-                </div>
-            </section>
-            <section
-                role="tabpanel"
-                tabindex="0"
-                slot="page-users"
-                id="page-users"
-                aria-label="${msg("Users")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-c-card">
-                    <div class="pf-c-card__body">
-                        <ak-user-related-list .targetGroup=${this.group}> </ak-user-related-list>
-                    </div>
-                </div>
-            </section>
-            <ak-rbac-object-permission-page
-                role="tabpanel"
-                tabindex="0"
-                slot="page-permissions"
-                id="page-permissions"
-                aria-label="${msg("Permissions")}"
-                model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikCoreGroup}
-                objectPk=${this.group.pk}
-            ></ak-rbac-object-permission-page>
-        </ak-tabs>`;
+                </section>
+                <ak-rbac-object-permission-page
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-permissions"
+                    id="page-permissions"
+                    aria-label="${msg("Permissions")}"
+                    model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikCoreGroup}
+                    objectPk=${this.group.pk}
+                ></ak-rbac-object-permission-page>
+            </ak-tabs>
+        </main>`;
     }
 }
 

--- a/web/src/admin/providers/ProviderListPage.ts
+++ b/web/src/admin/providers/ProviderListPage.ts
@@ -46,7 +46,7 @@ export class ProviderListPage extends TablePage<Provider> {
     @property()
     public order = "name";
 
-    public searchLabel = msg("Provider name");
+    public searchLabel = msg("Provider Search");
     public searchPlaceholder = msg("Search for providers…");
 
     override async apiEndpoint(): Promise<PaginatedResponse<Provider>> {

--- a/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderViewPage.ts
+++ b/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderViewPage.ts
@@ -87,12 +87,21 @@ export class GoogleWorkspaceProviderViewPage extends AKElement {
             return nothing;
         }
         return html` <ak-tabs>
-            <section slot="page-overview" data-tab-title="${msg("Overview")}">
+            <section
+                role="tabpanel"
+                tabindex="0"
+                slot="page-overview"
+                id="page-overview"
+                aria-label="${msg("Overview")}"
+            >
                 ${this.renderTabOverview()}
             </section>
             <section
+                role="tabpanel"
+                tabindex="0"
                 slot="page-changelog"
-                data-tab-title="${msg("Changelog")}"
+                id="page-changelog"
+                aria-label="${msg("Changelog")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-c-card">
@@ -106,8 +115,11 @@ export class GoogleWorkspaceProviderViewPage extends AKElement {
                 </div>
             </section>
             <section
+                role="tabpanel"
+                tabindex="0"
                 slot="page-users"
-                data-tab-title="${msg("Provisioned Users")}"
+                id="page-users"
+                aria-label="${msg("Provisioned Users")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-l-grid pf-m-gutter">
@@ -117,8 +129,11 @@ export class GoogleWorkspaceProviderViewPage extends AKElement {
                 </div>
             </section>
             <section
+                role="tabpanel"
+                tabindex="0"
                 slot="page-groups"
-                data-tab-title="${msg("Provisioned Groups")}"
+                id="page-groups"
+                aria-label="${msg("Provisioned Groups")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-l-grid pf-m-gutter">
@@ -128,8 +143,11 @@ export class GoogleWorkspaceProviderViewPage extends AKElement {
                 </div>
             </section>
             <ak-rbac-object-permission-page
+                role="tabpanel"
+                tabindex="0"
                 slot="page-permissions"
-                data-tab-title="${msg("Permissions")}"
+                id="page-permissions"
+                aria-label="${msg("Permissions")}"
                 model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersGoogleWorkspaceGoogleworkspaceprovider}
                 objectPk=${this.provider.pk}
             ></ak-rbac-object-permission-page>

--- a/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderViewPage.ts
+++ b/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderViewPage.ts
@@ -86,72 +86,74 @@ export class GoogleWorkspaceProviderViewPage extends AKElement {
         if (!this.provider) {
             return nothing;
         }
-        return html` <ak-tabs>
-            <section
-                role="tabpanel"
-                tabindex="0"
-                slot="page-overview"
-                id="page-overview"
-                aria-label="${msg("Overview")}"
-            >
-                ${this.renderTabOverview()}
-            </section>
-            <section
-                role="tabpanel"
-                tabindex="0"
-                slot="page-changelog"
-                id="page-changelog"
-                aria-label="${msg("Changelog")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-c-card">
-                    <div class="pf-c-card__body">
-                        <ak-object-changelog
-                            targetModelPk=${this.provider?.pk || ""}
-                            targetModelName=${this.provider?.metaModelName || ""}
-                        >
-                        </ak-object-changelog>
+        return html` <main>
+            <ak-tabs>
+                <section
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-overview"
+                    id="page-overview"
+                    aria-label="${msg("Overview")}"
+                >
+                    ${this.renderTabOverview()}
+                </section>
+                <section
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-changelog"
+                    id="page-changelog"
+                    aria-label="${msg("Changelog")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-c-card">
+                        <div class="pf-c-card__body">
+                            <ak-object-changelog
+                                targetModelPk=${this.provider?.pk || ""}
+                                targetModelName=${this.provider?.metaModelName || ""}
+                            >
+                            </ak-object-changelog>
+                        </div>
                     </div>
-                </div>
-            </section>
-            <section
-                role="tabpanel"
-                tabindex="0"
-                slot="page-users"
-                id="page-users"
-                aria-label="${msg("Provisioned Users")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-l-grid pf-m-gutter">
-                    <ak-provider-google-workspace-users-list
-                        providerId=${this.provider.pk}
-                    ></ak-provider-google-workspace-users-list>
-                </div>
-            </section>
-            <section
-                role="tabpanel"
-                tabindex="0"
-                slot="page-groups"
-                id="page-groups"
-                aria-label="${msg("Provisioned Groups")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-l-grid pf-m-gutter">
-                    <ak-provider-google-workspace-groups-list
-                        providerId=${this.provider.pk}
-                    ></ak-provider-google-workspace-groups-list>
-                </div>
-            </section>
-            <ak-rbac-object-permission-page
-                role="tabpanel"
-                tabindex="0"
-                slot="page-permissions"
-                id="page-permissions"
-                aria-label="${msg("Permissions")}"
-                model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersGoogleWorkspaceGoogleworkspaceprovider}
-                objectPk=${this.provider.pk}
-            ></ak-rbac-object-permission-page>
-        </ak-tabs>`;
+                </section>
+                <section
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-users"
+                    id="page-users"
+                    aria-label="${msg("Provisioned Users")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-l-grid pf-m-gutter">
+                        <ak-provider-google-workspace-users-list
+                            providerId=${this.provider.pk}
+                        ></ak-provider-google-workspace-users-list>
+                    </div>
+                </section>
+                <section
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-groups"
+                    id="page-groups"
+                    aria-label="${msg("Provisioned Groups")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-l-grid pf-m-gutter">
+                        <ak-provider-google-workspace-groups-list
+                            providerId=${this.provider.pk}
+                        ></ak-provider-google-workspace-groups-list>
+                    </div>
+                </section>
+                <ak-rbac-object-permission-page
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-permissions"
+                    id="page-permissions"
+                    aria-label="${msg("Permissions")}"
+                    model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersGoogleWorkspaceGoogleworkspaceprovider}
+                    objectPk=${this.provider.pk}
+                ></ak-rbac-object-permission-page>
+            </ak-tabs>
+        </main>`;
     }
 
     renderTabOverview(): SlottedTemplateResult {

--- a/web/src/admin/providers/ldap/LDAPProviderFormForm.ts
+++ b/web/src/admin/providers/ldap/LDAPProviderFormForm.ts
@@ -140,6 +140,8 @@ export function renderForm(
                     .errorMessages=${errors?.certificate}
                 >
                     <ak-crypto-certificate-search
+                        label=${msg("Certificate")}
+                        placeholder=${msg("Select a certificate...")}
                         certificate=${ifDefined(provider?.certificate ?? nothing)}
                         name="certificate"
                     >

--- a/web/src/admin/providers/ldap/LDAPProviderFormForm.ts
+++ b/web/src/admin/providers/ldap/LDAPProviderFormForm.ts
@@ -48,9 +48,9 @@ export function renderForm(
     return html`
         <ak-text-input
             name="name"
-            placeholder=${msg("Provider name")}
+            placeholder=${msg("Provider name...")}
             value=${ifDefined(provider?.name)}
-            label=${msg("Name")}
+            label=${msg("Provider Name")}
             .errorMessages=${errors?.name}
             required
             help=${msg("Method's display Name.")}

--- a/web/src/admin/providers/ldap/LDAPProviderViewPage.ts
+++ b/web/src/admin/providers/ldap/LDAPProviderViewPage.ts
@@ -90,44 +90,46 @@ export class LDAPProviderViewPage extends AKElement {
         if (!this.provider) {
             return nothing;
         }
-        return html` <ak-tabs>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-overview"
-                id="page-overview"
-                aria-label="${msg("Overview")}"
-            >
-                ${this.renderTabOverview()}
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-changelog"
-                id="page-changelog"
-                aria-label="${msg("Changelog")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-c-card">
-                    <div class="pf-c-card__body">
-                        <ak-object-changelog
-                            targetModelPk=${this.provider?.pk || ""}
-                            targetModelName=${this.provider?.metaModelName || ""}
-                        >
-                        </ak-object-changelog>
+        return html` <main>
+            <ak-tabs>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-overview"
+                    id="page-overview"
+                    aria-label="${msg("Overview")}"
+                >
+                    ${this.renderTabOverview()}
+                </div>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-changelog"
+                    id="page-changelog"
+                    aria-label="${msg("Changelog")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-c-card">
+                        <div class="pf-c-card__body">
+                            <ak-object-changelog
+                                targetModelPk=${this.provider?.pk || ""}
+                                targetModelName=${this.provider?.metaModelName || ""}
+                            >
+                            </ak-object-changelog>
+                        </div>
                     </div>
                 </div>
-            </div>
-            <ak-rbac-object-permission-page
-                role="tabpanel"
-                tabindex="0"
-                slot="page-permissions"
-                id="page-permissions"
-                aria-label="${msg("Permissions")}"
-                model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersLdapLdapprovider}
-                objectPk=${this.provider.pk}
-            ></ak-rbac-object-permission-page>
-        </ak-tabs>`;
+                <ak-rbac-object-permission-page
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-permissions"
+                    id="page-permissions"
+                    aria-label="${msg("Permissions")}"
+                    model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersLdapLdapprovider}
+                    objectPk=${this.provider.pk}
+                ></ak-rbac-object-permission-page>
+            </ak-tabs>
+        </main>`;
     }
 
     renderTabOverview(): SlottedTemplateResult {

--- a/web/src/admin/providers/ldap/LDAPProviderViewPage.ts
+++ b/web/src/admin/providers/ldap/LDAPProviderViewPage.ts
@@ -91,12 +91,21 @@ export class LDAPProviderViewPage extends AKElement {
             return nothing;
         }
         return html` <ak-tabs>
-            <section slot="page-overview" data-tab-title="${msg("Overview")}">
+            <div
+                role="tabpanel"
+                tabindex="0"
+                slot="page-overview"
+                id="page-overview"
+                aria-label="${msg("Overview")}"
+            >
                 ${this.renderTabOverview()}
-            </section>
-            <section
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-changelog"
-                data-tab-title="${msg("Changelog")}"
+                id="page-changelog"
+                aria-label="${msg("Changelog")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-c-card">
@@ -108,10 +117,13 @@ export class LDAPProviderViewPage extends AKElement {
                         </ak-object-changelog>
                     </div>
                 </div>
-            </section>
+            </div>
             <ak-rbac-object-permission-page
+                role="tabpanel"
+                tabindex="0"
                 slot="page-permissions"
-                data-tab-title="${msg("Permissions")}"
+                id="page-permissions"
+                aria-label="${msg("Permissions")}"
                 model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersLdapLdapprovider}
                 objectPk=${this.provider.pk}
             ></ak-rbac-object-permission-page>

--- a/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderViewPage.ts
+++ b/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderViewPage.ts
@@ -86,72 +86,74 @@ export class MicrosoftEntraProviderViewPage extends AKElement {
         if (!this.provider) {
             return nothing;
         }
-        return html` <ak-tabs>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-overview"
-                id="page-overview"
-                aria-label="${msg("Overview")}"
-            >
-                ${this.renderTabOverview()}
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-changelog"
-                id="page-changelog"
-                aria-label="${msg("Changelog")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-c-card">
-                    <div class="pf-c-card__body">
-                        <ak-object-changelog
-                            targetModelPk=${this.provider?.pk || ""}
-                            targetModelName=${this.provider?.metaModelName || ""}
-                        >
-                        </ak-object-changelog>
+        return html` <main>
+            <ak-tabs>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-overview"
+                    id="page-overview"
+                    aria-label="${msg("Overview")}"
+                >
+                    ${this.renderTabOverview()}
+                </div>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-changelog"
+                    id="page-changelog"
+                    aria-label="${msg("Changelog")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-c-card">
+                        <div class="pf-c-card__body">
+                            <ak-object-changelog
+                                targetModelPk=${this.provider?.pk || ""}
+                                targetModelName=${this.provider?.metaModelName || ""}
+                            >
+                            </ak-object-changelog>
+                        </div>
                     </div>
                 </div>
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-users"
-                id="page-users"
-                aria-label="${msg("Provisioned Users")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-l-grid pf-m-gutter">
-                    <ak-provider-microsoft-entra-users-list
-                        providerId=${this.provider.pk}
-                    ></ak-provider-microsoft-entra-users-list>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-users"
+                    id="page-users"
+                    aria-label="${msg("Provisioned Users")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-l-grid pf-m-gutter">
+                        <ak-provider-microsoft-entra-users-list
+                            providerId=${this.provider.pk}
+                        ></ak-provider-microsoft-entra-users-list>
+                    </div>
                 </div>
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-groups"
-                id="page-groups"
-                aria-label="${msg("Provisioned Groups")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-l-grid pf-m-gutter">
-                    <ak-provider-microsoft-entra-groups-list
-                        providerId=${this.provider.pk}
-                    ></ak-provider-microsoft-entra-groups-list>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-groups"
+                    id="page-groups"
+                    aria-label="${msg("Provisioned Groups")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-l-grid pf-m-gutter">
+                        <ak-provider-microsoft-entra-groups-list
+                            providerId=${this.provider.pk}
+                        ></ak-provider-microsoft-entra-groups-list>
+                    </div>
                 </div>
-            </div>
-            <ak-rbac-object-permission-page
-                role="tabpanel"
-                tabindex="0"
-                slot="page-permissions"
-                id="page-permissions"
-                aria-label="${msg("Permissions")}"
-                model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersMicrosoftEntraMicrosoftentraprovider}
-                objectPk=${this.provider.pk}
-            ></ak-rbac-object-permission-page>
-        </ak-tabs>`;
+                <ak-rbac-object-permission-page
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-permissions"
+                    id="page-permissions"
+                    aria-label="${msg("Permissions")}"
+                    model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersMicrosoftEntraMicrosoftentraprovider}
+                    objectPk=${this.provider.pk}
+                ></ak-rbac-object-permission-page>
+            </ak-tabs>
+        </main>`;
     }
 
     renderTabOverview(): SlottedTemplateResult {

--- a/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderViewPage.ts
+++ b/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderViewPage.ts
@@ -87,12 +87,21 @@ export class MicrosoftEntraProviderViewPage extends AKElement {
             return nothing;
         }
         return html` <ak-tabs>
-            <section slot="page-overview" data-tab-title="${msg("Overview")}">
+            <div
+                role="tabpanel"
+                tabindex="0"
+                slot="page-overview"
+                id="page-overview"
+                aria-label="${msg("Overview")}"
+            >
                 ${this.renderTabOverview()}
-            </section>
-            <section
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-changelog"
-                data-tab-title="${msg("Changelog")}"
+                id="page-changelog"
+                aria-label="${msg("Changelog")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-c-card">
@@ -104,10 +113,13 @@ export class MicrosoftEntraProviderViewPage extends AKElement {
                         </ak-object-changelog>
                     </div>
                 </div>
-            </section>
-            <section
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-users"
-                data-tab-title="${msg("Provisioned Users")}"
+                id="page-users"
+                aria-label="${msg("Provisioned Users")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-l-grid pf-m-gutter">
@@ -115,10 +127,13 @@ export class MicrosoftEntraProviderViewPage extends AKElement {
                         providerId=${this.provider.pk}
                     ></ak-provider-microsoft-entra-users-list>
                 </div>
-            </section>
-            <section
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-groups"
-                data-tab-title="${msg("Provisioned Groups")}"
+                id="page-groups"
+                aria-label="${msg("Provisioned Groups")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-l-grid pf-m-gutter">
@@ -126,10 +141,13 @@ export class MicrosoftEntraProviderViewPage extends AKElement {
                         providerId=${this.provider.pk}
                     ></ak-provider-microsoft-entra-groups-list>
                 </div>
-            </section>
+            </div>
             <ak-rbac-object-permission-page
+                role="tabpanel"
+                tabindex="0"
                 slot="page-permissions"
-                data-tab-title="${msg("Permissions")}"
+                id="page-permissions"
+                aria-label="${msg("Permissions")}"
                 model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersMicrosoftEntraMicrosoftentraprovider}
                 objectPk=${this.provider.pk}
             ></ak-rbac-object-permission-page>

--- a/web/src/admin/providers/oauth2/OAuth2ProviderFormForm.ts
+++ b/web/src/admin/providers/oauth2/OAuth2ProviderFormForm.ts
@@ -21,6 +21,7 @@ import { oauth2SourcesProvider, oauth2SourcesSelector } from "./OAuth2Sources.js
 import { ascii_letters, digits, randomString } from "#common/utils";
 
 import { RadioOption } from "#elements/forms/Radio";
+import { ifPresent } from "#elements/utils/attributes";
 
 import {
     ClientTypeEnum,
@@ -224,7 +225,7 @@ export function renderForm(
                     <ak-crypto-certificate-search
                         label=${msg("Signing Key")}
                         placeholder=${msg("Select a signing key...")}
-                        certificate=${ifDefined(provider?.signingKey ?? undefined)}
+                        certificate=${ifPresent(provider?.signingKey)}
                         singleton
                     ></ak-crypto-certificate-search>
                     <p class="pf-c-form__helper-text">${msg("Key used to sign the tokens.")}</p>
@@ -234,7 +235,7 @@ export function renderForm(
                     <ak-crypto-certificate-search
                         label=${msg("Encryption Key")}
                         placeholder=${msg("Select an encryption key...")}
-                        certificate=${ifDefined(provider?.encryptionKey ?? undefined)}
+                        certificate=${ifPresent(provider?.encryptionKey)}
                     ></ak-crypto-certificate-search>
                     <p class="pf-c-form__helper-text">${msg("Key used to encrypt the tokens.")}</p>
                 </ak-form-element-horizontal>

--- a/web/src/admin/providers/oauth2/OAuth2ProviderFormForm.ts
+++ b/web/src/admin/providers/oauth2/OAuth2ProviderFormForm.ts
@@ -131,8 +131,8 @@ export function renderForm(
 ) {
     return html` <ak-text-input
             name="name"
-            placeholder=${msg("Provider name")}
-            label=${msg("Name")}
+            placeholder=${msg("Provider name...")}
+            label=${msg("Provider Name")}
             value=${ifDefined(provider?.name)}
             .errorMessages=${errors?.name}
             required

--- a/web/src/admin/providers/oauth2/OAuth2ProviderFormForm.ts
+++ b/web/src/admin/providers/oauth2/OAuth2ProviderFormForm.ts
@@ -131,6 +131,7 @@ export function renderForm(
 ) {
     return html` <ak-text-input
             name="name"
+            placeholder=${msg("Provider name")}
             label=${msg("Name")}
             value=${ifDefined(provider?.name)}
             .errorMessages=${errors?.name}
@@ -143,6 +144,8 @@ export function renderForm(
             required
         >
             <ak-flow-search
+                label=${msg("Authorization flow")}
+                placeholder=${msg("Select an authorization flow...")}
                 flowType=${FlowsInstancesListDesignationEnum.Authorization}
                 .currentFlow=${provider?.authorizationFlow}
                 .errorMessages=${errors?.authorizationFlow}
@@ -219,6 +222,8 @@ export function renderForm(
                 <ak-form-element-horizontal label=${msg("Signing Key")} name="signingKey">
                     <!-- NOTE: 'null' cast to 'undefined' on signingKey to satisfy Lit requirements -->
                     <ak-crypto-certificate-search
+                        label=${msg("Signing Key")}
+                        placeholder=${msg("Select a signing key...")}
                         certificate=${ifDefined(provider?.signingKey ?? undefined)}
                         singleton
                     ></ak-crypto-certificate-search>
@@ -227,6 +232,8 @@ export function renderForm(
                 <ak-form-element-horizontal label=${msg("Encryption Key")} name="encryptionKey">
                     <!-- NOTE: 'null' cast to 'undefined' on encryptionKey to satisfy Lit requirements -->
                     <ak-crypto-certificate-search
+                        label=${msg("Encryption Key")}
+                        placeholder=${msg("Select an encryption key...")}
                         certificate=${ifDefined(provider?.encryptionKey ?? undefined)}
                     ></ak-crypto-certificate-search>
                     <p class="pf-c-form__helper-text">${msg("Key used to encrypt the tokens.")}</p>
@@ -241,6 +248,8 @@ export function renderForm(
                     label=${msg("Authentication flow")}
                 >
                     <ak-flow-search
+                        label=${msg("Authentication flow")}
+                        placeholder=${msg("Select an authentication flow...")}
                         flowType=${FlowsInstancesListDesignationEnum.Authentication}
                         .currentFlow=${provider?.authenticationFlow}
                     ></ak-flow-search>
@@ -256,6 +265,8 @@ export function renderForm(
                     required
                 >
                     <ak-flow-search
+                        label=${msg("Invalidation flow")}
+                        placeholder=${msg("Select an invalidation flow...")}
                         flowType=${FlowsInstancesListDesignationEnum.Invalidation}
                         .currentFlow=${provider?.invalidationFlow}
                         defaultFlowSlug="default-provider-invalidation-flow"

--- a/web/src/admin/providers/oauth2/OAuth2ProviderRedirectURI.ts
+++ b/web/src/admin/providers/oauth2/OAuth2ProviderRedirectURI.ts
@@ -2,6 +2,7 @@ import "#admin/providers/oauth2/OAuth2ProviderRedirectURI";
 
 import { AkControlElement } from "#elements/AkControlElement";
 import { LitPropertyRecord } from "#elements/types";
+import { ifPresent } from "#elements/utils/attributes";
 
 import { MatchingModeEnum, RedirectURI } from "@goauthentik/api";
 
@@ -83,7 +84,7 @@ export class OAuth2ProviderRedirectURI extends AkControlElement<RedirectURI> {
             <input
                 type="text"
                 @change=${onChange}
-                value="${ifDefined(this.redirectURI.url ?? undefined)}"
+                value="${ifPresent(this.redirectURI.url)}"
                 class="pf-c-form-control ak-form-control pf-m-monospace"
                 spellcheck="false"
                 autocomplete="off"

--- a/web/src/admin/providers/oauth2/OAuth2ProviderViewPage.ts
+++ b/web/src/admin/providers/oauth2/OAuth2ProviderViewPage.ts
@@ -121,65 +121,67 @@ export class OAuth2ProviderViewPage extends AKElement {
         if (!this.provider) {
             return nothing;
         }
-        return html` <ak-tabs>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-overview"
-                id="page-overview"
-                aria-label="${msg("Overview")}"
-                @activate=${() => {
-                    new ProvidersApi(DEFAULT_CONFIG)
-                        .providersOauth2SetupUrlsRetrieve({
-                            id: this.provider?.pk || 0,
-                        })
-                        .then((prov) => {
-                            this.providerUrls = prov;
-                        });
-                }}
-            >
-                ${this.renderTabOverview()}
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-preview"
-                id="page-preview"
-                aria-label="${msg("Preview")}"
-                @activate=${() => {
-                    this.fetchPreview();
-                }}
-            >
-                ${this.renderTabPreview()}
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-changelog"
-                id="page-changelog"
-                aria-label="${msg("Changelog")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-c-card">
-                    <div class="pf-c-card__body">
-                        <ak-object-changelog
-                            targetModelPk=${this.provider?.pk || ""}
-                            targetModelName=${this.provider?.metaModelName || ""}
-                        >
-                        </ak-object-changelog>
+        return html` <main>
+            <ak-tabs>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-overview"
+                    id="page-overview"
+                    aria-label="${msg("Overview")}"
+                    @activate=${() => {
+                        new ProvidersApi(DEFAULT_CONFIG)
+                            .providersOauth2SetupUrlsRetrieve({
+                                id: this.provider?.pk || 0,
+                            })
+                            .then((prov) => {
+                                this.providerUrls = prov;
+                            });
+                    }}
+                >
+                    ${this.renderTabOverview()}
+                </div>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-preview"
+                    id="page-preview"
+                    aria-label="${msg("Preview")}"
+                    @activate=${() => {
+                        this.fetchPreview();
+                    }}
+                >
+                    ${this.renderTabPreview()}
+                </div>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-changelog"
+                    id="page-changelog"
+                    aria-label="${msg("Changelog")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-c-card">
+                        <div class="pf-c-card__body">
+                            <ak-object-changelog
+                                targetModelPk=${this.provider?.pk || ""}
+                                targetModelName=${this.provider?.metaModelName || ""}
+                            >
+                            </ak-object-changelog>
+                        </div>
                     </div>
                 </div>
-            </div>
-            <ak-rbac-object-permission-page
-                role="tabpanel"
-                tabindex="0"
-                slot="page-permissions"
-                id="page-permissions"
-                aria-label="${msg("Permissions")}"
-                model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersOauth2Oauth2provider}
-                objectPk=${this.provider.pk}
-            ></ak-rbac-object-permission-page>
-        </ak-tabs>`;
+                <ak-rbac-object-permission-page
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-permissions"
+                    id="page-permissions"
+                    aria-label="${msg("Permissions")}"
+                    model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersOauth2Oauth2provider}
+                    objectPk=${this.provider.pk}
+                ></ak-rbac-object-permission-page>
+            </ak-tabs>
+        </main>`;
     }
 
     renderTabOverview(): SlottedTemplateResult {

--- a/web/src/admin/providers/oauth2/OAuth2ProviderViewPage.ts
+++ b/web/src/admin/providers/oauth2/OAuth2ProviderViewPage.ts
@@ -29,6 +29,7 @@ import {
     RbacPermissionsAssignedByUsersListModelEnum,
     User,
 } from "@goauthentik/api";
+import { IDGenerator } from "@goauthentik/core/id";
 
 import MDProviderOAuth2 from "~docs/add-secure-apps/providers/oauth2/index.mdx";
 
@@ -283,12 +284,16 @@ export class OAuth2ProviderViewPage extends AKElement {
                     <div class="pf-c-card__body">
                         <form class="pf-c-form">
                             <div class="pf-c-form__group">
-                                <label class="pf-c-form__label">
+                                <label
+                                    class="pf-c-form__label"
+                                    for="${IDGenerator.elementID("providerInfo")}"
+                                >
                                     <span class="pf-c-form__label-text"
                                         >${msg("OpenID Configuration URL")}</span
                                     >
                                 </label>
                                 <input
+                                    id="${IDGenerator.elementID("providerInfo")}"
                                     class="pf-c-form-control"
                                     readonly
                                     type="text"
@@ -296,12 +301,16 @@ export class OAuth2ProviderViewPage extends AKElement {
                                 />
                             </div>
                             <div class="pf-c-form__group">
-                                <label class="pf-c-form__label">
+                                <label
+                                    class="pf-c-form__label"
+                                    for="${IDGenerator.elementID("issuer")}"
+                                >
                                     <span class="pf-c-form__label-text"
                                         >${msg("OpenID Configuration Issuer")}</span
                                     >
                                 </label>
                                 <input
+                                    id="${IDGenerator.elementID("issuer")}"
                                     class="pf-c-form-control"
                                     readonly
                                     type="text"
@@ -310,12 +319,16 @@ export class OAuth2ProviderViewPage extends AKElement {
                             </div>
                             <hr class="pf-c-divider" />
                             <div class="pf-c-form__group">
-                                <label class="pf-c-form__label">
+                                <label
+                                    class="pf-c-form__label"
+                                    for="${IDGenerator.elementID("authorize")}"
+                                >
                                     <span class="pf-c-form__label-text"
                                         >${msg("Authorize URL")}</span
                                     >
                                 </label>
                                 <input
+                                    id="${IDGenerator.elementID("authorize")}"
                                     class="pf-c-form-control"
                                     readonly
                                     type="text"
@@ -323,10 +336,14 @@ export class OAuth2ProviderViewPage extends AKElement {
                                 />
                             </div>
                             <div class="pf-c-form__group">
-                                <label class="pf-c-form__label">
+                                <label
+                                    class="pf-c-form__label"
+                                    for="${IDGenerator.elementID("token")}"
+                                >
                                     <span class="pf-c-form__label-text">${msg("Token URL")}</span>
                                 </label>
                                 <input
+                                    id="${IDGenerator.elementID("token")}"
                                     class="pf-c-form-control"
                                     readonly
                                     type="text"
@@ -334,12 +351,16 @@ export class OAuth2ProviderViewPage extends AKElement {
                                 />
                             </div>
                             <div class="pf-c-form__group">
-                                <label class="pf-c-form__label">
+                                <label
+                                    class="pf-c-form__label"
+                                    for="${IDGenerator.elementID("userInfo")}"
+                                >
                                     <span class="pf-c-form__label-text"
                                         >${msg("Userinfo URL")}</span
                                     >
                                 </label>
                                 <input
+                                    id="${IDGenerator.elementID("userInfo")}"
                                     class="pf-c-form-control"
                                     readonly
                                     type="text"
@@ -347,10 +368,14 @@ export class OAuth2ProviderViewPage extends AKElement {
                                 />
                             </div>
                             <div class="pf-c-form__group">
-                                <label class="pf-c-form__label">
+                                <label
+                                    class="pf-c-form__label"
+                                    for="${IDGenerator.elementID("logout")}"
+                                >
                                     <span class="pf-c-form__label-text">${msg("Logout URL")}</span>
                                 </label>
                                 <input
+                                    id="${IDGenerator.elementID("logout")}"
                                     class="pf-c-form-control"
                                     readonly
                                     type="text"
@@ -358,10 +383,14 @@ export class OAuth2ProviderViewPage extends AKElement {
                                 />
                             </div>
                             <div class="pf-c-form__group">
-                                <label class="pf-c-form__label">
+                                <label
+                                    class="pf-c-form__label"
+                                    for="${IDGenerator.elementID("jwks")}"
+                                >
                                     <span class="pf-c-form__label-text">${msg("JWKS URL")}</span>
                                 </label>
                                 <input
+                                    id="${IDGenerator.elementID("jwks")}"
                                     class="pf-c-form-control"
                                     readonly
                                     type="text"
@@ -419,9 +448,12 @@ export class OAuth2ProviderViewPage extends AKElement {
                     ${renderDescriptionList(
                         [
                             [
-                                msg("Preview for user"),
+                                html`<label for="${IDGenerator.elementID("preview-user")}"
+                                    >${msg("Preview for user")}</label
+                                >`,
                                 html`
                                     <ak-search-select
+                                        id="${IDGenerator.elementID("preview-user")}"
                                         .fetchObjects=${async (query?: string): Promise<User[]> => {
                                             const args: CoreUsersListRequest = {
                                                 ordering: "username",

--- a/web/src/admin/providers/oauth2/OAuth2ProviderViewPage.ts
+++ b/web/src/admin/providers/oauth2/OAuth2ProviderViewPage.ts
@@ -122,9 +122,12 @@ export class OAuth2ProviderViewPage extends AKElement {
             return nothing;
         }
         return html` <ak-tabs>
-            <section
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-overview"
-                data-tab-title="${msg("Overview")}"
+                id="page-overview"
+                aria-label="${msg("Overview")}"
                 @activate=${() => {
                     new ProvidersApi(DEFAULT_CONFIG)
                         .providersOauth2SetupUrlsRetrieve({
@@ -136,19 +139,25 @@ export class OAuth2ProviderViewPage extends AKElement {
                 }}
             >
                 ${this.renderTabOverview()}
-            </section>
-            <section
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-preview"
-                data-tab-title="${msg("Preview")}"
+                id="page-preview"
+                aria-label="${msg("Preview")}"
                 @activate=${() => {
                     this.fetchPreview();
                 }}
             >
                 ${this.renderTabPreview()}
-            </section>
-            <section
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-changelog"
-                data-tab-title="${msg("Changelog")}"
+                id="page-changelog"
+                aria-label="${msg("Changelog")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-c-card">
@@ -160,10 +169,13 @@ export class OAuth2ProviderViewPage extends AKElement {
                         </ak-object-changelog>
                     </div>
                 </div>
-            </section>
+            </div>
             <ak-rbac-object-permission-page
+                role="tabpanel"
+                tabindex="0"
                 slot="page-permissions"
-                data-tab-title="${msg("Permissions")}"
+                id="page-permissions"
+                aria-label="${msg("Permissions")}"
                 model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersOauth2Oauth2provider}
                 objectPk=${this.provider.pk}
             ></ak-rbac-object-permission-page>

--- a/web/src/admin/providers/proxy/ProxyProviderViewPage.ts
+++ b/web/src/admin/providers/proxy/ProxyProviderViewPage.ts
@@ -184,13 +184,16 @@ export class ProxyProviderViewPage extends AKElement {
         ];
         return html`<ak-tabs pageIdentifier="proxy-setup">
             ${servers.map((server) => {
-                return html`<section
+                return html`<div
+                    role="tabpanel"
+                    tabindex="0"
                     slot="page-${formatSlug(server.label)}"
-                    data-tab-title="${server.label}"
+                    id="page-${formatSlug(server.label)}"
+                    aria-label="${server.label}"
                     class="pf-c-page__main-section pf-m-no-padding-mobile ak-markdown-section"
                 >
                     <ak-mdx .url=${server.md} .replacers=${replacers}></ak-mdx>
-                </section>`;
+                </div>`;
             })}</ak-tabs
         >`;
     }
@@ -200,15 +203,30 @@ export class ProxyProviderViewPage extends AKElement {
             return nothing;
         }
         return html` <ak-tabs>
-            <section slot="page-overview" data-tab-title="${msg("Overview")}">
+            <div
+                role="tabpanel"
+                tabindex="0"
+                slot="page-overview"
+                id="page-overview"
+                aria-label="${msg("Overview")}"
+            >
                 ${this.renderTabOverview()}
-            </section>
-            <section slot="page-authentication" data-tab-title="${msg("Authentication")}">
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
+                slot="page-authentication"
+                id="page-authentication"
+                aria-label="${msg("Authentication")}"
+            >
                 ${this.renderTabAuthentication()}
-            </section>
-            <section
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-changelog"
-                data-tab-title="${msg("Changelog")}"
+                id="page-changelog"
+                aria-label="${msg("Changelog")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-c-card">
@@ -220,10 +238,13 @@ export class ProxyProviderViewPage extends AKElement {
                         </ak-object-changelog>
                     </div>
                 </div>
-            </section>
+            </div>
             <ak-rbac-object-permission-page
+                role="tabpanel"
+                tabindex="0"
                 slot="page-permissions"
-                data-tab-title="${msg("Permissions")}"
+                id="page-permissions"
+                aria-label="${msg("Permissions")}"
                 model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersProxyProxyprovider}
                 objectPk=${this.provider.pk}
             ></ak-rbac-object-permission-page>

--- a/web/src/admin/providers/proxy/ProxyProviderViewPage.ts
+++ b/web/src/admin/providers/proxy/ProxyProviderViewPage.ts
@@ -202,53 +202,55 @@ export class ProxyProviderViewPage extends AKElement {
         if (!this.provider) {
             return nothing;
         }
-        return html` <ak-tabs>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-overview"
-                id="page-overview"
-                aria-label="${msg("Overview")}"
-            >
-                ${this.renderTabOverview()}
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-authentication"
-                id="page-authentication"
-                aria-label="${msg("Authentication")}"
-            >
-                ${this.renderTabAuthentication()}
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-changelog"
-                id="page-changelog"
-                aria-label="${msg("Changelog")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-c-card">
-                    <div class="pf-c-card__body">
-                        <ak-object-changelog
-                            targetModelPk=${this.provider?.pk || ""}
-                            targetModelName=${this.provider?.metaModelName || ""}
-                        >
-                        </ak-object-changelog>
+        return html` <main>
+            <ak-tabs>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-overview"
+                    id="page-overview"
+                    aria-label="${msg("Overview")}"
+                >
+                    ${this.renderTabOverview()}
+                </div>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-authentication"
+                    id="page-authentication"
+                    aria-label="${msg("Authentication")}"
+                >
+                    ${this.renderTabAuthentication()}
+                </div>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-changelog"
+                    id="page-changelog"
+                    aria-label="${msg("Changelog")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-c-card">
+                        <div class="pf-c-card__body">
+                            <ak-object-changelog
+                                targetModelPk=${this.provider?.pk || ""}
+                                targetModelName=${this.provider?.metaModelName || ""}
+                            >
+                            </ak-object-changelog>
+                        </div>
                     </div>
                 </div>
-            </div>
-            <ak-rbac-object-permission-page
-                role="tabpanel"
-                tabindex="0"
-                slot="page-permissions"
-                id="page-permissions"
-                aria-label="${msg("Permissions")}"
-                model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersProxyProxyprovider}
-                objectPk=${this.provider.pk}
-            ></ak-rbac-object-permission-page>
-        </ak-tabs>`;
+                <ak-rbac-object-permission-page
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-permissions"
+                    id="page-permissions"
+                    aria-label="${msg("Permissions")}"
+                    model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersProxyProxyprovider}
+                    objectPk=${this.provider.pk}
+                ></ak-rbac-object-permission-page>
+            </ak-tabs>
+        </main>`;
     }
 
     renderTabAuthentication(): SlottedTemplateResult {

--- a/web/src/admin/providers/rac/RACProviderViewPage.ts
+++ b/web/src/admin/providers/rac/RACProviderViewPage.ts
@@ -85,60 +85,62 @@ export class RACProviderViewPage extends AKElement {
         if (!this.provider) {
             return nothing;
         }
-        return html`<ak-tabs>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-overview"
-                id="page-overview"
-                aria-label="${msg("Overview")}"
-            >
-                ${this.renderTabOverview()}
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-connections"
-                id="page-connections"
-                aria-label="${msg("Connections")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-c-card">
-                    <div class="pf-c-card__body">
-                        <ak-rac-connection-token-list
-                            .provider=${this.provider}
-                        ></ak-rac-connection-token-list>
+        return html`<main>
+            <ak-tabs>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-overview"
+                    id="page-overview"
+                    aria-label="${msg("Overview")}"
+                >
+                    ${this.renderTabOverview()}
+                </div>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-connections"
+                    id="page-connections"
+                    aria-label="${msg("Connections")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-c-card">
+                        <div class="pf-c-card__body">
+                            <ak-rac-connection-token-list
+                                .provider=${this.provider}
+                            ></ak-rac-connection-token-list>
+                        </div>
                     </div>
                 </div>
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-changelog"
-                id="page-changelog"
-                aria-label="${msg("Changelog")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-c-card">
-                    <div class="pf-c-card__body">
-                        <ak-object-changelog
-                            targetModelPk=${this.provider?.pk || ""}
-                            targetModelName=${this.provider?.metaModelName || ""}
-                        >
-                        </ak-object-changelog>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-changelog"
+                    id="page-changelog"
+                    aria-label="${msg("Changelog")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-c-card">
+                        <div class="pf-c-card__body">
+                            <ak-object-changelog
+                                targetModelPk=${this.provider?.pk || ""}
+                                targetModelName=${this.provider?.metaModelName || ""}
+                            >
+                            </ak-object-changelog>
+                        </div>
                     </div>
                 </div>
-            </div>
-            <ak-rbac-object-permission-page
-                role="tabpanel"
-                tabindex="0"
-                slot="page-permissions"
-                id="page-permissions"
-                aria-label="${msg("Permissions")}"
-                model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersRacRacprovider}
-                objectPk=${this.provider.pk}
-            ></ak-rbac-object-permission-page>
-        </ak-tabs>`;
+                <ak-rbac-object-permission-page
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-permissions"
+                    id="page-permissions"
+                    aria-label="${msg("Permissions")}"
+                    model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersRacRacprovider}
+                    objectPk=${this.provider.pk}
+                ></ak-rbac-object-permission-page>
+            </ak-tabs>
+        </main>`;
     }
 
     renderTabOverview(): SlottedTemplateResult {

--- a/web/src/admin/providers/rac/RACProviderViewPage.ts
+++ b/web/src/admin/providers/rac/RACProviderViewPage.ts
@@ -86,12 +86,21 @@ export class RACProviderViewPage extends AKElement {
             return nothing;
         }
         return html`<ak-tabs>
-            <section slot="page-overview" data-tab-title="${msg("Overview")}">
+            <div
+                role="tabpanel"
+                tabindex="0"
+                slot="page-overview"
+                id="page-overview"
+                aria-label="${msg("Overview")}"
+            >
                 ${this.renderTabOverview()}
-            </section>
-            <section
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-connections"
-                data-tab-title="${msg("Connections")}"
+                id="page-connections"
+                aria-label="${msg("Connections")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-c-card">
@@ -101,10 +110,13 @@ export class RACProviderViewPage extends AKElement {
                         ></ak-rac-connection-token-list>
                     </div>
                 </div>
-            </section>
-            <section
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-changelog"
-                data-tab-title="${msg("Changelog")}"
+                id="page-changelog"
+                aria-label="${msg("Changelog")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-c-card">
@@ -116,10 +128,13 @@ export class RACProviderViewPage extends AKElement {
                         </ak-object-changelog>
                     </div>
                 </div>
-            </section>
+            </div>
             <ak-rbac-object-permission-page
+                role="tabpanel"
+                tabindex="0"
                 slot="page-permissions"
-                data-tab-title="${msg("Permissions")}"
+                id="page-permissions"
+                aria-label="${msg("Permissions")}"
                 model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersRacRacprovider}
                 objectPk=${this.provider.pk}
             ></ak-rbac-object-permission-page>

--- a/web/src/admin/providers/radius/RadiusProviderFormForm.ts
+++ b/web/src/admin/providers/radius/RadiusProviderFormForm.ts
@@ -45,6 +45,7 @@ export function renderForm(
         <ak-text-input
             name="name"
             label=${msg("Name")}
+            placeholder=${msg("Provider name")}
             value=${ifDefined(provider?.name)}
             .errorMessages=${errors?.name}
             required
@@ -58,6 +59,8 @@ export function renderForm(
             .errorMessages=${errors?.authorizationFlow}
         >
             <ak-branded-flow-search
+                label=${msg("Authentication flow")}
+                placeholder=${msg("Select an authentication flow...")}
                 flowType=${FlowsInstancesListDesignationEnum.Authentication}
                 .currentFlow=${provider?.authorizationFlow}
                 .brandFlow=${brand?.flowAuthentication}

--- a/web/src/admin/providers/radius/RadiusProviderFormForm.ts
+++ b/web/src/admin/providers/radius/RadiusProviderFormForm.ts
@@ -44,8 +44,8 @@ export function renderForm(
     return html`
         <ak-text-input
             name="name"
-            label=${msg("Name")}
-            placeholder=${msg("Provider name")}
+            label=${msg("Provider Name")}
+            placeholder=${msg("Provider name...")}
             value=${ifDefined(provider?.name)}
             .errorMessages=${errors?.name}
             required

--- a/web/src/admin/providers/radius/RadiusProviderViewPage.ts
+++ b/web/src/admin/providers/radius/RadiusProviderViewPage.ts
@@ -77,112 +77,116 @@ export class RadiusProviderViewPage extends AKElement {
         if (!this.provider) {
             return nothing;
         }
-        return html`<ak-tabs>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-overview"
-                id="page-overview"
-                aria-label="${msg("Overview")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                ${this.provider?.outpostSet.length < 1
-                    ? html`<div slot="header" class="pf-c-banner pf-m-warning">
-                          ${msg("Warning: Provider is not used by any Outpost.")}
-                      </div>`
-                    : nothing}
-                <div class="pf-u-display-flex pf-u-justify-content-center">
-                    <div class="pf-u-w-75">
-                        <div class="pf-c-card">
-                            <div class="pf-c-card__body">
-                                <dl class="pf-c-description-list pf-m-3-col-on-lg">
-                                    <div class="pf-c-description-list__group">
-                                        <dt class="pf-c-description-list__term">
-                                            <span class="pf-c-description-list__text"
-                                                >${msg("Name")}</span
-                                            >
-                                        </dt>
-                                        <dd class="pf-c-description-list__description">
-                                            <div class="pf-c-description-list__text">
-                                                ${this.provider.name}
-                                            </div>
-                                        </dd>
-                                    </div>
-                                    <div class="pf-c-description-list__group">
-                                        <dt class="pf-c-description-list__term">
-                                            <span class="pf-c-description-list__text"
-                                                >${msg("Assigned to application")}</span
-                                            >
-                                        </dt>
-                                        <dd class="pf-c-description-list__description">
-                                            <div class="pf-c-description-list__text">
-                                                <ak-provider-related-application
-                                                    .provider=${this.provider}
-                                                ></ak-provider-related-application>
-                                            </div>
-                                        </dd>
-                                    </div>
-                                    <div class="pf-c-description-list__group">
-                                        <dt class="pf-c-description-list__term">
-                                            <span class="pf-c-description-list__text"
-                                                >${msg("Client Networks")}</span
-                                            >
-                                        </dt>
-                                        <dd class="pf-c-description-list__description">
-                                            <div class="pf-c-description-list__text">
-                                                ${this.provider.clientNetworks}
-                                            </div>
-                                        </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                            <div class="pf-c-card__footer">
-                                <ak-forms-modal>
-                                    <span slot="submit"> ${msg("Update")} </span>
-                                    <span slot="header"> ${msg("Update Radius Provider")} </span>
-                                    <ak-provider-radius-form
-                                        slot="form"
-                                        .instancePk=${this.provider.pk}
-                                    >
-                                    </ak-provider-radius-form>
-                                    <button slot="trigger" class="pf-c-button pf-m-primary">
-                                        ${msg("Edit")}
-                                    </button>
-                                </ak-forms-modal>
+        return html`<main>
+            <ak-tabs>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-overview"
+                    id="page-overview"
+                    aria-label="${msg("Overview")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    ${this.provider?.outpostSet.length < 1
+                        ? html`<div slot="header" class="pf-c-banner pf-m-warning">
+                              ${msg("Warning: Provider is not used by any Outpost.")}
+                          </div>`
+                        : nothing}
+                    <div class="pf-u-display-flex pf-u-justify-content-center">
+                        <div class="pf-u-w-75">
+                            <div class="pf-c-card">
+                                <div class="pf-c-card__body">
+                                    <dl class="pf-c-description-list pf-m-3-col-on-lg">
+                                        <div class="pf-c-description-list__group">
+                                            <dt class="pf-c-description-list__term">
+                                                <span class="pf-c-description-list__text"
+                                                    >${msg("Name")}</span
+                                                >
+                                            </dt>
+                                            <dd class="pf-c-description-list__description">
+                                                <div class="pf-c-description-list__text">
+                                                    ${this.provider.name}
+                                                </div>
+                                            </dd>
+                                        </div>
+                                        <div class="pf-c-description-list__group">
+                                            <dt class="pf-c-description-list__term">
+                                                <span class="pf-c-description-list__text"
+                                                    >${msg("Assigned to application")}</span
+                                                >
+                                            </dt>
+                                            <dd class="pf-c-description-list__description">
+                                                <div class="pf-c-description-list__text">
+                                                    <ak-provider-related-application
+                                                        .provider=${this.provider}
+                                                    ></ak-provider-related-application>
+                                                </div>
+                                            </dd>
+                                        </div>
+                                        <div class="pf-c-description-list__group">
+                                            <dt class="pf-c-description-list__term">
+                                                <span class="pf-c-description-list__text"
+                                                    >${msg("Client Networks")}</span
+                                                >
+                                            </dt>
+                                            <dd class="pf-c-description-list__description">
+                                                <div class="pf-c-description-list__text">
+                                                    ${this.provider.clientNetworks}
+                                                </div>
+                                            </dd>
+                                        </div>
+                                    </dl>
+                                </div>
+                                <div class="pf-c-card__footer">
+                                    <ak-forms-modal>
+                                        <span slot="submit"> ${msg("Update")} </span>
+                                        <span slot="header">
+                                            ${msg("Update Radius Provider")}
+                                        </span>
+                                        <ak-provider-radius-form
+                                            slot="form"
+                                            .instancePk=${this.provider.pk}
+                                        >
+                                        </ak-provider-radius-form>
+                                        <button slot="trigger" class="pf-c-button pf-m-primary">
+                                            ${msg("Edit")}
+                                        </button>
+                                    </ak-forms-modal>
+                                </div>
                             </div>
                         </div>
                     </div>
                 </div>
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-changelog"
-                id="page-changelog"
-                aria-label="${msg("Changelog")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-c-card">
-                    <div class="pf-c-card__body">
-                        <ak-object-changelog
-                            targetModelPk=${this.provider.pk || ""}
-                            targetModelApp="authentik_providers_radius"
-                            targetModelName="radiusprovider"
-                        >
-                        </ak-object-changelog>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-changelog"
+                    id="page-changelog"
+                    aria-label="${msg("Changelog")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-c-card">
+                        <div class="pf-c-card__body">
+                            <ak-object-changelog
+                                targetModelPk=${this.provider.pk || ""}
+                                targetModelApp="authentik_providers_radius"
+                                targetModelName="radiusprovider"
+                            >
+                            </ak-object-changelog>
+                        </div>
                     </div>
                 </div>
-            </div>
-            <ak-rbac-object-permission-page
-                role="tabpanel"
-                tabindex="0"
-                slot="page-permissions"
-                id="page-permissions"
-                aria-label="${msg("Permissions")}"
-                model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersRadiusRadiusprovider}
-                objectPk=${this.provider.pk}
-            ></ak-rbac-object-permission-page>
-        </ak-tabs>`;
+                <ak-rbac-object-permission-page
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-permissions"
+                    id="page-permissions"
+                    aria-label="${msg("Permissions")}"
+                    model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersRadiusRadiusprovider}
+                    objectPk=${this.provider.pk}
+                ></ak-rbac-object-permission-page>
+            </ak-tabs>
+        </main>`;
     }
 }
 

--- a/web/src/admin/providers/radius/RadiusProviderViewPage.ts
+++ b/web/src/admin/providers/radius/RadiusProviderViewPage.ts
@@ -78,9 +78,12 @@ export class RadiusProviderViewPage extends AKElement {
             return nothing;
         }
         return html`<ak-tabs>
-            <section
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-overview"
-                data-tab-title="${msg("Overview")}"
+                id="page-overview"
+                aria-label="${msg("Overview")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 ${this.provider?.outpostSet.length < 1
@@ -150,10 +153,13 @@ export class RadiusProviderViewPage extends AKElement {
                         </div>
                     </div>
                 </div>
-            </section>
-            <section
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-changelog"
-                data-tab-title="${msg("Changelog")}"
+                id="page-changelog"
+                aria-label="${msg("Changelog")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-c-card">
@@ -166,10 +172,13 @@ export class RadiusProviderViewPage extends AKElement {
                         </ak-object-changelog>
                     </div>
                 </div>
-            </section>
+            </div>
             <ak-rbac-object-permission-page
+                role="tabpanel"
+                tabindex="0"
                 slot="page-permissions"
-                data-tab-title="${msg("Permissions")}"
+                id="page-permissions"
+                aria-label="${msg("Permissions")}"
                 model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersRadiusRadiusprovider}
                 objectPk=${this.provider.pk}
             ></ak-rbac-object-permission-page>

--- a/web/src/admin/providers/saml/SAMLProviderViewPage.ts
+++ b/web/src/admin/providers/saml/SAMLProviderViewPage.ts
@@ -229,57 +229,59 @@ export class SAMLProviderViewPage extends AKElement {
         if (!this.provider) {
             return nothing;
         }
-        return html` <ak-tabs>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-overview"
-                id="page-overview"
-                aria-label="${msg("Overview")}"
-            >
-                ${this.renderTabOverview()}
-            </div>
-            ${this.renderTabMetadata()}
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-preview"
-                id="page-preview"
-                aria-label="${msg("Preview")}"
-                @activate=${() => {
-                    this.fetchPreview();
-                }}
-            >
-                ${this.renderTabPreview()}
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-changelog"
-                id="page-changelog"
-                aria-label="${msg("Changelog")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-c-card">
-                    <div class="pf-c-card__body">
-                        <ak-object-changelog
-                            targetModelPk=${this.provider?.pk || ""}
-                            targetModelName=${this.provider?.metaModelName || ""}
-                        >
-                        </ak-object-changelog>
+        return html` <main>
+            <ak-tabs>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-overview"
+                    id="page-overview"
+                    aria-label="${msg("Overview")}"
+                >
+                    ${this.renderTabOverview()}
+                </div>
+                ${this.renderTabMetadata()}
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-preview"
+                    id="page-preview"
+                    aria-label="${msg("Preview")}"
+                    @activate=${() => {
+                        this.fetchPreview();
+                    }}
+                >
+                    ${this.renderTabPreview()}
+                </div>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-changelog"
+                    id="page-changelog"
+                    aria-label="${msg("Changelog")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-c-card">
+                        <div class="pf-c-card__body">
+                            <ak-object-changelog
+                                targetModelPk=${this.provider?.pk || ""}
+                                targetModelName=${this.provider?.metaModelName || ""}
+                            >
+                            </ak-object-changelog>
+                        </div>
                     </div>
                 </div>
-            </div>
-            <ak-rbac-object-permission-page
-                role="tabpanel"
-                tabindex="0"
-                slot="page-permissions"
-                id="page-permissions"
-                aria-label="${msg("Permissions")}"
-                model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersSamlSamlprovider}
-                objectPk=${this.provider.pk}
-            ></ak-rbac-object-permission-page>
-        </ak-tabs>`;
+                <ak-rbac-object-permission-page
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-permissions"
+                    id="page-permissions"
+                    aria-label="${msg("Permissions")}"
+                    model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersSamlSamlprovider}
+                    objectPk=${this.provider.pk}
+                ></ak-rbac-object-permission-page>
+            </ak-tabs>
+        </main>`;
     }
 
     renderTabOverview(): SlottedTemplateResult {

--- a/web/src/admin/providers/saml/SAMLProviderViewPage.ts
+++ b/web/src/admin/providers/saml/SAMLProviderViewPage.ts
@@ -230,22 +230,34 @@ export class SAMLProviderViewPage extends AKElement {
             return nothing;
         }
         return html` <ak-tabs>
-            <section slot="page-overview" data-tab-title="${msg("Overview")}">
+            <div
+                role="tabpanel"
+                tabindex="0"
+                slot="page-overview"
+                id="page-overview"
+                aria-label="${msg("Overview")}"
+            >
                 ${this.renderTabOverview()}
-            </section>
+            </div>
             ${this.renderTabMetadata()}
-            <section
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-preview"
-                data-tab-title="${msg("Preview")}"
+                id="page-preview"
+                aria-label="${msg("Preview")}"
                 @activate=${() => {
                     this.fetchPreview();
                 }}
             >
                 ${this.renderTabPreview()}
-            </section>
-            <section
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-changelog"
-                data-tab-title="${msg("Changelog")}"
+                id="page-changelog"
+                aria-label="${msg("Changelog")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-c-card">
@@ -257,10 +269,13 @@ export class SAMLProviderViewPage extends AKElement {
                         </ak-object-changelog>
                     </div>
                 </div>
-            </section>
+            </div>
             <ak-rbac-object-permission-page
+                role="tabpanel"
+                tabindex="0"
                 slot="page-permissions"
-                data-tab-title="${msg("Permissions")}"
+                id="page-permissions"
+                aria-label="${msg("Permissions")}"
                 model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersSamlSamlprovider}
                 objectPk=${this.provider.pk}
             ></ak-rbac-object-permission-page>
@@ -456,9 +471,12 @@ export class SAMLProviderViewPage extends AKElement {
         }
         return html`
             ${this.provider.assignedApplicationName
-                ? html` <section
+                ? html` <div
+                      role="tabpanel"
+                      tabindex="0"
                       slot="page-metadata"
-                      data-tab-title="${msg("Metadata")}"
+                      id="page-metadata"
+                      aria-label="${msg("Metadata")}"
                       @activate=${() => {
                           new ProvidersApi(DEFAULT_CONFIG)
                               .providersSamlMetadataRetrieve({
@@ -509,7 +527,7 @@ export class SAMLProviderViewPage extends AKElement {
                               </div>
                           </div>
                       </div>
-                  </section>`
+                  </div>`
                 : nothing}
         `;
     }

--- a/web/src/admin/providers/scim/SCIMProviderViewPage.ts
+++ b/web/src/admin/providers/scim/SCIMProviderViewPage.ts
@@ -93,12 +93,21 @@ export class SCIMProviderViewPage extends AKElement {
             return nothing;
         }
         return html` <ak-tabs>
-            <section slot="page-overview" data-tab-title="${msg("Overview")}">
+            <div
+                role="tabpanel"
+                tabindex="0"
+                slot="page-overview"
+                id="page-overview"
+                aria-label="${msg("Overview")}"
+            >
                 ${this.renderTabOverview()}
-            </section>
-            <section
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-changelog"
-                data-tab-title="${msg("Changelog")}"
+                id="page-changelog"
+                aria-label="${msg("Changelog")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-c-card">
@@ -110,10 +119,13 @@ export class SCIMProviderViewPage extends AKElement {
                         </ak-object-changelog>
                     </div>
                 </div>
-            </section>
-            <section
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-users"
-                data-tab-title="${msg("Provisioned Users")}"
+                id="page-users"
+                aria-label="${msg("Provisioned Users")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-l-grid pf-m-gutter">
@@ -121,10 +133,13 @@ export class SCIMProviderViewPage extends AKElement {
                         providerId=${this.provider.pk}
                     ></ak-provider-scim-users-list>
                 </div>
-            </section>
-            <section
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-groups"
-                data-tab-title="${msg("Provisioned Groups")}"
+                id="page-groups"
+                aria-label="${msg("Provisioned Groups")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-l-grid pf-m-gutter">
@@ -132,10 +147,13 @@ export class SCIMProviderViewPage extends AKElement {
                         providerId=${this.provider.pk}
                     ></ak-provider-scim-groups-list>
                 </div>
-            </section>
+            </div>
             <ak-rbac-object-permission-page
+                role="tabpanel"
+                tabindex="0"
                 slot="page-permissions"
-                data-tab-title="${msg("Permissions")}"
+                id="page-permissions"
+                aria-label="${msg("Permissions")}"
                 model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersScimScimprovider}
                 objectPk=${this.provider.pk}
             ></ak-rbac-object-permission-page>

--- a/web/src/admin/providers/scim/SCIMProviderViewPage.ts
+++ b/web/src/admin/providers/scim/SCIMProviderViewPage.ts
@@ -92,72 +92,74 @@ export class SCIMProviderViewPage extends AKElement {
         if (!this.provider) {
             return nothing;
         }
-        return html` <ak-tabs>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-overview"
-                id="page-overview"
-                aria-label="${msg("Overview")}"
-            >
-                ${this.renderTabOverview()}
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-changelog"
-                id="page-changelog"
-                aria-label="${msg("Changelog")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-c-card">
-                    <div class="pf-c-card__body">
-                        <ak-object-changelog
-                            targetModelPk=${this.provider?.pk || ""}
-                            targetModelName=${this.provider?.metaModelName || ""}
-                        >
-                        </ak-object-changelog>
+        return html` <main>
+            <ak-tabs>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-overview"
+                    id="page-overview"
+                    aria-label="${msg("Overview")}"
+                >
+                    ${this.renderTabOverview()}
+                </div>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-changelog"
+                    id="page-changelog"
+                    aria-label="${msg("Changelog")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-c-card">
+                        <div class="pf-c-card__body">
+                            <ak-object-changelog
+                                targetModelPk=${this.provider?.pk || ""}
+                                targetModelName=${this.provider?.metaModelName || ""}
+                            >
+                            </ak-object-changelog>
+                        </div>
                     </div>
                 </div>
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-users"
-                id="page-users"
-                aria-label="${msg("Provisioned Users")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-l-grid pf-m-gutter">
-                    <ak-provider-scim-users-list
-                        providerId=${this.provider.pk}
-                    ></ak-provider-scim-users-list>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-users"
+                    id="page-users"
+                    aria-label="${msg("Provisioned Users")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-l-grid pf-m-gutter">
+                        <ak-provider-scim-users-list
+                            providerId=${this.provider.pk}
+                        ></ak-provider-scim-users-list>
+                    </div>
                 </div>
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-groups"
-                id="page-groups"
-                aria-label="${msg("Provisioned Groups")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-l-grid pf-m-gutter">
-                    <ak-provider-scim-groups-list
-                        providerId=${this.provider.pk}
-                    ></ak-provider-scim-groups-list>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-groups"
+                    id="page-groups"
+                    aria-label="${msg("Provisioned Groups")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-l-grid pf-m-gutter">
+                        <ak-provider-scim-groups-list
+                            providerId=${this.provider.pk}
+                        ></ak-provider-scim-groups-list>
+                    </div>
                 </div>
-            </div>
-            <ak-rbac-object-permission-page
-                role="tabpanel"
-                tabindex="0"
-                slot="page-permissions"
-                id="page-permissions"
-                aria-label="${msg("Permissions")}"
-                model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersScimScimprovider}
-                objectPk=${this.provider.pk}
-            ></ak-rbac-object-permission-page>
-        </ak-tabs>`;
+                <ak-rbac-object-permission-page
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-permissions"
+                    id="page-permissions"
+                    aria-label="${msg("Permissions")}"
+                    model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersScimScimprovider}
+                    objectPk=${this.provider.pk}
+                ></ak-rbac-object-permission-page>
+            </ak-tabs>
+        </main>`;
     }
 
     renderTabOverview(): SlottedTemplateResult {

--- a/web/src/admin/providers/ssf/SSFProviderFormPage.ts
+++ b/web/src/admin/providers/ssf/SSFProviderFormPage.ts
@@ -9,6 +9,8 @@ import "#elements/utils/TimeDeltaHelp";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
 
+import { ifPresent } from "#elements/utils/attributes";
+
 import { BaseProviderForm } from "#admin/providers/BaseProviderForm";
 import {
     oauth2ProvidersProvider,
@@ -66,9 +68,8 @@ export class SSFProviderFormPage extends BaseProviderForm<SSFProvider> {
                         name="signingKey"
                         required
                     >
-                        <!-- NOTE: 'null' cast to 'undefined' on signingKey to satisfy Lit requirements -->
                         <ak-crypto-certificate-search
-                            certificate=${ifDefined(provider?.signingKey ?? undefined)}
+                            certificate=${ifPresent(provider?.signingKey)}
                             singleton
                         ></ak-crypto-certificate-search>
                         <p class="pf-c-form__helper-text">${msg("Key used to sign the events.")}</p>

--- a/web/src/admin/providers/ssf/SSFProviderViewPage.ts
+++ b/web/src/admin/providers/ssf/SSFProviderViewPage.ts
@@ -81,12 +81,21 @@ export class SSFProviderViewPage extends AKElement {
             return nothing;
         }
         return html` <ak-tabs>
-            <section slot="page-overview" data-tab-title="${msg("Overview")}">
+            <div
+                role="tabpanel"
+                tabindex="0"
+                slot="page-overview"
+                id="page-overview"
+                aria-label="${msg("Overview")}"
+            >
                 ${this.renderTabOverview()}
-            </section>
-            <section
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-changelog"
-                data-tab-title="${msg("Changelog")}"
+                id="page-changelog"
+                aria-label="${msg("Changelog")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-c-card">
@@ -98,10 +107,13 @@ export class SSFProviderViewPage extends AKElement {
                         </ak-object-changelog>
                     </div>
                 </div>
-            </section>
+            </div>
             <ak-rbac-object-permission-page
+                role="tabpanel"
+                tabindex="0"
                 slot="page-permissions"
-                data-tab-title="${msg("Permissions")}"
+                id="page-permissions"
+                aria-label="${msg("Permissions")}"
                 model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersSsfSsfprovider}
                 objectPk=${this.provider.pk}
             ></ak-rbac-object-permission-page>

--- a/web/src/admin/providers/ssf/SSFProviderViewPage.ts
+++ b/web/src/admin/providers/ssf/SSFProviderViewPage.ts
@@ -80,44 +80,46 @@ export class SSFProviderViewPage extends AKElement {
         if (!this.provider) {
             return nothing;
         }
-        return html` <ak-tabs>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-overview"
-                id="page-overview"
-                aria-label="${msg("Overview")}"
-            >
-                ${this.renderTabOverview()}
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-changelog"
-                id="page-changelog"
-                aria-label="${msg("Changelog")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-c-card">
-                    <div class="pf-c-card__body">
-                        <ak-object-changelog
-                            targetModelPk=${this.provider?.pk || ""}
-                            targetModelName=${this.provider?.metaModelName || ""}
-                        >
-                        </ak-object-changelog>
+        return html` <main>
+            <ak-tabs>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-overview"
+                    id="page-overview"
+                    aria-label="${msg("Overview")}"
+                >
+                    ${this.renderTabOverview()}
+                </div>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-changelog"
+                    id="page-changelog"
+                    aria-label="${msg("Changelog")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-c-card">
+                        <div class="pf-c-card__body">
+                            <ak-object-changelog
+                                targetModelPk=${this.provider?.pk || ""}
+                                targetModelName=${this.provider?.metaModelName || ""}
+                            >
+                            </ak-object-changelog>
+                        </div>
                     </div>
                 </div>
-            </div>
-            <ak-rbac-object-permission-page
-                role="tabpanel"
-                tabindex="0"
-                slot="page-permissions"
-                id="page-permissions"
-                aria-label="${msg("Permissions")}"
-                model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersSsfSsfprovider}
-                objectPk=${this.provider.pk}
-            ></ak-rbac-object-permission-page>
-        </ak-tabs>`;
+                <ak-rbac-object-permission-page
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-permissions"
+                    id="page-permissions"
+                    aria-label="${msg("Permissions")}"
+                    model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersSsfSsfprovider}
+                    objectPk=${this.provider.pk}
+                ></ak-rbac-object-permission-page>
+            </ak-tabs>
+        </main>`;
     }
 
     renderTabOverview(): SlottedTemplateResult {

--- a/web/src/admin/rbac/ObjectPermissionsPage.ts
+++ b/web/src/admin/rbac/ObjectPermissionsPage.ts
@@ -40,9 +40,12 @@ export class ObjectPermissionPage extends AKElement {
             ${this.model === RbacPermissionsAssignedByUsersListModelEnum.AuthentikRbacRole
                 ? this.renderRbacRole()
                 : nothing}
-            <section
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-object-user"
-                data-tab-title="${msg("User Object Permissions")}"
+                id="page-object-user"
+                aria-label="${msg("User Object Permissions")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-l-grid pf-m-gutter">
@@ -60,10 +63,13 @@ export class ObjectPermissionPage extends AKElement {
                         </div>
                     </div>
                 </div>
-            </section>
-            <section
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-object-role"
-                data-tab-title="${msg("Role Object Permissions")}"
+                id="page-object-role"
+                aria-label="${msg("Role Object Permissions")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-l-grid pf-m-gutter">
@@ -81,17 +87,20 @@ export class ObjectPermissionPage extends AKElement {
                         </div>
                     </div>
                 </div>
-            </section>
+            </div>
         </ak-tabs>`;
     }
 
     renderCoreUser() {
         return html`
             <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-assigned-global-permissions"
-                data-tab-title="${msg("Assigned global permissions")}"
+                id="page-assigned-global-permissions"
+                aria-label="${msg("Assigned global permissions")}"
             >
-                <section class="pf-c-page__main-section pf-m-no-padding-mobile">
+                <div class="pf-c-page__main-section pf-m-no-padding-mobile">
                     <div class="pf-c-card">
                         <div class="pf-c-card__title">${msg("Assigned global permissions")}</div>
                         <div class="pf-c-card__body">
@@ -106,13 +115,16 @@ export class ObjectPermissionPage extends AKElement {
                             </ak-user-assigned-global-permissions-table>
                         </div>
                     </div>
-                </section>
+                </div>
             </div>
             <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-assigned-object-permissions"
-                data-tab-title="${msg("Assigned object permissions")}"
+                id="page-assigned-object-permissions"
+                aria-label="${msg("Assigned object permissions")}"
             >
-                <section class="pf-c-page__main-section pf-m-no-padding-mobile">
+                <div class="pf-c-page__main-section pf-m-no-padding-mobile">
                     <div class="pf-c-card">
                         <div class="pf-c-card__title">${msg("Assigned object permissions")}</div>
                         <div class="pf-c-card__body">
@@ -127,7 +139,7 @@ export class ObjectPermissionPage extends AKElement {
                             </ak-user-assigned-object-permissions-table>
                         </div>
                     </div>
-                </section>
+                </div>
             </div>
         `;
     }
@@ -135,10 +147,13 @@ export class ObjectPermissionPage extends AKElement {
     renderRbacRole() {
         return html`
             <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-assigned-global-permissions"
-                data-tab-title="${msg("Assigned global permissions")}"
+                id="page-assigned-global-permissions"
+                aria-label="${msg("Assigned global permissions")}"
             >
-                <section class="pf-c-page__main-section pf-m-no-padding-mobile">
+                <div class="pf-c-page__main-section pf-m-no-padding-mobile">
                     <div class="pf-c-card">
                         <div class="pf-c-card__title">${msg("Assigned global permissions")}</div>
                         <div class="pf-c-card__body">
@@ -153,13 +168,16 @@ export class ObjectPermissionPage extends AKElement {
                             </ak-role-assigned-global-permissions-table>
                         </div>
                     </div>
-                </section>
+                </div>
             </div>
             <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-assigned-object-permissions"
-                data-tab-title="${msg("Assigned object permissions")}"
+                id="page-assigned-object-permissions"
+                aria-label="${msg("Assigned object permissions")}"
             >
-                <section class="pf-c-page__main-section pf-m-no-padding-mobile">
+                <div class="pf-c-page__main-section pf-m-no-padding-mobile">
                     <div class="pf-c-card">
                         <div class="pf-c-card__title">${msg("Assigned object permissions")}</div>
                         <div class="pf-c-card__body">
@@ -174,7 +192,7 @@ export class ObjectPermissionPage extends AKElement {
                             </ak-role-assigned-object-permissions-table>
                         </div>
                     </div>
-                </section>
+                </div>
             </div>
         `;
     }

--- a/web/src/admin/rbac/ObjectPermissionsPage.ts
+++ b/web/src/admin/rbac/ObjectPermissionsPage.ts
@@ -34,12 +34,16 @@ export class ObjectPermissionPage extends AKElement {
 
     render() {
         return html` <ak-tabs pageIdentifier="permissionPage" ?vertical=${!this.embedded}>
-            ${this.model === RbacPermissionsAssignedByUsersListModelEnum.AuthentikCoreUser
-                ? this.renderCoreUser()
-                : nothing}
-            ${this.model === RbacPermissionsAssignedByUsersListModelEnum.AuthentikRbacRole
-                ? this.renderRbacRole()
-                : nothing}
+            ${
+                this.model === RbacPermissionsAssignedByUsersListModelEnum.AuthentikCoreUser
+                    ? this.renderCoreUser()
+                    : nothing
+            }
+            ${
+                this.model === RbacPermissionsAssignedByUsersListModelEnum.AuthentikRbacRole
+                    ? this.renderRbacRole()
+                    : nothing
+            }
             <div
                 role="tabpanel"
                 tabindex="0"
@@ -88,7 +92,8 @@ export class ObjectPermissionPage extends AKElement {
                     </div>
                 </div>
             </div>
-        </ak-tabs>`;
+        </ak-tabs>
+</main>`;
     }
 
     renderCoreUser() {

--- a/web/src/admin/roles/RoleViewPage.ts
+++ b/web/src/admin/roles/RoleViewPage.ts
@@ -98,52 +98,54 @@ export class RoleViewPage extends AKElement {
             return nothing;
         }
 
-        return html` <ak-tabs>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-overview"
-                id="page-overview"
-                aria-label="${msg("Overview")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-l-grid pf-m-gutter">
-                    <div
-                        class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-3-col-on-xl pf-m-3-col-on-2xl"
-                    >
-                        <div class="pf-c-card__title">${msg("Role Info")}</div>
-                        <div class="pf-c-card__body">
-                            ${renderDescriptionList([
-                                [msg("Name"), this._role.name],
-                                [msg("Edit"), this.renderUpdateControl(this._role)],
-                            ])}
+        return html` <main>
+            <ak-tabs>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-overview"
+                    id="page-overview"
+                    aria-label="${msg("Overview")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-l-grid pf-m-gutter">
+                        <div
+                            class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-3-col-on-xl pf-m-3-col-on-2xl"
+                        >
+                            <div class="pf-c-card__title">${msg("Role Info")}</div>
+                            <div class="pf-c-card__body">
+                                ${renderDescriptionList([
+                                    [msg("Name"), this._role.name],
+                                    [msg("Edit"), this.renderUpdateControl(this._role)],
+                                ])}
+                            </div>
                         </div>
-                    </div>
-                    <div
-                        class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-9-col-on-xl pf-m-9-col-on-2xl"
-                    >
-                        <div class="pf-c-card__title">${msg("Changelog")}</div>
-                        <div class="pf-c-card__body">
-                            <ak-object-changelog
-                                targetModelPk=${this._role.pk}
-                                targetModelApp="authentik_rbac"
-                                targetModelName="role"
-                            >
-                            </ak-object-changelog>
+                        <div
+                            class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-9-col-on-xl pf-m-9-col-on-2xl"
+                        >
+                            <div class="pf-c-card__title">${msg("Changelog")}</div>
+                            <div class="pf-c-card__body">
+                                <ak-object-changelog
+                                    targetModelPk=${this._role.pk}
+                                    targetModelApp="authentik_rbac"
+                                    targetModelName="role"
+                                >
+                                </ak-object-changelog>
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-            <ak-rbac-object-permission-page
-                role="tabpanel"
-                tabindex="0"
-                slot="page-permissions"
-                id="page-permissions"
-                aria-label="${msg("Permissions")}"
-                model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikRbacRole}
-                objectPk=${this._role.pk}
-            ></ak-rbac-object-permission-page>
-        </ak-tabs>`;
+                <ak-rbac-object-permission-page
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-permissions"
+                    id="page-permissions"
+                    aria-label="${msg("Permissions")}"
+                    model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikRbacRole}
+                    objectPk=${this._role.pk}
+                ></ak-rbac-object-permission-page>
+            </ak-tabs>
+        </main>`;
     }
 }
 

--- a/web/src/admin/roles/RoleViewPage.ts
+++ b/web/src/admin/roles/RoleViewPage.ts
@@ -99,9 +99,12 @@ export class RoleViewPage extends AKElement {
         }
 
         return html` <ak-tabs>
-            <section
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-overview"
-                data-tab-title="${msg("Overview")}"
+                id="page-overview"
+                aria-label="${msg("Overview")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-l-grid pf-m-gutter">
@@ -130,10 +133,13 @@ export class RoleViewPage extends AKElement {
                         </div>
                     </div>
                 </div>
-            </section>
+            </div>
             <ak-rbac-object-permission-page
+                role="tabpanel"
+                tabindex="0"
                 slot="page-permissions"
-                data-tab-title="${msg("Permissions")}"
+                id="page-permissions"
+                aria-label="${msg("Permissions")}"
                 model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikRbacRole}
                 objectPk=${this._role.pk}
             ></ak-rbac-object-permission-page>

--- a/web/src/admin/sources/kerberos/KerberosSourceViewPage.ts
+++ b/web/src/admin/sources/kerberos/KerberosSourceViewPage.ts
@@ -80,141 +80,143 @@ export class KerberosSourceViewPage extends AKElement {
             return nothing;
         }
         const [appLabel, modelName] = ModelEnum.AuthentikSourcesKerberosKerberossource.split(".");
-        return html`<ak-tabs>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-overview"
-                id="page-overview"
-                aria-label="${msg("Overview")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div slot="header" class="pf-c-banner pf-m-info">
-                    ${msg("Kerberos Source is in preview.")}
-                    <a href="mailto:hello+feature/kerberos-source@goauthentik.io"
-                        >${msg("Send us feedback!")}</a
-                    >
-                </div>
-                <div class="pf-l-grid pf-m-gutter">
-                    <div
-                        class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-6-col-on-xl pf-m-6-col-on-2xl"
-                    >
-                        <div class="pf-c-card__body">
-                            <dl class="pf-c-description-list pf-m-2-col-on-lg">
-                                <div class="pf-c-description-list__group">
-                                    <dt class="pf-c-description-list__term">
-                                        <span class="pf-c-description-list__text"
-                                            >${msg("Name")}</span
-                                        >
-                                    </dt>
-                                    <dd class="pf-c-description-list__description">
-                                        <div class="pf-c-description-list__text">
-                                            ${this.source.name}
-                                        </div>
-                                    </dd>
-                                </div>
-                                <div class="pf-c-description-list__group">
-                                    <dt class="pf-c-description-list__term">
-                                        <span class="pf-c-description-list__text"
-                                            >${msg("Realm")}</span
-                                        >
-                                    </dt>
-                                    <dd class="pf-c-description-list__description">
-                                        <div class="pf-c-description-list__text">
-                                            ${this.source.realm}
-                                        </div>
-                                    </dd>
-                                </div>
-                            </dl>
+        return html`<main>
+            <ak-tabs>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-overview"
+                    id="page-overview"
+                    aria-label="${msg("Overview")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div slot="header" class="pf-c-banner pf-m-info">
+                        ${msg("Kerberos Source is in preview.")}
+                        <a href="mailto:hello+feature/kerberos-source@goauthentik.io"
+                            >${msg("Send us feedback!")}</a
+                        >
+                    </div>
+                    <div class="pf-l-grid pf-m-gutter">
+                        <div
+                            class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-6-col-on-xl pf-m-6-col-on-2xl"
+                        >
+                            <div class="pf-c-card__body">
+                                <dl class="pf-c-description-list pf-m-2-col-on-lg">
+                                    <div class="pf-c-description-list__group">
+                                        <dt class="pf-c-description-list__term">
+                                            <span class="pf-c-description-list__text"
+                                                >${msg("Name")}</span
+                                            >
+                                        </dt>
+                                        <dd class="pf-c-description-list__description">
+                                            <div class="pf-c-description-list__text">
+                                                ${this.source.name}
+                                            </div>
+                                        </dd>
+                                    </div>
+                                    <div class="pf-c-description-list__group">
+                                        <dt class="pf-c-description-list__term">
+                                            <span class="pf-c-description-list__text"
+                                                >${msg("Realm")}</span
+                                            >
+                                        </dt>
+                                        <dd class="pf-c-description-list__description">
+                                            <div class="pf-c-description-list__text">
+                                                ${this.source.realm}
+                                            </div>
+                                        </dd>
+                                    </div>
+                                </dl>
+                            </div>
+                            <div class="pf-c-card__footer">
+                                <ak-forms-modal>
+                                    <span slot="submit"> ${msg("Update")} </span>
+                                    <span slot="header"> ${msg("Update Kerberos Source")} </span>
+                                    <ak-source-kerberos-form
+                                        slot="form"
+                                        .instancePk=${this.source.slug}
+                                    >
+                                    </ak-source-kerberos-form>
+                                    <button slot="trigger" class="pf-c-button pf-m-primary">
+                                        ${msg("Edit")}
+                                    </button>
+                                </ak-forms-modal>
+                            </div>
                         </div>
-                        <div class="pf-c-card__footer">
-                            <ak-forms-modal>
-                                <span slot="submit"> ${msg("Update")} </span>
-                                <span slot="header"> ${msg("Update Kerberos Source")} </span>
-                                <ak-source-kerberos-form
-                                    slot="form"
-                                    .instancePk=${this.source.slug}
+                        <div
+                            class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-6-col-on-xl pf-m-6-col-on-2xl"
+                        >
+                            <ak-sync-status-card
+                                .fetch=${() => {
+                                    return new SourcesApi(
+                                        DEFAULT_CONFIG,
+                                    ).sourcesKerberosSyncStatusRetrieve({
+                                        slug: this.source?.slug,
+                                    });
+                                }}
+                            ></ak-sync-status-card>
+                        </div>
+                        <div class="pf-c-card pf-l-grid__item pf-m-12-col">
+                            <div class="pf-c-card__title">
+                                <p>${msg("Connectivity")}</p>
+                            </div>
+                            <div class="pf-c-card__body">
+                                <ak-source-kerberos-connectivity
+                                    .connectivity=${this.source.connectivity}
+                                ></ak-source-kerberos-connectivity>
+                            </div>
+                        </div>
+                        <div class="pf-c-card pf-l-grid__item pf-m-12-col">
+                            <div class="pf-c-card__title">
+                                <p>${msg("Schedules")}</p>
+                            </div>
+                            <div class="pf-c-card__body">
+                                <ak-schedule-list
+                                    .relObjAppLabel=${appLabel}
+                                    .relObjModel=${modelName}
+                                    .relObjId="${this.source.pk}"
+                                ></ak-schedule-list>
+                            </div>
+                        </div>
+                        <div class="pf-c-card pf-l-grid__item pf-m-12-col">
+                            <div class="pf-c-card__body">
+                                <ak-mdx .url=${MDSourceKerberosBrowser}></ak-mdx>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-changelog"
+                    id="page-changelog"
+                    aria-label="${msg("Changelog")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-l-grid pf-m-gutter">
+                        <div class="pf-c-card pf-l-grid__item pf-m-12-col">
+                            <div class="pf-c-card__body">
+                                <ak-object-changelog
+                                    targetModelPk=${this.source.pk || ""}
+                                    targetModelApp="authentik_sources_kerberos"
+                                    targetModelName="kerberossource"
                                 >
-                                </ak-source-kerberos-form>
-                                <button slot="trigger" class="pf-c-button pf-m-primary">
-                                    ${msg("Edit")}
-                                </button>
-                            </ak-forms-modal>
-                        </div>
-                    </div>
-                    <div
-                        class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-6-col-on-xl pf-m-6-col-on-2xl"
-                    >
-                        <ak-sync-status-card
-                            .fetch=${() => {
-                                return new SourcesApi(
-                                    DEFAULT_CONFIG,
-                                ).sourcesKerberosSyncStatusRetrieve({
-                                    slug: this.source?.slug,
-                                });
-                            }}
-                        ></ak-sync-status-card>
-                    </div>
-                    <div class="pf-c-card pf-l-grid__item pf-m-12-col">
-                        <div class="pf-c-card__title">
-                            <p>${msg("Connectivity")}</p>
-                        </div>
-                        <div class="pf-c-card__body">
-                            <ak-source-kerberos-connectivity
-                                .connectivity=${this.source.connectivity}
-                            ></ak-source-kerberos-connectivity>
-                        </div>
-                    </div>
-                    <div class="pf-c-card pf-l-grid__item pf-m-12-col">
-                        <div class="pf-c-card__title">
-                            <p>${msg("Schedules")}</p>
-                        </div>
-                        <div class="pf-c-card__body">
-                            <ak-schedule-list
-                                .relObjAppLabel=${appLabel}
-                                .relObjModel=${modelName}
-                                .relObjId="${this.source.pk}"
-                            ></ak-schedule-list>
-                        </div>
-                    </div>
-                    <div class="pf-c-card pf-l-grid__item pf-m-12-col">
-                        <div class="pf-c-card__body">
-                            <ak-mdx .url=${MDSourceKerberosBrowser}></ak-mdx>
+                                </ak-object-changelog>
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-changelog"
-                id="page-changelog"
-                aria-label="${msg("Changelog")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-l-grid pf-m-gutter">
-                    <div class="pf-c-card pf-l-grid__item pf-m-12-col">
-                        <div class="pf-c-card__body">
-                            <ak-object-changelog
-                                targetModelPk=${this.source.pk || ""}
-                                targetModelApp="authentik_sources_kerberos"
-                                targetModelName="kerberossource"
-                            >
-                            </ak-object-changelog>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <ak-rbac-object-permission-page
-                role="tabpanel"
-                tabindex="0"
-                slot="page-permissions"
-                id="page-permissions"
-                aria-label="${msg("Permissions")}"
-                model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikSourcesKerberosKerberossource}
-                objectPk=${this.source.pk}
-            ></ak-rbac-object-permission-page>
-        </ak-tabs>`;
+                <ak-rbac-object-permission-page
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-permissions"
+                    id="page-permissions"
+                    aria-label="${msg("Permissions")}"
+                    model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikSourcesKerberosKerberossource}
+                    objectPk=${this.source.pk}
+                ></ak-rbac-object-permission-page>
+            </ak-tabs>
+        </main>`;
     }
 }
 

--- a/web/src/admin/sources/kerberos/KerberosSourceViewPage.ts
+++ b/web/src/admin/sources/kerberos/KerberosSourceViewPage.ts
@@ -81,9 +81,12 @@ export class KerberosSourceViewPage extends AKElement {
         }
         const [appLabel, modelName] = ModelEnum.AuthentikSourcesKerberosKerberossource.split(".");
         return html`<ak-tabs>
-            <section
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-overview"
-                data-tab-title="${msg("Overview")}"
+                id="page-overview"
+                aria-label="${msg("Overview")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div slot="header" class="pf-c-banner pf-m-info">
@@ -180,10 +183,13 @@ export class KerberosSourceViewPage extends AKElement {
                         </div>
                     </div>
                 </div>
-            </section>
-            <section
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-changelog"
-                data-tab-title="${msg("Changelog")}"
+                id="page-changelog"
+                aria-label="${msg("Changelog")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-l-grid pf-m-gutter">
@@ -198,10 +204,13 @@ export class KerberosSourceViewPage extends AKElement {
                         </div>
                     </div>
                 </div>
-            </section>
+            </div>
             <ak-rbac-object-permission-page
+                role="tabpanel"
+                tabindex="0"
                 slot="page-permissions"
-                data-tab-title="${msg("Permissions")}"
+                id="page-permissions"
+                aria-label="${msg("Permissions")}"
                 model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikSourcesKerberosKerberossource}
                 objectPk=${this.source.pk}
             ></ak-rbac-object-permission-page>

--- a/web/src/admin/sources/ldap/LDAPSourceViewPage.ts
+++ b/web/src/admin/sources/ldap/LDAPSourceViewPage.ts
@@ -77,9 +77,12 @@ export class LDAPSourceViewPage extends AKElement {
         }
         const [appLabel, modelName] = ModelEnum.AuthentikSourcesLdapLdapsource.split(".");
         return html`<ak-tabs>
-            <section
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-overview"
-                data-tab-title="${msg("Overview")}"
+                id="page-overview"
+                aria-label="${msg("Overview")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-l-grid pf-m-gutter">
@@ -176,10 +179,13 @@ export class LDAPSourceViewPage extends AKElement {
                         </div>
                     </div>
                 </div>
-            </section>
-            <section
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-changelog"
-                data-tab-title="${msg("Changelog")}"
+                id="page-changelog"
+                aria-label="${msg("Changelog")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-l-grid pf-m-gutter">
@@ -194,10 +200,13 @@ export class LDAPSourceViewPage extends AKElement {
                         </div>
                     </div>
                 </div>
-            </section>
+            </div>
             <ak-rbac-object-permission-page
+                role="tabpanel"
+                tabindex="0"
                 slot="page-permissions"
-                data-tab-title="${msg("Permissions")}"
+                id="page-permissions"
+                aria-label="${msg("Permissions")}"
                 model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikSourcesLdapLdapsource}
                 objectPk=${this.source.pk}
             ></ak-rbac-object-permission-page>

--- a/web/src/admin/sources/ldap/LDAPSourceViewPage.ts
+++ b/web/src/admin/sources/ldap/LDAPSourceViewPage.ts
@@ -76,141 +76,146 @@ export class LDAPSourceViewPage extends AKElement {
             return nothing;
         }
         const [appLabel, modelName] = ModelEnum.AuthentikSourcesLdapLdapsource.split(".");
-        return html`<ak-tabs>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-overview"
-                id="page-overview"
-                aria-label="${msg("Overview")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-l-grid pf-m-gutter">
-                    <div
-                        class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-6-col-on-xl pf-m-6-col-on-2xl"
-                    >
-                        <div class="pf-c-card__body">
-                            <dl class="pf-c-description-list pf-m-2-col-on-lg">
-                                <div class="pf-c-description-list__group">
-                                    <dt class="pf-c-description-list__term">
-                                        <span class="pf-c-description-list__text"
-                                            >${msg("Name")}</span
-                                        >
-                                    </dt>
-                                    <dd class="pf-c-description-list__description">
-                                        <div class="pf-c-description-list__text">
-                                            ${this.source.name}
-                                        </div>
-                                    </dd>
-                                </div>
-                                <div class="pf-c-description-list__group">
-                                    <dt class="pf-c-description-list__term">
-                                        <span class="pf-c-description-list__text"
-                                            >${msg("Server URI")}</span
-                                        >
-                                    </dt>
-                                    <dd class="pf-c-description-list__description">
-                                        <div class="pf-c-description-list__text">
-                                            ${this.source.serverUri}
-                                        </div>
-                                    </dd>
-                                </div>
-                                <div class="pf-c-description-list__group">
-                                    <dt class="pf-c-description-list__term">
-                                        <span class="pf-c-description-list__text"
-                                            >${msg("Base DN")}</span
-                                        >
-                                    </dt>
-                                    <dd class="pf-c-description-list__description">
-                                        <div class="pf-c-description-list__text">
-                                            <ul>
-                                                <li>${this.source.baseDn}</li>
-                                            </ul>
-                                        </div>
-                                    </dd>
-                                </div>
-                            </dl>
+        return html`<main>
+            <ak-tabs>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-overview"
+                    id="page-overview"
+                    aria-label="${msg("Overview")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-l-grid pf-m-gutter">
+                        <div
+                            class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-6-col-on-xl pf-m-6-col-on-2xl"
+                        >
+                            <div class="pf-c-card__body">
+                                <dl class="pf-c-description-list pf-m-2-col-on-lg">
+                                    <div class="pf-c-description-list__group">
+                                        <dt class="pf-c-description-list__term">
+                                            <span class="pf-c-description-list__text"
+                                                >${msg("Name")}</span
+                                            >
+                                        </dt>
+                                        <dd class="pf-c-description-list__description">
+                                            <div class="pf-c-description-list__text">
+                                                ${this.source.name}
+                                            </div>
+                                        </dd>
+                                    </div>
+                                    <div class="pf-c-description-list__group">
+                                        <dt class="pf-c-description-list__term">
+                                            <span class="pf-c-description-list__text"
+                                                >${msg("Server URI")}</span
+                                            >
+                                        </dt>
+                                        <dd class="pf-c-description-list__description">
+                                            <div class="pf-c-description-list__text">
+                                                ${this.source.serverUri}
+                                            </div>
+                                        </dd>
+                                    </div>
+                                    <div class="pf-c-description-list__group">
+                                        <dt class="pf-c-description-list__term">
+                                            <span class="pf-c-description-list__text"
+                                                >${msg("Base DN")}</span
+                                            >
+                                        </dt>
+                                        <dd class="pf-c-description-list__description">
+                                            <div class="pf-c-description-list__text">
+                                                <ul>
+                                                    <li>${this.source.baseDn}</li>
+                                                </ul>
+                                            </div>
+                                        </dd>
+                                    </div>
+                                </dl>
+                            </div>
+                            <div class="pf-c-card__footer">
+                                <ak-forms-modal>
+                                    <span slot="submit"> ${msg("Update")} </span>
+                                    <span slot="header"> ${msg("Update LDAP Source")} </span>
+                                    <ak-source-ldap-form
+                                        slot="form"
+                                        .instancePk=${this.source.slug}
+                                    >
+                                    </ak-source-ldap-form>
+                                    <button slot="trigger" class="pf-c-button pf-m-primary">
+                                        ${msg("Edit")}
+                                    </button>
+                                </ak-forms-modal>
+                            </div>
                         </div>
-                        <div class="pf-c-card__footer">
-                            <ak-forms-modal>
-                                <span slot="submit"> ${msg("Update")} </span>
-                                <span slot="header"> ${msg("Update LDAP Source")} </span>
-                                <ak-source-ldap-form slot="form" .instancePk=${this.source.slug}>
-                                </ak-source-ldap-form>
-                                <button slot="trigger" class="pf-c-button pf-m-primary">
-                                    ${msg("Edit")}
-                                </button>
-                            </ak-forms-modal>
-                        </div>
-                    </div>
-                    <div
-                        class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-6-col-on-xl pf-m-6-col-on-2xl"
-                    >
-                        <ak-sync-status-card
-                            .fetch=${() => {
-                                return new SourcesApi(DEFAULT_CONFIG).sourcesLdapSyncStatusRetrieve(
-                                    {
+                        <div
+                            class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-6-col-on-xl pf-m-6-col-on-2xl"
+                        >
+                            <ak-sync-status-card
+                                .fetch=${() => {
+                                    return new SourcesApi(
+                                        DEFAULT_CONFIG,
+                                    ).sourcesLdapSyncStatusRetrieve({
                                         slug: this.source?.slug,
-                                    },
-                                );
-                            }}
-                        ></ak-sync-status-card>
-                    </div>
-                    <div class="pf-c-card pf-l-grid__item pf-m-12-col">
-                        <div class="pf-c-card__title">
-                            <p>${msg("Connectivity")}</p>
+                                    });
+                                }}
+                            ></ak-sync-status-card>
                         </div>
-                        <div class="pf-c-card__body">
-                            <ak-source-ldap-connectivity
-                                .connectivity=${this.source.connectivity}
-                            ></ak-source-ldap-connectivity>
+                        <div class="pf-c-card pf-l-grid__item pf-m-12-col">
+                            <div class="pf-c-card__title">
+                                <p>${msg("Connectivity")}</p>
+                            </div>
+                            <div class="pf-c-card__body">
+                                <ak-source-ldap-connectivity
+                                    .connectivity=${this.source.connectivity}
+                                ></ak-source-ldap-connectivity>
+                            </div>
                         </div>
-                    </div>
-                    <div class="pf-c-card pf-l-grid__item pf-m-12-col">
-                        <div class="pf-c-card__title">
-                            <p>${msg("Schedules")}</p>
-                        </div>
-                        <div class="pf-c-card__body">
-                            <ak-schedule-list
-                                .relObjAppLabel=${appLabel}
-                                .relObjModel=${modelName}
-                                .relObjId="${this.source.pk}"
-                            ></ak-schedule-list>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-changelog"
-                id="page-changelog"
-                aria-label="${msg("Changelog")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-l-grid pf-m-gutter">
-                    <div class="pf-c-card pf-l-grid__item pf-m-12-col">
-                        <div class="pf-c-card__body">
-                            <ak-object-changelog
-                                targetModelPk=${this.source.pk || ""}
-                                targetModelApp="authentik_sources_ldap"
-                                targetModelName="ldapsource"
-                            >
-                            </ak-object-changelog>
+                        <div class="pf-c-card pf-l-grid__item pf-m-12-col">
+                            <div class="pf-c-card__title">
+                                <p>${msg("Schedules")}</p>
+                            </div>
+                            <div class="pf-c-card__body">
+                                <ak-schedule-list
+                                    .relObjAppLabel=${appLabel}
+                                    .relObjModel=${modelName}
+                                    .relObjId="${this.source.pk}"
+                                ></ak-schedule-list>
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-            <ak-rbac-object-permission-page
-                role="tabpanel"
-                tabindex="0"
-                slot="page-permissions"
-                id="page-permissions"
-                aria-label="${msg("Permissions")}"
-                model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikSourcesLdapLdapsource}
-                objectPk=${this.source.pk}
-            ></ak-rbac-object-permission-page>
-        </ak-tabs>`;
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-changelog"
+                    id="page-changelog"
+                    aria-label="${msg("Changelog")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-l-grid pf-m-gutter">
+                        <div class="pf-c-card pf-l-grid__item pf-m-12-col">
+                            <div class="pf-c-card__body">
+                                <ak-object-changelog
+                                    targetModelPk=${this.source.pk || ""}
+                                    targetModelApp="authentik_sources_ldap"
+                                    targetModelName="ldapsource"
+                                >
+                                </ak-object-changelog>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <ak-rbac-object-permission-page
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-permissions"
+                    id="page-permissions"
+                    aria-label="${msg("Permissions")}"
+                    model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikSourcesLdapLdapsource}
+                    objectPk=${this.source.pk}
+                ></ak-rbac-object-permission-page>
+            </ak-tabs>
+        </main>`;
     }
 }
 

--- a/web/src/admin/sources/oauth/OAuthSourceViewPage.ts
+++ b/web/src/admin/sources/oauth/OAuthSourceViewPage.ts
@@ -113,9 +113,12 @@ export class OAuthSourceViewPage extends AKElement {
             return nothing;
         }
         return html`<ak-tabs>
-            <section
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-overview"
-                data-tab-title="${msg("Overview")}"
+                id="page-overview"
+                aria-label="${msg("Overview")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-l-grid pf-m-gutter">
@@ -220,10 +223,13 @@ export class OAuthSourceViewPage extends AKElement {
                         </div>
                     </div>
                 </div>
-            </section>
-            <section
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-changelog"
-                data-tab-title="${msg("Changelog")}"
+                id="page-changelog"
+                aria-label="${msg("Changelog")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-l-grid pf-m-gutter">
@@ -238,10 +244,13 @@ export class OAuthSourceViewPage extends AKElement {
                         </div>
                     </div>
                 </div>
-            </section>
+            </div>
             <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-policy-binding"
-                data-tab-title="${msg("Policy Bindings")}"
+                id="page-policy-binding"
+                aria-label="${msg("Policy Bindings")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-l-grid pf-m-gutter">
@@ -264,8 +273,11 @@ export class OAuthSourceViewPage extends AKElement {
                 </div>
             </div>
             <ak-rbac-object-permission-page
+                role="tabpanel"
+                tabindex="0"
                 slot="page-permissions"
-                data-tab-title="${msg("Permissions")}"
+                id="page-permissions"
+                aria-label="${msg("Permissions")}"
                 model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikSourcesOauthOauthsource}
                 objectPk=${this.source.pk}
             ></ak-rbac-object-permission-page>

--- a/web/src/admin/sources/oauth/OAuthSourceViewPage.ts
+++ b/web/src/admin/sources/oauth/OAuthSourceViewPage.ts
@@ -112,176 +112,181 @@ export class OAuthSourceViewPage extends AKElement {
         if (!this.source) {
             return nothing;
         }
-        return html`<ak-tabs>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-overview"
-                id="page-overview"
-                aria-label="${msg("Overview")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-l-grid pf-m-gutter">
-                    <div class="pf-c-card pf-l-grid__item pf-m-12-col">
-                        <div class="pf-c-card__title">${msg("Details")}</div>
-                        <div class="pf-c-card__body">
-                            <dl class="pf-c-description-list pf-m-2-col-on-lg">
-                                <div class="pf-c-description-list__group">
-                                    <dt class="pf-c-description-list__term">
-                                        <span class="pf-c-description-list__text"
-                                            >${msg("Name")}</span
-                                        >
-                                    </dt>
-                                    <dd class="pf-c-description-list__description">
-                                        <div class="pf-c-description-list__text">
-                                            ${this.source.name}
-                                        </div>
-                                    </dd>
-                                </div>
-                                <div class="pf-c-description-list__group">
-                                    <dt class="pf-c-description-list__term">
-                                        <span class="pf-c-description-list__text"
-                                            >${msg("Provider Type")}</span
-                                        >
-                                    </dt>
-                                    <dd class="pf-c-description-list__description">
-                                        <div class="pf-c-description-list__text">
-                                            ${ProviderToLabel(this.source.providerType)}
-                                        </div>
-                                    </dd>
-                                </div>
-                                <div class="pf-c-description-list__group">
-                                    <dt class="pf-c-description-list__term">
-                                        <span class="pf-c-description-list__text"
-                                            >${msg("Callback URL")}</span
-                                        >
-                                    </dt>
-                                    <dd class="pf-c-description-list__description">
-                                        <code class="pf-c-description-list__text"
-                                            >${this.source.callbackUrl}</code
-                                        >
-                                    </dd>
-                                </div>
-                                <div class="pf-c-description-list__group">
-                                    <dt class="pf-c-description-list__term">
-                                        <span class="pf-c-description-list__text"
-                                            >${msg("Access Key")}</span
-                                        >
-                                    </dt>
-                                    <dd class="pf-c-description-list__description">
-                                        <div class="pf-c-description-list__text">
-                                            ${this.source.consumerKey}
-                                        </div>
-                                    </dd>
-                                </div>
-                                <div class="pf-c-description-list__group">
-                                    <dt class="pf-c-description-list__term">
-                                        <span class="pf-c-description-list__text"
-                                            >${msg("Authorization URL")}</span
-                                        >
-                                    </dt>
-                                    <dd class="pf-c-description-list__description">
-                                        <div class="pf-c-description-list__text">
-                                            ${this.source.type?.authorizationUrl ||
-                                            this.source.authorizationUrl}
-                                        </div>
-                                    </dd>
-                                </div>
-                                <div class="pf-c-description-list__group">
-                                    <dt class="pf-c-description-list__term">
-                                        <span class="pf-c-description-list__text"
-                                            >${msg("Token URL")}</span
-                                        >
-                                    </dt>
-                                    <dd class="pf-c-description-list__description">
-                                        <div class="pf-c-description-list__text">
-                                            ${this.source.type?.accessTokenUrl ||
-                                            this.source.accessTokenUrl}
-                                        </div>
-                                    </dd>
-                                </div>
-                            </dl>
+        return html`<main>
+            <ak-tabs>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-overview"
+                    id="page-overview"
+                    aria-label="${msg("Overview")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-l-grid pf-m-gutter">
+                        <div class="pf-c-card pf-l-grid__item pf-m-12-col">
+                            <div class="pf-c-card__title">${msg("Details")}</div>
+                            <div class="pf-c-card__body">
+                                <dl class="pf-c-description-list pf-m-2-col-on-lg">
+                                    <div class="pf-c-description-list__group">
+                                        <dt class="pf-c-description-list__term">
+                                            <span class="pf-c-description-list__text"
+                                                >${msg("Name")}</span
+                                            >
+                                        </dt>
+                                        <dd class="pf-c-description-list__description">
+                                            <div class="pf-c-description-list__text">
+                                                ${this.source.name}
+                                            </div>
+                                        </dd>
+                                    </div>
+                                    <div class="pf-c-description-list__group">
+                                        <dt class="pf-c-description-list__term">
+                                            <span class="pf-c-description-list__text"
+                                                >${msg("Provider Type")}</span
+                                            >
+                                        </dt>
+                                        <dd class="pf-c-description-list__description">
+                                            <div class="pf-c-description-list__text">
+                                                ${ProviderToLabel(this.source.providerType)}
+                                            </div>
+                                        </dd>
+                                    </div>
+                                    <div class="pf-c-description-list__group">
+                                        <dt class="pf-c-description-list__term">
+                                            <span class="pf-c-description-list__text"
+                                                >${msg("Callback URL")}</span
+                                            >
+                                        </dt>
+                                        <dd class="pf-c-description-list__description">
+                                            <code class="pf-c-description-list__text"
+                                                >${this.source.callbackUrl}</code
+                                            >
+                                        </dd>
+                                    </div>
+                                    <div class="pf-c-description-list__group">
+                                        <dt class="pf-c-description-list__term">
+                                            <span class="pf-c-description-list__text"
+                                                >${msg("Access Key")}</span
+                                            >
+                                        </dt>
+                                        <dd class="pf-c-description-list__description">
+                                            <div class="pf-c-description-list__text">
+                                                ${this.source.consumerKey}
+                                            </div>
+                                        </dd>
+                                    </div>
+                                    <div class="pf-c-description-list__group">
+                                        <dt class="pf-c-description-list__term">
+                                            <span class="pf-c-description-list__text"
+                                                >${msg("Authorization URL")}</span
+                                            >
+                                        </dt>
+                                        <dd class="pf-c-description-list__description">
+                                            <div class="pf-c-description-list__text">
+                                                ${this.source.type?.authorizationUrl ||
+                                                this.source.authorizationUrl}
+                                            </div>
+                                        </dd>
+                                    </div>
+                                    <div class="pf-c-description-list__group">
+                                        <dt class="pf-c-description-list__term">
+                                            <span class="pf-c-description-list__text"
+                                                >${msg("Token URL")}</span
+                                            >
+                                        </dt>
+                                        <dd class="pf-c-description-list__description">
+                                            <div class="pf-c-description-list__text">
+                                                ${this.source.type?.accessTokenUrl ||
+                                                this.source.accessTokenUrl}
+                                            </div>
+                                        </dd>
+                                    </div>
+                                </dl>
+                            </div>
+                            <div class="pf-c-card__footer">
+                                <ak-forms-modal>
+                                    <span slot="submit"> ${msg("Update")} </span>
+                                    <span slot="header"> ${msg("Update OAuth Source")} </span>
+                                    <ak-source-oauth-form
+                                        slot="form"
+                                        .instancePk=${this.source.slug}
+                                    >
+                                    </ak-source-oauth-form>
+                                    <button slot="trigger" class="pf-c-button pf-m-primary">
+                                        ${msg("Edit")}
+                                    </button>
+                                </ak-forms-modal>
+                            </div>
                         </div>
-                        <div class="pf-c-card__footer">
-                            <ak-forms-modal>
-                                <span slot="submit"> ${msg("Update")} </span>
-                                <span slot="header"> ${msg("Update OAuth Source")} </span>
-                                <ak-source-oauth-form slot="form" .instancePk=${this.source.slug}>
-                                </ak-source-oauth-form>
-                                <button slot="trigger" class="pf-c-button pf-m-primary">
-                                    ${msg("Edit")}
-                                </button>
-                            </ak-forms-modal>
-                        </div>
-                    </div>
-                    <div class="pf-c-card pf-l-grid__item pf-m-12-col">
-                        <div class="pf-c-card__title">${msg("Diagram")}</div>
-                        <div class="pf-c-card__body">
-                            <ak-source-oauth-diagram
-                                .source=${this.source}
-                            ></ak-source-oauth-diagram>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-changelog"
-                id="page-changelog"
-                aria-label="${msg("Changelog")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-l-grid pf-m-gutter">
-                    <div class="pf-c-card pf-l-grid__item pf-m-12-col">
-                        <div class="pf-c-card__body">
-                            <ak-object-changelog
-                                targetModelPk=${this.source.pk || ""}
-                                targetModelApp="authentik_sources_oauth"
-                                targetModelName="oauthsource"
-                            >
-                            </ak-object-changelog>
+                        <div class="pf-c-card pf-l-grid__item pf-m-12-col">
+                            <div class="pf-c-card__title">${msg("Diagram")}</div>
+                            <div class="pf-c-card__body">
+                                <ak-source-oauth-diagram
+                                    .source=${this.source}
+                                ></ak-source-oauth-diagram>
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-policy-binding"
-                id="page-policy-binding"
-                aria-label="${msg("Policy Bindings")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-l-grid pf-m-gutter">
-                    <div class="pf-c-card pf-l-grid__item pf-m-12-col">
-                        <div class="pf-c-card__title">
-                            ${msg(
-                                `These bindings control which users can access this source.
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-changelog"
+                    id="page-changelog"
+                    aria-label="${msg("Changelog")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-l-grid pf-m-gutter">
+                        <div class="pf-c-card pf-l-grid__item pf-m-12-col">
+                            <div class="pf-c-card__body">
+                                <ak-object-changelog
+                                    targetModelPk=${this.source.pk || ""}
+                                    targetModelApp="authentik_sources_oauth"
+                                    targetModelName="oauthsource"
+                                >
+                                </ak-object-changelog>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-policy-binding"
+                    id="page-policy-binding"
+                    aria-label="${msg("Policy Bindings")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-l-grid pf-m-gutter">
+                        <div class="pf-c-card pf-l-grid__item pf-m-12-col">
+                            <div class="pf-c-card__title">
+                                ${msg(
+                                    `These bindings control which users can access this source.
             You can only use policies here as access is checked before the user is authenticated.`,
-                            )}
-                        </div>
-                        <div class="pf-c-card__body">
-                            <ak-bound-policies-list
-                                .target=${this.source.pk}
-                                .typeNotices=${sourceBindingTypeNotices()}
-                                .policyEngineMode=${this.source.policyEngineMode}
-                            >
-                            </ak-bound-policies-list>
+                                )}
+                            </div>
+                            <div class="pf-c-card__body">
+                                <ak-bound-policies-list
+                                    .target=${this.source.pk}
+                                    .typeNotices=${sourceBindingTypeNotices()}
+                                    .policyEngineMode=${this.source.policyEngineMode}
+                                >
+                                </ak-bound-policies-list>
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-            <ak-rbac-object-permission-page
-                role="tabpanel"
-                tabindex="0"
-                slot="page-permissions"
-                id="page-permissions"
-                aria-label="${msg("Permissions")}"
-                model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikSourcesOauthOauthsource}
-                objectPk=${this.source.pk}
-            ></ak-rbac-object-permission-page>
-        </ak-tabs>`;
+                <ak-rbac-object-permission-page
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-permissions"
+                    id="page-permissions"
+                    aria-label="${msg("Permissions")}"
+                    model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikSourcesOauthOauthsource}
+                    objectPk=${this.source.pk}
+                ></ak-rbac-object-permission-page>
+            </ak-tabs>
+        </main>`;
     }
 }
 

--- a/web/src/admin/sources/plex/PlexSourceViewPage.ts
+++ b/web/src/admin/sources/plex/PlexSourceViewPage.ts
@@ -72,9 +72,12 @@ export class PlexSourceViewPage extends AKElement {
             return nothing;
         }
         return html`<ak-tabs>
-            <section
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-overview"
-                data-tab-title="${msg("Overview")}"
+                id="page-overview"
+                aria-label="${msg("Overview")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-l-grid pf-m-gutter">
@@ -108,10 +111,13 @@ export class PlexSourceViewPage extends AKElement {
                         </div>
                     </div>
                 </div>
-            </section>
-            <section
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-changelog"
-                data-tab-title="${msg("Changelog")}"
+                id="page-changelog"
+                aria-label="${msg("Changelog")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-l-grid pf-m-gutter">
@@ -126,10 +132,13 @@ export class PlexSourceViewPage extends AKElement {
                         </div>
                     </div>
                 </div>
-            </section>
+            </div>
             <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-policy-binding"
-                data-tab-title="${msg("Policy Bindings")}"
+                id="page-policy-binding"
+                aria-label="${msg("Policy Bindings")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-l-grid pf-m-gutter">
@@ -152,8 +161,11 @@ export class PlexSourceViewPage extends AKElement {
                 </div>
             </div>
             <ak-rbac-object-permission-page
+                role="tabpanel"
+                tabindex="0"
                 slot="page-permissions"
-                data-tab-title="${msg("Permissions")}"
+                id="page-permissions"
+                aria-label="${msg("Permissions")}"
                 model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikSourcesPlexPlexsource}
                 objectPk=${this.source.pk}
             ></ak-rbac-object-permission-page>

--- a/web/src/admin/sources/plex/PlexSourceViewPage.ts
+++ b/web/src/admin/sources/plex/PlexSourceViewPage.ts
@@ -71,105 +71,110 @@ export class PlexSourceViewPage extends AKElement {
         if (!this.source) {
             return nothing;
         }
-        return html`<ak-tabs>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-overview"
-                id="page-overview"
-                aria-label="${msg("Overview")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-l-grid pf-m-gutter">
-                    <div class="pf-c-card pf-l-grid__item pf-m-12-col">
-                        <div class="pf-c-card__body">
-                            <dl class="pf-c-description-list pf-m-2-col-on-lg">
-                                <div class="pf-c-description-list__group">
-                                    <dt class="pf-c-description-list__term">
-                                        <span class="pf-c-description-list__text"
-                                            >${msg("Name")}</span
-                                        >
-                                    </dt>
-                                    <dd class="pf-c-description-list__description">
-                                        <div class="pf-c-description-list__text">
-                                            ${this.source.name}
-                                        </div>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
-                        <div class="pf-c-card__footer">
-                            <ak-forms-modal>
-                                <span slot="submit"> ${msg("Update")} </span>
-                                <span slot="header"> ${msg("Update Plex Source")} </span>
-                                <ak-source-plex-form slot="form" .instancePk=${this.source.slug}>
-                                </ak-source-plex-form>
-                                <button slot="trigger" class="pf-c-button pf-m-primary">
-                                    ${msg("Edit")}
-                                </button>
-                            </ak-forms-modal>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-changelog"
-                id="page-changelog"
-                aria-label="${msg("Changelog")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-l-grid pf-m-gutter">
-                    <div class="pf-c-card pf-l-grid__item pf-m-12-col">
-                        <div class="pf-c-card__body">
-                            <ak-object-changelog
-                                targetModelPk=${this.source.pk || ""}
-                                targetModelApp="authentik_sources_plex"
-                                targetModelName="plexsource"
-                            >
-                            </ak-object-changelog>
+        return html`<main>
+            <ak-tabs>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-overview"
+                    id="page-overview"
+                    aria-label="${msg("Overview")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-l-grid pf-m-gutter">
+                        <div class="pf-c-card pf-l-grid__item pf-m-12-col">
+                            <div class="pf-c-card__body">
+                                <dl class="pf-c-description-list pf-m-2-col-on-lg">
+                                    <div class="pf-c-description-list__group">
+                                        <dt class="pf-c-description-list__term">
+                                            <span class="pf-c-description-list__text"
+                                                >${msg("Name")}</span
+                                            >
+                                        </dt>
+                                        <dd class="pf-c-description-list__description">
+                                            <div class="pf-c-description-list__text">
+                                                ${this.source.name}
+                                            </div>
+                                        </dd>
+                                    </div>
+                                </dl>
+                            </div>
+                            <div class="pf-c-card__footer">
+                                <ak-forms-modal>
+                                    <span slot="submit"> ${msg("Update")} </span>
+                                    <span slot="header"> ${msg("Update Plex Source")} </span>
+                                    <ak-source-plex-form
+                                        slot="form"
+                                        .instancePk=${this.source.slug}
+                                    >
+                                    </ak-source-plex-form>
+                                    <button slot="trigger" class="pf-c-button pf-m-primary">
+                                        ${msg("Edit")}
+                                    </button>
+                                </ak-forms-modal>
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-policy-binding"
-                id="page-policy-binding"
-                aria-label="${msg("Policy Bindings")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-l-grid pf-m-gutter">
-                    <div class="pf-c-card pf-l-grid__item pf-m-12-col">
-                        <div class="pf-c-card__title">
-                            ${msg(
-                                `These bindings control which users can access this source.
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-changelog"
+                    id="page-changelog"
+                    aria-label="${msg("Changelog")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-l-grid pf-m-gutter">
+                        <div class="pf-c-card pf-l-grid__item pf-m-12-col">
+                            <div class="pf-c-card__body">
+                                <ak-object-changelog
+                                    targetModelPk=${this.source.pk || ""}
+                                    targetModelApp="authentik_sources_plex"
+                                    targetModelName="plexsource"
+                                >
+                                </ak-object-changelog>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-policy-binding"
+                    id="page-policy-binding"
+                    aria-label="${msg("Policy Bindings")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-l-grid pf-m-gutter">
+                        <div class="pf-c-card pf-l-grid__item pf-m-12-col">
+                            <div class="pf-c-card__title">
+                                ${msg(
+                                    `These bindings control which users can access this source.
             You can only use policies here as access is checked before the user is authenticated.`,
-                            )}
-                        </div>
-                        <div class="pf-c-card__body">
-                            <ak-bound-policies-list
-                                .target=${this.source.pk}
-                                .typeNotices=${sourceBindingTypeNotices()}
-                                .policyEngineMode=${this.source.policyEngineMode}
-                            >
-                            </ak-bound-policies-list>
+                                )}
+                            </div>
+                            <div class="pf-c-card__body">
+                                <ak-bound-policies-list
+                                    .target=${this.source.pk}
+                                    .typeNotices=${sourceBindingTypeNotices()}
+                                    .policyEngineMode=${this.source.policyEngineMode}
+                                >
+                                </ak-bound-policies-list>
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-            <ak-rbac-object-permission-page
-                role="tabpanel"
-                tabindex="0"
-                slot="page-permissions"
-                id="page-permissions"
-                aria-label="${msg("Permissions")}"
-                model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikSourcesPlexPlexsource}
-                objectPk=${this.source.pk}
-            ></ak-rbac-object-permission-page>
-        </ak-tabs>`;
+                <ak-rbac-object-permission-page
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-permissions"
+                    id="page-permissions"
+                    aria-label="${msg("Permissions")}"
+                    model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikSourcesPlexPlexsource}
+                    objectPk=${this.source.pk}
+                ></ak-rbac-object-permission-page>
+            </ak-tabs>
+        </main>`;
     }
 }
 

--- a/web/src/admin/sources/saml/SAMLSourceViewPage.ts
+++ b/web/src/admin/sources/saml/SAMLSourceViewPage.ts
@@ -78,9 +78,12 @@ export class SAMLSourceViewPage extends AKElement {
             return nothing;
         }
         return html`<ak-tabs>
-            <section
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-overview"
-                data-tab-title="${msg("Overview")}"
+                id="page-overview"
+                aria-label="${msg("Overview")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-l-grid pf-m-gutter">
@@ -150,10 +153,13 @@ export class SAMLSourceViewPage extends AKElement {
                         </div>
                     </div>
                 </div>
-            </section>
-            <section
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-changelog"
-                data-tab-title="${msg("Changelog")}"
+                id="page-changelog"
+                aria-label="${msg("Changelog")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-l-grid pf-m-gutter">
@@ -168,10 +174,13 @@ export class SAMLSourceViewPage extends AKElement {
                         </div>
                     </div>
                 </div>
-            </section>
-            <section
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-metadata"
-                data-tab-title="${msg("Metadata")}"
+                id="page-metadata"
+                aria-label="${msg("Metadata")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
                 @activate=${() => {
                     new SourcesApi(DEFAULT_CONFIG)
@@ -203,10 +212,13 @@ export class SAMLSourceViewPage extends AKElement {
                         </div>
                     </div>
                 </div>
-            </section>
+            </div>
             <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-policy-bindings"
-                data-tab-title="${msg("Policy Bindings")}"
+                id="page-policy-bindings"
+                aria-label="${msg("Policy Bindings")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-l-grid pf-m-gutter">
@@ -229,8 +241,11 @@ export class SAMLSourceViewPage extends AKElement {
                 </div>
             </div>
             <ak-rbac-object-permission-page
+                role="tabpanel"
+                tabindex="0"
                 slot="page-permissions"
-                data-tab-title="${msg("Permissions")}"
+                id="page-permissions"
+                aria-label="${msg("Permissions")}"
                 model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikSourcesSamlSamlsource}
                 objectPk=${this.source.pk}
             ></ak-rbac-object-permission-page>

--- a/web/src/admin/sources/saml/SAMLSourceViewPage.ts
+++ b/web/src/admin/sources/saml/SAMLSourceViewPage.ts
@@ -77,179 +77,184 @@ export class SAMLSourceViewPage extends AKElement {
         if (!this.source) {
             return nothing;
         }
-        return html`<ak-tabs>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-overview"
-                id="page-overview"
-                aria-label="${msg("Overview")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-l-grid pf-m-gutter">
-                    <div class="pf-c-card pf-l-grid__item pf-m-12-col">
-                        <div class="pf-c-card__body">
-                            <dl class="pf-c-description-list pf-m-3-col-on-lg">
-                                <div class="pf-c-description-list__group">
-                                    <dt class="pf-c-description-list__term">
-                                        <span class="pf-c-description-list__text"
-                                            >${msg("Name")}</span
-                                        >
-                                    </dt>
-                                    <dd class="pf-c-description-list__description">
-                                        <div class="pf-c-description-list__text">
-                                            ${this.source.name}
-                                        </div>
-                                    </dd>
-                                </div>
-                                <div class="pf-c-description-list__group">
-                                    <dt class="pf-c-description-list__term">
-                                        <span class="pf-c-description-list__text"
-                                            >${msg("SSO URL")}</span
-                                        >
-                                    </dt>
-                                    <dd class="pf-c-description-list__description">
-                                        <div class="pf-c-description-list__text">
-                                            ${this.source.ssoUrl}
-                                        </div>
-                                    </dd>
-                                </div>
-                                <div class="pf-c-description-list__group">
-                                    <dt class="pf-c-description-list__term">
-                                        <span class="pf-c-description-list__text"
-                                            >${msg("SLO URL")}</span
-                                        >
-                                    </dt>
-                                    <dd class="pf-c-description-list__description">
-                                        <div class="pf-c-description-list__text">
-                                            ${this.source.sloUrl}
-                                        </div>
-                                    </dd>
-                                </div>
-                                <div class="pf-c-description-list__group">
-                                    <dt class="pf-c-description-list__term">
-                                        <span class="pf-c-description-list__text"
-                                            >${msg("Issuer")}</span
-                                        >
-                                    </dt>
-                                    <dd class="pf-c-description-list__description">
-                                        <div class="pf-c-description-list__text">
-                                            ${this.source.issuer}
-                                        </div>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
-                        <div class="pf-c-card__footer">
-                            <ak-forms-modal>
-                                <span slot="submit"> ${msg("Update")} </span>
-                                <span slot="header"> ${msg("Update SAML Source")} </span>
-                                <ak-source-saml-form slot="form" .instancePk=${this.source.slug}>
-                                </ak-source-saml-form>
-                                <button slot="trigger" class="pf-c-button pf-m-primary">
-                                    ${msg("Edit")}
-                                </button>
-                            </ak-forms-modal>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-changelog"
-                id="page-changelog"
-                aria-label="${msg("Changelog")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-l-grid pf-m-gutter">
-                    <div class="pf-c-card pf-l-grid__item pf-m-12-col">
-                        <div class="pf-c-card__body">
-                            <ak-object-changelog
-                                targetModelPk=${this.source.pk || ""}
-                                targetModelApp="authentik_sources_saml"
-                                targetModelName="samlsource"
-                            >
-                            </ak-object-changelog>
+        return html`<main>
+            <ak-tabs>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-overview"
+                    id="page-overview"
+                    aria-label="${msg("Overview")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-l-grid pf-m-gutter">
+                        <div class="pf-c-card pf-l-grid__item pf-m-12-col">
+                            <div class="pf-c-card__body">
+                                <dl class="pf-c-description-list pf-m-3-col-on-lg">
+                                    <div class="pf-c-description-list__group">
+                                        <dt class="pf-c-description-list__term">
+                                            <span class="pf-c-description-list__text"
+                                                >${msg("Name")}</span
+                                            >
+                                        </dt>
+                                        <dd class="pf-c-description-list__description">
+                                            <div class="pf-c-description-list__text">
+                                                ${this.source.name}
+                                            </div>
+                                        </dd>
+                                    </div>
+                                    <div class="pf-c-description-list__group">
+                                        <dt class="pf-c-description-list__term">
+                                            <span class="pf-c-description-list__text"
+                                                >${msg("SSO URL")}</span
+                                            >
+                                        </dt>
+                                        <dd class="pf-c-description-list__description">
+                                            <div class="pf-c-description-list__text">
+                                                ${this.source.ssoUrl}
+                                            </div>
+                                        </dd>
+                                    </div>
+                                    <div class="pf-c-description-list__group">
+                                        <dt class="pf-c-description-list__term">
+                                            <span class="pf-c-description-list__text"
+                                                >${msg("SLO URL")}</span
+                                            >
+                                        </dt>
+                                        <dd class="pf-c-description-list__description">
+                                            <div class="pf-c-description-list__text">
+                                                ${this.source.sloUrl}
+                                            </div>
+                                        </dd>
+                                    </div>
+                                    <div class="pf-c-description-list__group">
+                                        <dt class="pf-c-description-list__term">
+                                            <span class="pf-c-description-list__text"
+                                                >${msg("Issuer")}</span
+                                            >
+                                        </dt>
+                                        <dd class="pf-c-description-list__description">
+                                            <div class="pf-c-description-list__text">
+                                                ${this.source.issuer}
+                                            </div>
+                                        </dd>
+                                    </div>
+                                </dl>
+                            </div>
+                            <div class="pf-c-card__footer">
+                                <ak-forms-modal>
+                                    <span slot="submit"> ${msg("Update")} </span>
+                                    <span slot="header"> ${msg("Update SAML Source")} </span>
+                                    <ak-source-saml-form
+                                        slot="form"
+                                        .instancePk=${this.source.slug}
+                                    >
+                                    </ak-source-saml-form>
+                                    <button slot="trigger" class="pf-c-button pf-m-primary">
+                                        ${msg("Edit")}
+                                    </button>
+                                </ak-forms-modal>
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-metadata"
-                id="page-metadata"
-                aria-label="${msg("Metadata")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-                @activate=${() => {
-                    new SourcesApi(DEFAULT_CONFIG)
-                        .sourcesSamlMetadataRetrieve({
-                            slug: this.source?.slug || "",
-                        })
-                        .then((metadata) => {
-                            this.metadata = metadata;
-                        });
-                }}
-            >
-                <div class="pf-l-grid pf-m-gutter">
-                    <div class="pf-c-card pf-l-grid__item pf-m-12-col">
-                        <div class="pf-c-card__body">
-                            <ak-codemirror
-                                mode=${CodeMirrorMode.XML}
-                                readonly
-                                value="${ifDefined(this.metadata?.metadata)}"
-                            ></ak-codemirror>
-                        </div>
-                        <div class="pf-c-card__footer">
-                            <a
-                                class="pf-c-button pf-m-primary"
-                                target="_blank"
-                                href=${ifDefined(this.metadata?.downloadUrl)}
-                            >
-                                ${msg("Download")}
-                            </a>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-changelog"
+                    id="page-changelog"
+                    aria-label="${msg("Changelog")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-l-grid pf-m-gutter">
+                        <div class="pf-c-card pf-l-grid__item pf-m-12-col">
+                            <div class="pf-c-card__body">
+                                <ak-object-changelog
+                                    targetModelPk=${this.source.pk || ""}
+                                    targetModelApp="authentik_sources_saml"
+                                    targetModelName="samlsource"
+                                >
+                                </ak-object-changelog>
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-policy-bindings"
-                id="page-policy-bindings"
-                aria-label="${msg("Policy Bindings")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-l-grid pf-m-gutter">
-                    <div class="pf-c-card pf-l-grid__item pf-m-12-col">
-                        <div class="pf-c-card__title">
-                            ${msg(
-                                `These bindings control which users can access this source.
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-metadata"
+                    id="page-metadata"
+                    aria-label="${msg("Metadata")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                    @activate=${() => {
+                        new SourcesApi(DEFAULT_CONFIG)
+                            .sourcesSamlMetadataRetrieve({
+                                slug: this.source?.slug || "",
+                            })
+                            .then((metadata) => {
+                                this.metadata = metadata;
+                            });
+                    }}
+                >
+                    <div class="pf-l-grid pf-m-gutter">
+                        <div class="pf-c-card pf-l-grid__item pf-m-12-col">
+                            <div class="pf-c-card__body">
+                                <ak-codemirror
+                                    mode=${CodeMirrorMode.XML}
+                                    readonly
+                                    value="${ifDefined(this.metadata?.metadata)}"
+                                ></ak-codemirror>
+                            </div>
+                            <div class="pf-c-card__footer">
+                                <a
+                                    class="pf-c-button pf-m-primary"
+                                    target="_blank"
+                                    href=${ifDefined(this.metadata?.downloadUrl)}
+                                >
+                                    ${msg("Download")}
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-policy-bindings"
+                    id="page-policy-bindings"
+                    aria-label="${msg("Policy Bindings")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-l-grid pf-m-gutter">
+                        <div class="pf-c-card pf-l-grid__item pf-m-12-col">
+                            <div class="pf-c-card__title">
+                                ${msg(
+                                    `These bindings control which users can access this source.
             You can only use policies here as access is checked before the user is authenticated.`,
-                            )}
-                        </div>
-                        <div class="pf-c-card__body">
-                            <ak-bound-policies-list
-                                .target=${this.source.pk}
-                                .typeNotices=${sourceBindingTypeNotices()}
-                                .policyEngineMode=${this.source.policyEngineMode}
-                            >
-                            </ak-bound-policies-list>
+                                )}
+                            </div>
+                            <div class="pf-c-card__body">
+                                <ak-bound-policies-list
+                                    .target=${this.source.pk}
+                                    .typeNotices=${sourceBindingTypeNotices()}
+                                    .policyEngineMode=${this.source.policyEngineMode}
+                                >
+                                </ak-bound-policies-list>
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-            <ak-rbac-object-permission-page
-                role="tabpanel"
-                tabindex="0"
-                slot="page-permissions"
-                id="page-permissions"
-                aria-label="${msg("Permissions")}"
-                model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikSourcesSamlSamlsource}
-                objectPk=${this.source.pk}
-            ></ak-rbac-object-permission-page>
-        </ak-tabs>`;
+                <ak-rbac-object-permission-page
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-permissions"
+                    id="page-permissions"
+                    aria-label="${msg("Permissions")}"
+                    model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikSourcesSamlSamlsource}
+                    objectPk=${this.source.pk}
+                ></ak-rbac-object-permission-page>
+            </ak-tabs>
+        </main>`;
     }
 }
 

--- a/web/src/admin/sources/scim/SCIMSourceViewPage.ts
+++ b/web/src/admin/sources/scim/SCIMSourceViewPage.ts
@@ -75,153 +75,160 @@ export class SCIMSourceViewPage extends AKElement {
         if (!this.source) {
             return nothing;
         }
-        return html`<ak-tabs>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-overview"
-                id="page-overview"
-                aria-label="${msg("Overview")}"
-            >
-                <div class="pf-c-page__main-section pf-m-no-padding-mobile pf-l-grid pf-m-gutter">
-                    <div class="pf-c-card pf-l-grid__item pf-m-12-col">
-                        <div class="pf-c-card__body">
-                            <dl class="pf-c-description-list pf-m-2-col-on-lg">
-                                <div class="pf-c-description-list__group">
-                                    <dt class="pf-c-description-list__term">
-                                        <span class="pf-c-description-list__text"
-                                            >${msg("Name")}</span
-                                        >
-                                    </dt>
-                                    <dd class="pf-c-description-list__description">
-                                        <div class="pf-c-description-list__text">
-                                            ${this.source.name}
-                                        </div>
-                                    </dd>
-                                </div>
-                                <div class="pf-c-description-list__group">
-                                    <dt class="pf-c-description-list__term">
-                                        <span class="pf-c-description-list__text"
-                                            >${msg("Slug")}</span
-                                        >
-                                    </dt>
-                                    <dd class="pf-c-description-list__description">
-                                        <div class="pf-c-description-list__text">
-                                            ${this.source.slug}
-                                        </div>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
-                        <div class="pf-c-card__footer">
-                            <ak-forms-modal>
-                                <span slot="submit"> ${msg("Update")} </span>
-                                <span slot="header"> ${msg("Update SCIM Source")} </span>
-                                <ak-source-scim-form slot="form" .instancePk=${this.source.slug}>
-                                </ak-source-scim-form>
-                                <button slot="trigger" class="pf-c-button pf-m-primary">
-                                    ${msg("Edit")}
-                                </button>
-                            </ak-forms-modal>
-                        </div>
-                    </div>
-                    <div class="pf-c-card pf-l-grid__item pf-m-12-col">
-                        <div class="pf-c-card">
+        return html`<main>
+            <ak-tabs>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-overview"
+                    id="page-overview"
+                    aria-label="${msg("Overview")}"
+                >
+                    <div
+                        class="pf-c-page__main-section pf-m-no-padding-mobile pf-l-grid pf-m-gutter"
+                    >
+                        <div class="pf-c-card pf-l-grid__item pf-m-12-col">
                             <div class="pf-c-card__body">
-                                <form class="pf-c-form">
-                                    <div class="pf-c-form__group">
-                                        <label class="pf-c-form__label">
-                                            <span class="pf-c-form__label-text"
-                                                >${msg("SCIM Base URL")}</span
+                                <dl class="pf-c-description-list pf-m-2-col-on-lg">
+                                    <div class="pf-c-description-list__group">
+                                        <dt class="pf-c-description-list__term">
+                                            <span class="pf-c-description-list__text"
+                                                >${msg("Name")}</span
                                             >
-                                        </label>
-                                        <input
-                                            class="pf-c-form-control"
-                                            readonly
-                                            type="text"
-                                            value="${this.source.rootUrl}"
-                                        />
+                                        </dt>
+                                        <dd class="pf-c-description-list__description">
+                                            <div class="pf-c-description-list__text">
+                                                ${this.source.name}
+                                            </div>
+                                        </dd>
                                     </div>
-                                    <div class="pf-c-form__group">
-                                        <label class="pf-c-form__label">
-                                            <span class="pf-c-form__label-text"
-                                                >${msg("Token")}</span
+                                    <div class="pf-c-description-list__group">
+                                        <dt class="pf-c-description-list__term">
+                                            <span class="pf-c-description-list__text"
+                                                >${msg("Slug")}</span
                                             >
-                                        </label>
-                                        <div>
-                                            <ak-token-copy-button
-                                                class="pf-m-primary"
-                                                identifier="${this.source?.tokenObj.identifier}"
-                                            >
-                                                ${msg("Click to copy token")}
-                                            </ak-token-copy-button>
+                                        </dt>
+                                        <dd class="pf-c-description-list__description">
+                                            <div class="pf-c-description-list__text">
+                                                ${this.source.slug}
+                                            </div>
+                                        </dd>
+                                    </div>
+                                </dl>
+                            </div>
+                            <div class="pf-c-card__footer">
+                                <ak-forms-modal>
+                                    <span slot="submit"> ${msg("Update")} </span>
+                                    <span slot="header"> ${msg("Update SCIM Source")} </span>
+                                    <ak-source-scim-form
+                                        slot="form"
+                                        .instancePk=${this.source.slug}
+                                    >
+                                    </ak-source-scim-form>
+                                    <button slot="trigger" class="pf-c-button pf-m-primary">
+                                        ${msg("Edit")}
+                                    </button>
+                                </ak-forms-modal>
+                            </div>
+                        </div>
+                        <div class="pf-c-card pf-l-grid__item pf-m-12-col">
+                            <div class="pf-c-card">
+                                <div class="pf-c-card__body">
+                                    <form class="pf-c-form">
+                                        <div class="pf-c-form__group">
+                                            <label class="pf-c-form__label">
+                                                <span class="pf-c-form__label-text"
+                                                    >${msg("SCIM Base URL")}</span
+                                                >
+                                            </label>
+                                            <input
+                                                class="pf-c-form-control"
+                                                readonly
+                                                type="text"
+                                                value="${this.source.rootUrl}"
+                                            />
                                         </div>
-                                    </div>
-                                </form>
+                                        <div class="pf-c-form__group">
+                                            <label class="pf-c-form__label">
+                                                <span class="pf-c-form__label-text"
+                                                    >${msg("Token")}</span
+                                                >
+                                            </label>
+                                            <div>
+                                                <ak-token-copy-button
+                                                    class="pf-m-primary"
+                                                    identifier="${this.source?.tokenObj.identifier}"
+                                                >
+                                                    ${msg("Click to copy token")}
+                                                </ak-token-copy-button>
+                                            </div>
+                                        </div>
+                                    </form>
+                                </div>
                             </div>
                         </div>
                     </div>
                 </div>
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-changelog"
-                id="page-changelog"
-                aria-label="${msg("Changelog")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-l-grid pf-m-gutter">
-                    <div class="pf-c-card pf-l-grid__item pf-m-12-col">
-                        <div class="pf-c-card__body">
-                            <ak-object-changelog
-                                targetModelPk=${this.source.pk || ""}
-                                targetModelApp="authentik_sources_scim"
-                                targetModelName="scimsource"
-                            >
-                            </ak-object-changelog>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-changelog"
+                    id="page-changelog"
+                    aria-label="${msg("Changelog")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-l-grid pf-m-gutter">
+                        <div class="pf-c-card pf-l-grid__item pf-m-12-col">
+                            <div class="pf-c-card__body">
+                                <ak-object-changelog
+                                    targetModelPk=${this.source.pk || ""}
+                                    targetModelApp="authentik_sources_scim"
+                                    targetModelName="scimsource"
+                                >
+                                </ak-object-changelog>
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-users"
-                id="page-users"
-                aria-label="${msg("Provisioned Users")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-l-grid pf-m-gutter">
-                    <ak-source-scim-users-list
-                        sourceSlug=${this.source.slug}
-                    ></ak-source-scim-users-list>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-users"
+                    id="page-users"
+                    aria-label="${msg("Provisioned Users")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-l-grid pf-m-gutter">
+                        <ak-source-scim-users-list
+                            sourceSlug=${this.source.slug}
+                        ></ak-source-scim-users-list>
+                    </div>
                 </div>
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-groups"
-                id="page-groups"
-                aria-label="${msg("Provisioned Groups")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-l-grid pf-m-gutter">
-                    <ak-source-scim-groups-list
-                        sourceSlug=${this.source.slug}
-                    ></ak-source-scim-groups-list>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-groups"
+                    id="page-groups"
+                    aria-label="${msg("Provisioned Groups")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-l-grid pf-m-gutter">
+                        <ak-source-scim-groups-list
+                            sourceSlug=${this.source.slug}
+                        ></ak-source-scim-groups-list>
+                    </div>
                 </div>
-            </div>
-            <ak-rbac-object-permission-page
-                role="tabpanel"
-                tabindex="0"
-                slot="page-permissions"
-                id="page-permissions"
-                aria-label="${msg("Permissions")}"
-                model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikSourcesScimScimsource}
-                objectPk=${this.source.pk}
-            ></ak-rbac-object-permission-page>
-        </ak-tabs>`;
+                <ak-rbac-object-permission-page
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-permissions"
+                    id="page-permissions"
+                    aria-label="${msg("Permissions")}"
+                    model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikSourcesScimScimsource}
+                    objectPk=${this.source.pk}
+                ></ak-rbac-object-permission-page>
+            </ak-tabs>
+        </main>`;
     }
 }
 

--- a/web/src/admin/sources/scim/SCIMSourceViewPage.ts
+++ b/web/src/admin/sources/scim/SCIMSourceViewPage.ts
@@ -76,7 +76,13 @@ export class SCIMSourceViewPage extends AKElement {
             return nothing;
         }
         return html`<ak-tabs>
-            <section slot="page-overview" data-tab-title="${msg("Overview")}">
+            <div
+                role="tabpanel"
+                tabindex="0"
+                slot="page-overview"
+                id="page-overview"
+                aria-label="${msg("Overview")}"
+            >
                 <div class="pf-c-page__main-section pf-m-no-padding-mobile pf-l-grid pf-m-gutter">
                     <div class="pf-c-card pf-l-grid__item pf-m-12-col">
                         <div class="pf-c-card__body">
@@ -156,10 +162,13 @@ export class SCIMSourceViewPage extends AKElement {
                         </div>
                     </div>
                 </div>
-            </section>
-            <section
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-changelog"
-                data-tab-title="${msg("Changelog")}"
+                id="page-changelog"
+                aria-label="${msg("Changelog")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-l-grid pf-m-gutter">
@@ -174,10 +183,13 @@ export class SCIMSourceViewPage extends AKElement {
                         </div>
                     </div>
                 </div>
-            </section>
-            <section
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-users"
-                data-tab-title="${msg("Provisioned Users")}"
+                id="page-users"
+                aria-label="${msg("Provisioned Users")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-l-grid pf-m-gutter">
@@ -185,10 +197,13 @@ export class SCIMSourceViewPage extends AKElement {
                         sourceSlug=${this.source.slug}
                     ></ak-source-scim-users-list>
                 </div>
-            </section>
-            <section
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-groups"
-                data-tab-title="${msg("Provisioned Groups")}"
+                id="page-groups"
+                aria-label="${msg("Provisioned Groups")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-l-grid pf-m-gutter">
@@ -196,10 +211,13 @@ export class SCIMSourceViewPage extends AKElement {
                         sourceSlug=${this.source.slug}
                     ></ak-source-scim-groups-list>
                 </div>
-            </section>
+            </div>
             <ak-rbac-object-permission-page
+                role="tabpanel"
+                tabindex="0"
                 slot="page-permissions"
-                data-tab-title="${msg("Permissions")}"
+                id="page-permissions"
+                aria-label="${msg("Permissions")}"
                 model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikSourcesScimScimsource}
                 objectPk=${this.source.pk}
             ></ak-rbac-object-permission-page>

--- a/web/src/admin/users/UserApplicationTable.ts
+++ b/web/src/admin/users/UserApplicationTable.ts
@@ -5,6 +5,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
 import { SlottedTemplateResult } from "#elements/types";
+import { ifPresent } from "#elements/utils/attributes";
 
 import { applicationListStyle } from "#admin/applications/ApplicationListPage";
 
@@ -13,7 +14,6 @@ import { Application, CoreApi, User } from "@goauthentik/api";
 import { msg } from "@lit/localize";
 import { CSSResult, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
-import { ifDefined } from "lit/directives/if-defined.js";
 
 @customElement("ak-user-application-table")
 export class UserApplicationTable extends Table<Application> {
@@ -40,10 +40,7 @@ export class UserApplicationTable extends Table<Application> {
 
     row(item: Application): SlottedTemplateResult[] {
         return [
-            html`<ak-app-icon
-                name=${item.name}
-                icon=${ifDefined(item.metaIcon || undefined)}
-            ></ak-app-icon>`,
+            html`<ak-app-icon name=${item.name} icon=${ifPresent(item.metaIcon)}></ak-app-icon>`,
             html`<a href="#/core/applications/${item.slug}">
                 <div>${item.name}</div>
                 ${item.metaPublisher ? html`<small>${item.metaPublisher}</small>` : nothing}

--- a/web/src/admin/users/UserViewPage.ts
+++ b/web/src/admin/users/UserViewPage.ts
@@ -383,6 +383,7 @@ export class UserViewPage extends WithCapabilitiesConfig(AKElement) {
                     </div>
                 </div>
             </ak-tabs>
+</main>
         `;
     }
 
@@ -398,120 +399,123 @@ export class UserViewPage extends WithCapabilitiesConfig(AKElement) {
         if (!this.user) {
             return nothing;
         }
-        return html`<ak-tabs>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-overview"
-                id="page-overview"
-                aria-label="${msg("Overview")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-l-grid pf-m-gutter">
-                    <div
-                        class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                    >
-                        ${this.renderUserCard()}
-                    </div>
-                    <div
-                        class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-7-col-on-xl pf-m-7-col-on-2xl"
-                    >
-                        <div class="pf-c-card__title">
-                            ${msg("Actions over the last week (per 8 hours)")}
+        return html`<main>
+            <ak-tabs>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-overview"
+                    id="page-overview"
+                    aria-label="${msg("Overview")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-l-grid pf-m-gutter">
+                        <div
+                            class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                        >
+                            ${this.renderUserCard()}
                         </div>
-                        <div class="pf-c-card__body">
-                            <ak-charts-user username=${this.user.username}> </ak-charts-user>
+                        <div
+                            class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-7-col-on-xl pf-m-7-col-on-2xl"
+                        >
+                            <div class="pf-c-card__title">
+                                ${msg("Actions over the last week (per 8 hours)")}
+                            </div>
+                            <div class="pf-c-card__body">
+                                <ak-charts-user username=${this.user.username}> </ak-charts-user>
+                            </div>
                         </div>
-                    </div>
-                    <div
-                        class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-3-col-on-xl pf-m-3-col-on-2xl"
-                    >
-                        <div class="pf-c-card__title">${msg("Notes")}</div>
-                        <div class="pf-c-card__body">
-                            ${Object.hasOwn(this.user?.attributes || {}, "notes")
-                                ? html`${this.user.attributes?.notes}`
-                                : html`
-                                      <p>
-                                          ${msg(
-                                              "Edit the notes attribute of this user to add notes here.",
-                                          )}
-                                      </p>
-                                  `}
+                        <div
+                            class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-3-col-on-xl pf-m-3-col-on-2xl"
+                        >
+                            <div class="pf-c-card__title">${msg("Notes")}</div>
+                            <div class="pf-c-card__body">
+                                ${Object.hasOwn(this.user?.attributes || {}, "notes")
+                                    ? html`${this.user.attributes?.notes}`
+                                    : html`
+                                          <p>
+                                              ${msg(
+                                                  "Edit the notes attribute of this user to add notes here.",
+                                              )}
+                                          </p>
+                                      `}
+                            </div>
                         </div>
-                    </div>
-                    <div
-                        class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-9-col-on-xl pf-m-9-col-on-2xl"
-                    >
-                        <div class="pf-c-card__title">${msg("Changelog")}</div>
-                        <div class="pf-c-card__body">
-                            <ak-object-changelog
-                                targetModelPk=${this.user.pk}
-                                targetModelApp="authentik_core"
-                                targetModelName="user"
-                            >
-                            </ak-object-changelog>
+                        <div
+                            class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-9-col-on-xl pf-m-9-col-on-2xl"
+                        >
+                            <div class="pf-c-card__title">${msg("Changelog")}</div>
+                            <div class="pf-c-card__body">
+                                <ak-object-changelog
+                                    targetModelPk=${this.user.pk}
+                                    targetModelApp="authentik_core"
+                                    targetModelName="user"
+                                >
+                                </ak-object-changelog>
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-groups"
-                id="page-groups"
-                aria-label="${msg("Groups")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-c-card">
-                    <div class="pf-c-card__body">
-                        <ak-group-related-list .targetUser=${this.user}> </ak-group-related-list>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-groups"
+                    id="page-groups"
+                    aria-label="${msg("Groups")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-c-card">
+                        <div class="pf-c-card__body">
+                            <ak-group-related-list .targetUser=${this.user}>
+                            </ak-group-related-list>
+                        </div>
                     </div>
                 </div>
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-events"
-                id="page-events"
-                aria-label="${msg("User events")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                <div class="pf-c-card">
-                    <div class="pf-c-card__body">
-                        <ak-events-user targetUser=${this.user.username}> </ak-events-user>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-events"
+                    id="page-events"
+                    aria-label="${msg("User events")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-c-card">
+                        <div class="pf-c-card__body">
+                            <ak-events-user targetUser=${this.user.username}> </ak-events-user>
+                        </div>
                     </div>
                 </div>
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-credentials"
-                id="page-credentials"
-                aria-label="${msg("Credentials / Tokens")}"
-            >
-                ${this.renderTabCredentialsToken(this.user)}
-            </div>
-            <div
-                role="tabpanel"
-                tabindex="0"
-                slot="page-applications"
-                id="page-applications"
-                aria-label="${msg("Applications")}"
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
-                ${this.renderTabApplications(this.user)}
-            </div>
-            <ak-rbac-object-permission-page
-                role="tabpanel"
-                tabindex="0"
-                slot="page-permissions"
-                id="page-permissions"
-                aria-label="${msg("Permissions")}"
-                model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikCoreUser}
-                objectPk=${this.user.pk}
-            >
-            </ak-rbac-object-permission-page>
-        </ak-tabs>`;
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-credentials"
+                    id="page-credentials"
+                    aria-label="${msg("Credentials / Tokens")}"
+                >
+                    ${this.renderTabCredentialsToken(this.user)}
+                </div>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-applications"
+                    id="page-applications"
+                    aria-label="${msg("Applications")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    ${this.renderTabApplications(this.user)}
+                </div>
+                <ak-rbac-object-permission-page
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-permissions"
+                    id="page-permissions"
+                    aria-label="${msg("Permissions")}"
+                    model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikCoreUser}
+                    objectPk=${this.user.pk}
+                >
+                </ak-rbac-object-permission-page>
+            </ak-tabs>
+        </main>`;
     }
 }
 

--- a/web/src/admin/users/UserViewPage.ts
+++ b/web/src/admin/users/UserViewPage.ts
@@ -265,9 +265,12 @@ export class UserViewPage extends WithCapabilitiesConfig(AKElement) {
     renderTabCredentialsToken(user: User): TemplateResult {
         return html`
             <ak-tabs pageIdentifier="userCredentialsTokens" vertical>
-                <section
+                <div
+                    role="tabpanel"
+                    tabindex="0"
                     slot="page-sessions"
-                    data-tab-title="${msg("Sessions")}"
+                    id="page-sessions"
+                    aria-label="${msg("Sessions")}"
                     class="pf-c-page__main-section pf-m-no-padding-mobile"
                 >
                     <div class="pf-c-card">
@@ -276,10 +279,13 @@ export class UserViewPage extends WithCapabilitiesConfig(AKElement) {
                             </ak-user-session-list>
                         </div>
                     </div>
-                </section>
-                <section
+                </div>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
                     slot="page-reputation"
-                    data-tab-title="${msg("Reputation scores")}"
+                    id="page-reputation"
+                    aria-label="${msg("Reputation scores")}"
                     class="pf-c-page__main-section pf-m-no-padding-mobile"
                 >
                     <div class="pf-c-card">
@@ -291,10 +297,13 @@ export class UserViewPage extends WithCapabilitiesConfig(AKElement) {
                             </ak-user-reputation-list>
                         </div>
                     </div>
-                </section>
-                <section
+                </div>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
                     slot="page-consent"
-                    data-tab-title="${msg("Explicit Consent")}"
+                    id="page-consent"
+                    aria-label="${msg("Explicit Consent")}"
                     class="pf-c-page__main-section pf-m-no-padding-mobile"
                 >
                     <div class="pf-c-card">
@@ -302,10 +311,13 @@ export class UserViewPage extends WithCapabilitiesConfig(AKElement) {
                             <ak-user-consent-list userId=${user.pk}> </ak-user-consent-list>
                         </div>
                     </div>
-                </section>
-                <section
+                </div>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
                     slot="page-oauth-access"
-                    data-tab-title="${msg("OAuth Access Tokens")}"
+                    id="page-oauth-access"
+                    aria-label="${msg("OAuth Access Tokens")}"
                     class="pf-c-page__main-section pf-m-no-padding-mobile"
                 >
                     <div class="pf-c-card">
@@ -314,10 +326,13 @@ export class UserViewPage extends WithCapabilitiesConfig(AKElement) {
                             </ak-user-oauth-access-token-list>
                         </div>
                     </div>
-                </section>
-                <section
+                </div>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
                     slot="page-oauth-refresh"
-                    data-tab-title="${msg("OAuth Refresh Tokens")}"
+                    id="page-oauth-refresh"
+                    aria-label="${msg("OAuth Refresh Tokens")}"
                     class="pf-c-page__main-section pf-m-no-padding-mobile"
                 >
                     <div class="pf-c-card">
@@ -326,10 +341,13 @@ export class UserViewPage extends WithCapabilitiesConfig(AKElement) {
                             </ak-user-oauth-refresh-token-list>
                         </div>
                     </div>
-                </section>
-                <section
+                </div>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
                     slot="page-mfa-authenticators"
-                    data-tab-title="${msg("MFA Authenticators")}"
+                    id="page-mfa-authenticators"
+                    aria-label="${msg("MFA Authenticators")}"
                     class="pf-c-page__main-section pf-m-no-padding-mobile"
                 >
                     <div class="pf-c-card">
@@ -337,27 +355,33 @@ export class UserViewPage extends WithCapabilitiesConfig(AKElement) {
                             <ak-user-device-table userId=${user.pk}> </ak-user-device-table>
                         </div>
                     </div>
-                </section>
-                <section
+                </div>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
                     slot="page-source-connections"
-                    data-tab-title="${msg("Connected services")}"
+                    id="page-source-connections"
+                    aria-label="${msg("Connected services")}"
                     class="pf-c-page__main-section pf-m-no-padding-mobile"
                 >
                     <div class="pf-c-card">
                         <ak-user-settings-source userId=${user.pk} .canConnect=${false}>
                         </ak-user-settings-source>
                     </div>
-                </section>
-                <section
+                </div>
+                <div
+                    role="tabpanel"
+                    tabindex="0"
                     slot="page-rac-connection-tokens"
-                    data-tab-title="${msg("RAC Connections")}"
+                    id="page-rac-connection-tokens"
+                    aria-label="${msg("RAC Connections")}"
                     class="pf-c-page__main-section pf-m-no-padding-mobile"
                 >
                     <div class="pf-c-card">
                         <ak-rac-connection-token-list userId=${user.pk}>
                         </ak-rac-connection-token-list>
                     </div>
-                </section>
+                </div>
             </ak-tabs>
         `;
     }
@@ -375,9 +399,12 @@ export class UserViewPage extends WithCapabilitiesConfig(AKElement) {
             return nothing;
         }
         return html`<ak-tabs>
-            <section
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-overview"
-                data-tab-title="${msg("Overview")}"
+                id="page-overview"
+                aria-label="${msg("Overview")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-l-grid pf-m-gutter">
@@ -426,10 +453,13 @@ export class UserViewPage extends WithCapabilitiesConfig(AKElement) {
                         </div>
                     </div>
                 </div>
-            </section>
-            <section
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-groups"
-                data-tab-title="${msg("Groups")}"
+                id="page-groups"
+                aria-label="${msg("Groups")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-c-card">
@@ -437,10 +467,13 @@ export class UserViewPage extends WithCapabilitiesConfig(AKElement) {
                         <ak-group-related-list .targetUser=${this.user}> </ak-group-related-list>
                     </div>
                 </div>
-            </section>
-            <section
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-events"
-                data-tab-title="${msg("User events")}"
+                id="page-events"
+                aria-label="${msg("User events")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 <div class="pf-c-card">
@@ -448,20 +481,32 @@ export class UserViewPage extends WithCapabilitiesConfig(AKElement) {
                         <ak-events-user targetUser=${this.user.username}> </ak-events-user>
                     </div>
                 </div>
-            </section>
-            <section slot="page-credentials" data-tab-title="${msg("Credentials / Tokens")}">
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
+                slot="page-credentials"
+                id="page-credentials"
+                aria-label="${msg("Credentials / Tokens")}"
+            >
                 ${this.renderTabCredentialsToken(this.user)}
-            </section>
-            <section
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
                 slot="page-applications"
-                data-tab-title="${msg("Applications")}"
+                id="page-applications"
+                aria-label="${msg("Applications")}"
                 class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
                 ${this.renderTabApplications(this.user)}
-            </section>
+            </div>
             <ak-rbac-object-permission-page
+                role="tabpanel"
+                tabindex="0"
                 slot="page-permissions"
-                data-tab-title="${msg("Permissions")}"
+                id="page-permissions"
+                aria-label="${msg("Permissions")}"
                 model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikCoreUser}
                 objectPk=${this.user.pk}
             >

--- a/web/src/components/DescriptionList.ts
+++ b/web/src/components/DescriptionList.ts
@@ -1,10 +1,14 @@
+import { SlottedTemplateResult } from "#elements/types";
+
 import { html, nothing, TemplateResult } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { map } from "lit/directives/map.js";
 
-export type DescriptionDesc = string | TemplateResult | undefined | typeof nothing;
-export type DescriptionPair = [string, DescriptionDesc];
-export type DescriptionRecord = { term: string; desc: DescriptionDesc };
+export type DescriptionPair = [
+    term: SlottedTemplateResult,
+    desc: SlottedTemplateResult | undefined,
+];
+export type DescriptionRecord = { term: string; desc: SlottedTemplateResult | undefined };
 
 interface DescriptionConfig {
     horizontal?: boolean;

--- a/web/src/components/HorizontalLightComponent.ts
+++ b/web/src/components/HorizontalLightComponent.ts
@@ -14,9 +14,9 @@ import { property } from "lit/decorators.js";
 
 export interface HorizontalLightComponentProps<T> extends AKElementProps {
     name: string;
-    label?: string;
+    label: string | null;
     required?: boolean;
-    help?: string;
+    help: string | null;
     bighelp?: SlottedTemplateResult | SlottedTemplateResult[];
     hidden?: boolean;
     invalid?: boolean;
@@ -55,23 +55,48 @@ export abstract class HorizontalLightComponent<T>
      * @property
      * @attribute
      */
-    @property({ type: String, reflect: true })
-    label?: string;
+    @property({ type: String })
+    public get label() {
+        return this.ariaLabel;
+    }
+
+    public set label(value: string | null) {
+        this.ariaLabel = value;
+    }
+
+    /**
+     * The ARIA role for the input control
+     * @property
+     * @attribute
+     */
+    public get role() {
+        return super.role || "group";
+    }
+
+    public set role(value: string | null) {
+        super.role = value;
+    }
 
     /**
      * @property
      * @attribute
      */
-    @property({ type: Boolean, reflect: true })
-    public required?: boolean;
+    @property({ type: Boolean, reflect: false })
+    public get required() {
+        return this.ariaRequired === "true";
+    }
+
+    public set required(value: boolean) {
+        this.ariaRequired = value ? "true" : "false";
+    }
 
     /**
      * Help text to display below the form element. Optional
      * @property
      * @attribute
      */
-    @property({ type: String, reflect: true })
-    help = "";
+    @property({ reflect: false })
+    help: string | null = null;
 
     /**
      * Extended help content. Optional. Expects to be a TemplateResult
@@ -84,8 +109,14 @@ export abstract class HorizontalLightComponent<T>
      * @property
      * @attribute
      */
-    @property({ type: Boolean, reflect: true })
-    hidden = false;
+    @property({ type: Boolean })
+    public get hidden() {
+        return this.ariaHidden === "true";
+    }
+
+    public set hidden(value: boolean) {
+        this.ariaHidden = value ? "true" : "false";
+    }
 
     /**
      * @property
@@ -148,10 +179,11 @@ export abstract class HorizontalLightComponent<T>
             ?required=${this.required}
             ?hidden=${this.hidden}
             name=${this.name}
+            role="presentation"
             .errorMessages=${this.errorMessages}
         >
             <div slot="label" class="pf-c-form__group-label">
-                ${AKLabel({ htmlFor: this.fieldID, required: this.required }, this.label)}
+                ${AKLabel({ htmlFor: this.fieldID, required: this.required }, this.label || "")}
             </div>
 
             ${this.renderControl()} ${this.renderHelp()}

--- a/web/src/components/ak-hidden-text-input.ts
+++ b/web/src/components/ak-hidden-text-input.ts
@@ -6,18 +6,19 @@ import {
     HorizontalLightComponentProps,
 } from "./HorizontalLightComponent.js";
 
+import { ifPresent } from "#elements/utils/attributes";
+
 import { msg } from "@lit/localize";
 import { css, html } from "lit";
 import { customElement, property, query } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
-import { ifDefined } from "lit/directives/if-defined.js";
 
 type BaseProps = HorizontalLightComponentProps<string> &
     Pick<VisibilityToggleProps, "showMessage" | "hideMessage">;
 
 export interface AkHiddenTextInputProps extends BaseProps {
     revealed: boolean;
-    placeholder?: string;
+    placeholder: string | null;
 }
 
 export type InputLike = HTMLTextAreaElement | HTMLInputElement;
@@ -70,7 +71,7 @@ export class AkHiddenTextInput<T extends InputLike = HTMLInputElement>
      * @attribute
      */
     @property({ type: String })
-    public placeholder?: string;
+    public placeholder: string | null = null;
 
     /**
      * Specify kind of help the browser should try to provide
@@ -105,12 +106,12 @@ export class AkHiddenTextInput<T extends InputLike = HTMLInputElement>
     protected renderInputField(setValue: InputListener, code: boolean) {
         return html` <input
             part="input"
-            autocomplete=${ifDefined(this.autocomplete)}
+            autocomplete=${ifPresent(this.autocomplete)}
             type=${this.revealed ? "text" : "password"}
-            aria-label=${ifDefined(this.label || undefined)}
+            aria-label=${ifPresent(this.label)}
             @input=${setValue}
-            value=${ifDefined(this.value)}
-            placeholder=${ifDefined(this.placeholder)}
+            value=${ifPresent(this.value)}
+            placeholder=${ifPresent(this.placeholder)}
             class="${classMap({
                 "pf-c-form-control": true,
                 "pf-m-monospace": code,

--- a/web/src/components/ak-hidden-text-input.ts
+++ b/web/src/components/ak-hidden-text-input.ts
@@ -73,15 +73,6 @@ export class AkHiddenTextInput<T extends InputLike = HTMLInputElement>
     public placeholder?: string;
 
     /**
-     * Text for when the input has no set value
-     *
-     * @property
-     * @attribute
-     */
-    @property({ type: String })
-    public label?: string;
-
-    /**
      * Specify kind of help the browser should try to provide
      *
      * @property
@@ -116,7 +107,7 @@ export class AkHiddenTextInput<T extends InputLike = HTMLInputElement>
             part="input"
             autocomplete=${ifDefined(this.autocomplete)}
             type=${this.revealed ? "text" : "password"}
-            aria-label=${ifDefined(this.label)}
+            aria-label=${ifDefined(this.label || undefined)}
             @input=${setValue}
             value=${ifDefined(this.value)}
             placeholder=${ifDefined(this.placeholder)}

--- a/web/src/components/ak-hidden-textarea-input.ts
+++ b/web/src/components/ak-hidden-textarea-input.ts
@@ -109,7 +109,7 @@ export class AkHiddenTextAreaInput
                 part="textarea"
                 @input=${setValue}
                 placeholder=${ifDefined(this.placeholder)}
-                aria-label=${ifDefined(this.label)}
+                aria-label=${ifDefined(this.label || undefined)}
                 rows=${ifDefined(this.rows)}
                 cols=${ifDefined(this.cols)}
                 wrap=${ifDefined(wrap)}

--- a/web/src/components/ak-hidden-textarea-input.ts
+++ b/web/src/components/ak-hidden-textarea-input.ts
@@ -4,6 +4,8 @@ import {
     InputListener,
 } from "./ak-hidden-text-input.js";
 
+import { ifPresent } from "#elements/utils/attributes";
+
 import { html } from "lit";
 import { customElement, property, query } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
@@ -108,8 +110,8 @@ export class AkHiddenTextAreaInput
                 style="flex: 1 1 auto; min-width: 0;"
                 part="textarea"
                 @input=${setValue}
-                placeholder=${ifDefined(this.placeholder)}
-                aria-label=${ifDefined(this.label || undefined)}
+                placeholder=${ifPresent(this.placeholder)}
+                aria-label=${ifPresent(this.label)}
                 rows=${ifDefined(this.rows)}
                 cols=${ifDefined(this.cols)}
                 wrap=${ifDefined(wrap)}

--- a/web/src/components/ak-number-input.ts
+++ b/web/src/components/ak-number-input.ts
@@ -21,7 +21,7 @@ export class AkNumberInput extends HorizontalLightComponent<number> {
         return html`<input
             type="number"
             @input=${setValue}
-            aria-label=${ifDefined(this.label)}
+            aria-label=${ifDefined(this.label || undefined)}
             value=${ifDefined(this.value)}
             min=${ifDefined(this.min)}
             class="pf-c-form-control"

--- a/web/src/components/ak-number-input.ts
+++ b/web/src/components/ak-number-input.ts
@@ -1,5 +1,7 @@
 import { HorizontalLightComponent } from "./HorizontalLightComponent.js";
 
+import { ifPresent } from "#elements/utils/attributes";
+
 import { html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -21,8 +23,8 @@ export class AkNumberInput extends HorizontalLightComponent<number> {
         return html`<input
             type="number"
             @input=${setValue}
-            aria-label=${ifDefined(this.label || undefined)}
-            value=${ifDefined(this.value)}
+            aria-label=${ifPresent(this.label)}
+            value=${ifPresent(this.value)}
             min=${ifDefined(this.min)}
             class="pf-c-form-control"
             ?required=${this.required}

--- a/web/src/components/ak-radio-input.ts
+++ b/web/src/components/ak-radio-input.ts
@@ -7,7 +7,6 @@ import { SlottedTemplateResult } from "#elements/types";
 
 import { html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
-import { ifDefined } from "lit/directives/if-defined.js";
 
 @customElement("ak-radio-input")
 export class AkRadioInput<T> extends HorizontalLightComponent<T> {
@@ -23,15 +22,19 @@ export class AkRadioInput<T> extends HorizontalLightComponent<T> {
         }
     }
 
+    public override connectedCallback(): void {
+        super.connectedCallback();
+        this.role = "radiogroup";
+    }
+
     protected override renderHelp(): SlottedTemplateResult {
         return nothing;
     }
 
     renderControl() {
-        const helpText = this.help.trim();
+        const helpText = this.help?.trim();
 
         return html`<ak-radio
-                label=${ifDefined(this.label)}
                 .options=${this.options}
                 .value=${this.value}
                 @input=${this.handleInput}

--- a/web/src/components/ak-secret-text-input.ts
+++ b/web/src/components/ak-secret-text-input.ts
@@ -1,6 +1,6 @@
 import { HorizontalLightComponent } from "./HorizontalLightComponent.js";
 
-import { ifNotEmpty } from "#elements/utils/ifNotEmpty";
+import { ifPresent } from "#elements/utils/attributes";
 
 import { msg } from "@lit/localize";
 import { html } from "lit";
@@ -52,7 +52,7 @@ export class AkSecretTextInput extends HorizontalLightComponent<string> {
             @input=${setValue}
             value=${ifDefined(this.value)}
             class="${classMap(classes)}"
-            placeholder=${ifNotEmpty(this.placeholder)}
+            placeholder=${ifPresent(this.placeholder)}
             autocomplete=${ifDefined(code ? "off" : undefined)}
             spellcheck=${ifDefined(code ? "false" : undefined)}
             ?required=${this.required}

--- a/web/src/components/ak-secret-textarea-input.ts
+++ b/web/src/components/ak-secret-textarea-input.ts
@@ -1,6 +1,6 @@
 import { AkSecretTextInput } from "./ak-secret-text-input.js";
 
-import { ifNotEmpty } from "#elements/utils/ifNotEmpty";
+import { ifPresent } from "#elements/utils/attributes";
 
 import { html } from "lit";
 import { customElement } from "lit/decorators.js";
@@ -26,7 +26,7 @@ export class AkSecretTextAreaInput extends AkSecretTextInput {
             class="${classMap(classes)}"
             ?required=${this.required}
             name=${this.name}
-            placeholder=${ifNotEmpty(this.placeholder)}
+            placeholder=${ifPresent(this.placeholder)}
             autocomplete=${ifDefined(code ? "off" : undefined)}
             spellcheck=${ifDefined(code ? "false" : undefined)}
         >${this.value !== undefined ? this.value : ""}</textarea

--- a/web/src/components/ak-text-input.ts
+++ b/web/src/components/ak-text-input.ts
@@ -1,5 +1,7 @@
 import { HorizontalLightComponent } from "./HorizontalLightComponent.js";
 
+import { ifPresent } from "#elements/utils/attributes";
+
 import { html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
@@ -11,10 +13,10 @@ export class AkTextInput extends HorizontalLightComponent<string> {
     public value = "";
 
     @property({ type: String })
-    public autocomplete?: AutoFill;
+    public autocomplete: AutoFill | null = null;
 
     @property({ type: String })
-    public placeholder?: string;
+    public placeholder: string | null = null;
 
     #inputListener(ev: InputEvent) {
         this.value = (ev.target as HTMLInputElement).value;
@@ -22,7 +24,6 @@ export class AkTextInput extends HorizontalLightComponent<string> {
 
     public override renderControl() {
         const code = this.inputHint === "code";
-
         return html` <input
             type="text"
             role="textbox"
@@ -33,10 +34,10 @@ export class AkTextInput extends HorizontalLightComponent<string> {
                 "pf-c-form-control": true,
                 "pf-m-monospace": code,
             })}"
-            autocomplete=${ifDefined(code ? "off" : this.autocomplete)}
-            spellcheck=${ifDefined(code ? "false" : undefined)}
-            aria-label=${ifDefined(this.placeholder || this.label || undefined)}
-            placeholder=${ifDefined(this.placeholder)}
+            autocomplete=${ifPresent(code ? "off" : this.autocomplete)}
+            spellcheck=${ifPresent(code ? "false" : this.spellcheck)}
+            aria-label=${ifPresent(this.placeholder || this.label)}
+            placeholder=${ifPresent(this.placeholder)}
             ?required=${this.required}
         />`;
     }

--- a/web/src/components/ak-text-input.ts
+++ b/web/src/components/ak-text-input.ts
@@ -35,7 +35,7 @@ export class AkTextInput extends HorizontalLightComponent<string> {
             })}"
             autocomplete=${ifDefined(code ? "off" : this.autocomplete)}
             spellcheck=${ifDefined(code ? "false" : undefined)}
-            aria-label=${ifDefined(this.placeholder || this.label)}
+            aria-label=${ifDefined(this.placeholder || this.label || undefined)}
             placeholder=${ifDefined(this.placeholder)}
             ?required=${this.required}
         />`;

--- a/web/src/components/stories/ak-hidden-text-input.stories.ts
+++ b/web/src/components/stories/ak-hidden-text-input.stories.ts
@@ -72,7 +72,7 @@ const Template: Story = {
     },
     render: (args) => html`
         <ak-hidden-text-input
-            label=${ifDefined(args.label)}
+            label=${ifDefined(args.label || undefined)}
             value=${ifDefined(args.value)}
             ?revealed=${args.revealed}
             placeholder=${ifDefined(args.placeholder)}

--- a/web/src/components/stories/ak-hidden-text-input.stories.ts
+++ b/web/src/components/stories/ak-hidden-text-input.stories.ts
@@ -2,10 +2,11 @@ import "../ak-hidden-text-input.js";
 
 import { type AkHiddenTextInput, type AkHiddenTextInputProps } from "../ak-hidden-text-input.js";
 
+import { ifPresent } from "#elements/utils/attributes";
+
 import type { Meta, StoryObj } from "@storybook/web-components";
 
 import { html } from "lit";
-import { ifDefined } from "lit/directives/if-defined.js";
 
 const metadata: Meta<AkHiddenTextInputProps> = {
     title: "Components / <ak-hidden-text-input>",
@@ -72,14 +73,14 @@ const Template: Story = {
     },
     render: (args) => html`
         <ak-hidden-text-input
-            label=${ifDefined(args.label || undefined)}
-            value=${ifDefined(args.value)}
+            label=${ifPresent(args.label)}
+            value=${ifPresent(args.value)}
             ?revealed=${args.revealed}
-            placeholder=${ifDefined(args.placeholder)}
+            placeholder=${ifPresent(args.placeholder)}
             ?required=${args.required}
-            input-hint=${ifDefined(args.inputHint)}
-            show-message=${ifDefined(args.showMessage)}
-            hide-message=${ifDefined(args.hideMessage)}
+            input-hint=${ifPresent(args.inputHint)}
+            show-message=${ifPresent(args.showMessage)}
+            hide-message=${ifPresent(args.hideMessage)}
         ></ak-hidden-text-input>
     `,
 };

--- a/web/src/components/stories/ak-hidden-textarea-input.stories.ts
+++ b/web/src/components/stories/ak-hidden-textarea-input.stories.ts
@@ -94,7 +94,7 @@ const Template: Story = {
     },
     render: (args) => html`
         <ak-hidden-textarea-input
-            label=${ifDefined(args.label)}
+            label=${ifDefined(args.label || undefined)}
             value=${ifDefined(args.value)}
             ?revealed=${args.revealed}
             placeholder=${ifDefined(args.placeholder)}

--- a/web/src/components/stories/ak-hidden-textarea-input.stories.ts
+++ b/web/src/components/stories/ak-hidden-textarea-input.stories.ts
@@ -5,10 +5,11 @@ import {
     type AkHiddenTextAreaInputProps,
 } from "../ak-hidden-textarea-input.js";
 
+import { ifPresent } from "#elements/utils/attributes";
+
 import type { Meta, StoryObj } from "@storybook/web-components";
 
 import { html } from "lit";
-import { ifDefined } from "lit/directives/if-defined.js";
 
 const metadata: Meta<AkHiddenTextAreaInputProps> = {
     title: "Components / <ak-hidden-textarea-input>",
@@ -94,18 +95,18 @@ const Template: Story = {
     },
     render: (args) => html`
         <ak-hidden-textarea-input
-            label=${ifDefined(args.label || undefined)}
-            value=${ifDefined(args.value)}
+            label=${ifPresent(args.label)}
+            value=${ifPresent(args.value)}
             ?revealed=${args.revealed}
-            placeholder=${ifDefined(args.placeholder)}
-            rows=${ifDefined(args.rows)}
-            cols=${ifDefined(args.cols)}
-            resize=${ifDefined(args.resize)}
-            wrap=${ifDefined(args.wrap)}
+            placeholder=${ifPresent(args.placeholder)}
+            rows=${ifPresent(args.rows)}
+            cols=${ifPresent(args.cols)}
+            resize=${ifPresent(args.resize)}
+            wrap=${ifPresent(args.wrap)}
             ?required=${args.required}
-            input-hint=${ifDefined(args.inputHint)}
-            show-message=${ifDefined(args.showMessage)}
-            hide-message=${ifDefined(args.hideMessage)}
+            input-hint=${ifPresent(args.inputHint)}
+            show-message=${ifPresent(args.showMessage)}
+            hide-message=${ifPresent(args.hideMessage)}
         ></ak-hidden-textarea-input>
     `,
 };

--- a/web/src/elements/Tabs.ts
+++ b/web/src/elements/Tabs.ts
@@ -2,6 +2,7 @@ import { CURRENT_CLASS, EVENT_REFRESH, ROUTE_SEPARATOR } from "#common/constants
 
 import { AKElement } from "#elements/Base";
 import { getURLParams, updateURLParams } from "#elements/router/RouteMatch";
+import { ifPresent } from "#elements/utils/attributes";
 
 import { msg } from "@lit/localize";
 import { css, CSSResult, html, TemplateResult } from "lit";
@@ -86,7 +87,7 @@ export class Tabs extends AKElement {
                 role="tab"
                 id=${`${slot}-tab`}
                 aria-selected=${slot === this.currentPage ? "true" : "false"}
-                aria-controls=${slot}
+                aria-controls=${ifPresent(slot)}
                 class="pf-c-tabs__link"
                 @click=${() => this.onClick(slot)}
             >

--- a/web/src/elements/Tabs.ts
+++ b/web/src/elements/Tabs.ts
@@ -81,8 +81,16 @@ export class Tabs extends AKElement {
     renderTab(page: Element): TemplateResult {
         const slot = page.attributes.getNamedItem("slot")?.value;
         return html` <li class="pf-c-tabs__item ${slot === this.currentPage ? CURRENT_CLASS : ""}">
-            <button class="pf-c-tabs__link" @click=${() => this.onClick(slot)}>
-                <span class="pf-c-tabs__item-text"> ${page.getAttribute("data-tab-title")} </span>
+            <button
+                type="button"
+                role="tab"
+                id=${`${slot}-tab`}
+                aria-selected=${slot === this.currentPage ? "true" : "false"}
+                aria-controls=${slot}
+                class="pf-c-tabs__link"
+                @click=${() => this.onClick(slot)}
+            >
+                <span class="pf-c-tabs__item-text"> ${page.getAttribute("aria-label")} </span>
             </button>
         </li>`;
     }
@@ -108,7 +116,7 @@ export class Tabs extends AKElement {
             this.onClick(wantedPage);
         }
         return html`<div class="pf-c-tabs ${this.vertical ? "pf-m-vertical pf-m-box" : ""}">
-                <ul class="pf-c-tabs__list">
+                <ul class="pf-c-tabs__list" role="tablist">
                     ${pages.map((page) => this.renderTab(page))}
                 </ul>
             </div>

--- a/web/src/elements/ak-dual-select/ak-dual-select.ts
+++ b/web/src/elements/ak-dual-select/ak-dual-select.ts
@@ -312,7 +312,10 @@ export class AkDualSelect extends CustomEmitterElement(CustomListenerElement(AKE
                             </div>
                         </div>
                     </div>
-                    <ak-search-bar name="ak-dual-list-available-search"></ak-search-bar>
+                    <ak-search-bar
+                        placeholder=${msg(str`Search ${this.availableLabel}...`)}
+                        name="ak-dual-list-available-search"
+                    ></ak-search-bar>
                     <div class="pf-c-dual-list-selector__status">
                         <span
                             class="pf-c-dual-list-selector__status-text"
@@ -346,7 +349,10 @@ export class AkDualSelect extends CustomEmitterElement(CustomListenerElement(AKE
                             </div>
                         </div>
                     </div>
-                    <ak-search-bar name="ak-dual-list-selected-search"></ak-search-bar>
+                    <ak-search-bar
+                        placeholder=${msg(str`Search ${this.selectedLabel}...`)}
+                        name="ak-dual-list-selected-search"
+                    ></ak-search-bar>
                     <div class="pf-c-dual-list-selector__status">
                         <span
                             class="pf-c-dual-list-selector__status-text"

--- a/web/src/elements/ak-dual-select/components/ak-search-bar.ts
+++ b/web/src/elements/ak-dual-select/components/ak-search-bar.ts
@@ -2,6 +2,7 @@ import type { SearchbarEventDetail, SearchbarEventSource } from "../types.ts";
 import { globalVariables, searchStyles } from "./search.styles.js";
 
 import { AKElement } from "#elements/Base";
+import { ifPresent } from "#elements/utils/attributes";
 import { CustomEmitterElement } from "#elements/utils/eventEmitter";
 
 import { html } from "lit";
@@ -16,6 +17,9 @@ export class AkSearchbar extends CustomEmitterElement(AKElement) {
 
     @property({ type: String, reflect: true })
     public value = "";
+
+    @property({ type: String })
+    public placeholder: string | null = null;
 
     /**
      * If you're using more than one search, this token can help listeners distinguishing between
@@ -53,6 +57,7 @@ export class AkSearchbar extends CustomEmitterElement(AKElement) {
                             ><i class="fa fa-search fa-fw" aria-hidden="true"></i></span
                         ><input
                             type="search"
+                            placeholder=${ifPresent(this.placeholder)}
                             class="pf-c-text-input-group__text-input"
                             ${ref(this.inputRef)}
                             @input=${this.#changeListener}

--- a/web/src/elements/ak-list-select/ak-list-select.ts
+++ b/web/src/elements/ak-list-select/ak-list-select.ts
@@ -1,7 +1,6 @@
 import { groupOptions, isVisibleInScrollRegion } from "./utils.js";
 
 import { AKElement } from "#elements/Base";
-import { bound } from "#elements/decorators/bound";
 import type { GroupedOptions, SelectGroup, SelectOption, SelectOptions } from "#elements/types";
 import { randomId } from "#elements/utils/randomId";
 
@@ -16,7 +15,7 @@ import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 export interface IListSelect {
     options: SelectOptions;
-    value?: string;
+    value?: string | null;
     emptyOption?: string;
 }
 
@@ -68,21 +67,23 @@ export class ListSelect extends AKElement implements IListSelect {
         `,
     ];
 
+    //#region Properties
+
     /**
      * See the search options type, described in the `./types` file, for the relevant types.
      *
      * @prop
      */
     @property({ type: Array, attribute: false })
-    set options(options: SelectOptions) {
-        this._options = groupOptions(options);
+    public set options(options: SelectOptions) {
+        this.#options = groupOptions(options);
     }
 
-    get options() {
-        return this._options;
+    public get options() {
+        return this.#options;
     }
 
-    _options!: GroupedOptions;
+    #options!: GroupedOptions;
 
     /**
      * The current value of the menu.
@@ -90,7 +91,7 @@ export class ListSelect extends AKElement implements IListSelect {
      * @prop
      */
     @property({ type: String, reflect: true })
-    value?: string;
+    public value?: string | null = null;
 
     /**
      * The string representation that means an empty option. If not present, no empty option is
@@ -99,35 +100,56 @@ export class ListSelect extends AKElement implements IListSelect {
      * @prop
      */
     @property()
-    emptyOption?: string;
+    public emptyOption?: string;
 
     // We have two different states that we're tracking in this component: the `value`, which is the
     // element that is currently selected according to the client, and the `index`, which is the
     // element that is being tracked for keyboard interaction. On a click, the index points to the
-    // value element; on Keydown.Enter, the value becomes whatever the index points to.
+    // value element; on Keyup.Enter, the value becomes whatever the index points to.
     @state()
-    indexOfFocusedItem = 0;
+    protected indexOfFocusedItem = 0;
 
     @query("#ak-list-select-list")
-    ul!: HTMLUListElement;
+    protected ul!: HTMLUListElement;
+
+    //#endregion
 
     get json(): string {
         return this.value ?? "";
     }
 
-    public constructor() {
-        super();
-        this.addEventListener("focus", this.onFocus);
-        this.addEventListener("blur", this.onBlur);
-    }
+    //#region Lifecycle
 
     public override connectedCallback() {
         super.connectedCallback();
+
+        this.addEventListener("focus", this.#focusListener);
+        this.addEventListener("blur", this.#blurListener);
+
         this.setAttribute("data-ouia-component-type", "ak-menu-select");
         this.setAttribute("data-ouia-component-id", this.getAttribute("id") || randomId());
         this.setIndexOfFocusedItemFromValue();
         this.highlightFocusedItem();
     }
+
+    public override disconnectedCallback() {
+        super.disconnectedCallback();
+
+        this.removeEventListener("focus", this.#focusListener);
+        this.removeEventListener("blur", this.#blurListener);
+    }
+
+    public override performUpdate() {
+        this.removeAttribute("data-ouia-component-safe");
+        super.performUpdate();
+    }
+
+    public override updated(changed: PropertyValueMap<this>) {
+        super.updated(changed);
+        this.setAttribute("data-ouia-component-safe", "true");
+    }
+
+    //#endregion
 
     public get hasFocus() {
         return this.renderRoot.contains(document.activeElement) || document.activeElement === this;
@@ -176,30 +198,29 @@ export class ListSelect extends AKElement implements IListSelect {
         currentElement.setAttribute("aria-selected", "true");
     }
 
-    @bound
-    onFocus() {
+    //#region Event Listeners
+
+    #focusListener = () => {
         // Allow the event to propagate.
         this.currentElement?.focus();
-        this.addEventListener("keydown", this.onKeydown);
-    }
+        this.addEventListener("keyup", this.#delegateKey);
+    };
 
-    @bound
-    onBlur() {
+    #blurListener = () => {
         // Allow the event to propagate.
-        this.removeEventListener("keydown", this.onKeydown);
+        this.removeEventListener("keyup", this.#delegateKey);
         this.indexOfFocusedItem = 0;
-    }
+    };
 
-    @bound
-    onClick(value: string | undefined) {
+    #clickListener = (value: string | null) => {
         // let the click through, but include the change event.
         this.value = value;
-        this.setIndexOfFocusedItemFromValue();
-        this.dispatchEvent(new Event("change", { bubbles: true, composed: true })); // prettier-ignore
-    }
 
-    @bound
-    onKeydown(event: KeyboardEvent) {
+        this.setIndexOfFocusedItemFromValue();
+        this.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+    };
+
+    #delegateKey = (event: KeyboardEvent) => {
         const key = event.key;
         const lastItem = this.displayedElements.length - 1;
         const current = this.indexOfFocusedItem;
@@ -213,8 +234,9 @@ export class ListSelect extends AKElement implements IListSelect {
 
         const setValueAndDispatch = () => {
             event.preventDefault();
-            this.value = this.currentElement?.getAttribute("value") ?? undefined;
-            this.dispatchEvent(new Event("change", { bubbles: true, composed: true })); // prettier-ignore
+            this.value = this.currentElement?.getAttribute("value");
+
+            this.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
         };
 
         const pageBy = (direction: number) => {
@@ -234,17 +256,9 @@ export class ListSelect extends AKElement implements IListSelect {
             .with({ key: "End" }, () => updateIndex(lastItem))
             .with({ key: " " }, () => setValueAndDispatch())
             .with({ key: "Enter" }, () => setValueAndDispatch());
-    }
+    };
 
-    public override performUpdate() {
-        this.removeAttribute("data-ouia-component-safe");
-        super.performUpdate();
-    }
-
-    public override updated(changed: PropertyValueMap<this>) {
-        super.updated(changed);
-        this.setAttribute("data-ouia-component-safe", "true");
-    }
+    //#region Render
 
     private renderEmptyMenuItem() {
         return html`<li role="option" class="ak-select-item" part="ak-list-select-option">
@@ -252,7 +266,7 @@ export class ListSelect extends AKElement implements IListSelect {
                 class="pf-c-dropdown__menu-item"
                 role="option"
                 tabindex="0"
-                @click=${() => this.onClick(undefined)}
+                @click=${() => this.#clickListener(null)}
                 part="ak-list-select-button"
             >
                 ${this.emptyOption}
@@ -273,7 +287,7 @@ export class ListSelect extends AKElement implements IListSelect {
                         class="pf-c-dropdown__menu-item pf-m-description"
                         value="${value}"
                         tabindex="0"
-                        @click=${() => this.onClick(value)}
+                        @click=${() => this.#clickListener(value)}
                         part="ak-list-select-button"
                     >
                         <div class="pf-c-dropdown__menu-item-main" part="ak-list-select-label">
@@ -321,13 +335,15 @@ export class ListSelect extends AKElement implements IListSelect {
                 tabindex="0"
                 part="ak-list-select"
             >
-                ${this.emptyOption === undefined ? nothing : this.renderEmptyMenuItem()}
-                ${this._options.grouped
-                    ? this.renderMenuGroups(this._options.options)
-                    : this.renderMenuItems(this._options.options)}
+                ${this.emptyOption ? this.renderEmptyMenuItem() : nothing}
+                ${this.#options.grouped
+                    ? this.renderMenuGroups(this.#options.options)
+                    : this.renderMenuItems(this.#options.options)}
             </ul>
         </div> `;
     }
+
+    //#endregion
 }
 
 declare global {

--- a/web/src/elements/ak-list-select/ak-list-select.ts
+++ b/web/src/elements/ak-list-select/ak-list-select.ts
@@ -132,13 +132,6 @@ export class ListSelect extends AKElement implements IListSelect {
         this.highlightFocusedItem();
     }
 
-    public override disconnectedCallback() {
-        super.disconnectedCallback();
-
-        this.removeEventListener("focus", this.#focusListener);
-        this.removeEventListener("blur", this.#blurListener);
-    }
-
     public override performUpdate() {
         this.removeAttribute("data-ouia-component-safe");
         super.performUpdate();

--- a/web/src/elements/controllers/ModalOrchestrationController.ts
+++ b/web/src/elements/controllers/ModalOrchestrationController.ts
@@ -51,13 +51,13 @@ export class ModalOrchestrationController implements ReactiveController {
     #knownModals: ModalElement[] = [];
 
     public hostConnected() {
-        window.addEventListener("keyup", this.handleKeyup);
+        window.addEventListener("keyup", this.#keyupListener);
         window.addEventListener("ak-modal-show", this.#addModal);
         window.addEventListener("ak-modal-hide", this.closeModal);
     }
 
     public hostDisconnected() {
-        window.removeEventListener("keyup", this.handleKeyup);
+        window.removeEventListener("keyup", this.#keyupListener);
         window.removeEventListener("ak-modal-show", this.#addModal);
         window.removeEventListener("ak-modal-hide", this.closeModal);
     }
@@ -108,8 +108,16 @@ export class ModalOrchestrationController implements ReactiveController {
         this.#knownModals = knownModals;
     };
 
-    handleKeyup = ({ key }: KeyboardEvent) => {
+    #keyupListener = ({ key, defaultPrevented }: KeyboardEvent) => {
         // The latter handles Firefox 37 and earlier.
+        if (key !== "Escape" && key !== "Esc") {
+            return;
+        }
+
+        // Allow an event listener within the modal to prevent
+        // our default behavior of closing the modal.
+        if (defaultPrevented) return;
+
         if (key === "Escape" || key === "Esc") {
             this.#removeTopmostModal();
         }

--- a/web/src/elements/forms/HorizontalFormElement.ts
+++ b/web/src/elements/forms/HorizontalFormElement.ts
@@ -130,7 +130,7 @@ export class HorizontalFormElement extends AKElement {
     render(): TemplateResult {
         this.#synchronizeAttributes();
 
-        return html`<div class="pf-c-form__group" role="group">
+        return html`<div class="pf-c-form__group">
             <div class="pf-c-form__group-label">
                 ${this.label
                     ? html`

--- a/web/src/elements/forms/SearchSelect/SearchSelect.ts
+++ b/web/src/elements/forms/SearchSelect/SearchSelect.ts
@@ -10,12 +10,12 @@ import { groupBy } from "#common/utils";
 import { AkControlElement } from "#elements/AkControlElement";
 import { PreventFormSubmit } from "#elements/forms/helpers";
 import type { GroupedOptions, SelectGroup, SelectOption } from "#elements/types";
+import { ifPresent } from "#elements/utils/attributes";
 import { randomId } from "#elements/utils/randomId";
 
 import { msg } from "@lit/localize";
 import { html, PropertyValues, TemplateResult } from "lit";
 import { property, state } from "lit/decorators.js";
-import { ifDefined } from "lit/directives/if-defined.js";
 
 import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
@@ -27,7 +27,7 @@ export interface ISearchSelectBase<T> {
     objects?: T[];
     selectedObject: T | null;
     name?: string;
-    placeholder?: string;
+    placeholder: string | null;
     emptyOption?: string;
 }
 
@@ -135,7 +135,7 @@ export abstract class SearchSelectBase<T>
      * @attr
      */
     @property({ type: String })
-    public placeholder?: string = msg("Select an object.");
+    public placeholder: string | null = msg("Select an object.");
 
     /**
      * A textual string representing "The user has affirmed they want to leave the selection blank."
@@ -321,12 +321,12 @@ export abstract class SearchSelectBase<T>
             managed
             .fieldID=${this.fieldID}
             .options=${options}
-            value=${ifDefined(value)}
+            value=${ifPresent(value)}
             ?blankable=${this.blankable}
-            label=${ifDefined(this.label)}
-            name=${ifDefined(this.name)}
-            placeholder=${ifDefined(this.placeholder)}
-            emptyOption=${ifDefined(this.blankable ? this.emptyOption : undefined)}
+            label=${ifPresent(this.label)}
+            name=${ifPresent(this.name)}
+            placeholder=${ifPresent(this.placeholder)}
+            emptyOption=${ifPresent(this.blankable ? this.emptyOption : undefined)}
             @input=${this.#searchListener}
             @change=${this.onSelect}
         ></ak-search-select-view> `;

--- a/web/src/elements/forms/SearchSelect/SearchSelect.ts
+++ b/web/src/elements/forms/SearchSelect/SearchSelect.ts
@@ -47,14 +47,12 @@ export abstract class SearchSelectBase<T>
     public abstract fetchObjects: (query?: string) => Promise<T[]>;
 
     /**
-     * A function passed to this object that extracts a string representation of items of the
-     * collection under search.
+     * Render a string representation of items of the collection under search.
      */
     public abstract renderElement: (element: T) => string;
 
     /**
-     * A function passed to this object that extracts an HTML representation of additional
-     * information for items of the collection under search.
+     * Render a string description representation of items of the collection under search.
      */
     public abstract renderDescription?: (element: T) => string | TemplateResult;
 

--- a/web/src/elements/forms/SearchSelect/SearchSelect.ts
+++ b/web/src/elements/forms/SearchSelect/SearchSelect.ts
@@ -31,56 +31,85 @@ export interface ISearchSelectBase<T> {
     emptyOption: string;
 }
 
-export class SearchSelectBase<T> extends AkControlElement<string> implements ISearchSelectBase<T> {
+export abstract class SearchSelectBase<T>
+    extends AkControlElement<string>
+    implements ISearchSelectBase<T>
+{
     static styles = [PFBase];
 
-    // A function which takes the query state object (accepting that it may be empty) and returns a
-    // new collection of objects.
-    fetchObjects!: (query?: string) => Promise<T[]>;
+    //#region Properties
 
-    // A function passed to this object that extracts a string representation of items of the
-    // collection under search.
-    renderElement!: (element: T) => string;
+    /**
+     * A function which takes the query state object (accepting that it may be empty)
+     * and returns a
+     * new collection of objects.
+     */
+    public abstract fetchObjects: (query?: string) => Promise<T[]>;
 
-    // A function passed to this object that extracts an HTML representation of additional
-    // information for items of the collection under search.
-    renderDescription?: (element: T) => string | TemplateResult;
+    /**
+     * A function passed to this object that extracts a string representation of items of the
+     * collection under search.
+     */
+    public abstract renderElement: (element: T) => string;
 
-    // A function which returns the currently selected object's primary key, used for serialization
-    // into forms.
-    value!: (element: T | undefined) => string;
+    /**
+     * A function passed to this object that extracts an HTML representation of additional
+     * information for items of the collection under search.
+     */
+    public abstract renderDescription?: (element: T) => string | TemplateResult;
 
-    // A function passed to this object that determines an object in the collection under search
-    // should be automatically selected. Only used when the search itself is responsible for
-    // fetching the data; sets an initial default value.
-    selected?: (element: T, elements: T[]) => boolean;
+    /**
+     * A function which returns the currently selected object's primary key, used for serialization
+     * into forms.
+     */
+    public abstract value: (element?: T) => string;
 
-    // A function passed to this object (or using the default below) that groups objects in the
-    // collection under search into categories.
-    groupBy: (items: T[]) => [string, T[]][] = (items: T[]): [string, T[]][] => {
-        return groupBy(items, () => {
-            return "";
-        });
+    /**
+     * A function passed to this object that determines an object in the collection under search
+     * should be automatically selected. Only used when the search itself is responsible for
+     * fetching the data; sets an initial default value.
+     */
+    public abstract selected?: (element: T, elements: T[]) => boolean;
+
+    /**
+     * A function passed to this object (or using the default below) that groups objects in the
+     * collection under search into categories.
+     */
+    public groupBy: (items: T[]) => [string, T[]][] = (items) => {
+        return groupBy(items, () => "");
     };
 
-    // Whether or not the dropdown component can be left blank
+    /**
+     * Whether or not the dropdown component can be left blank
+     * @property
+     * @attr
+     */
     @property({ type: Boolean })
-    blankable = false;
+    public blankable = false;
 
-    // An initial string to filter the search contents, and the value of the input which further
-    // serves to restrict the search
-    @property()
-    query?: string;
+    /**
+     * An initial string to filter the search contents,
+     * and the value of the input which further serves to restrict the search.
+     * @property
+     */
+    @property({ type: String })
+    public query?: string;
 
     // The objects currently available under search
     @property({ attribute: false })
-    objects?: T[];
+    public objects?: T[];
 
-    // The currently selected object
+    /**
+     * The currently selected object.
+     * @property
+     */
     @property({ attribute: false })
-    selectedObject?: T;
+    public selectedObject?: T;
 
-    // Used to inform the form of the name of the object
+    /**
+     * Used to inform the form of the name of the object
+     * @property
+     */
     @property()
     public name?: string;
 
@@ -91,24 +120,42 @@ export class SearchSelectBase<T> extends AkControlElement<string> implements ISe
     @property({ type: String, reflect: false })
     public fieldID?: string;
 
-    // Used to inform the form of the input label.
+    /**
+     * Used to inform the form of the input label.
+     * @property
+     */
     @property()
     public label?: string;
 
-    // The textual placeholder for the search's <input> object, if currently empty. Used as the
-    // native <input> object's `placeholder` field.
-    @property()
-    placeholder: string = msg("Select an object.");
+    /**
+     * The textual placeholder for the search's <input> object, if currently empty.
+     *
+     * Used as the native <input> object's `placeholder` field.
+     * @property
+     * @attr
+     */
+    @property({ type: String })
+    public placeholder: string = msg("Select an object.");
 
-    // A textual string representing "The user has affirmed they want to leave the selection blank."
-    // Only used if `blankable` above is true.
-    @property()
-    emptyOption = "---------";
+    /**
+     * A textual string representing "The user has affirmed they want to leave the selection blank."
+     * Only used if `blankable` above is true.
+     *
+     * @property
+     */
+    @property({ type: String })
+    public emptyOption = "---------";
 
-    isFetchingData = false;
+    //#endregion
+
+    //#region State
+
+    #loading = false;
 
     @state()
-    error?: APIError;
+    protected error?: APIError;
+
+    //#endregion
 
     public toForm(): string {
         if (!this.objects) {
@@ -132,26 +179,27 @@ export class SearchSelectBase<T> extends AkControlElement<string> implements ISe
     }
 
     public async updateData() {
-        if (this.isFetchingData) {
+        if (this.#loading) {
             return Promise.resolve();
         }
-        this.isFetchingData = true;
+
+        this.#loading = true;
         this.dispatchEvent(new Event("loading"));
 
         return this.fetchObjects(this.query)
             .then((nextObjects) => {
-                nextObjects.forEach((obj) => {
-                    if (this.selected && this.selected(obj, nextObjects || [])) {
-                        this.selectedObject = obj;
-                        this.dispatchChangeEvent(this.selectedObject);
-                    }
-                });
+                const selectedObject = nextObjects.find((obj) => this.selected?.(obj, nextObjects));
+
+                if (selectedObject) {
+                    this.selectedObject = selectedObject;
+                    this.dispatchChangeEvent(this.selectedObject);
+                }
 
                 this.objects = nextObjects;
-                this.isFetchingData = false;
+                this.#loading = false;
             })
             .catch(async (error: unknown) => {
-                this.isFetchingData = false;
+                this.#loading = false;
                 this.objects = undefined;
 
                 const parsedError = await parseAPIResponseError(error);
@@ -174,9 +222,10 @@ export class SearchSelectBase<T> extends AkControlElement<string> implements ISe
         this.removeEventListener(EVENT_REFRESH, this.updateData);
     }
 
-    private onSearch(event: InputEvent) {
+    #searchListener = (event: InputEvent) => {
         const value = (event.target as SearchSelectView).rawValue;
-        if (value === undefined) {
+
+        if (!value) {
             this.selectedObject = undefined;
             return;
         }
@@ -185,7 +234,7 @@ export class SearchSelectBase<T> extends AkControlElement<string> implements ISe
         this.updateData()?.then(() => {
             this.dispatchChangeEvent(this.selectedObject);
         });
-    }
+    };
 
     private onSelect(event: InputEvent) {
         const value = (event.target as SearchSelectView).value;
@@ -270,21 +319,22 @@ export class SearchSelectBase<T> extends AkControlElement<string> implements ISe
             .options=${options}
             value=${ifDefined(value)}
             ?blankable=${this.blankable}
+            label=${ifDefined(this.label)}
             name=${ifDefined(this.name)}
             placeholder=${this.placeholder}
             emptyOption=${ifDefined(this.blankable ? this.emptyOption : undefined)}
-            @input=${this.onSearch}
+            @input=${this.#searchListener}
             @change=${this.onSelect}
         ></ak-search-select-view> `;
     }
 
     public override updated(changed: PropertyValues<this>) {
-        if (!this.isFetchingData && changed.has("objects")) {
+        if (!this.#loading && changed.has("objects")) {
             this.dispatchEvent(new Event("ready"));
         }
         // It is not safe for automated tests to interact with this component while it is fetching
         // data.
-        if (!this.isFetchingData) {
+        if (!this.#loading) {
             this.setAttribute("data-ouia-component-safe", "true");
         }
     }

--- a/web/src/elements/forms/SearchSelect/SearchSelect.ts
+++ b/web/src/elements/forms/SearchSelect/SearchSelect.ts
@@ -22,13 +22,13 @@ import PFBase from "@patternfly/patternfly/patternfly-base.css";
 type Group<T> = [string, T[]];
 
 export interface ISearchSelectBase<T> {
-    blankable: boolean;
+    blankable?: boolean;
     query?: string;
     objects?: T[];
-    selectedObject?: T;
+    selectedObject: T | null;
     name?: string;
-    placeholder: string;
-    emptyOption: string;
+    placeholder?: string;
+    emptyOption?: string;
 }
 
 export abstract class SearchSelectBase<T>
@@ -62,7 +62,7 @@ export abstract class SearchSelectBase<T>
      * A function which returns the currently selected object's primary key, used for serialization
      * into forms.
      */
-    public abstract value: (element?: T) => string;
+    public abstract value: (element: T | null) => string;
 
     /**
      * A function passed to this object that determines an object in the collection under search
@@ -85,7 +85,7 @@ export abstract class SearchSelectBase<T>
      * @attr
      */
     @property({ type: Boolean })
-    public blankable = false;
+    public blankable?: boolean;
 
     /**
      * An initial string to filter the search contents,
@@ -104,7 +104,7 @@ export abstract class SearchSelectBase<T>
      * @property
      */
     @property({ attribute: false })
-    public selectedObject?: T;
+    public selectedObject: T | null = null;
 
     /**
      * Used to inform the form of the name of the object
@@ -135,7 +135,7 @@ export abstract class SearchSelectBase<T>
      * @attr
      */
     @property({ type: String })
-    public placeholder: string = msg("Select an object.");
+    public placeholder?: string = msg("Select an object.");
 
     /**
      * A textual string representing "The user has affirmed they want to leave the selection blank."
@@ -144,7 +144,7 @@ export abstract class SearchSelectBase<T>
      * @property
      */
     @property({ type: String })
-    public emptyOption = "---------";
+    public emptyOption?: string = "---------";
 
     //#endregion
 
@@ -168,7 +168,7 @@ export abstract class SearchSelectBase<T>
         return this.toForm();
     }
 
-    protected dispatchChangeEvent(value: T | undefined) {
+    protected dispatchChangeEvent(value: T | null) {
         this.dispatchEvent(
             new CustomEvent("ak-change", {
                 composed: true,
@@ -226,7 +226,7 @@ export abstract class SearchSelectBase<T>
         const value = (event.target as SearchSelectView).rawValue;
 
         if (!value) {
-            this.selectedObject = undefined;
+            this.selectedObject = null;
             return;
         }
 
@@ -238,15 +238,19 @@ export abstract class SearchSelectBase<T>
 
     private onSelect(event: InputEvent) {
         const value = (event.target as SearchSelectView).value;
-        if (value === undefined) {
-            this.selectedObject = undefined;
-            this.dispatchChangeEvent(undefined);
+
+        if (!value) {
+            this.selectedObject = null;
+            this.dispatchChangeEvent(null);
+
             return;
         }
-        const selected = (this.objects ?? []).find((obj) => `${this.value(obj)}` === value);
+        const selected = this.objects?.find((obj) => this.value(obj) === value) || null;
+
         if (!selected) {
             console.warn(`ak-search-select: No corresponding object found for value (${value}`);
         }
+
         this.selectedObject = selected;
         this.dispatchChangeEvent(this.selectedObject);
     }
@@ -321,7 +325,7 @@ export abstract class SearchSelectBase<T>
             ?blankable=${this.blankable}
             label=${ifDefined(this.label)}
             name=${ifDefined(this.name)}
-            placeholder=${this.placeholder}
+            placeholder=${ifDefined(this.placeholder)}
             emptyOption=${ifDefined(this.blankable ? this.emptyOption : undefined)}
             @input=${this.#searchListener}
             @change=${this.onSelect}

--- a/web/src/elements/forms/SearchSelect/ak-search-select-ez.ts
+++ b/web/src/elements/forms/SearchSelect/ak-search-select-ez.ts
@@ -7,7 +7,7 @@ export interface ISearchSelectApi<T> {
     fetchObjects: (query?: string) => Promise<T[]>;
     renderElement: (element: T) => string;
     renderDescription?: (element: T) => string | TemplateResult;
-    value: (element: T | undefined) => string;
+    value: (element: T | null) => string;
     selected?: (element: T, elements: T[]) => boolean;
     groupBy?: (items: T[]) => [string, T[]][];
 }
@@ -50,7 +50,7 @@ export class SearchSelectEz<T> extends SearchSelectBase<T> implements ISearchSel
     public fetchObjects!: (query?: string) => Promise<T[]>;
     public renderElement!: (element: T) => string;
     public renderDescription?: ((element: T) => string | TemplateResult) | undefined;
-    public value!: (element?: T | undefined) => string;
+    public value!: (element: T | null) => string;
     public selected?: ((element: T, elements: T[]) => boolean) | undefined;
 
     @property({ type: Object, attribute: false })

--- a/web/src/elements/forms/SearchSelect/ak-search-select-ez.ts
+++ b/web/src/elements/forms/SearchSelect/ak-search-select-ez.ts
@@ -47,18 +47,26 @@ export interface ISearchSelectEz<T> extends ISearchSelectBase<T> {
 export class SearchSelectEz<T> extends SearchSelectBase<T> implements ISearchSelectEz<T> {
     static styles = [...SearchSelectBase.styles];
 
-    @property({ type: Object, attribute: false })
-    config!: ISearchSelectApi<T>;
+    public fetchObjects!: (query?: string) => Promise<T[]>;
+    public renderElement!: (element: T) => string;
+    public renderDescription?: ((element: T) => string | TemplateResult) | undefined;
+    public value!: (element?: T | undefined) => string;
+    public selected?: ((element: T, elements: T[]) => boolean) | undefined;
 
-    connectedCallback() {
+    @property({ type: Object, attribute: false })
+    public config!: ISearchSelectApi<T>;
+
+    public override connectedCallback() {
         this.fetchObjects = this.config.fetchObjects;
         this.renderElement = this.config.renderElement;
         this.renderDescription = this.config.renderDescription;
         this.value = this.config.value;
         this.selected = this.config.selected;
-        if (this.config.groupBy !== undefined) {
+
+        if (this.config.groupBy) {
             this.groupBy = this.config.groupBy;
         }
+
         super.connectedCallback();
     }
 }

--- a/web/src/elements/forms/SearchSelect/ak-search-select-view.ts
+++ b/web/src/elements/forms/SearchSelect/ak-search-select-view.ts
@@ -155,7 +155,7 @@ export class SearchSelectView extends AKElement implements ISearchSelectView {
      * @property
      */
     @property({ type: String, reflect: false })
-    protected fieldID?: string;
+    public fieldID?: string;
 
     /**
      * If true, the component only sends an input message up to a parent component. If false, the

--- a/web/src/elements/forms/SearchSelect/ak-search-select.ts
+++ b/web/src/elements/forms/SearchSelect/ak-search-select.ts
@@ -44,44 +44,28 @@ export interface ISearchSelect<T> extends ISearchSelectBase<T> {
  *   consequence of the user typing or when selecting from the list.
  *
  */
-
 @customElement("ak-search-select")
 export class SearchSelect<T> extends SearchSelectBase<T> implements ISearchSelect<T> {
     static styles = [...SearchSelectBase.styles];
 
-    // A function which takes the query state object (accepting that it may be empty) and returns a
-    // new collection of objects.
     @property({ attribute: false })
-    fetchObjects!: (query?: string) => Promise<T[]>;
+    public fetchObjects!: (query?: string) => Promise<T[]>;
 
-    // A function passed to this object that extracts a string representation of items of the
-    // collection under search.
     @property({ attribute: false })
-    renderElement!: (element: T) => string;
+    public renderElement!: (element: T) => string;
 
-    // A function passed to this object that extracts an HTML representation of additional
-    // information for items of the collection under search.
     @property({ attribute: false })
-    renderDescription?: (element: T) => string | TemplateResult;
+    public renderDescription?: (element: T) => string | TemplateResult;
 
-    // A function which returns the currently selected object's primary key, used for serialization
-    // into forms.
     @property({ attribute: false })
-    value!: (element: T | undefined) => string;
+    public value!: (element?: T) => string;
 
-    // A function passed to this object that determines an object in the collection under search
-    // should be automatically selected. Only used when the search itself is responsible for
-    // fetching the data; sets an initial default value.
     @property({ attribute: false })
-    selected?: (element: T, elements: T[]) => boolean;
+    public selected?: (element: T, elements: T[]) => boolean;
 
-    // A function passed to this object (or using the default below) that groups objects in the
-    // collection under search into categories.
     @property({ attribute: false })
-    groupBy: (items: T[]) => [string, T[]][] = (items: T[]): [string, T[]][] => {
-        return groupBy(items, () => {
-            return "";
-        });
+    public groupBy: (items: T[]) => [string, T[]][] = (items: T[]): [string, T[]][] => {
+        return groupBy(items, () => "");
     };
 }
 

--- a/web/src/elements/forms/SearchSelect/ak-search-select.ts
+++ b/web/src/elements/forms/SearchSelect/ak-search-select.ts
@@ -9,7 +9,7 @@ export interface ISearchSelect<T> extends ISearchSelectBase<T> {
     fetchObjects: (query?: string) => Promise<T[]>;
     renderElement: (element: T) => string;
     renderDescription?: (element: T) => string | TemplateResult;
-    value: (element: T | undefined) => string;
+    value: (element: T | null) => string;
     selected?: (element: T, elements: T[]) => boolean;
     groupBy: (items: T[]) => [string, T[]][];
 }
@@ -58,7 +58,7 @@ export class SearchSelect<T> extends SearchSelectBase<T> implements ISearchSelec
     public renderDescription?: (element: T) => string | TemplateResult;
 
     @property({ attribute: false })
-    public value!: (element?: T) => string;
+    public value!: (element: T | null) => string;
 
     @property({ attribute: false })
     public selected?: (element: T, elements: T[]) => boolean;

--- a/web/src/elements/forms/SearchSelect/stories/ak-search-select.stories.ts
+++ b/web/src/elements/forms/SearchSelect/stories/ak-search-select.stories.ts
@@ -95,7 +95,7 @@ export const GroupedAndEz = () => {
     const config: ISearchSelectApi<Sample> = {
         fetchObjects: getSamples,
         renderElement: (sample: Sample) => sample.name,
-        value: (sample: Sample | undefined) => sample?.pk ?? "",
+        value: (sample: Sample | null) => sample?.pk ?? "",
         groupBy: (samples: Sample[]) =>
             groupBy(samples, (sample: Sample) => sample.season[0] ?? ""),
     };

--- a/web/src/elements/table/TableColumn.ts
+++ b/web/src/elements/table/TableColumn.ts
@@ -1,9 +1,9 @@
 import { TableLike } from "#elements/table/shared";
+import { ifPresent } from "#elements/utils/attributes";
 
 import { msg, str } from "@lit/localize";
 import { html, TemplateResult } from "lit";
 import { classMap } from "lit/directives/class-map.js";
-import { ifDefined } from "lit/directives/if-defined.js";
 
 type SortDirection = "ascending" | "descending" | "none" | "other";
 
@@ -82,8 +82,8 @@ export function renderTableColumn({
 
     return html`<th
         id=${formatColumnID(columnIndex)}
-        aria-label=${ifDefined(resolvedLabel || undefined)}
-        data-column-id=${ifDefined(orderBy ?? undefined)}
+        aria-label=${ifPresent(resolvedLabel)}
+        data-column-id=${ifPresent(orderBy)}
         scope="col"
         aria-sort=${direction}
         class="${classMap(classes)}"

--- a/web/src/elements/types.ts
+++ b/web/src/elements/types.ts
@@ -64,7 +64,7 @@ export type LitPropertyKey<K> = K extends string ? `.${K}` | `?${K}` | K : K;
  */
 export type LitFC<P> = (
     props: P,
-    children?: SlottedTemplateResult,
+    children?: null | SlottedTemplateResult,
 ) => SlottedTemplateResult | SlottedTemplateResult[];
 
 //#endregion

--- a/web/src/elements/utils/attributes.ts
+++ b/web/src/elements/utils/attributes.ts
@@ -2,7 +2,7 @@ import { ifDefined } from "lit/directives/if-defined.js";
 
 /**
  * A variant of {@linkcode ifDefined} which allows for truthy values to apply
- * an atttribute value.
+ * an attribute value.
  */
 export function ifPresent<T = unknown>(predicateLike: unknown, attributeValue?: T) {
     return ifDefined(

--- a/web/src/elements/utils/attributes.ts
+++ b/web/src/elements/utils/attributes.ts
@@ -1,0 +1,11 @@
+import { ifDefined } from "lit/directives/if-defined.js";
+
+/**
+ * A variant of {@linkcode ifDefined} which allows for truthy values to apply
+ * an atttribute value.
+ */
+export function ifPresent<T = unknown>(predicateLike: unknown, attributeValue?: T) {
+    return ifDefined(
+        predicateLike ? attributeValue || predicateLike || undefined : undefined,
+    ) as NonNullable<T>;
+}

--- a/web/src/elements/utils/ifNotEmpty.ts
+++ b/web/src/elements/utils/ifNotEmpty.ts
@@ -1,5 +1,0 @@
-import { ifDefined } from "lit/directives/if-defined.js";
-
-// A variant of `ifDefined` that also doesn't do anything if the string is empty.
-export const ifNotEmpty = <T>(value: T) =>
-    ifDefined(value === "" ? undefined : (value ?? undefined));

--- a/web/src/user/LibraryApplication/index.ts
+++ b/web/src/user/LibraryApplication/index.ts
@@ -9,6 +9,7 @@ import { truncateWords } from "#common/utils";
 
 import { AKElement } from "#elements/Base";
 import { SlottedTemplateResult } from "#elements/types";
+import { ifPresent } from "#elements/utils/attributes";
 
 import type { UserInterface } from "#user/index.entrypoint";
 import type { RACLaunchEndpointModal } from "#user/LibraryApplication/RACLaunchEndpointModal";
@@ -19,7 +20,6 @@ import { msg } from "@lit/localize";
 import { css, CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, property, query } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
-import { ifDefined } from "lit/directives/if-defined.js";
 import { styleMap } from "lit/directives/style-map.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
@@ -109,7 +109,7 @@ export class LibraryApplication extends AKElement {
                         <ak-app-icon
                             size=${PFSize.Large}
                             name=${this.application.name}
-                            icon=${ifDefined(this.application.metaIcon || undefined)}
+                            icon=${ifPresent(this.application.metaIcon)}
                         ></ak-app-icon>
                     </a>
                 </div>
@@ -127,20 +127,20 @@ export class LibraryApplication extends AKElement {
         }
         return html`<div class="pf-c-card__header">
                 <a
-                    href="${ifDefined(this.application.launchUrl ?? "")}"
-                    target="${ifDefined(this.application.openInNewTab ? "_blank" : undefined)}"
+                    href="${ifPresent(this.application.launchUrl ?? "")}"
+                    target="${ifPresent(this.application.openInNewTab, "_blank")}"
                 >
                     <ak-app-icon
                         size=${PFSize.Large}
                         name=${this.application.name}
-                        icon=${ifDefined(this.application.metaIcon || undefined)}
+                        icon=${ifPresent(this.application.metaIcon)}
                     ></ak-app-icon>
                 </a>
             </div>
             <div class="pf-c-card__title">
                 <a
-                    href="${ifDefined(this.application.launchUrl ?? "")}"
-                    target="${ifDefined(this.application.openInNewTab ? "_blank" : undefined)}"
+                    href="${ifPresent(this.application.launchUrl ?? "")}"
+                    target="${ifPresent(this.application.openInNewTab, "_blank")}"
                     >${this.application.name}</a
                 >
             </div>`;

--- a/web/src/user/LibraryPage/ak-library-application-search.ts
+++ b/web/src/user/LibraryPage/ak-library-application-search.ts
@@ -156,6 +156,7 @@ export class LibraryPageApplicationSearch extends AKElement {
             type="text"
             class="pf-u-display-none pf-u-display-block-on-md"
             autofocus
+            aria-label=${msg("Search for an application by name")}
             placeholder=${msg("Search...")}
             value=${ifDefined(this.query)}
         />`;

--- a/web/src/user/LibraryPage/ak-library-impl.ts
+++ b/web/src/user/LibraryPage/ak-library-impl.ts
@@ -186,10 +186,10 @@ export class LibraryPage extends AKElement {
             tabindex="-1"
             id="main-content"
         >
-            <header class="pf-c-content header">
+            <div class="pf-c-content header">
                 <h1>${msg("My applications")}</h1>
                 ${this.uiConfig.searchEnabled ? this.renderSearch() : nothing}
-            </header>
+            </div>
             <section class="pf-c-page__main-section">${this.renderState()}</section>
         </main>`;
     }

--- a/web/src/user/user-settings/UserSettingsPage.ts
+++ b/web/src/user/user-settings/UserSettingsPage.ts
@@ -95,7 +95,7 @@ export class UserSettingsPage extends AKElement {
             this.userSettings?.filter((stage) => stage.component === "ak-user-settings-password") ||
             [];
         return html`<div class="pf-c-page">
-            <div class="pf-c-page__main" tabindex="-1">
+            <main class="pf-c-page__main" tabindex="-1">
                 <ak-tabs vertical>
                     <div
                         id="page-details"
@@ -202,7 +202,7 @@ export class UserSettingsPage extends AKElement {
                         </div>
                     </div>
                 </ak-tabs>
-            </div>
+            </main>
         </div>`;
     }
 }

--- a/web/src/user/user-settings/UserSettingsPage.ts
+++ b/web/src/user/user-settings/UserSettingsPage.ts
@@ -95,11 +95,14 @@ export class UserSettingsPage extends AKElement {
             this.userSettings?.filter((stage) => stage.component === "ak-user-settings-password") ||
             [];
         return html`<div class="pf-c-page">
-            <main role="main" class="pf-c-page__main" tabindex="-1">
+            <div class="pf-c-page__main" tabindex="-1">
                 <ak-tabs vertical>
-                    <section
+                    <div
+                        id="page-details"
+                        role="tabpanel"
+                        tabindex="0"
                         slot="page-details"
-                        data-tab-title="${msg("User details")}"
+                        aria-label=${msg("User details")}
                         class="pf-c-page__main-section pf-m-no-padding-mobile"
                     >
                         <div class="pf-l-stack pf-m-gutter">
@@ -114,10 +117,13 @@ export class UserSettingsPage extends AKElement {
                                     : nothing}
                             </div>
                         </div>
-                    </section>
-                    <section
+                    </div>
+                    <div
+                        id="page-sessions"
+                        role="tabpanel"
+                        tabindex="0"
                         slot="page-sessions"
-                        data-tab-title="${msg("Sessions")}"
+                        aria-label=${msg("Sessions")}
                         class="pf-c-page__main-section pf-m-no-padding-mobile"
                     >
                         <div class="pf-c-card">
@@ -129,10 +135,13 @@ export class UserSettingsPage extends AKElement {
                                 ></ak-user-session-list>
                             </div>
                         </div>
-                    </section>
-                    <section
+                    </div>
+                    <div
+                        id="page-consents"
+                        role="tabpanel"
+                        tabindex="0"
                         slot="page-consents"
-                        data-tab-title="${msg("Consent")}"
+                        aria-label=${msg("Consent")}
                         class="pf-c-page__main-section pf-m-no-padding-mobile"
                     >
                         <div class="pf-c-card">
@@ -142,10 +151,13 @@ export class UserSettingsPage extends AKElement {
                                 ></ak-user-consent-list>
                             </div>
                         </div>
-                    </section>
-                    <section
+                    </div>
+                    <div
+                        id="page-mfa"
+                        role="tabpanel"
+                        tabindex="0"
                         slot="page-mfa"
-                        data-tab-title="${msg("MFA Devices")}"
+                        aria-label=${msg("MFA Devices")}
                         class="pf-c-page__main-section pf-m-no-padding-mobile"
                     >
                         <div class="pf-c-card">
@@ -155,10 +167,13 @@ export class UserSettingsPage extends AKElement {
                                 ></ak-user-settings-mfa>
                             </div>
                         </div>
-                    </section>
-                    <section
+                    </div>
+                    <div
+                        id="page-sources"
+                        role="tabpanel"
+                        tabindex="0"
                         slot="page-sources"
-                        data-tab-title="${msg("Connected services")}"
+                        aria-label=${msg("Connected services")}
                         class="pf-c-page__main-section pf-m-no-padding-mobile"
                     >
                         <div class="pf-c-card">
@@ -171,10 +186,13 @@ export class UserSettingsPage extends AKElement {
                                 userId=${ifDefined(rootInterface<UserInterface>()?.me?.user.pk)}
                             ></ak-user-settings-source>
                         </div>
-                    </section>
-                    <section
+                    </div>
+                    <div
+                        id="page-tokens"
+                        role="tabpanel"
+                        tabindex="0"
                         slot="page-tokens"
-                        data-tab-title="${msg("Tokens and App passwords")}"
+                        aria-label=${msg("Tokens and App passwords")}
                         class="pf-c-page__main-section pf-m-no-padding-mobile"
                     >
                         <div class="pf-c-card">
@@ -182,9 +200,9 @@ export class UserSettingsPage extends AKElement {
                                 <ak-user-token-list></ak-user-token-list>
                             </div>
                         </div>
-                    </section>
+                    </div>
                 </ak-tabs>
-            </main>
+            </div>
         </div>`;
     }
 }

--- a/web/test/browser/prerequisites.setup.ts
+++ b/web/test/browser/prerequisites.setup.ts
@@ -1,0 +1,11 @@
+import { expect, test as setup } from "#e2e";
+
+setup("Web server availability", async ({ baseURL }) => {
+    expect(baseURL, "Base URL is set").toBeTruthy();
+
+    const ok = await fetch(baseURL!)
+        .then((res) => res.ok)
+        .catch(() => false);
+
+    expect(ok, `Web server should be listening on ${baseURL}`).toBeTruthy();
+});

--- a/web/test/browser/providers.test.ts
+++ b/web/test/browser/providers.test.ts
@@ -51,7 +51,7 @@ test.describe("Provider Wizard", () => {
         const providerName = providerNames.get(testId)!;
 
         const $provider = await test.step("Find provider via search", async () => {
-            const searchInput = page.getByRole("search").getByPlaceholder("Search for providers");
+            const searchInput = page.getByLabel("Provider Search");
 
             await searchInput.fill(providerName);
 


### PR DESCRIPTION
## Dependencies

- #16750

## Details

This PR prepares the flow search components for use in a screen reader and e2e test suite. The changes here represent a partial implementation of accessibility, curated for an approachable PR review.

- Fix issue where escape key closes modal when selecting search select item
- Clean up mismatch of instance bound methods 

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
