### PR TITLE
web/a11y: Navigation Banner 

### DIFF
--- a/web/src/components/ak-nav-buttons.ts
+++ b/web/src/components/ak-nav-buttons.ts
@@ -175,6 +175,7 @@ export class NavigationButtons extends AKElement {
         return html`<img
             class="pf-c-page__header-tools-item pf-c-avatar pf-m-hidden pf-m-visible-on-xl"
             src=${ifDefined(this.me?.user.avatar)}
+            aria-hidden="true"
             alt="${msg("Avatar image")}"
         />`;
     }
@@ -189,7 +190,7 @@ export class NavigationButtons extends AKElement {
     }
 
     render() {
-        return html`<div class="pf-c-page__header-tools">
+        return html`<div role="presentation" class="pf-c-page__header-tools">
             <div class="pf-c-page__header-tools-group">
                 ${this.renderApiDrawerTrigger()}
                 <!-- -->

--- a/web/src/components/ak-page-navbar.ts
+++ b/web/src/components/ak-page-navbar.ts
@@ -88,7 +88,7 @@ export class AKPageNavbar
                 color: var(--ak-dark-foreground);
             }
 
-            navbar {
+            .main-content {
                 border-bottom: var(--pf-global--BorderWidth--sm);
                 border-bottom-style: solid;
                 border-bottom-color: var(--pf-global--BorderColor--100);
@@ -350,7 +350,12 @@ export class AKPageNavbar
     renderIcon() {
         if (this.icon) {
             if (this.iconImage && !this.icon.startsWith("fa://")) {
-                return html`<img class="accent-icon pf-icon" src="${this.icon}" alt="page icon" />`;
+                return html`<img
+                    aria-hidden="true"
+                    class="accent-icon pf-icon"
+                    src="${this.icon}"
+                    alt="page icon"
+                />`;
             }
 
             const icon = this.icon.replaceAll("fa://", "fa ");
@@ -362,9 +367,9 @@ export class AKPageNavbar
 
     render(): TemplateResult {
         return html` <slot></slot>
-            <navbar aria-label="Main" class="navbar">
-                <aside class="brand ${this.open ? "" : "pf-m-collapsed"}">
-                    <a href="#/">
+            <div role="banner" aria-label="Main" class="main-content">
+                <aside role="presentation" class="brand ${this.open ? "" : "pf-m-collapsed"}">
+                    <a aria-label="${msg("Home")}" href="#/">
                         <div class="logo">
                             <img
                                 src=${themeImage(this.brandingLogo)}
@@ -375,31 +380,35 @@ export class AKPageNavbar
                     </a>
                 </aside>
                 <button
+                    aria-controls="global-nav"
                     class="sidebar-trigger pf-c-button pf-m-plain"
                     @click=${this.#toggleSidebar}
-                    aria-label=${msg("Toggle sidebar")}
+                    aria-label=${this.open ? msg("Collapse navigation") : msg("Expand navigation")}
                     aria-expanded=${this.open ? "true" : "false"}
                 >
-                    <i class="fas fa-bars"></i>
+                    <i aria-hidden="true" class="fas fa-bars"></i>
                 </button>
 
-                <section
-                    class="items primary pf-c-content ${this.description ? "block-sibling" : ""}"
-                >
-                    <h1 class="page-title">
+                <div class="items primary pf-c-content ${this.description ? "block-sibling" : ""}">
+                    <h1 aria-labelledby="page-navbar-heading" class="page-title">
                         ${this.hasIcon
-                            ? html`<slot name="icon">${this.renderIcon()}</slot>`
+                            ? html`<slot aria-hidden="true" name="icon">${this.renderIcon()}</slot>`
                             : nothing}
-                        ${this.header}
+                        <span id="page-navbar-heading">${this.header}</span>
                     </h1>
-                </section>
+                </div>
                 ${this.description
-                    ? html`<section class="items page-description pf-c-content">
+                    ? html`<div
+                          role="heading"
+                          aria-level="2"
+                          aria-label="${this.description}"
+                          class="items page-description pf-c-content"
+                      >
                           <p>${this.description}</p>
-                      </section>`
+                      </div>`
                     : nothing}
 
-                <section class="items secondary">
+                <div class="items secondary">
                     <div class="pf-c-page__header-tools-group">
                         <ak-nav-buttons .uiConfig=${this.uiConfig} .me=${this.session}>
                             <a
@@ -411,8 +420,8 @@ export class AKPageNavbar
                             </a>
                         </ak-nav-buttons>
                     </div>
-                </section>
-            </navbar>`;
+                </div>
+            </div>`;
     }
 
     //#endregion


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

This PR prepares the admin navigation (AKA "page banner") for use in a screen reader and e2e test suite. The changes here represent a partial implementation of accessibility, curated for an approachable PR review.

<img width="648" height="183" alt="Screenshot 2025-07-30 at 04 51 30" src="https://github.com/user-attachments/assets/5fb9055f-c969-435b-ad1b-5912bdafc71a" />


---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
