### PR TITLE
web: Form validation regressions, consistency fixes

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -57,7 +57,6 @@
                 "@types/react-dom": "^19.1.7",
                 "@typescript-eslint/eslint-plugin": "^8.38.0",
                 "@typescript-eslint/parser": "^8.38.0",
-                "@wdio/spec-reporter": "^9.19.0",
                 "@webcomponents/webcomponentsjs": "^2.8.0",
                 "base64-js": "^1.5.1",
                 "change-case": "^5.4.4",
@@ -126,7 +125,8 @@
                 "@wdio/browser-runner": "^9.19.0",
                 "@wdio/cli": "^9.19.0",
                 "@wdio/spec-reporter": "^9.19.0",
-                "@web/test-runner": "^0.20.2"
+                "@web/test-runner": "^0.20.2",
+                "chromedriver": "^139.0.0"
             }
         },
         "../packages/core": {
@@ -5837,6 +5837,13 @@
                 "node": ">=14.16"
             }
         },
+        "node_modules/@testim/chrome-version": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.1.4.tgz",
+            "integrity": "sha512-kIhULpw9TrGYnHp/8VfdcneIcxKnLixmADtukQRtJUmsVlMg0niMkwV0xZmi8hqa57xqilIHjWFA0GKvEjVU5g==",
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/@testing-library/dom": {
             "version": "10.4.0",
             "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
@@ -10703,6 +10710,29 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/chromedriver": {
+            "version": "139.0.0",
+            "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-139.0.0.tgz",
+            "integrity": "sha512-4hzJhx2B2WbGP1160KaDkAIWMHmEBabldes1SrU75JwrzviYevopcVCxQw9B9Ykx+500ij06fv2retL5mK7DbA==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@testim/chrome-version": "^1.1.4",
+                "axios": "^1.7.4",
+                "compare-versions": "^6.1.0",
+                "extract-zip": "^2.0.1",
+                "proxy-agent": "^6.4.0",
+                "proxy-from-env": "^1.1.0",
+                "tcp-port-used": "^1.0.2"
+            },
+            "bin": {
+                "chromedriver": "bin/chromedriver"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
         "node_modules/ci-info": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
@@ -10998,6 +11028,13 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
             "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="
+        },
+        "node_modules/compare-versions": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+            "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/compatx": {
             "version": "0.1.8",
@@ -17002,6 +17039,13 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-url": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+            "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/is-valid-element-name": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-valid-element-name/-/is-valid-element-name-1.0.0.tgz",
@@ -17063,6 +17107,21 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/is2": {
+            "version": "2.0.9",
+            "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.9.tgz",
+            "integrity": "sha512-rZkHeBn9Zzq52sd9IUIV3a5mfwBY+o2HePMh0wkGBM4z4qjvy2GwVxQ6nNXSfw6MmVP6gf1QIlWjiOavhM3x5g==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "deep-is": "^0.1.3",
+                "ip-regex": "^4.1.0",
+                "is-url": "^1.2.4"
+            },
+            "engines": {
+                "node": ">=v0.10.0"
             }
         },
         "node_modules/isarray": {
@@ -25133,6 +25192,42 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/tcp-port-used": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-1.0.2.tgz",
+            "integrity": "sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "debug": "4.3.1",
+                "is2": "^2.0.6"
+            }
+        },
+        "node_modules/tcp-port-used/node_modules/debug": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+            "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/tcp-port-used/node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/test-exclude": {
             "version": "6.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -193,7 +193,8 @@
         "@wdio/browser-runner": "^9.19.0",
         "@wdio/cli": "^9.19.0",
         "@wdio/spec-reporter": "^9.19.0",
-        "@web/test-runner": "^0.20.2"
+        "@web/test-runner": "^0.20.2",
+        "chromedriver": "^139.0.0"
     },
     "wireit": {
         "build": {

--- a/web/src/admin/applications/wizard/steps/ak-application-wizard-application-step.ts
+++ b/web/src/admin/applications/wizard/steps/ak-application-wizard-application-step.ts
@@ -21,7 +21,7 @@ import { snakeCase } from "change-case";
 
 import { msg } from "@lit/localize";
 import { html } from "lit";
-import { customElement, query, state } from "lit/decorators.js";
+import { customElement, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
 function trimMany<T extends object, K extends keyof T>(target: T, keys: K[]): Pick<T, K> {
@@ -43,8 +43,9 @@ export class ApplicationWizardApplicationStep extends ApplicationWizardStep {
     @state()
     errors = new Map<keyof ApplicationRequest, string>();
 
-    @query("form#applicationform")
-    form!: HTMLFormElement;
+    public get form(): HTMLFormElement | null {
+        return this.renderRoot.querySelector("form#applicationform");
+    }
 
     constructor() {
         super();

--- a/web/src/admin/applications/wizard/steps/ak-application-wizard-application-step.ts
+++ b/web/src/admin/applications/wizard/steps/ak-application-wizard-application-step.ts
@@ -71,7 +71,7 @@ export class ApplicationWizardApplicationStep extends ApplicationWizardStep {
             this.errors.set("name", msg("An application name is required"));
         }
 
-        if (!values.metaLaunchUrl || !URL.canParse(values.metaLaunchUrl)) {
+        if (values.metaLaunchUrl && !URL.canParse(values.metaLaunchUrl)) {
             this.errors.set("metaLaunchUrl", msg("Not a valid URL"));
         }
 

--- a/web/src/admin/applications/wizard/steps/ak-application-wizard-application-step.ts
+++ b/web/src/admin/applications/wizard/steps/ak-application-wizard-application-step.ts
@@ -123,7 +123,6 @@ export class ApplicationWizardApplicationStep extends ApplicationWizardStep {
                     value=${ifDefined(app.name)}
                     label=${msg("Name")}
                     required
-                    ?invalid=${this.errors.has("name")}
                     .errorMessages=${errors.name ?? this.errorMessages("name")}
                     help=${msg("The name displayed in the application library.")}
                 ></ak-text-input>

--- a/web/src/admin/applications/wizard/steps/ak-application-wizard-edit-binding-step.ts
+++ b/web/src/admin/applications/wizard/steps/ak-application-wizard-edit-binding-step.ts
@@ -48,8 +48,9 @@ export class ApplicationWizardEditBindingStep extends ApplicationWizardStep {
 
     hide = true;
 
-    @query("form#bindingform")
-    form!: HTMLFormElement;
+    public get form(): HTMLFormElement | null {
+        return this.renderRoot.querySelector("form#bindingform");
+    }
 
     @query(".policy-search-select")
     searchSelect!: SearchSelectBase<Policy> | SearchSelectBase<Group> | SearchSelectBase<User>;
@@ -71,7 +72,7 @@ export class ApplicationWizardEditBindingStep extends ApplicationWizardStep {
 
     override handleButton(button: NavigableButton) {
         if (button.kind === "next") {
-            if (!this.form.checkValidity()) {
+            if (!this.form?.checkValidity()) {
                 return;
             }
             const policyObject = this.searchSelect.selectedObject;

--- a/web/src/admin/applications/wizard/steps/ak-application-wizard-provider-step.ts
+++ b/web/src/admin/applications/wizard/steps/ak-application-wizard-provider-step.ts
@@ -33,7 +33,24 @@ export class ApplicationWizardProviderStep extends ApplicationWizardStep {
     label = msg("Configure Provider");
 
     @query("#providerform")
-    element!: ApplicationWizardProviderForm<OneOfProvider>;
+    protected element!: ApplicationWizardProviderForm<OneOfProvider>;
+
+    get form(): HTMLFormElement | null {
+        const providerForm = this.element.form;
+
+        if (!providerForm) {
+            // TODO: This needs to be removed once all steps can report their validity.
+            console.debug(
+                "authentik/wizard: Form not found within provider step",
+                this,
+                this.element,
+            );
+
+            return null;
+        }
+
+        return providerForm;
+    }
 
     get valid() {
         return this.element.valid;
@@ -100,6 +117,7 @@ export class ApplicationWizardProviderStep extends ApplicationWizardStep {
     updated(changed: PropertyValues<this>) {
         if (changed.has("wizard")) {
             const label = this.element?.label ?? this.label;
+
             if (label !== this.label) {
                 this.label = label;
             }

--- a/web/src/admin/applications/wizard/steps/providers/ApplicationWizardProviderForm.ts
+++ b/web/src/admin/applications/wizard/steps/providers/ApplicationWizardProviderForm.ts
@@ -16,7 +16,7 @@ import { snakeCase } from "change-case";
 import { CSSResult } from "lit";
 import { property, query } from "lit/decorators.js";
 
-export class ApplicationWizardProviderForm<T extends OneOfProvider> extends AKElement {
+export abstract class ApplicationWizardProviderForm<T extends OneOfProvider> extends AKElement {
     static styles: CSSResult[] = [...AwadStyles];
 
     label = "";
@@ -28,9 +28,13 @@ export class ApplicationWizardProviderForm<T extends OneOfProvider> extends AKEl
     errors: Record<string | number | symbol, string> = {};
 
     @query("form#providerform")
-    form!: HTMLFormElement;
+    public form!: HTMLFormElement | null;
 
     get formValues() {
+        if (!this.form) {
+            throw new TypeError("Form reference is not set");
+        }
+
         return serializeForm([
             ...this.form.querySelectorAll("ak-form-element-horizontal"),
             ...this.form.querySelectorAll("[data-ak-control]"),
@@ -39,7 +43,8 @@ export class ApplicationWizardProviderForm<T extends OneOfProvider> extends AKEl
 
     get valid() {
         this.errors = {};
-        return this.form.checkValidity();
+
+        return !!this.form?.checkValidity();
     }
 
     errorMessages(name: string) {

--- a/web/src/admin/applications/wizard/steps/providers/ak-application-wizard-provider-for-oauth.ts
+++ b/web/src/admin/applications/wizard/steps/providers/ak-application-wizard-provider-for-oauth.ts
@@ -48,7 +48,7 @@ export class ApplicationWizardOauth2ProviderForm extends ApplicationWizardProvid
             <form id="providerform" class="pf-c-form pf-m-horizontal" slot="form">
                 ${renderForm(
                     provider ?? {},
-                    errors,
+                    errors.provider ?? {},
                     this.showClientSecret,
                     showClientSecretCallback,
                 )}

--- a/web/src/admin/sources/kerberos/KerberosSourceForm.ts
+++ b/web/src/admin/sources/kerberos/KerberosSourceForm.ts
@@ -251,7 +251,7 @@ export class KerberosSourceForm extends WithCapabilitiesConfig(BaseSourceForm<Ke
                     <ak-secret-text-input
                         name="syncPassword"
                         label=${msg("Sync password")}
-                        ?revealed=${this.instance === undefined}
+                        ?revealed=${!this.instance}
                         help=${msg(
                             "Password used to authenticate to the KDC for syncing. Optional if Sync keytab or Sync credentials cache is provided.",
                         )}

--- a/web/src/admin/sources/ldap/LDAPSourceForm.ts
+++ b/web/src/admin/sources/ldap/LDAPSourceForm.ts
@@ -266,7 +266,7 @@ export class LDAPSourceForm extends BaseSourceForm<LDAPSource> {
                     <ak-secret-text-input
                         label=${msg("Bind Password")}
                         name="bindPassword"
-                        ?revealed=${this.instance === undefined}
+                        ?revealed=${!this.instance}
                     ></ak-secret-text-input>
                     <ak-form-element-horizontal label=${msg("Base DN")} required name="baseDn">
                         <input

--- a/web/src/admin/stages/authenticator_duo/AuthenticatorDuoStageForm.ts
+++ b/web/src/admin/stages/authenticator_duo/AuthenticatorDuoStageForm.ts
@@ -100,8 +100,8 @@ export class AuthenticatorDuoStageForm extends BaseStageForm<AuthenticatorDuoSta
                         name="clientSecret"
                         label=${msg("Secret key")}
                         input-hint="code"
-                        required
-                        ?revealed=${this.instance === undefined}
+                        ?required=${!this.instance}
+                        ?revealed=${!this.instance}
                     ></ak-secret-text-input>
                 </div>
             </ak-form-group>
@@ -128,7 +128,7 @@ export class AuthenticatorDuoStageForm extends BaseStageForm<AuthenticatorDuoSta
                         name="adminSecretKey"
                         label=${msg("Secret key")}
                         input-hint="code"
-                        ?revealed=${this.instance === undefined}
+                        ?revealed=${!this.instance}
                     ></ak-secret-text-input>
                 </div>
             </ak-form-group>

--- a/web/src/admin/stages/authenticator_email/AuthenticatorEmailStageForm.ts
+++ b/web/src/admin/stages/authenticator_email/AuthenticatorEmailStageForm.ts
@@ -81,7 +81,7 @@ export class AuthenticatorEmailStageForm extends BaseStageForm<AuthenticatorEmai
                 <ak-secret-text-input
                     name="password"
                     label=${msg("SMTP Password")}
-                    ?revealed=${this.instance === undefined}
+                    ?revealed=${!this.instance}
                 ></ak-secret-text-input>
 
                 <ak-form-element-horizontal name="useTls">

--- a/web/src/admin/stages/captcha/CaptchaStageForm.ts
+++ b/web/src/admin/stages/captcha/CaptchaStageForm.ts
@@ -75,8 +75,8 @@ export class CaptchaStageForm extends BaseStageForm<CaptchaStage> {
                         name="privateKey"
                         label=${msg("Private Key")}
                         input-hint="code"
-                        required
-                        ?revealed=${this.instance === undefined}
+                        ?required=${!this.instance}
+                        ?revealed=${!this.instance}
                         help=${msg(
                             "Private key, acquired from https://www.google.com/recaptcha/intro/v3.html.",
                         )}

--- a/web/src/admin/stages/captcha/CaptchaStageForm.ts
+++ b/web/src/admin/stages/captcha/CaptchaStageForm.ts
@@ -105,26 +105,14 @@ export class CaptchaStageForm extends BaseStageForm<CaptchaStage> {
                         value="${ifDefined(this.instance?.scoreMaxThreshold || -1)}"
                         help=${msg("Maximum allowed score to allow continuing")}
                     ></ak-number-input>
-                    <ak-form-element-horizontal name="errorOnInvalidScore">
-                        <label class="pf-c-switch">
-                            <input
-                                class="pf-c-switch__input"
-                                type="checkbox"
-                                ?checked=${this.instance?.errorOnInvalidScore ?? true}
-                            />
-                            <span class="pf-c-switch__toggle">
-                                <span class="pf-c-switch__toggle-icon">
-                                    <i class="fas fa-check" aria-hidden="true"></i>
-                                </span>
-                            </span>
-                            <span class="pf-c-switch__label">${msg("Error on invalid score")}</span>
-                        </label>
-                        <p class="pf-c-form__helper-text">
-                            ${msg(
-                                "When enabled and the resultant score is outside the threshold, the user will not be able to continue. When disabled, the user will be able to continue and the score can be used in policies to customize further stages.",
-                            )}
-                        </p>
-                    </ak-form-element-horizontal>
+                    <ak-switch-input
+                        ?checked=${!!(this.instance?.errorOnInvalidScore ?? true)}
+                        name="errorOnInvalidScore"
+                        label=${msg("Error on invalid score")}
+                        help=${msg(
+                            "When enabled and the resultant score is outside the threshold, the user will not be able to continue. When disabled, the user will be able to continue and the score can be used in policies to customize further stages.",
+                        )}
+                    ></ak-switch-input>
                 </div>
             </ak-form-group>
             <ak-form-group label="${msg("Advanced settings")}">

--- a/web/src/admin/stages/email/EmailStageForm.ts
+++ b/web/src/admin/stages/email/EmailStageForm.ts
@@ -77,7 +77,7 @@ export class EmailStageForm extends BaseStageForm<EmailStage> {
                 <ak-secret-text-input
                     label=${msg("SMTP Password")}
                     name="password"
-                    ?revealed=${this.instance === undefined}
+                    ?revealed=${!this.instance}
                 ></ak-secret-text-input>
                 <ak-form-element-horizontal name="useTls">
                     <label class="pf-c-switch">

--- a/web/src/common/errors/network.ts
+++ b/web/src/common/errors/network.ts
@@ -174,6 +174,10 @@ export function pluckErrorDetail(error: Error, fallback?: string): string;
  */
 export function pluckErrorDetail(errorLike: unknown, fallback?: string): string;
 export function pluckErrorDetail(errorLike: unknown, fallback?: string): string {
+    if (typeof errorLike === "string" && errorLike) {
+        return errorLike;
+    }
+
     fallback ||= composeResponseErrorDescriptor(
         ResponseErrorMessages[HTTPStatusCode.InternalServiceError],
     );

--- a/web/src/common/styles/authentik.css
+++ b/web/src/common/styles/authentik.css
@@ -35,6 +35,31 @@
     --ak-navbar--height: 7rem;
 }
 
+.pf-c-form__group {
+    --pf-c-form--m-horizontal__group-label--md--GridColumnWidth: minmax(max-content, 9.375rem);
+    column-gap: var(--pf-global--spacer--md);
+}
+
+.pf-c-form__group-label {
+    display: flex;
+    user-select: none;
+    padding-top: var(--pf-c-form--m-horizontal__group-label--md--PaddingTop);
+
+    /* Increase the pressable area of the label. */
+    .pf-c-form__label {
+        display: block;
+        flex: 1 1 auto;
+    }
+}
+
+.pf-c-form__label[aria-required] .pf-c-form__label-text::after {
+    content: "*";
+    user-select: none;
+    margin-left: var(--pf-c-form__label-required--MarginLeft);
+    font-size: var(--pf-c-form__label-required--FontSize);
+    color: var(--pf-c-form__label-required--Color);
+}
+
 @supports selector(::-webkit-scrollbar) {
     ::-webkit-scrollbar {
         width: 5px;

--- a/web/src/common/styles/authentik.css
+++ b/web/src/common/styles/authentik.css
@@ -36,7 +36,6 @@
 }
 
 .pf-c-form__group {
-    --pf-c-form--m-horizontal__group-label--md--GridColumnWidth: minmax(max-content, 9.375rem);
     column-gap: var(--pf-global--spacer--md);
 }
 

--- a/web/src/components/HorizontalLightComponent.ts
+++ b/web/src/components/HorizontalLightComponent.ts
@@ -139,7 +139,6 @@ export abstract class HorizontalLightComponent<T>
             ?hidden=${this.hidden}
             name=${this.name}
             .errorMessages=${this.errorMessages}
-            ?invalid=${this.invalid}
         >
             ${this.renderControl()} ${this.renderHelp()}
         </ak-form-element-horizontal> `;

--- a/web/src/components/ak-label.ts
+++ b/web/src/components/ak-label.ts
@@ -1,0 +1,27 @@
+import { LitFC } from "#elements/types";
+
+import { spread } from "@open-wc/lit-helpers";
+import type { LabelHTMLAttributes } from "react";
+
+import { html, nothing } from "lit";
+import { ifDefined } from "lit/directives/if-defined.js";
+
+export interface FormLabelProps extends LabelHTMLAttributes<HTMLLabelElement> {
+    required?: boolean;
+}
+
+export const AKLabel: LitFC<FormLabelProps> = (
+    { required, htmlFor, ...labelAttributes } = {},
+    children,
+) => {
+    if (!children) return nothing;
+
+    return html`<label
+        class="pf-c-form__label"
+        for=${ifDefined(htmlFor)}
+        ?aria-required=${required}
+        ${spread(labelAttributes)}
+    >
+        <span class="pf-c-form__label-text">${children}</span>
+    </label>`;
+};

--- a/web/src/components/ak-switch-input.ts
+++ b/web/src/components/ak-switch-input.ts
@@ -44,6 +44,8 @@ export class AkSwitchInput extends AKElement {
         const helpText = this.help.trim();
 
         return html` <ak-form-element-horizontal name=${this.name} ?required=${this.required}>
+            <div slot="label" class="pf-c-form__group-label"></div>
+
             <label class="pf-c-switch" for="${this.#fieldID}">
                 <input
                     id="${this.#fieldID}"

--- a/web/src/components/ak-wizard/WizardStep.ts
+++ b/web/src/components/ak-wizard/WizardStep.ts
@@ -60,7 +60,7 @@ const BUTTON_KIND_TO_LABEL: Record<ButtonKind, string> = {
  * @fires WizardCloseEvent - request parent container (Wizard) to close the wizard
  */
 
-export class WizardStep extends AKElement {
+export abstract class WizardStep extends AKElement {
     // These additions are necessary because we don't want to inherit *all* of the modal box
     // modifiers, just the ones related to managing the height of the display box.
     static styles = [
@@ -107,6 +107,20 @@ export class WizardStep extends AKElement {
      * Show the [Cancel] icon and offer the [Cancel] button
      */
     public canCancel = false;
+
+    /**
+     * Report the validity of the element, triggering client-side validation.
+     *
+     * @returns Whether the form is valid.
+     */
+    public abstract reportValidity(): boolean;
+
+    /**
+     * Check the validity of the element.
+     *
+     * @returns Whether the form is valid.
+     */
+    public abstract checkValidity(): boolean;
 
     /**
      * The ID of the current step.
@@ -177,9 +191,15 @@ export class WizardStep extends AKElement {
     @bound
     onWizardNavigationEvent(ev: Event, button: WizardButton) {
         ev.stopPropagation();
+
         if (!isNavigable(button)) {
             throw new Error("Non-navigable button sent to handleNavigationEvent");
         }
+
+        if (button.kind === "next" && !this.reportValidity()) {
+            return;
+        }
+
         this.handleButton(button);
     }
 

--- a/web/src/elements/forms/Form.ts
+++ b/web/src/elements/forms/Form.ts
@@ -189,7 +189,7 @@ export abstract class Form<T = Record<string, unknown>> extends AKElement {
     //#endregion
 
     public get form(): HTMLFormElement | null {
-        return this.shadowRoot?.querySelector("form") || null;
+        return this.renderRoot?.querySelector("form") || null;
     }
 
     @state()

--- a/web/src/elements/forms/HorizontalFormElement.ts
+++ b/web/src/elements/forms/HorizontalFormElement.ts
@@ -5,7 +5,7 @@ import { isNameableElement, NamedElement } from "#elements/utils/inputs";
 import { AKFormErrors, ErrorProp } from "#components/ak-field-errors";
 import { AKLabel } from "#components/ak-label";
 
-import { css, CSSResult, html, nothing, PropertyValues, TemplateResult } from "lit";
+import { css, CSSResult, html, PropertyValues, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import PFForm from "@patternfly/patternfly/components/Form/form.css";
@@ -117,12 +117,13 @@ export class HorizontalFormElement extends AKElement {
         this.#synchronizeAttributes();
 
         return html`<div class="pf-c-form__group" role="group">
-            ${this.label
-                ? html`<div class="pf-c-form__group-label">
+            <div class="pf-c-form__group-label">
+                ${this.label
+                    ? html`
                       ${AKLabel({ htmlFor: this.fieldID, required: this.required }, this.label)}
                   </div>`
-                : nothing}
-            <slot name="label"></slot>
+                    : html`<slot name="label"></slot>`}
+            </div>
 
             <div class="pf-c-form__group-control">
                 <slot class="pf-c-form__horizontal-group"></slot>

--- a/web/src/elements/forms/HorizontalFormElement.ts
+++ b/web/src/elements/forms/HorizontalFormElement.ts
@@ -59,7 +59,7 @@ export class HorizontalFormElement extends AKElement {
     @property({ type: String })
     public label?: string;
 
-    @property({ type: Boolean })
+    @property({ type: Boolean, reflect: false })
     public required?: boolean;
 
     @property({ attribute: false })

--- a/web/src/elements/forms/HorizontalFormElement.ts
+++ b/web/src/elements/forms/HorizontalFormElement.ts
@@ -4,10 +4,10 @@ import { AKFormGroup } from "#elements/forms/FormGroup";
 import { isNameableElement } from "#elements/utils/inputs";
 
 import { AKFormErrors, ErrorProp } from "#components/ak-field-errors";
+import { AKLabel } from "#components/ak-label";
 
-import { css, CSSResult, html, TemplateResult } from "lit";
+import { css, CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
-import { ifDefined } from "lit/directives/if-defined.js";
 
 import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
@@ -49,11 +49,22 @@ export class HorizontalFormElement extends AKElement {
         `,
     ];
 
+    //#region Properties
+
+    /**
+     * A unique ID to associate with the input and label.
+     */
     @property({ type: String, reflect: false })
     public fieldID?: string;
 
+    /**
+     * The label for the input control
+     * @property
+     * @attribute
+     * @deprecated Labels cannot associate with inputs across DOM roots. Use the slotted `label` element instead.
+     */
     @property({ type: String })
-    public label = "";
+    public label?: string;
 
     @property({ type: Boolean })
     public required?: boolean;
@@ -110,19 +121,21 @@ export class HorizontalFormElement extends AKElement {
         }
     }
 
+    //#endregion
+
+    //#region Rendering
+
     render(): TemplateResult {
         this.updated();
-        return html`<div class="pf-c-form__group" role="group" aria-label="${this.label}">
-            <div class="pf-c-form__group-label">
-                <label
-                    id="group-label"
-                    class="pf-c-form__label"
-                    ?aria-required=${this.required}
-                    for="${ifDefined(this.fieldID)}"
-                >
-                    <span class="pf-c-form__label-text">${this.label}</span>
-                </label>
-            </div>
+
+        return html`<div class="pf-c-form__group" role="group">
+            ${this.label
+                ? html`<div class="pf-c-form__group-label">
+                      ${AKLabel({ htmlFor: this.fieldID, required: this.required }, this.label)}
+                  </div>`
+                : nothing}
+            <slot name="label"></slot>
+
             <div class="pf-c-form__group-control">
                 <slot class="pf-c-form__horizontal-group"></slot>
                 <div class="pf-c-form__horizontal-group">
@@ -131,6 +144,8 @@ export class HorizontalFormElement extends AKElement {
             </div>
         </div>`;
     }
+
+    //#endregion
 }
 
 declare global {

--- a/web/src/elements/forms/Radio.ts
+++ b/web/src/elements/forms/Radio.ts
@@ -43,8 +43,8 @@ export class Radio<T> extends CustomEmitterElement(AKElement) {
                     var(--pf-c-form--m-horizontal__group-label--md--PaddingTop) * 1.3
                 );
             }
-            .pf-c-radio label,
-            .pf-c-radio span {
+            .pf-c-radio {
+                cursor: pointer;
                 user-select: none;
             }
 

--- a/web/src/elements/utils/inputs.ts
+++ b/web/src/elements/utils/inputs.ts
@@ -7,6 +7,11 @@ export type NamedElement<T = Element> = T & {
     name: string;
 };
 
+/**
+ * Type predicate to check if an element currently has a `name` attribute.
+ *
+ * @see {@linkcode isNameableElement} to check if an element is nameable.
+ */
 export function isNamedElement(element: Element): element is NamedElement {
     if (!(element instanceof HTMLElement)) {
         return false;
@@ -16,26 +21,56 @@ export function isNamedElement(element: Element): element is NamedElement {
 }
 
 /**
+ * A set of elements that can be named, i.e. have a `name` attribute.
+ *
+ * @deprecated This should be replaced with a less brittle approach.
+ */
+const NameableElements = new Set([
+    "INPUT",
+    "TEXTAREA",
+    "SELECT",
+    "AK-CODEMIRROR",
+    "AK-CHIP-GROUP",
+    "AK-SEARCH-SELECT",
+    "AK-RADIO",
+]);
+
+/**
+ * Type predicate to check if an element is nameable.
+ *
+ * @see {@linkcode isNamedElement} to check if an element currently has a `name` attribute.
+ */
+export function isNameableElement(element: Element): element is NamedElement {
+    if (!(element instanceof HTMLElement)) {
+        return false;
+    }
+
+    return NameableElements.has(element.tagName);
+}
+
+/**
  * Create a map of files provided by input elements within the given iterable.
  */
 export function createFileMap<T extends PropertyKey = PropertyKey>(
-    fileInputParents?: Iterable<NamedElement<LitElement>> | null,
+    fileInputParents?: Iterable<LitElement> | null,
 ): Map<T, File> {
     const record = new Map<T, File>();
 
     for (const element of fileInputParents || []) {
         element.requestUpdate();
 
+        if (!isNamedElement(element)) continue;
+
         const inputElement = element.querySelector<HTMLInputElement>("input[type=file]");
 
         if (!inputElement) continue;
 
         const file = inputElement.files?.[0];
-        const name = element.name;
+        const name = element.name as T;
 
         if (!file || !name) continue;
 
-        record.set(name as T, file);
+        record.set(name, file);
     }
 
     return record;

--- a/web/src/elements/wizard/FormWizardPage.ts
+++ b/web/src/elements/wizard/FormWizardPage.ts
@@ -1,7 +1,6 @@
 import { Form } from "#elements/forms/Form";
 import { WizardPage } from "#elements/wizard/WizardPage";
 
-import { msg } from "@lit/localize";
 import { customElement } from "lit/decorators.js";
 
 /**
@@ -20,16 +19,26 @@ export class FormWizardPage extends WizardPage {
     };
 
     nextCallback = async (): Promise<boolean> => {
-        const form = this.querySelector<Form<unknown>>("*");
+        if (!this.children.length) {
+            throw new TypeError(`No child elements found in ${this.slot}.`);
+        }
+
+        const form = Array.from(this.children).find((childElement) => {
+            return childElement instanceof Form;
+        });
 
         if (!form) {
-            return Promise.reject(msg("No form found"));
+            throw new TypeError(`${this.slot} does not contain a Form element.`);
+        }
+
+        if (!form.reportValidity()) {
+            return false;
         }
 
         const formPromise = form.submit(new SubmitEvent("submit"));
 
         if (!formPromise) {
-            return Promise.reject(msg("Form didn't return a promise for submitting"));
+            throw new TypeError("Expected a Promise from the Form.submit() method.");
         }
 
         return formPromise

--- a/web/src/flow/components/ak-flow-password-input.ts
+++ b/web/src/flow/components/ak-flow-password-input.ts
@@ -8,7 +8,6 @@ import { msg } from "@lit/localize";
 import { html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
-import { ifDefined } from "lit/directives/if-defined.js";
 import { createRef, ref, Ref } from "lit/directives/ref.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
@@ -89,13 +88,6 @@ export class InputPassword extends AKElement {
      */
     @property({ type: Object })
     errors: Record<string, string> = {};
-
-    /**
-     * Forwarded to the input tag's aria-invalid attribute, if set
-     * @attr
-     */
-    @property({ type: String })
-    invalid?: string;
 
     /**
      * Whether to allow the user to toggle the visibility of the password.
@@ -334,7 +326,7 @@ export class InputPassword extends AKElement {
                             "pf-m-caps-lock": this.capsLock,
                         })}"
                         required
-                        aria-invalid=${ifDefined(this.invalid)}
+                        aria-invalid=${this.errors?.length ? "true" : "false"}
                         value=${this.initialValue}
                         ${ref(this.inputRef)}
                     />

--- a/web/src/flow/stages/password/PasswordStage.ts
+++ b/web/src/flow/stages/password/PasswordStage.ts
@@ -3,6 +3,8 @@ import "#flow/FormStatic";
 import "#flow/components/ak-flow-card";
 import "#flow/components/ak-flow-password-input";
 
+import { ErrorProp } from "#components/ak-field-errors";
+
 import { BaseStage } from "#flow/stages/base";
 import { PasswordManagerPrefill } from "#flow/stages/identification/IdentificationStage";
 
@@ -33,9 +35,10 @@ export class PasswordStage extends BaseStage<PasswordChallenge, PasswordChalleng
         PFTitle,
     ];
 
-    hasError(field: string): boolean {
-        const errors = (this.challenge?.responseErrors || {})[field];
-        return (errors || []).length > 0;
+    #errors(field: string): ErrorProp[] | undefined {
+        const errors = this.challenge?.responseErrors?.[field];
+
+        return errors;
     }
 
     render(): TemplateResult {
@@ -65,9 +68,8 @@ export class PasswordStage extends BaseStage<PasswordChallenge, PasswordChalleng
                     required
                     grab-focus
                     class="pf-c-form__group"
-                    .errors=${(this.challenge?.responseErrors || {}).password}
+                    .errors=${this.#errors("password")}
                     ?allow-show-password=${this.challenge.allowShowPassword}
-                    invalid=${this.hasError("password").toString()}
                     prefill=${PasswordManagerPrefill.password ?? ""}
                 ></ak-flow-input-password>
                 <div class="pf-c-form__group pf-m-action">

--- a/web/src/user/user-settings/details/stages/prompt/PromptStage.ts
+++ b/web/src/user/user-settings/details/stages/prompt/PromptStage.ts
@@ -35,7 +35,6 @@ export class UserSettingsPromptStage extends PromptStage {
                     label=${msg(str`${prompt.label}`)}
                     ?required=${prompt.required}
                     name=${prompt.fieldKey}
-                    ?invalid=${!!errors}
                     .errorMessages=${errors}
                 >
                     ${this.renderPromptInner(prompt)} ${this.renderPromptHelpText(prompt)}

--- a/web/tests/pageobjects/admin.page.ts
+++ b/web/tests/pageobjects/admin.page.ts
@@ -3,8 +3,8 @@ import Page from "../pageobjects/page.js";
 import { $ } from "@wdio/globals";
 
 export default class AdminPage extends Page {
-    public async pageHeader() {
-        return await $(">>>ak-page-header").$('>>>slot[name="header"]');
+    public pageHeader() {
+        return $(">>>ak-page-navbar").$(".page-title");
     }
 
     async openApplicationsListPage() {

--- a/web/tests/pageobjects/controls.ts
+++ b/web/tests/pageobjects/controls.ts
@@ -1,5 +1,4 @@
 import { browser } from "@wdio/globals";
-import { match } from "ts-pattern";
 import { Key } from "webdriverio";
 
 export async function doBlur(el: WebdriverIO.Element | ChainablePromiseElement) {
@@ -85,11 +84,13 @@ export async function setFormGroup(name: string | RegExp, setting: "open" | "clo
     }
 
     await formGroup.scrollIntoView();
-    const toggle = await formGroup.$(">>>div.pf-c-form__field-group-toggle-button button");
-    await match([await toggle.getAttribute("aria-expanded"), setting])
-        .with(["false", "open"], async () => await toggle.click())
-        .with(["true", "closed"], async () => await toggle.click())
-        .otherwise(async () => {});
+
+    const open = await formGroup.getAttribute("open").then((value) => value !== null);
+
+    if ((setting === "open" && !open) || (setting === "closed" && open)) {
+        await formGroup.$(">>>summary").click();
+    }
+
     await doBlur(formGroup);
 }
 

--- a/web/tests/pageobjects/forms/application.form.ts
+++ b/web/tests/pageobjects/forms/application.form.ts
@@ -8,7 +8,7 @@ export class ApplicationForm extends Page {
     }
 
     async uiSettings() {
-        return await $(">>>ak-form-group").$('button[aria-label="UI Settings"]');
+        return $('>>>ak-form-group[label="UI Settings"]');
     }
 
     async launchUrl() {

--- a/web/tests/specs/new-application-by-wizard.ts
+++ b/web/tests/specs/new-application-by-wizard.ts
@@ -1,5 +1,6 @@
 import ApplicationWizardView from "../pageobjects/application-wizard.page.js";
 import ApplicationsListPage from "../pageobjects/applications-list.page.js";
+import type { TestProvider, TestSequence } from "../pageobjects/controls.js";
 import { randomId } from "../utils/index.js";
 import { login } from "../utils/login.js";
 import {
@@ -26,7 +27,6 @@ import {
 // via `defineProperties` is how we installed the OUID finders for the various
 // wizard types.
 import { expect } from "@wdio/globals";
-import type { TestProvider, TestSequence } from "pageobjects/controls.js";
 
 const SUCCESS_MESSAGE = "Your application has been saved";
 

--- a/web/tests/specs/provider-shared-sequences.ts
+++ b/web/tests/specs/provider-shared-sequences.ts
@@ -1,5 +1,3 @@
-import { ascii_letters, digits, randomId, randomString } from "../utils/index.js";
-
 import {
     checkIsPresent,
     clickButton,
@@ -13,7 +11,8 @@ import {
     setTypeCreate,
     type TestProvider,
     type TestSequence,
-} from "pageobjects/controls.js";
+} from "../pageobjects/controls.js";
+import { ascii_letters, digits, randomId, randomString } from "../utils/index.js";
 
 const newObjectName = (prefix: string) => `${prefix} - ${randomId()}`;
 


### PR DESCRIPTION
## Details

This PR resolves a collection of form validation issues, as well as a partial fix for our WebDriverIO tests to run while Playwright is in review.

### Fixed Issues

- `ErrorProp`s containing strings are now parsed correctly instead of defaulting to a generic network error
- Single-step modal forms perform client-side validation before submitting their data
- Wizards now perform client-side validation before progressing to the next step
- Form Groups no longer fight for focus when multiple invalid inputs exist.
- Form Groups no longer scroll into view when a previously invalid field becomes valid
- Invalid inputs within Form Groups now wait for their parent to expand before attempting to focus the element while still hidden
- Both server and client-side errors now trigger Form Group expansion.
- Inputs with server-side errors are now marked with ARIA attributes to match their status
- The inner `form` element getter within AKForm now uses `renderRoot` over `shadowRoot`, fixing selector issues when in compatibility mode. 

## See also

- #16119 (Split off from this PR)
- #15876
- #15701 