### PR TITLE
web: Fix scroll-event induced tab crash

### DIFF
--- a/web/src/components/ak-toggle-group.ts
+++ b/web/src/components/ak-toggle-group.ts
@@ -35,7 +35,7 @@ export class AkToggleGroup extends CustomEmitterElement(AKElement) {
         `,
     ];
 
-    /*
+    /**
      * The value (causes highlighting, value is returned)
      *
      * @attr

--- a/web/src/elements/ak-dual-select/components/ak-dual-select-available-pane.ts
+++ b/web/src/elements/ak-dual-select/components/ak-dual-select-available-pane.ts
@@ -46,7 +46,7 @@ export class AkDualSelectAvailablePane extends CustomEmitterElement<DualSelectEv
 
     /* The array of key/value pairs this pane is currently showing */
     @property({ type: Array })
-    readonly options: DualSelectPair[] = [];
+    public readonly options?: DualSelectPair[];
 
     /**
      * A set (set being easy for lookups) of keys with all the pairs selected,
@@ -54,7 +54,7 @@ export class AkDualSelectAvailablePane extends CustomEmitterElement<DualSelectEv
      * can be marked and their clicks ignored.
      */
     @property({ type: Object })
-    readonly selected: Set<string> = new Set();
+    public readonly selected: Set<string> = new Set();
 
     //#endregion
 
@@ -75,11 +75,17 @@ export class AkDualSelectAvailablePane extends CustomEmitterElement<DualSelectEv
 
     //#region Refs
 
-    protected listRef = createRef<HTMLDivElement>();
+    #listRef = createRef<HTMLDivElement>();
+
+    #scrollAnimationFrame = -1;
+
+    #scrollIntoView = (): void => {
+        this.#listRef.value?.scrollTo(0, 0);
+    };
 
     //#region Lifecycle
 
-    connectedCallback() {
+    public overrideconnectedCallback() {
         super.connectedCallback();
 
         for (const [attr, value] of hostAttributes) {
@@ -89,9 +95,11 @@ export class AkDualSelectAvailablePane extends CustomEmitterElement<DualSelectEv
         }
     }
 
-    protected updated(changed: PropertyValues<this>) {
-        if (changed.has("options")) {
-            this.listRef.value?.scrollTo(0, 0);
+    protected override updated(changed: PropertyValues<this>) {
+        if (changed.has("options") && this.options?.length) {
+            cancelAnimationFrame(this.#scrollAnimationFrame);
+
+            this.#scrollAnimationFrame = requestAnimationFrame(this.#scrollIntoView);
         }
     }
 
@@ -118,10 +126,9 @@ export class AkDualSelectAvailablePane extends CustomEmitterElement<DualSelectEv
             this.toMove.add(key);
         }
 
-        this.dispatchCustomEvent(
-            DualSelectEventType.MoveChanged,
-            Array.from(this.toMove.values()).sort(),
-        );
+        const moved = [...this.toMove].sort();
+
+        this.dispatchCustomEvent(DualSelectEventType.MoveChanged, moved);
 
         this.dispatchCustomEvent(DualSelectEventType.Move);
 
@@ -145,7 +152,7 @@ export class AkDualSelectAvailablePane extends CustomEmitterElement<DualSelectEv
 
     render() {
         return html`
-            <div ${ref(this.listRef)} class="pf-c-dual-list-selector__menu">
+            <div ${ref(this.#listRef)} class="pf-c-dual-list-selector__menu">
                 <ul class="pf-c-dual-list-selector__list">
                     ${map(this.options, ([key, label]) => {
                         const selected = classMap({

--- a/web/src/elements/ak-dual-select/components/styles.ts
+++ b/web/src/elements/ak-dual-select/components/styles.ts
@@ -100,9 +100,11 @@ export const globalVariables = css`
         --pf-c-dual-list-selector__list-item-row--BackgroundColor: var(
             --ak-dark-background-light-ish
         );
-        --pf-c-dual-list-selector__list-item-row--hover--BackgroundColor: var(
-            --ak-dark-background-lighter;
+
+        --pf-c-dual-list-selector__list-item-row--focus-within--BackgroundColor: var(
+            --ak-dark-background-darker
         );
+
         --pf-c-dual-list-selector__list-item-row--hover--BackgroundColor: var(
             --pf-global--BackgroundColor--400
         );

--- a/web/src/elements/forms/FormGroup.ts
+++ b/web/src/elements/forms/FormGroup.ts
@@ -1,7 +1,7 @@
 import { AKElement } from "#elements/Base";
 
 import { msg } from "@lit/localize";
-import { css, CSSResult, html, TemplateResult } from "lit";
+import { css, CSSResult, html, PropertyValues, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { createRef, ref } from "lit/directives/ref.js";
 
@@ -20,15 +20,6 @@ import PFBase from "@patternfly/patternfly/patternfly-base.css";
  */
 @customElement("ak-form-group")
 export class AKFormGroup extends AKElement {
-    @property({ type: Boolean, reflect: true })
-    public open = false;
-
-    @property({ type: String, reflect: true })
-    public label = msg("Details");
-
-    @property({ type: String, reflect: true })
-    public description?: string;
-
     static styles: CSSResult[] = [
         PFBase,
         PFForm,
@@ -46,27 +37,6 @@ export class AKFormGroup extends AKElement {
             }
 
             details {
-                &::details-content {
-                    height: 0;
-                    overflow: clip;
-                    transition-behavior: normal, allow-discrete;
-                    transition-duration: var(--pf-global--TransitionDuration);
-                    transition-timing-function: var(--pf-global--TimingFunction);
-                    transition-property: height, content-visibility;
-
-                    @media (prefers-reduced-motion) {
-                        transition-duration: 0;
-                    }
-                }
-
-                @supports (interpolate-size: allow-keywords) {
-                    interpolate-size: allow-keywords;
-
-                    &[open]::details-content {
-                        height: auto;
-                    }
-                }
-
                 &::details-content {
                     padding-inline-start: var(
                         --pf-c-form__field-group--GridTemplateColumns--toggle
@@ -102,12 +72,39 @@ export class AKFormGroup extends AKElement {
         `,
     ];
 
-    formRef = createRef<HTMLFormElement>();
+    //region Properties
 
-    scrollAnimationFrame = -1;
+    @property({ type: Boolean, reflect: true })
+    public open = false;
 
-    scrollIntoView = (): void => {
-        this.formRef.value?.scrollIntoView({
+    @property({ type: String, reflect: true })
+    public label = msg("Details");
+
+    @property({ type: String, reflect: true })
+    public description?: string;
+
+    //#endregion
+
+    //#region Lifecycle
+
+    public override updated(changedProperties: PropertyValues<this>): void {
+        const previousOpen = changedProperties.get("open");
+
+        if (typeof previousOpen !== "boolean") return;
+
+        if (this.open && this.open !== previousOpen) {
+            cancelAnimationFrame(this.#scrollAnimationFrame);
+
+            this.#scrollAnimationFrame = requestAnimationFrame(this.#scrollIntoView);
+        }
+    }
+
+    #detailsRef = createRef<HTMLDetailsElement>();
+
+    #scrollAnimationFrame = -1;
+
+    #scrollIntoView = (): void => {
+        this.#detailsRef.value?.scrollIntoView({
             behavior: "smooth",
         });
     };
@@ -117,19 +114,16 @@ export class AKFormGroup extends AKElement {
      */
     public toggle = (event: Event): void => {
         event.preventDefault();
-        cancelAnimationFrame(this.scrollAnimationFrame);
 
         this.open = !this.open;
-
-        if (this.open) {
-            this.scrollAnimationFrame = requestAnimationFrame(this.scrollIntoView);
-        }
     };
+
+    //#region Render
 
     public render(): TemplateResult {
         return html`
             <details
-                ${ref(this.formRef)}
+                ${ref(this.#detailsRef)}
                 ?open=${this.open}
                 ?aria-expanded="${this.open}"
                 role="group"
@@ -167,6 +161,8 @@ export class AKFormGroup extends AKElement {
             </details>
         `;
     }
+
+    //#endregion
 }
 
 declare global {


### PR DESCRIPTION
## Details

This PR addresses an issue that can cause the browser tab to crash:

1. Edit an existing SAML Provider
2. Within the modal, expand the "Advanced Protocol Settings" form group.
3. Collapse the group
4. Browser crash 💥 

This stems from two competing elements attempting to trigger scroll events with conflicting goals: The form group wants to collapse, and the scroll dual select wants to scroll its contents into view. The fix is a combination of better animation frame timing, and more cautious update callbacks.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
