### PR TITLE
web: Fix stale application slug, missing error state.

### DIFF
--- a/web/src/admin/applications/ApplicationViewPage.ts
+++ b/web/src/admin/applications/ApplicationViewPage.ts
@@ -216,7 +216,7 @@ export class ApplicationViewPage extends AKElement {
                                         >
                                     </dt>
                                     <dd class="pf-c-description-list__description">
-                                        <div class="pf-c-description-list__text">
+                                        <div class="pf-c-description-list__text pf-m-monospace">
                                             ${this.application.policyEngineMode?.toUpperCase()}
                                         </div>
                                     </dd>

--- a/web/src/admin/applications/wizard/steps/ak-application-wizard-application-step.ts
+++ b/web/src/admin/applications/wizard/steps/ak-application-wizard-application-step.ts
@@ -114,12 +114,14 @@ export class ApplicationWizardApplicationStep extends ApplicationWizardStep {
             <form id="applicationform" class="pf-c-form pf-m-horizontal" slot="form">
                 <ak-text-input
                     name="name"
+                    autocomplete="off"
+                    placeholder=${msg("Application name")}
                     value=${ifDefined(app.name)}
                     label=${msg("Name")}
                     required
                     ?invalid=${this.errors.has("name")}
                     .errorMessages=${errors.name ?? this.errorMessages("name")}
-                    help=${msg("Application's display Name.")}
+                    help=${msg("The name displayed in the application library.")}
                 ></ak-text-input>
                 <ak-slug-input
                     name="slug"
@@ -154,6 +156,7 @@ export class ApplicationWizardApplicationStep extends ApplicationWizardStep {
                         <ak-text-input
                             name="metaLaunchUrl"
                             label=${msg("Launch URL")}
+                            placeholder="https://..."
                             value=${ifDefined(app.metaLaunchUrl)}
                             ?invalid=${this.errors.has("metaLaunchUrl")}
                             .errorMessages=${errors.metaLaunchUrl ??

--- a/web/src/admin/flows/StageBindingForm.ts
+++ b/web/src/admin/flows/StageBindingForm.ts
@@ -7,12 +7,13 @@ import { groupBy } from "#common/utils";
 
 import { ModelForm } from "#elements/forms/ModelForm";
 
+import { policyEngineModes } from "#admin/policies/PolicyEngineModes";
+
 import {
     FlowsApi,
     FlowsInstancesListDesignationEnum,
     FlowStageBinding,
     InvalidResponseActionEnum,
-    PolicyEngineMode,
     Stage,
     StagesAllListRequest,
     StagesApi,
@@ -202,22 +203,7 @@ export class StageBindingForm extends ModelForm<FlowStageBinding, string> {
                 required
                 name="policyEngineMode"
             >
-                <ak-radio
-                    .options=${[
-                        {
-                            label: "any",
-                            value: PolicyEngineMode.Any,
-                            default: true,
-                            description: html`${msg("Any policy must match to grant access")}`,
-                        },
-                        {
-                            label: "all",
-                            value: PolicyEngineMode.All,
-                            description: html`${msg("All policies must match to grant access")}`,
-                        },
-                    ]}
-                    .value=${this.instance?.policyEngineMode}
-                >
+                <ak-radio .options=${policyEngineModes} .value=${this.instance?.policyEngineMode}>
                 </ak-radio>
             </ak-form-element-horizontal>`;
     }

--- a/web/src/admin/policies/PolicyEngineModes.ts
+++ b/web/src/admin/policies/PolicyEngineModes.ts
@@ -1,17 +1,21 @@
+import type { RadioOption } from "#elements/forms/Radio";
+
 import { PolicyEngineMode } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
 import { html } from "lit";
 
-export const policyEngineModes = [
+export const policyEngineModes: RadioOption<PolicyEngineMode>[] = [
     {
-        label: "any",
+        label: "ANY",
+        className: "pf-m-monospace",
         value: PolicyEngineMode.Any,
         default: true,
         description: html`${msg("Any policy must match to grant access")}`,
     },
     {
-        label: "all",
+        label: "ALL",
+        className: "pf-m-monospace",
         value: PolicyEngineMode.All,
         description: html`${msg("All policies must match to grant access")}`,
     },

--- a/web/src/elements/forms/Form.ts
+++ b/web/src/elements/forms/Form.ts
@@ -220,7 +220,10 @@ export abstract class Form<T = Record<string, unknown>> extends AKElement {
         return rect.x + rect.y + rect.width + rect.height !== 0;
     }
 
-    public getSuccessMessage(): string {
+    /**
+     * An overridable method for returning a success message after a successful submission.
+     */
+    protected getSuccessMessage(): string {
         return this.successMessage;
     }
 
@@ -365,6 +368,9 @@ export abstract class Form<T = Record<string, unknown>> extends AKElement {
         </form>`;
     }
 
+    /**
+     * An overridable method for rendering the form content.
+     */
     public renderForm(): SlottedTemplateResult | null {
         return null;
     }

--- a/web/src/elements/forms/ModelForm.ts
+++ b/web/src/elements/forms/ModelForm.ts
@@ -9,15 +9,24 @@ import { html, TemplateResult } from "lit";
 import { property } from "lit/decorators.js";
 
 /**
- * Model form
- *
  * A base form that automatically tracks the server-side object (instance)
  * that we're interested in.  Handles loading and tracking of the instance.
  */
-
 export abstract class ModelForm<T, PKT extends string | number> extends Form<T> {
-    abstract loadInstance(pk: PKT): Promise<T>;
+    /**
+     * An overridable method for loading an instance.
+     *
+     * @param pk The primary key of the instance to load.
+     * @returns A promise that resolves to the loaded instance.
+     */
+    protected abstract loadInstance(pk: PKT): Promise<T>;
 
+    /**
+     * An overridable method for loading any data, beyond the instance.
+     *
+     * @see {@linkcode loadInstance}
+     * @returns A promise that resolves when the data has been loaded.
+     */
     async load(): Promise<void> {
         return Promise.resolve();
     }

--- a/web/src/elements/forms/Radio.ts
+++ b/web/src/elements/forms/Radio.ts
@@ -14,6 +14,7 @@ import PFBase from "@patternfly/patternfly/patternfly-base.css";
 export interface RadioOption<T> {
     label: string;
     description?: TemplateResult;
+    className?: string;
     default?: boolean;
     value: T;
     disabled?: boolean;
@@ -100,7 +101,9 @@ export class Radio<T> extends CustomEmitterElement(AKElement) {
                 .checked=${option.value === this.value}
                 .disabled=${option.disabled}
             />
-            <label class="pf-c-radio__label" for=${id}>${option.label}</label>
+            <label class="pf-c-radio__label ${option.className ?? ""}" for=${id}
+                >${option.label}</label
+            >
             ${option.description
                 ? html`<span class="pf-c-radio__description">${option.description}</span>`
                 : nothing}


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

This PR fixes an issue where changing the slug of an existing application results in blank client-side error. Additionally, this also adds an error state when loading the application.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
