### PR TITLE
website/docs: removed weird phrase in Warning

### DIFF
--- a/website/docs/install-config/install/docker-compose.mdx
+++ b/website/docs/install-config/install/docker-compose.mdx
@@ -101,9 +101,7 @@ See [Configuration](../configuration/configuration.mdx) to change the internal p
 
 :::warning
 The server assumes to have local timezone as UTC.
-All internals are handled in UTC; whenever a time is displayed to the user in UI, the time shown is localized.
-Do not update or mount `/etc/timezone` or `/etc/localtime` in the authentik containers.
-This will not give any advantages. It will cause problems with OAuth and SAML authentication, e.g. [see this GitHub issue](https://github.com/goauthentik/authentik/issues/3005).
+All internals are handled in UTC; whenever a time is displayed to the user in UI, the time shown is localized. Do not update or mount `/etc/timezone` or `/etc/localtime` in the authentik containers; it will cause problems with OAuth and SAML authentication, as seen this [GitHub issue](https://github.com/goauthentik/authentik/issues/3005).
 :::
 
 Afterward, run these commands to finish:

--- a/website/docs/install-config/install/docker-compose.mdx
+++ b/website/docs/install-config/install/docker-compose.mdx
@@ -100,8 +100,7 @@ See [Configuration](../configuration/configuration.mdx) to change the internal p
 ## Startup
 
 :::warning
-The server assumes to have local timezone as UTC.
-All internals are handled in UTC; whenever a time is displayed to the user in UI, the time shown is localized. Do not update or mount `/etc/timezone` or `/etc/localtime` in the authentik containers; it will cause problems with OAuth and SAML authentication, as seen this [GitHub issue](https://github.com/goauthentik/authentik/issues/3005).
+The server assumes to have local timezone as UTC. All internals are handled in UTC; whenever a time is displayed to the user in UI, the time shown is localized. Do not update or mount `/etc/timezone` or `/etc/localtime` in the authentik containers; it will cause problems with OAuth and SAML authentication, as seen this [GitHub issue](https://github.com/goauthentik/authentik/issues/3005).
 :::
 
 Afterward, run these commands to finish:

--- a/website/docs/install-config/install/docker-compose.mdx
+++ b/website/docs/install-config/install/docker-compose.mdx
@@ -100,7 +100,7 @@ See [Configuration](../configuration/configuration.mdx) to change the internal p
 ## Startup
 
 :::warning
-The server assumes to have local timezone as UTC. All internals are handled in UTC; whenever a time is displayed to the user in UI, the time shown is localized. Do not update or mount `/etc/timezone` or `/etc/localtime` in the authentik containers; it will cause problems with OAuth and SAML authentication, as seen this [GitHub issue](https://github.com/goauthentik/authentik/issues/3005).
+The server assumes to have local timezone as UTC. All internal operations use UTC; When displaying times in the UI, they are automatically localized for the user. Do not update or mount `/etc/timezone` or `/etc/localtime` in the authentik containers; it will cause problems with OAuth and SAML authentication, as seen this [GitHub issue](https://github.com/goauthentik/authentik/issues/3005).
 :::
 
 Afterward, run these commands to finish:


### PR DESCRIPTION
This PR rewords a Warning in the Docker install docs about handling timezones. 

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
