### PR TITLE
website/docs: reword Warning in Docker install docs

### DIFF
--- a/website/docs/install-config/install/docker-compose.mdx
+++ b/website/docs/install-config/install/docker-compose.mdx
@@ -100,10 +100,7 @@ See [Configuration](../configuration/configuration.mdx) to change the internal p
 ## Startup
 
 :::warning
-The server assumes to have local timezone as UTC.
-All internals are handled in UTC; whenever a time is displayed to the user in UI, the time shown is localized.
-Do not update or mount `/etc/timezone` or `/etc/localtime` in the authentik containers.
-This will not give any advantages. It will cause problems with OAuth and SAML authentication, e.g. [see this GitHub issue](https://github.com/goauthentik/authentik/issues/3005).
+The server assumes to have local timezone as UTC. All internal operations use UTC; When displaying times in the UI, they are automatically localized for the user. Do not update or mount `/etc/timezone` or `/etc/localtime` in the authentik containers; it will cause problems with OAuth and SAML authentication, as seen this [GitHub issue](https://github.com/goauthentik/authentik/issues/3005).
 :::
 
 Afterward, run these commands to finish:

--- a/website/docs/install-config/install/docker-compose.mdx
+++ b/website/docs/install-config/install/docker-compose.mdx
@@ -100,7 +100,7 @@ See [Configuration](../configuration/configuration.mdx) to change the internal p
 ## Startup
 
 :::warning
-The server assumes to have local timezone as UTC. All internal operations use UTC; When displaying times in the UI, they are automatically localized for the user. Do not update or mount `/etc/timezone` or `/etc/localtime` in the authentik containers; it will cause problems with OAuth and SAML authentication, as seen this [GitHub issue](https://github.com/goauthentik/authentik/issues/3005).
+All internal operations use UTC. Times displayed in the UI are automatically localized for the user. Do not update or mount `/etc/timezone` or `/etc/localtime` in the authentik containers; it will cause problems with OAuth and SAML authentication, as seen this [GitHub issue](https://github.com/goauthentik/authentik/issues/3005).
 :::
 
 Afterward, run these commands to finish:


### PR DESCRIPTION
This POR improves the Warning about UTC times.

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
