### PR TITLE
website/docs: add tips for image optimization

### DIFF
--- a/website/docs/customize/branding.md
+++ b/website/docs/customize/branding.md
@@ -5,6 +5,6 @@ slug: /branding
 
 You can configure several differently "branded" options depending on the associated domain, even though objects such as applications, providers, etc, are still global. This can be handy to use the same authentik instance, but branded differently for different domains.
 
-The main settings that control your instance's appearance and behaviour are the _default flows_ and the _branding settings_.
+The main settings that control your instance's appearance and behaviour are the [_branding settings_](../sys-mgmt/brands.md#branding-settings) and the the [_default flows_](../sys-mgmt/brands.md#default-flows). Review our tips for using images and icons in the [Image optimization](../sys-mgmt/brands.md#image-optimization) section.
 
 To create or modify a brand, open the Admin interface and navigate to **System** > **Brands**. For complete instructions refer to our [Brands documentation](../sys-mgmt/brands.md).

--- a/website/docs/sys-mgmt/brands.md
+++ b/website/docs/sys-mgmt/brands.md
@@ -32,26 +32,6 @@ The brand settings define the visual identity of the brand, including:
 - **Default flow background** :ak-version[2025.4]: Default background image for the flow executor, can be overridden per flow, see [Flow configuration options](../add-secure-apps/flows-stages/flow/index.md#flow-configuration-options).
 - **Custom CSS** :ak-version[2025.4]: Add custom CSS to further customize the look of authentik. Creating such a file is outside the scope of this document.
 
-### Image optimization
-
-When you use images and icons for a brand's logo, favicon, etc., be aware of the following optimization tips:
-
-- Use an SVG version of the image.
-
-- Trim excess whitespace from around the logo. You can use an SVG editor such as Inkscape, Sketch, or Adobe Illustrator.
-
-- Adjust the viewBox: Ensure the SVG’s `viewBox` attribute tightly wraps the actual logo content. This helps in scaling the logo appropriately.
-
-- Remove fixed dimensions: delete any fixed width and height attributes from the SVG. This allows the logo to scale responsively within its container.
-
-- Check if your SVG needs `preserveAspectRatio` to retain its shape when resized.
-
-- Wordmark logos: aim for an aspect ratio of approximately 7:1 (width to height).
-
-- Icon logos: use a 1:1 aspect ratio, ensuring the icon fills the entire viewBox and is centered.
-
-- the SVG tool [SVGOMG](https://svgomg.net/) is useful for trimming any excess metadata that might affect how the browser rasterizes the image.
-
 ### External user settings
 
 You can configure authentik to redirect external users to a default application after they log in (if they weren't originally redirected from a specific application). To do this:
@@ -92,3 +72,23 @@ When using the [Mutual TLS Stage](../add-secure-apps/flows-stages/stages/mtls/in
 #### Attributes
 
 Attributes such as locale, theme settings (light/dark mode), and custom attributes can be set to a per-brand default value here. Any custom attributes can be retrieved via [`group_attributes()`](../users-sources/user/user_ref.mdx#object-properties).
+
+## Image optimization
+
+When you use images and icons for a brand's logo, favicon, etc., be aware of the following optimization tips:
+
+- Use an SVG version of the image.
+
+- Trim excess whitespace from around the logo. You can use an SVG editor such as Inkscape, Sketch, or Adobe Illustrator.
+
+- Adjust the viewBox: Ensure the SVG’s `viewBox` attribute tightly wraps the actual logo content. This helps in scaling the logo appropriately.
+
+- Remove fixed dimensions: delete any fixed width and height attributes from the SVG. This allows the logo to scale responsively within its container.
+
+- Check if your SVG needs `preserveAspectRatio` to retain its shape when resized.
+
+- Wordmark logos: aim for an aspect ratio of approximately 7:1 (width to height).
+
+- Icon logos: use a 1:1 aspect ratio, ensuring the icon fills the entire viewBox and is centered.
+
+- The SVG tool [SVGOMG](https://svgomg.net/) is useful for trimming any excess metadata that might affect how the browser rasterizes the image.

--- a/website/docs/sys-mgmt/brands.md
+++ b/website/docs/sys-mgmt/brands.md
@@ -32,6 +32,26 @@ The brand settings define the visual identity of the brand, including:
 - **Default flow background** :ak-version[2025.4]: Default background image for the flow executor, can be overridden per flow, see [Flow configuration options](../add-secure-apps/flows-stages/flow/index.md#flow-configuration-options).
 - **Custom CSS** :ak-version[2025.4]: Add custom CSS to further customize the look of authentik. Creating such a file is outside the scope of this document.
 
+### Image optimization
+
+When you use images and icons for a brand's logo, favicon, etc., be aware of the following optimization tips:
+
+- Use an SVG version of the image.
+
+- Trim excess whitespace from around the logo. You can use an SVG editor such as Inkscape, Sketch, or Adobe Illustrator.
+
+- Adjust the viewBox: Ensure the SVG’s `viewBox` attribute tightly wraps the actual logo content. This helps in scaling the logo appropriately.
+
+- Remove fixed dimensions: delete any fixed width and height attributes from the SVG. This allows the logo to scale responsively within its container.
+
+- Check if your SVG needs `preserveAspectRatio` to retain its shape when resized.
+
+- Wordmark logos: aim for an aspect ratio of approximately 7:1 (width to height).
+
+- Icon logos: use a 1:1 aspect ratio, ensuring the icon fills the entire viewBox and is centered.
+
+- the SVG tool [SVGOMG](https://svgomg.net/) is useful for trimming any excess metadata that might affect how the browser rasterizes the image.
+
 ### External user settings
 
 You can configure authentik to redirect external users to a default application after they log in (if they weren't originally redirected from a specific application). To do this:


### PR DESCRIPTION
This PR adds a new section with the tips for image optimization that @GirlBossRush added to Issue #14670.

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
