### PR TITLE
web: Fix issue where `aria-owns` attribute triggers Chrome crash.

### DIFF
--- a/web/src/elements/forms/FormGroup.ts
+++ b/web/src/elements/forms/FormGroup.ts
@@ -27,9 +27,9 @@ export class AKFormGroup extends AKElement {
         PFFormControl,
 
         css`
-            :host {
+            :host([theme="dark"]) {
                 --marker-color: var(--pf-global--Color--200);
-                --marker-color-hover: var(--pf-global--Color--100);
+                --marker-color-hover: var(--ak-dark-foreground-darker);
             }
 
             .pf-c-form__field-group-header-description {
@@ -53,7 +53,7 @@ export class AKFormGroup extends AKElement {
                     user-select: none;
 
                     &::marker {
-                        color: var(--marker-color);
+                        color: var(--marker-color, var(--pf-global--Color--200));
                         transition: var(--pf-c-form__field-group-toggle-icon--Transition);
                         font-family: "Font Awesome 5 Free";
                         font-weight: 900;
@@ -61,7 +61,7 @@ export class AKFormGroup extends AKElement {
 
                     &:hover::marker {
                         outline: 1px dashed red;
-                        color: var(--marker-color-hover);
+                        color: var(--marker-color-hover, var(--pf-global--Color--100));
                     }
                 }
 
@@ -125,9 +125,8 @@ export class AKFormGroup extends AKElement {
             <details
                 ${ref(this.#detailsRef)}
                 ?open=${this.open}
-                ?aria-expanded="${this.open}"
+                aria-expanded=${this.open ? "true" : "false"}
                 role="group"
-                aria-owns="form-group-expandable-content"
                 aria-labelledby="form-group-header-title"
                 aria-describedby="form-group-expandable-content-description"
             >


### PR DESCRIPTION
## Details

This PR extends on #15939, fixing an issue stemming from the `aria-owns` attribute and its relationship with collapsable elements. The root cause seems to be within Chrome's accessibility tree, causing an invalid memory access when the "owned" element is no longer visible.

The issue has been reported in a few incidents:

- https://issues.chromium.org/issues/40932224
- https://issues.chromium.org/issues/335553723
- https://github.com/angular/components/issues/28905

It seems (for now) that `aria-owns` should not be used when the referenced element can be hidden, removed, or omitted from the user's view.

## Also Included

- Fixed regression in dark them on form group buttons.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
