### PR TITLE
web/a11y: Codemirror

### DIFF
--- a/packages/esbuild-plugin-live-reload/client/ESBuildObserver.js
+++ b/packages/esbuild-plugin-live-reload/client/ESBuildObserver.js
@@ -1,13 +1,13 @@
 /**
  * @file Client-side observer for ESBuild events.
  *
- * @import { Logger } from "#shared";
+ * @import { Logger } from "@goauthentik/esbuild-plugin-live-reload/shared";
  * @import { Message as ESBuildMessage } from "esbuild";
  */
 
 /// <reference types="./types.js" />
 
-import { createLogger } from "#shared";
+import { createLogger } from "@goauthentik/esbuild-plugin-live-reload/shared";
 
 if (typeof EventSource === "undefined") {
     throw new TypeError("Environment doesn't appear to have an EventSource constructor");

--- a/packages/esbuild-plugin-live-reload/package-lock.json
+++ b/packages/esbuild-plugin-live-reload/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@goauthentik/esbuild-plugin-live-reload",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@goauthentik/esbuild-plugin-live-reload",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "license": "MIT",
             "dependencies": {
                 "find-free-ports": "^3.1.1"

--- a/packages/esbuild-plugin-live-reload/package.json
+++ b/packages/esbuild-plugin-live-reload/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@goauthentik/esbuild-plugin-live-reload",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "ESBuild + browser refresh. Build completes, page reloads.",
     "license": "MIT",
     "scripts": {
@@ -18,6 +18,10 @@
             "types": "./out/index.d.ts",
             "import": "./index.js"
         },
+        "./shared": {
+            "types": "./out/shared/index.d.ts",
+            "import": "./shared/index.js"
+        },
         "./client": {
             "types": "./out/client/index.d.ts",
             "import": "./client/index.js"
@@ -26,9 +30,6 @@
             "types": "./out/plugin/index.d.ts",
             "import": "./plugin/index.js"
         }
-    },
-    "imports": {
-        "#shared": "./shared/index.js"
     },
     "dependencies": {
         "find-free-ports": "^3.1.1"
@@ -69,6 +70,7 @@
         "./index.js",
         "client/**/*",
         "plugin/**/*",
+        "shared/**/*",
         "out/**/*"
     ],
     "prettier": "@goauthentik/prettier-config",

--- a/packages/esbuild-plugin-live-reload/plugin/index.js
+++ b/packages/esbuild-plugin-live-reload/plugin/index.js
@@ -4,13 +4,13 @@
  * @import { ListenOptions } from "node:net";
  * @import {Server as HTTPServer} from "node:http";
  * @import {Server as HTTPSServer} from "node:https";
- * @import { Logger } from "#shared";
+ * @import { Logger } from "@goauthentik/esbuild-plugin-live-reload/shared";
  */
 
 import * as http from "node:http";
 import { resolve as resolvePath } from "node:path";
 
-import { createLogger } from "#shared";
+import { createLogger } from "@goauthentik/esbuild-plugin-live-reload/shared";
 
 import { findFreePorts } from "find-free-ports";
 

--- a/web/src/admin/blueprints/BlueprintForm.ts
+++ b/web/src/admin/blueprints/BlueprintForm.ts
@@ -169,7 +169,7 @@ export class BlueprintForm extends ModelForm<BlueprintInstance, string> {
                         ? html`<ak-form-element-horizontal label=${msg("Blueprint")} name="content">
                               <ak-codemirror
                                   mode=${CodeMirrorMode.YAML}
-                                  .parseValue=${false}
+                                  raw
                                   value="${ifDefined(this.instance?.content)}"
                               ></ak-codemirror>
                           </ak-form-element-horizontal>`

--- a/web/src/admin/brands/BrandForm.ts
+++ b/web/src/admin/brands/BrandForm.ts
@@ -162,6 +162,7 @@ export class BrandForm extends ModelForm<Brand, string> {
                         name="brandingCustomCss"
                     >
                         <ak-codemirror
+                            id="branding-custom-css"
                             mode=${CodeMirrorMode.CSS}
                             value="${this.instance?.brandingCustomCss ??
                             DefaultBrand.brandingCustomCss}"
@@ -320,6 +321,9 @@ export class BrandForm extends ModelForm<Brand, string> {
                     </ak-form-element-horizontal>
                     <ak-form-element-horizontal label=${msg("Attributes")} name="attributes">
                         <ak-codemirror
+                            required
+                            id="attributes"
+                            name="attributes"
                             mode=${CodeMirrorMode.YAML}
                             value="${YAML.stringify(this.instance?.attributes ?? {})}"
                         >

--- a/web/src/admin/property-mappings/PropertyMappingTestForm.ts
+++ b/web/src/admin/property-mappings/PropertyMappingTestForm.ts
@@ -57,7 +57,7 @@ export class PolicyTestForm extends Form<PropertyMappingTestRequest> {
             ${this.result?.successful
                 ? html`<ak-codemirror
                       mode=${CodeMirrorMode.JavaScript}
-                      readOnly
+                      readonly
                       value="${ifDefined(this.result?.result)}"
                   >
                   </ak-codemirror>`

--- a/web/src/admin/providers/saml/SAMLProviderViewPage.ts
+++ b/web/src/admin/providers/saml/SAMLProviderViewPage.ts
@@ -502,7 +502,7 @@ export class SAMLProviderViewPage extends AKElement {
                               <div class="pf-c-card__footer">
                                   <ak-codemirror
                                       mode=${CodeMirrorMode.XML}
-                                      readOnly
+                                      readonly
                                       value="${ifDefined(this.metadata?.metadata)}"
                                   ></ak-codemirror>
                               </div>

--- a/web/src/admin/sources/saml/SAMLSourceViewPage.ts
+++ b/web/src/admin/sources/saml/SAMLSourceViewPage.ts
@@ -187,7 +187,7 @@ export class SAMLSourceViewPage extends AKElement {
                         <div class="pf-c-card__body">
                             <ak-codemirror
                                 mode=${CodeMirrorMode.XML}
-                                readOnly
+                                readonly
                                 value="${ifDefined(this.metadata?.metadata)}"
                             ></ak-codemirror>
                         </div>


### PR DESCRIPTION
## Details

This PR resolves a collection of accessibility issues in the Codemirror web component. In addition to fleshing out Codemirror's lifecycle with Lit, our element now makes use of [`ElementInternals`](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals), allowing for a more native form input serialization. 

## See also

- #16011 (For full form compatibility)