### PR TITLE
web: Clean up ak-mdx linter warnings.

### DIFF
--- a/web/src/elements/ak-mdx/ak-mdx.tsx
+++ b/web/src/elements/ak-mdx/ak-mdx.tsx
@@ -57,20 +57,16 @@ export type Replacer = (input: string) => string;
 
 @customElement("ak-mdx")
 export class AKMDX extends AKElement {
-    @property({
-        reflect: true,
-    })
-    url: string = "";
+    @property({ type: String, reflect: true })
+    public url?: string;
 
     @property()
-    content: string = "";
+    public content?: string;
 
     @property({ attribute: false })
-    replacers: Replacer[] = [];
+    public replacers: Replacer[] = [];
 
     #reactRoot: Root | null = null;
-
-    resolvedHTML = "";
 
     static styles = [
         PFBase,
@@ -181,7 +177,7 @@ export class AKMDX extends AKElement {
             nextMDXModule = await fetchMDXModule(pathname);
         } else {
             nextMDXModule = {
-                content: this.content,
+                content: this.content || "",
             };
         }
 


### PR DESCRIPTION
## Details

Fixes some long-standing warnings surrounding the properties and types within our MDX wrapper component.