### PR TITLE
packages/django-dramatiq-postgres: run worker in the same base process, use structlog

### DIFF
--- a/authentik/lib/logging.py
+++ b/authentik/lib/logging.py
@@ -14,7 +14,7 @@ LOG_PRE_CHAIN = [
     # is not from structlog.
     structlog.stdlib.add_log_level,
     structlog.stdlib.add_logger_name,
-    structlog.processors.TimeStamper(),
+    structlog.processors.TimeStamper(fmt="iso", utc=False),
     structlog.processors.StackInfoRenderer(),
 ]
 

--- a/authentik/lib/sentry.py
+++ b/authentik/lib/sentry.py
@@ -10,6 +10,7 @@ from django.db import DatabaseError, InternalError, OperationalError, Programmin
 from django.http.response import Http404
 from django_redis.exceptions import ConnectionInterrupted
 from docker.errors import DockerException
+from dramatiq.errors import Retry
 from h11 import LocalProtocolError
 from ldap3.core.exceptions import LDAPException
 from psycopg.errors import Error
@@ -68,6 +69,8 @@ ignored_classes = (
     LocalProtocolError,
     # rest_framework error
     APIException,
+    # dramatiq errors
+    Retry,
     # custom baseclass
     SentryIgnoredException,
     # ldap errors

--- a/authentik/tasks/middleware.py
+++ b/authentik/tasks/middleware.py
@@ -23,6 +23,7 @@ from authentik.tenants.models import Tenant
 from authentik.tenants.utils import get_current_tenant
 
 LOGGER = get_logger()
+HEALTHCHECK_LOGGER = get_logger("authentik.worker").bind()
 
 
 class TenantMiddleware(Middleware):
@@ -148,6 +149,17 @@ class DescriptionMiddleware(Middleware):
 
 
 class _healthcheck_handler(BaseHTTPRequestHandler):
+
+    def log_request(self, code="-", size="-"):
+        HEALTHCHECK_LOGGER.info(
+            self.path,
+            method=self.command,
+            status=code,
+        )
+
+    def log_error(self, format, *args):
+        HEALTHCHECK_LOGGER.warning(format, *args)
+
     def do_HEAD(self):
         try:
             for db_conn in connections.all():

--- a/packages/django-dramatiq-postgres/django_dramatiq_postgres/broker.py
+++ b/packages/django-dramatiq-postgres/django_dramatiq_postgres/broker.py
@@ -23,7 +23,6 @@ from django.utils.module_loading import import_string
 from dramatiq.broker import Broker, Consumer, MessageProxy
 from dramatiq.common import compute_backoff, current_millis, dq_name, xq_name
 from dramatiq.errors import ConnectionError, QueueJoinTimeout
-from dramatiq.logging import get_logger
 from dramatiq.message import Message
 from dramatiq.middleware import (
     Middleware,
@@ -31,6 +30,7 @@ from dramatiq.middleware import (
 from pglock.core import _cast_lock_id
 from psycopg import Notify, sql
 from psycopg.errors import AdminShutdown
+from structlog.stdlib import get_logger
 
 from django_dramatiq_postgres.conf import Conf
 from django_dramatiq_postgres.models import CHANNEL_PREFIX, ChannelIdentifier, TaskBase, TaskState
@@ -146,7 +146,9 @@ class PostgresBroker(Broker):
             )
 
         self.declare_queue(canonical_queue_name)
-        self.logger.debug(f"Enqueueing message {message.message_id} on queue {queue_name}")
+        self.logger.debug(
+            "Enqueueing message on queue", message_id=message.message_id, queue=queue_name
+        )
 
         message.options["model_defaults"] = self.model_defaults(message)
         self.emit_before("enqueue", message, delay)
@@ -310,7 +312,7 @@ class _PostgresConsumer(Consumer):
         self._purge_locks()
 
     def _fetch_pending_notifies(self) -> list[Notify]:
-        self.logger.debug(f"Polling for lost messages in {self.queue_name}")
+        self.logger.debug("Polling for lost messages", queue=self.queue_name)
         notifies = (
             self.query_set.filter(
                 state__in=(TaskState.QUEUED, TaskState.CONSUMED),
@@ -327,7 +329,9 @@ class _PostgresConsumer(Consumer):
         with self.listen_connection.cursor() as cursor:
             notifies = list(cursor.connection.notifies(timeout=self.timeout, stop_after=1))
             self.logger.debug(
-                f"Received {len(notifies)} postgres notifies on channel {self.postgres_channel}"
+                "Received postgres notifies on channel",
+                notifies=len(notifies),
+                channel=self.postgres_channel,
             )
             self.notifies += notifies
 
@@ -338,7 +342,7 @@ class _PostgresConsumer(Consumer):
 
     def _consume_one(self, message: Message) -> bool:
         if message.message_id in self.in_processing:
-            self.logger.debug(f"Message {message.message_id} already consumed by self")
+            self.logger.debug("Message already consumed by self", message_id=message.message_id)
             return False
 
         result = (
@@ -367,7 +371,9 @@ class _PostgresConsumer(Consumer):
             # notifications, it doesn't matter because we re-fetch for missed messages later on.
             self.notifies = self._fetch_pending_notifies()
             self.logger.debug(
-                f"Found {len(self.notifies)} pending messages in queue {self.queue_name}"
+                "Found pending messages in queue",
+                notifies=len(self.notifies),
+                queue=self.queue_name,
             )
 
         processing = len(self.in_processing)
@@ -375,7 +381,9 @@ class _PostgresConsumer(Consumer):
             # Wait and don't consume the message, other worker will be faster
             self.misses, backoff_ms = compute_backoff(self.misses, max_backoff=1000)
             self.logger.debug(
-                f"Too many messages in processing: {processing}. Sleeping {backoff_ms} ms"
+                "Too many messages in processing, Sleeping",
+                processing=processing,
+                backoff_ms=backoff_ms,
             )
             time.sleep(backoff_ms / 1000)
             return None
@@ -400,7 +408,9 @@ class _PostgresConsumer(Consumer):
                 self.in_processing.add(message.message_id)
                 return MessageProxy(message)
             else:
-                self.logger.debug(f"Message {message.message_id} already consumed. Skipping.")
+                self.logger.debug(
+                    "Message already consumed. Skipping.", message_id=message.message_id
+                )
 
         # No message to process
         self._purge_locks()
@@ -415,7 +425,7 @@ class _PostgresConsumer(Consumer):
                 message_id = self.unlock_queue.get(block=False)
             except Empty:
                 return
-            self.logger.debug(f"Unlocking message {message_id}")
+            self.logger.debug("Unlocking message", message_id=message_id)
             with self.connection.cursor() as cursor:
                 cursor.execute(
                     "SELECT pg_advisory_unlock(%s)", (self._get_message_lock_id(message_id),)
@@ -431,7 +441,7 @@ class _PostgresConsumer(Consumer):
             mtime__lte=timezone.now() - timezone.timedelta(seconds=Conf().task_purge_interval),
             result_expiry__lte=timezone.now(),
         ).delete()
-        self.logger.info(f"Purged {count} messages in all queues")
+        self.logger.info("Purged messages in all queues", count=count)
 
     def _scheduler(self):
         if not self.scheduler:

--- a/packages/django-dramatiq-postgres/django_dramatiq_postgres/management/commands/worker.py
+++ b/packages/django-dramatiq-postgres/django_dramatiq_postgres/management/commands/worker.py
@@ -3,6 +3,7 @@ from argparse import Namespace
 
 from django.apps.registry import apps
 from django.core.management.base import BaseCommand
+from django.db import connections
 from django.utils.module_loading import import_string, module_has_submodule
 from dramatiq.__main__ import main
 
@@ -68,6 +69,7 @@ class Command(BaseCommand):
 
         args.verbose = verbosity - 1
 
+        connections.close_all()
         sys.exit(main(args))
 
     def _discover_tasks_modules(self) -> tuple[str, list[str]]:

--- a/packages/django-dramatiq-postgres/django_dramatiq_postgres/middleware.py
+++ b/packages/django-dramatiq-postgres/django_dramatiq_postgres/middleware.py
@@ -13,9 +13,9 @@ from django.db import (
 from dramatiq.actor import Actor
 from dramatiq.broker import Broker
 from dramatiq.common import current_millis
-from dramatiq.logging import get_logger
 from dramatiq.message import Message
 from dramatiq.middleware.middleware import Middleware
+from structlog.stdlib import get_logger
 
 from django_dramatiq_postgres.conf import Conf
 from django_dramatiq_postgres.models import TaskBase

--- a/packages/django-dramatiq-postgres/django_dramatiq_postgres/scheduler.py
+++ b/packages/django-dramatiq-postgres/django_dramatiq_postgres/scheduler.py
@@ -5,7 +5,7 @@ from django.utils.functional import cached_property
 from django.utils.module_loading import import_string
 from django.utils.timezone import now
 from dramatiq.broker import Broker
-from dramatiq.logging import get_logger
+from structlog.stdlib import get_logger
 
 from django_dramatiq_postgres.conf import Conf
 from django_dramatiq_postgres.models import ScheduleBase
@@ -54,4 +54,4 @@ class Scheduler:
                 self.logger.debug("Could not acquire lock, skipping scheduling")
                 return
             count = self._run()
-            self.logger.info(f"Sent {count} scheduled tasks")
+            self.logger.info("Sent scheduled tasks", count=count)

--- a/packages/django-dramatiq-postgres/pyproject.toml
+++ b/packages/django-dramatiq-postgres/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
   "django-pgtrigger >=4,<5",
   "dramatiq[watch] >=1.17,<1.18",
   "tenacity >=9,<10",
+  "structlog >=25,<26"
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.13.*"
 
 [manifest]
@@ -956,6 +956,7 @@ dependencies = [
     { name = "django" },
     { name = "django-pgtrigger" },
     { name = "dramatiq", extra = ["watch"] },
+    { name = "structlog" },
     { name = "tenacity" },
 ]
 
@@ -965,6 +966,7 @@ requires-dist = [
     { name = "django", specifier = ">=4.2,<6.0" },
     { name = "django-pgtrigger", specifier = ">=4,<5" },
     { name = "dramatiq", extras = ["watch"], specifier = ">=1.17,<1.18" },
+    { name = "structlog", specifier = ">=25,<26" },
     { name = "tenacity", specifier = ">=9,<10" },
 ]
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

a) run in the same process to avoid extra memory overhead by loading all of django twice
b) to give easier to parse logs

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
