### PR TITLE
core: Mark impersonation reason field as required in UI and fix status codes

### DIFF
--- a/authentik/core/api/users.py
+++ b/authentik/core/api/users.py
@@ -678,8 +678,7 @@ class UserViewSet(UsedByMixin, ModelViewSet):
             },
         ),
         responses={
-            "204": OpenApiResponse(description="Successfully started impersonation"),
-            "401": OpenApiResponse(description="Access denied"),
+            204: OpenApiResponse(description="Successfully started impersonation"),
         },
     )
     @action(detail=True, methods=["POST"], permission_classes=[])
@@ -698,7 +697,7 @@ class UserViewSet(UsedByMixin, ModelViewSet):
                 "User attempted to impersonate without permissions",
                 user=request.user,
             )
-            return Response(status=401)
+            return Response(status=403)
         if user_to_be.pk == self.request.user.pk:
             LOGGER.debug("User attempted to impersonate themselves", user=request.user)
             return Response(status=401)
@@ -707,14 +706,14 @@ class UserViewSet(UsedByMixin, ModelViewSet):
                 "User attempted to impersonate without providing a reason",
                 user=request.user,
             )
-            return Response(status=401)
+            raise ValidationError({"reason": _("This field is required.")})
 
         request.session[SESSION_KEY_IMPERSONATE_ORIGINAL_USER] = request.user
         request.session[SESSION_KEY_IMPERSONATE_USER] = user_to_be
 
         Event.new(EventAction.IMPERSONATION_STARTED, reason=reason).from_http(request, user_to_be)
 
-        return Response(status=201)
+        return Response(status=204)
 
     @extend_schema(
         request=OpenApiTypes.NONE,

--- a/authentik/core/tests/test_impersonation.py
+++ b/authentik/core/tests/test_impersonation.py
@@ -59,7 +59,7 @@ class TestImpersonation(APITestCase):
             ),
             data={"reason": "some reason"},
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 204)
 
         response = self.client.get(reverse("authentik_api:user-me"))
         response_body = loads(response.content.decode())
@@ -80,7 +80,7 @@ class TestImpersonation(APITestCase):
             ),
             data={"reason": "some reason"},
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 204)
 
         response = self.client.get(reverse("authentik_api:user-me"))
         response_body = loads(response.content.decode())
@@ -137,10 +137,10 @@ class TestImpersonation(APITestCase):
         self.client.force_login(self.user)
 
         response = self.client.post(
-            reverse("authentik_api:user-impersonate", kwargs={"pk": self.user.pk}),
+            reverse("authentik_api:user-impersonate", kwargs={"pk": self.other_user.pk}),
             data={"reason": ""},
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, 400)
 
         response = self.client.get(reverse("authentik_api:user-me"))
         response_body = loads(response.content.decode())

--- a/schema.yml
+++ b/schema.yml
@@ -6006,8 +6006,6 @@ paths:
       responses:
         '204':
           description: Successfully started impersonation
-        '401':
-          description: Access denied
         '400':
           content:
             application/json:

--- a/web/src/admin/users/UserImpersonateForm.ts
+++ b/web/src/admin/users/UserImpersonateForm.ts
@@ -6,16 +6,29 @@ import { MessageLevel } from "#common/messages";
 import { Form } from "#elements/forms/Form";
 import { APIMessage } from "#elements/messages/Message";
 
-import { CoreApi, ImpersonationRequest } from "@goauthentik/api";
+import { AdminApi, CoreApi, ImpersonationRequest } from "@goauthentik/api";
 
 import { msg, str } from "@lit/localize";
 import { html, TemplateResult } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import { customElement, property, state } from "lit/decorators.js";
 
 @customElement("ak-user-impersonate-form")
 export class UserImpersonateForm extends Form<ImpersonationRequest> {
     @property({ type: Number })
     public instancePk?: number;
+
+    @state()
+    private requireReason = false;
+
+    async firstUpdated(): Promise<void> {
+        try {
+            const settings = await new AdminApi(DEFAULT_CONFIG).adminSettingsRetrieve();
+            this.requireReason = settings.impersonationRequireReason ?? false;
+        } catch (e) {
+            // fallback to reason not required as the backend will still validate it
+            this.requireReason = false;
+        }
+    }
 
     protected override formatAPISuccessMessage(): APIMessage | null {
         return {
@@ -45,7 +58,7 @@ export class UserImpersonateForm extends Form<ImpersonationRequest> {
             help=${msg(
                 "A brief explanation of why you are impersonating the user. This will be included in audit logs.",
             )}
-            required
+            ?required=${this.requireReason}
         ></ak-text-input>`;
     }
 }


### PR DESCRIPTION
Signed-off-by: Dominic R <dominic@sdko.org>
Closes: https://github.com/goauthentik/authentik/issues/15991

Updates the Impersonation modal to have the reason field marked as mandatory when necessary as well as updating the API to return a 400 by raising a validationerror when the reason is not set and the tenant requires an impersonation reason.