### PR TITLE
website/integrations: nextcloud: Cleanup SAML service config

### DIFF
--- a/website/integrations/chat-communication-collaboration/nextcloud/index.mdx
+++ b/website/integrations/chat-communication-collaboration/nextcloud/index.mdx
@@ -288,24 +288,27 @@ To grant Nextcloud admin access to authentik users you will need to create a pro
 
 1. Log in to Nextcloud as an administrator and navigate to **Apps** by clicking your profile picture in the top right corner.
 2. Under **App bundles**, install the **SSO & SAML authentication** bundle.
-3. Click your profile picture in the top right corner and select **Administrative settings**. Under **SSO & SAML authentication**, click on **Use built-in SAML authentication**.
-4. Configure the following settings in the **General** section:
+3. Click your profile picture in the top right corner and select **Administrative settings**. Under **SSO & SAML authentication**, click **Use built-in SAML authentication**.
+4. In the **General** section, set:
     - **Attribute to map the UID to**: `http://schemas.goauthentik.io/2021/02/saml/uid`
-
-    :::danger
-    Using the UID attribute as username is **not recommended** because of its mutable nature. If you map to the username instead, [disable username changing](https://docs.goauthentik.io/docs/sys-mgmt/settings#allow-users-to-change-username) and set the UID attribute to `http://schemas.goauthentik.io/2021/02/saml/username`.
-    :::
     - **Optional display name**: `authentik`
 
-5. Configure the following settings in the **Identity Provider Data** section:
+    :::danger
+    Using the UID attribute as username is **not recommended** because of its mutable nature. If you map to the username instead, [disable username changing](/docs/sys-mgmt/settings#allow-users-to-change-username) and set the UID attribute to `http://schemas.goauthentik.io/2021/02/saml/username`.
+    :::
+
+5. In the **Identity Provider Data** section, set:
     - **Identifier of the IdP entity**: `https://authentik.company`
     - **URL Target of the IdP where the SP will send the Authentication Request Message**: `https://authentik.company/application/saml/<application_slug>/sso/binding/redirect/`
 
     Under _Show optional Identity Provider settings_:
     - **URL Location of the IdP where the SP will send the SLO Request**: `https://authentik.company/application/saml/<application_slug>/slo/binding/redirect/`
-    - **X.509 certificate of the IdP**: Paste the contents of your certificate file.
+    - **X.509 certificate of the IdP**: paste the contents of your certificate file
 
-6. Configure the following settings in the **Attribute mapping** section: - **Attribute to map the displayname to**: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name` - **Attribute to map the email address to**: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress` - **Attribute to map the users groups to**: `http://schemas.xmlsoap.org/claims/Group`
+6. In the **Attribute mapping** section, set:
+    - **Attribute to map the display name to**: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name`
+    - **Attribute to map the email address to**: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress`
+    - **Attribute to map the user's groups to**: `http://schemas.xmlsoap.org/claims/Group`
 
 :::note
 If Nextcloud is behind a reverse proxy, force HTTPS by adding `'overwriteprotocol' => 'https'` to the Nextcloud `config/config.php` file. See [this guide](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/reverse_proxy_configuration.html#overwrite-parameters) for more details.

--- a/website/integrations/chat-communication-collaboration/nextcloud/index.mdx
+++ b/website/integrations/chat-communication-collaboration/nextcloud/index.mdx
@@ -308,7 +308,7 @@ To grant Nextcloud admin access to authentik users you will need to create a pro
 6. In the **Attribute mapping** section, set:
     - **Attribute to map the display name to**: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name`
     - **Attribute to map the email address to**: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress`
-    - **Attribute to map the user's groups to**: `http://schemas.xmlsoap.org/claims/Group`
+    - **Attribute to map the user's groups to**: `http://schemas.xmlsoap.org/claims/Group` _(optional)_
 
 :::note
 If Nextcloud is behind a reverse proxy, force HTTPS by adding `'overwriteprotocol' => 'https'` to the Nextcloud `config/config.php` file. See [this guide](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/reverse_proxy_configuration.html#overwrite-parameters) for more details.

--- a/website/integrations/chat-communication-collaboration/nextcloud/index.mdx
+++ b/website/integrations/chat-communication-collaboration/nextcloud/index.mdx
@@ -284,30 +284,28 @@ To grant Nextcloud admin access to authentik users you will need to create a pro
                 yield "admin"
             ```
 
-### Configure group attribute in Nextcloud _(optional)_
-
-1. Log in to Nextcloud as an administrator.
-2. Navigate to **Settings** > **SSO & SAML Authentication**.
-3. Set the groups mapping to `http://schemas.xmlsoap.org/claims/Group`.
-
 ## Nextcloud configuration
 
-1. In Nextcloud, ensure that the **SSO & SAML Authentication** app is installed.
-2. Log in to Nextcloud as an administrator, navigate to **Settings** > **SSO & SAML Authentication**, and configure the following settings:
+1. Log in to Nextcloud as an administrator and navigate to **Apps** by clicking your profile picture in the top right corner.
+2. Under **App bundles**, install the **SSO & SAML authentication** bundle.
+3. Click your profile picture in the top right corner and select **Administrative settings**. Under **SSO & SAML authentication**, click on **Use built-in SAML authentication**.
+4. Configure the following settings in the **General** section:
     - **Attribute to map the UID to**: `http://schemas.goauthentik.io/2021/02/saml/uid`
 
     :::danger
     Using the UID attribute as username is **not recommended** because of its mutable nature. If you map to the username instead, [disable username changing](https://docs.goauthentik.io/docs/sys-mgmt/settings#allow-users-to-change-username) and set the UID attribute to `http://schemas.goauthentik.io/2021/02/saml/username`.
     :::
     - **Optional display name**: `authentik`
+
+5. Configure the following settings in the **Identity Provider Data** section:
     - **Identifier of the IdP entity**: `https://authentik.company`
-    - **URL target for authentication requests**: `https://authentik.company/application/saml/<application_slug>/sso/binding/redirect/`
-    - **URL for SLO requests**: `https://authentik.company/application/saml/<application_slug>/slo/binding/redirect/`
-    - **Public X.509 certificate of the IdP**: Paste the contents of your certificate file.
-    - **Set attribute mappings**:
-        - **Display name**: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name`
-        - **Email**: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress`
-        - **User groups**: `http://schemas.xmlsoap.org/claims/Group`
+    - **URL Target of the IdP where the SP will send the Authentication Request Message**: `https://authentik.company/application/saml/<application_slug>/sso/binding/redirect/`
+
+    Under _Show optional Identity Provider settings_:
+    - **URL Location of the IdP where the SP will send the SLO Request**: `https://authentik.company/application/saml/<application_slug>/slo/binding/redirect/`
+    - **X.509 certificate of the IdP**: Paste the contents of your certificate file.
+
+6. Configure the following settings in the **Attribute mapping** section: - **Attribute to map the displayname to**: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name` - **Attribute to map the email address to**: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress` - **Attribute to map the users groups to**: `http://schemas.xmlsoap.org/claims/Group`
 
 :::note
 If Nextcloud is behind a reverse proxy, force HTTPS by adding `'overwriteprotocol' => 'https'` to the Nextcloud `config/config.php` file. See [this guide](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/reverse_proxy_configuration.html#overwrite-parameters) for more details.


### PR DESCRIPTION
Signed-off-by: Dominic R <dominic@sdko.org>
CC: @dewi-tik, @tanberry 

Created following creation of https://github.com/goauthentik/authentik/issues/16050

This PR includes:

* the :::danger now uses a relative link
* updated field names and logically sorted them following what's in the UI
* Removed the section "Configure group attribute in Nextcloud" because  before it tells you to configure it before you even configure the rest of the SSO which is... interesting. Also, on the old line 310 you were adding the group mapping anyways, so I just added an (optional) nexto it