### PR TITLE
rbac: assign `InitialPermission`s in a middleware

### DIFF
--- a/authentik/core/api/utils.py
+++ b/authentik/core/api/utils.py
@@ -21,8 +21,6 @@ from rest_framework.serializers import (
     raise_errors_on_nested_writes,
 )
 
-from authentik.rbac.permissions import assign_initial_permissions
-
 
 def is_dict(value: Any):
     """Ensure a value is a dictionary, useful for JSONFields"""
@@ -51,15 +49,6 @@ class ModelSerializer(BaseModelSerializer):
     # By default, JSON fields we have are used to store dictionaries
     serializer_field_mapping = BaseModelSerializer.serializer_field_mapping.copy()
     serializer_field_mapping[models.JSONField] = JSONDictField
-
-    def create(self, validated_data):
-        instance = super().create(validated_data)
-
-        request = self.context.get("request")
-        if request and hasattr(request, "user") and not request.user.is_anonymous:
-            assign_initial_permissions(request.user, instance)
-
-        return instance
 
     def update(self, instance: Model, validated_data):
         raise_errors_on_nested_writes("update", self, validated_data)

--- a/authentik/rbac/middleware.py
+++ b/authentik/rbac/middleware.py
@@ -1,0 +1,69 @@
+"""InitialPermissions middleware"""
+
+from collections.abc import Callable
+from contextvars import ContextVar
+from functools import partial
+
+from django.db.models import Model
+from django.db.models.signals import post_save
+from django.http import HttpRequest, HttpResponse
+
+from authentik.core.models import User
+from authentik.rbac.permissions import assign_initial_permissions
+
+_CTX_REQUEST = ContextVar[HttpRequest | None]("authentik_initial_permissions_request", default=None)
+
+
+class InitialPermissionsMiddleware:
+    """Register a handler for duration of request-response that assigns InitialPermissions"""
+
+    get_response: Callable[[HttpRequest], HttpResponse]
+
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]):
+        self.get_response = get_response
+
+    def get_uid(self, request_id: str) -> str:
+        return f"InitialPermissionMiddleware-{request_id}"
+
+    def connect(self, request: HttpRequest):
+        if not hasattr(request, "request_id"):
+            return
+        post_save.connect(
+            partial(self.post_save_handler, request=request),
+            dispatch_uid=self.get_uid(request.request_id),
+            weak=False,
+        )
+
+    def disconnect(self, request: HttpRequest):
+        if not hasattr(request, "request_id"):
+            return
+        post_save.disconnect(dispatch_uid=self.get_uid(request.request_id))
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        _CTX_REQUEST.set(request)
+        self.connect(request)
+
+        response = self.get_response(request)
+
+        self.disconnect(request)
+        _CTX_REQUEST.set(None)
+        return response
+
+    def process_exception(self, request: HttpRequest, exception: Exception):
+        self.disconnect(request)
+
+    def post_save_handler(
+        self,
+        request: HttpRequest,
+        instance: Model,
+        created: bool,
+        **_,
+    ):
+        if not created:
+            return
+        if request.request_id != _CTX_REQUEST.get().request_id:
+            return
+        user: User = request.user
+        if not user or user.is_anonymous:
+            return
+        assign_initial_permissions(user, instance)

--- a/authentik/rbac/permissions.py
+++ b/authentik/rbac/permissions.py
@@ -5,8 +5,11 @@ from django.db.models import Model
 from guardian.shortcuts import assign_perm
 from rest_framework.permissions import BasePermission, DjangoObjectPermissions
 from rest_framework.request import Request
+from structlog.stdlib import get_logger
 
 from authentik.rbac.models import InitialPermissions, InitialPermissionsMode
+
+LOGGER = get_logger()
 
 
 class ObjectPermissions(DjangoObjectPermissions):
@@ -70,5 +73,11 @@ def assign_initial_permissions(user, instance: Model):
                 user
                 if initial_permissions.mode == InitialPermissionsMode.USER
                 else initial_permissions.role.group
+            )
+            LOGGER.debug(
+                "Adding initial permission",
+                initial_permission=permission,
+                subject=assign_to,
+                object=instance,
             )
             assign_perm(permission, assign_to, instance)

--- a/authentik/root/settings.py
+++ b/authentik/root/settings.py
@@ -266,6 +266,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "authentik.core.middleware.ImpersonateMiddleware",
+    "authentik.rbac.middleware.InitialPermissionsMiddleware",
 ]
 MIDDLEWARE_LAST = [
     "django_prometheus.middleware.PrometheusAfterMiddleware",


### PR DESCRIPTION
This will catch more creation events, hopefully fixing things like https://github.com/goauthentik/authentik/issues/14313

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
