### PR TITLE
core: Fix docstring for core_users_recovery_email_create and core_users_recovery_create

### DIFF
--- a/authentik/core/api/users.py
+++ b/authentik/core/api/users.py
@@ -620,7 +620,7 @@ class UserViewSet(UsedByMixin, ModelViewSet):
     )
     @action(detail=True, pagination_class=None, filter_backends=[], methods=["POST"])
     def recovery(self, request: Request, pk: int) -> Response:
-        """Create a temporary link that a user can use to recover their accounts"""
+        """Create a temporary link that a user can use to recover their account"""
         link, _ = self._create_recovery_link()
         return Response({"link": link})
 
@@ -641,7 +641,7 @@ class UserViewSet(UsedByMixin, ModelViewSet):
     )
     @action(detail=True, pagination_class=None, filter_backends=[], methods=["POST"])
     def recovery_email(self, request: Request, pk: int) -> Response:
-        """Create a temporary link that a user can use to recover their accounts"""
+        """Send an email with a temporary link that a user can use to recover their account"""
         for_user: User = self.get_object()
         if for_user.email == "":
             LOGGER.debug("User doesn't have an email address")

--- a/schema.yml
+++ b/schema.yml
@@ -6023,7 +6023,7 @@ paths:
   /core/users/{id}/recovery/:
     post:
       operationId: core_users_recovery_create
-      description: Create a temporary link that a user can use to recover their accounts
+      description: Create a temporary link that a user can use to recover their account
       parameters:
       - in: path
         name: id
@@ -6057,7 +6057,7 @@ paths:
   /core/users/{id}/recovery_email/:
     post:
       operationId: core_users_recovery_email_create
-      description: Create a temporary link that a user can use to recover their accounts
+      description: Send an email with a temporary link that a user can use to recover their account
       parameters:
       - in: query
         name: email_stage


### PR DESCRIPTION
## Details

Fixing documentation issue for `core_users_recovery_email_create` and `core_users_recovery_create`

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)

Notice: Wan't able to run "make web|docs"