### PR TITLE
web: Improvements to ReCaptcha resizing 

### DIFF
--- a/web/src/common/purify.ts
+++ b/web/src/common/purify.ts
@@ -105,7 +105,9 @@ export function renderStaticHTMLUnsafe(untrustedHTML: unknown): string {
 
     render(untrustedHTML, container);
 
-    const result = container.innerHTML;
-
+    const result = container.innerHTML
+        // Remove all comments as they can interfere with the styles.
+        .replaceAll("<!---->", "")
+        .replaceAll(/<!--\?lit\$\d+\$-->/g, "");
     return result;
 }

--- a/web/src/flow/stages/captcha/CaptchaStage.ts
+++ b/web/src/flow/stages/captcha/CaptchaStage.ts
@@ -9,7 +9,7 @@ import { ListenerController } from "#elements/utils/listenerController";
 import { randomId } from "#elements/utils/randomId";
 
 import { BaseStage } from "#flow/stages/base";
-import { CaptchaHandler, iframeTemplate } from "#flow/stages/captcha/shared";
+import { CaptchaHandler, CaptchaProvider, iframeTemplate } from "#flow/stages/captcha/shared";
 
 import { CaptchaChallenge, CaptchaChallengeResponseRequest } from "@goauthentik/api";
 
@@ -109,7 +109,7 @@ export class CaptchaStage extends BaseStage<CaptchaChallenge, CaptchaChallengeRe
     //#region State
 
     @state()
-    protected activeHandler: CaptchaHandler | null = null;
+    protected activeHandler: CaptchaProvider | null = null;
 
     @state()
     protected error: string | null = null;
@@ -265,7 +265,12 @@ export class CaptchaStage extends BaseStage<CaptchaChallenge, CaptchaChallengeRe
 
     //#endregion
 
-    #handlers = new Map<string, CaptchaHandler>([
+    /**
+     * Mapping of captcha provider names to their respective JS API global.
+     *
+     * Note that this is a `Map` to ensure the preferred order of discovering provider globals.
+     */
+    #handlers = new Map<CaptchaProvider, CaptchaHandler>([
         [
             "grecaptcha",
             {
@@ -415,7 +420,7 @@ export class CaptchaStage extends BaseStage<CaptchaChallenge, CaptchaChallengeRe
 
     //#endregion
 
-    //#region Listeners
+    //#region Resizing
 
     #loadListener = () => {
         const iframe = this.#iframeRef.value;
@@ -423,17 +428,73 @@ export class CaptchaStage extends BaseStage<CaptchaChallenge, CaptchaChallengeRe
 
         if (!iframe || !contentDocument) return;
 
-        const resizeListener: ResizeObserverCallback = () => {
-            if (!this.#iframeRef) return;
+        let synchronizeHeight: () => void;
 
-            const target = contentDocument.getElementById("ak-container");
+        if (this.activeHandler === CaptchaProvider.reCAPTCHA) {
+            // reCAPTCHA's use of nested iframes prevents their internal resize observer from
+            // reporting the correct height back to our iframe, so we have to do it ourselves.
 
-            if (!target) return;
+            synchronizeHeight = () => {
+                if (!this.#iframeRef) return;
 
-            this.iframeHeight = Math.round(target.clientHeight);
-        };
+                const target = contentDocument.getElementById("ak-container");
 
-        const resizeObserver = new ResizeObserver(resizeListener);
+                if (!target) return;
+
+                const innerIFrame = contentDocument.querySelector<HTMLIFrameElement>(
+                    'iframe[style~="height:"]',
+                );
+
+                const innerBottom = innerIFrame?.getBoundingClientRect().bottom ?? 0;
+
+                const actualHeight = Math.max(innerBottom, target.clientHeight);
+
+                this.iframeHeight = Math.round(actualHeight * 1.1);
+
+                if (innerIFrame?.parentElement) {
+                    innerIFrame.parentElement.style.height = `${actualHeight}px`;
+                }
+            };
+
+            // We watch for any newly inserted iframes, as they may alter the height
+            // of the parent iframe...
+            const mutationObserver = new MutationObserver((mutations) => {
+                for (const mutation of mutations) {
+                    if (mutation.type !== "childList") continue;
+
+                    for (const node of mutation.addedNodes as NodeListOf<HTMLElement>) {
+                        if (node.tagName !== "IFRAME") continue;
+
+                        // And then resize the iframe to match the new size.
+                        //
+                        // This doesn't fix the issue entirely since the challenge frame
+                        // doesn't yet know the correct height, but at least the user can
+                        // try to load the challenge again with the correct height.
+
+                        resizeObserver.observe(node as HTMLIFrameElement);
+
+                        requestAnimationFrame(synchronizeHeight);
+                    }
+                }
+            });
+
+            mutationObserver.observe(contentDocument.body, {
+                childList: true,
+                subtree: true,
+            });
+        } else {
+            synchronizeHeight = () => {
+                if (!this.#iframeRef) return;
+
+                const target = contentDocument.getElementById("ak-container");
+
+                if (!target) return;
+
+                this.iframeHeight = Math.round(target.clientHeight);
+            };
+        }
+
+        const resizeObserver = new ResizeObserver(synchronizeHeight);
 
         requestAnimationFrame(() => {
             resizeObserver.observe(contentDocument.body);
@@ -442,22 +503,26 @@ export class CaptchaStage extends BaseStage<CaptchaChallenge, CaptchaChallengeRe
         });
     };
 
+    //#endregion
+
+    //#region Loading
+
     #scriptLoadListener = async (): Promise<void> => {
         console.debug("authentik/stages/captcha: script loaded");
 
         this.error = null;
         this.#iframeLoaded = false;
 
-        for (const [name, handler] of this.#handlers) {
+        for (const name of this.#handlers.keys()) {
             if (!Object.hasOwn(window, name)) {
                 continue;
             }
 
             try {
-                await this.#run(handler);
+                await this.#run(name);
                 console.debug(`authentik/stages/captcha[${name}]: handler succeeded`);
 
-                this.activeHandler = handler;
+                this.activeHandler = name;
 
                 return;
             } catch (error) {
@@ -469,12 +534,24 @@ export class CaptchaStage extends BaseStage<CaptchaChallenge, CaptchaChallengeRe
         }
     };
 
-    async #run(handler: CaptchaHandler) {
+    async #run(captchaProvider: CaptchaProvider) {
+        const handler = this.#handlers.get(captchaProvider)!;
+
         if (this.challenge.interactive) {
             const iframe = this.#iframeRef.value;
 
             if (!iframe) {
                 console.debug(`authentik/stages/captcha: No iframe found, skipping.`);
+                return;
+            }
+
+            const { contentDocument } = iframe;
+
+            if (!contentDocument) {
+                console.debug(
+                    `authentik/stages/captcha: No iframe content window found, skipping.`,
+                );
+
                 return;
             }
 
@@ -486,13 +563,26 @@ export class CaptchaStage extends BaseStage<CaptchaChallenge, CaptchaChallengeRe
                 theme: this.activeTheme,
             });
 
-            URL.revokeObjectURL(this.#iframeSource);
+            if (captchaProvider === CaptchaProvider.reCAPTCHA) {
+                // reCAPTCHA's domain verification can't seem to penetrate the true origin
+                // of the page when loaded from a blob URL, likely due to their double-nested
+                // iframe structure.
+                // We fallback to the deprecated `document.write` to get around this.
+                this.#iframeSource = "about:blank";
+                contentDocument.open();
+                contentDocument.write(template);
+                contentDocument.close();
 
-            const url = URL.createObjectURL(new Blob([template], { type: "text/html" }));
+                // this.#loadListener();
+            } else {
+                URL.revokeObjectURL(this.#iframeSource);
 
-            this.#iframeSource = url;
+                const url = URL.createObjectURL(new Blob([template], { type: "text/html" }));
 
-            iframe.src = url;
+                this.#iframeSource = url;
+
+                iframe.src = url;
+            }
 
             return;
         }

--- a/web/src/flow/stages/captcha/CaptchaStage.ts
+++ b/web/src/flow/stages/captcha/CaptchaStage.ts
@@ -481,7 +481,10 @@ export class CaptchaStage extends BaseStage<CaptchaChallenge, CaptchaChallengeRe
             console.debug(`authentik/stages/captcha: Rendering interactive.`);
 
             const captchaElement = handler.interactive();
-            const template = iframeTemplate(captchaElement, this.challenge.jsUrl);
+            const template = iframeTemplate(captchaElement, {
+                challengeURL: this.challenge.jsUrl,
+                theme: this.activeTheme,
+            });
 
             URL.revokeObjectURL(this.#iframeSource);
 

--- a/web/src/flow/stages/captcha/shared.ts
+++ b/web/src/flow/stages/captcha/shared.ts
@@ -4,6 +4,17 @@ import { createDocumentTemplate } from "#elements/utils/iframe";
 
 import { html, TemplateResult } from "lit";
 
+/**
+ * Mapping of captcha provider names to their respective JS API global.
+ */
+export const CaptchaProvider = {
+    reCAPTCHA: "grecaptcha",
+    hCaptcha: "hcaptcha",
+    Turnstile: "turnstile",
+} as const satisfies Record<string, string>;
+
+export type CaptchaProvider = (typeof CaptchaProvider)[keyof typeof CaptchaProvider];
+
 export interface CaptchaHandler {
     interactive(): TemplateResult;
     execute(): Promise<void>;


### PR DESCRIPTION
## Details

This PR focuses on a few visual issues that arise in the Captcha stage when using ReCaptcha.
As reported in #15598, Recaptcha v2 and v3 do not resize in response to their parent iframe's change in height. Additionally, ReCaptcha's (latest?) logic for handling domain verification isn't compatible with our switch to blob URLs as a source for frames.

The current fix for this limited due to the nature of this three-layer deep iframe structure.
We have a few options for fixing this:

1. Move the captcha out of the iframe, sacrificing the encapsulation of vendor scripts
2. Apply an estimated height to reCaptcha's iframe and trigger a resize event
3. Use a different captcha provider such as Turnstile or hCaptcha

This PR uses option 2, expanding our existing resize logic to traverse the DOM tree and resize all relevant elements. This is a bit of a hack, and it's limited to expanding the captcha's iframe, but it has the least impact on the other captcha vendors.

Also included is a fix captcha iframes not inheriting the color scheme of the parent page, ensuring **fewer** slivers of white around the captcha.

<img width="1470" height="919" alt="Screenshot 2025-08-13 at 19 57 09" src="https://github.com/user-attachments/assets/2a50488e-1d46-43c1-ba94-d5d05079d448" />

<img width="902" height="826" alt="Screenshot 2025-08-13 at 19 58 47" src="https://github.com/user-attachments/assets/4ad8e6b8-d428-4ffd-9fc7-062e1adb1bcb" />

## What's not included

- The ability to configure recaptcha's `size` parameter
- Shrinking reCaptcha's iframe after the challenge is completed

---

Closes #15598