### PR TITLE
website/docs: Advanced queries, remove reference to QL and add more examples

### DIFF
--- a/website/docs/releases/2025/v2025.8.mdx
+++ b/website/docs/releases/2025/v2025.8.mdx
@@ -139,6 +139,7 @@ An integration is a how authentik connects to third-party applications, director
 - [Papra](https://integrations.goauthentik.io/documentation/papra/)
 - [Planka](https://integrations.goauthentik.io/chat-communication-collaboration/planka/)
 - [Seafile](https://integrations.goauthentik.io/media/seafile/)
+- [Vaultwarden](https://integrations.goauthentik.io/security/vaultwarden/)
 - [Zoho](https://integrations.goauthentik.io/platforms/zoho/)
 
 ## Upgrading

--- a/website/docs/sys-mgmt/events/logging-events.md
+++ b/website/docs/sys-mgmt/events/logging-events.md
@@ -51,8 +51,11 @@ You can construct advanced queries to find specific event logs. In the Admin int
     - search event by brand: `brand.name = "my brand"`
     - search event by user: `user.username in ["ana", "akadmin"]`
 
+For more examples, refer to the list of [Event actions](./event-actions.md) and the related examples for each type of event.
+
 :::info
 
 1. To dismiss an unwanted drop-down menu option, click **ESC**.
 2. If the list of operators does not appear in a drop-down menu you will need to manually enter it.
+3. Wuesries that include `user`, `brand`, or `context` you need to use a compound term such as `user.username` or `brand.
    :::

--- a/website/docs/sys-mgmt/events/logging-events.md
+++ b/website/docs/sys-mgmt/events/logging-events.md
@@ -55,7 +55,7 @@ For more examples, refer to the list of [Event actions](./event-actions.md) and 
 
 :::info
 
-1. To dismiss an unwanted drop-down menu option, click **ESC**.
+1. To dismiss an unneeded drop-down menu option, click **ESC**.
 2. If the list of operators does not appear in a drop-down menu you will need to manually enter it.
-3. Wuesries that include `user`, `brand`, or `context` you need to use a compound term such as `user.username` or `brand.
+3. For queries that include `user`, `brand`, or `context` you need to use a compound term such as `user.username` or `brand.name`.
    :::

--- a/website/docs/sys-mgmt/events/logging-events.md
+++ b/website/docs/sys-mgmt/events/logging-events.md
@@ -58,4 +58,4 @@ For more examples, refer to the list of [Event actions](./event-actions.md) and 
 1. To dismiss the drop-down menu option, click **ESC**.
 2. If the list of operators does not appear in a drop-down menu you will need to manually enter it.
 3. For queries that include `user`, `brand`, or `context` you need to use a compound term such as `user.username` or `brand.name`.
-:::
+   :::

--- a/website/docs/sys-mgmt/events/logging-events.md
+++ b/website/docs/sys-mgmt/events/logging-events.md
@@ -55,7 +55,7 @@ For more examples, refer to the list of [Event actions](./event-actions.md) and 
 
 :::info
 
-1. To dismiss an unneeded drop-down menu option, click **ESC**.
+1. To dismiss the drop-down menu option, click **ESC**.
 2. If the list of operators does not appear in a drop-down menu you will need to manually enter it.
 3. For queries that include `user`, `brand`, or `context` you need to use a compound term such as `user.username` or `brand.name`.
-   :::
+:::

--- a/website/docs/sys-mgmt/events/logging-events.md
+++ b/website/docs/sys-mgmt/events/logging-events.md
@@ -52,6 +52,7 @@ You can construct advanced queries to find specific event logs. In the Admin int
     - search event by user: `user.username in ["ana", "akadmin"]`
 
 :::info
+
 1. To dismiss an unwanted drop-down menu option, click **ESC**.
 2. If the list of operators does not appear in a drop-down menu you will need to manually enter it.
-:::
+   :::

--- a/website/docs/sys-mgmt/events/logging-events.md
+++ b/website/docs/sys-mgmt/events/logging-events.md
@@ -43,7 +43,7 @@ You can construct advanced queries to find specific event logs. In the Admin int
 - **Values**: `True`, `False`, `None`
 
 - **Example queries**:
-    - search application by name: `app startswith "N"`
+    - search event by application name: `app startswith "N"`
     - search event by action: `action = "login"`
     - search event by authorized application context: `authorized_application.name = "My app"`
     - search event by country: `context.geo.country = "Germany"`

--- a/website/docs/sys-mgmt/events/logging-events.md
+++ b/website/docs/sys-mgmt/events/logging-events.md
@@ -34,7 +34,7 @@ With the enterprise version, you can view recent events on both a world map view
 
 ## Advanced queries for event logs:ak-enterprise {#tell-me-more}
 
-You can construct advanced queries, based on [DjangoQL](https://github.com/ivelum/djangoql), to find specific event logs. In the Admin interface, navigate to **Events > Logs**, and then use the auto-complete in the **Search** field or enter your own queries to return results with greater specificity.
+You can construct advanced queries to find specific event logs. In the Admin interface, navigate to **Events > Logs**, and then use the auto-complete in the **Search** field or enter your own queries to return results with greater specificity.
 
 - **Model/object**: `action`, `event_uuid`, `app`, `client_ip`, `user`, `brnad`, `context`, `created`
 

--- a/website/docs/sys-mgmt/events/logging-events.md
+++ b/website/docs/sys-mgmt/events/logging-events.md
@@ -52,7 +52,6 @@ You can construct advanced queries to find specific event logs. In the Admin int
     - search event by user: `user.username in ["ana", "akadmin"]`
 
 :::info
-
 1. To dismiss an unwanted drop-down menu option, click **ESC**.
 2. If the list of operators does not appear in a drop-down menu you will need to manually enter it.
-   :::
+:::

--- a/website/docs/sys-mgmt/events/logging-events.md
+++ b/website/docs/sys-mgmt/events/logging-events.md
@@ -42,4 +42,10 @@ You can construct advanced queries to find specific event logs. In the Admin int
 
 - **Values**: `True`, `False`, `None`
 
-- **Example queries**: `action = "login"`, `app startswith "N"`
+- **Example queries**:
+    - search application by name: `app startswith "N"`
+    - search event by action: `action = "login"`
+    - search event by authorized application context: `authorized_application.name = "My app"`
+    - search event by country: `context.geo.country = "Germany"`
+    - search event by IP address: `client_ip = "10.0.0.1"`
+    - search event by brand: `brand.name = "my brand"`

--- a/website/docs/sys-mgmt/events/logging-events.md
+++ b/website/docs/sys-mgmt/events/logging-events.md
@@ -36,9 +36,9 @@ With the enterprise version, you can view recent events on both a world map view
 
 You can construct advanced queries to find specific event logs. In the Admin interface, navigate to **Events > Logs**, and then use the auto-complete in the **Search** field or enter your own queries to return results with greater specificity.
 
-- **Model/object**: `action`, `event_uuid`, `app`, `client_ip`, `user`, `brnad`, `context`, `created`
+- **Field**: `action`, `event_uuid`, `app`, `client_ip`, `user`, `brand`, `context`, `created`
 
-- **Operators**: `=`, `!=`, `~`, `!~`
+- **Operators**: `=`, `!=`, `~`, `!~`, `startswith`, `not startswith`, `endswidth`, `not endswith`, `in`, `not in`
 
 - **Values**: `True`, `False`, `None`
 
@@ -49,3 +49,10 @@ You can construct advanced queries to find specific event logs. In the Admin int
     - search event by country: `context.geo.country = "Germany"`
     - search event by IP address: `client_ip = "10.0.0.1"`
     - search event by brand: `brand.name = "my brand"`
+    - search event by user: `user.username in ["ana", "akadmin"]`
+
+:::info
+
+1. To dismiss an unwanted drop-down menu option, click **ESC**.
+2. If the list of operators does not appear in a drop-down menu you will need to manually enter it.
+   :::

--- a/website/docs/sys-mgmt/events/logging-events.md
+++ b/website/docs/sys-mgmt/events/logging-events.md
@@ -40,7 +40,7 @@ You can construct advanced queries to find specific event logs. In the Admin int
 
 - **Operators**: `=`, `!=`, `~`, `!~`, `startswith`, `not startswith`, `endswidth`, `not endswith`, `in`, `not in`
 
-- **Values**: `True`, `False`, `None`
+- **Values**: `True`, `False`, `None`, and more
 
 - **Example queries**:
     - search event by application name: `app startswith "N"`

--- a/website/docs/users-sources/user/user_basic_operations.md
+++ b/website/docs/users-sources/user/user_basic_operations.md
@@ -51,7 +51,7 @@ You can create advanced queries to locate specific users within the list shown u
 
 :::info
 
-1. To dismiss an unneeded drop-down menu option, click **ESC**.
+1. To dismiss the drop-down menu option, click **ESC**.
 2. If the list of operators does not appear in a drop-down menu you will need to manually enter it.
    :::
 

--- a/website/docs/users-sources/user/user_basic_operations.md
+++ b/website/docs/users-sources/user/user_basic_operations.md
@@ -35,7 +35,7 @@ To create a super-user, you need to add the user to a group that has super-user 
 
 ## Advanced queries for users:ak-enterprise {#tell-me-more}
 
-You can construct advanced queries to find specific users in the list under **Directory > Users**. Use the auto-complete in the **Search** field or enter your own queries to return results with greater specificity.
+You can construct advanced queries to find specific users in the list displayed on **Directory > Users** in the Admin interface. Use the auto-complete in the **Search** field or enter your own queries to return results with greater specificity.
 
 - **Field**: `username`, `path`, `name`, `email`, `path`, `is_active`, `type`, `attributes`
 
@@ -51,7 +51,7 @@ You can construct advanced queries to find specific users in the list under **Di
 
 :::info
 
-1. To dismiss an unwanted drop-down menu option, click **ESC**.
+1. To dismiss an unneeded drop-down menu option, click **ESC**.
 2. If the list of operators does not appear in a drop-down menu you will need to manually enter it.
    :::
 

--- a/website/docs/users-sources/user/user_basic_operations.md
+++ b/website/docs/users-sources/user/user_basic_operations.md
@@ -35,7 +35,7 @@ To create a super-user, you need to add the user to a group that has super-user 
 
 ## Advanced queries for users:ak-enterprise {#tell-me-more}
 
-You can construct advanced queries to find specific users in the list displayed on **Directory > Users** in the Admin interface. Use the auto-complete in the **Search** field or enter your own queries to return results with greater specificity.
+You can create advanced queries to locate specific users within the list shown under **Directory** > **Users** in the Admin interface. Use the auto-complete in the **Search** field or enter your own queries to return results with greater specificity.
 
 - **Field**: `username`, `path`, `name`, `email`, `path`, `is_active`, `type`, `attributes`
 

--- a/website/docs/users-sources/user/user_basic_operations.md
+++ b/website/docs/users-sources/user/user_basic_operations.md
@@ -35,21 +35,7 @@ To create a super-user, you need to add the user to a group that has super-user 
 
 ## Advanced queries for users:ak-enterprise {#tell-me-more}
 
-You can construct advanced queries, based on [DjangoQL](https://github.com/ivelum/djangoql), to find specific users in the list under **Directory > Users**. Use the auto-complete in the **Search** field or enter your own queries to return results with greater specificity.
-
-<!--| Model/Object | Operators | Examples |
-| ---- | ---- | ----------- |
-| `username` | `=` | `username = "Joel Bonne"` |
-| `path` | !=  |  |
-| `name` | ~| |
-| `email` | !~ |
-| `path` | `startswith` |
-| `is_active` | `not startswith` |
-| `type` | `endswith` |
-| `attributes`| `endswith` |
-| | `not endswith` |
-| | `in` |
-| | `not in` |-->
+You can construct advanced queries to find specific users in the list under **Directory > Users**. Use the auto-complete in the **Search** field or enter your own queries to return results with greater specificity.
 
 - **Model/object**: `username`, `path`, `name`, `email`, `path`, `is_active`, `type`, `attributes`
 

--- a/website/docs/users-sources/user/user_basic_operations.md
+++ b/website/docs/users-sources/user/user_basic_operations.md
@@ -46,7 +46,7 @@ You can construct advanced queries to find specific users in the list under **Di
 - **Example queries**:
     - search user by status: `is_active = False`
     - search user by username: `username = "bob"`
-    - search user by email email = "bob@authentik.company"
+    - search user by email address: `email = "bob@authentik.company"`
     - search user by attribute: `attribute.my_custom_attribute = "foo"`
 
 ## View user details

--- a/website/docs/users-sources/user/user_basic_operations.md
+++ b/website/docs/users-sources/user/user_basic_operations.md
@@ -37,7 +37,7 @@ To create a super-user, you need to add the user to a group that has super-user 
 
 You can construct advanced queries to find specific users in the list under **Directory > Users**. Use the auto-complete in the **Search** field or enter your own queries to return results with greater specificity.
 
-- **Model/object**: `username`, `path`, `name`, `email`, `path`, `is_active`, `type`, `attributes`
+- **Field**: `username`, `path`, `name`, `email`, `path`, `is_active`, `type`, `attributes`
 
 - **Operators**: `=`, `!=`, `~`, `!~`, `startswith`, `not startswith`, `endswidth`, `not endswith`, `in`, `not in`
 
@@ -48,6 +48,12 @@ You can construct advanced queries to find specific users in the list under **Di
     - search user by username: `username = "bob"`
     - search user by email address: `email = "bob@authentik.company"`
     - search user by attribute: `attribute.my_custom_attribute = "foo"`
+
+:::info
+
+1. To dismiss an unwanted drop-down menu option, click **ESC**.
+2. If the list of operators does not appear in a drop-down menu you will need to manually enter it.
+   :::
 
 ## View user details
 

--- a/website/docs/users-sources/user/user_basic_operations.md
+++ b/website/docs/users-sources/user/user_basic_operations.md
@@ -43,7 +43,11 @@ You can construct advanced queries to find specific users in the list under **Di
 
 - **Values**: `True`, `False`, `None`
 
-- **Example queries**: `username = "Joel Bonne"`, `is_active = false`
+- **Example queries**:
+    - search user by status: `is_active = false`
+    - search user by username: `username = "bob"`
+    - search user by email email = "bob@authentik.company"
+    - search user by attribute: `attribute.my_custom_attribute = "foo"`
 
 ## View user details
 

--- a/website/docs/users-sources/user/user_basic_operations.md
+++ b/website/docs/users-sources/user/user_basic_operations.md
@@ -44,7 +44,7 @@ You can construct advanced queries to find specific users in the list under **Di
 - **Values**: `True`, `False`, `None`
 
 - **Example queries**:
-    - search user by status: `is_active = false`
+    - search user by status: `is_active = False`
     - search user by username: `username = "bob"`
     - search user by email email = "bob@authentik.company"
     - search user by attribute: `attribute.my_custom_attribute = "foo"`

--- a/website/docs/users-sources/user/user_basic_operations.md
+++ b/website/docs/users-sources/user/user_basic_operations.md
@@ -41,7 +41,7 @@ You can construct advanced queries to find specific users in the list under **Di
 
 - **Operators**: `=`, `!=`, `~`, `!~`, `startswith`, `not startswith`, `endswidth`, `not endswith`, `in`, `not in`
 
-- **Values**: `True`, `False`, `None`
+- **Values**: `True`, `False`, `None`, and more
 
 - **Example queries**:
     - search user by status: `is_active = False`


### PR DESCRIPTION
This PR updates the Advanced Queroies docs, and adds Vaultwarden to the list of new Int guides in the 2025.8 Release Notes.

-   [x] Find out how many examples we want to show
-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
