### PR TITLE
policies/password: Fix amount_uppercase in password policy check

### DIFF
--- a/authentik/policies/password/models.py
+++ b/authentik/policies/password/models.py
@@ -103,7 +103,7 @@ class PasswordPolicy(Policy):
         if self.amount_lowercase > 0 and len(RE_LOWER.findall(password)) < self.amount_lowercase:
             LOGGER.debug("password failed", check="static", reason="amount_lowercase")
             return PolicyResult(False, self.error_message)
-        if self.amount_uppercase > 0 and len(RE_UPPER.findall(password)) < self.amount_lowercase:
+        if self.amount_uppercase > 0 and len(RE_UPPER.findall(password)) < self.amount_uppercase:
             LOGGER.debug("password failed", check="static", reason="amount_uppercase")
             return PolicyResult(False, self.error_message)
         if self.amount_symbols > 0:


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->

The `amount_uppercase` field was being compared to `self.amount_lowercase` instead of `self.amount_uppercase`. 

closes #16027

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [x] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
