### PR TITLE
web/a11y: QL Search Input

### DIFF
--- a/web/src/common/purify.ts
+++ b/web/src/common/purify.ts
@@ -21,6 +21,22 @@ export const EscapeTrustPolicy = trustedTypes.createPolicy("authentik-escape", {
 });
 
 /**
+ * Trusted types policy that removes all HTML content.
+ *
+ *
+ * @returns {TrustedHTML} All remaining text content.
+ */
+export const StripHTMLTrustPolicy = trustedTypes.createPolicy("authentik-strip-html", {
+    createHTML: (untrustedHTML: string) => {
+        return DOMPurify.sanitize(untrustedHTML, {
+            RETURN_TRUSTED_TYPE: false,
+            ALLOWED_TAGS: [],
+            ALLOWED_ATTR: [],
+        });
+    },
+});
+
+/**
  * Trusted types policy, stripping all HTML content.
  *
  * @returns {TrustedHTML} Text content only, all HTML tags stripped.

--- a/web/src/components/ak-search-ql/index.ts
+++ b/web/src/components/ak-search-ql/index.ts
@@ -1,14 +1,18 @@
 import "#elements/buttons/Dropdown";
 
-import { AKElement } from "#elements/Base";
+import { StripHTMLTrustPolicy } from "#common/purify";
+import { rootInterface } from "#common/theme";
+
+import { FormAssociated, FormAssociatedElement } from "#elements/forms/form-associated-element";
 import { PaginatedResponse } from "#elements/table/Table";
 
 import DjangoQL, { Introspections } from "@mrmarble/djangoql-completion";
 
 import { msg } from "@lit/localize";
-import { css, CSSResult, html, nothing, TemplateResult } from "lit";
-import { customElement, property, query, state } from "lit/decorators.js";
+import { css, CSSResult, html, LitElement, nothing, PropertyValues, TemplateResult } from "lit";
+import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
+import { createRef, ref, Ref } from "lit/directives/ref.js";
 
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFSearchInput from "@patternfly/patternfly/components/SearchInput/search-input.css";
@@ -25,40 +29,26 @@ export class QL extends DjangoQL {
     textareaResize() {}
 }
 
-@customElement("ak-search-ql")
-export class QLSearch extends AKElement {
-    @property()
-    value?: string;
+/**
+ * Given an array or length, return logical index of the element at the given delta.
+ * This is effectively a modulo loop, allowing for positive and negative deltas.
+ */
+function torusIndex(lengthLike: number | ArrayLike<number>, delta: number): number {
+    const length = typeof lengthLike === "number" ? lengthLike : lengthLike.length;
 
-    @query("[name=search]")
-    searchElement?: HTMLTextAreaElement;
-
-    @state()
-    menuOpen = false;
-
-    @property()
-    onSearch?: (value: string) => void;
-
-    @state()
-    selected?: number;
-
-    @state()
-    cursorX: number = 0;
-
-    @state()
-    cursorY: number = 0;
-
-    ql?: QL;
-    canvas?: CanvasRenderingContext2D;
-
-    set apiResponse(value: PaginatedResponse<unknown> | undefined) {
-        if (!value || !value.autocomplete || !this.ql) {
-            return;
-        }
-        this.ql.loadIntrospections(value.autocomplete as unknown as Introspections);
+    if (delta < 0) {
+        return (length + delta) % length;
     }
 
-    static styles: CSSResult[] = [
+    return ((delta % length) + length) % length;
+}
+
+@customElement("ak-search-ql")
+export class QLSearch extends FormAssociatedElement<string> implements FormAssociated {
+    declare anchorRef: Ref<HTMLTextAreaElement>;
+    declare anchor: HTMLTextAreaElement | null;
+
+    public static styles: CSSResult[] = [
         PFBase,
         PFFormControl,
         PFSearchInput,
@@ -66,207 +56,409 @@ export class QLSearch extends AKElement {
             ::-webkit-search-cancel-button {
                 display: none;
             }
+
             .ql.pf-c-form-control {
-                font-family: monospace;
+                --input-height: 2.25em;
+
+                height: var(--input-height);
+                min-height: var(--input-height);
+                max-height: calc(var(--input-height) * 6);
                 resize: vertical;
-                height: 2.25em;
             }
+
             .selected {
                 background-color: var(--pf-c-search-input__menu-item--hover--BackgroundColor);
             }
-            :host([theme="dark"]) .pf-c-search-input__menu {
-                --pf-c-search-input__menu--BackgroundColor: var(--ak-dark-background-light-ish);
-                color: var(--ak-dark-foreground);
+
+            :host([theme="dark"]) {
+                .pf-c-search-input__menu {
+                    --pf-c-search-input__menu--BackgroundColor: var(--ak-dark-background-light-ish);
+                    color: var(--ak-dark-foreground);
+                }
+
+                .pf-c-search-input__menu-item {
+                    --pf-c-search-input__menu-item--Color: var(--ak-dark-foreground);
+                }
+
+                .pf-c-search-input__menu-item:hover {
+                    --pf-c-search-input__menu-item--BackgroundColor: var(
+                        --ak-dark-background-lighter
+                    );
+                }
+
+                .pf-c-search-input__menu-list-item.selected {
+                    --pf-c-search-input__menu-item--hover--BackgroundColor: var(
+                        --ak-dark-background-light
+                    );
+                }
+
+                .pf-c-search-input__text::before {
+                    border: 0;
+                }
             }
-            :host([theme="dark"]) .pf-c-search-input__menu-item {
-                --pf-c-search-input__menu-item--Color: var(--ak-dark-foreground);
-            }
-            :host([theme="dark"]) .pf-c-search-input__menu-item:hover {
-                --pf-c-search-input__menu-item--BackgroundColor: var(--ak-dark-background-lighter);
-            }
-            :host([theme="dark"]) .pf-c-search-input__menu-list-item.selected {
-                --pf-c-search-input__menu-item--hover--BackgroundColor: var(
-                    --ak-dark-background-light
-                );
-            }
-            :host([theme="dark"]) .pf-c-search-input__text::before {
-                border: 0;
-            }
+
             .pf-c-search-input__menu {
                 position: fixed;
                 min-width: 0;
+                overflow-y: auto;
+                max-height: 50vh;
             }
         `,
     ];
 
-    firstUpdated() {
-        if (!this.searchElement) {
+    //#region Properties
+
+    @property({ type: Boolean })
+    public open = false;
+
+    @property({ type: Number, attribute: false })
+    public selectionIndex = -1;
+
+    #value = "";
+
+    @property({ type: String })
+    public get value(): string {
+        return this.#value;
+    }
+
+    public set value(value: unknown) {
+        const parsed = typeof value === "string" ? value : "";
+
+        this.setFormValue(parsed.trim(), parsed);
+        this.#value = parsed;
+
+        if (this.anchor) {
+            this.anchor.value = this.#value;
+        }
+    }
+
+    //#endregion
+
+    //#region State
+
+    #menuRef = createRef<HTMLDivElement>();
+
+    #ql: QL | null = null;
+    #ctx: OffscreenCanvasRenderingContext2D | null = null;
+    #letterWidth = -1;
+    #scrollContainer: HTMLElement | null = null;
+
+    public set apiResponse(value: PaginatedResponse<unknown> | undefined) {
+        if (!value?.autocomplete || !this.#ql) {
             return;
         }
-        this.ql = new QL({
+
+        this.#ql.loadIntrospections(value.autocomplete as unknown as Introspections);
+    }
+
+    //#endregion
+
+    //#region Lifecycle
+
+    public override connectedCallback() {
+        super.connectedCallback();
+
+        this.internals.ariaAutoComplete = "list";
+        this.internals.role = "combobox";
+        this.internals.ariaHasPopup = "listbox";
+
+        this.#scrollContainer =
+            rootInterface<LitElement>().renderRoot.querySelector("#main-content");
+
+        this.#scrollContainer?.addEventListener("scroll", this.#updateDropdownPosition, {
+            passive: true,
+        });
+
+        this.tabIndex = 0;
+    }
+
+    public override disconnectedCallback() {
+        super.disconnectedCallback();
+
+        this.#scrollContainer?.removeEventListener("scroll", this.#updateDropdownPosition);
+    }
+
+    public formStateRestoreCallback(state: string) {
+        this.value = state;
+    }
+
+    public formResetCallback() {
+        this.value = "";
+    }
+
+    public toJSON() {
+        return this.value;
+    }
+
+    public override updated(changedProperties: PropertyValues<this>) {
+        if (changedProperties.has("open")) {
+            this.internals.ariaExpanded = this.open ? "true" : "false";
+        }
+
+        if (changedProperties.has("selectionIndex")) {
+            const id = `suggestion-${this.selectionIndex}`;
+
+            this.setAttribute("aria-activedescendant", this.selectionIndex === -1 ? "" : id);
+
+            this.renderRoot.querySelector(`#${id}`)?.scrollIntoView({
+                behavior: "auto",
+                block: "nearest",
+            });
+        }
+    }
+
+    public override firstUpdated() {
+        const textarea = this.anchorRef.value;
+
+        if (!textarea) return;
+
+        this.#ql = new QL({
             completionEnabled: true,
             introspections: {
                 current_model: "",
                 models: {},
             },
-            selector: this.searchElement,
+            selector: textarea,
             autoResize: false,
         });
-        const canvas = document.createElement("canvas");
-        const context = canvas.getContext("2d");
-        if (!context) {
+
+        const canvas = new OffscreenCanvas(300, 150);
+        this.#ctx = canvas.getContext("2d");
+
+        if (!this.#ctx) {
             console.error("authentik/ql: failed to get canvas context");
             return;
         }
-        context.font = window.getComputedStyle(this.searchElement).font;
-        this.canvas = context;
-    }
 
-    refreshCompletions() {
-        this.value = this.searchElement?.value;
-        if (!this.ql) {
-            return;
-        }
-        this.ql.generateSuggestions();
-        if (this.ql.suggestions.length < 1 || this.ql.loading) {
-            this.menuOpen = false;
-            return;
-        }
-        this.menuOpen = true;
-        this.updateDropdownPosition();
-        this.requestUpdate();
-    }
+        this.#ctx.font = window.getComputedStyle(textarea).font;
 
-    updateDropdownPosition() {
-        if (!this.searchElement) {
-            return;
-        }
-        const bcr = this.getBoundingClientRect();
         // We need the width of a letter to measure x; we use a monospaced font but still
         // check the length for `m` as its the widest ASCII char
-        const metrics = this.canvas?.measureText("m");
-        const letterWidth = Math.ceil(metrics?.width || 0) + 1;
+        const metrics = this.#ctx?.measureText("m");
+        this.#letterWidth = Math.ceil(metrics?.width || 0) + 1;
+    }
+
+    //#endregion
+
+    //#region Completions
+
+    #refreshCompletions = () => {
+        if (this.anchor) {
+            this.value = this.anchor.value;
+        }
+
+        if (!this.#ql) {
+            return;
+        }
+
+        this.#ql.generateSuggestions();
+
+        if (this.#ql.suggestions.length < 1 || this.#ql.loading) {
+            this.open = false;
+            return;
+        }
+
+        this.open = true;
+
+        this.requestUpdate();
+
+        requestAnimationFrame(this.#updateDropdownPosition);
+    };
+
+    #updateDropdownPosition = () => {
+        const anchor = this.anchorRef.value;
+        const menu = this.#menuRef.value;
+
+        if (!anchor || !menu) return;
+
+        const bcr = this.getBoundingClientRect();
+        const style = window.getComputedStyle(anchor);
 
         // Mostly static variables for padding, font line-height and how many
-        const lineHeight = parseInt(window.getComputedStyle(this.searchElement).lineHeight, 10);
-        const paddingTop = parseInt(window.getComputedStyle(this.searchElement).paddingTop, 10);
-        const paddingLeft = parseInt(window.getComputedStyle(this.searchElement).paddingLeft, 10);
-        const paddingRight = parseInt(window.getComputedStyle(this.searchElement).paddingRight, 10);
+        const lineHeight = parseInt(style.lineHeight, 10);
+        const paddingTop = parseInt(style.paddingTop, 10);
+        const paddingLeft = parseInt(style.paddingLeft, 10);
+        const paddingRight = parseInt(style.paddingRight, 10);
+
         const actualInnerWidth = bcr.width - paddingLeft - paddingRight;
 
         let relX = 0;
         let relY = 1;
         let letterIndex = 0;
 
-        this.searchElement.value.split(" ").some((word, idx) => {
+        for (const word of anchor.value.split(" ")) {
             letterIndex += word.length;
-            const newRelX = relX + word.length * letterWidth;
+            const newRelX = relX + word.length * this.#letterWidth;
+
             if (newRelX > actualInnerWidth) {
                 relY += 1;
-                if (letterIndex > this.searchElement!.selectionStart) {
+
+                if (letterIndex > anchor.selectionStart) {
                     relX =
-                        letterWidth * word.length -
-                        (letterIndex - this.searchElement!.selectionStart) * letterWidth;
-                    return true;
+                        this.#letterWidth * word.length -
+                        (letterIndex - anchor.selectionStart) * this.#letterWidth;
+
+                    break;
                 }
-                relX = word.length * letterWidth;
+
+                relX = word.length * this.#letterWidth;
             } else {
                 relX = newRelX + 1;
             }
-        });
+        }
 
-        this.cursorX = bcr.x + paddingLeft + relX;
-        this.cursorY = bcr.y + paddingTop + relY * lineHeight;
-    }
+        const x = bcr.x + paddingLeft + relX;
+        const y = bcr.y + paddingTop + relY * lineHeight;
 
-    onKeyDown(ev: KeyboardEvent) {
-        this.updateDropdownPosition();
-        if (ev.key === "Enter" && ev.metaKey && this.onSearch && this.searchElement) {
-            this.onSearch(this.searchElement?.value);
+        Object.assign(menu.style, {
+            left: `${x}px`,
+            top: `${y}px`,
+        } satisfies Partial<CSSStyleDeclaration>);
+    };
+
+    //#endregion
+
+    //#region Event Listeners
+
+    #keydownListener = (event: KeyboardEvent) => {
+        this.#updateDropdownPosition();
+
+        const suggestionsLength = this.#ql?.suggestions.length;
+
+        if (event.key === "Enter" && !this.open && this.form) {
+            const submitEvent = new SubmitEvent("submit", {
+                submitter: this,
+                bubbles: true,
+                composed: true,
+                cancelable: true,
+            });
+
+            this.form.dispatchEvent(submitEvent);
+
             return;
         }
-        if (!this.menuOpen) return;
-        switch (ev.key) {
+
+        if (event.key === "ArrowDown") {
+            event.preventDefault();
+
+            if (this.open && suggestionsLength) {
+                if (this.selectionIndex === -1) {
+                    this.selectionIndex = 0;
+                } else {
+                    this.selectionIndex = torusIndex(suggestionsLength, this.selectionIndex + 1);
+                }
+
+                this.#refreshCompletions();
+
+                return;
+            }
+
+            this.selectionIndex = 0;
+            this.#refreshCompletions();
+
+            return;
+        }
+
+        if (!this.open) return;
+
+        switch (event.key) {
             case "ArrowUp":
-                if (this.ql?.suggestions.length) {
-                    if (this.selected === undefined) {
-                        this.selected = this.ql?.suggestions.length - 1;
-                    } else if (this.selected === 0) {
-                        this.selected = undefined;
+                if (suggestionsLength) {
+                    if (this.selectionIndex === -1) {
+                        this.selectionIndex = suggestionsLength - 1;
                     } else {
-                        this.selected -= 1;
+                        this.selectionIndex = torusIndex(
+                            suggestionsLength,
+                            this.selectionIndex - 1,
+                        );
                     }
-                    this.refreshCompletions();
-                    ev.preventDefault();
+
+                    this.#refreshCompletions();
+                    event.preventDefault();
                 }
-                break;
-            case "ArrowDown":
-                if (this.ql?.suggestions.length) {
-                    if (this.selected === undefined) {
-                        this.selected = 0;
-                    } else if (this.selected < this.ql?.suggestions.length - 1) {
-                        this.selected += 1;
-                    } else {
-                        this.selected = undefined;
-                    }
-                    this.refreshCompletions();
-                    ev.preventDefault();
-                }
-                break;
+
+                return;
+
             case "Tab":
-                if (this.selected) {
-                    this.ql?.selectCompletion(this.selected);
-                    ev.preventDefault();
+                if (this.selectionIndex) {
+                    this.#ql?.selectCompletion(this.selectionIndex);
+                    event.preventDefault();
                 }
-                break;
+
+                return;
             case "Enter":
                 // Technically this is a textarea, due to automatic multi-line feature,
                 // but other than that it should look and behave like a normal input.
                 // So expected behavior when pressing Enter is to submit the form,
                 // not to add a new line.
-                if (this.selected !== undefined) {
-                    this.ql?.selectCompletion(this.selected);
+                if (this.selectionIndex !== -1) {
+                    this.#ql?.selectCompletion(this.selectionIndex);
+                    this.selectionIndex = 0;
                 }
-                ev.preventDefault();
-                break;
-            case "Escape":
-                this.menuOpen = false;
-                break;
-            case "Shift": // Shift
-            case "Control": // Ctrl
-            case "Alt": // Alt
-            case "Meta": // Windows Key or Cmd on Mac
-                // Control keys shouldn't trigger completion popup
-                break;
-        }
-    }
 
-    renderMenu() {
-        if (!this.menuOpen || !this.ql) {
+                event.preventDefault();
+
+                return;
+            case "Escape":
+                this.open = false;
+                return;
+        }
+    };
+
+    #blurListener = ({ relatedTarget }: FocusEvent) => {
+        if (relatedTarget instanceof Node && this.renderRoot.contains(relatedTarget)) {
+            return;
+        }
+
+        this.open = false;
+    };
+
+    #focusListener = () => {
+        this.selectionIndex = this.selectionIndex === -1 ? 0 : this.selectionIndex;
+
+        this.#refreshCompletions();
+    };
+
+    //#endregion
+
+    //#region Render
+
+    protected renderMenu() {
+        if (!this.open || !this.#ql) {
             return nothing;
         }
+
         return html`
-            <div
-                class="pf-c-search-input__menu"
-                style="left: ${this.cursorX}px; top: ${this.cursorY}px;"
-            >
-                <ul class="pf-c-search-input__menu-list">
-                    ${this.ql.suggestions.map((suggestion, idx) => {
+            <div ${ref(this.#menuRef)} class="pf-c-search-input__menu">
+                <ul
+                    class="pf-c-search-input__menu-list"
+                    role="listbox"
+                    id="ql-suggestions"
+                    aria-label=${msg("Query suggestions")}
+                >
+                    ${this.#ql.suggestions.map((suggestion, idx) => {
+                        // Cast to string to sooth Lit Analyzer's primitive type rule.
+                        const label = `${StripHTMLTrustPolicy.createHTML(suggestion.suggestionText)}`;
+
                         return html`<li
-                            class="pf-c-search-input__menu-list-item ${this.selected === idx
+                            role="option"
+                            id="suggestion-${idx}"
+                            aria-selected=${this.selectionIndex === idx ? "true" : "false"}
+                            class="pf-c-search-input__menu-list-item ${this.selectionIndex === idx
                                 ? "selected"
                                 : ""}"
                         >
                             <button
                                 class="pf-c-search-input__menu-item"
                                 type="button"
+                                aria-label=${label}
                                 @click=${() => {
-                                    this.ql?.selectCompletion(idx);
-                                    this.refreshCompletions();
+                                    this.#ql?.selectCompletion(idx);
+                                    this.#refreshCompletions();
                                 }}
                             >
-                                <span class="pf-c-search-input__menu-item-text"
-                                    >${suggestion.text}</span
+                                <span class="pf-c-search-input__menu-item-text pf-m-monospace">
+                                    ${suggestion.text}</span
                                 >
                             </button>
                         </li>`;
@@ -276,25 +468,33 @@ export class QLSearch extends AKElement {
         `;
     }
 
-    render(): TemplateResult {
+    public override render(): TemplateResult {
         return html`<div class="pf-c-search-input">
             <div class="pf-c-search-input__bar">
                 <span class="pf-c-search-input__text">
                     <textarea
-                        class="pf-c-form-control ql"
+                        ${ref(this.anchorRef)}
+                        class="pf-c-form-control pf-m-monospace ql"
                         name="search"
+                        autocomplete="off"
+                        aria-controls="ql-suggestions"
+                        ?required=${this.required}
                         placeholder=${msg("Search...")}
                         spellcheck="false"
-                        @input=${(ev: InputEvent) => this.refreshCompletions()}
-                        @keydown=${this.onKeyDown}
+                        @input=${this.#refreshCompletions}
+                        @focus=${this.#focusListener}
+                        @blur=${this.#blurListener}
+                        @keydown=${this.#keydownListener}
                     >
-${ifDefined(this.value)}</textarea
+${ifDefined(this.#value)}</textarea
                     >
                 </span>
             </div>
             ${this.renderMenu()}
         </div>`;
     }
+
+    //#endregion
 }
 
 declare global {

--- a/web/src/elements/forms/form-associated-element.ts
+++ b/web/src/elements/forms/form-associated-element.ts
@@ -1,0 +1,216 @@
+import { AKElement } from "#elements/Base";
+
+import { Jsonifiable } from "type-fest";
+
+import { msg } from "@lit/localize";
+import { LitElement } from "lit";
+import { property } from "lit/decorators.js";
+import { createRef, Ref } from "lit/directives/ref.js";
+
+/**
+ * A subset of form associated {@linkcode ElementInternals} properties.
+ *
+ * @see {@linkcode FormAssociatedElement} for usage.
+ */
+export interface FormAssociated
+    extends Pick<
+        ElementInternals,
+        | "form"
+        | "validity"
+        | "validationMessage"
+        | "willValidate"
+        | "labels"
+        | "checkValidity"
+        | "reportValidity"
+    > {
+    /**
+     * The name of the input, provided to the form.
+     */
+    readonly name: string | null;
+
+    /**
+     * The type of the input, provided to the form.
+     */
+    readonly type: string;
+
+    /**
+     * Whether or not the input is required.
+     */
+    required?: boolean;
+
+    /**
+     * Whether or not the input is read-only.
+     */
+    readonly?: boolean;
+
+    /**
+     * A JSON representation of the value.
+     */
+    toJSON(): Jsonifiable;
+}
+
+export type FormValue = File | string | FormData | null;
+
+/**
+ * A base element which provides reactive properties and methods for interacting with a parent form.
+ *
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals | MDN}
+ */
+export abstract class FormAssociatedElement<
+        V extends FormValue = string,
+        T extends Jsonifiable = V extends string ? V : Jsonifiable,
+        S extends FormValue = V,
+    >
+    extends AKElement
+    implements FormAssociated
+{
+    static shadowRootOptions = { ...LitElement.shadowRootOptions, delegatesFocus: true };
+
+    public static readonly formAssociated = true;
+
+    /**
+     * The internals of the element.
+     *
+     * @protected
+     * @see {@linkcode FormAssociated}
+     */
+    protected internals = this.attachInternals();
+
+    //#region Reactive Properties
+
+    @property({ type: Boolean })
+    public get required() {
+        return this.internals.ariaRequired === "true";
+    }
+
+    public set required(value: boolean) {
+        this.internals.ariaRequired = value ? "true" : "false";
+    }
+
+    @property({ type: Boolean, attribute: "readonly" })
+    public get readOnly() {
+        return this.internals.ariaReadOnly === "true";
+    }
+
+    public set readOnly(value: boolean) {
+        this.internals.ariaReadOnly = value ? "true" : "false";
+    }
+
+    @property({ type: Boolean })
+    public get disabled() {
+        return this.internals.ariaDisabled === "true";
+    }
+
+    public set disabled(value: boolean) {
+        this.internals.ariaDisabled = value ? "true" : "false";
+    }
+
+    //#endregion
+
+    //#region Aliased Properties
+
+    public get form(): HTMLFormElement | null {
+        return this.internals.form;
+    }
+
+    public get name() {
+        return this.getAttribute("name");
+    }
+
+    public get type() {
+        return this.localName;
+    }
+
+    public get validity() {
+        return this.internals.validity;
+    }
+
+    public get validationMessage() {
+        return this.internals.validationMessage;
+    }
+
+    public get willValidate() {
+        return this.internals.willValidate;
+    }
+
+    public get labels() {
+        return this.internals.labels;
+    }
+
+    //#endregion
+
+    //#region Values
+
+    /**
+     * A reference to an element that is focusable when validation fails.
+     */
+    protected anchorRef: Ref<HTMLElement>;
+
+    /**
+     * The element that is focusable when validation fails.
+     */
+    declare protected anchor: HTMLElement | null;
+
+    /**
+     * Set the value of the form.
+     *
+     * @param value The value visible to the form during submission.
+     * @param state The value as provided by the user.
+     */
+    protected setFormValue(value: V, state?: S) {
+        this.internals.setFormValue(value, state);
+
+        if (this.required) {
+            if (value) {
+                this.internals.setValidity({});
+            } else {
+                this.internals.setValidity(
+                    {
+                        valueMissing: true,
+                    },
+                    msg("This field is required."),
+                    this.anchorRef.value,
+                );
+            }
+        }
+    }
+
+    public abstract toJSON(): T;
+
+    //#endregion
+
+    //#region Validation
+
+    public checkValidity = this.internals.checkValidity.bind(this.internals);
+    public reportValidity = this.internals.reportValidity.bind(this.internals);
+
+    //#endregion
+
+    /**
+     * Set the validity state of the form.
+     *
+     * @param flags The validity state flags.
+     * @param message The validation message.
+     * @param element The element to set the validity state on.
+     */
+    protected setValidity(flags: ValidityStateFlags = {}, message?: string, element?: HTMLElement) {
+        this.internals.setValidity(flags, message, element ?? this.anchorRef.value);
+    }
+
+    //#endregion
+
+    public constructor() {
+        super();
+        this.anchorRef = createRef<HTMLElement>();
+
+        // We define the getter here to allow the base type to be extended,
+        // letting the subclasses define a more accurate HTMLElement type.
+        Object.defineProperty(this, "anchor", {
+            get() {
+                return this.anchorRef.value || null;
+            },
+            enumerable: true,
+            configurable: true,
+        });
+    }
+}

--- a/web/src/elements/forms/types.d.ts
+++ b/web/src/elements/forms/types.d.ts
@@ -1,0 +1,41 @@
+/**
+ * @file Type definitions for form-associated elements.
+ *
+ * While these types are part of the HTML standard, they're not yet defined
+ * in the TypeScript standard library, so we define them here.
+ *
+ * @expires 2026-01-01
+ */
+
+/**
+ * Callbacks for form-associated elements.
+ */
+interface HTMLElement {
+    /**
+     * A callback invoked when the browser autofilling sets a value.
+     */
+    formStateRestoreCallback?(state: FormValue, mode: "autocomplete"): void;
+    /**
+     * A callback invoked when the browser restores a value from a previous session.
+     */
+    formStateRestoreCallback?(state: FormValue, mode: "restore"): void;
+    /**
+     * A callback invoked when the browser restores a value from a previous session.
+     */
+    formStateRestoreCallback?(state: FormValue, mode: "restore" | "autocomplete"): void;
+
+    /**
+     * A callback that is invoked when the form is reset.
+     */
+    formResetCallback?(): void;
+
+    /**
+     * A callback that is invoked when the element's disabled state changes.
+     */
+    formDisabledCallback?(disabled: boolean): void;
+
+    /**
+     * A callback that is invoked when the element is associated with a form.
+     */
+    formAssociatedCallback?(form: HTMLFormElement): void;
+}

--- a/web/src/elements/table/Table.ts
+++ b/web/src/elements/table/Table.ts
@@ -124,8 +124,8 @@ export abstract class Table<T extends object>
     @property({ type: String })
     public order?: string;
 
-    @property({ type: String })
-    public search: string = "";
+    @property({ type: String, attribute: false })
+    public search?: string;
 
     @property({ type: Boolean })
     public checkbox = false;
@@ -547,11 +547,11 @@ export abstract class Table<T extends object>
         return html`<div class="pf-c-toolbar__group pf-m-search-filter ${isQL ? "ql" : ""}">
             <ak-table-search
                 class="pf-c-toolbar__item pf-m-search-filter ${isQL ? "ql" : ""}"
-                value=${ifDefined(this.search)}
+                .defaultValue=${this.search}
                 label=${ifDefined(this.searchLabel)}
                 placeholder=${ifDefined(this.searchPlaceholder)}
                 .onSearch=${this.#searchListener}
-                ?supportsQL=${this.supportsQL}
+                .supportsQL=${this.supportsQL}
                 .apiResponse=${this.data}
             >
             </ak-table-search>


### PR DESCRIPTION
## Details

This PR polishes the UX of the new query search input element and adds additional coverage to its ARIA attributes.

<img width="878" height="809" alt="Screenshot 2025-08-15 at 04 54 02" src="https://github.com/user-attachments/assets/e2aa9855-9ff2-4ce9-8ec7-b9da05e6cb21" />


## Fixes

- Query search elements now participate in client-side form submission and validation
- Elements within the search field now participate in ARIA states for expansion and selected menu item focus
- Suggestions now reposition when scrolling the page, and resizing the page
- Suggestions now close when focus moves away from element
- Suggestions no longer render outside the viewport, opting to scroll instead.
- Suggestions are now opened on input focus 
- Suggestions now provide ARIA labels that communicate the result of each logical operator
- Keyboard input no longer selects menu indexes outside of the list
- Keyboard interactions now conform to the [recommended ARIA behavior for comboboxes](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/combobox_role#keyboard_interactions)
- The textarea has a minimal and max height when resized

