### PR TITLE
web: Group stages by type.

### DIFF
--- a/web/src/admin/stages/StageListPage.ts
+++ b/web/src/admin/stages/StageListPage.ts
@@ -31,6 +31,7 @@ import "#elements/forms/ProxyForm";
 import "@patternfly/elements/pf-tooltip/pf-tooltip.js";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
+import { groupBy } from "#common/utils";
 
 import { PaginatedResponse, TableColumn } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
@@ -77,6 +78,12 @@ export class StageListPage extends TablePage<Stage> {
         ];
     }
 
+    groupBy(items: Stage[]): [string, Stage[]][] {
+        return groupBy(items, (stage) => {
+            return stage.verboseNamePlural;
+        });
+    }
+
     renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;
         return html`<ak-forms-delete-bulk
@@ -120,8 +127,7 @@ export class StageListPage extends TablePage<Stage> {
 
     row(item: Stage): TemplateResult[] {
         return [
-            html`<div>${item.name}</div>
-                <small>${item.verboseName}</small>`,
+            html`<div>${item.name}</div>`,
             html`<ul class="pf-c-list">
                 ${item.flowSet?.map((flow) => {
                     return html`<li>


### PR DESCRIPTION
## Details

Similar to our row grouping on other tables, this PR groups stages by their type, which helped greatly when swapping between debugging different captcha configurations.

## Before

<img width="1470" height="837" alt="Screenshot 2025-08-15 at 14 18 03" src="https://github.com/user-attachments/assets/2128cbf0-13e1-4afb-aced-d23e95313ce9" />

## After


<img width="1470" height="837" alt="Screenshot 2025-08-15 at 14 17 39" src="https://github.com/user-attachments/assets/2a77d65a-5847-44d0-983c-4af7096f1483" />
