### PR TITLE
blueprints: fix email address verified by default

### DIFF
--- a/blueprints/system/providers-oauth2.yaml
+++ b/blueprints/system/providers-oauth2.yaml
@@ -24,7 +24,7 @@ entries:
       expression: |
         return {
             "email": request.user.email,
-            "email_verified": True
+            "email_verified": False
         }
   - identifiers:
       managed: goauthentik.io/providers/oauth2/scope-profile


### PR DESCRIPTION
## Details

Authentik should consider emails not verified by default.
Explained in detail in matching issue: #16205

closes #16205

---

## Checklist

I did not run the test, this change is small enough ig

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If applicable

One might add something to the docs but I think it is not necessary.

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
