### PR TITLE
web/a11y: Tables -- labels, input handlers, selection and expanded state

### DIFF
--- a/web/src/admin/AdminInterface/index.entrypoint.ts
+++ b/web/src/admin/AdminInterface/index.entrypoint.ts
@@ -31,7 +31,6 @@ import { ROUTES } from "#admin/Routes";
 
 import { CapabilitiesEnum, SessionUser, UiThemeEnum } from "@goauthentik/api";
 
-import { msg } from "@lit/localize";
 import { css, CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, eventOptions, property, query } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
@@ -218,8 +217,7 @@ export class AdminInterface extends WithCapabilitiesConfig(AuthenticatedInterfac
                                 <div class="pf-c-drawer__body">
                                     <div class="pf-c-page__main">
                                         <ak-router-outlet
-                                            role="main"
-                                            aria-label="${msg("Main content")}"
+                                            role="presentation"
                                             class="pf-c-page__main"
                                             tabindex="-1"
                                             id="main-content"

--- a/web/src/admin/admin-overview/TopApplicationsTable.ts
+++ b/web/src/admin/admin-overview/TopApplicationsTable.ts
@@ -31,10 +31,10 @@ export class TopApplicationsTable extends AKElement {
     }
 
     renderRow(event: EventTopPerUser): TemplateResult {
-        return html`<tr role="row">
-            <td role="cell">${event.application.name}</td>
-            <td role="cell">${event.countedEvents}</td>
-            <td role="cell">
+        return html`<tr>
+            <td>${event.application.name}</td>
+            <td>${event.countedEvents}</td>
+            <td>
                 <progress
                     value="${event.countedEvents}"
                     max="${this.topN ? this.topN[0].countedEvents : 0}"
@@ -44,12 +44,12 @@ export class TopApplicationsTable extends AKElement {
     }
 
     render(): TemplateResult {
-        return html`<table class="pf-c-table pf-m-compact" role="grid">
+        return html`<table class="pf-c-table pf-m-compact">
             <thead>
-                <tr role="row">
-                    <th role="columnheader" scope="col">${msg("Application")}</th>
-                    <th role="columnheader" scope="col">${msg("Logins")}</th>
-                    <th role="columnheader" scope="col"></th>
+                <tr>
+                    <th scope="col">${msg("Application")}</th>
+                    <th scope="col">${msg("Logins")}</th>
+                    <th scope="col"></th>
                 </tr>
             </thead>
             <tbody role="rowgroup">

--- a/web/src/admin/admin-overview/cards/AdminStatusCard.ts
+++ b/web/src/admin/admin-overview/cards/AdminStatusCard.ts
@@ -108,7 +108,7 @@ export abstract class AdminStatusCard<T> extends AggregateCard {
      */
     private renderStatus(status: AdminStatus): SlottedTemplateResult {
         return html`
-            <p><i class="${status.icon}"></i>&nbsp;${this.renderValue()}</p>
+            <p><i class="${status.icon}" aria-hidden="true"></i>&nbsp;${this.renderValue()}</p>
             ${status.message ? html`<p class="subtext">${status.message}</p>` : nothing}
         `;
     }

--- a/web/src/admin/admin-overview/cards/RecentEventsCard.ts
+++ b/web/src/admin/admin-overview/cards/RecentEventsCard.ts
@@ -7,9 +7,8 @@ import "#elements/buttons/SpinnerButton/index";
 import { DEFAULT_CONFIG } from "#common/api/config";
 import { EventWithContext } from "#common/events";
 import { actionToLabel } from "#common/labels";
-import { formatElapsedTime } from "#common/temporal";
 
-import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { PaginatedResponse, Table, TableColumn, Timestamp } from "#elements/table/Table";
 import { SlottedTemplateResult } from "#elements/types";
 
 import { EventGeo, renderEventUser } from "#admin/events/utils";
@@ -71,8 +70,7 @@ export class RecentEventsCard extends Table<Event> {
             html`<div><a href="${`#/events/log/${item.pk}`}">${actionToLabel(item.action)}</a></div>
                 <small>${item.app}</small>`,
             renderEventUser(item),
-            html`<div>${formatElapsedTime(item.created)}</div>
-                <small>${item.created.toLocaleString()}</small>`,
+            Timestamp(item.created),
             html` <div>${item.clientIp || msg("-")}</div>
                 <small>${EventGeo(item)}</small>`,
             html`<span>${item.brand?.name || msg("-")}</span>`,

--- a/web/src/admin/admin-overview/cards/RecentEventsCard.ts
+++ b/web/src/admin/admin-overview/cards/RecentEventsCard.ts
@@ -62,7 +62,7 @@ export class RecentEventsCard extends Table<Event> {
 
     renderToolbar(): TemplateResult {
         return html`<div class="pf-c-card__title">
-            <i class="pf-icon pf-icon-catalog"></i>&nbsp;${msg("Recent events")}
+            <i class="pf-icon pf-icon-catalog" aria-hidden="true"></i>&nbsp;${msg("Recent events")}
         </div>`;
     }
 

--- a/web/src/admin/admin-overview/cards/RecentEventsCard.ts
+++ b/web/src/admin/admin-overview/cards/RecentEventsCard.ts
@@ -51,6 +51,10 @@ export class RecentEventsCard extends Table<Event> {
         `,
     ];
 
+    protected override rowLabel(item: Event): string {
+        return actionToLabel(item.action);
+    }
+
     protected columns: TableColumn[] = [
         [msg("Action"), "action"],
         [msg("User"), "user"],

--- a/web/src/admin/admin-overview/cards/RecentEventsCard.ts
+++ b/web/src/admin/admin-overview/cards/RecentEventsCard.ts
@@ -52,15 +52,13 @@ export class RecentEventsCard extends Table<Event> {
         `,
     ];
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Action"), "action"),
-            new TableColumn(msg("User"), "user"),
-            new TableColumn(msg("Creation Date"), "created"),
-            new TableColumn(msg("Client IP"), "client_ip"),
-            new TableColumn(msg("Brand"), "brand_name"),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Action"), "action"],
+        [msg("User"), "user"],
+        [msg("Creation Date"), "created"],
+        [msg("Client IP"), "client_ip"],
+        [msg("Brand"), "brand_name"],
+    ];
 
     renderToolbar(): TemplateResult {
         return html`<div class="pf-c-card__title">

--- a/web/src/admin/applications/ApplicationForm.ts
+++ b/web/src/admin/applications/ApplicationForm.ts
@@ -228,7 +228,7 @@ export class ApplicationForm extends WithCapabilitiesConfig(ModelForm<Applicatio
                                             @change=${this.handleClearIcon}
                                         ></ak-switch-input>
                                     `
-                                  : html``}`
+                                  : nothing}`
                         : html` <ak-text-input
                               label=${msg("Icon")}
                               name="metaIcon"

--- a/web/src/admin/applications/ApplicationListPage.ts
+++ b/web/src/admin/applications/ApplicationListPage.ts
@@ -43,20 +43,12 @@ export const applicationListStyle = css`
 
 @customElement("ak-application-list")
 export class ApplicationListPage extends WithBrandConfig(TablePage<Application>) {
-    searchEnabled(): boolean {
-        return true;
-    }
-    pageTitle(): string {
-        return msg("Applications");
-    }
-    pageDescription(): string {
-        return msg(
-            str`External applications that use ${this.brandingTitle} as an identity provider via protocols like OAuth2 and SAML. All applications are shown here, even ones you cannot access.`,
-        );
-    }
-    pageIcon(): string {
-        return "pf-icon pf-icon-applications";
-    }
+    protected override searchEnabled = true;
+    public pageTitle = msg("Applications");
+    public pageDescription = msg(
+        str`External applications that use ${this.brandingTitle} as an identity provider via protocols like OAuth2 and SAML. All applications are shown here, even ones you cannot access.`,
+    );
+    public pageIcon = "pf-icon pf-icon-applications";
 
     checkbox = true;
     clearOnRefresh = true;

--- a/web/src/admin/applications/ApplicationListPage.ts
+++ b/web/src/admin/applications/ApplicationListPage.ts
@@ -138,14 +138,14 @@ export class ApplicationListPage extends WithBrandConfig(TablePage<Application>)
                     </ak-application-form>
                     <button slot="trigger" class="pf-c-button pf-m-plain">
                         <pf-tooltip position="top" content=${msg("Edit")}>
-                            <i class="fas fa-edit"></i>
+                            <i class="fas fa-edit" aria-hidden="true"></i>
                         </pf-tooltip>
                     </button>
                 </ak-forms-modal>
                 ${item.launchUrl
                     ? html`<a href=${item.launchUrl} target="_blank" class="pf-c-button pf-m-plain">
                           <pf-tooltip position="top" content=${msg("Open")}>
-                              <i class="fas fa-share-square"></i>
+                              <i class="fas fa-share-square" aria-hidden="true"></i>
                           </pf-tooltip>
                       </a>`
                     : html``}`,

--- a/web/src/admin/applications/ApplicationListPage.ts
+++ b/web/src/admin/applications/ApplicationListPage.ts
@@ -13,13 +13,14 @@ import { WithBrandConfig } from "#elements/mixins/branding";
 import { getURLParam } from "#elements/router/RouteMatch";
 import { PaginatedResponse, TableColumn } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { Application, CoreApi, PoliciesApi } from "@goauthentik/api";
 
 import MDApplication from "~docs/add-secure-apps/applications/index.md";
 
 import { msg, str } from "@lit/localize";
-import { css, CSSResult, html, TemplateResult } from "lit";
+import { css, CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
@@ -111,7 +112,7 @@ export class ApplicationListPage extends WithBrandConfig(TablePage<Application>)
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: Application): TemplateResult[] {
+    row(item: Application): SlottedTemplateResult[] {
         return [
             html`<ak-app-icon
                 aria-label=${msg(str`Application icon for "${item.name}"`)}
@@ -120,7 +121,7 @@ export class ApplicationListPage extends WithBrandConfig(TablePage<Application>)
             ></ak-app-icon>`,
             html`<a href="#/core/applications/${item.slug}">
                 <div>${item.name}</div>
-                ${item.metaPublisher ? html`<small>${item.metaPublisher}</small>` : html``}
+                ${item.metaPublisher ? html`<small>${item.metaPublisher}</small>` : nothing}
             </a>`,
             item.group ? html`${item.group}` : html`<span aria-label="None">${msg("-")}</span>`,
             item.provider
@@ -151,7 +152,7 @@ export class ApplicationListPage extends WithBrandConfig(TablePage<Application>)
                               <i class="fas fa-share-square" aria-hidden="true"></i>
                           </pf-tooltip>
                       </a>`
-                    : html``}`,
+                    : nothing}`,
         ];
     }
 

--- a/web/src/admin/applications/ApplicationListPage.ts
+++ b/web/src/admin/applications/ApplicationListPage.ts
@@ -79,7 +79,7 @@ export class ApplicationListPage extends WithBrandConfig(TablePage<Application>)
         [msg("Group"), "group"],
         [msg("Provider")],
         [msg("Provider Type")],
-        [msg("Actions")],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     protected renderSidebarAfter(): TemplateResult {
@@ -128,7 +128,7 @@ export class ApplicationListPage extends WithBrandConfig(TablePage<Application>)
                 <div>${item.name}</div>
                 ${item.metaPublisher ? html`<small>${item.metaPublisher}</small>` : html``}
             </a>`,
-            html`${item.group || msg("-")}`,
+            item.group ? html`${item.group}` : html`<span aria-label="None">${msg("-")}</span>`,
             item.provider
                 ? html`<a href="#/core/providers/${item.providerObj?.pk}">
                       ${item.providerObj?.name}
@@ -140,14 +140,19 @@ export class ApplicationListPage extends WithBrandConfig(TablePage<Application>)
                     <span slot="header"> ${msg("Update Application")} </span>
                     <ak-application-form slot="form" .instancePk=${item.slug}>
                     </ak-application-form>
-                    <button slot="trigger" class="pf-c-button pf-m-plain">
+                    <button slot="trigger" class="pf-c-button pf-m-plain" aria-label=${msg("Edit")}>
                         <pf-tooltip position="top" content=${msg("Edit")}>
                             <i class="fas fa-edit" aria-hidden="true"></i>
                         </pf-tooltip>
                     </button>
                 </ak-forms-modal>
                 ${item.launchUrl
-                    ? html`<a href=${item.launchUrl} target="_blank" class="pf-c-button pf-m-plain">
+                    ? html`<a
+                          href=${item.launchUrl}
+                          target="_blank"
+                          class="pf-c-button pf-m-plain"
+                          aria-label=${msg("Open")}
+                      >
                           <pf-tooltip position="top" content=${msg("Open")}>
                               <i class="fas fa-share-square" aria-hidden="true"></i>
                           </pf-tooltip>

--- a/web/src/admin/applications/ApplicationListPage.ts
+++ b/web/src/admin/applications/ApplicationListPage.ts
@@ -74,7 +74,7 @@ export class ApplicationListPage extends WithBrandConfig(TablePage<Application>)
     static styles: CSSResult[] = [...TablePage.styles, PFCard, applicationListStyle];
 
     protected columns: TableColumn[] = [
-        [""],
+        ["", undefined, msg("Application Icon")],
         [msg("Name"), "name"],
         [msg("Group"), "group"],
         [msg("Provider")],
@@ -120,6 +120,7 @@ export class ApplicationListPage extends WithBrandConfig(TablePage<Application>)
     row(item: Application): TemplateResult[] {
         return [
             html`<ak-app-icon
+                aria-label=${msg(str`Application icon for "${item.name}"`)}
                 name=${item.name}
                 icon=${ifDefined(item.metaIcon || undefined)}
             ></ak-app-icon>`,

--- a/web/src/admin/applications/ApplicationListPage.ts
+++ b/web/src/admin/applications/ApplicationListPage.ts
@@ -83,13 +83,16 @@ export class ApplicationListPage extends WithBrandConfig(TablePage<Application>)
     ];
 
     protected renderSidebarAfter(): TemplateResult {
-        return html`<div class="pf-c-sidebar__panel pf-m-width-25">
+        return html`<aside
+            aria-label=${msg("Applications Documentation")}
+            class="pf-c-sidebar__panel pf-m-width-25"
+        >
             <div class="pf-c-card">
                 <div class="pf-c-card__body">
                     <ak-mdx .url=${MDApplication}></ak-mdx>
                 </div>
             </div>
-        </div>`;
+        </aside>`;
     }
 
     renderToolbarSelected(): TemplateResult {

--- a/web/src/admin/applications/ApplicationListPage.ts
+++ b/web/src/admin/applications/ApplicationListPage.ts
@@ -73,16 +73,14 @@ export class ApplicationListPage extends WithBrandConfig(TablePage<Application>)
 
     static styles: CSSResult[] = [...TablePage.styles, PFCard, applicationListStyle];
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(""),
-            new TableColumn(msg("Name"), "name"),
-            new TableColumn(msg("Group"), "group"),
-            new TableColumn(msg("Provider")),
-            new TableColumn(msg("Provider Type")),
-            new TableColumn(msg("Actions")),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [""],
+        [msg("Name"), "name"],
+        [msg("Group"), "group"],
+        [msg("Provider")],
+        [msg("Provider Type")],
+        [msg("Actions")],
+    ];
 
     protected renderSidebarAfter(): TemplateResult {
         return html`<div class="pf-c-sidebar__panel pf-m-width-25">

--- a/web/src/admin/applications/ApplicationListPage.ts
+++ b/web/src/admin/applications/ApplicationListPage.ts
@@ -45,9 +45,11 @@ export const applicationListStyle = css`
 export class ApplicationListPage extends WithBrandConfig(TablePage<Application>) {
     protected override searchEnabled = true;
     public pageTitle = msg("Applications");
-    public pageDescription = msg(
-        str`External applications that use ${this.brandingTitle} as an identity provider via protocols like OAuth2 and SAML. All applications are shown here, even ones you cannot access.`,
-    );
+    public get pageDescription() {
+        return msg(
+            str`External applications that use ${this.brandingTitle} as an identity provider via protocols like OAuth2 and SAML. All applications are shown here, even ones you cannot access.`,
+        );
+    }
     public pageIcon = "pf-icon pf-icon-applications";
 
     checkbox = true;

--- a/web/src/admin/applications/ApplicationViewPage.ts
+++ b/web/src/admin/applications/ApplicationViewPage.ts
@@ -25,7 +25,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg, str } from "@lit/localize";
-import { CSSResult, html, PropertyValues, TemplateResult } from "lit";
+import { CSSResult, html, nothing, PropertyValues, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
@@ -147,7 +147,7 @@ export class ApplicationViewPage extends AKElement {
                 ? html`<div slot="header" class="pf-c-banner pf-m-warning">
                       ${msg("Warning: Application is not used by any Outpost.")}
                   </div>`
-                : html``}
+                : nothing}
             <section
                 slot="page-overview"
                 data-tab-title="${msg("Overview")}"
@@ -179,7 +179,7 @@ export class ApplicationViewPage extends AKElement {
                                               </div>
                                           </dd>
                                       </div>`
-                                    : html``}
+                                    : nothing}
                                 ${(this.application.backchannelProvidersObj || []).length > 0
                                     ? html`<div class="pf-c-description-list__group">
                                           <dt class="pf-c-description-list__term">
@@ -208,7 +208,7 @@ export class ApplicationViewPage extends AKElement {
                                               </div>
                                           </dd>
                                       </div>`
-                                    : html``}
+                                    : nothing}
                                 <div class="pf-c-description-list__group">
                                     <dt class="pf-c-description-list__term">
                                         <span class="pf-c-description-list__text"
@@ -297,7 +297,7 @@ export class ApplicationViewPage extends AKElement {
                                               </div>
                                           </dd>
                                       </div>`
-                                    : html``}
+                                    : nothing}
                             </dl>
                         </div>
                     </div>

--- a/web/src/admin/applications/ProviderSelectModal.ts
+++ b/web/src/admin/applications/ProviderSelectModal.ts
@@ -16,9 +16,7 @@ export class ProviderSelectModal extends TableModal<Provider> {
     checkbox = true;
     checkboxChip = true;
 
-    searchEnabled(): boolean {
-        return true;
-    }
+    protected override searchEnabled = true;
 
     @property({ type: Boolean })
     backchannel = false;

--- a/web/src/admin/applications/ProviderSelectModal.ts
+++ b/web/src/admin/applications/ProviderSelectModal.ts
@@ -4,6 +4,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, TableColumn } from "#elements/table/Table";
 import { TableModal } from "#elements/table/TableModal";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { Provider, ProvidersApi } from "@goauthentik/api";
 
@@ -39,7 +40,7 @@ export class ProviderSelectModal extends TableModal<Provider> {
         [msg("Type")],
     ];
 
-    row(item: Provider): TemplateResult[] {
+    row(item: Provider): SlottedTemplateResult[] {
         return [
             html`<div>
                 <div>${item.name}</div>

--- a/web/src/admin/applications/ProviderSelectModal.ts
+++ b/web/src/admin/applications/ProviderSelectModal.ts
@@ -35,9 +35,11 @@ export class ProviderSelectModal extends TableModal<Provider> {
         });
     }
 
-    columns(): TableColumn[] {
-        return [new TableColumn(msg("Name"), "username"), new TableColumn(msg("Type"))];
-    }
+    protected columns: TableColumn[] = [
+        // ---
+        [msg("Name"), "username"],
+        [msg("Type")],
+    ];
 
     row(item: Provider): TemplateResult[] {
         return [

--- a/web/src/admin/applications/entitlements/ApplicationEntitlementPage.ts
+++ b/web/src/admin/applications/entitlements/ApplicationEntitlementPage.ts
@@ -43,9 +43,11 @@ export class ApplicationEntitlementsPage extends Table<ApplicationEntitlement> {
         });
     }
 
-    columns(): TableColumn[] {
-        return [new TableColumn(msg("Name"), "name"), new TableColumn(msg("Actions"))];
-    }
+    protected columns: TableColumn[] = [
+        // ---
+        [msg("Name"), "name"],
+        [msg("Actions")],
+    ];
 
     renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;

--- a/web/src/admin/applications/entitlements/ApplicationEntitlementPage.ts
+++ b/web/src/admin/applications/entitlements/ApplicationEntitlementPage.ts
@@ -46,7 +46,7 @@ export class ApplicationEntitlementsPage extends Table<ApplicationEntitlement> {
     protected columns: TableColumn[] = [
         // ---
         [msg("Name"), "name"],
-        [msg("Actions")],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     renderToolbarSelected(): TemplateResult {

--- a/web/src/admin/applications/entitlements/ApplicationEntitlementPage.ts
+++ b/web/src/admin/applications/entitlements/ApplicationEntitlementPage.ts
@@ -11,6 +11,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { PFSize } from "#common/enums";
 
 import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { PolicyBindingCheckTarget } from "#admin/policies/utils";
 
@@ -71,7 +72,7 @@ export class ApplicationEntitlementsPage extends Table<ApplicationEntitlement> {
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: ApplicationEntitlement): TemplateResult[] {
+    row(item: ApplicationEntitlement): SlottedTemplateResult[] {
         return [
             html`${item.name}`,
             html`<ak-forms-modal size=${PFSize.Medium}>

--- a/web/src/admin/applications/entitlements/ApplicationEntitlementPage.ts
+++ b/web/src/admin/applications/entitlements/ApplicationEntitlementPage.ts
@@ -85,7 +85,7 @@ export class ApplicationEntitlementsPage extends Table<ApplicationEntitlement> {
                     </ak-application-entitlement-form>
                     <button slot="trigger" class="pf-c-button pf-m-plain">
                         <pf-tooltip position="top" content=${msg("Edit")}>
-                            <i class="fas fa-edit"></i>
+                            <i class="fas fa-edit" aria-hidden="true"></i>
                         </pf-tooltip>
                     </button>
                 </ak-forms-modal>

--- a/web/src/admin/applications/entitlements/ApplicationEntitlementPage.ts
+++ b/web/src/admin/applications/entitlements/ApplicationEntitlementPage.ts
@@ -99,7 +99,7 @@ export class ApplicationEntitlementsPage extends Table<ApplicationEntitlement> {
 
     renderExpanded(item: ApplicationEntitlement): TemplateResult {
         return html`<td></td>
-            <td role="cell" colspan="4">
+            <td colspan="4">
                 <div class="pf-c-table__expandable-row-content">
                     <div class="pf-c-content">
                         <p>

--- a/web/src/admin/applications/wizard/steps/ak-application-wizard-bindings-step.ts
+++ b/web/src/admin/applications/wizard/steps/ak-application-wizard-bindings-step.ts
@@ -30,7 +30,7 @@ const COLUMNS = [
     [msg("Binding")],
     [msg("Enabled"), "enabled"],
     [msg("Timeout"), "timeout"],
-    [msg("Actions")],
+    [msg("Actions"), null, msg("Row Actions")],
 ];
 
 @customElement("ak-application-wizard-bindings-step")

--- a/web/src/admin/blueprints/BlueprintForm.ts
+++ b/web/src/admin/blueprints/BlueprintForm.ts
@@ -15,7 +15,7 @@ import { BlueprintFile, BlueprintInstance, ManagedApi } from "@goauthentik/api";
 import YAML from "yaml";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
@@ -138,7 +138,7 @@ export class BlueprintForm extends ModelForm<BlueprintInstance, string> {
                               >
                               </ak-search-select>
                           </ak-form-element-horizontal>`
-                        : html``}
+                        : nothing}
                     ${this.source === blueprintSource.oci
                         ? html`<ak-form-element-horizontal label=${msg("URL")} name="path">
                               <input
@@ -164,7 +164,7 @@ export class BlueprintForm extends ModelForm<BlueprintInstance, string> {
                                   >
                               </p>
                           </ak-form-element-horizontal>`
-                        : html``}
+                        : nothing}
                     ${this.source === blueprintSource.internal
                         ? html`<ak-form-element-horizontal label=${msg("Blueprint")} name="content">
                               <ak-codemirror
@@ -173,7 +173,7 @@ export class BlueprintForm extends ModelForm<BlueprintInstance, string> {
                                   value="${ifDefined(this.instance?.content)}"
                               ></ak-codemirror>
                           </ak-form-element-horizontal>`
-                        : html``}
+                        : nothing}
                 </div>
             </div>
 

--- a/web/src/admin/blueprints/BlueprintListPage.ts
+++ b/web/src/admin/blueprints/BlueprintListPage.ts
@@ -74,15 +74,13 @@ export class BlueprintListPage extends TablePage<BlueprintInstance> {
         );
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Name"), "name"),
-            new TableColumn(msg("Status"), "status"),
-            new TableColumn(msg("Last applied"), "last_applied"),
-            new TableColumn(msg("Enabled"), "enabled"),
-            new TableColumn(msg("Actions")),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Name"), "name"],
+        [msg("Status"), "status"],
+        [msg("Last applied"), "last_applied"],
+        [msg("Enabled"), "enabled"],
+        [msg("Actions")],
+    ];
 
     renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;

--- a/web/src/admin/blueprints/BlueprintListPage.ts
+++ b/web/src/admin/blueprints/BlueprintListPage.ts
@@ -10,9 +10,8 @@ import "@patternfly/elements/pf-tooltip/pf-tooltip.js";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
 import { EVENT_REFRESH } from "#common/constants";
-import { formatElapsedTime } from "#common/temporal";
 
-import { PaginatedResponse, TableColumn } from "#elements/table/Table";
+import { PaginatedResponse, TableColumn, Timestamp } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
 
 import {
@@ -157,8 +156,7 @@ export class BlueprintListPage extends TablePage<BlueprintInstance> {
             html`<div>${item.name}</div>
                 ${description ? html`<small>${description}</small>` : html``}`,
             html`${BlueprintStatus(item)}`,
-            html`<div>${formatElapsedTime(item.lastApplied)}</div>
-                <small>${item.lastApplied.toLocaleString()}</small>`,
+            Timestamp(item.lastApplied),
             html`<ak-status-label ?good=${item.enabled}></ak-status-label>`,
             html`<ak-forms-modal>
                     <span slot="submit"> ${msg("Update")} </span>

--- a/web/src/admin/blueprints/BlueprintListPage.ts
+++ b/web/src/admin/blueprints/BlueprintListPage.ts
@@ -79,7 +79,7 @@ export class BlueprintListPage extends TablePage<BlueprintInstance> {
         [msg("Status"), "status"],
         [msg("Last applied"), "last_applied"],
         [msg("Enabled"), "enabled"],
-        [msg("Actions")],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     renderToolbarSelected(): TemplateResult {

--- a/web/src/admin/blueprints/BlueprintListPage.ts
+++ b/web/src/admin/blueprints/BlueprintListPage.ts
@@ -13,6 +13,7 @@ import { EVENT_REFRESH } from "#common/constants";
 
 import { PaginatedResponse, TableColumn, Timestamp } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     BlueprintInstance,
@@ -23,7 +24,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import PFDescriptionList from "@patternfly/patternfly/components/DescriptionList/description-list.css";
@@ -134,7 +135,7 @@ export class BlueprintListPage extends TablePage<BlueprintInstance> {
         </td>`;
     }
 
-    row(item: BlueprintInstance): TemplateResult[] {
+    row(item: BlueprintInstance): SlottedTemplateResult[] {
         let description = undefined;
         const descKey = "blueprints.goauthentik.io/description";
         if (
@@ -146,7 +147,7 @@ export class BlueprintListPage extends TablePage<BlueprintInstance> {
         }
         return [
             html`<div>${item.name}</div>
-                ${description ? html`<small>${description}</small>` : html``}`,
+                ${description ? html`<small>${description}</small>` : nothing}`,
             html`${BlueprintStatus(item)}`,
             Timestamp(item.lastApplied),
             html`<ak-status-label ?good=${item.enabled}></ak-status-label>`,

--- a/web/src/admin/blueprints/BlueprintListPage.ts
+++ b/web/src/admin/blueprints/BlueprintListPage.ts
@@ -166,7 +166,7 @@ export class BlueprintListPage extends TablePage<BlueprintInstance> {
                     <ak-blueprint-form slot="form" .instancePk=${item.pk}> </ak-blueprint-form>
                     <button slot="trigger" class="pf-c-button pf-m-plain">
                         <pf-tooltip position="top" content=${msg("Edit")}>
-                            <i class="fas fa-edit"></i>
+                            <i class="fas fa-edit" aria-hidden="true"></i>
                         </pf-tooltip>
                     </button>
                 </ak-forms-modal>

--- a/web/src/admin/blueprints/BlueprintListPage.ts
+++ b/web/src/admin/blueprints/BlueprintListPage.ts
@@ -45,18 +45,10 @@ export function BlueprintStatus(blueprint?: BlueprintInstance): string {
 
 @customElement("ak-blueprint-list")
 export class BlueprintListPage extends TablePage<BlueprintInstance> {
-    searchEnabled(): boolean {
-        return true;
-    }
-    pageTitle(): string {
-        return msg("Blueprints");
-    }
-    pageDescription(): string {
-        return msg("Automate and template configuration within authentik.");
-    }
-    pageIcon(): string {
-        return "pf-icon pf-icon-blueprint";
-    }
+    protected override searchEnabled = true;
+    public pageTitle = msg("Blueprints");
+    public pageDescription = msg("Automate and template configuration within authentik.");
+    public pageIcon = "pf-icon pf-icon-blueprint";
 
     expandable = true;
     checkbox = true;
@@ -108,7 +100,7 @@ export class BlueprintListPage extends TablePage<BlueprintInstance> {
 
     renderExpanded(item: BlueprintInstance): TemplateResult {
         const [appLabel, modelName] = ModelEnum.AuthentikBlueprintsBlueprintinstance.split(".");
-        return html`<td role="cell" colspan="5">
+        return html`<td colspan="5">
             <div class="pf-c-table__expandable-row-content">
                 <dl class="pf-c-description-list pf-m-horizontal">
                     <div class="pf-c-description-list__group">

--- a/web/src/admin/brands/BrandListPage.ts
+++ b/web/src/admin/brands/BrandListPage.ts
@@ -10,6 +10,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, TableColumn } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { Brand, CoreApi, RbacPermissionsAssignedByUsersListModelEnum } from "@goauthentik/api";
 
@@ -70,7 +71,7 @@ export class BrandListPage extends TablePage<Brand> {
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: Brand): TemplateResult[] {
+    row(item: Brand): SlottedTemplateResult[] {
         return [
             html`${item.domain}`,
             html`${item.brandingTitle}`,

--- a/web/src/admin/brands/BrandListPage.ts
+++ b/web/src/admin/brands/BrandListPage.ts
@@ -19,18 +19,10 @@ import { customElement, property } from "lit/decorators.js";
 
 @customElement("ak-brand-list")
 export class BrandListPage extends TablePage<Brand> {
-    searchEnabled(): boolean {
-        return true;
-    }
-    pageTitle(): string {
-        return msg("Brands");
-    }
-    pageDescription(): string {
-        return msg("Configure visual settings and defaults for different domains.");
-    }
-    pageIcon(): string {
-        return "pf-icon pf-icon-tenant";
-    }
+    protected override searchEnabled = true;
+    public pageTitle = msg("Brands");
+    public pageDescription = msg("Configure visual settings and defaults for different domains.");
+    public pageIcon = "pf-icon pf-icon-tenant";
 
     checkbox = true;
     clearOnRefresh = true;

--- a/web/src/admin/brands/BrandListPage.ts
+++ b/web/src/admin/brands/BrandListPage.ts
@@ -85,7 +85,7 @@ export class BrandListPage extends TablePage<Brand> {
                     <ak-brand-form slot="form" .instancePk=${item.brandUuid}> </ak-brand-form>
                     <button slot="trigger" class="pf-c-button pf-m-plain">
                         <pf-tooltip position="top" content=${msg("Edit")}>
-                            <i class="fas fa-edit"></i>
+                            <i class="fas fa-edit" aria-hidden="true"></i>
                         </pf-tooltip>
                     </button>
                 </ak-forms-modal>

--- a/web/src/admin/brands/BrandListPage.ts
+++ b/web/src/admin/brands/BrandListPage.ts
@@ -42,14 +42,12 @@ export class BrandListPage extends TablePage<Brand> {
         return new CoreApi(DEFAULT_CONFIG).coreBrandsList(await this.defaultEndpointConfig());
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Domain"), "domain"),
-            new TableColumn(msg("Brand name"), "branding_title"),
-            new TableColumn(msg("Default?"), "default"),
-            new TableColumn(msg("Actions")),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Domain"), "domain"],
+        [msg("Brand name"), "branding_title"],
+        [msg("Default?"), "default"],
+        [msg("Actions")],
+    ];
 
     renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;

--- a/web/src/admin/brands/BrandListPage.ts
+++ b/web/src/admin/brands/BrandListPage.ts
@@ -46,7 +46,7 @@ export class BrandListPage extends TablePage<Brand> {
         [msg("Domain"), "domain"],
         [msg("Brand name"), "branding_title"],
         [msg("Default?"), "default"],
-        [msg("Actions")],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     renderToolbarSelected(): TemplateResult {

--- a/web/src/admin/brands/BrandListPage.ts
+++ b/web/src/admin/brands/BrandListPage.ts
@@ -42,6 +42,10 @@ export class BrandListPage extends TablePage<Brand> {
         return new CoreApi(DEFAULT_CONFIG).coreBrandsList(await this.defaultEndpointConfig());
     }
 
+    protected override rowLabel(item: Brand): string | null {
+        return item.domain ?? null;
+    }
+
     protected columns: TableColumn[] = [
         [msg("Domain"), "domain"],
         [msg("Brand name"), "branding_title"],

--- a/web/src/admin/crypto/CertificateKeyPairListPage.ts
+++ b/web/src/admin/crypto/CertificateKeyPairListPage.ts
@@ -31,20 +31,12 @@ export class CertificateKeyPairListPage extends TablePage<CertificateKeyPair> {
     checkbox = true;
     clearOnRefresh = true;
 
-    searchEnabled(): boolean {
-        return true;
-    }
-    pageTitle(): string {
-        return msg("Certificate-Key Pairs");
-    }
-    pageDescription(): string {
-        return msg(
-            "Import certificates of external providers or create certificates to sign requests with.",
-        );
-    }
-    pageIcon(): string {
-        return "pf-icon pf-icon-key";
-    }
+    protected override searchEnabled = true;
+    public pageTitle = msg("Certificate-Key Pairs");
+    public pageDescription = msg(
+        "Import certificates of external providers or create certificates to sign requests with.",
+    );
+    public pageIcon = "pf-icon pf-icon-key";
 
     @property()
     order = "name";
@@ -139,7 +131,7 @@ export class CertificateKeyPairListPage extends TablePage<CertificateKeyPair> {
     }
 
     renderExpanded(item: CertificateKeyPair): TemplateResult {
-        return html`<td role="cell" colspan="4">
+        return html`<td colspan="4">
                 <div class="pf-c-table__expandable-row-content">
                     <dl class="pf-c-description-list pf-m-horizontal">
                         <div class="pf-c-description-list__group">

--- a/web/src/admin/crypto/CertificateKeyPairListPage.ts
+++ b/web/src/admin/crypto/CertificateKeyPairListPage.ts
@@ -57,14 +57,12 @@ export class CertificateKeyPairListPage extends TablePage<CertificateKeyPair> {
         );
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Name"), "name"),
-            new TableColumn(msg("Private key available?")),
-            new TableColumn(msg("Expiry date")),
-            new TableColumn(msg("Actions")),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Name"), "name"],
+        [msg("Private key available?")],
+        [msg("Expiry date")],
+        [msg("Actions")],
+    ];
 
     renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;

--- a/web/src/admin/crypto/CertificateKeyPairListPage.ts
+++ b/web/src/admin/crypto/CertificateKeyPairListPage.ts
@@ -12,6 +12,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { PFColor } from "#elements/Label";
 import { PaginatedResponse, TableColumn } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     CertificateKeyPair,
@@ -20,7 +21,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg, str } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import PFDescriptionList from "@patternfly/patternfly/components/DescriptionList/description-list.css";
@@ -84,7 +85,7 @@ export class CertificateKeyPairListPage extends TablePage<CertificateKeyPair> {
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: CertificateKeyPair): TemplateResult[] {
+    row(item: CertificateKeyPair): SlottedTemplateResult[] {
         let managedSubText = msg("Managed by authentik");
         if (item.managed && item.managed.startsWith("goauthentik.io/crypto/discovered")) {
             managedSubText = msg("Managed by authentik (Discovered)");
@@ -103,7 +104,7 @@ export class CertificateKeyPairListPage extends TablePage<CertificateKeyPair> {
         }
         return [
             html`<div>${item.name}</div>
-                ${item.managed ? html`<small>${managedSubText}</small>` : html``}`,
+                ${item.managed ? html`<small>${managedSubText}</small>` : nothing}`,
             html`<ak-status-label
                 type="info"
                 ?good=${item.privateKeyAvailable}
@@ -189,7 +190,7 @@ export class CertificateKeyPairListPage extends TablePage<CertificateKeyPair> {
                                           >
                                               ${msg("Download Private key")}
                                           </a>`
-                                        : html``}
+                                        : nothing}
                                 </div>
                             </dd>
                         </div>

--- a/web/src/admin/crypto/CertificateKeyPairListPage.ts
+++ b/web/src/admin/crypto/CertificateKeyPairListPage.ts
@@ -126,7 +126,7 @@ export class CertificateKeyPairListPage extends TablePage<CertificateKeyPair> {
                     </ak-crypto-certificate-form>
                     <button slot="trigger" class="pf-c-button pf-m-plain">
                         <pf-tooltip position="top" content=${msg("Edit")}>
-                            <i class="fas fa-edit"></i>
+                            <i class="fas fa-edit" aria-hidden="true"></i>
                         </pf-tooltip>
                     </button>
                 </ak-forms-modal>

--- a/web/src/admin/crypto/CertificateKeyPairListPage.ts
+++ b/web/src/admin/crypto/CertificateKeyPairListPage.ts
@@ -61,7 +61,7 @@ export class CertificateKeyPairListPage extends TablePage<CertificateKeyPair> {
         [msg("Name"), "name"],
         [msg("Private key available?")],
         [msg("Expiry date")],
-        [msg("Actions")],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     renderToolbarSelected(): TemplateResult {

--- a/web/src/admin/enterprise/EnterpriseLicenseListPage.ts
+++ b/web/src/admin/enterprise/EnterpriseLicenseListPage.ts
@@ -222,7 +222,7 @@ export class EnterpriseLicenseListPage extends TablePage<License> {
                     </ak-enterprise-license-form>
                     <button slot="trigger" class="pf-c-button pf-m-plain">
                         <pf-tooltip position="top" content=${msg("Edit")}>
-                            <i class="fas fa-edit"></i>
+                            <i class="fas fa-edit" aria-hidden="true"></i>
                         </pf-tooltip>
                     </button>
                 </ak-forms-modal>

--- a/web/src/admin/enterprise/EnterpriseLicenseListPage.ts
+++ b/web/src/admin/enterprise/EnterpriseLicenseListPage.ts
@@ -13,6 +13,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { PFColor } from "#elements/Label";
 import { PaginatedResponse, TableColumn, Timestamp } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     EnterpriseApi,
@@ -24,7 +25,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg, str } from "@lit/localize";
-import { css, CSSResult, html, TemplateResult } from "lit";
+import { css, CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
 import PFBanner from "@patternfly/patternfly/components/Banner/banner.css";
@@ -101,7 +102,7 @@ export class EnterpriseLicenseListPage extends TablePage<License> {
                 : html`<ak-empty-state icon=${this.pageIcon}
                       ><span>${msg("No licenses found.")}</span>
                       <div slot="body">
-                          ${this.searchEnabled ? this.renderEmptyClearSearch() : html``}
+                          ${this.searchEnabled ? this.renderEmptyClearSearch() : nothing}
                       </div>
                       <div slot="primary">${this.renderObjectCreate()}</div>
                   </ak-empty-state>`}
@@ -187,7 +188,7 @@ export class EnterpriseLicenseListPage extends TablePage<License> {
         `;
     }
 
-    row(item: License): TemplateResult[] {
+    row(item: License): SlottedTemplateResult[] {
         let color = PFColor.Green;
         if (item.expiry) {
             const now = new Date();

--- a/web/src/admin/enterprise/EnterpriseLicenseListPage.ts
+++ b/web/src/admin/enterprise/EnterpriseLicenseListPage.ts
@@ -9,10 +9,9 @@ import "#elements/forms/ModalForm";
 import "@patternfly/elements/pf-tooltip/pf-tooltip.js";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
-import { formatElapsedTime } from "#common/temporal";
 
 import { PFColor } from "#elements/Label";
-import { PaginatedResponse, TableColumn } from "#elements/table/Table";
+import { PaginatedResponse, TableColumn, Timestamp } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
 
 import {
@@ -182,8 +181,7 @@ export class EnterpriseLicenseListPage extends TablePage<License> {
                     >
                         ${this.summary &&
                         this.summary?.status !== LicenseSummaryStatusEnum.Unlicensed
-                            ? html`<div>${formatElapsedTime(this.summary.latestValid)}</div>
-                                  <small>${this.summary.latestValid.toLocaleString()}</small>`
+                            ? Timestamp(this.summary.latestValid)
                             : "-"}
                     </ak-aggregate-card>
                 </div>

--- a/web/src/admin/enterprise/EnterpriseLicenseListPage.ts
+++ b/web/src/admin/enterprise/EnterpriseLicenseListPage.ts
@@ -38,18 +38,10 @@ export class EnterpriseLicenseListPage extends TablePage<License> {
     checkbox = true;
     clearOnRefresh = true;
 
-    searchEnabled(): boolean {
-        return true;
-    }
-    pageTitle(): string {
-        return msg("Licenses");
-    }
-    pageDescription(): string {
-        return msg("Manage enterprise licenses");
-    }
-    pageIcon(): string {
-        return "pf-icon pf-icon-key";
-    }
+    protected override searchEnabled = true;
+    public pageTitle = msg("Licenses");
+    public pageDescription = msg("Manage enterprise licenses");
+    public pageIcon = "pf-icon pf-icon-key";
 
     @property()
     order = "name";
@@ -106,10 +98,10 @@ export class EnterpriseLicenseListPage extends TablePage<License> {
         return super.renderEmpty(html`
             ${inner
                 ? inner
-                : html`<ak-empty-state icon=${this.pageIcon()}
+                : html`<ak-empty-state icon=${this.pageIcon}
                       ><span>${msg("No licenses found.")}</span>
                       <div slot="body">
-                          ${this.searchEnabled() ? this.renderEmptyClearSearch() : html``}
+                          ${this.searchEnabled ? this.renderEmptyClearSearch() : html``}
                       </div>
                       <div slot="primary">${this.renderObjectCreate()}</div>
                   </ak-empty-state>`}

--- a/web/src/admin/enterprise/EnterpriseLicenseListPage.ts
+++ b/web/src/admin/enterprise/EnterpriseLicenseListPage.ts
@@ -94,14 +94,12 @@ export class EnterpriseLicenseListPage extends TablePage<License> {
         );
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Name"), "name"),
-            new TableColumn(msg("Users")),
-            new TableColumn(msg("Expiry date")),
-            new TableColumn(msg("Actions")),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Name"), "name"],
+        [msg("Users")],
+        [msg("Expiry date")],
+        [msg("Actions")],
+    ];
 
     // TODO: Make this more generic, maybe automatically get the plural name
     // of the object to use in the renderEmpty

--- a/web/src/admin/enterprise/EnterpriseLicenseListPage.ts
+++ b/web/src/admin/enterprise/EnterpriseLicenseListPage.ts
@@ -98,7 +98,7 @@ export class EnterpriseLicenseListPage extends TablePage<License> {
         [msg("Name"), "name"],
         [msg("Users")],
         [msg("Expiry date")],
-        [msg("Actions")],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     // TODO: Make this more generic, maybe automatically get the plural name

--- a/web/src/admin/events/EventListPage.ts
+++ b/web/src/admin/events/EventListPage.ts
@@ -7,10 +7,9 @@ import "@patternfly/elements/pf-tooltip/pf-tooltip.js";
 import { DEFAULT_CONFIG } from "#common/api/config";
 import { EventWithContext } from "#common/events";
 import { actionToLabel } from "#common/labels";
-import { formatElapsedTime } from "#common/temporal";
 
 import { WithLicenseSummary } from "#elements/mixins/license";
-import { PaginatedResponse, TableColumn } from "#elements/table/Table";
+import { PaginatedResponse, TableColumn, Timestamp } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
 import { SlottedTemplateResult } from "#elements/types";
 
@@ -68,6 +67,10 @@ export class EventListPage extends WithLicenseSummary(TablePage<Event>) {
         [msg("Actions"), null, msg("Row Actions")],
     ];
 
+    protected rowLabel(item: Event): string | null {
+        return actionToLabel(item.action);
+    }
+
     renderSectionBefore(): TemplateResult {
         if (this.hasEnterpriseLicense) {
             return html`<div
@@ -107,8 +110,7 @@ export class EventListPage extends WithLicenseSummary(TablePage<Event>) {
             html`<div>${actionToLabel(item.action)}</div>
                 <small>${item.app}</small>`,
             renderEventUser(item),
-            html`<div>${formatElapsedTime(item.created)}</div>
-                <small>${item.created.toLocaleString()}</small>`,
+            Timestamp(item.created),
             html`<div>${item.clientIp || msg("-")}</div>
                 <small>${EventGeo(item)}</small>`,
             html`<span>${item.brand?.name || msg("-")}</span>`,

--- a/web/src/admin/events/EventListPage.ts
+++ b/web/src/admin/events/EventListPage.ts
@@ -28,18 +28,11 @@ export class EventListPage extends WithLicenseSummary(TablePage<Event>) {
     expandable = true;
     supportsQL = true;
 
-    pageTitle(): string {
-        return msg("Event Log");
-    }
-    pageDescription(): string | undefined {
-        return;
-    }
-    pageIcon(): string {
-        return "pf-icon pf-icon-catalog";
-    }
-    searchEnabled(): boolean {
-        return true;
-    }
+    public pageTitle = msg("Event Log");
+    public pageDescription = "";
+
+    public pageIcon = "pf-icon pf-icon-catalog";
+    protected override searchEnabled = true;
 
     @property()
     order = "-created";
@@ -123,7 +116,7 @@ export class EventListPage extends WithLicenseSummary(TablePage<Event>) {
     }
 
     renderExpanded(item: Event): TemplateResult {
-        return html` <td role="cell" colspan="5">
+        return html` <td colspan="5">
                 <div class="pf-c-table__expandable-row-content">
                     <ak-event-info .event=${item as EventWithContext}></ak-event-info>
                 </div>

--- a/web/src/admin/events/EventListPage.ts
+++ b/web/src/admin/events/EventListPage.ts
@@ -67,7 +67,7 @@ export class EventListPage extends WithLicenseSummary(TablePage<Event>) {
         [msg("Actions"), null, msg("Row Actions")],
     ];
 
-    protected rowLabel(item: Event): string | null {
+    protected override rowLabel(item: Event): string | null {
         return actionToLabel(item.action);
     }
 

--- a/web/src/admin/events/EventListPage.ts
+++ b/web/src/admin/events/EventListPage.ts
@@ -114,7 +114,7 @@ export class EventListPage extends WithLicenseSummary(TablePage<Event>) {
             html`<span>${item.brand?.name || msg("-")}</span>`,
             html`<a href="#/events/log/${item.pk}">
                 <pf-tooltip position="top" content=${msg("Show details")}>
-                    <i class="fas fa-share-square"></i>
+                    <i class="fas fa-share-square" aria-hidden="true"></i>
                 </pf-tooltip>
             </a>`,
         ];

--- a/web/src/admin/events/EventListPage.ts
+++ b/web/src/admin/events/EventListPage.ts
@@ -59,16 +59,14 @@ export class EventListPage extends WithLicenseSummary(TablePage<Event>) {
         return new EventsApi(DEFAULT_CONFIG).eventsEventsList(await this.defaultEndpointConfig());
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Action"), "action"),
-            new TableColumn(msg("User"), "user"),
-            new TableColumn(msg("Creation Date"), "created"),
-            new TableColumn(msg("Client IP"), "client_ip"),
-            new TableColumn(msg("Brand"), "brand_name"),
-            new TableColumn(msg("Actions")),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Action"), "action"],
+        [msg("User"), "user"],
+        [msg("Creation Date"), "created"],
+        [msg("Client IP"), "client_ip"],
+        [msg("Brand"), "brand_name"],
+        [msg("Actions")],
+    ];
 
     renderSectionBefore(): TemplateResult {
         if (this.hasEnterpriseLicense) {

--- a/web/src/admin/events/EventListPage.ts
+++ b/web/src/admin/events/EventListPage.ts
@@ -65,7 +65,7 @@ export class EventListPage extends WithLicenseSummary(TablePage<Event>) {
         [msg("Creation Date"), "created"],
         [msg("Client IP"), "client_ip"],
         [msg("Brand"), "brand_name"],
-        [msg("Actions")],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     renderSectionBefore(): TemplateResult {

--- a/web/src/admin/events/EventViewPage.ts
+++ b/web/src/admin/events/EventViewPage.ts
@@ -4,9 +4,9 @@ import "#components/ak-page-header";
 import { DEFAULT_CONFIG } from "#common/api/config";
 import { EventWithContext } from "#common/events";
 import { actionToLabel } from "#common/labels";
-import { formatElapsedTime } from "#common/temporal";
 
 import { AKElement } from "#elements/Base";
+import { Timestamp } from "#elements/table/shared";
 
 import { EventGeo, renderEventUser } from "#admin/events/utils";
 
@@ -105,8 +105,7 @@ export class EventViewPage extends AKElement {
                                     </dt>
                                     <dd class="pf-c-description-list__description">
                                         <div class="pf-c-description-list__text">
-                                            <div>${formatElapsedTime(this.event.created)}</div>
-                                            <small>${this.event.created.toLocaleString()}</small>
+                                            ${Timestamp(this.event.created)}
                                         </div>
                                     </dd>
                                 </div>

--- a/web/src/admin/events/RuleListPage.ts
+++ b/web/src/admin/events/RuleListPage.ts
@@ -100,7 +100,7 @@ export class RuleListPage extends TablePage<NotificationRule> {
                     <ak-event-rule-form slot="form" .instancePk=${item.pk}> </ak-event-rule-form>
                     <button slot="trigger" class="pf-c-button pf-m-plain">
                         <pf-tooltip position="top" content=${msg("Edit")}>
-                            <i class="fas fa-edit"></i>
+                            <i class="fas fa-edit" aria-hidden="true"></i>
                         </pf-tooltip>
                     </button>
                 </ak-forms-modal>

--- a/web/src/admin/events/RuleListPage.ts
+++ b/web/src/admin/events/RuleListPage.ts
@@ -31,20 +31,12 @@ export class RuleListPage extends TablePage<NotificationRule> {
     checkbox = true;
     clearOnRefresh = true;
 
-    searchEnabled(): boolean {
-        return true;
-    }
-    pageTitle(): string {
-        return msg("Notification Rules");
-    }
-    pageDescription(): string {
-        return msg(
-            "Send notifications whenever a specific Event is created and matched by policies.",
-        );
-    }
-    pageIcon(): string {
-        return "pf-icon pf-icon-attention-bell";
-    }
+    protected override searchEnabled = true;
+    public pageTitle = msg("Notification Rules");
+    public pageDescription = msg(
+        "Send notifications whenever a specific Event is created and matched by policies.",
+    );
+    public pageIcon = "pf-icon pf-icon-attention-bell";
 
     @property()
     order = "name";
@@ -126,7 +118,7 @@ export class RuleListPage extends TablePage<NotificationRule> {
 
     renderExpanded(item: NotificationRule): TemplateResult {
         const [appLabel, modelName] = ModelEnum.AuthentikEventsNotificationrule.split(".");
-        return html` <td role="cell" colspan="4">
+        return html` <td colspan="4">
             <div class="pf-c-table__expandable-row-content">
                 <p>
                     ${msg(

--- a/web/src/admin/events/RuleListPage.ts
+++ b/web/src/admin/events/RuleListPage.ts
@@ -58,7 +58,7 @@ export class RuleListPage extends TablePage<NotificationRule> {
         [msg("Name"), "name"],
         [msg("Severity"), "severity"],
         [msg("Sent to group"), "group"],
-        [msg("Actions")],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     renderToolbarSelected(): TemplateResult {

--- a/web/src/admin/events/RuleListPage.ts
+++ b/web/src/admin/events/RuleListPage.ts
@@ -13,6 +13,7 @@ import { severityToLabel } from "#common/labels";
 
 import { PaginatedResponse, TableColumn } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     EventsApi,
@@ -75,7 +76,7 @@ export class RuleListPage extends TablePage<NotificationRule> {
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: NotificationRule): TemplateResult[] {
+    row(item: NotificationRule): SlottedTemplateResult[] {
         const enabled = !!item.destinationGroupObj || item.destinationEventUser;
         return [
             html`<ak-status-label type="warning" ?good=${enabled}></ak-status-label>`,

--- a/web/src/admin/events/RuleListPage.ts
+++ b/web/src/admin/events/RuleListPage.ts
@@ -53,15 +53,13 @@ export class RuleListPage extends TablePage<NotificationRule> {
         return new EventsApi(DEFAULT_CONFIG).eventsRulesList(await this.defaultEndpointConfig());
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Enabled")),
-            new TableColumn(msg("Name"), "name"),
-            new TableColumn(msg("Severity"), "severity"),
-            new TableColumn(msg("Sent to group"), "group"),
-            new TableColumn(msg("Actions")),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Enabled")],
+        [msg("Name"), "name"],
+        [msg("Severity"), "severity"],
+        [msg("Sent to group"), "group"],
+        [msg("Actions")],
+    ];
 
     renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;

--- a/web/src/admin/events/TransportListPage.ts
+++ b/web/src/admin/events/TransportListPage.ts
@@ -11,6 +11,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, TableColumn } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     EventsApi,
@@ -73,7 +74,7 @@ export class TransportListPage extends TablePage<NotificationTransport> {
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: NotificationTransport): TemplateResult[] {
+    row(item: NotificationTransport): SlottedTemplateResult[] {
         return [
             html`${item.name}`,
             html`${item.modeVerbose}`,

--- a/web/src/admin/events/TransportListPage.ts
+++ b/web/src/admin/events/TransportListPage.ts
@@ -25,18 +25,12 @@ import { customElement, property } from "lit/decorators.js";
 
 @customElement("ak-event-transport-list")
 export class TransportListPage extends TablePage<NotificationTransport> {
-    searchEnabled(): boolean {
-        return true;
-    }
-    pageTitle(): string {
-        return msg("Notification Transports");
-    }
-    pageDescription(): string {
-        return msg("Define how notifications are sent to users, like Email or Webhook.");
-    }
-    pageIcon(): string {
-        return "pf-icon pf-icon-export";
-    }
+    protected override searchEnabled = true;
+    public pageTitle = msg("Notification Transports");
+    public pageDescription = msg(
+        "Define how notifications are sent to users, like Email or Webhook.",
+    );
+    public pageIcon = "pf-icon pf-icon-export";
 
     checkbox = true;
     clearOnRefresh = true;
@@ -117,7 +111,7 @@ export class TransportListPage extends TablePage<NotificationTransport> {
 
     renderExpanded(item: NotificationTransport): TemplateResult {
         const [appLabel, modelName] = ModelEnum.AuthentikEventsNotificationtransport.split(".");
-        return html`<td role="cell" colspan="5">
+        return html`<td colspan="5">
             <div class="pf-c-table__expandable-row-content">
                 <dl class="pf-c-description-list pf-m-horizontal">
                     <div class="pf-c-description-list__group">

--- a/web/src/admin/events/TransportListPage.ts
+++ b/web/src/admin/events/TransportListPage.ts
@@ -90,7 +90,7 @@ export class TransportListPage extends TablePage<NotificationTransport> {
                     </ak-event-transport-form>
                     <button slot="trigger" class="pf-c-button pf-m-plain">
                         <pf-tooltip position="top" content=${msg("Edit")}>
-                            <i class="fas fa-edit"></i>
+                            <i class="fas fa-edit" aria-hidden="true"></i>
                         </pf-tooltip>
                     </button>
                 </ak-forms-modal>

--- a/web/src/admin/events/TransportListPage.ts
+++ b/web/src/admin/events/TransportListPage.ts
@@ -54,7 +54,7 @@ export class TransportListPage extends TablePage<NotificationTransport> {
     protected columns: TableColumn[] = [
         [msg("Name"), "name"],
         [msg("Mode"), "mode"],
-        [msg("Actions")],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     renderToolbarSelected(): TemplateResult {

--- a/web/src/admin/events/TransportListPage.ts
+++ b/web/src/admin/events/TransportListPage.ts
@@ -51,13 +51,11 @@ export class TransportListPage extends TablePage<NotificationTransport> {
         );
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Name"), "name"),
-            new TableColumn(msg("Mode"), "mode"),
-            new TableColumn(msg("Actions")),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Name"), "name"],
+        [msg("Mode"), "mode"],
+        [msg("Actions")],
+    ];
 
     renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;

--- a/web/src/admin/flows/BoundStagesList.ts
+++ b/web/src/admin/flows/BoundStagesList.ts
@@ -40,6 +40,10 @@ export class BoundStagesList extends Table<FlowStageBinding> {
         });
     }
 
+    protected override rowLabel(item: FlowStageBinding): string {
+        return `#${item.order} ${item.stageObj?.name || ""}`;
+    }
+
     protected columns: TableColumn[] = [
         [msg("Order"), "order"],
         [msg("Name"), "stage__name"],

--- a/web/src/admin/flows/BoundStagesList.ts
+++ b/web/src/admin/flows/BoundStagesList.ts
@@ -10,6 +10,7 @@ import "#elements/forms/ProxyForm";
 import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     FlowsApi,
@@ -79,7 +80,7 @@ export class BoundStagesList extends Table<FlowStageBinding> {
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: FlowStageBinding): TemplateResult[] {
+    row(item: FlowStageBinding): SlottedTemplateResult[] {
         return [
             html`<pre>${item.order}</pre>`,
             html`${item.stageObj?.name}`,

--- a/web/src/admin/flows/BoundStagesList.ts
+++ b/web/src/admin/flows/BoundStagesList.ts
@@ -44,7 +44,7 @@ export class BoundStagesList extends Table<FlowStageBinding> {
         [msg("Order"), "order"],
         [msg("Name"), "stage__name"],
         [msg("Type")],
-        [msg("Actions")],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     renderToolbarSelected(): TemplateResult {

--- a/web/src/admin/flows/BoundStagesList.ts
+++ b/web/src/admin/flows/BoundStagesList.ts
@@ -118,7 +118,7 @@ export class BoundStagesList extends Table<FlowStageBinding> {
 
     renderExpanded(item: FlowStageBinding): TemplateResult {
         return html` <td></td>
-            <td role="cell" colspan="4">
+            <td colspan="4">
                 <div class="pf-c-table__expandable-row-content">
                     <div class="pf-c-content">
                         <p>

--- a/web/src/admin/flows/BoundStagesList.ts
+++ b/web/src/admin/flows/BoundStagesList.ts
@@ -40,14 +40,12 @@ export class BoundStagesList extends Table<FlowStageBinding> {
         });
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Order"), "order"),
-            new TableColumn(msg("Name"), "stage__name"),
-            new TableColumn(msg("Type")),
-            new TableColumn(msg("Actions")),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Order"), "order"],
+        [msg("Name"), "stage__name"],
+        [msg("Type")],
+        [msg("Actions")],
+    ];
 
     renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;

--- a/web/src/admin/flows/FlowForm.ts
+++ b/web/src/admin/flows/FlowForm.ts
@@ -21,7 +21,7 @@ import {
 import { AuthenticationEnum } from "@goauthentik/api/dist/models/AuthenticationEnum.js";
 
 import { msg } from "@lit/localize";
-import { html, TemplateResult } from "lit";
+import { html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
@@ -337,7 +337,7 @@ export class FlowForm extends WithCapabilitiesConfig(ModelForm<Flow, string>) {
                                                 ${this.instance?.background}
                                             </p>
                                         `
-                                      : html``}
+                                      : nothing}
 
                                   <p class="pf-c-form__helper-text">
                                       ${msg("Background shown during execution.")}
@@ -373,7 +373,7 @@ export class FlowForm extends WithCapabilitiesConfig(ModelForm<Flow, string>) {
                                             </p>
                                         </ak-form-element-horizontal>
                                     `
-                                  : html``}`
+                                  : nothing}`
                         : html`<ak-form-element-horizontal
                               label=${msg("Background")}
                               name="background"

--- a/web/src/admin/flows/FlowImportForm.ts
+++ b/web/src/admin/flows/FlowImportForm.ts
@@ -10,7 +10,7 @@ import { Form } from "#elements/forms/Form";
 import { Flow, FlowImportResult, FlowsApi } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 
 import PFDescriptionList from "@patternfly/patternfly/components/DescriptionList/description-list.css";
@@ -73,7 +73,7 @@ export class FlowImportForm extends Form<Flow> {
                     )}
                 </p>
             </ak-form-element-horizontal>
-            ${this.result ? this.renderResult() : html``}`;
+            ${this.result ? this.renderResult() : nothing}`;
     }
 }
 

--- a/web/src/admin/flows/FlowListPage.ts
+++ b/web/src/admin/flows/FlowListPage.ts
@@ -100,7 +100,7 @@ export class FlowListPage extends TablePage<Flow> {
                     <ak-flow-form slot="form" .instancePk=${item.slug}> </ak-flow-form>
                     <button slot="trigger" class="pf-c-button pf-m-plain">
                         <pf-tooltip position="top" content=${msg("Edit")}>
-                            <i class="fas fa-edit"></i>
+                            <i class="fas fa-edit" aria-hidden="true"></i>
                         </pf-tooltip>
                     </button>
                 </ak-forms-modal>
@@ -119,7 +119,7 @@ export class FlowListPage extends TablePage<Flow> {
                 </button>
                 <a class="pf-c-button pf-m-plain" href=${item.exportUrl}>
                     <pf-tooltip position="top" content=${msg("Export")}>
-                        <i class="fas fa-download"></i>
+                        <i class="fas fa-download" aria-hidden="true"></i>
                     </pf-tooltip>
                 </a>`,
         ];

--- a/web/src/admin/flows/FlowListPage.ts
+++ b/web/src/admin/flows/FlowListPage.ts
@@ -22,20 +22,12 @@ import { customElement, property } from "lit/decorators.js";
 
 @customElement("ak-flow-list")
 export class FlowListPage extends TablePage<Flow> {
-    searchEnabled(): boolean {
-        return true;
-    }
-    pageTitle(): string {
-        return msg("Flows");
-    }
-    pageDescription(): string {
-        return msg(
-            "Flows describe a chain of Stages to authenticate, enroll or recover a user. Stages are chosen based on policies applied to them.",
-        );
-    }
-    pageIcon(): string {
-        return "pf-icon pf-icon-process-automation";
-    }
+    protected override searchEnabled = true;
+    public pageTitle = msg("Flows");
+    public pageDescription = msg(
+        "Flows describe a chain of Stages to authenticate, enroll or recover a user. Stages are chosen based on policies applied to them.",
+    );
+    public pageIcon = "pf-icon pf-icon-process-automation";
 
     checkbox = true;
     clearOnRefresh = true;

--- a/web/src/admin/flows/FlowListPage.ts
+++ b/web/src/admin/flows/FlowListPage.ts
@@ -11,6 +11,7 @@ import { groupBy } from "#common/utils";
 
 import { PaginatedResponse, TableColumn } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { DesignationToLabel } from "#admin/flows/utils";
 
@@ -75,7 +76,7 @@ export class FlowListPage extends TablePage<Flow> {
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: Flow): TemplateResult[] {
+    row(item: Flow): SlottedTemplateResult[] {
         return [
             html`<div>
                     <a href="#/flow/flows/${item.slug}">

--- a/web/src/admin/flows/FlowListPage.ts
+++ b/web/src/admin/flows/FlowListPage.ts
@@ -53,15 +53,13 @@ export class FlowListPage extends TablePage<Flow> {
         });
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Identifier"), "slug"),
-            new TableColumn(msg("Name"), "name"),
-            new TableColumn(msg("Stages")),
-            new TableColumn(msg("Policies")),
-            new TableColumn(msg("Actions")),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Identifier"), "slug"],
+        [msg("Name"), "name"],
+        [msg("Stages")],
+        [msg("Policies")],
+        [msg("Actions")],
+    ];
 
     renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;

--- a/web/src/admin/flows/FlowListPage.ts
+++ b/web/src/admin/flows/FlowListPage.ts
@@ -16,7 +16,7 @@ import { DesignationToLabel } from "#admin/flows/utils";
 
 import { Flow, FlowsApi } from "@goauthentik/api";
 
-import { msg } from "@lit/localize";
+import { msg, str } from "@lit/localize";
 import { html, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
@@ -90,13 +90,18 @@ export class FlowListPage extends TablePage<Flow> {
                     <span slot="submit"> ${msg("Update")} </span>
                     <span slot="header"> ${msg("Update Flow")} </span>
                     <ak-flow-form slot="form" .instancePk=${item.slug}> </ak-flow-form>
-                    <button slot="trigger" class="pf-c-button pf-m-plain">
+                    <button
+                        slot="trigger"
+                        class="pf-c-button pf-m-plain"
+                        aria-label=${msg(str`Edit "${item.name}"`)}
+                    >
                         <pf-tooltip position="top" content=${msg("Edit")}>
                             <i class="fas fa-edit" aria-hidden="true"></i>
                         </pf-tooltip>
                     </button>
                 </ak-forms-modal>
                 <button
+                    aria-label=${msg(str`Execute "${item.name}"`)}
                     class="pf-c-button pf-m-plain"
                     @click=${() => {
                         const finalURL = `${window.location.origin}/if/flow/${item.slug}/${AndNext(
@@ -109,7 +114,11 @@ export class FlowListPage extends TablePage<Flow> {
                         <i class="fas fa-play" aria-hidden="true"></i>
                     </pf-tooltip>
                 </button>
-                <a class="pf-c-button pf-m-plain" href=${item.exportUrl}>
+                <a
+                    class="pf-c-button pf-m-plain"
+                    href=${item.exportUrl}
+                    aria-label=${msg(str`Export "${item.name}"`)}
+                >
                     <pf-tooltip position="top" content=${msg("Export")}>
                         <i class="fas fa-download" aria-hidden="true"></i>
                     </pf-tooltip>

--- a/web/src/admin/flows/FlowListPage.ts
+++ b/web/src/admin/flows/FlowListPage.ts
@@ -58,7 +58,7 @@ export class FlowListPage extends TablePage<Flow> {
         [msg("Name"), "name"],
         [msg("Stages")],
         [msg("Policies")],
-        [msg("Actions")],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     renderToolbarSelected(): TemplateResult {

--- a/web/src/admin/flows/FlowViewPage.ts
+++ b/web/src/admin/flows/FlowViewPage.ts
@@ -12,13 +12,14 @@ import { AndNext, DEFAULT_CONFIG } from "#common/api/config";
 import { isResponseErrorLike } from "#common/errors/network";
 
 import { AKElement } from "#elements/Base";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { DesignationToLabel } from "#admin/flows/utils";
 
 import { Flow, FlowsApi, RbacPermissionsAssignedByUsersListModelEnum } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { css, CSSResult, html, PropertyValues, TemplateResult } from "lit";
+import { css, CSSResult, html, nothing, PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
@@ -67,9 +68,9 @@ export class FlowViewPage extends AKElement {
         }
     }
 
-    render(): TemplateResult {
+    render(): SlottedTemplateResult {
         if (!this.flow) {
-            return html``;
+            return nothing;
         }
         return html`<ak-page-header
                 icon="pf-icon pf-icon-process-automation"

--- a/web/src/admin/flows/StageBindingForm.ts
+++ b/web/src/admin/flows/StageBindingForm.ts
@@ -6,6 +6,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { groupBy } from "#common/utils";
 
 import { ModelForm } from "#elements/forms/ModelForm";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { policyEngineModes } from "#admin/policies/PolicyEngineModes";
 
@@ -20,7 +21,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { html, TemplateResult } from "lit";
+import { html, nothing, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
 @customElement("ak-stage-binding-form")
@@ -75,9 +76,9 @@ export class StageBindingForm extends ModelForm<FlowStageBinding, string> {
         return Math.max(...orders) + 1;
     }
 
-    renderTarget(): TemplateResult {
+    renderTarget(): SlottedTemplateResult {
         if (this.instance?.target || this.targetPk) {
-            return html``;
+            return nothing;
         }
         return html`<ak-form-element-horizontal label=${msg("Target")} required name="target">
             <ak-flow-search

--- a/web/src/admin/groups/GroupListPage.ts
+++ b/web/src/admin/groups/GroupListPage.ts
@@ -48,7 +48,7 @@ export class GroupListPage extends TablePage<Group> {
         [msg("Parent"), "parent"],
         [msg("Members")],
         [msg("Superuser privileges?")],
-        [msg("Actions")],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     renderToolbarSelected(): TemplateResult {

--- a/web/src/admin/groups/GroupListPage.ts
+++ b/web/src/admin/groups/GroupListPage.ts
@@ -9,6 +9,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, TableColumn } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { CoreApi, Group } from "@goauthentik/api";
 
@@ -67,7 +68,7 @@ export class GroupListPage extends TablePage<Group> {
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: Group): TemplateResult[] {
+    row(item: Group): SlottedTemplateResult[] {
         return [
             html`<a href="#/identity/groups/${item.pk}">${item.name}</a>`,
             html`${item.parentName || msg("-")}`,

--- a/web/src/admin/groups/GroupListPage.ts
+++ b/web/src/admin/groups/GroupListPage.ts
@@ -43,15 +43,13 @@ export class GroupListPage extends TablePage<Group> {
         });
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Name"), "name"),
-            new TableColumn(msg("Parent"), "parent"),
-            new TableColumn(msg("Members")),
-            new TableColumn(msg("Superuser privileges?")),
-            new TableColumn(msg("Actions")),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Name"), "name"],
+        [msg("Parent"), "parent"],
+        [msg("Members")],
+        [msg("Superuser privileges?")],
+        [msg("Actions")],
+    ];
 
     renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;

--- a/web/src/admin/groups/GroupListPage.ts
+++ b/web/src/admin/groups/GroupListPage.ts
@@ -85,7 +85,7 @@ export class GroupListPage extends TablePage<Group> {
                 <ak-group-form slot="form" .instancePk=${item.pk}> </ak-group-form>
                 <button slot="trigger" class="pf-c-button pf-m-plain">
                     <pf-tooltip position="top" content=${msg("Edit")}>
-                        <i class="fas fa-edit"></i>
+                        <i class="fas fa-edit" aria-hidden="true"></i>
                     </pf-tooltip>
                 </button>
             </ak-forms-modal>`,

--- a/web/src/admin/groups/GroupListPage.ts
+++ b/web/src/admin/groups/GroupListPage.ts
@@ -20,18 +20,12 @@ import { customElement, property } from "lit/decorators.js";
 export class GroupListPage extends TablePage<Group> {
     checkbox = true;
     clearOnRefresh = true;
-    searchEnabled(): boolean {
-        return true;
-    }
-    pageTitle(): string {
-        return msg("Groups");
-    }
-    pageDescription(): string {
-        return msg("Group users together and give them permissions based on the membership.");
-    }
-    pageIcon(): string {
-        return "pf-icon pf-icon-users";
-    }
+    protected override searchEnabled = true;
+    public pageTitle = msg("Groups");
+    public pageDescription = msg(
+        "Group users together and give them permissions based on the membership.",
+    );
+    public pageIcon = "pf-icon pf-icon-users";
 
     @property()
     order = "name";

--- a/web/src/admin/groups/GroupViewPage.ts
+++ b/web/src/admin/groups/GroupViewPage.ts
@@ -14,11 +14,12 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { EVENT_REFRESH } from "#common/constants";
 
 import { AKElement } from "#elements/Base";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { CoreApi, Group, RbacPermissionsAssignedByUsersListModelEnum } from "@goauthentik/api";
 
 import { msg, str } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
@@ -80,9 +81,9 @@ export class GroupViewPage extends AKElement {
             ${this.renderBody()}`;
     }
 
-    renderBody(): TemplateResult {
+    renderBody(): SlottedTemplateResult {
         if (!this.group) {
-            return html``;
+            return nothing;
         }
         return html`<ak-tabs>
             <section

--- a/web/src/admin/groups/MemberSelectModal.ts
+++ b/web/src/admin/groups/MemberSelectModal.ts
@@ -5,6 +5,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, TableColumn, Timestamp } from "#elements/table/Table";
 import { TableModal } from "#elements/table/TableModal";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { CoreApi, CoreUsersListRequest, User } from "@goauthentik/api";
 
@@ -98,7 +99,7 @@ export class MemberSelectTable extends TableModal<User> {
             </div>`;
     }
 
-    row(item: User): TemplateResult[] {
+    row(item: User): SlottedTemplateResult[] {
         return [
             html`<div>${item.username}</div>
                 <small>${item.name}</small>`,

--- a/web/src/admin/groups/MemberSelectModal.ts
+++ b/web/src/admin/groups/MemberSelectModal.ts
@@ -60,6 +60,10 @@ export class MemberSelectTable extends TableModal<User> {
         });
     }
 
+    protected override rowLabel(item: User): string | null {
+        return item.username ?? item.name ?? null;
+    }
+
     protected columns: TableColumn[] = [
         [msg("Name"), "username"],
         [msg("Active"), "is_active"],

--- a/web/src/admin/groups/MemberSelectModal.ts
+++ b/web/src/admin/groups/MemberSelectModal.ts
@@ -61,13 +61,11 @@ export class MemberSelectTable extends TableModal<User> {
         });
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Name"), "username"),
-            new TableColumn(msg("Active"), "is_active"),
-            new TableColumn(msg("Last login"), "last_login"),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Name"), "username"],
+        [msg("Active"), "is_active"],
+        [msg("Last login"), "last_login"],
+    ];
 
     renderToolbarAfter() {
         const toggleShowDisabledUsers = () => {

--- a/web/src/admin/groups/MemberSelectModal.ts
+++ b/web/src/admin/groups/MemberSelectModal.ts
@@ -2,9 +2,8 @@ import "#components/ak-status-label";
 import "#elements/buttons/SpinnerButton/index";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
-import { formatElapsedTime } from "#common/temporal";
 
-import { PaginatedResponse, TableColumn } from "#elements/table/Table";
+import { PaginatedResponse, TableColumn, Timestamp } from "#elements/table/Table";
 import { TableModal } from "#elements/table/TableModal";
 
 import { CoreApi, CoreUsersListRequest, User } from "@goauthentik/api";
@@ -102,10 +101,7 @@ export class MemberSelectTable extends TableModal<User> {
             html`<div>${item.username}</div>
                 <small>${item.name}</small>`,
             html` <ak-status-label type="warning" ?good=${item.isActive}></ak-status-label>`,
-            html`${item.lastLogin
-                ? html`<div>${formatElapsedTime(item.lastLogin)}</div>
-                      <small>${item.lastLogin.toLocaleString()}</small>`
-                : msg("-")}`,
+            Timestamp(item.lastLogin),
         ];
     }
 

--- a/web/src/admin/groups/MemberSelectModal.ts
+++ b/web/src/admin/groups/MemberSelectModal.ts
@@ -33,9 +33,7 @@ export class MemberSelectTable extends TableModal<User> {
     checkbox = true;
     checkboxChip = true;
 
-    searchEnabled(): boolean {
-        return true;
-    }
+    protected override searchEnabled = true;
 
     @property()
     confirm!: (selectedItems: User[]) => Promise<unknown>;

--- a/web/src/admin/groups/RelatedGroupList.ts
+++ b/web/src/admin/groups/RelatedGroupList.ts
@@ -11,11 +11,12 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { Form } from "#elements/forms/Form";
 import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { CoreApi, Group, User } from "@goauthentik/api";
 
 import { msg, str } from "@lit/localize";
-import { html, TemplateResult } from "lit";
+import { html, nothing, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
@@ -136,7 +137,7 @@ export class RelatedGroupList extends Table<Group> {
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: Group): TemplateResult[] {
+    row(item: Group): SlottedTemplateResult[] {
         return [
             html`<a href="#/identity/groups/${item.pk}">${item.name}</a>`,
             html`${item.parentName || msg("-")}`,
@@ -166,7 +167,7 @@ export class RelatedGroupList extends Table<Group> {
                           ${msg("Add to existing group")}
                       </button>
                   </ak-forms-modal>`
-                : html``}
+                : nothing}
             <ak-forms-modal>
                 <span slot="submit"> ${msg("Create")} </span>
                 <span slot="header"> ${msg("Create Group")} </span>

--- a/web/src/admin/groups/RelatedGroupList.ts
+++ b/web/src/admin/groups/RelatedGroupList.ts
@@ -105,14 +105,12 @@ export class RelatedGroupList extends Table<Group> {
         });
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Name"), "name"),
-            new TableColumn(msg("Parent"), "parent"),
-            new TableColumn(msg("Superuser privileges?")),
-            new TableColumn(msg("Actions")),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Name"), "name"],
+        [msg("Parent"), "parent"],
+        [msg("Superuser privileges?")],
+        [msg("Actions")],
+    ];
 
     renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;

--- a/web/src/admin/groups/RelatedGroupList.ts
+++ b/web/src/admin/groups/RelatedGroupList.ts
@@ -87,9 +87,7 @@ export class RelatedGroupAdd extends Form<{ groups: string[] }> {
 export class RelatedGroupList extends Table<Group> {
     checkbox = true;
     clearOnRefresh = true;
-    searchEnabled(): boolean {
-        return true;
-    }
+    protected override searchEnabled = true;
 
     @property()
     order = "name";

--- a/web/src/admin/groups/RelatedGroupList.ts
+++ b/web/src/admin/groups/RelatedGroupList.ts
@@ -109,7 +109,7 @@ export class RelatedGroupList extends Table<Group> {
         [msg("Name"), "name"],
         [msg("Parent"), "parent"],
         [msg("Superuser privileges?")],
-        [msg("Actions")],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     renderToolbarSelected(): TemplateResult {

--- a/web/src/admin/groups/RelatedGroupList.ts
+++ b/web/src/admin/groups/RelatedGroupList.ts
@@ -149,7 +149,7 @@ export class RelatedGroupList extends Table<Group> {
                 <ak-group-form slot="form" .instancePk=${item.pk}> </ak-group-form>
                 <button slot="trigger" class="pf-c-button pf-m-plain">
                     <pf-tooltip position="top" content=${msg("Edit")}>
-                        <i class="fas fa-edit"></i>
+                        <i class="fas fa-edit" aria-hidden="true"></i>
                     </pf-tooltip>
                 </button>
             </ak-forms-modal>`,

--- a/web/src/admin/groups/RelatedUserList.ts
+++ b/web/src/admin/groups/RelatedUserList.ts
@@ -143,7 +143,7 @@ export class RelatedUserList extends WithBrandConfig(WithCapabilitiesConfig(Tabl
         [msg("Name"), "username"],
         [msg("Active"), "is_active"],
         [msg("Last login"), "last_login"],
-        [msg("Actions")],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     renderToolbarSelected(): TemplateResult {

--- a/web/src/admin/groups/RelatedUserList.ts
+++ b/web/src/admin/groups/RelatedUserList.ts
@@ -24,6 +24,7 @@ import { WithBrandConfig } from "#elements/mixins/branding";
 import { CapabilitiesEnum, WithCapabilitiesConfig } from "#elements/mixins/capabilities";
 import { getURLParam, updateURLParams } from "#elements/router/RouteMatch";
 import { PaginatedResponse, Table, TableColumn, Timestamp } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 import { UserOption } from "#elements/user/utils";
 
 import { CoreApi, CoreUsersListTypeEnum, Group, SessionUser, User } from "@goauthentik/api";
@@ -179,7 +180,7 @@ export class RelatedUserList extends WithBrandConfig(WithCapabilitiesConfig(Tabl
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: User): TemplateResult[] {
+    row(item: User): SlottedTemplateResult[] {
         const canImpersonate =
             this.can(CapabilitiesEnum.CanImpersonate) && item.pk !== this.me?.user.pk;
         return [
@@ -219,7 +220,7 @@ export class RelatedUserList extends WithBrandConfig(WithCapabilitiesConfig(Tabl
                               </button>
                           </ak-forms-modal>
                       `
-                    : html``}`,
+                    : nothing}`,
         ];
     }
 
@@ -385,14 +386,14 @@ export class RelatedUserList extends WithBrandConfig(WithCapabilitiesConfig(Tabl
                                     )}
                                 </div>
                             `
-                          : html``}
+                          : nothing}
                       <ak-user-related-add .group=${this.targetGroup} slot="form">
                       </ak-user-related-add>
                       <button slot="trigger" class="pf-c-button pf-m-primary">
                           ${msg("Add existing user")}
                       </button>
                   </ak-forms-modal>`
-                : html``}
+                : nothing}
             <ak-dropdown class="pf-c-dropdown">
                 <button class="pf-m-secondary pf-c-dropdown__toggle" type="button">
                     <span class="pf-c-dropdown__toggle-text">${msg("Create user")}</span>

--- a/web/src/admin/groups/RelatedUserList.ts
+++ b/web/src/admin/groups/RelatedUserList.ts
@@ -139,14 +139,12 @@ export class RelatedUserList extends WithBrandConfig(WithCapabilitiesConfig(Tabl
         return users;
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Name"), "username"),
-            new TableColumn(msg("Active"), "is_active"),
-            new TableColumn(msg("Last login"), "last_login"),
-            new TableColumn(msg("Actions")),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Name"), "username"],
+        [msg("Active"), "is_active"],
+        [msg("Last login"), "last_login"],
+        [msg("Actions")],
+    ];
 
     renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;

--- a/web/src/admin/groups/RelatedUserList.ts
+++ b/web/src/admin/groups/RelatedUserList.ts
@@ -197,7 +197,7 @@ export class RelatedUserList extends WithBrandConfig(WithCapabilitiesConfig(Tabl
                     <ak-user-form slot="form" .instancePk=${item.pk}> </ak-user-form>
                     <button slot="trigger" class="pf-c-button pf-m-plain">
                         <pf-tooltip position="top" content=${msg("Edit")}>
-                            <i class="fas fa-edit"></i>
+                            <i class="fas fa-edit" aria-hidden="true"></i>
                         </pf-tooltip>
                     </button>
                 </ak-forms-modal>

--- a/web/src/admin/groups/RelatedUserList.ts
+++ b/web/src/admin/groups/RelatedUserList.ts
@@ -107,9 +107,7 @@ export class RelatedUserList extends WithBrandConfig(WithCapabilitiesConfig(Tabl
     checkbox = true;
     clearOnRefresh = true;
 
-    searchEnabled(): boolean {
-        return true;
-    }
+    protected override searchEnabled = true;
 
     @property({ attribute: false })
     targetGroup?: Group;
@@ -226,7 +224,7 @@ export class RelatedUserList extends WithBrandConfig(WithCapabilitiesConfig(Tabl
     }
 
     renderExpanded(item: User): TemplateResult {
-        return html`<td role="cell" colspan="3">
+        return html`<td colspan="3">
                 <div class="pf-c-table__expandable-row-content">
                     <dl class="pf-c-description-list pf-m-horizontal">
                         <div class="pf-c-description-list__group">

--- a/web/src/admin/groups/RelatedUserList.ts
+++ b/web/src/admin/groups/RelatedUserList.ts
@@ -16,7 +16,6 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { PFSize } from "#common/enums";
 import { parseAPIResponseError, pluckErrorDetail } from "#common/errors/network";
 import { MessageLevel } from "#common/messages";
-import { formatElapsedTime } from "#common/temporal";
 import { me } from "#common/users";
 
 import { Form } from "#elements/forms/Form";
@@ -24,7 +23,7 @@ import { showMessage } from "#elements/messages/MessageContainer";
 import { WithBrandConfig } from "#elements/mixins/branding";
 import { CapabilitiesEnum, WithCapabilitiesConfig } from "#elements/mixins/capabilities";
 import { getURLParam, updateURLParams } from "#elements/router/RouteMatch";
-import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { PaginatedResponse, Table, TableColumn, Timestamp } from "#elements/table/Table";
 import { UserOption } from "#elements/user/utils";
 
 import { CoreApi, CoreUsersListTypeEnum, Group, SessionUser, User } from "@goauthentik/api";
@@ -187,10 +186,8 @@ export class RelatedUserList extends WithBrandConfig(WithCapabilitiesConfig(Tabl
                 <small>${item.name}</small>
             </a>`,
             html`<ak-status-label ?good=${item.isActive}></ak-status-label>`,
-            html`${item.lastLogin
-                ? html`<div>${formatElapsedTime(item.lastLogin)}</div>
-                      <small>${item.lastLogin.toLocaleString()}</small>`
-                : msg("-")}`,
+            Timestamp(item.lastLogin),
+
             html`<ak-forms-modal>
                     <span slot="submit"> ${msg("Update")} </span>
                     <span slot="header"> ${msg("Update User")} </span>

--- a/web/src/admin/groups/RelatedUserList.ts
+++ b/web/src/admin/groups/RelatedUserList.ts
@@ -138,6 +138,10 @@ export class RelatedUserList extends WithBrandConfig(WithCapabilitiesConfig(Tabl
         return users;
     }
 
+    protected override rowLabel(item: User): string | null {
+        return item.username ?? item.name ?? null;
+    }
+
     protected columns: TableColumn[] = [
         [msg("Name"), "username"],
         [msg("Active"), "is_active"],

--- a/web/src/admin/outposts/OutpostDeploymentModal.ts
+++ b/web/src/admin/outposts/OutpostDeploymentModal.ts
@@ -7,7 +7,7 @@ import { ModalButton } from "#elements/buttons/ModalButton";
 import { Outpost, OutpostTypeEnum } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { html, TemplateResult } from "lit";
+import { html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
@@ -88,7 +88,7 @@ export class OutpostDeploymentModal extends ModalButton {
                                   />
                               </div>
                           `
-                        : html``}
+                        : nothing}
                 </form>
             </div>
             <footer class="pf-c-modal-box__footer pf-m-align-left">

--- a/web/src/admin/outposts/OutpostListPage.ts
+++ b/web/src/admin/outposts/OutpostListPage.ts
@@ -141,7 +141,7 @@ export class OutpostListPage extends TablePage<Outpost> {
                     </ak-outpost-form>
                     <button slot="trigger" class="pf-c-button pf-m-plain">
                         <pf-tooltip position="top" content=${msg("Edit")}>
-                            <i class="fas fa-edit"></i>
+                            <i class="fas fa-edit" aria-hidden="true"></i>
                         </pf-tooltip>
                     </button>
                 </ak-forms-modal>

--- a/web/src/admin/outposts/OutpostListPage.ts
+++ b/web/src/admin/outposts/OutpostListPage.ts
@@ -16,6 +16,7 @@ import { PFSize } from "#common/enums";
 import { PFColor } from "#elements/Label";
 import { PaginatedResponse, TableColumn } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     ModelEnum,
@@ -27,7 +28,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg, str } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
@@ -99,7 +100,7 @@ export class OutpostListPage extends TablePage<Outpost> {
     @property()
     order = "name";
 
-    row(item: Outpost): TemplateResult[] {
+    row(item: Outpost): SlottedTemplateResult[] {
         return [
             html`<div>${item.name}</div>
                 ${item.config.authentik_host === ""
@@ -149,7 +150,7 @@ export class OutpostListPage extends TablePage<Outpost> {
                               ${msg("View Deployment Info")}
                           </button>
                       </ak-outpost-deployment-modal>`
-                    : html``}`,
+                    : nothing}`,
         ];
     }
 

--- a/web/src/admin/outposts/OutpostListPage.ts
+++ b/web/src/admin/outposts/OutpostListPage.ts
@@ -53,20 +53,13 @@ export function TypeToLabel(type?: OutpostTypeEnum): string {
 export class OutpostListPage extends TablePage<Outpost> {
     expandable = true;
 
-    pageTitle(): string {
-        return msg("Outposts");
-    }
-    pageDescription(): string | undefined {
-        return msg(
-            "Outposts are deployments of authentik components to support different environments and protocols, like reverse proxies.",
-        );
-    }
-    pageIcon(): string {
-        return "pf-icon pf-icon-zone";
-    }
-    searchEnabled(): boolean {
-        return true;
-    }
+    public pageTitle = msg("Outposts");
+    public pageDescription = msg(
+        "Outposts are deployments of authentik components to support different environments and protocols, like reverse proxies.",
+    );
+
+    public pageIcon = "pf-icon pf-icon-zone";
+    protected override searchEnabled = true;
 
     async apiEndpoint(): Promise<PaginatedResponse<Outpost>> {
         const outposts = await new OutpostsApi(DEFAULT_CONFIG).outpostsInstancesList(
@@ -162,7 +155,7 @@ export class OutpostListPage extends TablePage<Outpost> {
 
     renderExpanded(item: Outpost): TemplateResult {
         const [appLabel, modelName] = ModelEnum.AuthentikOutpostsOutpost.split(".");
-        return html`<td role="cell" colspan="7">
+        return html`<td colspan="7">
             <div class="pf-c-table__expandable-row-content">
                 <h3>
                     ${msg(

--- a/web/src/admin/outposts/OutpostListPage.ts
+++ b/web/src/admin/outposts/OutpostListPage.ts
@@ -89,16 +89,14 @@ export class OutpostListPage extends TablePage<Outpost> {
     @state()
     health: { [key: string]: OutpostHealth[] } = {};
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Name"), "name"),
-            new TableColumn(msg("Type"), "type"),
-            new TableColumn(msg("Providers")),
-            new TableColumn(msg("Integration"), "service_connection__name"),
-            new TableColumn(msg("Health and Version")),
-            new TableColumn(msg("Actions")),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Name"), "name"],
+        [msg("Type"), "type"],
+        [msg("Providers")],
+        [msg("Integration"), "service_connection__name"],
+        [msg("Health and Version")],
+        [msg("Actions")],
+    ];
 
     static styles: CSSResult[] = [...super.styles, PFDescriptionList];
 

--- a/web/src/admin/outposts/OutpostListPage.ts
+++ b/web/src/admin/outposts/OutpostListPage.ts
@@ -95,7 +95,7 @@ export class OutpostListPage extends TablePage<Outpost> {
         [msg("Providers")],
         [msg("Integration"), "service_connection__name"],
         [msg("Health and Version")],
-        [msg("Actions")],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     static styles: CSSResult[] = [...super.styles, PFDescriptionList];

--- a/web/src/admin/outposts/ServiceConnectionListPage.ts
+++ b/web/src/admin/outposts/ServiceConnectionListPage.ts
@@ -72,7 +72,7 @@ export class OutpostServiceConnectionListPage extends TablePage<ServiceConnectio
         [msg("Type")],
         [msg("Local"), "local"],
         [msg("State")],
-        [msg("Actions")],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     @property()

--- a/web/src/admin/outposts/ServiceConnectionListPage.ts
+++ b/web/src/admin/outposts/ServiceConnectionListPage.ts
@@ -101,7 +101,7 @@ export class OutpostServiceConnectionListPage extends TablePage<ServiceConnectio
                     </ak-proxy-form>
                     <button slot="trigger" class="pf-c-button pf-m-plain">
                         <pf-tooltip position="top" content=${msg("Edit")}>
-                            <i class="fas fa-edit"></i>
+                            <i class="fas fa-edit" aria-hidden="true"></i>
                         </pf-tooltip>
                     </button>
                 </ak-forms-modal>

--- a/web/src/admin/outposts/ServiceConnectionListPage.ts
+++ b/web/src/admin/outposts/ServiceConnectionListPage.ts
@@ -17,6 +17,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { PFColor } from "#elements/Label";
 import { PaginatedResponse, TableColumn } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { OutpostsApi, ServiceConnection, ServiceConnectionState } from "@goauthentik/api";
 
@@ -71,7 +72,7 @@ export class OutpostServiceConnectionListPage extends TablePage<ServiceConnectio
     @property()
     order = "name";
 
-    row(item: ServiceConnection): TemplateResult[] {
+    row(item: ServiceConnection): SlottedTemplateResult[] {
         const itemState = this.state[item.pk];
         return [
             html`${item.name}`,

--- a/web/src/admin/outposts/ServiceConnectionListPage.ts
+++ b/web/src/admin/outposts/ServiceConnectionListPage.ts
@@ -67,15 +67,13 @@ export class OutpostServiceConnectionListPage extends TablePage<ServiceConnectio
     @state()
     state: { [key: string]: ServiceConnectionState } = {};
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Name"), "name"),
-            new TableColumn(msg("Type")),
-            new TableColumn(msg("Local"), "local"),
-            new TableColumn(msg("State")),
-            new TableColumn(msg("Actions")),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Name"), "name"],
+        [msg("Type")],
+        [msg("Local"), "local"],
+        [msg("State")],
+        [msg("Actions")],
+    ];
 
     @property()
     order = "name";

--- a/web/src/admin/outposts/ServiceConnectionListPage.ts
+++ b/web/src/admin/outposts/ServiceConnectionListPage.ts
@@ -27,20 +27,13 @@ import { ifDefined } from "lit/directives/if-defined.js";
 
 @customElement("ak-outpost-service-connection-list")
 export class OutpostServiceConnectionListPage extends TablePage<ServiceConnection> {
-    pageTitle(): string {
-        return msg("Outpost integrations");
-    }
-    pageDescription(): string | undefined {
-        return msg(
-            "Outpost integrations define how authentik connects to external platforms to manage and deploy Outposts.",
-        );
-    }
-    pageIcon(): string {
-        return "pf-icon pf-icon-integration";
-    }
-    searchEnabled(): boolean {
-        return true;
-    }
+    public pageTitle = msg("Outpost integrations");
+    public pageDescription = msg(
+        "Outpost integrations define how authentik connects to external platforms to manage and deploy Outposts.",
+    );
+
+    public pageIcon = "pf-icon pf-icon-integration";
+    protected override searchEnabled = true;
 
     checkbox = true;
     expandable = true;
@@ -113,7 +106,7 @@ export class OutpostServiceConnectionListPage extends TablePage<ServiceConnectio
 
     renderExpanded(item: ServiceConnection): TemplateResult {
         const [appLabel, modelName] = item.metaModelName.split(".");
-        return html` <td role="cell" colspan="5">
+        return html` <td colspan="5">
             <div class="pf-c-table__expandable-row-content">
                 <dl class="pf-c-description-list pf-m-horizontal">
                     <div class="pf-c-description-list__group">

--- a/web/src/admin/policies/BoundPoliciesList.ts
+++ b/web/src/admin/policies/BoundPoliciesList.ts
@@ -69,15 +69,13 @@ export class BoundPoliciesList extends Table<PolicyBinding> {
         });
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Order"), "order"),
-            new TableColumn(this.allowedTypesLabel),
-            new TableColumn(msg("Enabled"), "enabled"),
-            new TableColumn(msg("Timeout"), "timeout"),
-            new TableColumn(msg("Actions")),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Order"), "order"],
+        [this.allowedTypesLabel],
+        [msg("Enabled"), "enabled"],
+        [msg("Timeout"), "timeout"],
+        [msg("Actions")],
+    ];
 
     getPolicyUserGroupRowLabel(item: PolicyBinding): string {
         if (item.policy) {

--- a/web/src/admin/policies/BoundPoliciesList.ts
+++ b/web/src/admin/policies/BoundPoliciesList.ts
@@ -69,6 +69,10 @@ export class BoundPoliciesList extends Table<PolicyBinding> {
         });
     }
 
+    protected override rowLabel(item: PolicyBinding): string | null {
+        return item.order?.toString() ?? null;
+    }
+
     protected columns: TableColumn[] = [
         [msg("Order"), "order"],
         [this.allowedTypesLabel],

--- a/web/src/admin/policies/BoundPoliciesList.ts
+++ b/web/src/admin/policies/BoundPoliciesList.ts
@@ -74,7 +74,7 @@ export class BoundPoliciesList extends Table<PolicyBinding> {
         [this.allowedTypesLabel],
         [msg("Enabled"), "enabled"],
         [msg("Timeout"), "timeout"],
-        [msg("Actions")],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     getPolicyUserGroupRowLabel(item: PolicyBinding): string {

--- a/web/src/admin/policies/BoundPoliciesList.ts
+++ b/web/src/admin/policies/BoundPoliciesList.ts
@@ -13,6 +13,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { PFSize } from "#common/enums";
 
 import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { PolicyBindingNotice } from "#admin/policies/PolicyBindingForm";
 import { policyEngineModes } from "#admin/policies/PolicyEngineModes";
@@ -103,7 +104,7 @@ export class BoundPoliciesList extends Table<PolicyBinding> {
         return html`${label}`;
     }
 
-    getObjectEditButton(item: PolicyBinding): TemplateResult {
+    getObjectEditButton(item: PolicyBinding): SlottedTemplateResult {
         if (item.policy) {
             return html`<ak-forms-modal>
                 <span slot="submit"> ${msg("Update")} </span>
@@ -139,7 +140,7 @@ export class BoundPoliciesList extends Table<PolicyBinding> {
                 </button>
             </ak-forms-modal>`;
         }
-        return html``;
+        return nothing;
     }
 
     renderToolbarSelected(): TemplateResult {
@@ -173,7 +174,7 @@ export class BoundPoliciesList extends Table<PolicyBinding> {
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: PolicyBinding): TemplateResult[] {
+    row(item: PolicyBinding): SlottedTemplateResult[] {
         return [
             html`<pre>${item.order}</pre>`,
             html`${this.getPolicyUserGroupRow(item)}`,
@@ -270,7 +271,7 @@ export class BoundPoliciesList extends Table<PolicyBinding> {
         </p>`;
     }
 
-    renderToolbarContainer(): TemplateResult {
+    renderToolbarContainer(): SlottedTemplateResult {
         return html`${this.renderPolicyEngineMode()} ${super.renderToolbarContainer()}`;
     }
 }

--- a/web/src/admin/policies/PolicyListPage.ts
+++ b/web/src/admin/policies/PolicyListPage.ts
@@ -19,6 +19,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { PFColor } from "#elements/Label";
 import { PaginatedResponse, TableColumn } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { PoliciesApi, Policy } from "@goauthentik/api";
 
@@ -53,7 +54,7 @@ export class PolicyListPage extends TablePage<Policy> {
         [msg("Actions")],
     ];
 
-    row(item: Policy): TemplateResult[] {
+    row(item: Policy): SlottedTemplateResult[] {
         return [
             html`<div>${item.name}</div>
                 ${(item.boundTo || 0) > 0

--- a/web/src/admin/policies/PolicyListPage.ts
+++ b/web/src/admin/policies/PolicyListPage.ts
@@ -54,7 +54,12 @@ export class PolicyListPage extends TablePage<Policy> {
         return new PoliciesApi(DEFAULT_CONFIG).policiesAllList(await this.defaultEndpointConfig());
     }
 
-    protected columns: TableColumn[] = [[msg("Name"), "name"], [msg("Type")], [msg("Actions")]];
+    protected columns: TableColumn[] = [
+        // ---
+        [msg("Name"), "name"],
+        [msg("Type")],
+        [msg("Actions")],
+    ];
 
     row(item: Policy): TemplateResult[] {
         return [

--- a/web/src/admin/policies/PolicyListPage.ts
+++ b/web/src/admin/policies/PolicyListPage.ts
@@ -80,7 +80,7 @@ export class PolicyListPage extends TablePage<Policy> {
                     </ak-proxy-form>
                     <button slot="trigger" class="pf-c-button pf-m-plain">
                         <pf-tooltip position="top" content=${msg("Edit")}>
-                            <i class="fas fa-edit"></i>
+                            <i class="fas fa-edit" aria-hidden="true"></i>
                         </pf-tooltip>
                     </button>
                 </ak-forms-modal>

--- a/web/src/admin/policies/PolicyListPage.ts
+++ b/web/src/admin/policies/PolicyListPage.ts
@@ -29,20 +29,12 @@ import { ifDefined } from "lit/directives/if-defined.js";
 
 @customElement("ak-policy-list")
 export class PolicyListPage extends TablePage<Policy> {
-    searchEnabled(): boolean {
-        return true;
-    }
-    pageTitle(): string {
-        return msg("Policies");
-    }
-    pageDescription(): string {
-        return msg(
-            "Allow users to use Applications based on properties, enforce Password Criteria and selectively apply Stages.",
-        );
-    }
-    pageIcon(): string {
-        return "pf-icon pf-icon-infrastructure";
-    }
+    protected override searchEnabled = true;
+    public pageTitle = msg("Policies");
+    public pageDescription = msg(
+        "Allow users to use Applications based on properties, enforce Password Criteria and selectively apply Stages.",
+    );
+    public pageIcon = "pf-icon pf-icon-infrastructure";
 
     checkbox = true;
     clearOnRefresh = true;

--- a/web/src/admin/policies/PolicyListPage.ts
+++ b/web/src/admin/policies/PolicyListPage.ts
@@ -54,13 +54,7 @@ export class PolicyListPage extends TablePage<Policy> {
         return new PoliciesApi(DEFAULT_CONFIG).policiesAllList(await this.defaultEndpointConfig());
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Name"), "name"),
-            new TableColumn(msg("Type")),
-            new TableColumn(msg("Actions")),
-        ];
-    }
+    protected columns: TableColumn[] = [[msg("Name"), "name"], [msg("Type")], [msg("Actions")]];
 
     row(item: Policy): TemplateResult[] {
         return [

--- a/web/src/admin/policies/PolicyTestForm.ts
+++ b/web/src/admin/policies/PolicyTestForm.ts
@@ -22,7 +22,7 @@ import {
 import YAML from "yaml";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
 import PFDescriptionList from "@patternfly/patternfly/components/DescriptionList/description-list.css";
@@ -132,7 +132,7 @@ export class PolicyTestForm extends Form<PolicyTestRequest> {
                     ${msg("Set custom attributes using YAML or JSON.")}
                 </p>
             </ak-form-element-horizontal>
-            ${this.result ? this.renderResult() : html``}`;
+            ${this.result ? this.renderResult() : nothing}`;
     }
 }
 

--- a/web/src/admin/policies/PolicyWizard.ts
+++ b/web/src/admin/policies/PolicyWizard.ts
@@ -23,7 +23,7 @@ import { PoliciesApi, Policy, PolicyBinding, TypeCreate } from "@goauthentik/api
 
 import { msg, str } from "@lit/localize";
 import { customElement } from "@lit/reactive-element/decorators/custom-element.js";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { property, query } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
@@ -113,7 +113,7 @@ export class PolicyWizard extends AKElement {
                               .targetPk=${this.bindingTarget}
                           ></ak-policy-binding-form>
                       </ak-wizard-page-form>`
-                    : html``}
+                    : nothing}
                 <button slot="trigger" class="pf-c-button pf-m-primary">${this.createText}</button>
             </ak-wizard>
         `;

--- a/web/src/admin/policies/password/PasswordPolicyForm.ts
+++ b/web/src/admin/policies/password/PasswordPolicyForm.ts
@@ -8,7 +8,7 @@ import { BasePolicyForm } from "#admin/policies/BasePolicyForm";
 import { PasswordPolicy, PoliciesApi } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { html, TemplateResult } from "lit";
+import { html, nothing, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
@@ -331,9 +331,9 @@ export class PasswordPolicyForm extends BasePolicyForm<PasswordPolicy> {
                     <a href="https://github.com/dropbox/zxcvbn#readme">dropbox/zxcvbn</a>
                 </p>
             </ak-form-element-horizontal>
-            ${this.showStatic ? this.renderStaticRules() : html``}
-            ${this.showHIBP ? this.renderHIBP() : html``}
-            ${this.showZxcvbn ? this.renderZxcvbn() : html``}`;
+            ${this.showStatic ? this.renderStaticRules() : nothing}
+            ${this.showHIBP ? this.renderHIBP() : nothing}
+            ${this.showZxcvbn ? this.renderZxcvbn() : nothing}`;
     }
 }
 

--- a/web/src/admin/policies/reputation/ReputationListPage.ts
+++ b/web/src/admin/policies/reputation/ReputationListPage.ts
@@ -51,15 +51,13 @@ export class ReputationListPage extends TablePage<Reputation> {
         });
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Identifier"), "identifier"),
-            new TableColumn(msg("IP"), "ip"),
-            new TableColumn(msg("Score"), "score"),
-            new TableColumn(msg("Updated"), "updated"),
-            new TableColumn(msg("Actions")),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Identifier"), "identifier"],
+        [msg("IP"), "ip"],
+        [msg("Score"), "score"],
+        [msg("Updated"), "updated"],
+        [msg("Actions")],
+    ];
 
     renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;

--- a/web/src/admin/policies/reputation/ReputationListPage.ts
+++ b/web/src/admin/policies/reputation/ReputationListPage.ts
@@ -50,6 +50,10 @@ export class ReputationListPage extends TablePage<Reputation> {
         });
     }
 
+    protected override rowLabel(item: Reputation): string | null {
+        return item.identifier ?? null;
+    }
+
     protected columns: TableColumn[] = [
         [msg("Identifier"), "identifier"],
         [msg("IP"), "ip"],

--- a/web/src/admin/policies/reputation/ReputationListPage.ts
+++ b/web/src/admin/policies/reputation/ReputationListPage.ts
@@ -23,20 +23,12 @@ import { customElement, property } from "lit/decorators.js";
 
 @customElement("ak-policy-reputation-list")
 export class ReputationListPage extends TablePage<Reputation> {
-    searchEnabled(): boolean {
-        return true;
-    }
-    pageTitle(): string {
-        return msg("Reputation scores");
-    }
-    pageDescription(): string {
-        return msg(
-            "Reputation for IP and user identifiers. Scores are decreased for each failed login and increased for each successful login.",
-        );
-    }
-    pageIcon(): string {
-        return "fa fa-ban";
-    }
+    protected override searchEnabled = true;
+    public pageTitle = msg("Reputation scores");
+    public pageDescription = msg(
+        "Reputation for IP and user identifiers. Scores are decreased for each failed login and increased for each successful login.",
+    );
+    public pageIcon = "fa fa-ban";
 
     @property()
     order = "identifier";

--- a/web/src/admin/policies/reputation/ReputationListPage.ts
+++ b/web/src/admin/policies/reputation/ReputationListPage.ts
@@ -8,6 +8,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, TableColumn, Timestamp } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     PoliciesApi,
@@ -18,7 +19,7 @@ import {
 import getUnicodeFlagIcon from "country-flag-icons/unicode";
 
 import { msg } from "@lit/localize";
-import { html, TemplateResult } from "lit";
+import { html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 @customElement("ak-policy-reputation-list")
@@ -76,12 +77,12 @@ export class ReputationListPage extends TablePage<Reputation> {
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: Reputation): TemplateResult[] {
+    row(item: Reputation): SlottedTemplateResult[] {
         return [
             html`${item.identifier}`,
             html`${item.ipGeoData?.country
                 ? html` ${getUnicodeFlagIcon(item.ipGeoData.country)} `
-                : html``}
+                : nothing}
             ${item.ip}`,
             html`${item.score}`,
             Timestamp(item.updated),

--- a/web/src/admin/policies/reputation/ReputationListPage.ts
+++ b/web/src/admin/policies/reputation/ReputationListPage.ts
@@ -56,7 +56,7 @@ export class ReputationListPage extends TablePage<Reputation> {
         [msg("IP"), "ip"],
         [msg("Score"), "score"],
         [msg("Updated"), "updated"],
-        [msg("Actions")],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     renderToolbarSelected(): TemplateResult {

--- a/web/src/admin/policies/reputation/ReputationListPage.ts
+++ b/web/src/admin/policies/reputation/ReputationListPage.ts
@@ -5,9 +5,8 @@ import "#elements/forms/DeleteBulkForm";
 import "#elements/forms/ModalForm";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
-import { formatElapsedTime } from "#common/temporal";
 
-import { PaginatedResponse, TableColumn } from "#elements/table/Table";
+import { PaginatedResponse, TableColumn, Timestamp } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
 
 import {
@@ -89,8 +88,7 @@ export class ReputationListPage extends TablePage<Reputation> {
                 : html``}
             ${item.ip}`,
             html`${item.score}`,
-            html`<div>${formatElapsedTime(item.updated)}</div>
-                <small>${item.updated.toLocaleString()}</small>`,
+            Timestamp(item.updated),
             html`
                 <ak-rbac-object-permission-modal
                     model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikPoliciesReputationReputationpolicy}

--- a/web/src/admin/property-mappings/BasePropertyMappingForm.ts
+++ b/web/src/admin/property-mappings/BasePropertyMappingForm.ts
@@ -2,9 +2,10 @@ import { docLink } from "#common/global";
 
 import { CodeMirrorMode } from "#elements/CodeMirror";
 import { ModelForm } from "#elements/forms/ModelForm";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { msg } from "@lit/localize";
-import { html, TemplateResult } from "lit";
+import { html, nothing, TemplateResult } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
 
 interface PropertyMapping {
@@ -26,8 +27,8 @@ export abstract class BasePropertyMappingForm<T extends PropertyMapping> extends
             : msg("Successfully created mapping.");
     }
 
-    renderExtraFields(): TemplateResult {
-        return html``;
+    renderExtraFields(): SlottedTemplateResult {
+        return nothing;
     }
 
     renderForm(): TemplateResult {

--- a/web/src/admin/property-mappings/PropertyMappingListPage.ts
+++ b/web/src/admin/property-mappings/PropertyMappingListPage.ts
@@ -109,7 +109,7 @@ export class PropertyMappingListPage extends TablePage<PropertyMapping> {
                     </ak-proxy-form>
                     <button slot="trigger" class="pf-c-button pf-m-plain">
                         <pf-tooltip position="top" content=${msg("Edit")}>
-                            <i class="fas fa-edit"></i>
+                            <i class="fas fa-edit" aria-hidden="true"></i>
                         </pf-tooltip>
                     </button>
                 </ak-forms-modal>

--- a/web/src/admin/property-mappings/PropertyMappingListPage.ts
+++ b/web/src/admin/property-mappings/PropertyMappingListPage.ts
@@ -35,18 +35,10 @@ import { ifDefined } from "lit/directives/if-defined.js";
 
 @customElement("ak-property-mapping-list")
 export class PropertyMappingListPage extends TablePage<PropertyMapping> {
-    searchEnabled(): boolean {
-        return true;
-    }
-    pageTitle(): string {
-        return msg("Property Mappings");
-    }
-    pageDescription(): string {
-        return msg("Control how authentik exposes and interprets information.");
-    }
-    pageIcon(): string {
-        return "pf-icon pf-icon-blueprint";
-    }
+    protected override searchEnabled = true;
+    public pageTitle = msg("Property Mappings");
+    public pageDescription = msg("Control how authentik exposes and interprets information.");
+    public pageIcon = "pf-icon pf-icon-blueprint";
 
     checkbox = true;
     clearOnRefresh = true;

--- a/web/src/admin/property-mappings/PropertyMappingListPage.ts
+++ b/web/src/admin/property-mappings/PropertyMappingListPage.ts
@@ -25,6 +25,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { getURLParam, updateURLParams } from "#elements/router/RouteMatch";
 import { PaginatedResponse, TableColumn } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { PropertyMapping, PropertymappingsApi } from "@goauthentik/api";
 
@@ -84,7 +85,7 @@ export class PropertyMappingListPage extends TablePage<PropertyMapping> {
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: PropertyMapping): TemplateResult[] {
+    row(item: PropertyMapping): SlottedTemplateResult[] {
         return [
             html`${item.name}`,
             html`${item.verboseName}`,

--- a/web/src/admin/property-mappings/PropertyMappingListPage.ts
+++ b/web/src/admin/property-mappings/PropertyMappingListPage.ts
@@ -64,13 +64,11 @@ export class PropertyMappingListPage extends TablePage<PropertyMapping> {
         });
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Name"), "name"),
-            new TableColumn(msg("Type"), "type"),
-            new TableColumn(msg("Actions")),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Name"), "name"],
+        [msg("Type"), "type"],
+        [msg("Actions")],
+    ];
 
     renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;

--- a/web/src/admin/property-mappings/PropertyMappingListPage.ts
+++ b/web/src/admin/property-mappings/PropertyMappingListPage.ts
@@ -67,7 +67,7 @@ export class PropertyMappingListPage extends TablePage<PropertyMapping> {
     protected columns: TableColumn[] = [
         [msg("Name"), "name"],
         [msg("Type"), "type"],
-        [msg("Actions")],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     renderToolbarSelected(): TemplateResult {

--- a/web/src/admin/property-mappings/PropertyMappingTestForm.ts
+++ b/web/src/admin/property-mappings/PropertyMappingTestForm.ts
@@ -188,7 +188,7 @@ export class PolicyTestForm extends Form<PropertyMappingTestRequest> {
                 </ak-codemirror>
                 <p class="pf-c-form__helper-text">${this.renderExampleButtons()}</p>
             </ak-form-element-horizontal>
-            ${this.result ? this.renderResult() : html``}`;
+            ${this.result ? this.renderResult() : nothing}`;
     }
 }
 

--- a/web/src/admin/providers/ProviderListPage.ts
+++ b/web/src/admin/providers/ProviderListPage.ts
@@ -92,7 +92,7 @@ export class ProviderListPage extends TablePage<Provider> {
 
     #rowApp(item: Provider): TemplateResult {
         if (item.assignedApplicationName) {
-            return html`<i class="pf-icon pf-icon-ok pf-m-success"></i>
+            return html`<i class="pf-icon pf-icon-ok pf-m-success" aria-hidden="true"></i>
                 ${msg("Assigned to application ")}
                 <a href="#/core/applications/${item.assignedApplicationSlug}"
                     >${item.assignedApplicationName}</a
@@ -100,7 +100,7 @@ export class ProviderListPage extends TablePage<Provider> {
         }
 
         if (item.assignedBackchannelApplicationName) {
-            return html`<i class="pf-icon pf-icon-ok pf-m-success"></i>
+            return html`<i class="pf-icon pf-icon-ok pf-m-success" aria-hidden="true"></i>
                 ${msg("Assigned to application (backchannel) ")}
                 <a href="#/core/applications/${item.assignedBackchannelApplicationSlug}"
                     >${item.assignedBackchannelApplicationName}</a

--- a/web/src/admin/providers/ProviderListPage.ts
+++ b/web/src/admin/providers/ProviderListPage.ts
@@ -20,6 +20,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, TableColumn } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { Provider, ProvidersApi } from "@goauthentik/api";
 
@@ -105,7 +106,7 @@ export class ProviderListPage extends TablePage<Provider> {
             ><span>${msg("Provider not assigned to any application.")}</span>`;
     }
 
-    override row(item: Provider): TemplateResult[] {
+    override row(item: Provider): SlottedTemplateResult[] {
         return [
             html`<a href="#/core/providers/${item.pk}">${item.name}</a>`,
             this.#rowApp(item),

--- a/web/src/admin/providers/ProviderListPage.ts
+++ b/web/src/admin/providers/ProviderListPage.ts
@@ -107,13 +107,13 @@ export class ProviderListPage extends TablePage<Provider> {
                 >`;
         }
 
-        return html`<i aria-hidden="true" class="pf-icon pf-icon-warning-triangle pf-m-warning"></i>
-            ${msg("Warning: Provider not assigned to any application.")}`;
+        return html`<i aria-hidden="true" class="pf-icon pf-icon-warning-triangle pf-m-warning"></i
+            ><span>${msg("Provider not assigned to any application.")}</span>`;
     }
 
     override row(item: Provider): TemplateResult[] {
         return [
-            html`<a href="#/core/providers/${item.pk}"> ${item.name} </a>`,
+            html`<a href="#/core/providers/${item.pk}">${item.name}</a>`,
             this.#rowApp(item),
             html`${item.verboseName}`,
             html`<ak-forms-modal>

--- a/web/src/admin/providers/ProviderListPage.ts
+++ b/web/src/admin/providers/ProviderListPage.ts
@@ -64,7 +64,7 @@ export class ProviderListPage extends TablePage<Provider> {
         [msg("Name"), "name"],
         [msg("Application")],
         [msg("Type")],
-        [msg("Actions")],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     override renderToolbarSelected(): TemplateResult {

--- a/web/src/admin/providers/ProviderListPage.ts
+++ b/web/src/admin/providers/ProviderListPage.ts
@@ -29,21 +29,15 @@ import { customElement, property } from "lit/decorators.js";
 
 @customElement("ak-provider-list")
 export class ProviderListPage extends TablePage<Provider> {
-    override searchEnabled(): boolean {
-        return true;
-    }
+    protected override searchEnabled = true;
 
-    override pageTitle(): string {
-        return msg("Providers");
-    }
+    override pageTitle = msg("Providers");
 
-    override pageDescription(): string {
-        return msg("Provide support for protocols like SAML and OAuth to assigned applications.");
-    }
+    public pageDescription = msg(
+        "Provide support for protocols like SAML and OAuth to assigned applications.",
+    );
 
-    override pageIcon(): string {
-        return "pf-icon pf-icon-integration";
-    }
+    public pageIcon = "pf-icon pf-icon-integration";
 
     override checkbox = true;
     override clearOnRefresh = true;

--- a/web/src/admin/providers/ProviderListPage.ts
+++ b/web/src/admin/providers/ProviderListPage.ts
@@ -60,14 +60,12 @@ export class ProviderListPage extends TablePage<Provider> {
         );
     }
 
-    override columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Name"), "name"),
-            new TableColumn(msg("Application")),
-            new TableColumn(msg("Type")),
-            new TableColumn(msg("Actions")),
-        ];
-    }
+    protected override columns: TableColumn[] = [
+        [msg("Name"), "name"],
+        [msg("Application")],
+        [msg("Type")],
+        [msg("Actions")],
+    ];
 
     override renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;

--- a/web/src/admin/providers/ProviderListPage.ts
+++ b/web/src/admin/providers/ProviderListPage.ts
@@ -122,7 +122,7 @@ export class ProviderListPage extends TablePage<Provider> {
                 >
                 </ak-proxy-form>
                 <button
-                    aria-label=${msg("Edit provider")}
+                    aria-label=${msg(str`Edit "${item.name}" provider`)}
                     slot="trigger"
                     class="pf-c-button pf-m-plain"
                 >

--- a/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderGroupList.ts
+++ b/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderGroupList.ts
@@ -75,9 +75,11 @@ export class GoogleWorkspaceProviderGroupList extends Table<GoogleWorkspaceProvi
         });
     }
 
-    columns(): TableColumn[] {
-        return [new TableColumn(msg("Name")), new TableColumn(msg("ID"))];
-    }
+    protected columns: TableColumn[] = [
+        // ---
+        [msg("Name")],
+        [msg("ID")],
+    ];
 
     row(item: GoogleWorkspaceProviderGroup): TemplateResult[] {
         return [

--- a/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderGroupList.ts
+++ b/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderGroupList.ts
@@ -5,6 +5,7 @@ import "#elements/sync/SyncObjectForm";
 import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     GoogleWorkspaceProviderGroup,
@@ -83,7 +84,7 @@ export class GoogleWorkspaceProviderGroupList extends Table<GoogleWorkspaceProvi
         [msg("ID")],
     ];
 
-    row(item: GoogleWorkspaceProviderGroup): TemplateResult[] {
+    row(item: GoogleWorkspaceProviderGroup): SlottedTemplateResult[] {
         return [
             html`<a href="#/identity/groups/${item.groupObj.pk}">
                 <div>${item.groupObj.name}</div>

--- a/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderGroupList.ts
+++ b/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderGroupList.ts
@@ -24,9 +24,7 @@ export class GoogleWorkspaceProviderGroupList extends Table<GoogleWorkspaceProvi
 
     expandable = true;
 
-    searchEnabled(): boolean {
-        return true;
-    }
+    protected override searchEnabled = true;
 
     checkbox = true;
     clearOnRefresh = true;
@@ -95,7 +93,7 @@ export class GoogleWorkspaceProviderGroupList extends Table<GoogleWorkspaceProvi
     }
 
     renderExpanded(item: GoogleWorkspaceProviderGroup): TemplateResult {
-        return html`<td role="cell" colspan="4">
+        return html`<td colspan="4">
             <div class="pf-c-table__expandable-row-content">
                 <pre>${JSON.stringify(item.attributes, null, 4)}</pre>
             </div>

--- a/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderGroupList.ts
+++ b/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderGroupList.ts
@@ -75,6 +75,10 @@ export class GoogleWorkspaceProviderGroupList extends Table<GoogleWorkspaceProvi
         });
     }
 
+    protected override rowLabel(item: GoogleWorkspaceProviderGroup): string {
+        return item.groupObj.name;
+    }
+
     protected columns: TableColumn[] = [
         // ---
         [msg("Name")],

--- a/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderUserList.ts
+++ b/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderUserList.ts
@@ -22,9 +22,7 @@ export class GoogleWorkspaceProviderUserList extends Table<GoogleWorkspaceProvid
     @property({ type: Number })
     providerId?: number;
 
-    searchEnabled(): boolean {
-        return true;
-    }
+    protected override searchEnabled = true;
 
     expandable = true;
 
@@ -96,7 +94,7 @@ export class GoogleWorkspaceProviderUserList extends Table<GoogleWorkspaceProvid
     }
 
     renderExpanded(item: GoogleWorkspaceProviderUser): TemplateResult {
-        return html`<td role="cell" colspan="4">
+        return html`<td colspan="4">
             <div class="pf-c-table__expandable-row-content">
                 <pre>${JSON.stringify(item.attributes, null, 4)}</pre>
             </div>

--- a/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderUserList.ts
+++ b/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderUserList.ts
@@ -75,6 +75,10 @@ export class GoogleWorkspaceProviderUserList extends Table<GoogleWorkspaceProvid
         });
     }
 
+    protected override rowLabel(item: GoogleWorkspaceProviderUser): string {
+        return item.userObj.name || item.userObj.username;
+    }
+
     protected columns: TableColumn[] = [
         // ---
         [msg("Username")],

--- a/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderUserList.ts
+++ b/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderUserList.ts
@@ -75,9 +75,11 @@ export class GoogleWorkspaceProviderUserList extends Table<GoogleWorkspaceProvid
         });
     }
 
-    columns(): TableColumn[] {
-        return [new TableColumn(msg("Username")), new TableColumn(msg("ID"))];
-    }
+    protected columns: TableColumn[] = [
+        // ---
+        [msg("Username")],
+        [msg("ID")],
+    ];
 
     row(item: GoogleWorkspaceProviderUser): TemplateResult[] {
         return [

--- a/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderUserList.ts
+++ b/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderUserList.ts
@@ -5,6 +5,7 @@ import "#elements/sync/SyncObjectForm";
 import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     GoogleWorkspaceProviderUser,
@@ -83,7 +84,7 @@ export class GoogleWorkspaceProviderUserList extends Table<GoogleWorkspaceProvid
         [msg("ID")],
     ];
 
-    row(item: GoogleWorkspaceProviderUser): TemplateResult[] {
+    row(item: GoogleWorkspaceProviderUser): SlottedTemplateResult[] {
         return [
             html`<a href="#/identity/users/${item.userObj.pk}">
                 <div>${item.userObj.username}</div>

--- a/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderViewPage.ts
+++ b/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderViewPage.ts
@@ -15,6 +15,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { EVENT_REFRESH } from "#common/constants";
 
 import { AKElement } from "#elements/Base";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     GoogleWorkspaceProvider,
@@ -24,7 +25,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, PropertyValues, TemplateResult } from "lit";
+import { CSSResult, html, nothing, PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
@@ -81,9 +82,9 @@ export class GoogleWorkspaceProviderViewPage extends AKElement {
         }
     }
 
-    render(): TemplateResult {
+    render(): SlottedTemplateResult {
         if (!this.provider) {
-            return html``;
+            return nothing;
         }
         return html` <ak-tabs>
             <section slot="page-overview" data-tab-title="${msg("Overview")}">
@@ -135,9 +136,9 @@ export class GoogleWorkspaceProviderViewPage extends AKElement {
         </ak-tabs>`;
     }
 
-    renderTabOverview(): TemplateResult {
+    renderTabOverview(): SlottedTemplateResult {
         if (!this.provider) {
-            return html``;
+            return nothing;
         }
         const [appLabel, modelName] =
             ModelEnum.AuthentikProvidersGoogleWorkspaceGoogleworkspaceprovider.split(".");
@@ -147,7 +148,7 @@ export class GoogleWorkspaceProviderViewPage extends AKElement {
                           "Warning: Provider is not assigned to an application as backchannel provider.",
                       )}
                   </div>`
-                : html``}
+                : nothing}
             <div class="pf-c-page__main-section pf-m-no-padding-mobile pf-l-grid pf-m-gutter">
                 <div
                     class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-6-col-on-xl pf-m-6-col-on-2xl"

--- a/web/src/admin/providers/ldap/LDAPProviderViewPage.ts
+++ b/web/src/admin/providers/ldap/LDAPProviderViewPage.ts
@@ -12,6 +12,7 @@ import { EVENT_REFRESH } from "#common/constants";
 import { me } from "#common/users";
 
 import { AKElement } from "#elements/Base";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     LDAPProvider,
@@ -21,7 +22,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, PropertyValues, TemplateResult } from "lit";
+import { CSSResult, html, nothing, PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
@@ -85,9 +86,9 @@ export class LDAPProviderViewPage extends AKElement {
         }
     }
 
-    render(): TemplateResult {
+    render(): SlottedTemplateResult {
         if (!this.provider) {
-            return html``;
+            return nothing;
         }
         return html` <ak-tabs>
             <section slot="page-overview" data-tab-title="${msg("Overview")}">
@@ -117,9 +118,9 @@ export class LDAPProviderViewPage extends AKElement {
         </ak-tabs>`;
     }
 
-    renderTabOverview(): TemplateResult {
+    renderTabOverview(): SlottedTemplateResult {
         if (!this.provider) {
-            return html``;
+            return nothing;
         }
         return html`
             ${
@@ -127,7 +128,7 @@ export class LDAPProviderViewPage extends AKElement {
                     ? html`<div slot="header" class="pf-c-banner pf-m-warning">
                           ${msg("Warning: Provider is not used by any Outpost.")}
                       </div>`
-                    : html``
+                    : nothing
             }
             <div class="pf-c-page__main-section pf-m-no-padding-mobile pf-l-grid pf-m-gutter">
                 <div class="pf-c-card pf-l-grid__item pf-m-12-col">

--- a/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderGroupList.ts
+++ b/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderGroupList.ts
@@ -72,9 +72,11 @@ export class MicrosoftEntraProviderGroupList extends Table<MicrosoftEntraProvide
         });
     }
 
-    columns(): TableColumn[] {
-        return [new TableColumn(msg("Name")), new TableColumn(msg("ID"))];
-    }
+    protected columns: TableColumn[] = [
+        // ---
+        [msg("Name")],
+        [msg("ID")],
+    ];
 
     row(item: MicrosoftEntraProviderGroup): TemplateResult[] {
         return [

--- a/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderGroupList.ts
+++ b/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderGroupList.ts
@@ -5,6 +5,7 @@ import "#elements/sync/SyncObjectForm";
 import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     MicrosoftEntraProviderGroup,
@@ -80,7 +81,7 @@ export class MicrosoftEntraProviderGroupList extends Table<MicrosoftEntraProvide
         [msg("ID")],
     ];
 
-    row(item: MicrosoftEntraProviderGroup): TemplateResult[] {
+    row(item: MicrosoftEntraProviderGroup): SlottedTemplateResult[] {
         return [
             html`<a href="#/identity/groups/${item.groupObj.pk}">
                 <div>${item.groupObj.name}</div>

--- a/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderGroupList.ts
+++ b/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderGroupList.ts
@@ -24,9 +24,7 @@ export class MicrosoftEntraProviderGroupList extends Table<MicrosoftEntraProvide
 
     expandable = true;
 
-    searchEnabled(): boolean {
-        return true;
-    }
+    protected override searchEnabled = true;
 
     renderToolbar(): TemplateResult {
         return html`<ak-forms-modal cancelText=${msg("Close")} ?closeAfterSuccessfulSubmit=${false}>
@@ -92,7 +90,7 @@ export class MicrosoftEntraProviderGroupList extends Table<MicrosoftEntraProvide
     }
 
     renderExpanded(item: MicrosoftEntraProviderGroup): TemplateResult {
-        return html`<td role="cell" colspan="4">
+        return html`<td colspan="4">
             <div class="pf-c-table__expandable-row-content">
                 <pre>${JSON.stringify(item.attributes, null, 4)}</pre>
             </div>

--- a/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderGroupList.ts
+++ b/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderGroupList.ts
@@ -72,6 +72,10 @@ export class MicrosoftEntraProviderGroupList extends Table<MicrosoftEntraProvide
         });
     }
 
+    protected override rowLabel(item: MicrosoftEntraProviderGroup): string {
+        return item.groupObj.name;
+    }
+
     protected columns: TableColumn[] = [
         // ---
         [msg("Name")],

--- a/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderUserList.ts
+++ b/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderUserList.ts
@@ -75,6 +75,10 @@ export class MicrosoftEntraProviderUserList extends Table<MicrosoftEntraProvider
         });
     }
 
+    protected override rowLabel(item: MicrosoftEntraProviderUser): string {
+        return item.userObj.name || item.userObj.username;
+    }
+
     protected columns: TableColumn[] = [
         // ---
         [msg("Username")],

--- a/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderUserList.ts
+++ b/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderUserList.ts
@@ -5,6 +5,7 @@ import "#elements/sync/SyncObjectForm";
 import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     MicrosoftEntraProviderUser,
@@ -83,7 +84,7 @@ export class MicrosoftEntraProviderUserList extends Table<MicrosoftEntraProvider
         [msg("ID")],
     ];
 
-    row(item: MicrosoftEntraProviderUser): TemplateResult[] {
+    row(item: MicrosoftEntraProviderUser): SlottedTemplateResult[] {
         return [
             html`<a href="#/identity/users/${item.userObj.pk}">
                 <div>${item.userObj.username}</div>

--- a/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderUserList.ts
+++ b/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderUserList.ts
@@ -24,9 +24,7 @@ export class MicrosoftEntraProviderUserList extends Table<MicrosoftEntraProvider
 
     expandable = true;
 
-    searchEnabled(): boolean {
-        return true;
-    }
+    protected override searchEnabled = true;
 
     checkbox = true;
     clearOnRefresh = true;
@@ -96,7 +94,7 @@ export class MicrosoftEntraProviderUserList extends Table<MicrosoftEntraProvider
     }
 
     renderExpanded(item: MicrosoftEntraProviderUser): TemplateResult {
-        return html`<td role="cell" colspan="4">
+        return html`<td colspan="4">
             <div class="pf-c-table__expandable-row-content">
                 <pre>${JSON.stringify(item.attributes, null, 4)}</pre>
             </div>

--- a/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderUserList.ts
+++ b/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderUserList.ts
@@ -75,9 +75,11 @@ export class MicrosoftEntraProviderUserList extends Table<MicrosoftEntraProvider
         });
     }
 
-    columns(): TableColumn[] {
-        return [new TableColumn(msg("Username")), new TableColumn(msg("ID"))];
-    }
+    protected columns: TableColumn[] = [
+        // ---
+        [msg("Username")],
+        [msg("ID")],
+    ];
 
     row(item: MicrosoftEntraProviderUser): TemplateResult[] {
         return [

--- a/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderViewPage.ts
+++ b/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderViewPage.ts
@@ -15,6 +15,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { EVENT_REFRESH } from "#common/constants";
 
 import { AKElement } from "#elements/Base";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     MicrosoftEntraProvider,
@@ -24,7 +25,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, PropertyValues, TemplateResult } from "lit";
+import { CSSResult, html, nothing, PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
@@ -81,9 +82,9 @@ export class MicrosoftEntraProviderViewPage extends AKElement {
         }
     }
 
-    render(): TemplateResult {
+    render(): SlottedTemplateResult {
         if (!this.provider) {
-            return html``;
+            return nothing;
         }
         return html` <ak-tabs>
             <section slot="page-overview" data-tab-title="${msg("Overview")}">
@@ -135,9 +136,9 @@ export class MicrosoftEntraProviderViewPage extends AKElement {
         </ak-tabs>`;
     }
 
-    renderTabOverview(): TemplateResult {
+    renderTabOverview(): SlottedTemplateResult {
         if (!this.provider) {
-            return html``;
+            return nothing;
         }
         const [appLabel, modelName] =
             ModelEnum.AuthentikProvidersMicrosoftEntraMicrosoftentraprovider.split(".");
@@ -147,7 +148,7 @@ export class MicrosoftEntraProviderViewPage extends AKElement {
                           "Warning: Provider is not assigned to an application as backchannel provider.",
                       )}
                   </div>`
-                : html``}
+                : nothing}
             <div class="pf-c-page__main-section pf-m-no-padding-mobile pf-l-grid pf-m-gutter">
                 <div
                     class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-6-col-on-xl pf-m-6-col-on-2xl"

--- a/web/src/admin/providers/oauth2/OAuth2ProviderViewPage.ts
+++ b/web/src/admin/providers/oauth2/OAuth2ProviderViewPage.ts
@@ -13,6 +13,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { EVENT_REFRESH } from "#common/constants";
 
 import { AKElement } from "#elements/Base";
+import { SlottedTemplateResult } from "#elements/types";
 
 import renderDescriptionList from "#components/DescriptionList";
 
@@ -32,7 +33,7 @@ import {
 import MDProviderOAuth2 from "~docs/add-secure-apps/providers/oauth2/index.mdx";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
 import PFBanner from "@patternfly/patternfly/components/Banner/banner.css";
@@ -115,9 +116,9 @@ export class OAuth2ProviderViewPage extends AKElement {
             .then((preview) => (this.preview = preview));
     }
 
-    render(): TemplateResult {
+    render(): SlottedTemplateResult {
         if (!this.provider) {
-            return html``;
+            return nothing;
         }
         return html` <ak-tabs>
             <section
@@ -168,13 +169,13 @@ export class OAuth2ProviderViewPage extends AKElement {
         </ak-tabs>`;
     }
 
-    renderTabOverview(): TemplateResult {
+    renderTabOverview(): SlottedTemplateResult {
         if (!this.provider) {
-            return html``;
+            return nothing;
         }
         const [appLabel, modelName] = ModelEnum.AuthentikProvidersOauth2Oauth2provider.split(".");
         return html` ${this.provider?.assignedApplicationName
-                ? html``
+                ? nothing
                 : html`<div slot="header" class="pf-c-banner pf-m-warning">
                       ${msg("Warning: Provider is not used by an Application.")}
                   </div>`}
@@ -405,9 +406,9 @@ export class OAuth2ProviderViewPage extends AKElement {
             </div>`;
     }
 
-    renderTabPreview(): TemplateResult {
+    renderTabPreview(): SlottedTemplateResult {
         if (!this.provider) {
-            return html``;
+            return nothing;
         }
         return html` <div
             class="pf-c-page__main-section pf-m-no-padding-mobile pf-l-grid pf-m-gutter"

--- a/web/src/admin/providers/proxy/ProxyProviderViewPage.ts
+++ b/web/src/admin/providers/proxy/ProxyProviderViewPage.ts
@@ -16,6 +16,7 @@ import type { Replacer } from "#elements/ak-mdx/index";
 import { AKElement } from "#elements/Base";
 import { getURLParam } from "#elements/router/RouteMatch";
 import { formatSlug } from "#elements/router/utils";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     ProvidersApi,
@@ -34,7 +35,7 @@ import MDTraefikStandalone from "~docs/add-secure-apps/providers/proxy/_traefik_
 import MDHeaderAuthentication from "~docs/add-secure-apps/providers/proxy/header_authentication.mdx";
 
 import { msg } from "@lit/localize";
-import { css, CSSResult, html, PropertyValues, TemplateResult } from "lit";
+import { css, CSSResult, html, nothing, PropertyValues, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
 import PFBanner from "@patternfly/patternfly/components/Banner/banner.css";
@@ -194,9 +195,9 @@ export class ProxyProviderViewPage extends AKElement {
         >`;
     }
 
-    render(): TemplateResult {
+    render(): SlottedTemplateResult {
         if (!this.provider) {
-            return html``;
+            return nothing;
         }
         return html` <ak-tabs>
             <section slot="page-overview" data-tab-title="${msg("Overview")}">
@@ -229,9 +230,9 @@ export class ProxyProviderViewPage extends AKElement {
         </ak-tabs>`;
     }
 
-    renderTabAuthentication(): TemplateResult {
+    renderTabAuthentication(): SlottedTemplateResult {
         if (!this.provider) {
-            return html``;
+            return nothing;
         }
         return html`<div
             class="pf-c-page__main-section pf-m-no-padding-mobile pf-l-grid pf-m-gutter"
@@ -260,12 +261,12 @@ export class ProxyProviderViewPage extends AKElement {
         </div>`;
     }
 
-    renderTabOverview(): TemplateResult {
+    renderTabOverview(): SlottedTemplateResult {
         if (!this.provider) {
-            return html``;
+            return nothing;
         }
         return html`${this.provider?.assignedApplicationName
-                ? html``
+                ? nothing
                 : html`<div slot="header" class="pf-c-banner pf-m-warning">
                       ${msg("Warning: Provider is not used by an Application.")}
                   </div>`}
@@ -273,7 +274,7 @@ export class ProxyProviderViewPage extends AKElement {
                 ? html`<div slot="header" class="pf-c-banner pf-m-warning">
                       ${msg("Warning: Provider is not used by any Outpost.")}
                   </div>`
-                : html``}
+                : nothing}
             <div class="pf-c-page__main-section pf-m-no-padding-mobile pf-l-grid pf-m-gutter">
                 <div class="pf-c-card pf-l-grid__item pf-m-12-col">
                     <div class="pf-c-card__body">

--- a/web/src/admin/providers/rac/ConnectionTokenList.ts
+++ b/web/src/admin/providers/rac/ConnectionTokenList.ts
@@ -20,9 +20,7 @@ export class ConnectionTokenListPage extends Table<ConnectionToken> {
     checkbox = true;
     clearOnRefresh = true;
 
-    searchEnabled(): boolean {
-        return true;
-    }
+    protected override searchEnabled = true;
 
     @property()
     order = "name";

--- a/web/src/admin/providers/rac/ConnectionTokenList.ts
+++ b/web/src/admin/providers/rac/ConnectionTokenList.ts
@@ -71,16 +71,17 @@ export class ConnectionTokenListPage extends Table<ConnectionToken> {
         </ak-forms-delete-bulk>`;
     }
 
-    columns(): TableColumn[] {
+    protected get columns(): TableColumn[] {
         if (this.provider) {
             return [
-                new TableColumn(msg("Endpoint"), "endpoint__name"),
-                new TableColumn(msg("User"), "session__user"),
+                [msg("Endpoint"), "endpoint__name"],
+                [msg("User"), "session__user"],
             ];
         }
+
         return [
-            new TableColumn(msg("Provider"), "provider__name"),
-            new TableColumn(msg("Endpoint"), "endpoint__name"),
+            [msg("Provider"), "provider__name"],
+            [msg("Endpoint"), "endpoint__name"],
         ];
     }
 

--- a/web/src/admin/providers/rac/ConnectionTokenList.ts
+++ b/web/src/admin/providers/rac/ConnectionTokenList.ts
@@ -71,6 +71,13 @@ export class ConnectionTokenListPage extends Table<ConnectionToken> {
         </ak-forms-delete-bulk>`;
     }
 
+    protected override rowLabel(item: ConnectionToken): string | null {
+        if (this.provider) {
+            return item.endpointObj.name ?? null;
+        }
+        return item.providerObj.name ?? null;
+    }
+
     protected get columns(): TableColumn[] {
         if (this.provider) {
             return [

--- a/web/src/admin/providers/rac/ConnectionTokenList.ts
+++ b/web/src/admin/providers/rac/ConnectionTokenList.ts
@@ -6,6 +6,7 @@ import "@patternfly/elements/pf-tooltip/pf-tooltip.js";
 import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { ConnectionToken, RacApi, RACProvider } from "@goauthentik/api";
 
@@ -90,7 +91,7 @@ export class ConnectionTokenListPage extends Table<ConnectionToken> {
         ];
     }
 
-    row(item: ConnectionToken): TemplateResult[] {
+    row(item: ConnectionToken): SlottedTemplateResult[] {
         if (this.provider) {
             return [html`${item.endpointObj.name}`, html`${item.user.username}`];
         }

--- a/web/src/admin/providers/rac/EndpointList.ts
+++ b/web/src/admin/providers/rac/EndpointList.ts
@@ -9,6 +9,7 @@ import "@patternfly/elements/pf-tooltip/pf-tooltip.js";
 import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     Endpoint,
@@ -81,7 +82,7 @@ export class EndpointListPage extends Table<Endpoint> {
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: Endpoint): TemplateResult[] {
+    row(item: Endpoint): SlottedTemplateResult[] {
         return [
             html`${item.name}`,
             html`${item.host}`,

--- a/web/src/admin/providers/rac/EndpointList.ts
+++ b/web/src/admin/providers/rac/EndpointList.ts
@@ -49,13 +49,11 @@ export class EndpointListPage extends Table<Endpoint> {
         });
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Name"), "name"),
-            new TableColumn(msg("Host"), "host"),
-            new TableColumn(msg("Actions")),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Name"), "name"],
+        [msg("Host"), "host"],
+        [msg("Actions")],
+    ];
 
     renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;

--- a/web/src/admin/providers/rac/EndpointList.ts
+++ b/web/src/admin/providers/rac/EndpointList.ts
@@ -52,7 +52,7 @@ export class EndpointListPage extends Table<Endpoint> {
     protected columns: TableColumn[] = [
         [msg("Name"), "name"],
         [msg("Host"), "host"],
-        [msg("Actions")],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     renderToolbarSelected(): TemplateResult {

--- a/web/src/admin/providers/rac/EndpointList.ts
+++ b/web/src/admin/providers/rac/EndpointList.ts
@@ -29,9 +29,7 @@ export class EndpointListPage extends Table<Endpoint> {
     checkbox = true;
     clearOnRefresh = true;
 
-    searchEnabled(): boolean {
-        return true;
-    }
+    protected override searchEnabled = true;
 
     @property()
     order = "name";
@@ -108,7 +106,7 @@ export class EndpointListPage extends Table<Endpoint> {
 
     renderExpanded(item: Endpoint): TemplateResult {
         return html` <td></td>
-            <td role="cell" colspan="4">
+            <td colspan="4">
                 <div class="pf-c-table__expandable-row-content">
                     <div class="pf-c-content">
                         <p>

--- a/web/src/admin/providers/rac/EndpointList.ts
+++ b/web/src/admin/providers/rac/EndpointList.ts
@@ -94,7 +94,7 @@ export class EndpointListPage extends Table<Endpoint> {
                     </ak-rac-endpoint-form>
                     <button slot="trigger" class="pf-c-button pf-m-plain">
                         <pf-tooltip position="top" content=${msg("Edit")}>
-                            <i class="fas fa-edit"></i>
+                            <i class="fas fa-edit" aria-hidden="true"></i>
                         </pf-tooltip>
                     </button>
                 </ak-forms-modal>

--- a/web/src/admin/providers/rac/RACProviderViewPage.ts
+++ b/web/src/admin/providers/rac/RACProviderViewPage.ts
@@ -15,6 +15,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { EVENT_REFRESH } from "#common/constants";
 
 import { AKElement } from "#elements/Base";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     ProvidersApi,
@@ -23,7 +24,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, PropertyValues, TemplateResult } from "lit";
+import { CSSResult, html, nothing, PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
 import PFBanner from "@patternfly/patternfly/components/Banner/banner.css";
@@ -80,9 +81,9 @@ export class RACProviderViewPage extends AKElement {
         }
     }
 
-    render(): TemplateResult {
+    render(): SlottedTemplateResult {
         if (!this.provider) {
-            return html``;
+            return nothing;
         }
         return html`<ak-tabs>
             <section slot="page-overview" data-tab-title="${msg("Overview")}">
@@ -125,12 +126,12 @@ export class RACProviderViewPage extends AKElement {
         </ak-tabs>`;
     }
 
-    renderTabOverview(): TemplateResult {
+    renderTabOverview(): SlottedTemplateResult {
         if (!this.provider) {
-            return html``;
+            return nothing;
         }
         return html`${this.provider?.assignedApplicationName
-                ? html``
+                ? nothing
                 : html`<div slot="header" class="pf-c-banner pf-m-warning">
                       ${msg("Warning: Provider is not used by an Application.")}
                   </div>`}
@@ -138,7 +139,7 @@ export class RACProviderViewPage extends AKElement {
                 ? html`<div slot="header" class="pf-c-banner pf-m-warning">
                       ${msg("Warning: Provider is not used by any Outpost.")}
                   </div>`
-                : html``}
+                : nothing}
             <div class="pf-c-page__main-section pf-m-no-padding-mobile pf-l-grid pf-m-gutter">
                 <div class="pf-c-card pf-l-grid__item pf-m-12-col">
                     <div class="pf-c-card__body">

--- a/web/src/admin/providers/radius/RadiusProviderViewPage.ts
+++ b/web/src/admin/providers/radius/RadiusProviderViewPage.ts
@@ -11,6 +11,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { EVENT_REFRESH } from "#common/constants";
 
 import { AKElement } from "#elements/Base";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     ProvidersApi,
@@ -19,7 +20,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, PropertyValues, TemplateResult } from "lit";
+import { CSSResult, html, nothing, PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
@@ -72,9 +73,9 @@ export class RadiusProviderViewPage extends AKElement {
         }
     }
 
-    render(): TemplateResult {
+    render(): SlottedTemplateResult {
         if (!this.provider) {
-            return html``;
+            return nothing;
         }
         return html`<ak-tabs>
             <section
@@ -86,7 +87,7 @@ export class RadiusProviderViewPage extends AKElement {
                     ? html`<div slot="header" class="pf-c-banner pf-m-warning">
                           ${msg("Warning: Provider is not used by any Outpost.")}
                       </div>`
-                    : html``}
+                    : nothing}
                 <div class="pf-u-display-flex pf-u-justify-content-center">
                     <div class="pf-u-w-75">
                         <div class="pf-c-card">

--- a/web/src/admin/providers/saml/SAMLProviderViewPage.ts
+++ b/web/src/admin/providers/saml/SAMLProviderViewPage.ts
@@ -16,6 +16,7 @@ import { MessageLevel } from "#common/messages";
 import { AKElement } from "#elements/Base";
 import { CodeMirrorMode } from "#elements/CodeMirror";
 import { showMessage } from "#elements/messages/MessageContainer";
+import { SlottedTemplateResult } from "#elements/types";
 
 import renderDescriptionList from "#components/DescriptionList";
 
@@ -32,7 +33,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, PropertyValues, TemplateResult } from "lit";
+import { CSSResult, html, nothing, PropertyValues, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
@@ -224,9 +225,9 @@ export class SAMLProviderViewPage extends AKElement {
         </div>`;
     }
 
-    render(): TemplateResult {
+    render(): SlottedTemplateResult {
         if (!this.provider) {
-            return html``;
+            return nothing;
         }
         return html` <ak-tabs>
             <section slot="page-overview" data-tab-title="${msg("Overview")}">
@@ -266,13 +267,13 @@ export class SAMLProviderViewPage extends AKElement {
         </ak-tabs>`;
     }
 
-    renderTabOverview(): TemplateResult {
+    renderTabOverview(): SlottedTemplateResult {
         if (!this.provider) {
-            return html``;
+            return nothing;
         }
         return html`${
             this.provider?.assignedApplicationName
-                ? html``
+                ? nothing
                 : html`<div slot="header" class="pf-c-banner pf-m-warning">
                       ${msg("Warning: Provider is not used by an Application.")}
                   </div>`
@@ -443,15 +444,15 @@ export class SAMLProviderViewPage extends AKElement {
                                   </form>
                               </div>
                           </div>`
-                        : html``
+                        : nothing
                 }
             </div>
         </div>`;
     }
 
-    renderTabMetadata(): TemplateResult {
+    renderTabMetadata(): SlottedTemplateResult {
         if (!this.provider) {
-            return html``;
+            return nothing;
         }
         return html`
             ${this.provider.assignedApplicationName
@@ -509,11 +510,11 @@ export class SAMLProviderViewPage extends AKElement {
                           </div>
                       </div>
                   </section>`
-                : html``}
+                : nothing}
         `;
     }
 
-    renderTabPreview(): TemplateResult {
+    renderTabPreview(): SlottedTemplateResult {
         if (!this.preview) {
             return html`<ak-empty-state loading></ak-empty-state>`;
         }

--- a/web/src/admin/providers/scim/SCIMProviderGroupList.ts
+++ b/web/src/admin/providers/scim/SCIMProviderGroupList.ts
@@ -72,6 +72,10 @@ export class SCIMProviderGroupList extends Table<SCIMProviderGroup> {
         });
     }
 
+    protected override rowLabel(item: SCIMProviderGroup): string {
+        return item.groupObj.name;
+    }
+
     protected columns: TableColumn[] = [
         // ---
         [msg("Name")],

--- a/web/src/admin/providers/scim/SCIMProviderGroupList.ts
+++ b/web/src/admin/providers/scim/SCIMProviderGroupList.ts
@@ -22,9 +22,7 @@ export class SCIMProviderGroupList extends Table<SCIMProviderGroup> {
     @property({ type: Number })
     providerId?: number;
 
-    searchEnabled(): boolean {
-        return true;
-    }
+    protected override searchEnabled = true;
 
     expandable = true;
     checkbox = true;
@@ -91,7 +89,7 @@ export class SCIMProviderGroupList extends Table<SCIMProviderGroup> {
         ];
     }
     renderExpanded(item: SCIMProviderGroup): TemplateResult {
-        return html`<td role="cell" colspan="4">
+        return html`<td colspan="4">
             <div class="pf-c-table__expandable-row-content">
                 <pre>${JSON.stringify(item.attributes, null, 4)}</pre>
             </div>

--- a/web/src/admin/providers/scim/SCIMProviderGroupList.ts
+++ b/web/src/admin/providers/scim/SCIMProviderGroupList.ts
@@ -72,9 +72,11 @@ export class SCIMProviderGroupList extends Table<SCIMProviderGroup> {
         });
     }
 
-    columns(): TableColumn[] {
-        return [new TableColumn(msg("Name")), new TableColumn(msg("ID"))];
-    }
+    protected columns: TableColumn[] = [
+        // ---
+        [msg("Name")],
+        [msg("ID")],
+    ];
 
     row(item: SCIMProviderGroup): TemplateResult[] {
         return [

--- a/web/src/admin/providers/scim/SCIMProviderGroupList.ts
+++ b/web/src/admin/providers/scim/SCIMProviderGroupList.ts
@@ -5,6 +5,7 @@ import "#elements/sync/SyncObjectForm";
 import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     ProvidersApi,
@@ -80,7 +81,7 @@ export class SCIMProviderGroupList extends Table<SCIMProviderGroup> {
         [msg("ID")],
     ];
 
-    row(item: SCIMProviderGroup): TemplateResult[] {
+    row(item: SCIMProviderGroup): SlottedTemplateResult[] {
         return [
             html`<a href="#/identity/groups/${item.groupObj.pk}">
                 <div>${item.groupObj.name}</div>

--- a/web/src/admin/providers/scim/SCIMProviderUserList.ts
+++ b/web/src/admin/providers/scim/SCIMProviderUserList.ts
@@ -72,9 +72,11 @@ export class SCIMProviderUserList extends Table<SCIMProviderUser> {
         });
     }
 
-    columns(): TableColumn[] {
-        return [new TableColumn(msg("Username")), new TableColumn(msg("ID"))];
-    }
+    protected columns: TableColumn[] = [
+        // ---
+        [msg("Username")],
+        [msg("ID")],
+    ];
 
     row(item: SCIMProviderUser): TemplateResult[] {
         return [

--- a/web/src/admin/providers/scim/SCIMProviderUserList.ts
+++ b/web/src/admin/providers/scim/SCIMProviderUserList.ts
@@ -72,6 +72,10 @@ export class SCIMProviderUserList extends Table<SCIMProviderUser> {
         });
     }
 
+    protected override rowLabel(item: SCIMProviderUser): string {
+        return item.userObj.name || item.userObj.username;
+    }
+
     protected columns: TableColumn[] = [
         // ---
         [msg("Username")],

--- a/web/src/admin/providers/scim/SCIMProviderUserList.ts
+++ b/web/src/admin/providers/scim/SCIMProviderUserList.ts
@@ -22,9 +22,7 @@ export class SCIMProviderUserList extends Table<SCIMProviderUser> {
     @property({ type: Number })
     providerId?: number;
 
-    searchEnabled(): boolean {
-        return true;
-    }
+    protected override searchEnabled = true;
 
     expandable = true;
     checkbox = true;
@@ -92,7 +90,7 @@ export class SCIMProviderUserList extends Table<SCIMProviderUser> {
         ];
     }
     renderExpanded(item: SCIMProviderUser): TemplateResult {
-        return html`<td role="cell" colspan="4">
+        return html`<td colspan="4">
             <div class="pf-c-table__expandable-row-content">
                 <pre>${JSON.stringify(item.attributes, null, 4)}</pre>
             </div>

--- a/web/src/admin/providers/scim/SCIMProviderUserList.ts
+++ b/web/src/admin/providers/scim/SCIMProviderUserList.ts
@@ -5,6 +5,7 @@ import "#elements/sync/SyncObjectForm";
 import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     ProvidersApi,
@@ -80,7 +81,7 @@ export class SCIMProviderUserList extends Table<SCIMProviderUser> {
         [msg("ID")],
     ];
 
-    row(item: SCIMProviderUser): TemplateResult[] {
+    row(item: SCIMProviderUser): SlottedTemplateResult[] {
         return [
             html`<a href="#/identity/users/${item.userObj.pk}">
                 <div>${item.userObj.username}</div>

--- a/web/src/admin/providers/scim/SCIMProviderViewPage.ts
+++ b/web/src/admin/providers/scim/SCIMProviderViewPage.ts
@@ -17,6 +17,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { EVENT_REFRESH } from "#common/constants";
 
 import { AKElement } from "#elements/Base";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     ModelEnum,
@@ -28,7 +29,7 @@ import {
 import MDSCIMProvider from "~docs/add-secure-apps/providers/scim/index.md";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, PropertyValues, TemplateResult } from "lit";
+import { CSSResult, html, nothing, PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
 import PFBanner from "@patternfly/patternfly/components/Banner/banner.css";
@@ -87,9 +88,9 @@ export class SCIMProviderViewPage extends AKElement {
         }
     }
 
-    render(): TemplateResult {
+    render(): SlottedTemplateResult {
         if (!this.provider) {
-            return html``;
+            return nothing;
         }
         return html` <ak-tabs>
             <section slot="page-overview" data-tab-title="${msg("Overview")}">
@@ -141,9 +142,9 @@ export class SCIMProviderViewPage extends AKElement {
         </ak-tabs>`;
     }
 
-    renderTabOverview(): TemplateResult {
+    renderTabOverview(): SlottedTemplateResult {
         if (!this.provider) {
-            return html``;
+            return nothing;
         }
         const [appLabel, modelName] = ModelEnum.AuthentikProvidersScimScimprovider.split(".");
         return html` ${!this.provider?.assignedBackchannelApplicationName
@@ -152,7 +153,7 @@ export class SCIMProviderViewPage extends AKElement {
                           "Warning: Provider is not assigned to an application as backchannel provider.",
                       )}
                   </div>`
-                : html``}
+                : nothing}
             <div class="pf-c-page__main-section pf-m-no-padding-mobile pf-l-grid pf-m-gutter">
                 <div
                     class="pf-c-card pf-l-grid__item pf-m-12-col pf-m-6-col-on-xl pf-m-6-col-on-2xl"

--- a/web/src/admin/providers/ssf/SSFProviderViewPage.ts
+++ b/web/src/admin/providers/ssf/SSFProviderViewPage.ts
@@ -13,6 +13,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { EVENT_REFRESH } from "#common/constants";
 
 import { AKElement } from "#elements/Base";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     ModelEnum,
@@ -22,7 +23,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import PFBanner from "@patternfly/patternfly/components/Banner/banner.css";
@@ -75,9 +76,9 @@ export class SSFProviderViewPage extends AKElement {
         });
     }
 
-    render(): TemplateResult {
+    render(): SlottedTemplateResult {
         if (!this.provider) {
-            return html``;
+            return nothing;
         }
         return html` <ak-tabs>
             <section slot="page-overview" data-tab-title="${msg("Overview")}">
@@ -107,9 +108,9 @@ export class SSFProviderViewPage extends AKElement {
         </ak-tabs>`;
     }
 
-    renderTabOverview(): TemplateResult {
+    renderTabOverview(): SlottedTemplateResult {
         if (!this.provider) {
-            return html``;
+            return nothing;
         }
         const [appLabel, modelName] = ModelEnum.AuthentikProvidersSsfSsfprovider.split(".");
         return html`<div slot="header" class="pf-c-banner pf-m-info">

--- a/web/src/admin/providers/ssf/StreamTable.ts
+++ b/web/src/admin/providers/ssf/StreamTable.ts
@@ -7,11 +7,12 @@ import "@patternfly/elements/pf-tooltip/pf-tooltip.js";
 import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { SsfApi, SSFStream } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { html, TemplateResult } from "lit";
+import { html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 @customElement("ak-provider-ssf-stream-list")
@@ -42,7 +43,7 @@ export class SSFProviderStreamList extends Table<SSFStream> {
         [msg("Audience"), "aud"],
     ];
 
-    row(item: SSFStream): TemplateResult[] {
+    row(item: SSFStream): SlottedTemplateResult[] {
         return [html`${item.aud}`];
     }
 }

--- a/web/src/admin/providers/ssf/StreamTable.ts
+++ b/web/src/admin/providers/ssf/StreamTable.ts
@@ -35,9 +35,10 @@ export class SSFProviderStreamList extends Table<SSFStream> {
         });
     }
 
-    columns(): TableColumn[] {
-        return [new TableColumn(msg("Audience"), "aud")];
-    }
+    protected columns: TableColumn[] = [
+        // ---
+        [msg("Audience"), "aud"],
+    ];
 
     row(item: SSFStream): TemplateResult[] {
         return [html`${item.aud}`];

--- a/web/src/admin/providers/ssf/StreamTable.ts
+++ b/web/src/admin/providers/ssf/StreamTable.ts
@@ -35,6 +35,10 @@ export class SSFProviderStreamList extends Table<SSFStream> {
         });
     }
 
+    protected override rowLabel(item: SSFStream): string | null {
+        return item.aud?.join(", ") ?? null;
+    }
+
     protected columns: TableColumn[] = [
         // ---
         [msg("Audience"), "aud"],

--- a/web/src/admin/providers/ssf/StreamTable.ts
+++ b/web/src/admin/providers/ssf/StreamTable.ts
@@ -16,9 +16,7 @@ import { customElement, property } from "lit/decorators.js";
 
 @customElement("ak-provider-ssf-stream-list")
 export class SSFProviderStreamList extends Table<SSFStream> {
-    searchEnabled(): boolean {
-        return true;
-    }
+    protected override searchEnabled = true;
     checkbox = true;
     clearOnRefresh = true;
 

--- a/web/src/admin/rbac/InitialPermissionsListPage.ts
+++ b/web/src/admin/rbac/InitialPermissionsListPage.ts
@@ -92,7 +92,7 @@ export class InitialPermissionsListPage extends TablePage<InitialPermissions> {
                 </ak-initial-permissions-form>
                 <button slot="trigger" class="pf-c-button pf-m-plain">
                     <pf-tooltip position="top" content=${msg("Edit")}>
-                        <i class="fas fa-edit"></i>
+                        <i class="fas fa-edit" aria-hidden="true"></i>
                     </pf-tooltip>
                 </button>
             </ak-forms-modal>`,

--- a/web/src/admin/rbac/InitialPermissionsListPage.ts
+++ b/web/src/admin/rbac/InitialPermissionsListPage.ts
@@ -8,6 +8,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, TableColumn } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { InitialPermissions, RbacApi } from "@goauthentik/api";
 
@@ -74,7 +75,7 @@ export class InitialPermissionsListPage extends TablePage<InitialPermissions> {
             </section>`;
     }
 
-    row(item: InitialPermissions): TemplateResult[] {
+    row(item: InitialPermissions): SlottedTemplateResult[] {
         return [
             html`${item.name}`,
             html`<ak-forms-modal>

--- a/web/src/admin/rbac/InitialPermissionsListPage.ts
+++ b/web/src/admin/rbac/InitialPermissionsListPage.ts
@@ -42,9 +42,11 @@ export class InitialPermissionsListPage extends TablePage<InitialPermissions> {
         );
     }
 
-    columns(): TableColumn[] {
-        return [new TableColumn(msg("Name"), "name"), new TableColumn(msg("Actions"))];
-    }
+    protected columns: TableColumn[] = [
+        // ---
+        [msg("Name"), "name"],
+        [msg("Actions")],
+    ];
 
     renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;

--- a/web/src/admin/rbac/InitialPermissionsListPage.ts
+++ b/web/src/admin/rbac/InitialPermissionsListPage.ts
@@ -45,7 +45,7 @@ export class InitialPermissionsListPage extends TablePage<InitialPermissions> {
     protected columns: TableColumn[] = [
         // ---
         [msg("Name"), "name"],
-        [msg("Actions")],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     renderToolbarSelected(): TemplateResult {

--- a/web/src/admin/rbac/InitialPermissionsListPage.ts
+++ b/web/src/admin/rbac/InitialPermissionsListPage.ts
@@ -20,18 +20,10 @@ import { ifDefined } from "lit/directives/if-defined.js";
 export class InitialPermissionsListPage extends TablePage<InitialPermissions> {
     checkbox = true;
     clearOnRefresh = true;
-    searchEnabled(): boolean {
-        return true;
-    }
-    pageTitle(): string {
-        return msg("Initial Permissions");
-    }
-    pageDescription(): string {
-        return msg("Set initial permissions for newly created objects.");
-    }
-    pageIcon(): string {
-        return "fa fa-lock";
-    }
+    protected override searchEnabled = true;
+    public pageTitle = msg("Initial Permissions");
+    public pageDescription = msg("Set initial permissions for newly created objects.");
+    public pageIcon = "fa fa-lock";
 
     @property()
     order = "name";
@@ -72,9 +64,9 @@ export class InitialPermissionsListPage extends TablePage<InitialPermissions> {
 
     render(): HTMLTemplateResult {
         return html`<ak-page-header
-                icon=${this.pageIcon()}
-                header=${this.pageTitle()}
-                description=${ifDefined(this.pageDescription())}
+                icon=${this.pageIcon}
+                header=${this.pageTitle}
+                description=${ifDefined(this.pageDescription)}
             >
             </ak-page-header>
             <section class="pf-c-page__main-section pf-m-no-padding-mobile">

--- a/web/src/admin/rbac/ObjectPermissionModal.ts
+++ b/web/src/admin/rbac/ObjectPermissionModal.ts
@@ -65,7 +65,7 @@ export class ObjectPermissionModal extends AKElement {
                 ></ak-rbac-object-permission-modal-form>
                 <button slot="trigger" class="pf-c-button pf-m-plain">
                     <pf-tooltip position="top" content=${msg("Permissions")}>
-                        <i class="fas fa-lock"></i>
+                        <i class="fas fa-lock" aria-hidden="true"></i>
                     </pf-tooltip>
                 </button>
             </ak-forms-modal>

--- a/web/src/admin/rbac/PermissionSelectModal.ts
+++ b/web/src/admin/rbac/PermissionSelectModal.ts
@@ -5,6 +5,7 @@ import { groupBy } from "#common/utils";
 
 import { PaginatedResponse, TableColumn } from "#elements/table/Table";
 import { TableModal } from "#elements/table/TableModal";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { Permission, RbacApi } from "@goauthentik/api";
 
@@ -43,7 +44,7 @@ export class PermissionSelectModal extends TableModal<Permission> {
         [msg("Model"), ""],
     ];
 
-    row(item: Permission): TemplateResult[] {
+    row(item: Permission): SlottedTemplateResult[] {
         return [
             html`<div>
                 <div>${item.name}</div>

--- a/web/src/admin/rbac/PermissionSelectModal.ts
+++ b/web/src/admin/rbac/PermissionSelectModal.ts
@@ -40,9 +40,10 @@ export class PermissionSelectModal extends TableModal<Permission> {
         });
     }
 
-    columns(): TableColumn[] {
-        return [new TableColumn(msg("Name"), "codename"), new TableColumn(msg("Model"), "")];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Name"), "codename"],
+        [msg("Model"), ""],
+    ];
 
     row(item: Permission): TemplateResult[] {
         return [

--- a/web/src/admin/rbac/PermissionSelectModal.ts
+++ b/web/src/admin/rbac/PermissionSelectModal.ts
@@ -19,9 +19,7 @@ export class PermissionSelectModal extends TableModal<Permission> {
     checkbox = true;
     checkboxChip = true;
 
-    searchEnabled(): boolean {
-        return true;
-    }
+    protected override searchEnabled = true;
 
     @property()
     confirm!: (selectedItems: Permission[]) => Promise<unknown>;

--- a/web/src/admin/rbac/RoleObjectPermissionForm.ts
+++ b/web/src/admin/rbac/RoleObjectPermissionForm.ts
@@ -6,6 +6,7 @@ import "#elements/forms/SearchSelect/index";
 import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { ModelForm } from "#elements/forms/ModelForm";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     ModelEnum,
@@ -16,7 +17,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { html, TemplateResult } from "lit";
+import { html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
 interface RoleAssignData {
@@ -65,9 +66,9 @@ export class RoleObjectPermissionForm extends ModelForm<RoleAssignData, number> 
         });
     }
 
-    renderForm(): TemplateResult {
+    renderForm(): SlottedTemplateResult {
         if (!this.modelPermissions) {
-            return html``;
+            return nothing;
         }
         return html`<form class="pf-c-form pf-m-horizontal">
             <ak-form-element-horizontal label=${msg("Role")} name="role">

--- a/web/src/admin/rbac/RoleObjectPermissionTable.ts
+++ b/web/src/admin/rbac/RoleObjectPermissionTable.ts
@@ -116,9 +116,9 @@ export class RoleAssignedObjectPermissionTable extends Table<RoleAssignedObjectP
             baseRow.push(
                 html`${granted
                     ? html`<pf-tooltip position="top" content=${msg("Directly assigned")}
-                          ><i class="fas fa-check pf-m-success"></i
+                          ><i class="fas fa-check pf-m-success" aria-hidden="true"></i
                       ></pf-tooltip>`
-                    : html`<i class="fas fa-times pf-m-danger"></i>`} `,
+                    : html`<i class="fas fa-times pf-m-danger" aria-hidden="true"></i>`} `,
             );
         });
         return baseRow;

--- a/web/src/admin/rbac/RoleObjectPermissionTable.ts
+++ b/web/src/admin/rbac/RoleObjectPermissionTable.ts
@@ -6,6 +6,7 @@ import "@patternfly/elements/pf-tooltip/pf-tooltip.js";
 import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     PaginatedPermissionList,
@@ -108,7 +109,7 @@ export class RoleAssignedObjectPermissionTable extends Table<RoleAssignedObjectP
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: RoleAssignedObjectPermission): TemplateResult[] {
+    row(item: RoleAssignedObjectPermission): SlottedTemplateResult[] {
         const baseRow = [html` <a href="#/identity/roles/${item.rolePk}">${item.name}</a>`];
         this.modelPermissions?.results.forEach((perm) => {
             const granted =

--- a/web/src/admin/rbac/RoleObjectPermissionTable.ts
+++ b/web/src/admin/rbac/RoleObjectPermissionTable.ts
@@ -53,13 +53,14 @@ export class RoleAssignedObjectPermissionTable extends Table<RoleAssignedObjectP
         return perms;
     }
 
-    columns(): TableColumn[] {
-        const baseColumns = [new TableColumn(msg("User"), "user")];
-        // We don't check pagination since models shouldn't need to have that many permissions?
-        this.modelPermissions?.results.forEach((perm) => {
-            baseColumns.push(new TableColumn(perm.name, perm.codename));
-        });
-        return baseColumns;
+    protected get columns(): TableColumn[] {
+        const permissions = this.modelPermissions?.results ?? [];
+
+        return [
+            [msg("User"), "user"],
+            // We don't check pagination since models shouldn't need to have that many permissions?
+            ...permissions.map(({ name, codename }): TableColumn => [name, codename]),
+        ];
     }
 
     renderObjectCreate(): TemplateResult {

--- a/web/src/admin/rbac/UserObjectPermissionForm.ts
+++ b/web/src/admin/rbac/UserObjectPermissionForm.ts
@@ -6,6 +6,7 @@ import "#elements/forms/SearchSelect/index";
 import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { ModelForm } from "#elements/forms/ModelForm";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     CoreApi,
@@ -17,7 +18,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { html, TemplateResult } from "lit";
+import { html, nothing, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
 interface UserAssignData {
@@ -66,9 +67,9 @@ export class UserObjectPermissionForm extends ModelForm<UserAssignData, number> 
         });
     }
 
-    renderForm(): TemplateResult {
+    renderForm(): SlottedTemplateResult {
         if (!this.modelPermissions) {
-            return html``;
+            return nothing;
         }
         return html`<form class="pf-c-form pf-m-horizontal">
             <ak-form-element-horizontal label=${msg("User")} name="user">

--- a/web/src/admin/rbac/UserObjectPermissionTable.ts
+++ b/web/src/admin/rbac/UserObjectPermissionTable.ts
@@ -6,6 +6,7 @@ import "@patternfly/elements/pf-tooltip/pf-tooltip.js";
 import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     PaginatedPermissionList,
@@ -113,7 +114,7 @@ export class UserAssignedObjectPermissionTable extends Table<UserAssignedObjectP
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: UserAssignedObjectPermission): TemplateResult[] {
+    row(item: UserAssignedObjectPermission): SlottedTemplateResult[] {
         const baseRow = [html` <a href="#/identity/users/${item.pk}"> ${item.username} </a> `];
         this.modelPermissions?.results.forEach((perm) => {
             let cell = html`<i class="fas fa-times pf-m-danger" aria-hidden="true"></i>`;

--- a/web/src/admin/rbac/UserObjectPermissionTable.ts
+++ b/web/src/admin/rbac/UserObjectPermissionTable.ts
@@ -53,13 +53,14 @@ export class UserAssignedObjectPermissionTable extends Table<UserAssignedObjectP
         return perms;
     }
 
-    columns(): TableColumn[] {
-        const baseColumns = [new TableColumn(msg("User"), "user")];
-        // We don't check pagination since models shouldn't need to have that many permissions?
-        this.modelPermissions?.results.forEach((perm) => {
-            baseColumns.push(new TableColumn(perm.name, perm.codename));
-        });
-        return baseColumns;
+    protected get columns(): TableColumn[] {
+        const permissions = this.modelPermissions?.results ?? [];
+
+        return [
+            [msg("User"), "user"],
+            // We don't check pagination since models shouldn't need to have that many permissions?
+            ...permissions.map(({ name, codename }): TableColumn => [name, codename]),
+        ];
     }
 
     renderObjectCreate(): TemplateResult {

--- a/web/src/admin/rbac/UserObjectPermissionTable.ts
+++ b/web/src/admin/rbac/UserObjectPermissionTable.ts
@@ -116,14 +116,14 @@ export class UserAssignedObjectPermissionTable extends Table<UserAssignedObjectP
     row(item: UserAssignedObjectPermission): TemplateResult[] {
         const baseRow = [html` <a href="#/identity/users/${item.pk}"> ${item.username} </a> `];
         this.modelPermissions?.results.forEach((perm) => {
-            let cell = html`<i class="fas fa-times pf-m-danger"></i>`;
+            let cell = html`<i class="fas fa-times pf-m-danger" aria-hidden="true"></i>`;
             if (item.permissions.filter((uperm) => uperm.codename === perm.codename).length > 0) {
                 cell = html`<pf-tooltip position="top" content=${msg("Directly assigned")}
-                    ><i class="fas fa-check pf-m-success"></i
+                    ><i class="fas fa-check pf-m-success" aria-hidden="true"></i
                 ></pf-tooltip>`;
             } else if (item.isSuperuser) {
                 cell = html`<pf-tooltip position="top" content=${msg("Superuser")}
-                    ><i class="fas fa-check pf-m-success"></i
+                    ><i class="fas fa-check pf-m-success" aria-hidden="true"></i
                 ></pf-tooltip>`;
             }
             baseRow.push(cell);

--- a/web/src/admin/roles/RoleAssignedGlobalPermissionsTable.ts
+++ b/web/src/admin/roles/RoleAssignedGlobalPermissionsTable.ts
@@ -18,9 +18,7 @@ export class RoleAssignedGlobalPermissionsTable extends Table<Permission> {
     @property()
     roleUuid?: string;
 
-    searchEnabled(): boolean {
-        return true;
-    }
+    protected override searchEnabled = true;
 
     checkbox = true;
     clearOnRefresh = true;

--- a/web/src/admin/roles/RoleAssignedGlobalPermissionsTable.ts
+++ b/web/src/admin/roles/RoleAssignedGlobalPermissionsTable.ts
@@ -40,7 +40,12 @@ export class RoleAssignedGlobalPermissionsTable extends Table<Permission> {
         });
     }
 
-    protected columns: TableColumn[] = [[msg("Model"), "model"], [msg("Permission"), ""], [""]];
+    protected columns: TableColumn[] = [
+        // ---
+        [msg("Model"), "model"],
+        [msg("Permission"), ""],
+        ["", null, msg("Assigned to role")],
+    ];
 
     renderObjectCreate(): TemplateResult {
         return html`

--- a/web/src/admin/roles/RoleAssignedGlobalPermissionsTable.ts
+++ b/web/src/admin/roles/RoleAssignedGlobalPermissionsTable.ts
@@ -5,6 +5,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { groupBy } from "#common/utils";
 
 import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { Permission, RbacApi } from "@goauthentik/api";
 
@@ -81,7 +82,7 @@ export class RoleAssignedGlobalPermissionsTable extends Table<Permission> {
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: Permission): TemplateResult[] {
+    row(item: Permission): SlottedTemplateResult[] {
         return [
             html`${item.modelVerbose}`,
             html`${item.name}`,

--- a/web/src/admin/roles/RoleAssignedGlobalPermissionsTable.ts
+++ b/web/src/admin/roles/RoleAssignedGlobalPermissionsTable.ts
@@ -82,7 +82,7 @@ export class RoleAssignedGlobalPermissionsTable extends Table<Permission> {
         return [
             html`${item.modelVerbose}`,
             html`${item.name}`,
-            html`<i class="fas fa-check pf-m-success"></i>`,
+            html`<i class="fas fa-check pf-m-success" aria-hidden="true"></i>`,
         ];
     }
 }

--- a/web/src/admin/roles/RoleAssignedGlobalPermissionsTable.ts
+++ b/web/src/admin/roles/RoleAssignedGlobalPermissionsTable.ts
@@ -40,13 +40,7 @@ export class RoleAssignedGlobalPermissionsTable extends Table<Permission> {
         });
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Model"), "model"),
-            new TableColumn(msg("Permission"), ""),
-            new TableColumn(""),
-        ];
-    }
+    protected columns: TableColumn[] = [[msg("Model"), "model"], [msg("Permission"), ""], [""]];
 
     renderObjectCreate(): TemplateResult {
         return html`

--- a/web/src/admin/roles/RoleAssignedObjectPermissionTable.ts
+++ b/web/src/admin/roles/RoleAssignedObjectPermissionTable.ts
@@ -17,9 +17,7 @@ export class RoleAssignedObjectPermissionTable extends Table<ExtraRoleObjectPerm
     @property()
     roleUuid?: string;
 
-    searchEnabled(): boolean {
-        return true;
-    }
+    protected override searchEnabled = true;
 
     checkbox = true;
     clearOnRefresh = true;

--- a/web/src/admin/roles/RoleAssignedObjectPermissionTable.ts
+++ b/web/src/admin/roles/RoleAssignedObjectPermissionTable.ts
@@ -37,14 +37,12 @@ export class RoleAssignedObjectPermissionTable extends Table<ExtraRoleObjectPerm
         });
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Model"), "model"),
-            new TableColumn(msg("Permission"), ""),
-            new TableColumn(msg("Object"), ""),
-            new TableColumn(""),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Model"), "model"],
+        [msg("Permission"), ""],
+        [msg("Object"), ""],
+        [""],
+    ];
 
     renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;

--- a/web/src/admin/roles/RoleAssignedObjectPermissionTable.ts
+++ b/web/src/admin/roles/RoleAssignedObjectPermissionTable.ts
@@ -88,7 +88,7 @@ export class RoleAssignedObjectPermissionTable extends Table<ExtraRoleObjectPerm
                   >
                       <pre>${item.objectPk}</pre>
                   </pf-tooltip>`}`,
-            html`<i class="fas fa-check pf-m-success"></i>`,
+            html`<i class="fas fa-check pf-m-success" aria-hidden="true"></i>`,
         ];
     }
 }

--- a/web/src/admin/roles/RoleAssignedObjectPermissionTable.ts
+++ b/web/src/admin/roles/RoleAssignedObjectPermissionTable.ts
@@ -5,6 +5,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { groupBy } from "#common/utils";
 
 import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { ExtraRoleObjectPermission, ModelEnum, RbacApi } from "@goauthentik/api";
 
@@ -72,7 +73,7 @@ export class RoleAssignedObjectPermissionTable extends Table<ExtraRoleObjectPerm
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: ExtraRoleObjectPermission): TemplateResult[] {
+    row(item: ExtraRoleObjectPermission): SlottedTemplateResult[] {
         return [
             html`${item.modelVerbose}`,
             html`${item.name}`,

--- a/web/src/admin/roles/RoleListPage.ts
+++ b/web/src/admin/roles/RoleListPage.ts
@@ -89,7 +89,7 @@ export class RoleListPage extends TablePage<Role> {
                 <ak-role-form slot="form" .instancePk=${item.pk}> </ak-role-form>
                 <button slot="trigger" class="pf-c-button pf-m-plain">
                     <pf-tooltip position="top" content=${msg("Edit")}>
-                        <i class="fas fa-edit"></i>
+                        <i class="fas fa-edit" aria-hidden="true"></i>
                     </pf-tooltip>
                 </button>
             </ak-forms-modal>`,

--- a/web/src/admin/roles/RoleListPage.ts
+++ b/web/src/admin/roles/RoleListPage.ts
@@ -8,6 +8,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, TableColumn } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { RbacApi, Role } from "@goauthentik/api";
 
@@ -74,7 +75,7 @@ export class RoleListPage extends TablePage<Role> {
             </section>`;
     }
 
-    row(item: Role): TemplateResult[] {
+    row(item: Role): SlottedTemplateResult[] {
         return [
             html`<a href="#/identity/roles/${item.pk}">${item.name}</a>`,
             html`<ak-forms-modal>

--- a/web/src/admin/roles/RoleListPage.ts
+++ b/web/src/admin/roles/RoleListPage.ts
@@ -40,9 +40,11 @@ export class RoleListPage extends TablePage<Role> {
         return new RbacApi(DEFAULT_CONFIG).rbacRolesList(await this.defaultEndpointConfig());
     }
 
-    columns(): TableColumn[] {
-        return [new TableColumn(msg("Name"), "name"), new TableColumn(msg("Actions"))];
-    }
+    protected columns: TableColumn[] = [
+        // ---
+        [msg("Name"), "name"],
+        [msg("Actions")],
+    ];
 
     renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;

--- a/web/src/admin/roles/RoleListPage.ts
+++ b/web/src/admin/roles/RoleListPage.ts
@@ -20,18 +20,12 @@ import { ifDefined } from "lit/directives/if-defined.js";
 export class RoleListPage extends TablePage<Role> {
     checkbox = true;
     clearOnRefresh = true;
-    searchEnabled(): boolean {
-        return true;
-    }
-    pageTitle(): string {
-        return msg("Roles");
-    }
-    pageDescription(): string {
-        return msg("Manage roles which grant permissions to objects within authentik.");
-    }
-    pageIcon(): string {
-        return "fa fa-lock";
-    }
+    protected override searchEnabled = true;
+    public pageTitle = msg("Roles");
+    public pageDescription = msg(
+        "Manage roles which grant permissions to objects within authentik.",
+    );
+    public pageIcon = "fa fa-lock";
 
     @property()
     order = "name";
@@ -70,9 +64,9 @@ export class RoleListPage extends TablePage<Role> {
 
     render(): HTMLTemplateResult {
         return html`<ak-page-header
-                icon=${this.pageIcon()}
-                header=${this.pageTitle()}
-                description=${ifDefined(this.pageDescription())}
+                icon=${this.pageIcon}
+                header=${this.pageTitle}
+                description=${ifDefined(this.pageDescription)}
             >
             </ak-page-header>
             <section class="pf-c-page__main-section pf-m-no-padding-mobile">

--- a/web/src/admin/roles/RoleListPage.ts
+++ b/web/src/admin/roles/RoleListPage.ts
@@ -43,7 +43,7 @@ export class RoleListPage extends TablePage<Role> {
     protected columns: TableColumn[] = [
         // ---
         [msg("Name"), "name"],
-        [msg("Actions")],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     renderToolbarSelected(): TemplateResult {

--- a/web/src/admin/sources/SourceListPage.ts
+++ b/web/src/admin/sources/SourceListPage.ts
@@ -14,11 +14,12 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { PFColor } from "#elements/Label";
 import { PaginatedResponse, TableColumn } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { Source, SourcesApi } from "@goauthentik/api";
 
 import { msg, str } from "@lit/localize";
-import { html, TemplateResult } from "lit";
+import { html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
@@ -73,7 +74,7 @@ export class SourceListPage extends TablePage<Source> {
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: Source): TemplateResult[] {
+    row(item: Source): SlottedTemplateResult[] {
         if (item.component === "") {
             return this.rowInbuilt(item);
         }
@@ -81,7 +82,7 @@ export class SourceListPage extends TablePage<Source> {
             html`<a href="#/core/sources/${item.slug}">
                 <div>${item.name}</div>
                 ${item.enabled
-                    ? html``
+                    ? nothing
                     : html`<ak-label color=${PFColor.Orange} compact>
                           ${msg("Disabled")}</ak-label
                       >`}
@@ -107,14 +108,14 @@ export class SourceListPage extends TablePage<Source> {
         ];
     }
 
-    rowInbuilt(item: Source): TemplateResult[] {
+    rowInbuilt(item: Source): SlottedTemplateResult[] {
         return [
             html`<div>
                 <div>${item.name}</div>
                 <ak-label color=${PFColor.Grey} compact> ${msg("Built-in")}</ak-label>
             </div>`,
             html`${msg("Built-in")}`,
-            html``,
+            nothing,
         ];
     }
 

--- a/web/src/admin/sources/SourceListPage.ts
+++ b/web/src/admin/sources/SourceListPage.ts
@@ -49,7 +49,12 @@ export class SourceListPage extends TablePage<Source> {
         return new SourcesApi(DEFAULT_CONFIG).sourcesAllList(await this.defaultEndpointConfig());
     }
 
-    protected columns: TableColumn[] = [[msg("Name"), "name"], [msg("Type")], [""]];
+    protected columns: TableColumn[] = [
+        // ---
+        [msg("Name"), "name"],
+        [msg("Type")],
+        ["", null, msg("Row Actions")],
+    ];
 
     renderToolbarSelected(): TemplateResult {
         const disabled =

--- a/web/src/admin/sources/SourceListPage.ts
+++ b/web/src/admin/sources/SourceListPage.ts
@@ -49,13 +49,7 @@ export class SourceListPage extends TablePage<Source> {
         return new SourcesApi(DEFAULT_CONFIG).sourcesAllList(await this.defaultEndpointConfig());
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Name"), "name"),
-            new TableColumn(msg("Type")),
-            new TableColumn(""),
-        ];
-    }
+    protected columns: TableColumn[] = [[msg("Name"), "name"], [msg("Type")], [""]];
 
     renderToolbarSelected(): TemplateResult {
         const disabled =

--- a/web/src/admin/sources/SourceListPage.ts
+++ b/web/src/admin/sources/SourceListPage.ts
@@ -24,20 +24,12 @@ import { ifDefined } from "lit/directives/if-defined.js";
 
 @customElement("ak-source-list")
 export class SourceListPage extends TablePage<Source> {
-    pageTitle(): string {
-        return msg("Federation and Social login");
-    }
-    pageDescription(): string | undefined {
-        return msg(
-            "Sources of identities, which can either be synced into authentik's database, or can be used by users to authenticate and enroll themselves.",
-        );
-    }
-    pageIcon(): string {
-        return "pf-icon pf-icon-middleware";
-    }
-    searchEnabled(): boolean {
-        return true;
-    }
+    public pageTitle = msg("Federation and Social login");
+    public pageDescription = msg(
+        "Sources of identities, which can either be synced into authentik's database, or can be used by users to authenticate and enroll themselves.",
+    );
+    public pageIcon = "pf-icon pf-icon-middleware";
+    protected override searchEnabled = true;
 
     checkbox = true;
     clearOnRefresh = true;

--- a/web/src/admin/sources/SourceListPage.ts
+++ b/web/src/admin/sources/SourceListPage.ts
@@ -103,7 +103,7 @@ export class SourceListPage extends TablePage<Source> {
                 </ak-proxy-form>
                 <button slot="trigger" class="pf-c-button pf-m-plain">
                     <pf-tooltip position="top" content=${msg("Edit")}>
-                        <i class="fas fa-edit"></i>
+                        <i class="fas fa-edit" aria-hidden="true"></i>
                     </pf-tooltip>
                 </button>
             </ak-forms-modal>`,

--- a/web/src/admin/sources/kerberos/KerberosSourceConnectivity.ts
+++ b/web/src/admin/sources/kerberos/KerberosSourceConnectivity.ts
@@ -1,8 +1,9 @@
 import "@patternfly/elements/pf-tooltip/pf-tooltip.js";
 
 import { AKElement } from "#elements/Base";
+import { SlottedTemplateResult } from "#elements/types";
 
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import PFList from "@patternfly/patternfly/components/List/list.css";
@@ -19,9 +20,9 @@ export class KerberosSourceConnectivity extends AKElement {
 
     static styles: CSSResult[] = [PFBase, PFList];
 
-    render(): TemplateResult {
+    render(): SlottedTemplateResult {
         if (!this.connectivity) {
-            return html``;
+            return nothing;
         }
         return html`<ul class="pf-c-list">
             ${Object.keys(this.connectivity).map((serverKey) => {

--- a/web/src/admin/sources/kerberos/KerberosSourceForm.ts
+++ b/web/src/admin/sources/kerberos/KerberosSourceForm.ts
@@ -31,7 +31,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { html, TemplateResult } from "lit";
+import { html, nothing, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
@@ -391,7 +391,7 @@ export class KerberosSourceForm extends WithCapabilitiesConfig(BaseSourceForm<Ke
                                             ${msg("Currently set to:")} ${this.instance?.icon}
                                         </p>
                                     `
-                                  : html``}
+                                  : nothing}
                           </ak-form-element-horizontal>
                           ${this.instance?.icon
                               ? html`
@@ -419,7 +419,7 @@ export class KerberosSourceForm extends WithCapabilitiesConfig(BaseSourceForm<Ke
                                         </p>
                                     </ak-form-element-horizontal>
                                 `
-                              : html``}`
+                              : nothing}`
                     : html`<ak-form-element-horizontal label=${msg("Icon")} name="icon">
                           <input
                               type="text"

--- a/web/src/admin/sources/kerberos/KerberosSourceViewPage.ts
+++ b/web/src/admin/sources/kerberos/KerberosSourceViewPage.ts
@@ -14,6 +14,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { EVENT_REFRESH } from "#common/constants";
 
 import { AKElement } from "#elements/Base";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     KerberosSource,
@@ -25,7 +26,7 @@ import {
 import MDSourceKerberosBrowser from "~docs/users-sources/sources/protocols/kerberos/browser.md";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import PFBanner from "@patternfly/patternfly/components/Banner/banner.css";
@@ -74,9 +75,9 @@ export class KerberosSourceViewPage extends AKElement {
         });
     }
 
-    render(): TemplateResult {
+    render(): SlottedTemplateResult {
         if (!this.source) {
-            return html``;
+            return nothing;
         }
         const [appLabel, modelName] = ModelEnum.AuthentikSourcesKerberosKerberossource.split(".");
         return html`<ak-tabs>

--- a/web/src/admin/sources/ldap/LDAPSourceConnectivity.ts
+++ b/web/src/admin/sources/ldap/LDAPSourceConnectivity.ts
@@ -1,9 +1,10 @@
 import "@patternfly/elements/pf-tooltip/pf-tooltip.js";
 
 import { AKElement } from "#elements/Base";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import PFList from "@patternfly/patternfly/components/List/list.css";
@@ -20,9 +21,9 @@ export class LDAPSourceConnectivity extends AKElement {
 
     static styles: CSSResult[] = [PFBase, PFList];
 
-    render(): TemplateResult {
+    render(): SlottedTemplateResult {
         if (!this.connectivity) {
-            return html``;
+            return nothing;
         }
         return html`<ul class="pf-c-list">
             ${Object.keys(this.connectivity).map((serverKey) => {

--- a/web/src/admin/sources/ldap/LDAPSourceViewPage.ts
+++ b/web/src/admin/sources/ldap/LDAPSourceViewPage.ts
@@ -14,6 +14,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { EVENT_REFRESH } from "#common/constants";
 
 import { AKElement } from "#elements/Base";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     LDAPSource,
@@ -23,7 +24,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
@@ -70,9 +71,9 @@ export class LDAPSourceViewPage extends AKElement {
         });
     }
 
-    render(): TemplateResult {
+    render(): SlottedTemplateResult {
         if (!this.source) {
-            return html``;
+            return nothing;
         }
         const [appLabel, modelName] = ModelEnum.AuthentikSourcesLdapLdapsource.split(".");
         return html`<ak-tabs>

--- a/web/src/admin/sources/oauth/OAuthSourceForm.ts
+++ b/web/src/admin/sources/oauth/OAuthSourceForm.ts
@@ -15,6 +15,7 @@ import { config, DEFAULT_CONFIG } from "#common/api/config";
 
 import { CodeMirrorMode } from "#elements/CodeMirror";
 import { CapabilitiesEnum, WithCapabilitiesConfig } from "#elements/mixins/capabilities";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { iconHelperText, placeholderHelperText } from "#admin/helperText";
 import { policyEngineModes } from "#admin/policies/PolicyEngineModes";
@@ -34,7 +35,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { html, PropertyValues, TemplateResult } from "lit";
+import { html, nothing, PropertyValues, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
@@ -122,9 +123,9 @@ export class OAuthSourceForm extends WithCapabilitiesConfig(BaseSourceForm<OAuth
         }
     }
 
-    renderUrlOptions(): TemplateResult {
+    renderUrlOptions(): SlottedTemplateResult {
         if (!this.providerType?.urlsCustomizable) {
-            return html``;
+            return nothing;
         }
         return html` <ak-form-group open label="${msg("URL settings")}">
             <div class="pf-c-form">
@@ -188,7 +189,7 @@ export class OAuthSourceForm extends WithCapabilitiesConfig(BaseSourceForm<OAuth
                               )}
                           </p>
                       </ak-form-element-horizontal> `
-                    : html``}
+                    : nothing}
                 ${this.providerType.name === ProviderTypeEnum.Openidconnect ||
                 this.providerType.oidcWellKnownUrl !== ""
                     ? html`<ak-form-element-horizontal
@@ -210,7 +211,7 @@ export class OAuthSourceForm extends WithCapabilitiesConfig(BaseSourceForm<OAuth
                               )}
                           </p>
                       </ak-form-element-horizontal>`
-                    : html``}
+                    : nothing}
                 ${this.providerType.name === ProviderTypeEnum.Openidconnect ||
                 this.providerType.oidcJwksUrl !== ""
                     ? html`<ak-form-element-horizontal
@@ -240,7 +241,7 @@ export class OAuthSourceForm extends WithCapabilitiesConfig(BaseSourceForm<OAuth
                               </ak-codemirror>
                               <p class="pf-c-form__helper-text">${msg("Raw JWKS data.")}</p>
                           </ak-form-element-horizontal>`
-                    : html``}
+                    : nothing}
                 ${this.providerType.name === ProviderTypeEnum.Openidconnect
                     ? html`<ak-radio-input
                           label=${msg("Authorization code authentication method")}
@@ -253,7 +254,7 @@ export class OAuthSourceForm extends WithCapabilitiesConfig(BaseSourceForm<OAuth
                           )}
                       >
                       </ak-radio-input>`
-                    : html``}
+                    : nothing}
             </div>
         </ak-form-group>`;
     }
@@ -380,7 +381,7 @@ export class OAuthSourceForm extends WithCapabilitiesConfig(BaseSourceForm<OAuth
                                         ${msg("Currently set to:")} ${this.instance?.icon}
                                     </p>
                                 `
-                              : html``}
+                              : nothing}
                       </ak-form-element-horizontal>
                       ${this.instance?.icon
                           ? html`
@@ -408,7 +409,7 @@ export class OAuthSourceForm extends WithCapabilitiesConfig(BaseSourceForm<OAuth
                                     </p>
                                 </ak-form-element-horizontal>
                             `
-                          : html``}`
+                          : nothing}`
                 : html`<ak-form-element-horizontal label=${msg("Icon")} name="icon">
                       <input
                           type="text"

--- a/web/src/admin/sources/oauth/OAuthSourceViewPage.ts
+++ b/web/src/admin/sources/oauth/OAuthSourceViewPage.ts
@@ -12,6 +12,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { EVENT_REFRESH } from "#common/constants";
 
 import { AKElement } from "#elements/Base";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { sourceBindingTypeNotices } from "#admin/sources/utils";
 
@@ -23,7 +24,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
@@ -107,9 +108,9 @@ export class OAuthSourceViewPage extends AKElement {
         });
     }
 
-    render(): TemplateResult {
+    render(): SlottedTemplateResult {
         if (!this.source) {
-            return html``;
+            return nothing;
         }
         return html`<ak-tabs>
             <section

--- a/web/src/admin/sources/plex/PlexSourceForm.ts
+++ b/web/src/admin/sources/plex/PlexSourceForm.ts
@@ -28,7 +28,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { html, TemplateResult } from "lit";
+import { html, nothing, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
@@ -296,7 +296,7 @@ export class PlexSourceForm extends WithCapabilitiesConfig(BaseSourceForm<PlexSo
                                         ${msg("Currently set to:")} ${this.instance?.icon}
                                     </p>
                                 `
-                              : html``}
+                              : nothing}
                       </ak-form-element-horizontal>
                       ${this.instance?.icon
                           ? html`
@@ -324,7 +324,7 @@ export class PlexSourceForm extends WithCapabilitiesConfig(BaseSourceForm<PlexSo
                                     </p>
                                 </ak-form-element-horizontal>
                             `
-                          : html``}`
+                          : nothing}`
                 : html`<ak-form-element-horizontal label=${msg("Icon")} name="icon">
                       <input
                           type="text"

--- a/web/src/admin/sources/plex/PlexSourceViewPage.ts
+++ b/web/src/admin/sources/plex/PlexSourceViewPage.ts
@@ -11,6 +11,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { EVENT_REFRESH } from "#common/constants";
 
 import { AKElement } from "#elements/Base";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { sourceBindingTypeNotices } from "#admin/sources/utils";
 
@@ -21,7 +22,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
@@ -66,9 +67,9 @@ export class PlexSourceViewPage extends AKElement {
         });
     }
 
-    render(): TemplateResult {
+    render(): SlottedTemplateResult {
         if (!this.source) {
-            return html``;
+            return nothing;
         }
         return html`<ak-tabs>
             <section

--- a/web/src/admin/sources/saml/SAMLSourceForm.ts
+++ b/web/src/admin/sources/saml/SAMLSourceForm.ts
@@ -31,7 +31,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { html, TemplateResult } from "lit";
+import { html, nothing, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
@@ -195,7 +195,7 @@ export class SAMLSourceForm extends WithCapabilitiesConfig(BaseSourceForm<SAMLSo
                                         ${msg("Currently set to:")} ${this.instance?.icon}
                                     </p>
                                 `
-                              : html``}
+                              : nothing}
                       </ak-form-element-horizontal>
                       ${this.instance?.icon
                           ? html`
@@ -223,7 +223,7 @@ export class SAMLSourceForm extends WithCapabilitiesConfig(BaseSourceForm<SAMLSo
                                     </p>
                                 </ak-form-element-horizontal>
                             `
-                          : html``}`
+                          : nothing}`
                 : html`<ak-form-element-horizontal label=${msg("Icon")} name="icon">
                       <input
                           type="text"

--- a/web/src/admin/sources/saml/SAMLSourceViewPage.ts
+++ b/web/src/admin/sources/saml/SAMLSourceViewPage.ts
@@ -12,6 +12,7 @@ import { EVENT_REFRESH } from "#common/constants";
 
 import { AKElement } from "#elements/Base";
 import { CodeMirrorMode } from "#elements/CodeMirror";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { sourceBindingTypeNotices } from "#admin/sources/utils";
 
@@ -23,7 +24,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
@@ -72,9 +73,9 @@ export class SAMLSourceViewPage extends AKElement {
         });
     }
 
-    render(): TemplateResult {
+    render(): SlottedTemplateResult {
         if (!this.source) {
-            return html``;
+            return nothing;
         }
         return html`<ak-tabs>
             <section

--- a/web/src/admin/sources/scim/SCIMSourceGroups.ts
+++ b/web/src/admin/sources/scim/SCIMSourceGroups.ts
@@ -25,6 +25,10 @@ export class SCIMSourceGroupList extends Table<SCIMSourceGroup> {
         });
     }
 
+    protected override rowLabel(item: SCIMSourceGroup): string {
+        return item.groupObj.name;
+    }
+
     protected columns: TableColumn[] = [
         // ---
         [msg("Name")],

--- a/web/src/admin/sources/scim/SCIMSourceGroups.ts
+++ b/web/src/admin/sources/scim/SCIMSourceGroups.ts
@@ -25,9 +25,11 @@ export class SCIMSourceGroupList extends Table<SCIMSourceGroup> {
         });
     }
 
-    columns(): TableColumn[] {
-        return [new TableColumn(msg("Name")), new TableColumn(msg("ID"))];
-    }
+    protected columns: TableColumn[] = [
+        // ---
+        [msg("Name")],
+        [msg("ID")],
+    ];
 
     renderExpanded(item: SCIMSourceGroup): TemplateResult {
         return html`<td role="cell" colspan="4">

--- a/web/src/admin/sources/scim/SCIMSourceGroups.ts
+++ b/web/src/admin/sources/scim/SCIMSourceGroups.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { SCIMSourceGroup, SourcesApi } from "@goauthentik/api";
 
@@ -41,7 +42,7 @@ export class SCIMSourceGroupList extends Table<SCIMSourceGroup> {
         </td>`;
     }
 
-    row(item: SCIMSourceGroup): TemplateResult[] {
+    row(item: SCIMSourceGroup): SlottedTemplateResult[] {
         return [
             html`<a href="#/identity/groups/${item.groupObj.pk}">
                 <div>${item.groupObj.name}</div>

--- a/web/src/admin/sources/scim/SCIMSourceGroups.ts
+++ b/web/src/admin/sources/scim/SCIMSourceGroups.ts
@@ -14,9 +14,7 @@ export class SCIMSourceGroupList extends Table<SCIMSourceGroup> {
     sourceSlug?: string;
 
     expandable = true;
-    searchEnabled(): boolean {
-        return true;
-    }
+    protected override searchEnabled = true;
 
     async apiEndpoint(): Promise<PaginatedResponse<SCIMSourceGroup>> {
         return new SourcesApi(DEFAULT_CONFIG).sourcesScimGroupsList({
@@ -36,7 +34,7 @@ export class SCIMSourceGroupList extends Table<SCIMSourceGroup> {
     ];
 
     renderExpanded(item: SCIMSourceGroup): TemplateResult {
-        return html`<td role="cell" colspan="4">
+        return html`<td colspan="4">
             <div class="pf-c-table__expandable-row-content">
                 <pre>${JSON.stringify(item.attributes, null, 4)}</pre>
             </div>

--- a/web/src/admin/sources/scim/SCIMSourceUsers.ts
+++ b/web/src/admin/sources/scim/SCIMSourceUsers.ts
@@ -25,6 +25,10 @@ export class SCIMSourceUserList extends Table<SCIMSourceUser> {
         });
     }
 
+    protected override rowLabel(item: SCIMSourceUser): string {
+        return item.userObj.name || item.userObj.username;
+    }
+
     protected columns: TableColumn[] = [
         // ---
         [msg("Username")],

--- a/web/src/admin/sources/scim/SCIMSourceUsers.ts
+++ b/web/src/admin/sources/scim/SCIMSourceUsers.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { SCIMSourceUser, SourcesApi } from "@goauthentik/api";
 
@@ -41,7 +42,7 @@ export class SCIMSourceUserList extends Table<SCIMSourceUser> {
         </td>`;
     }
 
-    row(item: SCIMSourceUser): TemplateResult[] {
+    row(item: SCIMSourceUser): SlottedTemplateResult[] {
         return [
             html`<a href="#/identity/users/${item.userObj.pk}">
                 <div>${item.userObj.username}</div>

--- a/web/src/admin/sources/scim/SCIMSourceUsers.ts
+++ b/web/src/admin/sources/scim/SCIMSourceUsers.ts
@@ -14,9 +14,7 @@ export class SCIMSourceUserList extends Table<SCIMSourceUser> {
     sourceSlug?: string;
 
     expandable = true;
-    searchEnabled(): boolean {
-        return true;
-    }
+    protected override searchEnabled = true;
 
     async apiEndpoint(): Promise<PaginatedResponse<SCIMSourceUser>> {
         return new SourcesApi(DEFAULT_CONFIG).sourcesScimUsersList({
@@ -36,7 +34,7 @@ export class SCIMSourceUserList extends Table<SCIMSourceUser> {
     ];
 
     renderExpanded(item: SCIMSourceUser): TemplateResult {
-        return html`<td role="cell" colspan="4">
+        return html`<td colspan="4">
             <div class="pf-c-table__expandable-row-content">
                 <pre>${JSON.stringify(item.attributes, null, 4)}</pre>
             </div>

--- a/web/src/admin/sources/scim/SCIMSourceUsers.ts
+++ b/web/src/admin/sources/scim/SCIMSourceUsers.ts
@@ -25,9 +25,11 @@ export class SCIMSourceUserList extends Table<SCIMSourceUser> {
         });
     }
 
-    columns(): TableColumn[] {
-        return [new TableColumn(msg("Username")), new TableColumn(msg("ID"))];
-    }
+    protected columns: TableColumn[] = [
+        // ---
+        [msg("Username")],
+        [msg("ID")],
+    ];
 
     renderExpanded(item: SCIMSourceUser): TemplateResult {
         return html`<td role="cell" colspan="4">

--- a/web/src/admin/sources/scim/SCIMSourceViewPage.ts
+++ b/web/src/admin/sources/scim/SCIMSourceViewPage.ts
@@ -13,6 +13,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { EVENT_REFRESH } from "#common/constants";
 
 import { AKElement } from "#elements/Base";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     RbacPermissionsAssignedByUsersListModelEnum,
@@ -21,7 +22,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
@@ -70,9 +71,9 @@ export class SCIMSourceViewPage extends AKElement {
         });
     }
 
-    render(): TemplateResult {
+    render(): SlottedTemplateResult {
         if (!this.source) {
-            return html``;
+            return nothing;
         }
         return html`<ak-tabs>
             <section slot="page-overview" data-tab-title="${msg("Overview")}">

--- a/web/src/admin/stages/StageListPage.ts
+++ b/web/src/admin/stages/StageListPage.ts
@@ -69,7 +69,12 @@ export class StageListPage extends TablePage<Stage> {
         return new StagesApi(DEFAULT_CONFIG).stagesAllList(await this.defaultEndpointConfig());
     }
 
-    protected columns: TableColumn[] = [[msg("Name"), "name"], [msg("Flows")], [msg("Actions")]];
+    protected columns: TableColumn[] = [
+        // ---
+        [msg("Name"), "name"],
+        [msg("Flows")],
+        [msg("Actions"), null, msg("Row Actions")],
+    ];
 
     renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;

--- a/web/src/admin/stages/StageListPage.ts
+++ b/web/src/admin/stages/StageListPage.ts
@@ -44,20 +44,12 @@ import { ifDefined } from "lit/directives/if-defined.js";
 
 @customElement("ak-stage-list")
 export class StageListPage extends TablePage<Stage> {
-    pageTitle(): string {
-        return msg("Stages");
-    }
-    pageDescription(): string | undefined {
-        return msg(
-            "Stages are single steps of a Flow that a user is guided through. A stage can only be executed from within a flow.",
-        );
-    }
-    pageIcon(): string {
-        return "pf-icon pf-icon-plugged";
-    }
-    searchEnabled(): boolean {
-        return true;
-    }
+    public pageTitle = msg("Stages");
+    public pageDescription = msg(
+        "Stages are single steps of a Flow that a user is guided through. A stage can only be executed from within a flow.",
+    );
+    public pageIcon = "pf-icon pf-icon-plugged";
+    protected override searchEnabled = true;
 
     checkbox = true;
     clearOnRefresh = true;

--- a/web/src/admin/stages/StageListPage.ts
+++ b/web/src/admin/stages/StageListPage.ts
@@ -34,6 +34,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, TableColumn } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { Stage, StagesApi } from "@goauthentik/api";
 
@@ -109,7 +110,7 @@ export class StageListPage extends TablePage<Stage> {
             : nothing;
     }
 
-    row(item: Stage): TemplateResult[] {
+    row(item: Stage): SlottedTemplateResult[] {
         return [
             html`<div>${item.name}</div>
                 <small>${item.verboseName}</small>`,

--- a/web/src/admin/stages/StageListPage.ts
+++ b/web/src/admin/stages/StageListPage.ts
@@ -69,13 +69,7 @@ export class StageListPage extends TablePage<Stage> {
         return new StagesApi(DEFAULT_CONFIG).stagesAllList(await this.defaultEndpointConfig());
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Name"), "name"),
-            new TableColumn(msg("Flows")),
-            new TableColumn(msg("Actions")),
-        ];
-    }
+    protected columns: TableColumn[] = [[msg("Name"), "name"], [msg("Flows")], [msg("Actions")]];
 
     renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;

--- a/web/src/admin/stages/StageListPage.ts
+++ b/web/src/admin/stages/StageListPage.ts
@@ -138,7 +138,7 @@ export class StageListPage extends TablePage<Stage> {
                     </ak-proxy-form>
                     <button slot="trigger" class="pf-c-button pf-m-plain">
                         <pf-tooltip position="top" content=${msg("Edit")}>
-                            <i class="fas fa-edit"></i>
+                            <i class="fas fa-edit" aria-hidden="true"></i>
                         </pf-tooltip>
                     </button>
                 </ak-forms-modal>

--- a/web/src/admin/stages/StageWizard.ts
+++ b/web/src/admin/stages/StageWizard.ts
@@ -39,7 +39,7 @@ import { FlowStageBinding, Stage, StagesApi, TypeCreate } from "@goauthentik/api
 
 import { msg, str } from "@lit/localize";
 import { customElement } from "@lit/reactive-element/decorators/custom-element.js";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { property, query } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
@@ -125,7 +125,7 @@ export class StageWizard extends AKElement {
                               .targetPk=${this.bindingTarget}
                           ></ak-stage-binding-form>
                       </ak-wizard-page-form>`
-                    : html``}
+                    : nothing}
                 <button slot="trigger" class="pf-c-button pf-m-primary">${this.createText}</button>
             </ak-wizard>
         `;

--- a/web/src/admin/stages/authenticator_duo/DuoDeviceImportForm.ts
+++ b/web/src/admin/stages/authenticator_duo/DuoDeviceImportForm.ts
@@ -20,7 +20,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg, str } from "@lit/localize";
-import { html, TemplateResult } from "lit";
+import { html, nothing, TemplateResult } from "lit";
 import { customElement } from "lit/decorators.js";
 
 @customElement("ak-stage-authenticator-duo-device-import-form")
@@ -46,7 +46,7 @@ export class DuoDeviceImportForm extends ModelForm<AuthenticatorDuoStage, string
     renderForm(): TemplateResult {
         return html` ${this.instance?.adminIntegrationKey !== ""
             ? this.renderFormAutomatic()
-            : html``}
+            : nothing}
         ${this.renderFormManual()}`;
     }
 

--- a/web/src/admin/stages/authenticator_email/AuthenticatorEmailStageForm.ts
+++ b/web/src/admin/stages/authenticator_email/AuthenticatorEmailStageForm.ts
@@ -6,6 +6,8 @@ import "#elements/forms/SearchSelect/index";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
 
+import { SlottedTemplateResult } from "#elements/types";
+
 import { RenderFlowOption } from "#admin/flows/utils";
 import { BaseStageForm } from "#admin/stages/BaseStageForm";
 
@@ -20,7 +22,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { html, TemplateResult } from "lit";
+import { html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
@@ -55,9 +57,9 @@ export class AuthenticatorEmailStageForm extends BaseStageForm<AuthenticatorEmai
         });
     }
 
-    renderConnectionSettings(): TemplateResult {
+    renderConnectionSettings(): SlottedTemplateResult {
         if (!this.showConnectionSettings) {
-            return html``;
+            return nothing;
         }
         return html`<ak-form-group open label="${msg("Connection settings")}">
             <div class="pf-c-form">

--- a/web/src/admin/stages/authenticator_validate/AuthenticatorValidateStageForm.ts
+++ b/web/src/admin/stages/authenticator_validate/AuthenticatorValidateStageForm.ts
@@ -27,7 +27,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { html, TemplateResult } from "lit";
+import { html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
@@ -206,7 +206,7 @@ export class AuthenticatorValidateStageForm extends BaseStageForm<AuthenticatorV
                                   </p>
                               </ak-form-element-horizontal>
                           `
-                        : html``}
+                        : nothing}
                 </div>
             </ak-form-group>
             <ak-form-group open label="${msg("WebAuthn-specific settings")}">

--- a/web/src/admin/stages/email/EmailStageForm.ts
+++ b/web/src/admin/stages/email/EmailStageForm.ts
@@ -5,12 +5,14 @@ import "#elements/utils/TimeDeltaHelp";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
 
+import { SlottedTemplateResult } from "#elements/types";
+
 import { BaseStageForm } from "#admin/stages/BaseStageForm";
 
 import { EmailStage, StagesApi, TypeCreate } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { html, TemplateResult } from "lit";
+import { html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
@@ -45,9 +47,9 @@ export class EmailStageForm extends BaseStageForm<EmailStage> {
         });
     }
 
-    renderConnectionSettings(): TemplateResult {
+    renderConnectionSettings(): SlottedTemplateResult {
         if (!this.showConnectionSettings) {
-            return html``;
+            return nothing;
         }
         return html`<ak-form-group label="${msg("Connection settings")}">
             <div class="pf-c-form">

--- a/web/src/admin/stages/invitation/InvitationListLink.ts
+++ b/web/src/admin/stages/invitation/InvitationListLink.ts
@@ -5,7 +5,7 @@ import { AKElement } from "#elements/Base";
 import { Invitation, StagesApi } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { until } from "lit/directives/until.js";
 
@@ -63,7 +63,7 @@ export class InvitationListLink extends AKElement {
                                     return stages.results.map((stage) => {
                                         return stage.flowSet?.map((flow) => {
                                             if (seenFlowSlugs.includes(flow.slug)) {
-                                                return html``;
+                                                return nothing;
                                             }
                                             seenFlowSlugs.push(flow.slug);
                                             return html`<option
@@ -85,7 +85,7 @@ export class InvitationListLink extends AKElement {
 
     render(): TemplateResult {
         return html`<dl class="pf-c-description-list pf-m-horizontal">
-            ${this.invitation?.flow === undefined ? this.renderFlowSelector() : html``}
+            ${this.invitation?.flow === undefined ? this.renderFlowSelector() : nothing}
             <div class="pf-c-description-list__group">
                 <dt class="pf-c-description-list__term">
                     <span class="pf-c-description-list__text"

--- a/web/src/admin/stages/invitation/InvitationListPage.ts
+++ b/web/src/admin/stages/invitation/InvitationListPage.ts
@@ -84,14 +84,12 @@ export class InvitationListPage extends TablePage<Invitation> {
         });
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Name"), "name"),
-            new TableColumn(msg("Created by"), "created_by"),
-            new TableColumn(msg("Expiry")),
-            new TableColumn(msg("Actions")),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Name"), "name"],
+        [msg("Created by"), "created_by"],
+        [msg("Expiry")],
+        [msg("Actions")],
+    ];
 
     renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;

--- a/web/src/admin/stages/invitation/InvitationListPage.ts
+++ b/web/src/admin/stages/invitation/InvitationListPage.ts
@@ -31,20 +31,12 @@ import PFBanner from "@patternfly/patternfly/components/Banner/banner.css";
 export class InvitationListPage extends TablePage<Invitation> {
     expandable = true;
 
-    searchEnabled(): boolean {
-        return true;
-    }
-    pageTitle(): string {
-        return msg("Invitations");
-    }
-    pageDescription(): string {
-        return msg(
-            "Create Invitation Links to enroll Users, and optionally force specific attributes of their account.",
-        );
-    }
-    pageIcon(): string {
-        return "pf-icon pf-icon-migration";
-    }
+    protected override searchEnabled = true;
+    public pageTitle = msg("Invitations");
+    public pageDescription = msg(
+        "Create Invitation Links to enroll Users, and optionally force specific attributes of their account.",
+    );
+    public pageIcon = "pf-icon pf-icon-migration";
 
     static styles: CSSResult[] = [...super.styles, PFBanner];
 
@@ -146,7 +138,7 @@ export class InvitationListPage extends TablePage<Invitation> {
     }
 
     renderExpanded(item: Invitation): TemplateResult {
-        return html` <td role="cell" colspan="3">
+        return html` <td colspan="3">
                 <div class="pf-c-table__expandable-row-content">
                     <ak-stage-invitation-list-link
                         .invitation=${item}
@@ -171,9 +163,9 @@ export class InvitationListPage extends TablePage<Invitation> {
 
     render(): HTMLTemplateResult {
         return html`<ak-page-header
-                icon=${this.pageIcon()}
-                header=${this.pageTitle()}
-                description=${ifDefined(this.pageDescription())}
+                icon=${this.pageIcon}
+                header=${this.pageTitle}
+                description=${ifDefined(this.pageDescription)}
             >
             </ak-page-header>
             ${this.invitationStageExists

--- a/web/src/admin/stages/invitation/InvitationListPage.ts
+++ b/web/src/admin/stages/invitation/InvitationListPage.ts
@@ -12,6 +12,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { PFColor } from "#elements/Label";
 import { PaginatedResponse, TableColumn } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     FlowDesignationEnum,
@@ -21,7 +22,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, HTMLTemplateResult, TemplateResult } from "lit";
+import { CSSResult, html, HTMLTemplateResult, nothing, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
@@ -105,7 +106,7 @@ export class InvitationListPage extends TablePage<Invitation> {
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: Invitation): TemplateResult[] {
+    row(item: Invitation): SlottedTemplateResult[] {
         return [
             html`<div>${item.name}</div>
                 ${!item.flowObj && this.multipleEnrollmentFlows
@@ -116,7 +117,7 @@ export class InvitationListPage extends TablePage<Invitation> {
                               )}
                           </ak-label>
                       `
-                    : html``}`,
+                    : nothing}`,
             html`${item.createdBy?.username}`,
             html`${item.expires?.toLocaleString() || msg("-")}`,
             html` <ak-forms-modal>
@@ -169,7 +170,7 @@ export class InvitationListPage extends TablePage<Invitation> {
             >
             </ak-page-header>
             ${this.invitationStageExists
-                ? html``
+                ? nothing
                 : html`
                       <div class="pf-c-banner pf-m-warning">
                           ${msg(

--- a/web/src/admin/stages/invitation/InvitationListPage.ts
+++ b/web/src/admin/stages/invitation/InvitationListPage.ts
@@ -133,7 +133,7 @@ export class InvitationListPage extends TablePage<Invitation> {
                     <ak-invitation-form slot="form" .instancePk=${item.pk}> </ak-invitation-form>
                     <button slot="trigger" class="pf-c-button pf-m-plain">
                         <pf-tooltip position="top" content=${msg("Edit")}>
-                            <i class="fas fa-edit"></i>
+                            <i class="fas fa-edit" aria-hidden="true"></i>
                         </pf-tooltip>
                     </button>
                 </ak-forms-modal>

--- a/web/src/admin/stages/invitation/InvitationListPage.ts
+++ b/web/src/admin/stages/invitation/InvitationListPage.ts
@@ -88,7 +88,7 @@ export class InvitationListPage extends TablePage<Invitation> {
         [msg("Name"), "name"],
         [msg("Created by"), "created_by"],
         [msg("Expiry")],
-        [msg("Actions")],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     renderToolbarSelected(): TemplateResult {

--- a/web/src/admin/stages/prompt/PromptForm.ts
+++ b/web/src/admin/stages/prompt/PromptForm.ts
@@ -7,6 +7,7 @@ import { parseAPIResponseError, pluckErrorDetail } from "#common/errors/network"
 
 import { CodeMirrorMode } from "#elements/CodeMirror";
 import { ModelForm } from "#elements/forms/ModelForm";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { StageHost } from "#flow/stages/base";
 
@@ -19,7 +20,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { map } from "lit/directives/map.js";
@@ -166,7 +167,7 @@ export class PromptForm extends ModelForm<Prompt, string> {
         </div> `;
     }
 
-    renderPreview(): TemplateResult {
+    renderPreview(): SlottedTemplateResult {
         return html`
             <h3 class="pf-c-title pf-m-lg">${msg("Preview")}</h3>
             <div class="pf-l-grid pf-m-gutter">
@@ -188,7 +189,7 @@ export class PromptForm extends ModelForm<Prompt, string> {
                               </div>
                           </div>
                       `
-                    : html``}
+                    : nothing}
                 ${this.previewResult
                     ? html`
                           <div class="pf-c-card pf-l-grid__item pf-m-12-col">
@@ -198,7 +199,7 @@ export class PromptForm extends ModelForm<Prompt, string> {
                               </div>
                           </div>
                       `
-                    : html``}
+                    : nothing}
             </div>
         `;
     }

--- a/web/src/admin/stages/prompt/PromptListPage.ts
+++ b/web/src/admin/stages/prompt/PromptListPage.ts
@@ -20,18 +20,10 @@ import { customElement, property } from "lit/decorators.js";
 
 @customElement("ak-stage-prompt-list")
 export class PromptListPage extends TablePage<Prompt> {
-    searchEnabled(): boolean {
-        return true;
-    }
-    pageTitle(): string {
-        return msg("Prompts");
-    }
-    pageDescription(): string {
-        return msg("Single Prompts that can be used for Prompt Stages.");
-    }
-    pageIcon(): string {
-        return "pf-icon pf-icon-plugged";
-    }
+    protected override searchEnabled = true;
+    public pageTitle = msg("Prompts");
+    public pageDescription = msg("Single Prompts that can be used for Prompt Stages.");
+    public pageIcon = "pf-icon pf-icon-plugged";
 
     checkbox = true;
     clearOnRefresh = true;

--- a/web/src/admin/stages/prompt/PromptListPage.ts
+++ b/web/src/admin/stages/prompt/PromptListPage.ts
@@ -11,6 +11,7 @@ import { PFSize } from "#common/enums";
 
 import { PaginatedResponse, TableColumn } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { Prompt, RbacPermissionsAssignedByUsersListModelEnum, StagesApi } from "@goauthentik/api";
 
@@ -68,7 +69,7 @@ export class PromptListPage extends TablePage<Prompt> {
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: Prompt): TemplateResult[] {
+    row(item: Prompt): SlottedTemplateResult[] {
         return [
             html`${item.name}`,
             html`<code>${item.fieldKey}</code>`,

--- a/web/src/admin/stages/prompt/PromptListPage.ts
+++ b/web/src/admin/stages/prompt/PromptListPage.ts
@@ -45,16 +45,14 @@ export class PromptListPage extends TablePage<Prompt> {
         );
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Name"), "name"),
-            new TableColumn(msg("Field"), "field_key"),
-            new TableColumn(msg("Type"), "type"),
-            new TableColumn(msg("Order"), "order"),
-            new TableColumn(msg("Stages")),
-            new TableColumn(msg("Actions")),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Name"), "name"],
+        [msg("Field"), "field_key"],
+        [msg("Type"), "type"],
+        [msg("Order"), "order"],
+        [msg("Stages")],
+        [msg("Actions")],
+    ];
 
     renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;

--- a/web/src/admin/stages/prompt/PromptListPage.ts
+++ b/web/src/admin/stages/prompt/PromptListPage.ts
@@ -51,7 +51,7 @@ export class PromptListPage extends TablePage<Prompt> {
         [msg("Type"), "type"],
         [msg("Order"), "order"],
         [msg("Stages")],
-        [msg("Actions")],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     renderToolbarSelected(): TemplateResult {

--- a/web/src/admin/stages/prompt/PromptListPage.ts
+++ b/web/src/admin/stages/prompt/PromptListPage.ts
@@ -91,7 +91,7 @@ export class PromptListPage extends TablePage<Prompt> {
                     <ak-prompt-form slot="form" .instancePk=${item.pk}> </ak-prompt-form>
                     <button slot="trigger" class="pf-c-button pf-m-plain">
                         <pf-tooltip position="top" content=${msg("Edit")}>
-                            <i class="fas fa-edit"></i>
+                            <i class="fas fa-edit" aria-hidden="true"></i>
                         </pf-tooltip>
                     </button>
                 </ak-forms-modal>

--- a/web/src/admin/tokens/TokenForm.ts
+++ b/web/src/admin/tokens/TokenForm.ts
@@ -11,7 +11,7 @@ import { ModelForm } from "#elements/forms/ModelForm";
 import { CoreApi, CoreUsersListRequest, IntentEnum, Token, User } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { html, TemplateResult } from "lit";
+import { html, nothing, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 
 @customElement("ak-token-form")
@@ -151,7 +151,7 @@ export class TokenForm extends ModelForm<Token, string> {
                     )}
                 </p>
             </ak-form-element-horizontal>
-            ${this.showExpiry ? this.renderExpiry() : html``}`;
+            ${this.showExpiry ? this.renderExpiry() : nothing}`;
     }
 }
 

--- a/web/src/admin/tokens/TokenListPage.ts
+++ b/web/src/admin/tokens/TokenListPage.ts
@@ -9,9 +9,8 @@ import "@patternfly/elements/pf-tooltip/pf-tooltip.js";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
 import { intentToLabel } from "#common/labels";
-import { formatElapsedTime } from "#common/temporal";
 
-import { PaginatedResponse, TableColumn } from "#elements/table/Table";
+import { PaginatedResponse, TableColumn, Timestamp } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
 
 import {
@@ -105,10 +104,7 @@ export class TokenListPage extends TablePage<Token> {
                     : html``}`,
             html`<a href="#/identity/users/${item.userObj?.pk}">${item.userObj?.username}</a>`,
             html`<ak-status-label type="warning" ?good=${item.expiring}></ak-status-label>`,
-            html`${item.expires && item.expiring
-                ? html`<div>${formatElapsedTime(item.expires)}</div>
-                      <small>${item.expires.toLocaleString()}</small>`
-                : msg("-")}`,
+            Timestamp(item.expires && item.expiring ? item.expires : null),
             html`${intentToLabel(item.intent ?? IntentEnum.Api)}`,
             html`
                 ${!item.managed

--- a/web/src/admin/tokens/TokenListPage.ts
+++ b/web/src/admin/tokens/TokenListPage.ts
@@ -26,20 +26,12 @@ import { customElement, property } from "lit/decorators.js";
 
 @customElement("ak-token-list")
 export class TokenListPage extends TablePage<Token> {
-    searchEnabled(): boolean {
-        return true;
-    }
-    pageTitle(): string {
-        return msg("Tokens");
-    }
-    pageDescription(): string {
-        return msg(
-            "Tokens are used throughout authentik for Email validation stages, Recovery keys and API access.",
-        );
-    }
-    pageIcon(): string {
-        return "pf-icon pf-icon-security";
-    }
+    protected override searchEnabled = true;
+    public pageTitle = msg("Tokens");
+    public pageDescription = msg(
+        "Tokens are used throughout authentik for Email validation stages, Recovery keys and API access.",
+    );
+    public pageIcon = "pf-icon pf-icon-security";
 
     protected override rowLabel(item: Token): string | null {
         return item.identifier;

--- a/web/src/admin/tokens/TokenListPage.ts
+++ b/web/src/admin/tokens/TokenListPage.ts
@@ -58,7 +58,7 @@ export class TokenListPage extends TablePage<Token> {
         [msg("Expires?"), "expiring"],
         [msg("Expiry date"), "expires"],
         [msg("Intent"), "intent"],
-        [msg("Actions")],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     renderToolbarSelected(): TemplateResult {

--- a/web/src/admin/tokens/TokenListPage.ts
+++ b/web/src/admin/tokens/TokenListPage.ts
@@ -12,6 +12,7 @@ import { intentToLabel } from "#common/labels";
 
 import { PaginatedResponse, TableColumn, Timestamp } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     CoreApi,
@@ -21,7 +22,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { html, TemplateResult } from "lit";
+import { html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 @customElement("ak-token-list")
@@ -92,12 +93,12 @@ export class TokenListPage extends TablePage<Token> {
         `;
     }
 
-    row(item: Token): TemplateResult[] {
+    row(item: Token): SlottedTemplateResult[] {
         return [
             html`<div>${item.identifier}</div>
                 ${item.managed
                     ? html`<small>${msg("Token is managed by authentik.")}</small>`
-                    : html``}`,
+                    : nothing}`,
             html`<a href="#/identity/users/${item.userObj?.pk}">${item.userObj?.username}</a>`,
             html`<ak-status-label type="warning" ?good=${item.expiring}></ak-status-label>`,
             Timestamp(item.expires && item.expiring ? item.expires : null),

--- a/web/src/admin/tokens/TokenListPage.ts
+++ b/web/src/admin/tokens/TokenListPage.ts
@@ -52,16 +52,14 @@ export class TokenListPage extends TablePage<Token> {
         return new CoreApi(DEFAULT_CONFIG).coreTokensList(await this.defaultEndpointConfig());
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Identifier"), "identifier"),
-            new TableColumn(msg("User"), "user"),
-            new TableColumn(msg("Expires?"), "expiring"),
-            new TableColumn(msg("Expiry date"), "expires"),
-            new TableColumn(msg("Intent"), "intent"),
-            new TableColumn(msg("Actions")),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Identifier"), "identifier"],
+        [msg("User"), "user"],
+        [msg("Expires?"), "expiring"],
+        [msg("Expiry date"), "expires"],
+        [msg("Intent"), "intent"],
+        [msg("Actions")],
+    ];
 
     renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;

--- a/web/src/admin/tokens/TokenListPage.ts
+++ b/web/src/admin/tokens/TokenListPage.ts
@@ -118,7 +118,7 @@ export class TokenListPage extends TablePage<Token> {
                           <ak-token-form slot="form" .instancePk=${item.identifier}></ak-token-form>
                           <button slot="trigger" class="pf-c-button pf-m-plain">
                               <pf-tooltip position="top" content=${msg("Edit")}>
-                                  <i class="fas fa-edit"></i>
+                                  <i class="fas fa-edit" aria-hidden="true"></i>
                               </pf-tooltip>
                           </button>
                       </ak-forms-modal>`
@@ -127,7 +127,7 @@ export class TokenListPage extends TablePage<Token> {
                               position="top"
                               content=${msg("Editing is disabled for managed tokens")}
                           >
-                              <i class="fas fa-edit"></i>
+                              <i class="fas fa-edit" aria-hidden="true"></i>
                           </pf-tooltip>
                       </button>`}
                 <ak-rbac-object-permission-modal
@@ -140,7 +140,7 @@ export class TokenListPage extends TablePage<Token> {
                     identifier="${item.identifier}"
                 >
                     <pf-tooltip position="top" content=${msg("Copy token")}>
-                        <i class="fas fa-copy"></i>
+                        <i class="fas fa-copy" aria-hidden="true"></i>
                     </pf-tooltip>
                 </ak-token-copy-button>
             `,

--- a/web/src/admin/tokens/TokenListPage.ts
+++ b/web/src/admin/tokens/TokenListPage.ts
@@ -41,6 +41,10 @@ export class TokenListPage extends TablePage<Token> {
         return "pf-icon pf-icon-security";
     }
 
+    protected override rowLabel(item: Token): string | null {
+        return item.identifier;
+    }
+
     checkbox = true;
     clearOnRefresh = true;
 

--- a/web/src/admin/users/GroupSelectModal.ts
+++ b/web/src/admin/users/GroupSelectModal.ts
@@ -19,9 +19,7 @@ export class GroupSelectModal extends TableModal<Group> {
     checkbox = true;
     checkboxChip = true;
 
-    searchEnabled(): boolean {
-        return true;
-    }
+    protected override searchEnabled = true;
 
     @property()
     confirm!: (selectedItems: Group[]) => Promise<unknown>;

--- a/web/src/admin/users/GroupSelectModal.ts
+++ b/web/src/admin/users/GroupSelectModal.ts
@@ -5,11 +5,12 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, TableColumn } from "#elements/table/Table";
 import { TableModal } from "#elements/table/TableModal";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { CoreApi, Group } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import PFBanner from "@patternfly/patternfly/components/Banner/banner.css";
@@ -41,7 +42,7 @@ export class GroupSelectModal extends TableModal<Group> {
         [msg("Members"), ""],
     ];
 
-    row(item: Group): TemplateResult[] {
+    row(item: Group): SlottedTemplateResult[] {
         return [
             html`<div>
                 <div>${item.name}</div>
@@ -55,7 +56,7 @@ export class GroupSelectModal extends TableModal<Group> {
         return html`${item.name}`;
     }
 
-    renderModalInner(): TemplateResult {
+    renderModalInner(): SlottedTemplateResult {
         const willSuperuser = this.selectedElements.filter((g) => g.isSuperuser).length > 0;
         return html`<section class="pf-c-modal-box__header pf-c-page__main-section pf-m-light">
                 <div class="pf-c-content">
@@ -70,7 +71,7 @@ export class GroupSelectModal extends TableModal<Group> {
                           )}
                       </div>
                   `
-                : html``}
+                : nothing}
             <section class="pf-c-modal-box__body pf-m-light">${this.renderTable()}</section>
             <footer class="pf-c-modal-box__footer">
                 <ak-spinner-button

--- a/web/src/admin/users/GroupSelectModal.ts
+++ b/web/src/admin/users/GroupSelectModal.ts
@@ -37,13 +37,11 @@ export class GroupSelectModal extends TableModal<Group> {
         });
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Name"), "username"),
-            new TableColumn(msg("Superuser"), "is_superuser"),
-            new TableColumn(msg("Members"), ""),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Name"), "username"],
+        [msg("Superuser"), "is_superuser"],
+        [msg("Members"), ""],
+    ];
 
     row(item: Group): TemplateResult[] {
         return [

--- a/web/src/admin/users/UserApplicationTable.ts
+++ b/web/src/admin/users/UserApplicationTable.ts
@@ -4,13 +4,14 @@ import "@patternfly/elements/pf-tooltip/pf-tooltip.js";
 import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { applicationListStyle } from "#admin/applications/ApplicationListPage";
 
 import { Application, CoreApi, User } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
@@ -37,7 +38,7 @@ export class UserApplicationTable extends Table<Application> {
         [msg("Actions"), null, msg("Row Actions")],
     ];
 
-    row(item: Application): TemplateResult[] {
+    row(item: Application): SlottedTemplateResult[] {
         return [
             html`<ak-app-icon
                 name=${item.name}
@@ -45,7 +46,7 @@ export class UserApplicationTable extends Table<Application> {
             ></ak-app-icon>`,
             html`<a href="#/core/applications/${item.slug}">
                 <div>${item.name}</div>
-                ${item.metaPublisher ? html`<small>${item.metaPublisher}</small>` : html``}
+                ${item.metaPublisher ? html`<small>${item.metaPublisher}</small>` : nothing}
             </a>`,
             html`${item.group || msg("-")}`,
             item.provider
@@ -71,7 +72,7 @@ export class UserApplicationTable extends Table<Application> {
                               <i class="fas fa-share-square" aria-hidden="true"></i>
                           </pf-tooltip>
                       </a>`
-                    : html``}`,
+                    : nothing}`,
         ];
     }
 }

--- a/web/src/admin/users/UserApplicationTable.ts
+++ b/web/src/admin/users/UserApplicationTable.ts
@@ -61,14 +61,14 @@ export class UserApplicationTable extends Table<Application> {
                     </ak-application-form>
                     <button slot="trigger" class="pf-c-button pf-m-plain">
                         <pf-tooltip position="top" content=${msg("Edit")}>
-                            <i class="fas fa-edit"></i>
+                            <i class="fas fa-edit" aria-hidden="true"></i>
                         </pf-tooltip>
                     </button>
                 </ak-forms-modal>
                 ${item.launchUrl
                     ? html`<a href=${item.launchUrl} target="_blank" class="pf-c-button pf-m-plain">
                           <pf-tooltip position="top" content=${msg("Open")}>
-                              <i class="fas fa-share-square"></i>
+                              <i class="fas fa-share-square" aria-hidden="true"></i>
                           </pf-tooltip>
                       </a>`
                     : html``}`,

--- a/web/src/admin/users/UserApplicationTable.ts
+++ b/web/src/admin/users/UserApplicationTable.ts
@@ -28,16 +28,14 @@ export class UserApplicationTable extends Table<Application> {
         });
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(""),
-            new TableColumn(msg("Name"), "name"),
-            new TableColumn(msg("Group"), "group"),
-            new TableColumn(msg("Provider")),
-            new TableColumn(msg("Provider Type")),
-            new TableColumn(msg("Actions")),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [""],
+        [msg("Name"), "name"],
+        [msg("Group"), "group"],
+        [msg("Provider")],
+        [msg("Provider Type")],
+        [msg("Actions")],
+    ];
 
     row(item: Application): TemplateResult[] {
         return [

--- a/web/src/admin/users/UserApplicationTable.ts
+++ b/web/src/admin/users/UserApplicationTable.ts
@@ -34,7 +34,7 @@ export class UserApplicationTable extends Table<Application> {
         [msg("Group"), "group"],
         [msg("Provider")],
         [msg("Provider Type")],
-        [msg("Actions")],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     row(item: Application): TemplateResult[] {

--- a/web/src/admin/users/UserAssignedGlobalPermissionsTable.ts
+++ b/web/src/admin/users/UserAssignedGlobalPermissionsTable.ts
@@ -7,6 +7,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { groupBy } from "#common/utils";
 
 import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { Permission, RbacApi } from "@goauthentik/api";
 
@@ -82,7 +83,7 @@ export class UserAssignedGlobalPermissionsTable extends Table<Permission> {
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: Permission): TemplateResult[] {
+    row(item: Permission): SlottedTemplateResult[] {
         return [
             html`${item.modelVerbose}`,
             html`${item.name}`,

--- a/web/src/admin/users/UserAssignedGlobalPermissionsTable.ts
+++ b/web/src/admin/users/UserAssignedGlobalPermissionsTable.ts
@@ -81,7 +81,7 @@ export class UserAssignedGlobalPermissionsTable extends Table<Permission> {
         return [
             html`${item.modelVerbose}`,
             html`${item.name}`,
-            html`<i class="fas fa-check pf-m-success"></i>`,
+            html`<i class="fas fa-check pf-m-success" aria-hidden="true"></i>`,
         ];
     }
 }

--- a/web/src/admin/users/UserAssignedGlobalPermissionsTable.ts
+++ b/web/src/admin/users/UserAssignedGlobalPermissionsTable.ts
@@ -36,13 +36,7 @@ export class UserAssignedGlobalPermissionsTable extends Table<Permission> {
         });
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Model"), "model"),
-            new TableColumn(msg("Permission"), ""),
-            new TableColumn(""),
-        ];
-    }
+    protected columns: TableColumn[] = [[msg("Model"), "model"], [msg("Permission"), ""], [""]];
 
     renderObjectCreate(): TemplateResult {
         return html`

--- a/web/src/admin/users/UserAssignedGlobalPermissionsTable.ts
+++ b/web/src/admin/users/UserAssignedGlobalPermissionsTable.ts
@@ -36,7 +36,12 @@ export class UserAssignedGlobalPermissionsTable extends Table<Permission> {
         });
     }
 
-    protected columns: TableColumn[] = [[msg("Model"), "model"], [msg("Permission"), ""], [""]];
+    protected columns: TableColumn[] = [
+        // ---
+        [msg("Model"), "model"],
+        [msg("Permission"), ""],
+        ["", null, msg("Assigned to user")],
+    ];
 
     renderObjectCreate(): TemplateResult {
         return html`

--- a/web/src/admin/users/UserAssignedObjectPermissionsTable.ts
+++ b/web/src/admin/users/UserAssignedObjectPermissionsTable.ts
@@ -5,6 +5,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { groupBy } from "#common/utils";
 
 import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { ExtraUserObjectPermission, ModelEnum, RbacApi } from "@goauthentik/api";
 
@@ -70,7 +71,7 @@ export class UserAssignedObjectPermissionsTable extends Table<ExtraUserObjectPer
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: ExtraUserObjectPermission): TemplateResult[] {
+    row(item: ExtraUserObjectPermission): SlottedTemplateResult[] {
         return [
             html`${item.modelVerbose}`,
             html`${item.name}`,

--- a/web/src/admin/users/UserAssignedObjectPermissionsTable.ts
+++ b/web/src/admin/users/UserAssignedObjectPermissionsTable.ts
@@ -33,14 +33,12 @@ export class UserAssignedObjectPermissionsTable extends Table<ExtraUserObjectPer
         });
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Model"), "model"),
-            new TableColumn(msg("Permission"), ""),
-            new TableColumn(msg("Object"), ""),
-            new TableColumn(""),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Model"), "model"],
+        [msg("Permission"), ""],
+        [msg("Object"), ""],
+        [""],
+    ];
 
     renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;

--- a/web/src/admin/users/UserAssignedObjectPermissionsTable.ts
+++ b/web/src/admin/users/UserAssignedObjectPermissionsTable.ts
@@ -84,7 +84,7 @@ export class UserAssignedObjectPermissionsTable extends Table<ExtraUserObjectPer
                   >
                       <pre>${item.objectPk}</pre>
                   </pf-tooltip>`}`,
-            html`<i class="fas fa-check pf-m-success"></i>`,
+            html`<i class="fas fa-check pf-m-success" aria-hidden="true"></i>`,
         ];
     }
 }

--- a/web/src/admin/users/UserDevicesTable.ts
+++ b/web/src/admin/users/UserDevicesTable.ts
@@ -42,17 +42,14 @@ export class UserDeviceTable extends Table<Device> {
             });
     }
 
-    columns(): TableColumn[] {
-        // prettier-ignore
-        return [
-            msg("Name"),
-            msg("Type"),
-            msg("Confirmed"),
-            msg("Created at"),
-            msg("Last updated at"),
-            msg("Last used at"),
-        ].map((th) => new TableColumn(th, ""));
-    }
+    protected columns: TableColumn[] = [
+        [msg("Name")],
+        [msg("Type")],
+        [msg("Confirmed")],
+        [msg("Created at")],
+        [msg("Last updated at")],
+        [msg("Last used at")],
+    ];
 
     async deleteWrapper(device: Device) {
         const api = new AuthenticatorsApi(DEFAULT_CONFIG);

--- a/web/src/admin/users/UserDevicesTable.ts
+++ b/web/src/admin/users/UserDevicesTable.ts
@@ -5,6 +5,7 @@ import { deviceTypeName } from "#common/labels";
 import { SentryIgnoredError } from "#common/sentry/index";
 
 import { PaginatedResponse, Table, TableColumn, Timestamp } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { AuthenticatorsApi, Device } from "@goauthentik/api";
 
@@ -98,7 +99,7 @@ export class UserDeviceTable extends Table<Device> {
         >`;
     }
 
-    row(item: Device): TemplateResult[] {
+    row(item: Device): SlottedTemplateResult[] {
         return [
             html`${item.name}`,
             html`<div>

--- a/web/src/admin/users/UserDevicesTable.ts
+++ b/web/src/admin/users/UserDevicesTable.ts
@@ -3,9 +3,8 @@ import "#elements/forms/DeleteBulkForm";
 import { DEFAULT_CONFIG } from "#common/api/config";
 import { deviceTypeName } from "#common/labels";
 import { SentryIgnoredError } from "#common/sentry/index";
-import { formatElapsedTime } from "#common/temporal";
 
-import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { PaginatedResponse, Table, TableColumn, Timestamp } from "#elements/table/Table";
 
 import { AuthenticatorsApi, Device } from "@goauthentik/api";
 
@@ -108,18 +107,9 @@ export class UserDeviceTable extends Table<Device> {
                 </div>
                 ${item.externalId ? html` <small>${item.externalId}</small> ` : nothing} `,
             html`${item.confirmed ? msg("Yes") : msg("No")}`,
-            html`${item.created.getTime() > 0
-                ? html`<div>${formatElapsedTime(item.created)}</div>
-                      <small>${item.created.toLocaleString()}</small>`
-                : html`-`}`,
-            html`${item.lastUpdated
-                ? html`<div>${formatElapsedTime(item.lastUpdated)}</div>
-                      <small>${item.lastUpdated.toLocaleString()}</small>`
-                : html`-`}`,
-            html`${item.lastUsed
-                ? html`<div>${formatElapsedTime(item.lastUsed)}</div>
-                      <small>${item.lastUsed.toLocaleString()}</small>`
-                : html`-`}`,
+            Timestamp(item.created),
+            Timestamp(item.lastUpdated),
+            Timestamp(item.lastUsed),
         ];
     }
 }

--- a/web/src/admin/users/UserListPage.ts
+++ b/web/src/admin/users/UserListPage.ts
@@ -26,6 +26,7 @@ import { CapabilitiesEnum, WithCapabilitiesConfig } from "#elements/mixins/capab
 import { getURLParam, updateURLParams } from "#elements/router/RouteMatch";
 import { PaginatedResponse, TableColumn, Timestamp } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
+import { SlottedTemplateResult } from "#elements/types";
 import { writeToClipboard } from "#elements/utils/writeToClipboard";
 
 import type { AdminInterface } from "#admin/AdminInterface/index.entrypoint";
@@ -33,7 +34,7 @@ import type { AdminInterface } from "#admin/AdminInterface/index.entrypoint";
 import { CoreApi, SessionUser, User, UserPath } from "@goauthentik/api";
 
 import { msg, str } from "@lit/localize";
-import { css, CSSResult, html, TemplateResult } from "lit";
+import { css, CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
@@ -198,7 +199,7 @@ export class UserListPage extends WithBrandConfig(WithCapabilitiesConfig(TablePa
                           </h4>
                       </div>
                   </div>`
-                : html``}
+                : nothing}
             <button ?disabled=${disabled} slot="trigger" class="pf-c-button pf-m-danger">
                 ${msg("Delete")}
             </button>
@@ -236,7 +237,7 @@ export class UserListPage extends WithBrandConfig(WithCapabilitiesConfig(TablePa
             </div>`;
     }
 
-    row(item: User): TemplateResult[] {
+    row(item: User): SlottedTemplateResult[] {
         const canImpersonate =
             this.can(CapabilitiesEnum.CanImpersonate) && item.pk !== this.me?.user.pk;
         return [
@@ -276,7 +277,7 @@ export class UserListPage extends WithBrandConfig(WithCapabilitiesConfig(TablePa
                               </button>
                           </ak-forms-modal>
                       `
-                    : html``}`,
+                    : nothing}`,
         ];
     }
 

--- a/web/src/admin/users/UserListPage.ts
+++ b/web/src/admin/users/UserListPage.ts
@@ -150,6 +150,14 @@ export class UserListPage extends WithBrandConfig(WithCapabilitiesConfig(TablePa
         return users;
     }
 
+    protected override rowLabel(item: User): string {
+        if (item.name) {
+            return msg(str`${item.username} (${item.name})`);
+        }
+
+        return item.username;
+    }
+
     protected columns: TableColumn[] = [
         [msg("Name"), "username"],
         [msg("Active"), "is_active"],

--- a/web/src/admin/users/UserListPage.ts
+++ b/web/src/admin/users/UserListPage.ts
@@ -151,15 +151,13 @@ export class UserListPage extends WithBrandConfig(WithCapabilitiesConfig(TablePa
         return users;
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Name"), "username"),
-            new TableColumn(msg("Active"), "is_active"),
-            new TableColumn(msg("Last login"), "last_login"),
-            new TableColumn(msg("Type"), "type"),
-            new TableColumn(msg("Actions")),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Name"), "username"],
+        [msg("Active"), "is_active"],
+        [msg("Last login"), "last_login"],
+        [msg("Type"), "type"],
+        [msg("Actions")],
+    ];
 
     renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;

--- a/web/src/admin/users/UserListPage.ts
+++ b/web/src/admin/users/UserListPage.ts
@@ -190,7 +190,7 @@ export class UserListPage extends WithBrandConfig(WithCapabilitiesConfig(TablePa
                 ? html`<div slot="notice" class="pf-c-form__alert">
                       <div class="pf-c-alert pf-m-inline pf-m-warning">
                           <div class="pf-c-alert__icon">
-                              <i class="fas fa-exclamation-circle"></i>
+                              <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
                           </div>
                           <h4 class="pf-c-alert__title">
                               ${msg(
@@ -257,7 +257,7 @@ export class UserListPage extends WithBrandConfig(WithCapabilitiesConfig(TablePa
                     <ak-user-form slot="form" .instancePk=${item.pk}> </ak-user-form>
                     <button slot="trigger" class="pf-c-button pf-m-plain">
                         <pf-tooltip position="top" content=${msg("Edit")}>
-                            <i class="fas fa-edit"></i>
+                            <i class="fas fa-edit" aria-hidden="true"></i>
                         </pf-tooltip>
                     </button>
                 </ak-forms-modal>

--- a/web/src/admin/users/UserListPage.ts
+++ b/web/src/admin/users/UserListPage.ts
@@ -412,9 +412,19 @@ export class UserListPage extends WithBrandConfig(WithCapabilitiesConfig(TablePa
     }
 
     protected renderSidebarBefore(): TemplateResult {
-        return html`<div class="pf-c-sidebar__panel pf-m-width-25">
+        return html`<aside
+            aria-labelledby="sidebar-left-panel-header"
+            class="pf-c-sidebar__panel pf-m-width-25"
+        >
             <div class="pf-c-card">
-                <div class="pf-c-card__title">${msg("User folders")}</div>
+                <div
+                    role="heading"
+                    aria-level="2"
+                    id="sidebar-left-panel-header"
+                    class="pf-c-card__title"
+                >
+                    ${msg("User folders")}
+                </div>
                 <div class="pf-c-card__body">
                     <ak-treeview
                         .items=${this.userPaths?.paths || []}
@@ -425,7 +435,7 @@ export class UserListPage extends WithBrandConfig(WithCapabilitiesConfig(TablePa
                     ></ak-treeview>
                 </div>
             </div>
-        </div>`;
+        </aside>`;
     }
 }
 

--- a/web/src/admin/users/UserListPage.ts
+++ b/web/src/admin/users/UserListPage.ts
@@ -156,7 +156,7 @@ export class UserListPage extends WithBrandConfig(WithCapabilitiesConfig(TablePa
         [msg("Active"), "is_active"],
         [msg("Last login"), "last_login"],
         [msg("Type"), "type"],
-        [msg("Actions")],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     renderToolbarSelected(): TemplateResult {

--- a/web/src/admin/users/UserListPage.ts
+++ b/web/src/admin/users/UserListPage.ts
@@ -89,18 +89,10 @@ export class UserListPage extends WithBrandConfig(WithCapabilitiesConfig(TablePa
     clearOnRefresh = true;
     supportsQL = true;
 
-    searchEnabled(): boolean {
-        return true;
-    }
-    pageTitle(): string {
-        return msg("Users");
-    }
-    pageDescription(): string {
-        return "";
-    }
-    pageIcon(): string {
-        return "pf-icon pf-icon-user";
-    }
+    protected override searchEnabled = true;
+    public pageTitle = msg("Users");
+    public pageDescription = "";
+    public pageIcon = "pf-icon pf-icon-user";
 
     @property()
     order = "last_login";
@@ -289,7 +281,7 @@ export class UserListPage extends WithBrandConfig(WithCapabilitiesConfig(TablePa
     }
 
     renderExpanded(item: User): TemplateResult {
-        return html`<td role="cell" colspan="3">
+        return html`<td colspan="3">
                 <div class="pf-c-table__expandable-row-content">
                     <dl class="pf-c-description-list pf-m-horizontal">
                         <div class="pf-c-description-list__group">

--- a/web/src/admin/users/UserListPage.ts
+++ b/web/src/admin/users/UserListPage.ts
@@ -16,7 +16,6 @@ import { PFSize } from "#common/enums";
 import { parseAPIResponseError } from "#common/errors/network";
 import { userTypeToLabel } from "#common/labels";
 import { MessageLevel } from "#common/messages";
-import { formatElapsedTime } from "#common/temporal";
 import { rootInterface } from "#common/theme";
 import { DefaultUIConfig, uiConfig } from "#common/ui/config";
 import { me } from "#common/users";
@@ -25,7 +24,7 @@ import { showAPIErrorMessage, showMessage } from "#elements/messages/MessageCont
 import { WithBrandConfig } from "#elements/mixins/branding";
 import { CapabilitiesEnum, WithCapabilitiesConfig } from "#elements/mixins/capabilities";
 import { getURLParam, updateURLParams } from "#elements/router/RouteMatch";
-import { PaginatedResponse, TableColumn } from "#elements/table/Table";
+import { PaginatedResponse, TableColumn, Timestamp } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
 import { writeToClipboard } from "#elements/utils/writeToClipboard";
 
@@ -246,10 +245,7 @@ export class UserListPage extends WithBrandConfig(WithCapabilitiesConfig(TablePa
                 <small>${item.name ? item.name : html`&lt;${msg("No name set")}&gt;`}</small>
             </a>`,
             html`<ak-status-label ?good=${item.isActive}></ak-status-label>`,
-            html`${item.lastLogin
-                ? html`<div>${formatElapsedTime(item.lastLogin)}</div>
-                      <small>${item.lastLogin.toLocaleString()}</small>`
-                : msg("-")}`,
+            Timestamp(item.lastLogin),
             html`${userTypeToLabel(item.type)}`,
             html`<ak-forms-modal>
                     <span slot="submit"> ${msg("Update")} </span>

--- a/web/src/admin/users/UserViewPage.ts
+++ b/web/src/admin/users/UserViewPage.ts
@@ -29,11 +29,11 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { EVENT_REFRESH } from "#common/constants";
 import { PFSize } from "#common/enums";
 import { userTypeToLabel } from "#common/labels";
-import { formatElapsedTime } from "#common/temporal";
 import { me } from "#common/users";
 
 import { AKElement } from "#elements/Base";
 import { WithCapabilitiesConfig } from "#elements/mixins/capabilities";
+import { Timestamp } from "#elements/table/shared";
 
 import { type DescriptionPair, renderDescriptionList } from "#components/DescriptionList";
 
@@ -149,14 +149,8 @@ export class UserViewPage extends WithCapabilitiesConfig(AKElement) {
             [msg("Username"), user.username],
             [msg("Name"), user.name],
             [msg("Email"), user.email || "-"],
-            [msg("Last login"), user.lastLogin
-                ? html`<div>${formatElapsedTime(user.lastLogin)}</div>
-                      <small>${user.lastLogin.toLocaleString()}</small>`
-                : html`${msg("-")}`],
-            [msg("Last password change"), user.passwordChangeDate
-                ? html`<div>${formatElapsedTime(user.passwordChangeDate)}</div>
-                      <small>${user.passwordChangeDate.toLocaleString()}</small>`
-                : html`${msg("-")}`],
+            [msg("Last login"), Timestamp(user.lastLogin)],
+            [msg("Last password change"), Timestamp(user.passwordChangeDate)],
             [msg("Active"), html`<ak-status-label type="warning" ?good=${user.isActive}></ak-status-label>`],
             [msg("Type"), userTypeToLabel(user.type)],
             [msg("Superuser"), html`<ak-status-label type="warning" ?good=${user.isSuperuser}></ak-status-label>`],

--- a/web/src/common/styles/authentik.css
+++ b/web/src/common/styles/authentik.css
@@ -106,6 +106,10 @@ html > form > input {
     text-rendering: auto;
     line-height: 1;
     vertical-align: middle;
+
+    &:has(+ span) {
+        margin-inline-end: 0.5em;
+    }
 }
 
 .pf-c-form-control {

--- a/web/src/common/styles/authentik.css
+++ b/web/src/common/styles/authentik.css
@@ -97,6 +97,19 @@ html > form > input {
 
 /* #endregion */
 
+/* #region Screen readers */
+
+.sr-only {
+    position: absolute;
+    left: -10000px;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+}
+
+/* #endregion */
+
 /* #region Icons */
 
 .pf-icon {

--- a/web/src/common/utils.ts
+++ b/web/src/common/utils.ts
@@ -32,17 +32,26 @@ export function truncate(string: string, length = 10): string {
     return string.length > length ? `${string.substring(0, length)}...` : string;
 }
 
-export function groupBy<T>(objects: T[], callback: (obj: T) => string): Array<[string, T[]]> {
-    const m = new Map<string, T[]>();
-    objects.forEach((obj) => {
-        const group = callback(obj);
-        if (!m.has(group)) {
-            m.set(group, []);
+export type GroupKeyCallback<T> = (item: T, index: number, array: T[]) => string;
+export type GroupResult<T> = [groupKey: string, items: T[]];
+
+export function groupBy<T>(items: T[], callback: GroupKeyCallback<T>): Array<GroupResult<T>> {
+    const map = new Map<string, T[]>();
+
+    items.forEach((item, index) => {
+        const groupKey = callback(item, index, items);
+        let tProviders = map.get(groupKey);
+
+        if (!tProviders) {
+            tProviders = [];
+
+            map.set(groupKey, tProviders);
         }
-        const tProviders = m.get(group) || [];
-        tProviders.push(obj);
+
+        tProviders.push(item);
     });
-    return Array.from(m).sort();
+
+    return Array.from(map).sort(([a], [b]) => a.localeCompare(b));
 }
 
 // Taken from python's string module

--- a/web/src/components/ak-event-info.ts
+++ b/web/src/components/ak-event-info.ts
@@ -271,12 +271,12 @@ export class EventInfo extends AKElement {
         if (diff) {
             diffBody = html`<div class="pf-l-split__item pf-m-fill">
                     <div class="pf-c-card__title">${msg("Changes made:")}</div>
-                    <table class="pf-c-table pf-m-compact pf-m-grid-md" role="grid">
+                    <table class="pf-c-table pf-m-compact pf-m-grid-md">
                         <thead>
-                            <tr role="row">
-                                <th role="columnheader" scope="col">${msg("Key")}</th>
-                                <th role="columnheader" scope="col">${msg("Previous value")}</th>
-                                <th role="columnheader" scope="col">${msg("New value")}</th>
+                            <tr>
+                                <th scope="col">${msg("Key")}</th>
+                                <th scope="col">${msg("Previous value")}</th>
+                                <th scope="col">${msg("New value")}</th>
                             </tr>
                         </thead>
                         <tbody role="rowgroup">
@@ -306,12 +306,12 @@ export class EventInfo extends AKElement {
 ${JSON.stringify(value.new_value, null, 4)}</pre
                                     >`;
                                 }
-                                return html` <tr role="row">
-                                    <td role="cell"><pre>${key}</pre></td>
-                                    <td role="cell">
+                                return html` <tr>
+                                    <td><pre>${key}</pre></td>
+                                    <td>
                                         <pre>${previousCol}</pre>
                                     </td>
-                                    <td role="cell">${newCol}</td>
+                                    <td>${newCol}</td>
                                 </tr>`;
                             })}
                         </tbody>

--- a/web/src/components/ak-event-info.ts
+++ b/web/src/components/ak-event-info.ts
@@ -11,7 +11,7 @@ import { SlottedTemplateResult } from "#elements/types";
 import { EventActions, FlowsApi } from "@goauthentik/api";
 
 import { msg, str } from "@lit/localize";
-import { css, CSSResult, html, TemplateResult } from "lit";
+import { css, CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { map } from "lit/directives/map.js";
 import { until } from "lit/directives/until.js";
@@ -267,7 +267,7 @@ export class EventInfo extends AKElement {
                 clear?: boolean;
             };
         };
-        let diffBody = html``;
+        let diffBody: SlottedTemplateResult = nothing;
         if (diff) {
             diffBody = html`<div class="pf-l-split__item pf-m-fill">
                     <div class="pf-c-card__title">${msg("Changes made:")}</div>
@@ -286,7 +286,7 @@ export class EventInfo extends AKElement {
                                     value.previous_value !== null
                                         ? JSON.stringify(value.previous_value, null, 4)
                                         : msg("-");
-                                let newCol = html``;
+                                let newCol: SlottedTemplateResult = nothing;
                                 if (value.add || value.remove) {
                                     newCol = html`<ul class="pf-c-list">
                                         ${(value.add || value.remove)?.map((item) => {

--- a/web/src/components/ak-page-navbar.ts
+++ b/web/src/components/ak-page-navbar.ts
@@ -360,7 +360,7 @@ export class AKPageNavbar
 
             const icon = this.icon.replaceAll("fa://", "fa ");
 
-            return html`<i class="accent-icon ${icon}"></i>`;
+            return html`<i class="accent-icon ${icon}" aria-hidden="true"></i>`;
         }
         return nothing;
     }

--- a/web/src/components/events/ObjectChangelog.ts
+++ b/web/src/components/events/ObjectChangelog.ts
@@ -83,7 +83,7 @@ export class ObjectChangelog extends Table<Event> {
     }
 
     renderExpanded(item: Event): TemplateResult {
-        return html` <td role="cell" colspan="4">
+        return html` <td colspan="4">
                 <div class="pf-c-table__expandable-row-content">
                     <ak-event-info .event=${item as EventWithContext}></ak-event-info>
                 </div>

--- a/web/src/components/events/ObjectChangelog.ts
+++ b/web/src/components/events/ObjectChangelog.ts
@@ -55,6 +55,10 @@ export class ObjectChangelog extends Table<Event> {
         });
     }
 
+    protected override rowLabel(item: Event): string {
+        return actionToLabel(item.action);
+    }
+
     protected columns: TableColumn[] = [
         [msg("Action"), "action"],
         [msg("User"), "enabled"],

--- a/web/src/components/events/ObjectChangelog.ts
+++ b/web/src/components/events/ObjectChangelog.ts
@@ -56,14 +56,12 @@ export class ObjectChangelog extends Table<Event> {
         });
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Action"), "action"),
-            new TableColumn(msg("User"), "enabled"),
-            new TableColumn(msg("Creation Date"), "created"),
-            new TableColumn(msg("Client IP"), "client_ip"),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Action"), "action"],
+        [msg("User"), "enabled"],
+        [msg("Creation Date"), "created"],
+        [msg("Client IP"), "client_ip"],
+    ];
 
     willUpdate(changedProperties: PropertyValues<this>) {
         if (changedProperties.has("targetModelName") && this.targetModelName) {

--- a/web/src/components/events/ObjectChangelog.ts
+++ b/web/src/components/events/ObjectChangelog.ts
@@ -7,9 +7,8 @@ import "#elements/buttons/SpinnerButton/index";
 import { DEFAULT_CONFIG } from "#common/api/config";
 import { EventWithContext } from "#common/events";
 import { actionToLabel } from "#common/labels";
-import { formatElapsedTime } from "#common/temporal";
 
-import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { PaginatedResponse, Table, TableColumn, Timestamp } from "#elements/table/Table";
 import { SlottedTemplateResult } from "#elements/types";
 
 import { EventGeo, renderEventUser } from "#admin/events/utils";
@@ -73,8 +72,7 @@ export class ObjectChangelog extends Table<Event> {
         return [
             html`${actionToLabel(item.action)}`,
             renderEventUser(item),
-            html`<div>${formatElapsedTime(item.created)}</div>
-                <small>${item.created.toLocaleString()}</small>`,
+            Timestamp(item.created),
             html`<div>${item.clientIp || msg("-")}</div>
                 <small>${EventGeo(item)}</small>`,
         ];

--- a/web/src/components/events/UserEvents.ts
+++ b/web/src/components/events/UserEvents.ts
@@ -36,6 +36,10 @@ export class UserEvents extends Table<Event> {
         });
     }
 
+    protected override rowLabel(item: Event): string {
+        return actionToLabel(item.action);
+    }
+
     protected columns: TableColumn[] = [
         [msg("Action"), "action"],
         [msg("User"), "enabled"],

--- a/web/src/components/events/UserEvents.ts
+++ b/web/src/components/events/UserEvents.ts
@@ -37,14 +37,12 @@ export class UserEvents extends Table<Event> {
         });
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Action"), "action"),
-            new TableColumn(msg("User"), "enabled"),
-            new TableColumn(msg("Creation Date"), "created"),
-            new TableColumn(msg("Client IP"), "client_ip"),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Action"), "action"],
+        [msg("User"), "enabled"],
+        [msg("Creation Date"), "created"],
+        [msg("Client IP"), "client_ip"],
+    ];
 
     row(item: EventWithContext): SlottedTemplateResult[] {
         return [

--- a/web/src/components/events/UserEvents.ts
+++ b/web/src/components/events/UserEvents.ts
@@ -7,9 +7,8 @@ import "#elements/buttons/SpinnerButton/index";
 import { DEFAULT_CONFIG } from "#common/api/config";
 import { EventWithContext } from "#common/events";
 import { actionToLabel } from "#common/labels";
-import { formatElapsedTime } from "#common/temporal";
 
-import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { PaginatedResponse, Table, TableColumn, Timestamp } from "#elements/table/Table";
 import { SlottedTemplateResult } from "#elements/types";
 
 import { renderEventUser } from "#admin/events/utils";
@@ -48,8 +47,7 @@ export class UserEvents extends Table<Event> {
         return [
             html`${actionToLabel(item.action)}`,
             renderEventUser(item),
-            html`<div>${formatElapsedTime(item.created)}</div>
-                <small>${item.created.toLocaleString()}</small>`,
+            Timestamp(item.created),
             html`<span>${item.clientIp || msg("-")}</span>`,
         ];
     }

--- a/web/src/components/events/UserEvents.ts
+++ b/web/src/components/events/UserEvents.ts
@@ -57,7 +57,7 @@ export class UserEvents extends Table<Event> {
     }
 
     renderExpanded(item: Event): TemplateResult {
-        return html` <td role="cell" colspan="4">
+        return html` <td colspan="4">
                 <div class="pf-c-table__expandable-row-content">
                     <ak-event-info .event=${item as EventWithContext}></ak-event-info>
                 </div>

--- a/web/src/elements/AppIcon.ts
+++ b/web/src/elements/AppIcon.ts
@@ -78,7 +78,7 @@ export class AppIcon extends AKElement implements IAppIcon {
         // prettier-ignore
         return match([this.name, this.icon])
             .with([undefined, undefined],
-                () => html`<div><i class="icon fas fa-question-circle"></i></div>`)
+                () => html`<div><i class="icon fas fa-question-circle" aria-hidden="true"></i></div>`)
             .with([P._, P.string.startsWith("fa://")],
                 ([_name, icon]) => html`<div><i class="icon fas ${icon.replaceAll("fa://", "")}"></i></div>`)
             .with([P._, P.string],

--- a/web/src/elements/TreeView.ts
+++ b/web/src/elements/TreeView.ts
@@ -4,7 +4,7 @@ import { AKElement } from "#elements/Base";
 import { setURLParams } from "#elements/router/RouteMatch";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
 import PFTreeView from "@patternfly/patternfly/components/TreeView/tree-view.css";
@@ -112,7 +112,7 @@ export class TreeViewNode extends AKElement {
                                           <i class="fas fa-angle-right" aria-hidden="true"></i>
                                       </span>
                                   </button>`
-                                : html``}
+                                : nothing}
                             <span class="pf-c-tree-view__node-icon">
                                 <i
                                     class="fas ${this.open ? "fa-folder-open" : "fa-folder"}"

--- a/web/src/elements/ak-dual-select/components/ak-dual-select-available-pane.ts
+++ b/web/src/elements/ak-dual-select/components/ak-dual-select-available-pane.ts
@@ -175,7 +175,7 @@ export class AkDualSelectAvailablePane extends CustomEmitterElement<DualSelectEv
                                             ><span>${label}</span>${this.selected.has(key)
                                                 ? html`<span
                                                       class="pf-c-dual-list-selector__item-text-selected-indicator"
-                                                      ><i class="fa fa-check"></i
+                                                      ><i class="fa fa-check" aria-hidden="true"></i
                                                   ></span>`
                                                 : nothing}</span
                                         ></span

--- a/web/src/elements/ak-dual-select/components/ak-dual-select-controls.ts
+++ b/web/src/elements/ak-dual-select/components/ak-dual-select-controls.ts
@@ -105,7 +105,7 @@ export class AkDualSelectControls extends CustomEmitterElement<DualSelectEventTy
                     @click=${() => this.dispatchCustomEvent(eventType)}
                     data-ouia-component-type="AK/Button"
                 >
-                    <i class="fa ${direction}"></i>
+                    <i class="fa ${direction}" aria-hidden="true"></i>
                 </button>
             </div>
         </div>`;

--- a/web/src/elements/ak-dual-select/components/ak-search-bar.ts
+++ b/web/src/elements/ak-dual-select/components/ak-search-bar.ts
@@ -50,7 +50,7 @@ export class AkSearchbar extends CustomEmitterElement(AKElement) {
                 <div class="pf-c-text-input-group__main pf-m-icon">
                     <span class="pf-c-text-input-group__text"
                         ><span class="pf-c-text-input-group__icon"
-                            ><i class="fa fa-search fa-fw"></i></span
+                            ><i class="fa fa-search fa-fw" aria-hidden="true"></i></span
                         ><input
                             type="search"
                             class="pf-c-text-input-group__text-input"

--- a/web/src/elements/ak-table/TableColumn.ts
+++ b/web/src/elements/ak-table/TableColumn.ts
@@ -85,14 +85,9 @@ export class TableColumn {
             "pf-m-selected": Boolean(this.host && isSelected),
         };
 
-        return html`<td
-            part="column-item"
-            role="columnheader"
-            scope="col"
-            class="${classMap(classes)}"
-        >
+        return html`<th part="column-item" scope="col" class="${classMap(classes)}">
             ${orderBy && this.orderBy ? this.sortButton(orderBy) : html`${this.value}`}
-        </td>`;
+        </th>`;
     }
 }
 

--- a/web/src/elements/ak-table/TableColumn.ts
+++ b/web/src/elements/ak-table/TableColumn.ts
@@ -71,7 +71,7 @@ export class TableColumn {
             <div class="pf-c-table__button-content">
                 <span part="column-text" class="pf-c-table__text">${this.value}</span>
                 <span part="column-sort" class="pf-c-table__sort-indicator">
-                    <i class="fas ${this.sortIndicator(orderBy)}"></i>
+                    <i class="fas ${this.sortIndicator(orderBy)}" aria-hidden="true"></i>
                 </span>
             </div>
         </button>`;

--- a/web/src/elements/ak-table/ak-select-table.ts
+++ b/web/src/elements/ak-table/ak-select-table.ts
@@ -182,13 +182,13 @@ export class SelectTable extends SimpleTable {
 
     public renderCheckbox(key: string | undefined) {
         if (key === undefined) {
-            return html`<td class="pf-c-table__check" role="cell"></td>`;
+            return html`<td class="pf-c-table__check"></td>`;
         }
         // The double `checked` there is not a typo. The first one ensures the input's DOM object
         // receives the state; the second ensures the input tag on the page reflects the state
         // accurately. See https://github.com/lit/lit-element/issues/601
         const checked = this.selected.includes(key);
-        return html`<td part="select-cell" class="pf-c-table__check" role="cell">
+        return html`<td part="select-cell" class="pf-c-table__check">
             <input
                 type="checkbox"
                 name="${key}"
@@ -209,10 +209,7 @@ export class SelectTable extends SimpleTable {
     public override renderRow(row: TableRow, _rowidx: number) {
         return html` <tr part="row">
             ${this.renderCheckbox(row.key)}
-            ${map(
-                row.content,
-                (col, idx) => html`<td part="cell cell-${idx}" role="cell">${col}</td>`,
-            )}
+            ${map(row.content, (col, idx) => html`<td part="cell cell-${idx}">${col}</td>`)}
         </tr>`;
     }
 
@@ -233,7 +230,7 @@ export class SelectTable extends SimpleTable {
                   this.selected.filter((i) => !values.includes(i));
         };
 
-        return html`<td part="select-all-header" class="pf-c-table__check" role="cell">
+        return html`<td part="select-all-header" class="pf-c-table__check">
             <input
                 part="select-all-input"
                 name="select-all-input"

--- a/web/src/elements/ak-table/ak-simple-table.ts
+++ b/web/src/elements/ak-table/ak-simple-table.ts
@@ -145,10 +145,7 @@ export class SimpleTable extends AKElement implements ISimpleTable {
 
     public renderRow(row: TableRow, _rownum: number) {
         return html` <tr part="row">
-            ${map(
-                row.content,
-                (col, idx) => html`<td part="cell cell-${idx}" role="cell">${col}</td>`,
-            )}
+            ${map(row.content, (col, idx) => html`<td part="cell cell-${idx}">${col}</td>`)}
         </tr>`;
     }
 
@@ -177,7 +174,7 @@ export class SimpleTable extends AKElement implements ISimpleTable {
 
     public renderBody() {
         // prettier-ignore
-        return this.content.kind === 'flat' 
+        return this.content.kind === 'flat'
             ? this.renderRows(this.content.content)
             : this.renderRowGroups(this.content.content);
     }

--- a/web/src/elements/ak-table/ak-simple-table.ts
+++ b/web/src/elements/ak-table/ak-simple-table.ts
@@ -159,9 +159,7 @@ export class SimpleTable extends AKElement implements ISimpleTable {
     public renderRowGroup({ group, content }: TableGroup) {
         return html`<thead part="group-header">
                 <tr part="group-row">
-                    <td role="columnheader" scope="row" colspan="200" part="group-head">
-                        ${group}
-                    </td>
+                    <td colspan="200" part="group-head">${group}</td>
                 </tr>
             </thead>
             ${this.renderRows(content)}`;

--- a/web/src/elements/ak-table/types.ts
+++ b/web/src/elements/ak-table/types.ts
@@ -1,5 +1,7 @@
 import { TableColumn } from "./TableColumn.js";
 
+import { SlottedTemplateResult } from "#elements/types";
+
 import { TemplateResult } from "lit";
 
 // authentik's standard tables (ak-simple-table, ak-select-table) all take a variety of types, the
@@ -17,7 +19,7 @@ import { TemplateResult } from "lit";
  */
 export type TableRow = {
     key?: string;
-    content: TemplateResult[];
+    content: SlottedTemplateResult[];
     // expansion?: () => TemplateResult;
 };
 

--- a/web/src/elements/buttons/ModalButton.ts
+++ b/web/src/elements/buttons/ModalButton.ts
@@ -27,8 +27,9 @@ export const MODAL_BUTTON_STYLES = css`
         text-align: left;
         font-size: var(--pf-global--FontSize--md);
 
-        /* Fixes issue where browser inherits cursor from parent, typically a button. */
+        /* Fixes issue where browser inherits from modal parent with more restrictive style. */
         cursor: initial;
+        user-select: text;
     }
     .pf-c-modal-box > .pf-c-button + * {
         margin-right: 0;

--- a/web/src/elements/cards/AggregatePromiseCard.ts
+++ b/web/src/elements/cards/AggregatePromiseCard.ts
@@ -48,10 +48,12 @@ export class AggregatePromiseCard extends AggregateCard implements IAggregatePro
         }
         try {
             const value = await this.promise;
-            return html`<i class="fa fa-check-circle"></i>&nbsp;${value.toString()}`;
+            return html`<i class="fa fa-check-circle" aria-hidden="true"></i
+                >&nbsp;${value.toString()}`;
         } catch (error: unknown) {
             console.warn(error);
-            return html`<i class="fa fa-exclamation-circle"></i>&nbsp;${this.failureMessage}`;
+            return html`<i class="fa fa-exclamation-circle" aria-hidden="true"></i>&nbsp;${this
+                    .failureMessage}`;
         }
     }
 

--- a/web/src/elements/charts/Chart.ts
+++ b/web/src/elements/charts/Chart.ts
@@ -32,7 +32,7 @@ import {
 } from "chart.js";
 
 import { msg } from "@lit/localize";
-import { css, CSSResult, html, TemplateResult } from "lit";
+import { css, CSSResult, html, nothing, TemplateResult } from "lit";
 import { property, state } from "lit/decorators.js";
 
 Chart.register(Legend, Tooltip);
@@ -208,8 +208,8 @@ export abstract class AKChart<T> extends AKElement {
                               <p slot="body">${pluckErrorDetail(this.error)}</p>
                           </ak-empty-state>
                       `
-                    : html`${this.chart ? html`` : html`<ak-empty-state loading></ak-empty-state>`}`}
-                ${this.centerText ? html` <span>${this.centerText}</span> ` : html``}
+                    : html`${this.chart ? nothing : html`<ak-empty-state loading></ak-empty-state>`}`}
+                ${this.centerText ? html` <span>${this.centerText}</span> ` : nothing}
                 <canvas style="${this.chart === undefined ? "display: none;" : ""}"></canvas>
             </div>
         `;

--- a/web/src/elements/chips/Chip.ts
+++ b/web/src/elements/chips/Chip.ts
@@ -3,7 +3,7 @@ import "@patternfly/elements/pf-tooltip/pf-tooltip.js";
 import { AKElement } from "#elements/Base";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
@@ -43,7 +43,7 @@ export class Chip extends AKElement {
                               <i class="fas fa-times" aria-hidden="true"></i>
                           </pf-tooltip>
                       </button>`
-                    : html``}
+                    : nothing}
             </div>
         </li>`;
     }

--- a/web/src/elements/events/LogViewer.ts
+++ b/web/src/elements/events/LogViewer.ts
@@ -77,14 +77,12 @@ export class LogViewer extends Table<LogEvent> {
         return html``;
     }
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Time")),
-            new TableColumn(msg("Level")),
-            new TableColumn(msg("Event")),
-            new TableColumn(msg("Logger")),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Time")],
+        [msg("Level")],
+        [msg("Event")],
+        [msg("Logger")],
+    ];
 
     statusForItem(item: LogEvent): string {
         switch (item.logLevel) {

--- a/web/src/elements/events/LogViewer.ts
+++ b/web/src/elements/events/LogViewer.ts
@@ -45,7 +45,7 @@ export class LogViewer extends Table<LogEvent> {
     }
 
     renderExpanded(item: LogEvent): TemplateResult {
-        return html`<td role="cell" colspan="4">
+        return html`<td colspan="4">
             <div class="pf-c-table__expandable-row-content">
                 <dl class="pf-c-description-list pf-m-horizontal">
                     <div class="pf-c-description-list__group">

--- a/web/src/elements/events/LogViewer.ts
+++ b/web/src/elements/events/LogViewer.ts
@@ -98,6 +98,10 @@ export class LogViewer extends Table<LogEvent> {
         }
     }
 
+    protected override rowLabel(item: LogEvent): string {
+        return formatElapsedTime(item.timestamp);
+    }
+
     row(item: LogEvent): TemplateResult[] {
         return [
             html`${formatElapsedTime(item.timestamp)}`,

--- a/web/src/elements/events/LogViewer.ts
+++ b/web/src/elements/events/LogViewer.ts
@@ -4,11 +4,12 @@ import "#elements/EmptyState";
 import { formatElapsedTime } from "#common/temporal";
 
 import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { LogEvent, LogLevelEnum } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import PFDescriptionList from "@patternfly/patternfly/components/DescriptionList/description-list.css";
@@ -73,8 +74,8 @@ export class LogViewer extends Table<LogEvent> {
         </td>`;
     }
 
-    renderToolbarContainer(): TemplateResult {
-        return html``;
+    renderToolbarContainer(): SlottedTemplateResult {
+        return nothing;
     }
 
     protected columns: TableColumn[] = [
@@ -102,7 +103,7 @@ export class LogViewer extends Table<LogEvent> {
         return formatElapsedTime(item.timestamp);
     }
 
-    row(item: LogEvent): TemplateResult[] {
+    row(item: LogEvent): SlottedTemplateResult[] {
         return [
             html`${formatElapsedTime(item.timestamp)}`,
             html`<ak-status-label

--- a/web/src/elements/forms/DeleteBulkForm.ts
+++ b/web/src/elements/forms/DeleteBulkForm.ts
@@ -7,11 +7,12 @@ import { MessageLevel } from "#common/messages";
 import { ModalButton } from "#elements/buttons/ModalButton";
 import { showMessage } from "#elements/messages/MessageContainer";
 import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { UsedBy, UsedByActionEnum } from "@goauthentik/api";
 
 import { msg, str } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { until } from "lit/directives/until.js";
 
@@ -61,14 +62,14 @@ export class DeleteObjectsTable<T extends object> extends Table<T> {
         return this.metadata(this.objects[0]).map((element) => [element.key]);
     }
 
-    row(item: T): TemplateResult[] {
+    row(item: T): SlottedTemplateResult[] {
         return this.metadata(item).map((element) => {
             return html`${element.value}`;
         });
     }
 
-    renderToolbarContainer(): TemplateResult {
-        return html``;
+    renderToolbarContainer(): SlottedTemplateResult {
+        return nothing;
     }
 
     firstUpdated(): void {
@@ -87,7 +88,7 @@ export class DeleteObjectsTable<T extends object> extends Table<T> {
             <div class="pf-c-table__expandable-row-content">
                 ${this.usedBy
                     ? until(handler(), html`<ak-spinner size=${PFSize.Large}></ak-spinner>`)
-                    : html``}
+                    : nothing}
             </div>
         </td>`;
     }

--- a/web/src/elements/forms/DeleteBulkForm.ts
+++ b/web/src/elements/forms/DeleteBulkForm.ts
@@ -52,10 +52,8 @@ export class DeleteObjectsTable<T extends object> extends Table<T> {
         });
     }
 
-    columns(): TableColumn[] {
-        return this.metadata(this.objects[0]).map((element) => {
-            return new TableColumn(element.key);
-        });
+    protected get columns(): TableColumn[] {
+        return this.metadata(this.objects[0]).map((element) => [element.key]);
     }
 
     row(item: T): TemplateResult[] {

--- a/web/src/elements/forms/DeleteBulkForm.ts
+++ b/web/src/elements/forms/DeleteBulkForm.ts
@@ -83,7 +83,7 @@ export class DeleteObjectsTable<T extends object> extends Table<T> {
             }
             return this.renderUsedBy(this.usedByData.get(item) || []);
         };
-        return html`<td role="cell" colspan="2">
+        return html`<td colspan="2">
             <div class="pf-c-table__expandable-row-content">
                 ${this.usedBy
                     ? until(handler(), html`<ak-spinner size=${PFSize.Large}></ak-spinner>`)

--- a/web/src/elements/forms/DeleteBulkForm.ts
+++ b/web/src/elements/forms/DeleteBulkForm.ts
@@ -51,6 +51,11 @@ export class DeleteObjectsTable<T extends object> extends Table<T> {
             results: this.objects,
         });
     }
+    protected override rowLabel(item: T): string | null {
+        const name = "name" in item && typeof item.name === "string" ? item.name.trim() : null;
+
+        return name || null;
+    }
 
     protected get columns(): TableColumn[] {
         return this.metadata(this.objects[0]).map((element) => [element.key]);

--- a/web/src/elements/forms/DeleteForm.ts
+++ b/web/src/elements/forms/DeleteForm.ts
@@ -10,7 +10,7 @@ import { showMessage } from "#elements/messages/MessageContainer";
 import { UsedBy, UsedByActionEnum } from "@goauthentik/api";
 
 import { msg, str } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { until } from "lit/directives/until.js";
 
@@ -93,7 +93,7 @@ export class DeleteForm extends ModalButton {
                 ? until(
                       this.usedBy().then((usedBy) => {
                           if (usedBy.length < 1) {
-                              return html``;
+                              return nothing;
                           }
                           return html`
                               <section class="pf-c-modal-box__body pf-m-light">
@@ -132,7 +132,7 @@ export class DeleteForm extends ModalButton {
                           `;
                       }),
                   )
-                : html``}
+                : nothing}
             <footer class="pf-c-modal-box__footer">
                 <ak-spinner-button
                     .callAction=${() => {

--- a/web/src/elements/messages/Message.ts
+++ b/web/src/elements/messages/Message.ts
@@ -117,7 +117,7 @@ export class Message extends AKElement {
                 })}"
             >
                 <div class="pf-c-alert__icon">
-                    <i class="${LevelIconMap[level]}"></i>
+                    <i class="${LevelIconMap[level]}" aria-hidden="true"></i>
                 </div>
                 <p class="pf-c-alert__title" id="message-title">
                     <slot></slot>

--- a/web/src/elements/notifications/NotificationDrawer.ts
+++ b/web/src/elements/notifications/NotificationDrawer.ts
@@ -12,11 +12,12 @@ import { me } from "#common/users";
 import { AKElement } from "#elements/Base";
 import { showMessage } from "#elements/messages/MessageContainer";
 import { PaginatedResponse } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { EventsApi, Notification } from "@goauthentik/api";
 
 import { msg, str } from "@lit/localize";
-import { css, CSSResult, html, TemplateResult } from "lit";
+import { css, CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
@@ -176,9 +177,9 @@ export class NotificationDrawer extends AKElement {
         </ak-empty-state>`;
     }
 
-    render(): TemplateResult {
+    render(): SlottedTemplateResult {
         if (!this.notifications) {
-            return html``;
+            return nothing;
         }
         return html`<div class="pf-c-drawer__body pf-m-no-padding">
             <div class="pf-c-notification-drawer">

--- a/web/src/elements/notifications/NotificationDrawer.ts
+++ b/web/src/elements/notifications/NotificationDrawer.ts
@@ -109,7 +109,7 @@ export class NotificationDrawer extends AKElement {
                         href="${globalAK().api.base}if/admin/#/events/log/${item.event?.pk}"
                     >
                         <pf-tooltip position="top" content=${msg("Show details")}>
-                            <i class="fas fa-share-square"></i>
+                            <i class="fas fa-share-square" aria-hidden="true"></i>
                         </pf-tooltip>
                     </a>
                 `}
@@ -135,7 +135,7 @@ export class NotificationDrawer extends AKElement {
                             });
                     }}
                 >
-                    <i class="fas fa-times"></i>
+                    <i class="fas fa-times" aria-hidden="true"></i>
                 </button>
             </div>
             <p class="pf-c-notification-drawer__list-item-description">${item.body}</p>

--- a/web/src/elements/oauth/UserAccessTokenList.ts
+++ b/web/src/elements/oauth/UserAccessTokenList.ts
@@ -6,6 +6,7 @@ import "#elements/forms/DeleteBulkForm";
 import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, Table, TableColumn, Timestamp } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { ExpiringBaseGrantModel, Oauth2Api, TokenModel } from "@goauthentik/api";
 
@@ -82,7 +83,7 @@ export class UserOAuthAccessTokenList extends Table<TokenModel> {
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: TokenModel): TemplateResult[] {
+    row(item: TokenModel): SlottedTemplateResult[] {
         return [
             html`<a href="#/core/providers/${item.provider?.pk}"> ${item.provider?.name} </a>`,
             html`<ak-status-label

--- a/web/src/elements/oauth/UserAccessTokenList.ts
+++ b/web/src/elements/oauth/UserAccessTokenList.ts
@@ -34,6 +34,10 @@ export class UserOAuthAccessTokenList extends Table<TokenModel> {
     checkbox = true;
     order = "-expires";
 
+    protected override rowLabel(item: TokenModel): string | null {
+        return item.provider?.name ?? null;
+    }
+
     protected columns: TableColumn[] = [
         [msg("Provider"), "provider"],
         [msg("Revoked?"), "revoked"],

--- a/web/src/elements/oauth/UserAccessTokenList.ts
+++ b/web/src/elements/oauth/UserAccessTokenList.ts
@@ -46,7 +46,7 @@ export class UserOAuthAccessTokenList extends Table<TokenModel> {
     ];
 
     renderExpanded(item: TokenModel): TemplateResult {
-        return html` <td role="cell" colspan="4">
+        return html` <td colspan="4">
                 <div class="pf-c-table__expandable-row-content">
                     <div class="pf-l-flex">
                         <div class="pf-l-flex__item">

--- a/web/src/elements/oauth/UserAccessTokenList.ts
+++ b/web/src/elements/oauth/UserAccessTokenList.ts
@@ -35,14 +35,12 @@ export class UserOAuthAccessTokenList extends Table<TokenModel> {
     checkbox = true;
     order = "-expires";
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Provider"), "provider"),
-            new TableColumn(msg("Revoked?"), "revoked"),
-            new TableColumn(msg("Expires"), "expires"),
-            new TableColumn(msg("Scopes"), "scope"),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Provider"), "provider"],
+        [msg("Revoked?"), "revoked"],
+        [msg("Expires"), "expires"],
+        [msg("Scopes"), "scope"],
+    ];
 
     renderExpanded(item: TokenModel): TemplateResult {
         return html` <td role="cell" colspan="4">

--- a/web/src/elements/oauth/UserAccessTokenList.ts
+++ b/web/src/elements/oauth/UserAccessTokenList.ts
@@ -4,9 +4,8 @@ import "#elements/chips/ChipGroup";
 import "#elements/forms/DeleteBulkForm";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
-import { formatElapsedTime } from "#common/temporal";
 
-import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { PaginatedResponse, Table, TableColumn, Timestamp } from "#elements/table/Table";
 
 import { ExpiringBaseGrantModel, Oauth2Api, TokenModel } from "@goauthentik/api";
 
@@ -88,10 +87,7 @@ export class UserOAuthAccessTokenList extends Table<TokenModel> {
                 good-label=${msg("No")}
                 bad-label=${msg("Yes")}
             ></ak-status-label>`,
-            html`${item.expires
-                ? html`<div>${formatElapsedTime(item.expires)}</div>
-                      <small>${item.expires.toLocaleString()}</small>`
-                : msg("-")}`,
+            Timestamp(item.expires),
             html`<ak-chip-group>
                 ${item.scope.sort().map((scope) => {
                     return html`<ak-chip>${scope}</ak-chip>`;

--- a/web/src/elements/oauth/UserRefreshTokenList.ts
+++ b/web/src/elements/oauth/UserRefreshTokenList.ts
@@ -35,6 +35,10 @@ export class UserOAuthRefreshTokenList extends Table<TokenModel> {
     clearOnRefresh = true;
     order = "-expires";
 
+    protected override rowLabel(item: TokenModel): string | null {
+        return item.provider?.name ?? null;
+    }
+
     protected columns: TableColumn[] = [
         [msg("Provider"), "provider"],
         [msg("Revoked?"), "revoked"],

--- a/web/src/elements/oauth/UserRefreshTokenList.ts
+++ b/web/src/elements/oauth/UserRefreshTokenList.ts
@@ -6,6 +6,7 @@ import "#elements/forms/DeleteBulkForm";
 import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, Table, TableColumn, Timestamp } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { ExpiringBaseGrantModel, Oauth2Api, TokenModel } from "@goauthentik/api";
 
@@ -83,7 +84,7 @@ export class UserOAuthRefreshTokenList extends Table<TokenModel> {
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: TokenModel): TemplateResult[] {
+    row(item: TokenModel): SlottedTemplateResult[] {
         return [
             html`<a href="#/core/providers/${item.provider?.pk}"> ${item.provider?.name} </a>`,
             html`<ak-status-label

--- a/web/src/elements/oauth/UserRefreshTokenList.ts
+++ b/web/src/elements/oauth/UserRefreshTokenList.ts
@@ -47,7 +47,7 @@ export class UserOAuthRefreshTokenList extends Table<TokenModel> {
     ];
 
     renderExpanded(item: TokenModel): TemplateResult {
-        return html` <td role="cell" colspan="4">
+        return html` <td colspan="4">
                 <div class="pf-c-table__expandable-row-content">
                     <div class="pf-l-flex">
                         <div class="pf-l-flex__item">

--- a/web/src/elements/oauth/UserRefreshTokenList.ts
+++ b/web/src/elements/oauth/UserRefreshTokenList.ts
@@ -36,14 +36,12 @@ export class UserOAuthRefreshTokenList extends Table<TokenModel> {
     clearOnRefresh = true;
     order = "-expires";
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Provider"), "provider"),
-            new TableColumn(msg("Revoked?"), "revoked"),
-            new TableColumn(msg("Expires"), "expires"),
-            new TableColumn(msg("Scopes"), "scope"),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Provider"), "provider"],
+        [msg("Revoked?"), "revoked"],
+        [msg("Expires"), "expires"],
+        [msg("Scopes"), "scope"],
+    ];
 
     renderExpanded(item: TokenModel): TemplateResult {
         return html` <td role="cell" colspan="4">

--- a/web/src/elements/oauth/UserRefreshTokenList.ts
+++ b/web/src/elements/oauth/UserRefreshTokenList.ts
@@ -4,9 +4,8 @@ import "#elements/chips/ChipGroup";
 import "#elements/forms/DeleteBulkForm";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
-import { formatElapsedTime } from "#common/temporal";
 
-import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { PaginatedResponse, Table, TableColumn, Timestamp } from "#elements/table/Table";
 
 import { ExpiringBaseGrantModel, Oauth2Api, TokenModel } from "@goauthentik/api";
 
@@ -89,10 +88,7 @@ export class UserOAuthRefreshTokenList extends Table<TokenModel> {
                 good-label=${msg("No")}
                 bad-label=${msg("Yes")}
             ></ak-status-label>`,
-            html`${item.expires
-                ? html`<div>${formatElapsedTime(item.expires)}</div>
-                      <small>${item.expires.toLocaleString()}</small>`
-                : msg("-")}`,
+            Timestamp(item.expires),
             html`<ak-chip-group>
                 ${item.scope.sort().map((scope) => {
                     return html`<ak-chip>${scope}</ak-chip>`;

--- a/web/src/elements/router/Route.ts
+++ b/web/src/elements/router/Route.ts
@@ -1,6 +1,8 @@
 import "#elements/EmptyState";
 
-import { html, TemplateResult } from "lit";
+import { SlottedTemplateResult } from "#elements/types";
+
+import { html, nothing, TemplateResult } from "lit";
 import { until } from "lit/directives/until.js";
 
 export const SLUG_REGEX = "[-a-zA-Z0-9_]+";
@@ -15,7 +17,7 @@ export class Route {
     url: RegExp;
 
     private element?: TemplateResult;
-    private callback?: (args: RouteArgs) => Promise<TemplateResult>;
+    private callback?: (args: RouteArgs) => Promise<SlottedTemplateResult>;
 
     constructor(url: RegExp, callback?: (args: RouteArgs) => Promise<TemplateResult>) {
         this.url = url;
@@ -30,7 +32,7 @@ export class Route {
             } else {
                 window.location.hash = to;
             }
-            return html``;
+            return nothing;
         };
         return this;
     }

--- a/web/src/elements/sync/SyncObjectForm.ts
+++ b/web/src/elements/sync/SyncObjectForm.ts
@@ -142,7 +142,7 @@ export class SyncObjectForm extends Form<SyncObjectRequest> {
                     )}
                 </p>
             </ak-form-element-horizontal>
-            ${this.result ? this.renderResult() : html``}`;
+            ${this.result ? this.renderResult() : nothing}`;
     }
 }
 

--- a/web/src/elements/sync/SyncStatusCard.ts
+++ b/web/src/elements/sync/SyncStatusCard.ts
@@ -104,7 +104,7 @@ export class SyncStatusCard extends AKElement {
                             });
                         }}
                     >
-                        <i class="fa fa-sync"></i>
+                        <i class="fa fa-sync" aria-hidden="true"></i>
                     </button>
                 </div>
                 <div class="pf-c-card__title">${msg("Sync status")}</div>

--- a/web/src/elements/table/Table.ts
+++ b/web/src/elements/table/Table.ts
@@ -116,9 +116,16 @@ export abstract class Table<T extends object>
     protected abstract apiEndpoint(): Promise<PaginatedResponse<T>>;
     /**
      * The columns to display in the table.
+     *
+     * @abstract
      */
     protected abstract columns: TableColumn[];
 
+    /**
+     * Render a row for a given item.
+     *
+     * @abstract
+     */
     protected abstract row(item: T): SlottedTemplateResult[];
 
     #loading = false;
@@ -378,11 +385,7 @@ export abstract class Table<T extends object>
     protected rowLabel(item: T): string | null {
         const name = "name" in item && typeof item.name === "string" ? item.name.trim() : null;
 
-        if (!name) {
-            return null;
-        }
-
-        return msg(str`${name}`);
+        return name || null;
     }
 
     private renderRows(): SlottedTemplateResult | SlottedTemplateResult[] {

--- a/web/src/elements/table/Table.ts
+++ b/web/src/elements/table/Table.ts
@@ -139,10 +139,10 @@ export abstract class Table<T extends object>
     //#region Properties
 
     @property({ type: String })
-    public toolbarLabel = msg("Table actions");
+    public toolbarLabel: string | null = null;
 
     @property({ type: String })
-    public label?: string;
+    public label: string | null = null;
 
     @property({ attribute: false })
     public data?: PaginatedResponse<T>;
@@ -245,7 +245,7 @@ export abstract class Table<T extends object>
         super.connectedCallback();
         this.addEventListener(EVENT_REFRESH, this.#refreshListener);
 
-        if (this.searchEnabled()) {
+        if (this.searchEnabled) {
             this.search = getURLParam(this.#searchParam, "");
         }
     }
@@ -279,7 +279,7 @@ export abstract class Table<T extends object>
             ordering: this.order,
             page: this.page,
             pageSize: (await uiConfig()).pagination.perPage,
-            search: this.searchEnabled() ? this.search || "" : undefined,
+            search: this.searchEnabled ? this.search || "" : undefined,
         };
     }
 
@@ -589,7 +589,7 @@ export abstract class Table<T extends object>
                         ? `${groupHeaderID} ${columnHeaderID}`
                         : columnHeaderID;
 
-                    return html`<td headers=${headers} role="cell">${column}</td>`;
+                    return html`<td headers=${headers}>${column}</td>`;
                 })}
             </tr>
             <tr
@@ -628,7 +628,9 @@ export abstract class Table<T extends object>
     }
 
     protected renderToolbarContainer(): SlottedTemplateResult {
-        return html`<header class="pf-c-toolbar" role="toolbar" aria-label="${this.toolbarLabel}">
+        const label = this.toolbarLabel ?? msg(str`${this.label ?? "Table"} actions`);
+
+        return html`<header class="pf-c-toolbar" role="toolbar" aria-label="${label}">
             <div role="presentation" class="pf-c-toolbar__content">
                 ${this.renderSearch()}
                 <div role="presentation" class="pf-c-toolbar__bulk-select">
@@ -655,12 +657,10 @@ export abstract class Table<T extends object>
         this.fetch();
     };
 
-    protected searchEnabled(): boolean {
-        return false;
-    }
+    protected searchEnabled = false;
 
     protected renderSearch(): SlottedTemplateResult {
-        if (!this.searchEnabled()) {
+        if (!this.searchEnabled) {
             return nothing;
         }
 
@@ -773,6 +773,7 @@ export abstract class Table<T extends object>
 
         return html`
             <ak-table-pagination
+                label=${this.label}
                 class="pf-c-toolbar__item pf-m-pagination"
                 .pages=${this.data?.pagination}
                 .onPageChange=${handler}
@@ -790,7 +791,7 @@ export abstract class Table<T extends object>
         return html`${this.needChipGroup ? this.renderChipGroup() : nothing}
             ${this.renderToolbarContainer()}
             <table
-                aria-label=${this.label ? msg(str`Table of ${this.label}`) : msg("Table content")}
+                aria-label=${this.label ? msg(str`${this.label} table`) : msg("Table content")}
                 aria-rowcount=${totalItemCount}
                 class="pf-c-table pf-m-compact pf-m-grid-md pf-m-expandable"
             >

--- a/web/src/elements/table/Table.ts
+++ b/web/src/elements/table/Table.ts
@@ -782,7 +782,7 @@ export abstract class Table<T extends object>
 
         return html`
             <ak-table-pagination
-                label=${this.label}
+                label=${ifDefined(this.label || undefined)}
                 class="pf-c-toolbar__item pf-m-pagination"
                 .pages=${this.data?.pagination}
                 .onPageChange=${handler}

--- a/web/src/elements/table/Table.ts
+++ b/web/src/elements/table/Table.ts
@@ -710,7 +710,7 @@ export abstract class Table<T extends object>
         const indeterminate =
             pageItemCount !== 0 && selectedCount !== 0 && selectedCount < pageItemCount;
 
-        return html`<th class="pf-c-table__check" role="cell">
+        return html`<th class="pf-c-table__check" role="presentation">
             <input
                 ${ref(this.#selectAllCheckboxRef)}
                 name="select-all"
@@ -783,10 +783,11 @@ export abstract class Table<T extends object>
                 <thead aria-label=${msg("Column actions")}>
                     <tr role="presentation" class="pf-c-table__header-row">
                         ${this.checkbox ? this.renderAllOnThisPageCheckbox() : nothing}
-                        ${this.expandable ? html`<td role="cell"></td>` : nothing}
-                        ${this.columns.map(([label, orderBy], idx) =>
+                        ${this.expandable ? html`<td aria-hidden="true"></td>` : nothing}
+                        ${this.columns.map(([label, orderBy, ariaLabel], idx) =>
                             renderTableColumn({
                                 label,
+                                ariaLabel,
                                 orderBy,
                                 table: this,
                                 columnIndex: idx,

--- a/web/src/elements/table/Table.ts
+++ b/web/src/elements/table/Table.ts
@@ -66,6 +66,17 @@ export abstract class Table<T extends object>
         PFDropdown,
         PFPagination,
         css`
+            .pf-c-table {
+                --pf-c-table--cell--MinWidth: 9em;
+            }
+
+            td,
+            th {
+                &:last-child {
+                    white-space: nowrap;
+                }
+            }
+
             .pf-c-toolbar__group.pf-m-search-filter.ql {
                 flex-grow: 1;
             }

--- a/web/src/elements/table/Table.ts
+++ b/web/src/elements/table/Table.ts
@@ -68,6 +68,10 @@ export abstract class Table<T extends object>
         css`
             .pf-c-table {
                 --pf-c-table--cell--MinWidth: 9em;
+
+                .presentational {
+                    --pf-c-table--cell--MinWidth: 0;
+                }
             }
 
             td,
@@ -421,14 +425,9 @@ export abstract class Table<T extends object>
         return groups.map(([group, items], groupIndex) => {
             const groupHeaderID = `table-group-${groupIndex}`;
 
-            return html`<thead role="presentation">
+            return html`<thead>
                     <tr>
-                        <th
-                            id=${groupHeaderID}
-                            role="columnheader"
-                            scope="colgroup"
-                            colspan=${columnCount}
-                        >
+                        <th id=${groupHeaderID} scope="colgroup" colspan=${columnCount}>
                             ${group}
                         </th>
                     </tr>
@@ -572,7 +571,6 @@ export abstract class Table<T extends object>
 
         return html`
             <tr
-                aria-label=${rowLabel}
                 aria-selected=${selected ? "true" : "false"}
                 class="${classMap({
                     "pf-m-hoverable": this.checkbox || this.clickable,
@@ -583,23 +581,34 @@ export abstract class Table<T extends object>
             >
                 ${this.checkbox ? renderCheckbox() : nothing}
                 ${this.expandable ? renderExpansion() : nothing}
-                ${this.row(item).map((column, columnIndex) => {
+                ${this.row(item).map((cell, columnIndex) => {
+                    const [columnLabel] = this.columns[columnIndex];
+
                     const columnHeaderID = `table-header-${columnIndex}`;
                     const headers = groupHeaderID
                         ? `${groupHeaderID} ${columnHeaderID}`
                         : columnHeaderID;
 
-                    return html`<td headers=${headers}>${column}</td>`;
+                    return html`<td
+                        class=${classMap({
+                            presentational: !columnLabel,
+                        })}
+                        headers=${headers}
+                    >
+                        ${cell}
+                    </td>`;
                 })}
             </tr>
-            <tr
-                class="pf-c-table__expandable-row ${classMap({
-                    "pf-m-expanded": expanded,
-                })}"
-            >
-                <td aria-hidden="true"></td>
-                ${expanded ? this.renderExpanded(item) : nothing}
-            </tr>
+            ${this.expandable
+                ? html` <tr
+                      class="pf-c-table__expandable-row ${classMap({
+                          "pf-m-expanded": expanded,
+                      })}"
+                  >
+                      <td aria-hidden="true"></td>
+                      ${expanded ? this.renderExpanded(item) : nothing}
+                  </tr>`
+                : nothing}
         `;
     }
 
@@ -796,7 +805,7 @@ export abstract class Table<T extends object>
                 class="pf-c-table pf-m-compact pf-m-grid-md pf-m-expandable"
             >
                 <thead aria-label=${msg("Column actions")}>
-                    <tr role="presentation" class="pf-c-table__header-row">
+                    <tr class="pf-c-table__header-row">
                         ${this.checkbox ? this.renderAllOnThisPageCheckbox() : nothing}
                         ${this.expandable ? html`<td aria-hidden="true"></td>` : nothing}
                         ${this.columns.map(([label, orderBy, ariaLabel], idx) =>

--- a/web/src/elements/table/TableColumn.ts
+++ b/web/src/elements/table/TableColumn.ts
@@ -49,6 +49,7 @@ export function renderTableColumn({
     columnIndex,
 }: TableColumnProps): TemplateResult {
     const classes = {
+        "presentational": !label,
         "pf-c-table__sort": !!orderBy,
         "pf-m-selected": table.order === orderBy || table.order === `-${orderBy}`,
     };
@@ -62,9 +63,11 @@ export function renderTableColumn({
 
     const direction = formatSortDirection(table, orderBy);
 
+    const resolvedLabel = ariaLabel && ariaLabel !== label ? ariaLabel : label;
+
     const content = orderBy
         ? html` <button
-              aria-label=${msg(str`Sort by ${label}`)}
+              aria-label=${msg(str`Sort by "${label}"`)}
               class="pf-c-table__button"
               @click=${sortButtonListener}
           >
@@ -79,9 +82,8 @@ export function renderTableColumn({
 
     return html`<th
         id=${formatColumnID(columnIndex)}
-        aria-label=${ifDefined(ariaLabel ?? label)}
+        aria-label=${ifDefined(resolvedLabel || undefined)}
         data-column-id=${ifDefined(orderBy ?? undefined)}
-        role="columnheader"
         scope="col"
         aria-sort=${direction}
         class="${classMap(classes)}"

--- a/web/src/elements/table/TableColumn.ts
+++ b/web/src/elements/table/TableColumn.ts
@@ -1,84 +1,89 @@
 import { TableLike } from "#elements/table/shared";
 
+import { msg, str } from "@lit/localize";
 import { html, TemplateResult } from "lit";
 import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
-type ARIASort = "ascending" | "descending" | "none" | "other";
+type SortDirection = "ascending" | "descending" | "none" | "other";
 
-export class TableColumn {
-    static formatColumnID = (columnIndex: number): string => `table-header-${columnIndex}`;
-
-    public title: string;
-    public orderBy?: string;
-
-    public onClick?: () => void;
-
-    public constructor(title: string, orderBy?: string) {
-        this.title = title;
-        this.orderBy = orderBy;
+function formatSortIndicator(direction: SortDirection): string {
+    switch (direction) {
+        case "ascending":
+            return "fa-long-arrow-alt-up";
+        case "descending":
+            return "fa-long-arrow-alt-down";
+        default:
+            return "fa-arrows-alt-v";
     }
+}
 
-    //#region Sorting
+function formatSortDirection(table: TableLike, orderBy?: string): SortDirection {
+    switch (table.order) {
+        case orderBy:
+            return "ascending";
+        case `-${orderBy}`:
+            return "descending";
+        default:
+            return "none";
+    }
+}
 
-    #sortButtonListener(table: TableLike): void {
-        if (!this.orderBy) {
-            return;
-        }
+export type TableColumn = [label: string, orderBy?: string];
 
-        table.order = table.order === this.orderBy ? `-${this.orderBy}` : this.orderBy;
+const formatColumnID = (columnIndex: number): string => `table-header-${columnIndex}`;
+
+export interface TableColumnProps {
+    label: string;
+    orderBy?: string;
+    table: TableLike;
+    columnIndex: number;
+}
+
+export function renderTableColumn({
+    label,
+    orderBy,
+    table,
+    columnIndex,
+}: TableColumnProps): TemplateResult {
+    const classes = {
+        "pf-c-table__sort": !!orderBy,
+        "pf-m-selected": table.order === orderBy || table.order === `-${orderBy}`,
+    };
+
+    const sortButtonListener = () => {
+        if (!orderBy) return;
+
+        table.order = table.order === orderBy ? `-${orderBy}` : orderBy;
         table.fetch();
-    }
+    };
 
-    private getSortIndicator(table: TableLike): string {
-        switch (this.getARIASort(table)) {
-            case "ascending":
-                return "fa-long-arrow-alt-up";
-            case "descending":
-                return "fa-long-arrow-alt-down";
-            default:
-                return "fa-arrows-alt-v";
-        }
-    }
+    const direction = formatSortDirection(table, orderBy);
 
-    public getARIASort(table: TableLike): ARIASort {
-        switch (table.order) {
-            case this.orderBy:
-                return "ascending";
-            case `-${this.orderBy}`:
-                return "descending";
-            default:
-                return "none";
-        }
-    }
+    const content = orderBy
+        ? html` <button
+              aria-label=${msg(str`Sort by ${label}`)}
+              class="pf-c-table__button"
+              @click=${sortButtonListener}
+          >
+              <div class="pf-c-table__button-content">
+                  <span class="pf-c-table__text">${label}</span>
+                  <span class="pf-c-table__sort-indicator">
+                      <i aria-hidden="true" class="fas ${formatSortIndicator(direction)}"></i>
+                  </span>
+              </div>
+          </button>`
+        : html`${label}`;
 
-    protected renderSortable(table: TableLike): TemplateResult {
-        return html` <button
-            class="pf-c-table__button"
-            @click=${() => this.#sortButtonListener(table)}
-        >
-            <div class="pf-c-table__button-content">
-                <span class="pf-c-table__text">${this.title}</span>
-                <span class="pf-c-table__sort-indicator">
-                    <i aria-hidden="true" class="fas ${this.getSortIndicator(table)}"></i>
-                </span>
-            </div>
-        </button>`;
-    }
-
-    public render(table: TableLike, columnIndex: number): TemplateResult {
-        const classes = {
-            "pf-c-table__sort": !!this.orderBy,
-            "pf-m-selected": table.order === this.orderBy || table.order === `-${this.orderBy}`,
-        };
-
-        return html`<th
-            id=${TableColumn.formatColumnID(columnIndex)}
-            role="columnheader"
-            scope="col"
-            aria-sort=${this.getARIASort(table)}
-            class="${classMap(classes)}"
-        >
-            ${this.orderBy ? this.renderSortable(table) : html`${this.title}`}
-        </th>`;
-    }
+    return html`<th
+        id=${formatColumnID(columnIndex)}
+        aria-label=${ifDefined(label)}
+        data-column-id=${ifDefined(orderBy)}
+        role="columnheader"
+        scope="col"
+        aria-sort=${direction}
+        class="${classMap(classes)}"
+    >
+        ${content}
+    </th>`;
 }

--- a/web/src/elements/table/TableColumn.ts
+++ b/web/src/elements/table/TableColumn.ts
@@ -18,7 +18,7 @@ function formatSortIndicator(direction: SortDirection): string {
     }
 }
 
-function formatSortDirection(table: TableLike, orderBy?: string): SortDirection {
+function formatSortDirection(table: TableLike, orderBy?: string | null): SortDirection {
     switch (table.order) {
         case orderBy:
             return "ascending";
@@ -29,14 +29,14 @@ function formatSortDirection(table: TableLike, orderBy?: string): SortDirection 
     }
 }
 
-export type TableColumn = [label: string, orderBy?: string, ariaLabel?: string];
+export type TableColumn = [label: string, orderBy?: string | null, ariaLabel?: string | null];
 
 const formatColumnID = (columnIndex: number): string => `table-header-${columnIndex}`;
 
 export interface TableColumnProps {
     label: string;
-    ariaLabel?: string;
-    orderBy?: string;
+    ariaLabel?: string | null;
+    orderBy?: string | null;
     table: TableLike;
     columnIndex: number;
 }
@@ -80,7 +80,7 @@ export function renderTableColumn({
     return html`<th
         id=${formatColumnID(columnIndex)}
         aria-label=${ifDefined(ariaLabel ?? label)}
-        data-column-id=${ifDefined(orderBy)}
+        data-column-id=${ifDefined(orderBy ?? undefined)}
         role="columnheader"
         scope="col"
         aria-sort=${direction}

--- a/web/src/elements/table/TableColumn.ts
+++ b/web/src/elements/table/TableColumn.ts
@@ -29,12 +29,13 @@ function formatSortDirection(table: TableLike, orderBy?: string): SortDirection 
     }
 }
 
-export type TableColumn = [label: string, orderBy?: string];
+export type TableColumn = [label: string, orderBy?: string, ariaLabel?: string];
 
 const formatColumnID = (columnIndex: number): string => `table-header-${columnIndex}`;
 
 export interface TableColumnProps {
     label: string;
+    ariaLabel?: string;
     orderBy?: string;
     table: TableLike;
     columnIndex: number;
@@ -42,6 +43,7 @@ export interface TableColumnProps {
 
 export function renderTableColumn({
     label,
+    ariaLabel,
     orderBy,
     table,
     columnIndex,
@@ -77,7 +79,7 @@ export function renderTableColumn({
 
     return html`<th
         id=${formatColumnID(columnIndex)}
-        aria-label=${ifDefined(label)}
+        aria-label=${ifDefined(ariaLabel ?? label)}
         data-column-id=${ifDefined(orderBy)}
         role="columnheader"
         scope="col"

--- a/web/src/elements/table/TableColumn.ts
+++ b/web/src/elements/table/TableColumn.ts
@@ -6,12 +6,14 @@ import { classMap } from "lit/directives/class-map.js";
 type ARIASort = "ascending" | "descending" | "none" | "other";
 
 export class TableColumn {
-    title: string;
-    orderBy?: string;
+    static formatColumnID = (columnIndex: number): string => `table-header-${columnIndex}`;
 
-    onClick?: () => void;
+    public title: string;
+    public orderBy?: string;
 
-    constructor(title: string, orderBy?: string) {
+    public onClick?: () => void;
+
+    public constructor(title: string, orderBy?: string) {
         this.title = title;
         this.orderBy = orderBy;
     }
@@ -63,13 +65,14 @@ export class TableColumn {
         </button>`;
     }
 
-    public render(table: TableLike): TemplateResult {
+    public render(table: TableLike, columnIndex: number): TemplateResult {
         const classes = {
             "pf-c-table__sort": !!this.orderBy,
             "pf-m-selected": table.order === this.orderBy || table.order === `-${this.orderBy}`,
         };
 
         return html`<th
+            id=${TableColumn.formatColumnID(columnIndex)}
             role="columnheader"
             scope="col"
             aria-sort=${this.getARIASort(table)}

--- a/web/src/elements/table/TableModal.ts
+++ b/web/src/elements/table/TableModal.ts
@@ -90,7 +90,7 @@ export abstract class TableModal<T extends object> extends Table<T> {
     /**
      * @abstract
      */
-    protected renderModalInner(): TemplateResult {
+    protected renderModalInner(): SlottedTemplateResult {
         return this.renderTable();
     }
 

--- a/web/src/elements/table/TablePage.ts
+++ b/web/src/elements/table/TablePage.ts
@@ -113,21 +113,17 @@ export abstract class TablePage<T extends object> extends Table<T> {
             >
             </ak-page-header>
             ${this.renderSectionBefore?.()}
-            <section
-                id="table-page-main"
-                aria-label=${this.pageTitle()}
-                class="pf-c-page__main-section pf-m-no-padding-mobile"
-            >
+            <div class="pf-c-page__main-section pf-m-no-padding-mobile">
                 <div class="pf-c-sidebar pf-m-gutter">
                     <div class="pf-c-sidebar__main">
                         ${this.renderSidebarBefore?.()}
-                        <div class="pf-c-sidebar__content">
+                        <main aria-label=${this.pageTitle()} class="pf-c-sidebar__content">
                             <div class="pf-c-card">${this.renderTable()}</div>
-                        </div>
+                        </main>
                         ${this.renderSidebarAfter?.()}
                     </div>
                 </div>
-            </section>
+            </div>
             ${this.renderSectionAfter?.()}`;
     }
 }

--- a/web/src/elements/table/TablePage.ts
+++ b/web/src/elements/table/TablePage.ts
@@ -13,27 +13,47 @@ import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFSidebar from "@patternfly/patternfly/components/Sidebar/sidebar.css";
 
 export abstract class TablePage<T extends object> extends Table<T> {
-    static styles: CSSResult[] = [...super.styles, PFPage, PFContent, PFSidebar];
+    static styles: CSSResult[] = [
+        // ---
+        ...super.styles,
+        PFPage,
+        PFContent,
+        PFSidebar,
+    ];
 
-    //#region Abstract methods
+    //#region Abstract properties
 
     /**
      * The title of the page.
      * @abstract
      */
-    abstract pageTitle(): string;
+    public abstract pageTitle: string;
 
     /**
      * The description of the page.
      * @abstract
      */
-    abstract pageDescription(): string | undefined;
+    public abstract pageDescription: string;
 
     /**
      * The icon to display in the page header.
      * @abstract
      */
-    abstract pageIcon(): string;
+    public abstract pageIcon: string;
+
+    //#endregion
+
+    //#region Lifecycle
+
+    public override connectedCallback(): void {
+        super.connectedCallback();
+
+        this.label ??= this.pageTitle;
+    }
+
+    //#endregion
+
+    //#region Abstract methods
 
     /**
      * Render content before the sidebar.
@@ -59,22 +79,9 @@ export abstract class TablePage<T extends object> extends Table<T> {
      */
     protected renderSectionAfter?(): TemplateResult;
 
-    /**
-     * Render the empty state.
-     */
-    protected renderEmpty(inner?: TemplateResult): TemplateResult {
-        return super.renderEmpty(html`
-            ${inner
-                ? inner
-                : html`<ak-empty-state icon=${this.pageIcon()}
-                      ><span>${msg("No objects found.")}</span>
-                      <div slot="body">
-                          ${this.searchEnabled() ? this.renderEmptyClearSearch() : nothing}
-                      </div>
-                      <div slot="primary">${this.renderObjectCreate()}</div>
-                  </ak-empty-state>`}
-        `);
-    }
+    //#endregion
+
+    //#region Protected methods
 
     protected clearSearch = () => {
         this.search = "";
@@ -87,6 +94,27 @@ export abstract class TablePage<T extends object> extends Table<T> {
 
         return this.fetch();
     };
+
+    //#endregion
+
+    //#region Render methods
+
+    /**
+     * Render the empty state.
+     */
+    protected renderEmpty(inner?: TemplateResult): TemplateResult {
+        return super.renderEmpty(html`
+            ${inner
+                ? inner
+                : html`<ak-empty-state icon=${this.pageIcon}
+                      ><span>${msg("No objects found.")}</span>
+                      <div slot="body">
+                          ${this.searchEnabled ? this.renderEmptyClearSearch() : nothing}
+                      </div>
+                      <div slot="primary">${this.renderObjectCreate()}</div>
+                  </ak-empty-state>`}
+        `);
+    }
 
     protected renderEmptyClearSearch(): SlottedTemplateResult {
         if (!this.search) {
@@ -107,9 +135,9 @@ export abstract class TablePage<T extends object> extends Table<T> {
 
     render() {
         return html`<ak-page-header
-                icon=${this.pageIcon()}
-                header=${this.pageTitle()}
-                description=${ifDefined(this.pageDescription())}
+                icon=${this.pageIcon}
+                header=${this.pageTitle}
+                description=${ifDefined(this.pageDescription)}
             >
             </ak-page-header>
             ${this.renderSectionBefore?.()}
@@ -117,7 +145,7 @@ export abstract class TablePage<T extends object> extends Table<T> {
                 <div class="pf-c-sidebar pf-m-gutter">
                     <div class="pf-c-sidebar__main">
                         ${this.renderSidebarBefore?.()}
-                        <main aria-label=${this.pageTitle()} class="pf-c-sidebar__content">
+                        <main aria-label=${this.pageTitle} class="pf-c-sidebar__content">
                             <div class="pf-c-card">${this.renderTable()}</div>
                         </main>
                         ${this.renderSidebarAfter?.()}

--- a/web/src/elements/table/TablePagination.ts
+++ b/web/src/elements/table/TablePagination.ts
@@ -15,7 +15,7 @@ export type TablePageChangeListener = (page: number) => void;
 @customElement("ak-table-pagination")
 export class TablePagination extends AKElement {
     @property({ type: String })
-    public label?: string;
+    public label: string | null = null;
 
     @property({ attribute: false })
     public pages?: Pagination;
@@ -52,7 +52,7 @@ export class TablePagination extends AKElement {
         }
 
         return html` <nav
-            aria-label=${this.label || msg("Table pagination")}
+            aria-label=${msg(str`${this.label || ""} table pagination`)}
             class="pf-c-pagination pf-m-compact pf-m-hidden pf-m-visible-on-md"
         >
             <div class="pf-c-pagination pf-m-compact pf-m-compact pf-m-hidden pf-m-visible-on-md">

--- a/web/src/elements/table/shared.ts
+++ b/web/src/elements/table/shared.ts
@@ -1,8 +1,18 @@
 import { Pagination } from "@goauthentik/api";
 
 export interface TableLike {
+    /**
+     * The column name to order by, optionally prefixed with `-` to reverse the order.
+     */
     order?: string;
     fetch: () => void;
+}
+
+export interface BaseTableListRequest {
+    ordering?: string;
+    page: number;
+    pageSize: number;
+    search?: string;
 }
 
 export interface PaginatedResponse<T> {

--- a/web/src/elements/table/shared.ts
+++ b/web/src/elements/table/shared.ts
@@ -1,4 +1,8 @@
+import { formatElapsedTime } from "#common/temporal";
+
 import { Pagination } from "@goauthentik/api";
+
+import { html, TemplateResult } from "lit";
 
 export interface TableLike {
     /**
@@ -20,4 +24,22 @@ export interface PaginatedResponse<T> {
     autocomplete?: { [key: string]: string };
 
     results: Array<T>;
+}
+
+/**
+ * Render a timestamp as a human-readable string.
+ *
+ * @param timestamp - The timestamp to render.
+ */
+export function Timestamp(timestamp?: Date | null): TemplateResult {
+    if (!timestamp || timestamp.getTime() === 0) {
+        return html`<span role="time" aria-label="None">-</span>`;
+    }
+
+    const elapsed = formatElapsedTime(timestamp);
+
+    return html` <time datetime=${timestamp.toISOString()} aria-label=${elapsed}>
+        <div>${elapsed}</div>
+        <small>${timestamp.toLocaleString()}</small>
+    </time>`;
 }

--- a/web/src/elements/tasks/ScheduleList.ts
+++ b/web/src/elements/tasks/ScheduleList.ts
@@ -69,15 +69,13 @@ export class ScheduleList extends Table<Schedule> {
         return this.fetch();
     };
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Schedule"), "actor_name"),
-            new TableColumn(msg("Crontab"), "crontab"),
-            new TableColumn(msg("Next run"), "next_run"),
-            new TableColumn(msg("Last status")),
-            new TableColumn(msg("Actions")),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Schedule"), "actor_name"],
+        [msg("Crontab"), "crontab"],
+        [msg("Next run"), "next_run"],
+        [msg("Last status")],
+        [msg("Actions")],
+    ];
 
     renderToolbarAfter(): TemplateResult {
         if (this.relObjId !== undefined) {

--- a/web/src/elements/tasks/ScheduleList.ts
+++ b/web/src/elements/tasks/ScheduleList.ts
@@ -68,6 +68,10 @@ export class ScheduleList extends Table<Schedule> {
         return this.fetch();
     };
 
+    protected override rowLabel(item: Schedule): string | null {
+        return item.description ?? item.actorName ?? null;
+    }
+
     protected columns: TableColumn[] = [
         [msg("Schedule"), "actor_name"],
         [msg("Crontab"), "crontab"],

--- a/web/src/elements/tasks/ScheduleList.ts
+++ b/web/src/elements/tasks/ScheduleList.ts
@@ -74,7 +74,7 @@ export class ScheduleList extends Table<Schedule> {
         [msg("Crontab"), "crontab"],
         [msg("Next run"), "next_run"],
         [msg("Last status")],
-        [msg("Actions")],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     renderToolbarAfter(): TemplateResult {

--- a/web/src/elements/tasks/ScheduleList.ts
+++ b/web/src/elements/tasks/ScheduleList.ts
@@ -147,7 +147,7 @@ export class ScheduleList extends Table<Schedule> {
                     <ak-schedule-form slot="form" .instancePk=${item.id}> </ak-schedule-form>
                     <button slot="trigger" class="pf-c-button pf-m-plain">
                         <pf-tooltip position="top" content=${msg("Edit")}>
-                            <i class="fas fa-edit"></i>
+                            <i class="fas fa-edit" aria-hidden="true"></i>
                         </pf-tooltip>
                     </button>
                 </ak-forms-modal>`,

--- a/web/src/elements/tasks/ScheduleList.ts
+++ b/web/src/elements/tasks/ScheduleList.ts
@@ -11,11 +11,12 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { EVENT_REFRESH } from "#common/constants";
 
 import { PaginatedResponse, Table, TableColumn, Timestamp } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { ModelEnum, Schedule, TasksApi } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import PFDescriptionList from "@patternfly/patternfly/components/DescriptionList/description-list.css";
@@ -78,9 +79,9 @@ export class ScheduleList extends Table<Schedule> {
         [msg("Actions"), null, msg("Row Actions")],
     ];
 
-    renderToolbarAfter(): TemplateResult {
+    renderToolbarAfter(): SlottedTemplateResult {
         if (this.relObjId !== undefined) {
-            return html``;
+            return nothing;
         }
         return html`&nbsp;
             <div class="pf-c-toolbar__group pf-m-filter-group">
@@ -107,7 +108,7 @@ export class ScheduleList extends Table<Schedule> {
             </div>`;
     }
 
-    row(item: Schedule): TemplateResult[] {
+    row(item: Schedule): SlottedTemplateResult[] {
         return [
             html`<div>${item.description}</div>
                 <small>${item.uid}</small>`,

--- a/web/src/elements/tasks/ScheduleList.ts
+++ b/web/src/elements/tasks/ScheduleList.ts
@@ -25,9 +25,7 @@ export class ScheduleList extends Table<Schedule> {
     expandable = true;
     clearOnRefresh = true;
 
-    searchEnabled(): boolean {
-        return true;
-    }
+    protected override searchEnabled = true;
 
     @property()
     order = "next_run";
@@ -152,7 +150,7 @@ export class ScheduleList extends Table<Schedule> {
 
     renderExpanded(item: Schedule): TemplateResult {
         const [appLabel, modelName] = ModelEnum.AuthentikTasksSchedulesSchedule.split(".");
-        return html` <td role="cell" colspan="5">
+        return html` <td colspan="5">
             <div class="pf-c-table__expandable-row-content">
                 <div class="pf-c-content">
                     <ak-task-list

--- a/web/src/elements/tasks/ScheduleList.ts
+++ b/web/src/elements/tasks/ScheduleList.ts
@@ -9,9 +9,8 @@ import "@patternfly/elements/pf-tooltip/pf-tooltip.js";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
 import { EVENT_REFRESH } from "#common/constants";
-import { formatElapsedTime } from "#common/temporal";
 
-import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { PaginatedResponse, Table, TableColumn, Timestamp } from "#elements/table/Table";
 
 import { ModelEnum, Schedule, TasksApi } from "@goauthentik/api";
 
@@ -111,14 +110,7 @@ export class ScheduleList extends Table<Schedule> {
             html`<div>${item.description}</div>
                 <small>${item.uid}</small>`,
             html`${item.crontab}`,
-            html`
-                ${item.paused
-                    ? html`${msg("Paused")}`
-                    : html`
-                          <div>${formatElapsedTime(item.nextRun)}</div>
-                          <small>${item.nextRun.toLocaleString()}</small>
-                      `}
-            `,
+            html` ${item.paused ? html`${msg("Paused")}` : Timestamp(item.nextRun)} `,
             html`<ak-task-status .status=${item.lastTaskStatus}></ak-task-status>`,
             html`<ak-action-button
                     class="pf-m-plain"

--- a/web/src/elements/tasks/TaskList.ts
+++ b/web/src/elements/tasks/TaskList.ts
@@ -95,15 +95,13 @@ export class TaskList extends Table<Task> {
         return this.fetch();
     };
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Task"), "actor_name"),
-            new TableColumn(msg("Queue"), "queue_name"),
-            new TableColumn(msg("Last updated"), "mtime"),
-            new TableColumn(msg("Status"), "aggregated_status"),
-            new TableColumn(msg("Actions")),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Task"), "actor_name"],
+        [msg("Queue"), "queue_name"],
+        [msg("Last updated"), "mtime"],
+        [msg("Status"), "aggregated_status"],
+        [msg("Actions")],
+    ];
 
     renderToolbarAfter(): TemplateResult {
         return html`&nbsp;

--- a/web/src/elements/tasks/TaskList.ts
+++ b/web/src/elements/tasks/TaskList.ts
@@ -9,9 +9,8 @@ import "@patternfly/elements/pf-tooltip/pf-tooltip.js";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
 import { EVENT_REFRESH } from "#common/constants";
-import { formatElapsedTime } from "#common/temporal";
 
-import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { PaginatedResponse, Table, TableColumn, Timestamp } from "#elements/table/Table";
 
 import {
     Task,
@@ -152,8 +151,7 @@ export class TaskList extends Table<Task> {
             html`<div>${item.description}</div>
                 <small>${item.uid}</small>`,
             html`${item.queueName}`,
-            html`<div>${formatElapsedTime(item.mtime || new Date())}</div>
-                <small>${item.mtime?.toLocaleString()}</small>`,
+            Timestamp(item.mtime ?? new Date()),
             html`<ak-task-status .status=${item.aggregatedStatus}></ak-task-status>`,
             item.state === TasksTasksListStateEnum.Rejected ||
             item.state === TasksTasksListStateEnum.Done

--- a/web/src/elements/tasks/TaskList.ts
+++ b/web/src/elements/tasks/TaskList.ts
@@ -94,6 +94,10 @@ export class TaskList extends Table<Task> {
         return this.fetch();
     };
 
+    protected override rowLabel(item: Task): string | null {
+        return item.description ?? item.actorName ?? null;
+    }
+
     protected columns: TableColumn[] = [
         [msg("Task"), "actor_name"],
         [msg("Queue"), "queue_name"],

--- a/web/src/elements/tasks/TaskList.ts
+++ b/web/src/elements/tasks/TaskList.ts
@@ -45,9 +45,7 @@ export class TaskList extends Table<Task> {
     @property({ type: Boolean })
     excludeSuccessful: boolean = true;
 
-    searchEnabled(): boolean {
-        return true;
-    }
+    protected override searchEnabled = true;
 
     @property()
     order = "-mtime";
@@ -185,7 +183,7 @@ export class TaskList extends Table<Task> {
     }
 
     renderExpanded(item: Task): TemplateResult {
-        return html` <td role="cell" colspan="5">
+        return html` <td colspan="5">
             <div class="pf-c-table__expandable-row-content">
                 <div class="pf-c-content">
                     <p class="pf-c-title pf-u-mb-md">${msg("Current execution logs")}</p>

--- a/web/src/elements/tasks/TaskList.ts
+++ b/web/src/elements/tasks/TaskList.ts
@@ -11,6 +11,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { EVENT_REFRESH } from "#common/constants";
 
 import { PaginatedResponse, Table, TableColumn, Timestamp } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import {
     Task,
@@ -148,7 +149,7 @@ export class TaskList extends Table<Task> {
             </div>`;
     }
 
-    row(item: Task): TemplateResult[] {
+    row(item: Task): SlottedTemplateResult[] {
         return [
             html`<div>${item.description}</div>
                 <small>${item.uid}</small>`,
@@ -178,7 +179,7 @@ export class TaskList extends Table<Task> {
                           <i class="fas fa-redo" aria-hidden="true"></i>
                       </pf-tooltip>
                   </ak-action-button>`
-                : html``,
+                : nothing,
         ];
     }
 

--- a/web/src/elements/tasks/TaskList.ts
+++ b/web/src/elements/tasks/TaskList.ts
@@ -100,7 +100,7 @@ export class TaskList extends Table<Task> {
         [msg("Queue"), "queue_name"],
         [msg("Last updated"), "mtime"],
         [msg("Status"), "aggregated_status"],
-        [msg("Actions")],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     renderToolbarAfter(): TemplateResult {

--- a/web/src/elements/user/SessionList.ts
+++ b/web/src/elements/user/SessionList.ts
@@ -3,13 +3,14 @@ import "#elements/forms/DeleteBulkForm";
 import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, Table, TableColumn, Timestamp } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { AuthenticatedSession, CoreApi } from "@goauthentik/api";
 
 import getUnicodeFlagIcon from "country-flag-icons/unicode";
 
 import { msg } from "@lit/localize";
-import { html, TemplateResult } from "lit";
+import { html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 @customElement("ak-user-session-list")
@@ -66,13 +67,13 @@ export class AuthenticatedSessionList extends Table<AuthenticatedSession> {
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: AuthenticatedSession): TemplateResult[] {
+    row(item: AuthenticatedSession): SlottedTemplateResult[] {
         return [
             html`<div>
                     ${item.geoIp?.country
                         ? html`${getUnicodeFlagIcon(item.geoIp.country)}&nbsp;`
-                        : html``}
-                    ${item.current ? html`${msg("(Current session)")}&nbsp;` : html``}
+                        : nothing}
+                    ${item.current ? html`${msg("(Current session)")}&nbsp;` : nothing}
                     ${item.lastIp}
                 </div>
                 <small>${item.userAgent.userAgent?.family}, ${item.userAgent.os?.family}</small>`,

--- a/web/src/elements/user/SessionList.ts
+++ b/web/src/elements/user/SessionList.ts
@@ -28,6 +28,10 @@ export class AuthenticatedSessionList extends Table<AuthenticatedSession> {
     clearOnRefresh = true;
     order = "-expires";
 
+    protected override rowLabel(item: AuthenticatedSession): string | null {
+        return item.lastIp ?? null;
+    }
+
     protected columns: TableColumn[] = [
         [msg("Last IP"), "last_ip"],
         [msg("Last used"), "last_used"],

--- a/web/src/elements/user/SessionList.ts
+++ b/web/src/elements/user/SessionList.ts
@@ -29,13 +29,11 @@ export class AuthenticatedSessionList extends Table<AuthenticatedSession> {
     clearOnRefresh = true;
     order = "-expires";
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Last IP"), "last_ip"),
-            new TableColumn(msg("Last used"), "last_used"),
-            new TableColumn(msg("Expires"), "expires"),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Last IP"), "last_ip"],
+        [msg("Last used"), "last_used"],
+        [msg("Expires"), "expires"],
+    ];
 
     renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;

--- a/web/src/elements/user/SessionList.ts
+++ b/web/src/elements/user/SessionList.ts
@@ -1,9 +1,8 @@
 import "#elements/forms/DeleteBulkForm";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
-import { formatElapsedTime } from "#common/temporal";
 
-import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { PaginatedResponse, Table, TableColumn, Timestamp } from "#elements/table/Table";
 
 import { AuthenticatedSession, CoreApi } from "@goauthentik/api";
 
@@ -73,10 +72,8 @@ export class AuthenticatedSessionList extends Table<AuthenticatedSession> {
                     ${item.lastIp}
                 </div>
                 <small>${item.userAgent.userAgent?.family}, ${item.userAgent.os?.family}</small>`,
-            html`<div>${formatElapsedTime(item.lastUsed)}</div>
-                <small>${item.lastUsed?.toLocaleString()}</small>`,
-            html`<div>${formatElapsedTime(item.expires || new Date())}</div>
-                <small>${item.expires?.toLocaleString()}</small>`,
+            Timestamp(item.lastUsed),
+            Timestamp(item.expires ?? new Date()),
         ];
     }
 }

--- a/web/src/elements/user/UserConsentList.ts
+++ b/web/src/elements/user/UserConsentList.ts
@@ -28,6 +28,10 @@ export class UserConsentList extends Table<UserConsent> {
     clearOnRefresh = true;
     order = "-expires";
 
+    protected override rowLabel(item: UserConsent): string | null {
+        return item.application?.name ?? null;
+    }
+
     protected columns: TableColumn[] = [
         [msg("Application"), "application"],
         [msg("Expires"), "expires"],

--- a/web/src/elements/user/UserConsentList.ts
+++ b/web/src/elements/user/UserConsentList.ts
@@ -5,6 +5,7 @@ import "#elements/forms/DeleteBulkForm";
 import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, Table, TableColumn, Timestamp } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { CoreApi, UserConsent } from "@goauthentik/api";
 
@@ -60,7 +61,7 @@ export class UserConsentList extends Table<UserConsent> {
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: UserConsent): TemplateResult[] {
+    row(item: UserConsent): SlottedTemplateResult[] {
         return [
             html`${item.application.name}`,
             Timestamp(item.expires && item.expiring ? item.expires : null),

--- a/web/src/elements/user/UserConsentList.ts
+++ b/web/src/elements/user/UserConsentList.ts
@@ -29,13 +29,11 @@ export class UserConsentList extends Table<UserConsent> {
     clearOnRefresh = true;
     order = "-expires";
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Application"), "application"),
-            new TableColumn(msg("Expires"), "expires"),
-            new TableColumn(msg("Permissions"), "permissions"),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Application"), "application"],
+        [msg("Expires"), "expires"],
+        [msg("Permissions"), "permissions"],
+    ];
 
     renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;

--- a/web/src/elements/user/UserConsentList.ts
+++ b/web/src/elements/user/UserConsentList.ts
@@ -3,9 +3,8 @@ import "#elements/chips/ChipGroup";
 import "#elements/forms/DeleteBulkForm";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
-import { formatElapsedTime } from "#common/temporal";
 
-import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { PaginatedResponse, Table, TableColumn, Timestamp } from "#elements/table/Table";
 
 import { CoreApi, UserConsent } from "@goauthentik/api";
 
@@ -60,10 +59,7 @@ export class UserConsentList extends Table<UserConsent> {
     row(item: UserConsent): TemplateResult[] {
         return [
             html`${item.application.name}`,
-            html`${item.expires && item.expiring
-                ? html`<div>${formatElapsedTime(item.expires)}</div>
-                      <small>${item.expires.toLocaleString()}</small>`
-                : msg("-")}`,
+            Timestamp(item.expires && item.expiring ? item.expires : null),
             html`${item.permissions
                 ? html`<ak-chip-group>
                       ${item.permissions.split(" ").map((perm) => {

--- a/web/src/elements/user/UserReputationList.ts
+++ b/web/src/elements/user/UserReputationList.ts
@@ -3,13 +3,14 @@ import "#elements/forms/DeleteBulkForm";
 import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, Table, TableColumn, Timestamp } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { PoliciesApi, Reputation } from "@goauthentik/api";
 
 import getUnicodeFlagIcon from "country-flag-icons/unicode";
 
 import { msg } from "@lit/localize";
-import { html, TemplateResult } from "lit";
+import { html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 @customElement("ak-user-reputation-list")
@@ -68,12 +69,12 @@ export class UserReputationList extends Table<Reputation> {
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: Reputation): TemplateResult[] {
+    row(item: Reputation): SlottedTemplateResult[] {
         return [
             html`${item.identifier}`,
             html`${item.ipGeoData?.country
                 ? html` ${getUnicodeFlagIcon(item.ipGeoData.country)} `
-                : html``}
+                : nothing}
             ${item.ip}`,
             html`${item.score}`,
             Timestamp(item.updated),

--- a/web/src/elements/user/UserReputationList.ts
+++ b/web/src/elements/user/UserReputationList.ts
@@ -35,6 +35,10 @@ export class UserReputationList extends Table<Reputation> {
     clearOnRefresh = true;
     order = "identifier";
 
+    protected override rowLabel(item: Reputation): string | null {
+        return item.identifier ?? null;
+    }
+
     protected columns: TableColumn[] = [
         [msg("Identifier"), "identifier"],
         [msg("IP"), "ip"],

--- a/web/src/elements/user/UserReputationList.ts
+++ b/web/src/elements/user/UserReputationList.ts
@@ -36,14 +36,12 @@ export class UserReputationList extends Table<Reputation> {
     clearOnRefresh = true;
     order = "identifier";
 
-    columns(): TableColumn[] {
-        return [
-            new TableColumn(msg("Identifier"), "identifier"),
-            new TableColumn(msg("IP"), "ip"),
-            new TableColumn(msg("Score"), "score"),
-            new TableColumn(msg("Updated"), "updated"),
-        ];
-    }
+    protected columns: TableColumn[] = [
+        [msg("Identifier"), "identifier"],
+        [msg("IP"), "ip"],
+        [msg("Score"), "score"],
+        [msg("Updated"), "updated"],
+    ];
 
     renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;

--- a/web/src/elements/user/UserReputationList.ts
+++ b/web/src/elements/user/UserReputationList.ts
@@ -1,9 +1,8 @@
 import "#elements/forms/DeleteBulkForm";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
-import { formatElapsedTime } from "#common/temporal";
 
-import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { PaginatedResponse, Table, TableColumn, Timestamp } from "#elements/table/Table";
 
 import { PoliciesApi, Reputation } from "@goauthentik/api";
 
@@ -73,8 +72,7 @@ export class UserReputationList extends Table<Reputation> {
                 : html``}
             ${item.ip}`,
             html`${item.score}`,
-            html`<div>${formatElapsedTime(item.updated)}</div>
-                <small>${item.updated.toLocaleString()}</small>`,
+            Timestamp(item.updated),
         ];
     }
 }

--- a/web/src/elements/wizard/ActionWizardPage.ts
+++ b/web/src/elements/wizard/ActionWizardPage.ts
@@ -6,7 +6,7 @@ import { WizardPage } from "#elements/wizard/WizardPage";
 import { ResponseError } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import PFEmptyState from "@patternfly/patternfly/components/EmptyState/empty-state.css";
@@ -144,7 +144,7 @@ export class ActionWizardPage extends WizardPage {
                                               >
                                                   ${state.action.subText}
                                               </div>`
-                                            : html``}
+                                            : nothing}
                                     </div>
                                 </li>`;
                             })}

--- a/web/src/elements/wizard/WizardFormPage.ts
+++ b/web/src/elements/wizard/WizardFormPage.ts
@@ -1,7 +1,8 @@
 import { Form } from "#elements/forms/Form";
+import { SlottedTemplateResult } from "#elements/types";
 import { WizardPage } from "#elements/wizard/WizardPage";
 
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { property } from "lit/decorators.js";
 
 import PFAlert from "@patternfly/patternfly/components/Alert/alert.css";
@@ -73,8 +74,8 @@ export class WizardFormPage extends WizardPage {
             return false;
         };
 
-    renderForm(): TemplateResult {
-        return html``;
+    renderForm(): SlottedTemplateResult {
+        return nothing;
     }
 
     activeCallback = async () => {

--- a/web/src/flow/stages/authenticator_totp/AuthenticatorTOTPStage.ts
+++ b/web/src/flow/stages/authenticator_totp/AuthenticatorTOTPStage.ts
@@ -96,7 +96,9 @@ export class AuthenticatorTOTPStage extends BaseStage<
                                     });
                             }}
                         >
-                            <span class="pf-c-button__progress"><i class="fas fa-copy"></i></span>
+                            <span class="pf-c-button__progress"
+                                ><i class="fas fa-copy" aria-hidden="true"></i
+                            ></span>
                             ${msg("Copy")}
                         </button>
                     </div>

--- a/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStage.ts
+++ b/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStage.ts
@@ -179,37 +179,37 @@ export class AuthenticatorValidateStage
     renderDevicePickerSingle(deviceChallenge: DeviceChallenge) {
         switch (deviceChallenge.deviceClass) {
             case DeviceClassesEnum.Duo:
-                return html`<i class="fas fa-mobile-alt"></i>
+                return html`<i class="fas fa-mobile-alt" aria-hidden="true"></i>
                     <div class="right">
                         <p>${msg("Duo push-notifications")}</p>
                         <small>${msg("Receive a push notification on your device.")}</small>
                     </div>`;
             case DeviceClassesEnum.Webauthn:
-                return html`<i class="fas fa-mobile-alt"></i>
+                return html`<i class="fas fa-mobile-alt" aria-hidden="true"></i>
                     <div class="right">
                         <p>${msg("Authenticator")}</p>
                         <small>${msg("Use a security key to prove your identity.")}</small>
                     </div>`;
             case DeviceClassesEnum.Totp:
-                return html`<i class="fas fa-clock"></i>
+                return html`<i class="fas fa-clock" aria-hidden="true"></i>
                     <div class="right">
                         <p>${msg("Traditional authenticator")}</p>
                         <small>${msg("Use a code-based authenticator.")}</small>
                     </div>`;
             case DeviceClassesEnum.Static:
-                return html`<i class="fas fa-key"></i>
+                return html`<i class="fas fa-key" aria-hidden="true"></i>
                     <div class="right">
                         <p>${msg("Recovery keys")}</p>
                         <small>${msg("In case you can't access any other method.")}</small>
                     </div>`;
             case DeviceClassesEnum.Sms:
-                return html`<i class="fas fa-mobile-alt"></i>
+                return html`<i class="fas fa-mobile-alt" aria-hidden="true"></i>
                     <div class="right">
                         <p>${msg("SMS")}</p>
                         <small>${msg("Tokens sent via SMS.")}</small>
                     </div>`;
             case DeviceClassesEnum.Email:
-                return html`<i class="fas fa-envelope"></i>
+                return html`<i class="fas fa-envelope" aria-hidden="true"></i>
                     <div class="right">
                         <p>${msg("Email")}</p>
                         <small>${msg("Tokens sent via email.")}</small>

--- a/web/src/user/LibraryApplication/RACLaunchEndpointModal.ts
+++ b/web/src/user/LibraryApplication/RACLaunchEndpointModal.ts
@@ -42,9 +42,10 @@ export class RACLaunchEndpointModal extends TableModal<Endpoint> {
         return endpoints;
     }
 
-    columns(): TableColumn[] {
-        return [new TableColumn(msg("Name"))];
-    }
+    protected columns: TableColumn[] = [
+        // ---
+        [msg("Name")],
+    ];
 
     row(item: Endpoint): TemplateResult[] {
         return [html`${item.name}`];

--- a/web/src/user/LibraryApplication/RACLaunchEndpointModal.ts
+++ b/web/src/user/LibraryApplication/RACLaunchEndpointModal.ts
@@ -2,6 +2,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { PaginatedResponse, TableColumn } from "#elements/table/Table";
 import { TableModal } from "#elements/table/TableModal";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { Application, Endpoint, RacApi } from "@goauthentik/api";
 
@@ -45,7 +46,7 @@ export class RACLaunchEndpointModal extends TableModal<Endpoint> {
         [msg("Name")],
     ];
 
-    row(item: Endpoint): TemplateResult[] {
+    row(item: Endpoint): SlottedTemplateResult[] {
         return [html`${item.name}`];
     }
 

--- a/web/src/user/LibraryApplication/RACLaunchEndpointModal.ts
+++ b/web/src/user/LibraryApplication/RACLaunchEndpointModal.ts
@@ -12,9 +12,7 @@ import { customElement, property } from "lit/decorators.js";
 @customElement("ak-library-rac-endpoint-launch")
 export class RACLaunchEndpointModal extends TableModal<Endpoint> {
     clickable = true;
-    searchEnabled(): boolean {
-        return true;
-    }
+    protected override searchEnabled = true;
 
     clickHandler = (item: Endpoint) => {
         if (!item.launchUrl) {

--- a/web/src/user/LibraryApplication/index.ts
+++ b/web/src/user/LibraryApplication/index.ts
@@ -87,7 +87,7 @@ export class LibraryApplication extends AKElement {
                           href="${globalAK().api
                               .base}if/admin/#/core/applications/${application?.slug}"
                       >
-                          <i class="fas fa-edit"></i>&nbsp;${msg("Edit")}
+                          <i class="fas fa-edit" aria-hidden="true"></i>&nbsp;${msg("Edit")}
                       </a>
                   `
                 : html``}

--- a/web/src/user/LibraryApplication/index.ts
+++ b/web/src/user/LibraryApplication/index.ts
@@ -8,6 +8,7 @@ import { rootInterface } from "#common/theme";
 import { truncateWords } from "#common/utils";
 
 import { AKElement } from "#elements/Base";
+import { SlottedTemplateResult } from "#elements/types";
 
 import type { UserInterface } from "#user/index.entrypoint";
 import type { RACLaunchEndpointModal } from "#user/LibraryApplication/RACLaunchEndpointModal";
@@ -90,13 +91,13 @@ export class LibraryApplication extends AKElement {
                           <i class="fas fa-edit" aria-hidden="true"></i>&nbsp;${msg("Edit")}
                       </a>
                   `
-                : html``}
+                : nothing}
         </ak-expand>`;
     }
 
-    renderLaunch(): TemplateResult {
+    renderLaunch(): SlottedTemplateResult {
         if (!this.application) {
-            return html``;
+            return nothing;
         }
         if (this.application?.launchUrl === "goauthentik.io://providers/rac/launch") {
             return html`<div class="pf-c-card__header">

--- a/web/src/user/LibraryPage/ak-library-impl.ts
+++ b/web/src/user/LibraryPage/ak-library-impl.ts
@@ -73,9 +73,7 @@ export class LibraryPage extends AKElement {
     @state()
     filteredApps: Application[] = [];
 
-    pageTitle(): string {
-        return msg("My Applications");
-    }
+    public pageTitle = msg("My Applications");
 
     connectedCallback() {
         super.connectedCallback();

--- a/web/src/user/LibraryPage/ak-library.ts
+++ b/web/src/user/LibraryPage/ak-library.ts
@@ -103,9 +103,7 @@ export class LibraryPage extends AKElement {
         );
     }
 
-    pageTitle(): string {
-        return msg("My Applications");
-    }
+    public pageTitle = msg("My Applications");
 
     loading() {
         return html`<ak-empty-state default-label></ak-empty-state>`;

--- a/web/src/user/index.entrypoint.ts
+++ b/web/src/user/index.entrypoint.ts
@@ -197,7 +197,7 @@ class UserInterfacePresentation extends WithBrandConfig(AKElement) {
                 <div class="background-wrapper" style="${this.uiConfig.theme.background}">
                     ${(this.uiConfig.theme.background || "") === ""
                         ? html`<div class="background-default-slant"></div>`
-                        : html``}
+                        : nothing}
                 </div>
                 <header class="pf-c-page__header">
                     <div class="pf-c-page__header-brand">

--- a/web/src/user/user-settings/UserSettingsPage.ts
+++ b/web/src/user/user-settings/UserSettingsPage.ts
@@ -18,7 +18,7 @@ import type { UserInterface } from "#user/index.entrypoint";
 import { StagesApi, UserSetting } from "@goauthentik/api";
 
 import { localized, msg } from "@lit/localize";
-import { css, CSSResult, html, TemplateResult } from "lit";
+import { css, CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
@@ -111,7 +111,7 @@ export class UserSettingsPage extends AKElement {
                                     ? html`<ak-user-settings-password
                                           configureUrl=${ifDefined(pwStage[0].configureUrl)}
                                       ></ak-user-settings-password>`
-                                    : html``}
+                                    : nothing}
                             </div>
                         </div>
                     </section>

--- a/web/src/user/user-settings/details/UserSettingsFlowExecutor.ts
+++ b/web/src/user/user-settings/details/UserSettingsFlowExecutor.ts
@@ -10,6 +10,7 @@ import { refreshMe } from "#common/users";
 import { AKElement } from "#elements/Base";
 import { showMessage } from "#elements/messages/MessageContainer";
 import { WithBrandConfig } from "#elements/mixins/branding";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { StageHost } from "#flow/stages/base";
 
@@ -23,7 +24,7 @@ import {
 } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 
@@ -146,9 +147,9 @@ export class UserSettingsFlowExecutor
         });
     }
 
-    renderChallenge(): TemplateResult {
+    renderChallenge(): SlottedTemplateResult {
         if (!this.challenge) {
-            return html``;
+            return nothing;
         }
         switch (this.challenge.component) {
             case "ak-stage-prompt":

--- a/web/src/user/user-settings/details/stages/prompt/PromptStage.ts
+++ b/web/src/user/user-settings/details/stages/prompt/PromptStage.ts
@@ -8,7 +8,7 @@ import { PromptStage } from "#flow/stages/prompt/PromptStage";
 import { PromptTypeEnum, StagePrompt } from "@goauthentik/api";
 
 import { msg, str } from "@lit/localize";
-import { html, TemplateResult } from "lit";
+import { html, nothing, TemplateResult } from "lit";
 import { customElement } from "lit/decorators.js";
 
 @customElement("ak-user-stage-prompt")
@@ -57,7 +57,7 @@ export class UserSettingsPromptStage extends PromptStage {
                           >
                               ${msg("Delete account")}
                           </a>`
-                        : html``}
+                        : nothing}
                 </div>
             </div>
         </div>`;

--- a/web/src/user/user-settings/mfa/MFADevicesPage.ts
+++ b/web/src/user/user-settings/mfa/MFADevicesPage.ts
@@ -12,6 +12,7 @@ import { deviceTypeName } from "#common/labels";
 import { SentryIgnoredError } from "#common/sentry/index";
 
 import { PaginatedResponse, Table, TableColumn, Timestamp } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { AuthenticatorsApi, Device, UserSetting } from "@goauthentik/api";
 
@@ -125,7 +126,7 @@ export class MFADevicesPage extends Table<Device> {
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: Device): TemplateResult[] {
+    row(item: Device): SlottedTemplateResult[] {
         return [
             html`${item.name}`,
             html`<div>${deviceTypeName(item)}</div>

--- a/web/src/user/user-settings/mfa/MFADevicesPage.ts
+++ b/web/src/user/user-settings/mfa/MFADevicesPage.ts
@@ -52,7 +52,7 @@ export class MFADevicesPage extends Table<Device> {
         [msg("Type")],
         [msg("Created at")],
         [msg("Last used at")],
-        [""],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     renderToolbar(): TemplateResult {
@@ -144,7 +144,11 @@ export class MFADevicesPage extends Table<Device> {
                     <span slot="header">${msg("Update Device")}</span>
                     <ak-user-mfa-form slot="form" deviceType=${item.type} .instancePk=${item.pk}>
                     </ak-user-mfa-form>
-                    <button slot="trigger" class="pf-c-button pf-m-plain">
+                    <button
+                        aria-label=${msg("Edit device")}
+                        slot="trigger"
+                        class="pf-c-button pf-m-plain"
+                    >
                         <pf-tooltip position="top" content=${msg("Edit")}>
                             <i class="fas fa-edit" aria-hidden="true"></i>
                         </pf-tooltip>

--- a/web/src/user/user-settings/mfa/MFADevicesPage.ts
+++ b/web/src/user/user-settings/mfa/MFADevicesPage.ts
@@ -48,16 +48,13 @@ export class MFADevicesPage extends Table<Device> {
         };
     }
 
-    columns(): TableColumn[] {
-        // prettier-ignore
-        return [
-            msg("Name"),
-            msg("Type"),
-            msg("Created at"),
-            msg("Last used at"),
-            ""
-        ].map((th) => new TableColumn(th, ""));
-    }
+    protected columns: TableColumn[] = [
+        [msg("Name")],
+        [msg("Type")],
+        [msg("Created at")],
+        [msg("Last used at")],
+        [""],
+    ];
 
     renderToolbar(): TemplateResult {
         const settings = (this.userSettings || []).filter((stage) => {

--- a/web/src/user/user-settings/mfa/MFADevicesPage.ts
+++ b/web/src/user/user-settings/mfa/MFADevicesPage.ts
@@ -153,7 +153,7 @@ export class MFADevicesPage extends Table<Device> {
                     </ak-user-mfa-form>
                     <button slot="trigger" class="pf-c-button pf-m-plain">
                         <pf-tooltip position="top" content=${msg("Edit")}>
-                            <i class="fas fa-edit"></i>
+                            <i class="fas fa-edit" aria-hidden="true"></i>
                         </pf-tooltip>
                     </button>
                 </ak-forms-modal>

--- a/web/src/user/user-settings/mfa/MFADevicesPage.ts
+++ b/web/src/user/user-settings/mfa/MFADevicesPage.ts
@@ -10,9 +10,8 @@ import { AndNext, DEFAULT_CONFIG } from "#common/api/config";
 import { globalAK } from "#common/global";
 import { deviceTypeName } from "#common/labels";
 import { SentryIgnoredError } from "#common/sentry/index";
-import { formatElapsedTime } from "#common/temporal";
 
-import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { PaginatedResponse, Table, TableColumn, Timestamp } from "#elements/table/Table";
 
 import { AuthenticatorsApi, Device, UserSetting } from "@goauthentik/api";
 
@@ -137,14 +136,8 @@ export class MFADevicesPage extends Table<Device> {
                           </pf-tooltip>
                       `
                     : nothing} `,
-            html`${item.created.getTime() > 0
-                ? html`<div>${formatElapsedTime(item.created)}</div>
-                      <small>${item.created.toLocaleString()}</small>`
-                : html`-`}`,
-            html`${item.lastUsed
-                ? html`<div>${formatElapsedTime(item.lastUsed)}</div>
-                      <small>${item.lastUsed.toLocaleString()}</small>`
-                : html`-`}`,
+            Timestamp(item.created),
+            Timestamp(item.lastUsed),
             html`
                 <ak-forms-modal>
                     <span slot="submit">${msg("Update")}</span>

--- a/web/src/user/user-settings/tokens/UserTokenForm.ts
+++ b/web/src/user/user-settings/tokens/UserTokenForm.ts
@@ -8,7 +8,7 @@ import { ModelForm } from "#elements/forms/ModelForm";
 import { CoreApi, IntentEnum, Token } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { html, TemplateResult } from "lit";
+import { html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
@@ -79,7 +79,7 @@ export class UserTokenForm extends ModelForm<Token, string> {
                           class="pf-c-form-control"
                       />
                   </ak-form-element-horizontal>`
-                : html``}`;
+                : nothing}`;
     }
 }
 

--- a/web/src/user/user-settings/tokens/UserTokenList.ts
+++ b/web/src/user/user-settings/tokens/UserTokenList.ts
@@ -24,9 +24,7 @@ import PFDescriptionList from "@patternfly/patternfly/components/DescriptionList
 
 @customElement("ak-user-token-list")
 export class UserTokenList extends Table<Token> {
-    searchEnabled(): boolean {
-        return true;
-    }
+    protected override searchEnabled = true;
 
     expandable = true;
     checkbox = true;
@@ -81,7 +79,7 @@ export class UserTokenList extends Table<Token> {
     }
 
     renderExpanded(item: Token): TemplateResult {
-        return html` <td role="cell" colspan="3">
+        return html` <td colspan="3">
                 <div class="pf-c-table__expandable-row-content">
                     <dl class="pf-c-description-list pf-m-horizontal">
                         <div class="pf-c-description-list__group">

--- a/web/src/user/user-settings/tokens/UserTokenList.ts
+++ b/web/src/user/user-settings/tokens/UserTokenList.ts
@@ -45,11 +45,17 @@ export class UserTokenList extends Table<Token> {
         });
     }
 
-    columns(): TableColumn[] {
-        return [new TableColumn(msg("Identifier"), "identifier"), new TableColumn("")];
-    }
+    protected columns: TableColumn[] = [
+        // ---
+        [msg("Identifier"), "identifier"],
+        [""],
+    ];
 
     static styles: CSSResult[] = [...super.styles, PFDescriptionList];
+
+    protected override rowLabel(item: Token): string | null {
+        return item.identifier;
+    }
 
     renderToolbar(): TemplateResult {
         return html`

--- a/web/src/user/user-settings/tokens/UserTokenList.ts
+++ b/web/src/user/user-settings/tokens/UserTokenList.ts
@@ -13,6 +13,7 @@ import { formatElapsedTime } from "#common/temporal";
 import { me } from "#common/users";
 
 import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { CoreApi, IntentEnum, Token } from "@goauthentik/api";
 
@@ -152,7 +153,7 @@ export class UserTokenList extends Table<Token> {
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: Token): TemplateResult[] {
+    row(item: Token): SlottedTemplateResult[] {
         return [
             html`<span class="pf-m-monospace">${item.identifier}</span>`,
             html`

--- a/web/src/user/user-settings/tokens/UserTokenList.ts
+++ b/web/src/user/user-settings/tokens/UserTokenList.ts
@@ -169,7 +169,7 @@ export class UserTokenList extends Table<Token> {
                     </ak-user-token-form>
                     <button slot="trigger" class="pf-c-button pf-m-plain">
                         <pf-tooltip position="top" content=${msg("Edit")}>
-                            <i class="fas fa-edit"></i>
+                            <i aria-hidden="true" class="fas fa-edit"></i>
                         </pf-tooltip>
                     </button>
                 </ak-forms-modal>
@@ -178,7 +178,7 @@ export class UserTokenList extends Table<Token> {
                     identifier="${item.identifier}"
                 >
                     <pf-tooltip position="top" content=${msg("Copy token")}>
-                        <i class="fas fa-copy"></i>
+                        <i class="fas fa-copy" aria-hidden="true"></i>
                     </pf-tooltip>
                 </ak-token-copy-button>
             `,

--- a/web/src/user/user-settings/tokens/UserTokenList.ts
+++ b/web/src/user/user-settings/tokens/UserTokenList.ts
@@ -48,7 +48,7 @@ export class UserTokenList extends Table<Token> {
     protected columns: TableColumn[] = [
         // ---
         [msg("Identifier"), "identifier"],
-        [""],
+        [msg("Actions"), null, msg("Row Actions")],
     ];
 
     static styles: CSSResult[] = [...super.styles, PFDescriptionList];


### PR DESCRIPTION
## Details

This PR updates our table component with additional support for ARIA. The changes are focused on a few interconnected aspects within table columns and rows:

- Added indicator to rows when their role when used as a group header 
- Added expanded and selected state to rows
- Added relations between column labels and groups to rows
- Table "select all" buttons now communicate an indeterminate state
- Selected inputs are now tracked as a set, reducing the overhead of our new ARIA lookups
- Row expansion now uses a more accurate keying across table refreshes
- Selectable rows now prevent in-fighting on text selection interfering with pointer events
- Clarified `groupBy` return type
- Fix select/expand tracking from using O(n) arrays to a constant space O(1) Set.

## ARIA Tree
<img width="1470" height="883" alt="Screenshot 2025-09-15 at 14 56 29" src="https://github.com/user-attachments/assets/321297c4-4283-4077-a70e-5628502eb584" />
