### PR TITLE
Change to apt-get dist-upgrade and add upgrade operations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ RUN --mount=type=bind,target=/work/web/package.json,src=./web/package.json \
     --mount=type=bind,target=/work/web/packages/sfe/package.json,src=./web/packages/sfe/package.json \
     --mount=type=bind,target=/work/web/scripts,src=./web/scripts \
     --mount=type=cache,id=npm-ak,sharing=shared,target=/root/.npm \
+    apt-get update && \
+    apt-get dist-upgrade && \
     npm ci
 
 COPY ./package.json /work
@@ -40,6 +42,7 @@ WORKDIR /go/src/goauthentik.io
 RUN --mount=type=cache,id=apt-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/var/cache/apt \
     dpkg --add-architecture arm64 && \
     apt-get update && \
+    apt-get dist-upgrade && \
     apt-get install -y --no-install-recommends crossbuild-essential-arm64 gcc-aarch64-linux-gnu
 
 RUN --mount=type=bind,target=/go/src/goauthentik.io/go.mod,src=./go.mod \
@@ -103,6 +106,7 @@ ENV PATH="/root/.cargo/bin:$PATH"
 
 RUN --mount=type=cache,id=apt-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/var/cache/apt \
     apt-get update && \
+    apt-get dist-upgrade && \
     # Required for installing pip packages
     apt-get install -y --no-install-recommends \
     # Build essentials
@@ -149,7 +153,7 @@ WORKDIR /
 
 # We cannot cache this layer otherwise we'll end up with a bigger image
 RUN apt-get update && \
-    apt-get upgrade -y && \
+    apt-get dist-upgrade -y && \
     # Required for runtime
     apt-get install -y --no-install-recommends libpq5 libmaxminddb0 ca-certificates libkrb5-3 libkadm5clnt-mit12 libkdb5-10 libltdl7 libxslt1.1 && \
     # Required for bootstrap & healtcheck

--- a/ldap.Dockerfile
+++ b/ldap.Dockerfile
@@ -15,6 +15,7 @@ WORKDIR /go/src/goauthentik.io
 RUN --mount=type=cache,id=apt-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/var/cache/apt \
     dpkg --add-architecture arm64 && \
     apt-get update && \
+    apt-get dist-upgrade -y && \
     apt-get install -y --no-install-recommends crossbuild-essential-arm64 gcc-aarch64-linux-gnu
 
 RUN --mount=type=bind,target=/go/src/goauthentik.io/go.mod,src=./go.mod \
@@ -47,11 +48,6 @@ LABEL org.opencontainers.image.authors="Authentik Security Inc." \
     org.opencontainers.image.url="https://goauthentik.io" \
     org.opencontainers.image.vendor="Authentik Security Inc." \
     org.opencontainers.image.version=${VERSION}
-
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get clean && \
-    rm -rf /tmp/* /var/lib/apt/lists/*
 
 COPY --from=builder /go/ldap /
 

--- a/proxy.Dockerfile
+++ b/proxy.Dockerfile
@@ -3,6 +3,10 @@
 # Stage 1: Build web
 FROM --platform=${BUILDPLATFORM} docker.io/library/node:24 AS web-builder
 
+RUN --mount=type=cache,id=apt-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/var/cache/apt \
+    apt-get update && \
+    apt-get dist-upgrade -y
+
 ENV NODE_ENV=production
 WORKDIR /static
 
@@ -31,6 +35,7 @@ WORKDIR /go/src/goauthentik.io
 RUN --mount=type=cache,id=apt-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/var/cache/apt \
     dpkg --add-architecture arm64 && \
     apt-get update && \
+    apt-get dist-upgrade -y && \
     apt-get install -y --no-install-recommends crossbuild-essential-arm64 gcc-aarch64-linux-gnu
 
 RUN --mount=type=bind,target=/go/src/goauthentik.io/go.mod,src=./go.mod \

--- a/rac.Dockerfile
+++ b/rac.Dockerfile
@@ -15,6 +15,7 @@ WORKDIR /go/src/goauthentik.io
 RUN --mount=type=cache,id=apt-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/var/cache/apt \
     dpkg --add-architecture arm64 && \
     apt-get update && \
+    apt-get dist-upgrade -y && \
     apt-get install -y --no-install-recommends crossbuild-essential-arm64 gcc-aarch64-linux-gnu
 
 RUN --mount=type=bind,target=/go/src/goauthentik.io/go.mod,src=./go.mod \
@@ -50,7 +51,7 @@ LABEL org.opencontainers.image.authors="Authentik Security Inc." \
 
 USER root
 RUN apt-get update && \
-    apt-get upgrade -y && \
+    apt-get dist-upgrade -y && \
     apt-get clean && \
     rm -rf /tmp/* /var/lib/apt/lists/*
 USER 1000

--- a/radius.Dockerfile
+++ b/radius.Dockerfile
@@ -15,6 +15,7 @@ WORKDIR /go/src/goauthentik.io
 RUN --mount=type=cache,id=apt-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/var/cache/apt \
     dpkg --add-architecture arm64 && \
     apt-get update && \
+    apt-get dist-upgrade -y && \
     apt-get install -y --no-install-recommends crossbuild-essential-arm64 gcc-aarch64-linux-gnu
 
 RUN --mount=type=bind,target=/go/src/goauthentik.io/go.mod,src=./go.mod \
@@ -47,11 +48,6 @@ LABEL org.opencontainers.image.authors="Authentik Security Inc." \
     org.opencontainers.image.url="https://goauthentik.io" \
     org.opencontainers.image.vendor="Authentik Security Inc." \
     org.opencontainers.image.version=${VERSION}
-
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get clean && \
-    rm -rf /tmp/* /var/lib/apt/lists/*
 
 COPY --from=builder /go/radius /
 


### PR DESCRIPTION
- `apt-get upgrade` does not remove unnecessary packages, while `apt-get dist-upgrade` does. We want to limit the attack surface by removing unnecessary packages.
- It is generally good practice to have an up to date environment before building packages. We don't want stuff like vulnerable openssl or tar or whatever to affect the build.