### PR TITLE
core: Block usage of Django's createsuperuser

### DIFF
--- a/authentik/tenants/management/commands/createsuperuser.py
+++ b/authentik/tenants/management/commands/createsuperuser.py
@@ -1,0 +1,10 @@
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = "ak createsuperuser should not be used. Instead, use ak create_admin_group"
+
+    def handle(self, *args, **options):  # noqa: ANN001, D401
+        raise RuntimeError(
+            "ak createsuperuser should not be used. Instead, use ak create_admin_group"
+        )


### PR DESCRIPTION
django’s default create_superuser tries to set is_staff/is_superuser, but our User exposes these as read-only properties which are derived from group membershp

that would cause the attribute error seen in the user report.

Closes: https://github.com/goauthentik/authentik/issues/16212

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
