### PR TITLE
web: Fix reported error precedence

### DIFF
--- a/web/src/admin/providers/BaseProviderForm.ts
+++ b/web/src/admin/providers/BaseProviderForm.ts
@@ -1,4 +1,5 @@
 import { APIError } from "#common/errors/network";
+import { MessageLevel } from "#common/messages";
 
 import { ModelForm } from "#elements/forms/ModelForm";
 import { APIMessage } from "#elements/messages/Message";
@@ -14,6 +15,7 @@ export abstract class BaseProviderForm<T> extends ModelForm<T, number> {
 
     protected override formatAPIErrorMessage(error: APIError): APIMessage {
         return {
+            level: MessageLevel.error,
             ...super.formatAPIErrorMessage(error),
             message: this.instance
                 ? msg("An error occurred while updating the provider.")

--- a/web/src/admin/providers/BaseProviderForm.ts
+++ b/web/src/admin/providers/BaseProviderForm.ts
@@ -1,4 +1,7 @@
+import { APIError } from "#common/errors/network";
+
 import { ModelForm } from "#elements/forms/ModelForm";
+import { APIMessage } from "#elements/messages/Message";
 
 import { msg } from "@lit/localize";
 
@@ -7,5 +10,14 @@ export abstract class BaseProviderForm<T> extends ModelForm<T, number> {
         return this.instance
             ? msg("Successfully updated provider.")
             : msg("Successfully created provider.");
+    }
+
+    protected override formatAPIErrorMessage(error: APIError): APIMessage {
+        return {
+            ...super.formatAPIErrorMessage(error),
+            message: this.instance
+                ? msg("An error occurred while updating the provider.")
+                : msg("An error occurred while creating the provider."),
+        };
     }
 }

--- a/web/src/admin/users/UserImpersonateForm.ts
+++ b/web/src/admin/users/UserImpersonateForm.ts
@@ -1,20 +1,29 @@
 import "#components/ak-text-input";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
-import { globalAK } from "#common/global";
+import { MessageLevel } from "#common/messages";
 
 import { Form } from "#elements/forms/Form";
+import { APIMessage } from "#elements/messages/Message";
 
 import { CoreApi, ImpersonationRequest } from "@goauthentik/api";
 
-import { msg } from "@lit/localize";
+import { msg, str } from "@lit/localize";
 import { html, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 @customElement("ak-user-impersonate-form")
 export class UserImpersonateForm extends Form<ImpersonationRequest> {
     @property({ type: Number })
-    instancePk?: number;
+    public instancePk?: number;
+
+    protected override formatAPISuccessMessage(): APIMessage | null {
+        return {
+            level: MessageLevel.success,
+            message: msg(str`Impersonating user...`),
+            description: msg("This may take a few seconds."),
+        };
+    }
 
     async send(data: ImpersonationRequest): Promise<void> {
         return new CoreApi(DEFAULT_CONFIG)
@@ -23,7 +32,7 @@ export class UserImpersonateForm extends Form<ImpersonationRequest> {
                 impersonationRequest: data,
             })
             .then(() => {
-                window.location.href = globalAK().api.base;
+                window.location.reload();
             });
     }
 
@@ -31,7 +40,12 @@ export class UserImpersonateForm extends Form<ImpersonationRequest> {
         return html`<ak-text-input
             name="reason"
             label=${msg("Reason")}
-            help=${msg("Reason for impersonating the user")}
+            autocomplete="off"
+            placeholder=${msg("Reason for impersonating the user")}
+            help=${msg(
+                "A brief explanation of why you are impersonating the user. This will be included in audit logs.",
+            )}
+            required
         ></ak-text-input>`;
     }
 }

--- a/web/src/common/errors/network.ts
+++ b/web/src/common/errors/network.ts
@@ -6,6 +6,8 @@ import {
     ValidationErrorFromJSON,
 } from "@goauthentik/api";
 
+import { sentenceCase } from "change-case";
+
 //#region HTTP
 
 /**
@@ -230,6 +232,28 @@ export async function parseAPIResponseError<T extends APIError = APIError>(
 
             return createSyntheticGenericError(message || response.statusText) as T;
         });
+}
+
+//#endregion
+
+//#region Validation errors
+
+/**
+ * Pluck a field error from a validation error.
+ *
+ * This is used to create a fallback error message when the API returns
+ * a validation error that isn't associated with field within the form.
+ *
+ * We can still show the error message, to at least give the user some feedback.
+ */
+export function pluckFallbackFieldErrors(parsedError: APIError): string[] {
+    for (const [fieldName, fieldErrors] of Object.entries(parsedError)) {
+        if (Array.isArray(fieldErrors)) {
+            return [`${sentenceCase(fieldName)}: ${fieldErrors.join(", ")}`];
+        }
+    }
+
+    return [];
 }
 
 //#endregion

--- a/web/src/elements/forms/Form.ts
+++ b/web/src/elements/forms/Form.ts
@@ -1,5 +1,10 @@
 import { EVENT_REFRESH } from "#common/constants";
-import { parseAPIResponseError, pluckErrorDetail } from "#common/errors/network";
+import {
+    APIError,
+    parseAPIResponseError,
+    pluckErrorDetail,
+    pluckFallbackFieldErrors,
+} from "#common/errors/network";
 import { MessageLevel } from "#common/messages";
 import { dateToUTC } from "#common/temporal";
 
@@ -8,17 +13,18 @@ import { AKElement } from "#elements/Base";
 import { reportValidityDeep } from "#elements/forms/FormGroup";
 import { PreventFormSubmit } from "#elements/forms/helpers";
 import { HorizontalFormElement } from "#elements/forms/HorizontalFormElement";
+import { APIMessage } from "#elements/messages/Message";
 import { showMessage } from "#elements/messages/MessageContainer";
 import { SlottedTemplateResult } from "#elements/types";
 import { createFileMap, isNamedElement, NamedElement } from "#elements/utils/inputs";
 
 import { ErrorProp } from "#components/ak-field-errors";
 
-import { instanceOfValidationError } from "@goauthentik/api";
+import { instanceOfValidationError, ValidationError } from "@goauthentik/api";
 
 import { snakeCase } from "change-case";
 
-import { msg, str } from "@lit/localize";
+import { msg } from "@lit/localize";
 import { css, CSSResult, html, nothing, TemplateResult } from "lit";
 import { property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -143,6 +149,41 @@ export function serializeForm<T = Record<string, unknown>>(elements: Iterable<AK
     return json as unknown as T;
 }
 
+//#region Validation Reporting
+
+/**
+ * Assign all input-related errors to their respective elements.
+ */
+function reportInvalidFields(
+    parsedError: ValidationError,
+    elements: Iterable<HorizontalFormElement>,
+): HorizontalFormElement[] {
+    const invalidFields: HorizontalFormElement[] = [];
+
+    for (const element of elements) {
+        element.requestUpdate();
+
+        const elementName = element.name;
+
+        if (!elementName) continue;
+
+        const snakeProperty = snakeCase(elementName);
+        const errorMessages: ErrorProp[] = parsedError[snakeProperty] ?? [];
+
+        element.errorMessages = errorMessages;
+
+        if (Array.isArray(errorMessages) && errorMessages.length) {
+            invalidFields.push(element);
+        }
+    }
+
+    return invalidFields;
+}
+
+//#endregion
+
+//#region Form
+
 /**
  * Form
  *
@@ -231,6 +272,17 @@ export abstract class Form<T = Record<string, unknown>> extends AKElement {
         return this.successMessage;
     }
 
+    /**
+     * An overridable method for returning a formatted error message after a failed submission.
+     */
+    protected formatAPIErrorMessage(error: APIError): APIMessage {
+        return {
+            message: msg("There was an error submitting the form."),
+            description: pluckErrorDetail(error, pluckFallbackFieldErrors(error)[0]),
+            level: MessageLevel.error,
+        };
+    }
+
     //#region Public methods
 
     public reset(): void {
@@ -314,81 +366,32 @@ export abstract class Form<T = Record<string, unknown>> extends AKElement {
                 }
 
                 const parsedError = await parseAPIResponseError(error);
-                let errorMessage = pluckErrorDetail(error);
-                let focused = false;
-
-                //#region Validation errors
 
                 if (instanceOfValidationError(parsedError)) {
-                    // assign all input-related errors to their elements
-                    const elements =
-                        this.shadowRoot?.querySelectorAll<HorizontalFormElement>(
-                            "ak-form-element-horizontal",
-                        ) || [];
+                    const invalidFields = reportInvalidFields(
+                        parsedError,
+                        this.renderRoot.querySelectorAll("ak-form-element-horizontal"),
+                    );
 
-                    for (const element of elements) {
-                        element.requestUpdate();
+                    const focusTarget = Iterator.from(invalidFields)
+                        .map(({ focusTarget }) => focusTarget)
+                        .find(Boolean);
 
-                        const elementName = element.name;
-
-                        if (!elementName) continue;
-
-                        const snakeProperty = snakeCase(elementName);
-                        const errorMessages: ErrorProp[] = parsedError[snakeProperty] ?? [];
-
-                        element.errorMessages = errorMessages;
-                        const { controlledElement } = element;
-
-                        if (!focused && Array.isArray(errorMessages) && errorMessages.length) {
-                            if (
-                                controlledElement?.checkVisibility() &&
-                                controlledElement instanceof HTMLElement
-                            ) {
-                                focused = true;
-
-                                requestAnimationFrame(() => {
-                                    return controlledElement.focus?.();
-                                });
-                            }
-                        }
-                    }
-
-                    if (parsedError.nonFieldErrors) {
+                    if (focusTarget) {
+                        requestAnimationFrame(() => focusTarget.focus());
+                    } else if (Array.isArray(parsedError.nonFieldErrors)) {
                         this.nonFieldErrors = parsedError.nonFieldErrors;
-                    } else if (!focused) {
-                        // It's possible that the API has returned a field error that we're
-                        // not aware of. We can still show the error message, to at least
-                        // give the user some feedback.
-                        for (const [fieldName, fieldErrors] of Object.entries(parsedError)) {
-                            if (Array.isArray(fieldErrors)) {
-                                this.nonFieldErrors = [
-                                    msg(str`${fieldName}: ${fieldErrors.join(", ")}`),
-                                ];
-                                break;
-                            }
-                        }
+                    } else {
+                        this.nonFieldErrors = pluckFallbackFieldErrors(parsedError);
 
                         console.error(
                             "authentik/forms: API rejected the form submission due to an invalid field that doesn't appear to be in the form. This is likely a bug in authentik.",
                             parsedError,
                         );
                     }
-
-                    errorMessage = msg("Invalid update request.");
-
-                    // Only change the message when we have `detail`.
-                    // Everything else is handled in the form.
-                    if ("detail" in parsedError) {
-                        errorMessage = parsedError.detail;
-                    }
                 }
 
-                //#endregion
-
-                showMessage({
-                    message: errorMessage,
-                    level: MessageLevel.error,
-                });
+                showMessage(this.formatAPIErrorMessage(parsedError), true);
 
                 // Rethrow the error so the form doesn't close.
                 throw error;

--- a/web/src/elements/forms/HorizontalFormElement.ts
+++ b/web/src/elements/forms/HorizontalFormElement.ts
@@ -70,7 +70,20 @@ export class HorizontalFormElement extends AKElement {
 
     //#endregion
 
-    public controlledElement: NamedElement | AkControlElement | null = null;
+    #controlledElement: AkControlElement | NamedElement | null = null;
+
+    /**
+     * The element that should be focused when the form is submitted.
+     */
+    public get focusTarget(): AkControlElement | NamedElement<HTMLElement> | null {
+        if (!(this.#controlledElement instanceof HTMLElement)) {
+            return null;
+        }
+
+        if (!this.#controlledElement.checkVisibility()) return null;
+
+        return this.#controlledElement;
+    }
 
     //#region Lifecycle
 
@@ -79,8 +92,8 @@ export class HorizontalFormElement extends AKElement {
     }
 
     public override updated(changedProperties: PropertyValues<this>): void {
-        if (changedProperties.has("errorMessages") && this.controlledElement) {
-            this.controlledElement.setAttribute(
+        if (changedProperties.has("errorMessages") && this.#controlledElement) {
+            this.#controlledElement.setAttribute(
                 "aria-invalid",
                 this.errorMessages?.length ? "true" : "false",
             );
@@ -100,7 +113,7 @@ export class HorizontalFormElement extends AKElement {
             // Is this element capable of being named?
             if (!isControlElement(element) && !isNameableElement(element)) continue;
 
-            this.controlledElement = element;
+            this.#controlledElement = element;
 
             if (element.getAttribute("name") !== this.name) {
                 element.setAttribute("name", this.name);

--- a/web/src/elements/forms/HorizontalFormElement.ts
+++ b/web/src/elements/forms/HorizontalFormElement.ts
@@ -99,12 +99,13 @@ export class HorizontalFormElement extends AKElement {
         for (const element of this.querySelectorAll("*")) {
             // Is this element capable of being named?
             if (!isControlElement(element) && !isNameableElement(element)) continue;
-            // And does the element already match the name?
-            if (element.getAttribute("name") === this.name) continue;
-
-            element.setAttribute("name", this.name);
 
             this.controlledElement = element;
+
+            if (element.getAttribute("name") !== this.name) {
+                element.setAttribute("name", this.name);
+            }
+
             break;
         }
     }

--- a/web/src/elements/messages/MessageContainer.ts
+++ b/web/src/elements/messages/MessageContainer.ts
@@ -27,7 +27,11 @@ import PFBase from "@patternfly/patternfly/patternfly-base.css";
  *
  * @todo Consider making this a static method on singleton {@linkcode MessageContainer}
  */
-export function showMessage(message: APIMessage, unique = false): void {
+export function showMessage(message: APIMessage | null, unique = false): void {
+    if (!message) {
+        return;
+    }
+
     const container = document.querySelector<MessageContainer>("ak-message-container");
 
     if (!container) {
@@ -35,7 +39,10 @@ export function showMessage(message: APIMessage, unique = false): void {
     }
 
     if (!message.message.trim()) {
-        message.message = msg("Error");
+        console.warn("authentik/messages: `showMessage` received an empty message", message);
+
+        message.message = msg("An unknown error occurred");
+        message.description ??= msg("Please check the browser console for more details.");
     }
 
     container.addMessage(message, unique);

--- a/web/src/elements/utils/inputs.ts
+++ b/web/src/elements/utils/inputs.ts
@@ -45,7 +45,7 @@ export function isNameableElement(element: Element): element is NamedElement {
         return false;
     }
 
-    return NameableElements.has(element.tagName);
+    return NameableElements.has(element.tagName) || element.getAttribute("name") !== null;
 }
 
 /**


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

- Fix issue where controlled element is not assigned, such as when ak-search-select attempts to pluck its own name attribute from a parent form field.
- Fix the preferred order of errors to display when API response includes a more descriptive validation.
- Fix issue where impersonation form can be submitted with empty fields