### PR TITLE
web: Fix ak-flow-card footer alignment.

### DIFF
--- a/web/src/flow/components/ak-flow-card.ts
+++ b/web/src/flow/components/ak-flow-card.ts
@@ -33,13 +33,10 @@ export class FlowCard extends AKElement {
         PFLogin,
         PFTitle,
         css`
-            slot[name="footer"],
-            slot[name="footer-band"] {
-                display: flex;
-                flex-wrap: wrap;
-                justify-content: center;
-                flex-basis: 100%;
+            .pf-c-login__main-footer {
+                display: block;
             }
+
             slot[name="footer-band"] {
                 text-align: center;
                 background-color: var(--pf-c-login__main-footer-band--BackgroundColor);


### PR DESCRIPTION

## Details

Caused by nested flex containers. Solution -- set parent flex group to block.

### Before

<img width="618" height="233" alt="Screenshot 2025-08-18 at 19 40 36" src="https://github.com/user-attachments/assets/1a956999-dfdb-4db1-a015-31d1de513666" />


### After
<img width="610" height="271" alt="Screenshot 2025-08-18 at 19 40 09" src="https://github.com/user-attachments/assets/53218850-9b71-45ca-806b-9192d8fc44ce" />
