### PR TITLE
sources/ldap: fix malformed filter error with special characters in group DN

### DIFF
--- a/authentik/sources/ldap/sync/membership.py
+++ b/authentik/sources/ldap/sync/membership.py
@@ -53,7 +53,8 @@ class MembershipLDAPSynchronizer(BaseLDAPSynchronizer):
         for group in page_data:
             if self._source.lookup_groups_from_user:
                 group_dn = group.get("dn", {})
-                group_filter = f"({self._source.group_membership_field}={escape_filter_chars(group_dn)})"
+                escaped_dn = escape_filter_chars(group_dn)
+                group_filter = f"({self._source.group_membership_field}={escaped_dn})"
                 group_members = self._source.connection().extend.standard.paged_search(
                     search_base=self.base_dn_users,
                     search_filter=group_filter,

--- a/authentik/sources/ldap/sync/membership.py
+++ b/authentik/sources/ldap/sync/membership.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from django.db.models import Q
 from ldap3 import SUBTREE
+from ldap3.utils.conv import escape_filter_chars
 
 from authentik.core.models import Group, User
 from authentik.sources.ldap.models import LDAP_DISTINGUISHED_NAME, LDAP_UNIQUENESS, LDAPSource
@@ -52,7 +53,7 @@ class MembershipLDAPSynchronizer(BaseLDAPSynchronizer):
         for group in page_data:
             if self._source.lookup_groups_from_user:
                 group_dn = group.get("dn", {})
-                group_filter = f"({self._source.group_membership_field}={group_dn})"
+                group_filter = f"({self._source.group_membership_field}={escape_filter_chars(group_dn)})"
                 group_members = self._source.connection().extend.standard.paged_search(
                     search_base=self.base_dn_users,
                     search_filter=group_filter,

--- a/authentik/sources/ldap/tests/test_sync.py
+++ b/authentik/sources/ldap/tests/test_sync.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 from django.db.models import Q
 from django.test import TestCase
 from ldap3.core.exceptions import LDAPInvalidFilterError
+from ldap3.utils.conv import escape_filter_chars
 
 from authentik.blueprints.tests import apply_blueprint
 from authentik.core.models import Group, User
@@ -591,7 +592,6 @@ class LDAPSyncTests(TestCase):
 
     def test_escape_filter_chars_function(self):
         """Test the escape_filter_chars function directly"""
-        from ldap3.utils.conv import escape_filter_chars
         
         # Test various special characters that need escaping
         test_cases = [

--- a/authentik/sources/ldap/tests/test_sync.py
+++ b/authentik/sources/ldap/tests/test_sync.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 from django.db.models import Q
 from django.test import TestCase
+from ldap3.core.exceptions import LDAPInvalidFilterError
 
 from authentik.blueprints.tests import apply_blueprint
 from authentik.core.models import Group, User
@@ -519,3 +520,90 @@ class LDAPSyncTests(TestCase):
 
         self.assertFalse(User.objects.filter(username__startswith="not-in-the-source").exists())
         self.assertFalse(Group.objects.filter(name__startswith="not-in-the-source").exists())
+
+    def test_membership_sync_special_chars_in_group_dn(self):
+        """Test membership synchronization with special characters in group DN"""
+        self.source.object_uniqueness_field = "uid"
+        self.source.group_object_filter = "(objectClass=groupOfNames)"
+        self.source.lookup_groups_from_user = True
+        self.source.group_membership_field = "memberOf"
+        
+        # Mock connection with group DN containing special characters
+        mock_conn = MagicMock()
+        
+        # Simulate group with special characters in DN: parentheses, backslashes, asterisks
+        special_group_dn = "cn=test(group),ou=groups,dc=example,dc=com"
+        backslash_group_dn = "cn=test\\group,ou=groups,dc=example,dc=com"
+        asterisk_group_dn = "cn=test*group,ou=groups,dc=example,dc=com"
+        
+        # Mock the paged_search method that would be called with the filter
+        mock_standard = MagicMock()
+        mock_conn.extend.standard = mock_standard
+        
+        # Test case 1: Group DN with parentheses
+        with patch("authentik.sources.ldap.models.LDAPSource.connection", return_value=mock_conn):
+            membership_sync = MembershipLDAPSynchronizer(self.source, Task())
+            
+            # Simulate group data with special characters in DN
+            page_data = [{"dn": special_group_dn}]
+            
+            # This should not raise LDAPInvalidFilterError anymore
+            try:
+                membership_sync.sync_page(page_data)
+                # Verify that the filter was properly escaped
+                # The call should have been made with escaped characters
+                mock_standard.paged_search.assert_called()
+                call_args = mock_standard.paged_search.call_args
+                search_filter = call_args[1]["search_filter"]
+                # The parentheses should be escaped as \28 and \29
+                self.assertIn("\\28", search_filter)  # Escaped (
+                self.assertIn("\\29", search_filter)  # Escaped )
+            except LDAPInvalidFilterError:
+                self.fail("LDAPInvalidFilterError should not be raised with escaped filter")
+        
+        # Test case 2: Group DN with backslashes
+        with patch("authentik.sources.ldap.models.LDAPSource.connection", return_value=mock_conn):
+            membership_sync = MembershipLDAPSynchronizer(self.source, Task())
+            page_data = [{"dn": backslash_group_dn}]
+            
+            try:
+                membership_sync.sync_page(page_data)
+                call_args = mock_standard.paged_search.call_args
+                search_filter = call_args[1]["search_filter"]
+                # The backslash should be escaped as \5c
+                self.assertIn("\\5c", search_filter)  # Escaped \
+            except LDAPInvalidFilterError:
+                self.fail("LDAPInvalidFilterError should not be raised with escaped filter")
+        
+        # Test case 3: Group DN with asterisks
+        with patch("authentik.sources.ldap.models.LDAPSource.connection", return_value=mock_conn):
+            membership_sync = MembershipLDAPSynchronizer(self.source, Task())
+            page_data = [{"dn": asterisk_group_dn}]
+            
+            try:
+                membership_sync.sync_page(page_data)
+                call_args = mock_standard.paged_search.call_args
+                search_filter = call_args[1]["search_filter"]
+                # The asterisk should be escaped as \2a
+                self.assertIn("\\2a", search_filter)  # Escaped *
+            except LDAPInvalidFilterError:
+                self.fail("LDAPInvalidFilterError should not be raised with escaped filter")
+
+    def test_escape_filter_chars_function(self):
+        """Test the escape_filter_chars function directly"""
+        from ldap3.utils.conv import escape_filter_chars
+        
+        # Test various special characters that need escaping
+        test_cases = [
+            ("test(group)", "test\\28group\\29"),  # parentheses
+            ("test\\group", "test\\5cgroup"),      # backslash
+            ("test*group", "test\\2agroup"),       # asterisk
+            ("test(*)group", "test\\28\\2a\\29group"),  # multiple special chars
+            ("normalgroup", "normalgroup"),        # no special chars
+            ("", ""),                              # empty string
+        ]
+        
+        for input_str, expected in test_cases:
+            with self.subTest(input_str=input_str):
+                result = escape_filter_chars(input_str)
+                self.assertEqual(result, expected)


### PR DESCRIPTION
## Details

Fixed LDAPInvalidFilterError that occurs when group DN contains special characters (parentheses, backslashes, asterisks) during LDAP membership synchronization.

The issue was that group DN values were being used directly in LDAP filter construction without proper escaping, causing malformed filter errors when special characters were present. This fix uses ldap3's
`escape_filter_chars()` function to properly escape these characters before constructing the LDAP filter.

Changes made:
- Added import for `escape_filter_chars` from `ldap3.utils.conv`
- Updated group filter construction in `MembershipLDAPSynchronizer.sync_page()` to escape the group DN value
- Added comprehensive test cases covering various special characters and edge cases
- Tests verify both the membership synchronization process and the escape function directly

---

## Checklist

- [x] Local tests pass (`ak test authentik/`)
- [x] The code has been formatted (`make lint-fix`)

If an API change has been made

- [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

- [ ] The code has been formatted (`make web`)

If applicable

- [ ] The documentation has been updated
- [ ] The documentation has been formatted (`make docs`)