### PR TITLE
website: QL Search keyboard interactions docs, examples.

### DIFF
--- a/website/docs/endpoint-devices/device-compliance/device-reporting.md
+++ b/website/docs/endpoint-devices/device-compliance/device-reporting.md
@@ -37,7 +37,7 @@ For an example of the facts provided for a Linux device, see [here](./facts-linu
 
 ## Endpoint devices in event logs
 
-Authentication events involving endpoint devices are included in the [event logs](../../sys-mgmt/events/logging-events.md). For example:
+Authentication events involving endpoint devices are included in the [event logs](../../sys-mgmt/events/logging-events.mdx). For example:
 
 ![Example of device authentication event](device-event-example.png)
 
@@ -49,4 +49,4 @@ To search for event logs matching a specific endpoint device:
 2. Navigate to **Events** > **Logs**.
 3. In the search bar, enter: `context.device.name = "<device_name>"`
 
-For more information on searching the events logs, see [Logging events](../../sys-mgmt/events/logging-events.md).
+For more information on searching the events logs, see [Logging events](../../sys-mgmt/events/logging-events.mdx).

--- a/website/docs/releases/2025/v2025.8.mdx
+++ b/website/docs/releases/2025/v2025.8.mdx
@@ -11,7 +11,7 @@ slug: "/releases/2025.8"
 
 ![Screenshot of the admin interface showing events plotted on a histogram chart and on a map](../../sys-mgmt/events/event-map-chart.png)
 
-- **Advanced search**: :ak-enterprise Search for [users](../../users-sources/user/user_basic_operations.md#tell-me-more) and [event logs](../../sys-mgmt/events/logging-events.md#tell-me-more) with custom query language to filter on their properties and attributes.
+- **Advanced search**: :ak-enterprise Search for [users](../../users-sources/user/user_basic_operations.md#tell-me-more) and [event logs](../../sys-mgmt/events/logging-events.mdx#tell-me-more) with custom query language to filter on their properties and attributes.
 
 - **Email stage rate limiting**: The email stage can now be configured to set a maximum number of emails that can be sent within a specified time period.
 

--- a/website/docs/sys-mgmt/data-exports.md
+++ b/website/docs/sys-mgmt/data-exports.md
@@ -8,7 +8,7 @@ authentik enterprise allows you to export user and event data in CSV format for 
 
 The content included in a data export matches that returned by the API endpoints for the respective object types.
 
-For detailed instructions on exporting users and events, see [Export users](../users-sources/user/user_basic_operations.md#export-users-) and [Export events](events/logging-events.md#export-events-) respectively.
+For detailed instructions on exporting users and events, see [Export users](../users-sources/user/user_basic_operations.md#export-users-) and [Export events](events/logging-events.mdx#export-events-) respectively.
 
 You can access past data exports from the **Events** > **Data Exports** page. On this page you can view the query used for a specific export, search exports by data type and user, download completed exports and delete exports that you no longer need.
 

--- a/website/docs/sys-mgmt/events/index.md
+++ b/website/docs/sys-mgmt/events/index.md
@@ -14,7 +14,7 @@ Events can be used to define [notification rules](notifications.md), with specif
 
 Event logging in authentik provides several layers of transparency about user and system actions, from a quick view on the Overview dashboard, to a full, searchable list of all events, with a volume graph to highlight any spikes, in the Admin interface under **Events > Logs**.
 
-Refer to our [Logging documentation](./logging-events.md) for more information.
+Refer to our [Logging documentation](./logging-events.mdx) for more information.
 
 ## Event retention and forwarding
 

--- a/website/docs/sys-mgmt/events/logging-events.mdx
+++ b/website/docs/sys-mgmt/events/logging-events.mdx
@@ -34,17 +34,28 @@ With the enterprise version, you can view recent events on both a world map view
 
 ![](./event-map-chart.png)
 
+## Export events :ak-enterprise
+
+You can export your authentik instance's events to a CSV file. To generate a data export, follow these steps:
+
+1. Log in to authentik as an administrator and navigate to **Events > Logs**.
+2. Set a [search query](#tell-me-more) as well as the ordering, as needed. The data export will honor these settings.
+3. Click **Export** above the event list.
+4. Confirm the export parameters in the confirmation dialog.
+5. Note that the export is processed in the background. Once the export is ready, you will receive a notification in the notification drawer.
+6. In the notification, click **Download**.
+
+To review, download, or delete past data exports, navigate to **Events** > **Data Exports** in the Admin interface.
+
 ## Advanced queries for event logs:ak-enterprise {#tell-me-more}
 
 You can construct advanced queries to find specific event logs. In the Admin interface, navigate to **Events > Logs**, and then use the auto-complete in the **Search** field or enter your own queries to return results with greater specificity.
 
 - **Field**: `action`, `event_uuid`, `app`, `client_ip`, `user`, `brand`, `context`, `created`
-
 - **Operators**: `=`, `!=`, `~`, `!~`, `startswith`, `not startswith`, `endswith`, `not endswith`, `in`, `not in`
-
 - **Values**: `True`, `False`, `None`, and more
 
-### Keyboard Interactions
+### Keyboard shortcuts
 
 <KeyBindingsTable
     aria-label="Keyboard shortcuts for the Query Language (QL) search"
@@ -72,31 +83,31 @@ You can construct advanced queries to find specific event logs. In the Admin int
 
 ### Example queries
 
-```sh title="Search event by application name"
+```sh Search event by application name
 app startswith "N"
 ```
 
-```sh title="Search event by action"
+```sh Search event by action
 action = "login"
 ```
 
-```sh title="Search event by authorized application context"
+```sh Search event by authorized application context
 authorized_application.name = "My app"
 ```
 
-```sh title="Search event by country"
+```sh Search event by country
 context.geo.country = "Germany"
 ```
 
-```sh title="Search event by IP address"
+```sh Search event by IP address
 client_ip = "10.0.0.1"
 ```
 
-```sh title="Search event by brand"
+```sh Search event by brand
 brand.name = "my brand"
 ```
 
-```sh title="Search event by user"
+```sh Search event by user
 user.username in ["ana", "akadmin"]
 ```
 
@@ -106,7 +117,8 @@ For more examples, refer to the list of [Event actions](./event-actions.md) and 
 
 1. If the list of operators does not appear in a drop-down menu you will need to manually enter it.
 2. For queries that include `user`, `brand`, or `context` you need to use a compound term such as `user.username` or `brand.name`.
-   :::
+
+:::
 
 ## Export events :ak-enterprise
 

--- a/website/docs/sys-mgmt/events/logging-events.mdx
+++ b/website/docs/sys-mgmt/events/logging-events.mdx
@@ -55,33 +55,9 @@ You can construct advanced queries to find specific event logs. In the Admin int
 - **Operators**: `=`, `!=`, `~`, `!~`, `startswith`, `not startswith`, `endswith`, `not endswith`, `in`, `not in`
 - **Values**: `True`, `False`, `None`, and more
 
-### Keyboard shortcuts
+### Examples
 
-<KeyBindingsTable
-    aria-label="Keyboard shortcuts for the Query Language (QL) search"
-
-    bindings={[
-        [
-            "Autocomplete",
-            [
-                ["Select next suggestion", <kbd aria-label="Down arrow">↓</kbd>],
-                ["Select previous suggestion", <kbd aria-label="Up arrow">↑</kbd>],
-                ["Accept the current suggestion", <kbd aria-label="Enter key">Enter</kbd>],
-                ["Dismiss suggestions", <kbd aria-label="Escape key">ESC</kbd>],
-            ],
-        ],
-        [
-            "Search",
-            [
-                ["Submit the current query", <kbd aria-label="Enter key">Enter</kbd>],
-                ["Clear the current query", <kbd aria-label="Escape key">ESC</kbd>],
-            ],
-        ],
-    ]}
-
-/>
-
-### Example queries
+The following are examples of advanced queries:
 
 ```sh Search event by application name
 app startswith "N"
@@ -117,18 +93,32 @@ For more examples, refer to the list of [Event actions](./event-actions.md) and 
 
 1. If the list of operators does not appear in a drop-down menu you will need to manually enter it.
 2. For queries that include `user`, `brand`, or `context` you need to use a compound term such as `user.username` or `brand.name`.
+   :::
 
-:::
+### Keyboard shortcuts for advanced queries
 
-## Export events :ak-enterprise
+The following keyboard shortcuts can be used in the advanced query search:
 
-You can export your authentik instance's events to a CSV file. To generate a data export, follow these steps:
+<KeyBindingsTable
+    aria-label="Keyboard shortcuts for the Query Language (QL) search"
 
-1. Log in to authentik as an administrator and navigate to **Events > Logs**.
-2. Set a [search query](#tell-me-more) as well as the ordering, as needed. The data export will honor these settings.
-3. Click **Export** above the event list.
-4. Confirm the export parameters in the confirmation dialog.
-5. Note that the export is processed in the background. Once the export is ready, you will receive a notification in the notification drawer.
-6. In the notification, click **Download**.
+    bindings={[
+        [
+            "Autocomplete",
+            [
+                ["Select next suggestion", <kbd aria-label="Down arrow">↓</kbd>],
+                ["Select previous suggestion", <kbd aria-label="Up arrow">↑</kbd>],
+                ["Accept the current suggestion", <kbd aria-label="Enter key">Enter</kbd>],
+                ["Dismiss suggestions", <kbd aria-label="Escape key">ESC</kbd>],
+            ],
+        ],
+        [
+            "Search",
+            [
+                ["Submit the current query", <kbd aria-label="Enter key">Enter</kbd>],
+                ["Clear the current query", <kbd aria-label="Escape key">ESC</kbd>],
+            ],
+        ],
+    ]}
 
-To review, download, or delete past data exports, navigate to **Events** > **Data Exports** in the Admin interface.
+/>

--- a/website/docs/sys-mgmt/events/logging-events.mdx
+++ b/website/docs/sys-mgmt/events/logging-events.mdx
@@ -2,6 +2,8 @@
 title: Logging events
 ---
 
+import { KeyBindingsTable } from "@goauthentik/docusaurus-theme/components/KeyBindingsTable";
+
 Logs are a vital tool for system diagnostics, event auditing, user management, reporting, and more. They capture detailed information about each event including the client's IP address, the user involved, the date and time, and the specific action taken.
 
 Event logging in authentik is highly configurable. You can set the [retention period](./index.md#event-retention-and-forwarding) for storing and displaying events, specify which events should trigger a [notification](./notifications.md), and access low-level details about when and where each event occurred.
@@ -42,22 +44,68 @@ You can construct advanced queries to find specific event logs. In the Admin int
 
 - **Values**: `True`, `False`, `None`, and more
 
-- **Example queries**:
-    - search event by application name: `app startswith "N"`
-    - search event by action: `action = "login"`
-    - search event by authorized application context: `authorized_application.name = "My app"`
-    - search event by country: `context.geo.country = "Germany"`
-    - search event by IP address: `client_ip = "10.0.0.1"`
-    - search event by brand: `brand.name = "my brand"`
-    - search event by user: `user.username in ["ana", "akadmin"]`
+### Keyboard Interactions
+
+<KeyBindingsTable
+    aria-label="Keyboard shortcuts for the Query Language (QL) search"
+
+    bindings={[
+        [
+            "Autocomplete",
+            [
+                ["Select next suggestion", <kbd aria-label="Down arrow">↓</kbd>],
+                ["Select previous suggestion", <kbd aria-label="Up arrow">↑</kbd>],
+                ["Accept the current suggestion", <kbd aria-label="Enter key">Enter</kbd>],
+                ["Dismiss suggestions", <kbd aria-label="Escape key">ESC</kbd>],
+            ],
+        ],
+        [
+            "Search",
+            [
+                ["Submit the current query", <kbd aria-label="Enter key">Enter</kbd>],
+                ["Clear the current query", <kbd aria-label="Escape key">ESC</kbd>],
+            ],
+        ],
+    ]}
+
+/>
+
+### Example queries
+
+```sh title="Search event by application name"
+app startswith "N"
+```
+
+```sh title="Search event by action"
+action = "login"
+```
+
+```sh title="Search event by authorized application context"
+authorized_application.name = "My app"
+```
+
+```sh title="Search event by country"
+context.geo.country = "Germany"
+```
+
+```sh title="Search event by IP address"
+client_ip = "10.0.0.1"
+```
+
+```sh title="Search event by brand"
+brand.name = "my brand"
+```
+
+```sh title="Search event by user"
+user.username in ["ana", "akadmin"]
+```
 
 For more examples, refer to the list of [Event actions](./event-actions.md) and the related examples for each type of event.
 
 :::info
 
-1. To dismiss the drop-down menu option, click **ESC**.
-2. If the list of operators does not appear in a drop-down menu you will need to manually enter it.
-3. For queries that include `user`, `brand`, or `context` you need to use a compound term such as `user.username` or `brand.name`.
+1. If the list of operators does not appear in a drop-down menu you will need to manually enter it.
+2. For queries that include `user`, `brand`, or `context` you need to use a compound term such as `user.username` or `brand.name`.
    :::
 
 ## Export events :ak-enterprise

--- a/website/docusaurus-theme/components/KeyBindingsTable/index.tsx
+++ b/website/docusaurus-theme/components/KeyBindingsTable/index.tsx
@@ -1,0 +1,42 @@
+import styles from "./styles.module.css";
+
+export type KeyBindingGroup = [label: React.ReactNode, bindings: KeyBinding[]];
+
+export type KeyBinding = [label: React.ReactNode, key: React.ReactNode];
+
+export interface KeyBindingsTableProps extends React.HTMLAttributes<HTMLTableElement> {
+    bindings?: KeyBindingGroup[];
+}
+
+export const KeyBindingsTable: React.FC<KeyBindingsTableProps> = ({ bindings = [], ...props }) => {
+    return (
+        <table className={styles.table} {...props}>
+            <thead>
+                <tr>
+                    <th className={styles.actionColumn} scope="col" id="key-col-action">
+                        Action
+                    </th>
+                    <th className={styles.bindingColumn} scope="col" id="key-col-binding">
+                        Key Binding
+                    </th>
+                </tr>
+            </thead>
+
+            {bindings.map(([label, bindings], groupIndex) => (
+                <tbody key={groupIndex}>
+                    <tr>
+                        <th colSpan={2} scope="rowgroup">
+                            {label}
+                        </th>
+                    </tr>
+                    {bindings.map(([label, key], bindingIndex) => (
+                        <tr key={`${groupIndex}-${bindingIndex}`}>
+                            <td>{label}</td>
+                            <td>{key}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            ))}
+        </table>
+    );
+};

--- a/website/docusaurus-theme/components/KeyBindingsTable/styles.module.css
+++ b/website/docusaurus-theme/components/KeyBindingsTable/styles.module.css
@@ -1,0 +1,55 @@
+.table {
+    width: 100%;
+
+    --ifm-table-border-color: var(--ifm-color-info-contrast-background);
+    --ifm-table-stripe-background: transparent;
+    --ifm-table-stripe-background: var(--ifm-color-emphasis-100);
+
+    thead {
+        background-color: var(--ifm-color-info-contrast-background);
+        text-align: left;
+    }
+
+    tr,
+    td,
+    th {
+        border-color: transparent;
+    }
+
+    tr {
+        th {
+            border-block-end-color: var(--ifm-color-info-contrast-background);
+        }
+
+        td:first-child {
+            text-align: end;
+
+            font-family: var(--ifm-heading-font-family);
+            font-weight: 300;
+            border-inline-end-color: var(--ifm-color-secondary-dark);
+        }
+    }
+
+    tbody tr th {
+        --ifm-table-cell-padding: 0.5rem;
+        font-weight: 600;
+        font-family: var(--ifm-heading-font-family);
+        text-align: end;
+        background-color: transparent;
+    }
+
+    kbd {
+        user-select: none;
+        text-rendering: optimizeLegibility;
+        font-weight: 900;
+        letter-spacing: 0.05em;
+        padding: 0.25rem 0.25rem;
+    }
+    .actionColumn {
+        min-width: 20rem;
+    }
+
+    .bindingColumn {
+        width: 100%;
+    }
+}


### PR DESCRIPTION
## Details

This PR refines our QL search docs to be compatible with screen readers. Changes include:


- A table of keyboard interactions with ARIA attributes to clarify their use.
- Updates the example queries to allow the screen reader to better announce the contents, and to allow the user to copy the content to try in their authentik instance

## Screenshot

<img width="1454" height="839" alt="Screenshot 2025-08-19 at 21 54 41" src="https://github.com/user-attachments/assets/18c2ffc7-1312-4af1-9147-c97ff55fdb42" />


## ARIA Tree

<img width="793" height="500" alt="Screenshot 2025-08-19 at 21 59 10" src="https://github.com/user-attachments/assets/dd3d02d6-6e9a-4324-9c43-4d9b822073f4" />

