### PR TITLE
web: fix "Explore integrations" link in Quick actions

### DIFF
--- a/web/src/admin/admin-overview/AdminOverviewPage.ts
+++ b/web/src/admin/admin-overview/AdminOverviewPage.ts
@@ -66,7 +66,7 @@ export class AdminOverviewPage extends AdminOverviewBase {
     quickActions: QuickAction[] = [
         [msg("Create a new application"), paramURL("/core/applications", { createWizard: true })],
         [msg("Check the logs"), paramURL("/events/log")],
-        [msg("Explore integrations"), "https://goauthentik.io/integrations/", true],
+        [msg("Explore integrations"), "https://integrations.goauthentik.io/", true],
         [msg("Manage users"), paramURL("/identity/users")],
         [
             msg("Check the release notes"),

--- a/web/src/elements/cards/stories/QuickActionsCard.stories.ts
+++ b/web/src/elements/cards/stories/QuickActionsCard.stories.ts
@@ -9,7 +9,7 @@ import { html } from "lit";
 const ACTIONS: QuickAction[] = [
     ["Create a new application", "/core/applications"],
     ["Check the logs", "/events/log"],
-    ["Explore integrations", "https://goauthentik.io/integrations/", true],
+    ["Explore integrations", "https://integrations.goauthentik.io/", true],
     ["Manage users", "/identity/users"],
     ["Check the release notes", "https://goauthentik.io/docs/releases/", true],
 ];

--- a/web/src/elements/cards/tests/QuickActionCard.test.ts
+++ b/web/src/elements/cards/tests/QuickActionCard.test.ts
@@ -11,7 +11,7 @@ import { html } from "lit";
 const ACTIONS: QuickAction[] = [
     ["Create a new application", "/core/applications"],
     ["Check the logs", "/events/log"],
-    ["Explore integrations", "https://goauthentik.io/integrations/", true],
+    ["Explore integrations", "https://integrations.goauthentik.io/", true],
     ["Manage users", "/identity/users"],
     ["Check the release notes", "https://goauthentik.io/docs/releases/", true],
 ];


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
The "Explore integrations" link in Quick actions points to the defunct: url https://docs.goauthentik.io/integrations/
I've replaced the url with the new link: https://integrations.goauthentik.io/

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
