### PR TITLE
website/docs: adds a webhook header mapping example

### DIFF
--- a/website/docs/sys-mgmt/events/transports.md
+++ b/website/docs/sys-mgmt/events/transports.md
@@ -43,11 +43,27 @@ This will send a POST request to the given URL with the following contents:
 
 The `Content-Type` header is set to `text/json`.
 
-You can also select a Notification mapping. This allows you to freely configure the request's payload. For example:
+#### Webhook mappings
+
+You can use Webook mappings to configure the request's payload and/or header. These are a type of property mapping that can be applied to the `Webhook Body Mapping` or `Webhook Header Mapping` fields of the webhook notification transport. For example:
+
+##### Webhook body example
+
+An example of a webhook body mapping that sets a `foo` key with its value set to the body of the notificaiton:
 
 ```python
 return {
     "foo": request.context['notification'].body,
+}
+```
+
+##### Webhook header example
+
+An example of a webhook header mapping that sets an authentication key:
+
+```python
+return {
+  "Authorization": "Bearer <token>"
 }
 ```
 

--- a/website/docs/sys-mgmt/events/transports.md
+++ b/website/docs/sys-mgmt/events/transports.md
@@ -45,7 +45,7 @@ The `Content-Type` header is set to `text/json`.
 
 #### Webhook mappings
 
-You can use Webook mappings to configure the request's payload and/or header. These are a type of property mapping that can be applied to the `Webhook Body Mapping` or `Webhook Header Mapping` fields of the webhook notification transport. For example:
+You can use Webook mappings to configure the request's payload and/or header. These are a type of property mapping that can be applied to the `Webhook Body Mapping` or `Webhook Header Mapping` fields of the webhook notification transport.
 
 ##### Webhook body example
 
@@ -59,7 +59,7 @@ return {
 
 ##### Webhook header example
 
-An example of a webhook header mapping that sets an authentication key:
+An example of a webhook header mapping that sets an authorization key:
 
 ```python
 return {

--- a/website/docs/sys-mgmt/events/transports.md
+++ b/website/docs/sys-mgmt/events/transports.md
@@ -49,7 +49,7 @@ You can use Webook mappings to configure the request's payload and/or header. Th
 
 ##### Webhook body example
 
-An example of a webhook body mapping that sets a `foo` key with its value set to the body of the notificaiton:
+An example of a webhook body mapping that sets a `foo` key with its value set to the body of the notification:
 
 ```python
 return {


### PR DESCRIPTION
## Details

Closes #16254

Adds an example of a wehbook mapping used to set a header.

---

## Checklist

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
