### PR TITLE
fix(rac): restore proper AuthenticatedSession lookup in ConnectionToken creation

### DIFF
--- a/authentik/providers/rac/views.py
+++ b/authentik/providers/rac/views.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 from django.utils.timezone import now
 from django.utils.translation import gettext as _
 
-from authentik.core.models import Application
+from authentik.core.models import Application, AuthenticatedSession
 from authentik.core.views.interface import InterfaceView
 from authentik.events.models import Event, EventAction
 from authentik.flows.challenge import RedirectChallenge
@@ -124,7 +124,9 @@ class RACFinalStage(RedirectStage):
             provider=self.provider,
             endpoint=self.endpoint,
             settings=settings or {},
-            session=self.request.session["authenticatedsession"],
+            session=AuthenticatedSession.objects.filter(
+                session_key=self.request.session.session_key
+            ).first(),
             expires=now() + timedelta_from_string(self.provider.connection_expiry),
             expiring=True,
         )


### PR DESCRIPTION
## Description
Fixes RAC SSH connection failures caused by passing a session key string instead of an AuthenticatedSession object.

## Related Issue
Fixes #16303

## The Problem
In `/authentik/providers/rac/views.py`, the code was incorrectly passing `self.request.session["authenticatedsession"]` (a session key string) to `ConnectionToken.session` which expects an AuthenticatedSession object after migration 0007_migrate_session.

## The Solution
This PR restores the correct behavior from v2025.2.4 where the AuthenticatedSession object is properly fetched using:
```python
session=AuthenticatedSession.objects.filter(
    session_key=self.request.session.session_key
).first()
```

## Changes
- Added `AuthenticatedSession` to the imports in `views.py`
- Fixed the `ConnectionToken.objects.create()` call to properly fetch the AuthenticatedSession object

## Testing
- [ ] RAC SSH connections work after this fix
- [ ] No UUID type errors in logs
- [ ] Tested upgrade path from affected versions

## Notes
This regression was introduced in v2025.4.x and affects all versions from 2025.4.1 onwards including the current main branch.
