### PR TITLE
website/docs: adds details to certificates doc

### DIFF
--- a/website/docs/sys-mgmt/certificates.md
+++ b/website/docs/sys-mgmt/certificates.md
@@ -43,7 +43,7 @@ Certificate discovery can be manually triggered by restarting the `certificate_d
 #### Mounted directories
 
 - **Docker Compose**: A `certs` directory is mapped to `/certs` within the worker container.
-- **Kubernetes**: You can map custom secrets/volumes under `/certs`.
+- **Kubernetes**: You can mount custom Secrets or Volumes under `/certs` and configure them in the worker Pod specification.
 
 authentik checks for new or changed files every hour and automatically triggers an outpost refresh when changes are detected.
 

--- a/website/docs/sys-mgmt/certificates.md
+++ b/website/docs/sys-mgmt/certificates.md
@@ -37,7 +37,7 @@ To use externally managed certificates (e.g., from Certbot or HashiCorp Vault), 
 authentik can automatically discover and import certificates from a designated directory. This allows you to use externally managed certificates with minimal configuration.
 
 :::note
-Certificate discovery can be manually triggered by restarting the `certificate_discovery` system task via **Dashboards** > **System Tasks** in the admin interface.
+Certificate discovery can be manually initiated by restarting the `certificate_discovery` system task from the authentik Admin interface under **Dashboards** > **System Tasks**.
 :::
 
 #### Mounted directories

--- a/website/docs/sys-mgmt/certificates.md
+++ b/website/docs/sys-mgmt/certificates.md
@@ -42,7 +42,7 @@ Certificate discovery can be manually triggered by restarting the `certificate_d
 
 #### Mounted directories
 
-- **Docker Compose**: A `certs` directory is mapped to `/certs` within the server and worker containers.
+- **Docker Compose**: A `certs` directory is mapped to `/certs` within the worker container.
 - **Kubernetes**: You can map custom secrets/volumes under `/certs`.
 
 authentik checks for new or changed files every hour and automatically triggers an outpost refresh when changes are detected.

--- a/website/docs/sys-mgmt/certificates.md
+++ b/website/docs/sys-mgmt/certificates.md
@@ -36,10 +36,14 @@ To use externally managed certificates (e.g., from Certbot or HashiCorp Vault), 
 
 authentik can automatically discover and import certificates from a designated directory. This allows you to use externally managed certificates with minimal configuration.
 
+:::note
+Certificate discovery can be manually triggered by restarting the `certificate_discovery` system task via **Dashboards** > **System Tasks** in the admin interface.
+:::
+
 #### Mounted directories
 
-- **Docker Compose**: A `certs` directory is mapped to `/certs` within the container
-- **Kubernetes**: You can map custom secrets/volumes under `/certs`
+- **Docker Compose**: A `certs` directory is mapped to `/certs` within the server and worker containers.
+- **Kubernetes**: You can map custom secrets/volumes under `/certs`.
 
 authentik checks for new or changed files every hour and automatically triggers an outpost refresh when changes are detected.
 


### PR DESCRIPTION
## Details

Closes #16333

Adds instruction on how to manually trigger certs discovery via system tasks and adds mention of which containers have the certs directory mounted.

---

## Checklist

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
