### PR TITLE
web/admin: allow blank value for User path template in User Write Stage

### DIFF
--- a/web/src/admin/stages/user_write/UserWriteStageForm.ts
+++ b/web/src/admin/stages/user_write/UserWriteStageForm.ts
@@ -152,7 +152,6 @@ export class UserWriteStageForm extends BaseStageForm<UserWriteStage> {
                             class="pf-c-form-control pf-m-monospace"
                             autocomplete="off"
                             spellcheck="false"
-                            required
                         />
                         <p class="pf-c-form__helper-text">
                             ${msg(


### PR DESCRIPTION

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
The helper text for the User path template input states:

> Path new users will be created under. If left blank, the default path will be used.

But the field itself is marked as _required_ in html.

As there's no red asterix and it work's perfecly without a value this PR removes the _required_ attribute, so that the form can be submitted while leaving this field empty.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
