### PR TITLE
website/docs: fix missing trailing slash in vaultwarden documentation

### DIFF
--- a/website/integrations/security/vaultwarden/index.md
+++ b/website/integrations/security/vaultwarden/index.md
@@ -48,7 +48,7 @@ To configure authentik with Vaultwarden, you must add the following environment 
 
 ```yaml
 SSO_ENABLED=true
-SSO_AUTHORITY=https://authentik.company/application/o/<application_slug>
+SSO_AUTHORITY=https://authentik.company/application/o/<application_slug>/
 SSO_CLIENT_ID=<client_id>
 SSO_CLIENT_SECRET=<client_secret>
 SSO_SCOPES="openid email profile offline_access"


### PR DESCRIPTION
Won't work without the missing forward slash.
Source: https://github.com/dani-garcia/vaultwarden/wiki/Enabling-SSO-support-using-OpenId-Connect#authentik

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
