### PR TITLE
website/integrations: fix dead links

### DIFF
--- a/website/integrations/index.mdx
+++ b/website/integrations/index.mdx
@@ -21,4 +21,4 @@ To learn more, refer to the [Applications](./applications.mdx) page.
 
 Sources are a way for authentik to use external user credentials for authentication. Supported integrations with external sources via authentik include federated directories like Active Directory and social logins such as Facebook, Twitter, etc. These integrations support all major protocols, including [LDAP](/docs/users-sources/sources/protocols/ldap/index.md), [SCIM](/docs/users-sources/sources/protocols/scim/index.md), [SAML](/docs/users-sources/sources/protocols/saml/index.md), and [OAuth and OpenID Connect](/docs/users-sources/sources/protocols/oauth/index.mdx)
 
-To learn more, refer to the [Sources](/docs/users-sources/sources/index.md) page.
+To learn more, refer to the [Sources](/docs/users-sources/sources) page.

--- a/website/integrations/index.mdx
+++ b/website/integrations/index.mdx
@@ -19,6 +19,6 @@ To learn more, refer to the [Applications](./applications.mdx) page.
 
 ### Federated and social sources
 
-Sources are a way for authentik to use external user credentials for authentication. Supported integrations with external sources via authentik include federated directories like Active Directory and social logins such as Facebook, Twitter, etc. These integrations support all major protocols, including [LDAP](/docs/users-sources/sources/protocols/ldap/index.md), [SCIM](/docs/users-sources/sources/protocols/scim/index.md), [SAML](/docs/users-sources/sources/protocols/saml/index.md), and [OAuth and OpenID Connect](/docs/users-sources/sources/protocols/oauth/index.mdx)
+Sources are a way for authentik to use external user credentials for authentication. Supported integrations with external sources via authentik include federated directories like Active Directory and social logins such as Facebook, Twitter, etc. These integrations support all major protocols, including [LDAP](/docs/users-sources/sources/protocols/ldap), [SCIM](/docs/users-sources/sources/protocols/scim), [SAML](/docs/users-sources/sources/protocols/saml), and [OAuth and OpenID Connect](/docs/users-sources/sources/protocols/oauth)
 
 To learn more, refer to the [Sources](/docs/users-sources/sources) page.


### PR DESCRIPTION
## Details

Fixes dead links on integrations overview page

Closes #16391

---

## Checklist

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
