### PR TITLE
website/docs: capitalized proper name of stages, removed old version references.

### DIFF
--- a/website/docs/add-secure-apps/flows-stages/stages/user_delete.md
+++ b/website/docs/add-secure-apps/flows-stages/stages/user_delete.md
@@ -1,11 +1,11 @@
 ---
-title: User delete stage
+title: User Delete stage
 ---
 
 :::danger
 This stage deletes the `pending_user` without any confirmation. You have to make sure the user is aware of this.
 :::
 
-This stage is intended for an unenrollment flow. It deletes the currently pending user.
+The User Delete stage is intended for an unenrollment flow. It deletes the currently pending user.
 
 The pending user is also removed from the current session.

--- a/website/docs/add-secure-apps/flows-stages/stages/user_login/index.md
+++ b/website/docs/add-secure-apps/flows-stages/stages/user_login/index.md
@@ -1,8 +1,8 @@
 ---
-title: User login stage
+title: User Login stage
 ---
 
-This stage attaches a currently pending user to the current session.
+The User Login stage attaches a currently pending user to the current session.
 
 It can be used after `user_write` during an enrollment flow, or after a `password` stage during an authentication flow.
 

--- a/website/docs/add-secure-apps/flows-stages/stages/user_logout.md
+++ b/website/docs/add-secure-apps/flows-stages/stages/user_logout.md
@@ -1,5 +1,5 @@
 ---
-title: User logout stage
+title: User Logout stage
 ---
 
 Opposite stage of [User Login Stages](./user_login/index.md). It removes the user from the current session.

--- a/website/docs/add-secure-apps/flows-stages/stages/user_write.md
+++ b/website/docs/add-secure-apps/flows-stages/stages/user_write.md
@@ -1,14 +1,14 @@
 ---
-title: User write stage
+title: User Write stage
 ---
 
-This stages writes data from the current flow context to a user.
+The User Write stage writes data from the current flow context to a user.
 
 Newly created users can be created as inactive and can be assigned to a selected group.
 
 ### Dynamic groups
 
-Starting with authentik 2022.5, users can be added to dynamic groups. To do so, simply set `groups` in the flow plan context before this stage is run, for example
+To add users to dynamic groups set `groups` in the flow plan context before this stage is run, for example:
 
 ```python
 from authentik.core.models import Group
@@ -22,6 +22,6 @@ return True
 
 By default, this stage will create a new user when none is present in the flow context.
 
-Starting with authentik 2022.12, the stage can by default not create new users to prevent users from creating new accounts without authorization.
+You can configure this stage to not automatically create new users, if you want to prevent users from creating new accounts without authorization.
 
-Starting with authentik 2023.1, this option has been expanded to allow user creation, forbid it or force user creation.
+Alternatively, you can configure the stage to explicitly allow user creation, forbid it, or force user creation.

--- a/website/docs/add-secure-apps/flows-stages/stages/user_write.md
+++ b/website/docs/add-secure-apps/flows-stages/stages/user_write.md
@@ -8,7 +8,7 @@ Newly created users can be created as inactive and can be assigned to a selected
 
 ### Dynamic groups
 
-To add users to dynamic groups set `groups` in the flow plan context before this stage is run, for example:
+To add users to dynamic groups, set `groups` in the flow plan context before this stage is run. For example:
 
 ```python
 from authentik.core.models import Group
@@ -22,6 +22,6 @@ return True
 
 By default, this stage will create a new user when none is present in the flow context.
 
-You can configure this stage to not automatically create new users, if you want to prevent users from creating new accounts without authorization.
+To prevent users from creating new accounts without authorization, you can configure the User Write stage to not automatically create new users.
 
 Alternatively, you can configure the stage to explicitly allow user creation, forbid it, or force user creation.


### PR DESCRIPTION
Tiny PR to capitalize the few stage names that were not, also a few tweaks to one file to remove old version references.

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
