### PR TITLE
root: check for brew install of libxml2 before updating path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,19 @@ redis_db := $(shell uv run python -m authentik.lib.config redis.db 2>/dev/null)
 
 UNAME := $(shell uname)
 
-## For macOS users, add the libxml2 and libxmlsec1 installed from brew to the build path
-## to prevent SAML-related tests from failing and ensure correct compilation
+# For macOS users, add the libxml2 installed from brew libxmlsec1 to the build path
+# to prevent SAML-related tests from failing and ensure correct pip dependency compilation
 ifeq ($(UNAME), Darwin)
-BREW_LDFLAGS := -L$(shell brew --prefix libxml2)/lib $(LDFLAGS)
-BREW_CPPFLAGS := -I$(shell brew --prefix libxml2)/include $(CPPFLAGS)
-BREW_PKG_CONFIG_PATH := $(shell brew --prefix libxml2)/lib/pkgconfig:$(PKG_CONFIG_PATH)
+# Only add for brew users who installed libxmlsec1
+	BREW_EXISTS := $(shell command -v brew 2> /dev/null)
+	ifdef BREW_EXISTS
+		LIBXML2_EXISTS := $(shell brew list libxml2 2> /dev/null)
+		ifdef LIBXML2_EXISTS
+			BREW_LDFLAGS := -L$(shell brew --prefix libxml2)/lib $(LDFLAGS)
+			BREW_CPPFLAGS := -I$(shell brew --prefix libxml2)/include $(CPPFLAGS)
+			BREW_PKG_CONFIG_PATH := $(shell brew --prefix libxml2)/lib/pkgconfig:$(PKG_CONFIG_PATH)
+		endif
+	endif
 endif
 
 all: lint-fix lint gen web test  ## Lint, build, and test everything
@@ -60,10 +67,10 @@ lint: ## Lint the python and golang sources
 	golangci-lint run -v
 
 core-install:
-ifeq ($(UNAME), Darwin)
-	# Clear cache to ensure fresh compilation
+ifdef LIBXML2_EXISTS
+# Clear cache to ensure fresh compilation
 	uv cache clean
-	# Force compilation from source for lxml and xmlsec with correct environment
+# Force compilation from source for lxml and xmlsec with correct environment
 	LDFLAGS="$(BREW_LDFLAGS)" CPPFLAGS="$(BREW_CPPFLAGS)" PKG_CONFIG_PATH="$(BREW_PKG_CONFIG_PATH)" uv sync --frozen --reinstall-package lxml --reinstall-package xmlsec --no-binary-package lxml --no-binary-package xmlsec
 else
 	uv sync --frozen


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
My makefile changes made a bit too broad of changes and made problems for non-brew users. The makefile has been corrected to verify the makefile is being ran by a mac user, then check for brew, then check for libxml2 before modifying core-install

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
