### PR TITLE
root: bump openapi-generator-cli to v7.15.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ gen-client-ts: gen-clean-ts  ## Build and install the authentik API for Typescri
 	docker run \
 		--rm -v ${PWD}:/local \
 		--user ${UID}:${GID} \
-		docker.io/openapitools/openapi-generator-cli:v7.11.0 generate \
+		docker.io/openapitools/openapi-generator-cli:v7.15.0 generate \
 		-i /local/schema.yml \
 		-g typescript-fetch \
 		-o /local/${GEN_API_TS} \
@@ -193,7 +193,7 @@ gen-client-py: gen-clean-py ## Build and install the authentik API for Python
 	docker run \
 		--rm -v ${PWD}:/local \
 		--user ${UID}:${GID} \
-		docker.io/openapitools/openapi-generator-cli:v7.11.0 generate \
+		docker.io/openapitools/openapi-generator-cli:v7.15.0 generate \
 		-i /local/schema.yml \
 		-g python \
 		-o /local/${GEN_API_PY} \


### PR DESCRIPTION
## Details

This is just a small starting point to update the generator-cli version to use lazy imports in the python client (see #10865 ). Since I don't know that much about the build process, I just wanted to get the change started ...

Also see https://github.com/OpenAPITools/openapi-generator/pull/21486 for why version 7.15