### PR TITLE
website/integrations: Update Issuer URL for Immich

### DIFF
--- a/website/integrations/media/immich/index.md
+++ b/website/integrations/media/immich/index.md
@@ -45,7 +45,7 @@ Immich documentation can be found here: https://immich.app/docs/administration/o
 
 1. In Immich, navigate to **Administration** > **Settings** > **OAuth Authentication**
 2. Configure Immich as follows:
-    - **Issuer URL**: `https://authentik.company/application/o/<application_slug>/`
+    - **Issuer URL**: `https://authentik.company/application/o/<application_slug>/.well-known/openid-configuration`
     - **Client ID**: Enter your Client ID from authentik
     - **Client Secret**: Enter your Client Secret from authentik
     - **Scope**: `openid email profile`


### PR DESCRIPTION
This pull request updates the Immich integration documentation to clarify the correct value for the OAuth Issuer URL. The new Issuer URL now points directly to the OpenID configuration endpoint, which is required for proper OAuth authentication setup.

- Documentation update:
  * Changed the recommended Immich OAuth Issuer URL to use the `.well-known/openid-configuration` path for improved compatibility with OpenID Connect.
  
The [documentation](https://immich.app/docs/administration/oauth) at Immich website show correct URL and this PR follows it.

<img width="1687" height="806" alt="image" src="https://github.com/user-attachments/assets/02114106-9618-452f-ace8-b64f11d8ea77" />


## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
