### PR TITLE
core: fix client-side only validation allowing admin to set blank user password

### DIFF
--- a/authentik/core/api/users.py
+++ b/authentik/core/api/users.py
@@ -328,6 +328,12 @@ class SessionUserSerializer(PassiveSerializer):
     original = UserSelfSerializer(required=False)
 
 
+class UserPasswordSetSerializer(PassiveSerializer):
+    """Payload to set a users' password directly"""
+
+    password = CharField(required=True)
+
+
 class UsersFilter(FilterSet):
     """Filter for users"""
 
@@ -585,12 +591,7 @@ class UserViewSet(UsedByMixin, ModelViewSet):
 
     @permission_required("authentik_core.reset_user_password")
     @extend_schema(
-        request=inline_serializer(
-            "UserPasswordSetSerializer",
-            {
-                "password": CharField(required=True),
-            },
-        ),
+        request=UserPasswordSetSerializer,
         responses={
             204: OpenApiResponse(description="Successfully changed password"),
             400: OpenApiResponse(description="Bad request"),
@@ -599,9 +600,11 @@ class UserViewSet(UsedByMixin, ModelViewSet):
     @action(detail=True, methods=["POST"], permission_classes=[])
     def set_password(self, request: Request, pk: int) -> Response:
         """Set password for user"""
+        data = UserPasswordSetSerializer(data=request.data)
+        data.is_valid(raise_exception=True)
         user: User = self.get_object()
         try:
-            user.set_password(request.data.get("password"), request=request)
+            user.set_password(data.validated_data["password"], request=request)
             user.save()
         except (ValidationError, IntegrityError) as exc:
             LOGGER.debug("Failed to set password", exc=exc)

--- a/authentik/core/tests/test_users_api.py
+++ b/authentik/core/tests/test_users_api.py
@@ -102,6 +102,16 @@ class TestUsersAPI(APITestCase):
         self.admin.refresh_from_db()
         self.assertTrue(self.admin.check_password(new_pw))
 
+    def test_set_password_blank(self):
+        """Test Direct password set"""
+        self.client.force_login(self.admin)
+        response = self.client.post(
+            reverse("authentik_api:user-set-password", kwargs={"pk": self.admin.pk}),
+            data={"password": ""},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertJSONEqual(response.content, {"password": ["This field may not be blank."]})
+
     def test_recovery(self):
         """Test user recovery link"""
         flow = create_test_flow(

--- a/schema.yml
+++ b/schema.yml
@@ -61879,6 +61879,7 @@ components:
       - object_pk
     UserPasswordSetRequest:
       type: object
+      description: Payload to set a users' password directly
       properties:
         password:
           type: string


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Previously was only relying on client-side validation

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
