### PR TITLE
website/docs: add missing notification rule example doc to sidebar

### DIFF
--- a/website/docs/sidebar.mjs
+++ b/website/docs/sidebar.mjs
@@ -618,6 +618,7 @@ const items = [
                 },
                 items: [
                     "sys-mgmt/events/notifications",
+                    "sys-mgmt/events/notification_rule_expression_policies",
                     "sys-mgmt/events/transports",
                     "sys-mgmt/events/logging-events",
                     "sys-mgmt/events/event-actions",


### PR DESCRIPTION

## Details

Adds the currently missing notification rule examples doc to the sidebar.

---

## Checklist

If applicable

-   [x] The documentation has been formatted (`make docs`)
