### PR TITLE
web: Fix issue where refresh events within modals propagate.

### DIFF
--- a/web/src/admin/rbac/RoleObjectPermissionTable.ts
+++ b/web/src/admin/rbac/RoleObjectPermissionTable.ts
@@ -33,6 +33,12 @@ export class RoleAssignedObjectPermissionTable extends Table<RoleAssignedObjectP
     checkbox = true;
     clearOnRefresh = true;
 
+    protected override refreshListener(event: Event) {
+        event.stopPropagation();
+
+        return super.refreshListener(event);
+    }
+
     async apiEndpoint(): Promise<PaginatedResponse<RoleAssignedObjectPermission>> {
         const perms = await new RbacApi(DEFAULT_CONFIG).rbacPermissionsAssignedByRolesList({
             ...(await this.defaultEndpointConfig()),

--- a/web/src/elements/table/Table.ts
+++ b/web/src/elements/table/Table.ts
@@ -167,9 +167,16 @@ export abstract class Table<T extends object>
     @state()
     protected error?: APIError;
 
-    #refreshListener = () => {
+    constructor() {
+        super();
+        this.#refreshListener = this.refreshListener.bind(this);
+    }
+
+    protected refreshListener(event: Event): void | Promise<void> {
         return this.fetch();
-    };
+    }
+
+    #refreshListener: EventListener;
 
     public override connectedCallback(): void {
         super.connectedCallback();


### PR DESCRIPTION

## Details
This fixes a situation where a table with a modal... with a table and another modal can be closed prematurely.


---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
