### PR TITLE
policies: remove object pk from authentik_policies_execution_time to reduce cardinality

### DIFF
--- a/authentik/policies/apps.py
+++ b/authentik/policies/apps.py
@@ -26,7 +26,6 @@ HIST_POLICIES_EXECUTION_TIME = Histogram(
         "binding_order",
         "binding_target_type",
         "binding_target_name",
-        "object_pk",
         "object_type",
         "mode",
     ],

--- a/authentik/policies/engine.py
+++ b/authentik/policies/engine.py
@@ -86,7 +86,6 @@ class PolicyEngine:
             binding_order=binding.order,
             binding_target_type=binding.target_type,
             binding_target_name=binding.target_name,
-            object_pk=str(self.request.obj.pk),
             object_type=class_to_path(self.request.obj.__class__),
             mode="cache_retrieve",
         ).time():

--- a/authentik/policies/process.py
+++ b/authentik/policies/process.py
@@ -131,7 +131,6 @@ class PolicyProcess(PROCESS_CLASS):
                 binding_order=self.binding.order,
                 binding_target_type=self.binding.target_type,
                 binding_target_name=self.binding.target_name,
-                object_pk=str(self.request.obj.pk) if self.request.obj else "",
                 object_type=class_to_path(self.request.obj.__class__) if self.request.obj else "",
                 mode="execute_process",
             ).time(),


### PR DESCRIPTION
Signed-off-by: Jens Langhammer <jens@goauthentik.io>

#16386

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<img width="2132" height="894" alt="image" src="https://github.com/user-attachments/assets/39881769-436a-4e3d-9346-5923e77fc0dc" />

This metric has the most unique time series for the worker and adds a lot of the storage (and generally having the PK in a metric is not good practice)

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
