### PR TITLE
core: bump aiohttp-retry from 2.9.1 to v2.9.1

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.13.*"
 
 [manifest]


### PR DESCRIPTION
See https://pypi.org/project/aiohttp-retry/ for package information