### PR TITLE
core: bump argon2-cffi from 25.1.0 to v25.1.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.13.*"
 
 [manifest]


### PR DESCRIPTION
See https://pypi.org/project/argon2-cffi/ for package information