### PR TITLE
core: bump cachetools from 5.5.2 to v5.5.2

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.13.*"
 
 [manifest]


### PR DESCRIPTION
See https://pypi.org/project/cachetools/ for package information