### PR TITLE
core: bump certifi from 2025.8.3 to v2025.8.3

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.13.*"
 
 [manifest]


### PR DESCRIPTION
See https://pypi.org/project/certifi/ for package information