### PR TITLE
web/flows: only disable login button when interactive captcha is configured and not loaded

### DIFF
--- a/web/src/flow/stages/identification/IdentificationStage.ts
+++ b/web/src/flow/stages/identification/IdentificationStage.ts
@@ -383,7 +383,9 @@ export class IdentificationStage extends BaseStage<
 
             <div class="pf-c-form__group ${this.challenge.captchaStage ? "" : "pf-m-action"}">
                 <button
-                    ?disabled=${this.challenge.captchaStage && !this.captchaLoaded}
+                    ?disabled=${this.challenge.captchaStage &&
+                    this.challenge.captchaStage.interactive &&
+                    !this.captchaLoaded}
                     type="submit"
                     class="pf-c-button pf-m-primary pf-m-block"
                 >


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Non-interactive captchas like reCaptcha don't require the user to click on something to continue so they shouldn't disable the login button

closes #16494

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
