### PR TITLE
core: remove superuser condition on token list

### DIFF
--- a/authentik/core/api/tokens.py
+++ b/authentik/core/api/tokens.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from django.utils.timezone import now
 from drf_spectacular.utils import OpenApiResponse, extend_schema, inline_serializer
-from guardian.shortcuts import assign_perm, get_anonymous_user
+from guardian.shortcuts import assign_perm
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.fields import CharField
@@ -137,12 +137,6 @@ class TokenViewSet(UsedByMixin, ModelViewSet):
     ordering = ["identifier", "expires"]
     owner_field = "user"
     rbac_allow_create_without_perm = True
-
-    def get_queryset(self):
-        user = self.request.user if self.request else get_anonymous_user()
-        if user.is_superuser:
-            return super().get_queryset()
-        return super().get_queryset().filter(user=user.pk)
 
     def perform_create(self, serializer: TokenSerializer):
         if not self.request.user.is_superuser:


### PR DESCRIPTION
This is a remnant from before we had object-level permissions.