### PR TITLE
website/integrations: add missing comma paperless-ngx

### DIFF
--- a/website/integrations/documentation/paperless-ngx/index.mdx
+++ b/website/integrations/documentation/paperless-ngx/index.mdx
@@ -71,7 +71,7 @@ environment:
                 "client_id": "<client_id>",
                 "secret": "<client_secret>",
                 "settings": {
-                  "server_url": "https://authentik.company/application/o/<application_slug>/.well-known/openid-configuration"
+                  "server_url": "https://authentik.company/application/o/<application_slug>/.well-known/openid-configuration",
                   "claims": {"username": "email"}
                 }
               }


### PR DESCRIPTION
PAPERLESS_SOCIALACCOUNT_PROVIDERS environment variable

- Added missing comma between "server_url" and "claims" in compose.yaml

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
