### PR TITLE
core: Include region comments in VSCode Minimap.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,16 @@
 {
+    "[css]": {
+        "editor.minimap.markSectionHeaderRegex": "#\\bregion\\s*(?<separator>-?)\\s*(?<label>.*)\\*/$"
+    },
+    "[makefile]": {
+        "editor.minimap.markSectionHeaderRegex": "^#{25}\n##\\s\\s*(?<separator>-?)\\s*(?<label>[^\n]*)\n#{25}$"
+    },
+    "[dockerfile]": {
+        "editor.minimap.markSectionHeaderRegex": "\\bStage\\s*\\d:(?<separator>-?)\\s*(?<label>.*)$"
+    },
+    "[jsonc]": {
+        "editor.minimap.markSectionHeaderRegex": "#\\bregion\\s*(?<separator>-?)\\s*(?<label>.*)$"
+    },
     "todo-tree.tree.showCountsInTree": true,
     "todo-tree.tree.showBadges": true,
     "yaml.customTags": [


### PR DESCRIPTION
## Details

This PR modifies the monorepo's VS Code config to consistently match against `#region` and `#MARK`-style comments, allowing for region-folding and Minimap headers to work like our TypeScript code.

### Examples

#### Docker stages

<img width="1059" height="490" alt="Screenshot 2025-09-08 at 16 11 53" src="https://github.com/user-attachments/assets/44193951-93f5-4412-a7a7-6a67c3ce851f" />

#### CSS files

<img width="1052" height="757" alt="Screenshot 2025-09-08 at 16 12 43" src="https://github.com/user-attachments/assets/38a5c73b-235d-48d3-9369-e47c310ad8a7" />

#### Makefile

<img width="1055" height="770" alt="Screenshot 2025-09-08 at 16 12 30" src="https://github.com/user-attachments/assets/c7141670-902a-4b85-9e13-2d263ec8d596" />

