### PR TITLE
website/docs: add powershell syntax highlighting

### DIFF
--- a/website/docs/docusaurus.config.esm.mjs
+++ b/website/docs/docusaurus.config.esm.mjs
@@ -158,6 +158,9 @@ export default createDocusaurusConfig(
                     target: "_self",
                 },
             },
+            prism: {
+                additionalLanguages: ["powershell"],
+            },
         }),
 
         //#endregion

--- a/website/integrations/docusaurus.config.esm.mjs
+++ b/website/integrations/docusaurus.config.esm.mjs
@@ -115,6 +115,9 @@ export default createDocusaurusConfig(
                     target: "_self",
                 },
             },
+            prism: {
+                additionalLanguages: ["powershell"],
+            },
         }),
 
         //#endregion


### PR DESCRIPTION
## Details

Adds powershell syntax highlighting to docusaurus for docs and integrations as mentioned in the [docusaurus docs](add powershell syntax highlighting)

---

## Checklist

-   [x] The documentation has been formatted (`make docs`)
