### PR TITLE
website/docs: clarify docker compose install

### DIFF
--- a/website/docs/install-config/install/docker-compose.mdx
+++ b/website/docs/install-config/install/docker-compose.mdx
@@ -86,17 +86,6 @@ AUTHENTIK_EMAIL__TIMEOUT=10
 AUTHENTIK_EMAIL__FROM=authentik@localhost
 ```
 
-## Configure for port 80/443
-
-By default, authentik listens internally on port 9000 for HTTP and 9443 for HTTPS. To change the exposed ports to 80 and 443, you can set the following variables in `.env`:
-
-```shell
-COMPOSE_PORT_HTTP=80
-COMPOSE_PORT_HTTPS=443
-```
-
-See [Configuration](../configuration/configuration.mdx) to change the internal ports. Be sure to run `docker compose up -d` to rebuild with the new port numbers.
-
 ## Startup
 
 :::warning
@@ -121,3 +110,14 @@ You will get `Not Found` error if initial setup URL doesn't include the trailing
 There you are prompted to set a password for the `akadmin` user (the default user).
 
 For an explanation about what each service in the docker compose file does, see [Architecture](../../core/architecture.md).
+
+## Configure for port 80/443
+
+By default, authentik listens internally on port 9000 for HTTP and 9443 for HTTPS. To change the exposed ports to 80 and 443, you can set the following variables in `.env`:
+
+```shell
+COMPOSE_PORT_HTTP=80
+COMPOSE_PORT_HTTPS=443
+```
+
+See [Configuration](../configuration/configuration.mdx) to change the internal ports. Be sure to run `docker compose up -d` to rebuild with the new port numbers.

--- a/website/docs/install-config/install/docker-compose.mdx
+++ b/website/docs/install-config/install/docker-compose.mdx
@@ -111,9 +111,9 @@ There you are prompted to set a password for the `akadmin` user (the default use
 
 For an explanation about what each service in the docker compose file does, see [Architecture](../../core/architecture.md).
 
-## Configure for port 80/443
+## Configure custom ports
 
-By default, authentik listens internally on port 9000 for HTTP and 9443 for HTTPS. To change the exposed ports to 80 and 443, you can set the following variables in `.env`:
+By default, authentik listens internally on port 9000 for HTTP and 9443 for HTTPS. To use different exposed ports such as 80 and 443, you can set the following variables in `.env`:
 
 ```shell
 COMPOSE_PORT_HTTP=80


### PR DESCRIPTION
## Details

Users reported issues with accessing the initial setup page because they'd followed the setup guide and configured a custom HTTP and HTTPs port. This PR moves that section to the end of the document and changes the heading name.

---

## Checklist

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
