### PR TITLE
web: Remove deprecated `node:path` polyfill.

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -73,8 +73,6 @@
                 "dompurify": "^3.2.6",
                 "esbuild": "^0.25.9",
                 "esbuild-plugin-copy": "^2.1.1",
-                "esbuild-plugin-polyfill-node": "^0.3.0",
-                "esbuild-plugins-node-modules-polyfill": "^1.7.1",
                 "eslint": "^9.35.0",
                 "eslint-plugin-lit": "^2.1.1",
                 "eslint-plugin-wc": "^3.0.1",
@@ -2446,7 +2444,8 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/@jspm/core/-/core-2.1.0.tgz",
             "integrity": "sha512-3sRl+pkyFY/kLmHl0cgHiFp2xEqErA8N3ECjMs7serSUBmoJ70lBa0PG5t0IM6WJgdZNyyI0R8YFfi5wM8+mzg==",
-            "license": "Apache-2.0"
+            "license": "Apache-2.0",
+            "optional": true
         },
         "node_modules/@kurkle/color": {
             "version": "0.3.2",
@@ -14199,86 +14198,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/esbuild-plugin-polyfill-node": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/esbuild-plugin-polyfill-node/-/esbuild-plugin-polyfill-node-0.3.0.tgz",
-            "integrity": "sha512-SHG6CKUfWfYyYXGpW143NEZtcVVn8S/WHcEOxk62LuDXnY4Zpmc+WmxJKN6GMTgTClXJXhEM5KQlxKY6YjbucQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@jspm/core": "^2.0.1",
-                "import-meta-resolve": "^3.0.0"
-            },
-            "peerDependencies": {
-                "esbuild": "*"
-            }
-        },
-        "node_modules/esbuild-plugin-polyfill-node/node_modules/import-meta-resolve": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-3.1.1.tgz",
-            "integrity": "sha512-qeywsE/KC3w9Fd2ORrRDUw6nS/nLwZpXgfrOc2IILvZYnCaEMd+D56Vfg9k4G29gIeVi3XKql1RQatME8iYsiw==",
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/esbuild-plugins-node-modules-polyfill": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/esbuild-plugins-node-modules-polyfill/-/esbuild-plugins-node-modules-polyfill-1.7.1.tgz",
-            "integrity": "sha512-IEaUhaS1RukGGcatDzqJmR+AzUWJ2upTJZP2i7FzR37Iw5Lk0LReCTnWnPMWnGG9lO4MWTGKEGGLWEOPegTRJA==",
-            "license": "MIT",
-            "dependencies": {
-                "@jspm/core": "^2.1.0",
-                "local-pkg": "^1.1.1",
-                "resolve.exports": "^2.0.3"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "esbuild": ">=0.14.0 <=0.25.x"
-            }
-        },
-        "node_modules/esbuild-plugins-node-modules-polyfill/node_modules/confbox": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.1.tgz",
-            "integrity": "sha512-hkT3yDPFbs95mNCy1+7qNKC6Pro+/ibzYxtM2iqEigpf0sVw+bg4Zh9/snjsBcf990vfIsg5+1U7VyiyBb3etg==",
-            "license": "MIT"
-        },
-        "node_modules/esbuild-plugins-node-modules-polyfill/node_modules/local-pkg": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.1.tgz",
-            "integrity": "sha512-WunYko2W1NcdfAFpuLUoucsgULmgDBRkdxHxWQ7mK0cQqwPiy8E1enjuRBrhLtZkB5iScJ1XIPdhVEFK8aOLSg==",
-            "license": "MIT",
-            "dependencies": {
-                "mlly": "^1.7.4",
-                "pkg-types": "^2.0.1",
-                "quansync": "^0.2.8"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            }
-        },
-        "node_modules/esbuild-plugins-node-modules-polyfill/node_modules/pathe": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-            "license": "MIT"
-        },
-        "node_modules/esbuild-plugins-node-modules-polyfill/node_modules/pkg-types": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.1.0.tgz",
-            "integrity": "sha512-wmJwA+8ihJixSoHKxZJRBQG1oY8Yr9pGLzRmSsNms0iNWyHHAlZCa7mmKiFR10YPZuz/2k169JiS/inOjBCZ2A==",
-            "license": "MIT",
-            "dependencies": {
-                "confbox": "^0.2.1",
-                "exsolve": "^1.0.1",
-                "pathe": "^2.0.3"
-            }
-        },
         "node_modules/esbuild-register": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.6.0.tgz",
@@ -24224,15 +24143,6 @@
             "license": "MIT",
             "dependencies": {
                 "protocol-buffers-schema": "^3.3.1"
-            }
-        },
-        "node_modules/resolve.exports": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
-            "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/responselike": {

--- a/web/package.json
+++ b/web/package.json
@@ -149,8 +149,6 @@
         "dompurify": "^3.2.6",
         "esbuild": "^0.25.9",
         "esbuild-plugin-copy": "^2.1.1",
-        "esbuild-plugin-polyfill-node": "^0.3.0",
-        "esbuild-plugins-node-modules-polyfill": "^1.7.1",
         "eslint": "^9.35.0",
         "eslint-plugin-lit": "^2.1.1",
         "eslint-plugin-wc": "^3.0.1",

--- a/web/scripts/build-web.mjs
+++ b/web/scripts/build-web.mjs
@@ -23,7 +23,6 @@ import { readBuildIdentifier } from "@goauthentik/core/version/node";
 import { deepmerge } from "deepmerge-ts";
 import esbuild from "esbuild";
 import { copy } from "esbuild-plugin-copy";
-import { polyfillNode } from "esbuild-plugin-polyfill-node";
 
 /// <reference types="../types/esbuild.js" />
 
@@ -80,11 +79,6 @@ const BASE_ESBUILD_OPTIONS = {
                     to: "./assets/icons",
                 },
             ],
-        }),
-        polyfillNode({
-            polyfills: {
-                path: true,
-            },
         }),
         mdxPlugin({
             root: MonoRepoRoot,

--- a/web/src/common/global.ts
+++ b/web/src/common/global.ts
@@ -28,7 +28,7 @@ export function globalAK(): GlobalAuthentik {
         ak.brand = CurrentBrandFromJSON(ak.brand);
         ak.config = ConfigFromJSON(ak.config);
     }
-    const apiBase = new URL(process.env.AK_API_BASE_PATH || window.location.origin);
+    const apiBase = new URL(import.meta.env.AK_API_BASE_PATH || window.location.origin);
     if (!ak) {
         return {
             config: ConfigFromJSON({

--- a/web/src/elements/ak-mdx/components/MDXAnchor.tsx
+++ b/web/src/elements/ak-mdx/components/MDXAnchor.tsx
@@ -1,10 +1,21 @@
-import { resolve } from "node:path";
-
 import { useMDXModule } from "#elements/ak-mdx/MDXModuleContext";
 
 import React from "react";
 
 const DOCS_DOMAIN = "https://docs.goauthentik.io";
+
+/**
+ * A simplified version of Node's `path.resolve`:
+ */
+function resolvePath(...args: string[]): string {
+    const pathname = args
+        // Combine all arguments into a single path...
+        .join("/")
+        // Normalizing any delimiting slashes...
+        .replace(/\/{2,}/g, "/");
+
+    return new URL(pathname, "file:///").pathname;
+}
 
 /**
  * A custom anchor element that applies special behavior for MDX content.
@@ -20,7 +31,7 @@ export const MDXAnchor = ({
     const { publicDirectory } = useMDXModule();
 
     if (href?.startsWith(".") && publicDirectory) {
-        const nextPathname = resolve(publicDirectory, href);
+        const nextPathname = resolvePath(publicDirectory, href);
 
         const nextURL = new URL(nextPathname, DOCS_DOMAIN);
         // Remove trailing .md and .mdx, and trailing "index".


### PR DESCRIPTION
## Details

This PR removes the `node:path` polyfill used in the MDX anchor link parser with the built-in resolver from the URL constructor. Same functionality -- a few dozen NPM packages lesser
