### PR TITLE
web: Use Pino console logger, reduce live reload noise.

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -25,7 +25,7 @@
                 "@fortawesome/fontawesome-free": "^7.0.1",
                 "@goauthentik/api": "^2025.10.0-rc1-1756907691",
                 "@goauthentik/core": "^1.0.0",
-                "@goauthentik/esbuild-plugin-live-reload": "^1.1.0",
+                "@goauthentik/esbuild-plugin-live-reload": "^1.2.2",
                 "@goauthentik/eslint-config": "^1.0.5",
                 "@goauthentik/prettier-config": "^3.1.0",
                 "@goauthentik/tsconfig": "^1.0.4",
@@ -1533,18 +1533,18 @@
             "link": true
         },
         "node_modules/@goauthentik/esbuild-plugin-live-reload": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@goauthentik/esbuild-plugin-live-reload/-/esbuild-plugin-live-reload-1.1.0.tgz",
-            "integrity": "sha512-JueZpuJFMXTR2B4h44/hS0oqn4frfR8A7gmOilKuOa1F3zbfE/T6MzWRv+23I3vDFJYr3fwQEw4zUWnSv75FjA==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@goauthentik/esbuild-plugin-live-reload/-/esbuild-plugin-live-reload-1.2.2.tgz",
+            "integrity": "sha512-98yeDbChxVfnF/EFm8FpIOEod+DAeQhkF85+35964fOK/2sQG4P8OzlfyhM/91KUiFg2WKWeWlInmq7ScUcajg==",
             "license": "MIT",
             "dependencies": {
                 "find-free-ports": "^3.1.1"
             },
             "engines": {
-                "node": ">=22"
+                "node": ">=24"
             },
             "peerDependencies": {
-                "esbuild": "^0.25.5"
+                "esbuild": "^0.25.9"
             }
         },
         "node_modules/@goauthentik/eslint-config": {

--- a/web/package.json
+++ b/web/package.json
@@ -101,7 +101,7 @@
         "@fortawesome/fontawesome-free": "^7.0.1",
         "@goauthentik/api": "^2025.10.0-rc1-1756907691",
         "@goauthentik/core": "^1.0.0",
-        "@goauthentik/esbuild-plugin-live-reload": "^1.1.0",
+        "@goauthentik/esbuild-plugin-live-reload": "^1.2.2",
         "@goauthentik/eslint-config": "^1.0.5",
         "@goauthentik/prettier-config": "^3.1.0",
         "@goauthentik/tsconfig": "^1.0.4",

--- a/web/scripts/build-web.mjs
+++ b/web/scripts/build-web.mjs
@@ -14,6 +14,7 @@ import * as path from "node:path";
  */
 import { mdxPlugin } from "#bundler/mdx-plugin/node";
 import { createBundleDefinitions } from "#bundler/utils/node";
+import { ConsoleLogger } from "#logger/node";
 import { DistDirectory, EntryPoint, PackageRoot } from "#paths/node";
 
 import { NodeEnvironment } from "@goauthentik/core/environment/node";
@@ -26,7 +27,14 @@ import { copy } from "esbuild-plugin-copy";
 
 /// <reference types="../types/esbuild.js" />
 
-const logPrefix = "[Build]";
+const logger = ConsoleLogger.child({ name: "Build" });
+
+const bundleDefinitions = createBundleDefinitions();
+
+const publicBundledDefinitions = Object.fromEntries(
+    Object.entries(bundleDefinitions).map(([name, value]) => [name, JSON.parse(value)]),
+);
+logger.info(publicBundledDefinitions, "Bundle definitions");
 
 const patternflyPath = resolvePackage("@patternfly/patternfly", import.meta);
 
@@ -84,7 +92,7 @@ const BASE_ESBUILD_OPTIONS = {
             root: MonoRepoRoot,
         }),
     ],
-    define: createBundleDefinitions(),
+    define: bundleDefinitions,
     format: "esm",
     logOverride: {
         /**
@@ -98,9 +106,7 @@ const BASE_ESBUILD_OPTIONS = {
 };
 
 async function cleanDistDirectory() {
-    const timerLabel = `${logPrefix} ♻️ Cleaning previous builds...`;
-
-    console.time(timerLabel);
+    logger.info(`♻️ Cleaning previous builds...`);
 
     await fs.rm(DistDirectory, {
         recursive: true,
@@ -111,7 +117,7 @@ async function cleanDistDirectory() {
         recursive: true,
     });
 
-    console.timeEnd(timerLabel);
+    logger.info(`♻️ Done!`);
 }
 
 /**
@@ -130,7 +136,7 @@ export function createESBuildOptions(overrides) {
 }
 
 function doHelp() {
-    console.log(`Build the authentik UI
+    logger.info(`Build the authentik UI
 
         options:
             -w, --watch: Build all interfaces
@@ -142,20 +148,15 @@ function doHelp() {
 }
 
 async function doWatch() {
-    console.group(`${logPrefix} 🤖 Watching entry points`);
+    logger.info(`🤖 Watching entry points:\n\t${Object.keys(EntryPoint).join("\n\t")}`);
 
-    const entryPoints = Object.entries(EntryPoint).map(([entrypointID, target]) => {
-        console.log(entrypointID);
-
-        return target;
-    });
-
-    console.groupEnd();
+    const entryPoints = Object.values(EntryPoint);
 
     const developmentPlugins = await import("@goauthentik/esbuild-plugin-live-reload/plugin")
         .then(({ liveReloadPlugin }) => [
             liveReloadPlugin({
                 relativeRoot: PackageRoot,
+                logger: logger.child({ name: "Live Reload" }),
             }),
         ])
         .catch(() => []);
@@ -176,12 +177,10 @@ async function doWatch() {
     const httpsURL = new URL("https://localhost");
     httpsURL.port = process.env.COMPOSE_PORT_HTTPS ?? "9443";
 
-    console.log(`\n${logPrefix} 🚀 Server running\n\n`);
+    logger.info(`🚀 Server running`);
 
-    console.log(`  🔓 ${httpURL.href}`);
-    console.log(`  🔒 ${httpsURL.href}`);
-
-    console.log(`\n---`);
+    logger.info(`🔓 ${httpURL.href}`);
+    logger.info(`🔒 ${httpsURL.href}`);
 
     return /** @type {Promise<void>} */ (
         new Promise((resolve) => {
@@ -193,15 +192,13 @@ async function doWatch() {
 }
 
 async function doBuild() {
-    console.group(`${logPrefix} 🚀 Building entry points:`);
+    logger.info(`🚀 Building entry points:`);
 
     const entryPoints = Object.entries(EntryPoint).map(([entrypointID, target]) => {
-        console.log(entrypointID);
+        logger.info(entrypointID);
 
         return target;
     });
-
-    console.groupEnd();
 
     const buildOptions = createESBuildOptions({
         entryPoints,
@@ -209,7 +206,7 @@ async function doBuild() {
 
     await esbuild.build(buildOptions);
 
-    console.log("Build complete");
+    logger.info("Build complete");
 }
 
 async function doProxy() {
@@ -220,7 +217,7 @@ async function doProxy() {
     });
 
     await esbuild.build(buildOptions);
-    console.log("Proxy build complete");
+    logger.info("Proxy build complete");
 }
 
 async function delegateCommand() {
@@ -250,7 +247,7 @@ await cleanDistDirectory()
                 process.exit(0);
             })
             .catch((error) => {
-                console.error(error);
+                logger.error(error);
                 process.exit(1);
             }),
     );


### PR DESCRIPTION
## Details

This PR uses our Pino-based console logger during web builds. Some benefits include...

- JSON output for Github CI, pretty mode for development like our Python logger
- Timestamps built into each
- Auto prefixes, child loggers, nested, etc
- Support for optional levels, such as hiding debug messages to reduce noise 

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
