### PR TITLE
website/docs: moves display source notes

### DIFF
--- a/website/docs/users-sources/sources/social-logins/entra-id/index.mdx
+++ b/website/docs/users-sources/sources/social-logins/entra-id/index.mdx
@@ -75,6 +75,10 @@ To support the integration of Entra ID with authentik, you need to create an Ent
 When group membership information is synced from Entra ID, authentik creates all groups that a user is a member of.
 :::
 
+:::note
+For instructions on how to display the new source on the authentik login page, refer to the [Add sources to default login page documentation](../../index.md#add-sources-to-default-login-page).
+:::
+
 ### Machine-to-machine authentication :ak-version[2024.12]
 
 If using [Machine-to-Machine](../../../../add-secure-apps/providers/oauth2/client_credentials.mdx#jwt-authentication) authentication, some specific steps need to be considered.
@@ -93,7 +97,3 @@ client_secret=<application_client_secret>
 ```
 
 The JWT returned from the request above can be used in authentik and exchanged for an authentik JWT.
-
-:::note
-For instructions on how to display the new source on the authentik login page, refer to the [Add sources to default login page documentation](../../index.md#add-sources-to-default-login-page).
-:::

--- a/website/docs/users-sources/sources/social-logins/google/cloud/index.md
+++ b/website/docs/users-sources/sources/social-logins/google/cloud/index.md
@@ -80,7 +80,7 @@ Here is an example of a complete authentik Google OAuth Source
 Save, and you now have Google as a source.
 
 :::note
-For more details on how to have the new source display on the Login Page see [here](../../../index.md#add-sources-to-default-login-page).
+For instructions on how to display the new source on the authentik login page, refer to the [Add sources to default login page documentation](../../../index.md#add-sources-to-default-login-page).
 :::
 
 ## Username mapping
@@ -101,7 +101,3 @@ return False
 Afterwards, edit the source's enrollment flow (by default _default-source-enrollment_), expand the policies bound to the first stage (_default-source-enrollment-prompt_), and bind the policy created above. Make sure the newly created policy comes before _default-source-enrollment-if-username_. Afterwards, any new logins will automatically have their google email address used as their username.
 
 This can be combined with disallowing users from changing their usernames, see [Configuration](../../../../../sys-mgmt/settings.md#allow-users-to-change-username).
-
-:::note
-For instructions on how to display the new source on the authentik login page, refer to the [Add sources to default login page documentation](../../../index.md#add-sources-to-default-login-page).
-:::

--- a/website/docs/users-sources/sources/social-logins/google/workspace/index.md
+++ b/website/docs/users-sources/sources/social-logins/google/workspace/index.md
@@ -149,6 +149,10 @@ Your choice of `slug` should match the ACS URL you provided to Google Workspace.
 You can choose a different slug, but you will need to update the ACS URL in Google Workspace to match.
 :::
 
+:::note
+For instructions on how to display the new source on the authentik login page, refer to the [Add sources to default login page documentation](../../../index.md#add-sources-to-default-login-page).
+:::
+
 #### Protocol settings
 
 Next, we'll configure the SAML protocol settings for the source. Fill in the following fields with the values you copied from Google Workspace:
@@ -202,7 +206,3 @@ This may take a few minutes to propagate, so try logging in again after a short 
 - [Setting up SAML with Google Workspace](https://support.google.com/a/answer/6087519)
 - [SAML app error messages](https://support.google.com/a/answer/6301076)
 - [SAML authentication flow](https://infosec.mozilla.org/guidelines/iam/saml.html)
-
-:::note
-For instructions on how to display the new source on the authentik login page, refer to the [Add sources to default login page documentation](../../../index.md#add-sources-to-default-login-page).
-:::


### PR DESCRIPTION
## Details

Moves the 'display source' notes to better locations, just after the steps to add the source, rather than the end of the doc.

---

## Checklist

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
