### PR TITLE
core: Fix middlware race condition induced crash

### DIFF
--- a/authentik/events/middleware.py
+++ b/authentik/events/middleware.py
@@ -197,7 +197,8 @@ class AuditMiddleware:
             return
         if _CTX_IGNORE.get():
             return
-        if request.request_id != _CTX_REQUEST.get().request_id:
+        current_request = _CTX_REQUEST.get()
+        if current_request is None or request.request_id != current_request.request_id:
             return
         user = self.get_user(request)
 
@@ -212,7 +213,8 @@ class AuditMiddleware:
             return
         if _CTX_IGNORE.get():
             return
-        if request.request_id != _CTX_REQUEST.get().request_id:
+        current_request = _CTX_REQUEST.get()
+        if current_request is None or request.request_id != current_request.request_id:
             return
         user = self.get_user(request)
 
@@ -239,7 +241,8 @@ class AuditMiddleware:
             return
         if _CTX_IGNORE.get():
             return
-        if request.request_id != _CTX_REQUEST.get().request_id:
+        current_request = _CTX_REQUEST.get()
+        if current_request is None or request.request_id != current_request.request_id:
             return
         user = self.get_user(request)
 

--- a/authentik/rbac/middleware.py
+++ b/authentik/rbac/middleware.py
@@ -61,7 +61,8 @@ class InitialPermissionsMiddleware:
     ):
         if not created:
             return
-        if request.request_id != _CTX_REQUEST.get().request_id:
+        current_request = _CTX_REQUEST.get()
+        if current_request is None or request.request_id != current_request.request_id:
             return
         user: User = request.user
         if not user or user.is_anonymous:


### PR DESCRIPTION
## Details

I discovered this issue while investigating flakiness in the Playwright e2e tests.
The `InitialPermissionsMiddleware` was trying to access the current request's `request_id` during signal handling, but the request was already completed, triggering a runtime error:

```
AttributeError: 'NoneType' object has no attribute 'request_id'
```

I can reproduce this crash in a some scenarios where multiple requests are made in parallel while available memory is low. My Django knowledge is pretty narrow, but I think the issue manifests like this: 

1. Signal handlers (post_save, pre_delete, m2m_changed, etc) are connected during request processing
2. `_CTX_REQUEST` is set to the current request, then reset to `None` when the request completes
3. Django signals  fire asynchronously or be delayed, executing after the context has been cleared
4. Signal handlers tried to access `_CTX_REQUEST.get().request_id` when `_CTX_REQUEST.get()` returned `None`


This PR fixes the issue by checking if the current request is still available before accessing its request_id. 
