### PR TITLE
readme: Remove Docker pulls badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/goauthentik/authentik/ci-outpost.yml?branch=main&label=outpost%20build&style=for-the-badge)](https://github.com/goauthentik/authentik/actions/workflows/ci-outpost.yml)
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/goauthentik/authentik/ci-web.yml?branch=main&label=web%20build&style=for-the-badge)](https://github.com/goauthentik/authentik/actions/workflows/ci-web.yml)
 [![Code Coverage](https://img.shields.io/codecov/c/gh/goauthentik/authentik?style=for-the-badge)](https://codecov.io/gh/goauthentik/authentik)
-![Docker pulls](https://img.shields.io/docker/pulls/authentik/server.svg?style=for-the-badge)
 ![Latest version](https://img.shields.io/docker/v/authentik/server?sort=semver&style=for-the-badge)
 [![](https://img.shields.io/badge/Help%20translate-transifex-blue?style=for-the-badge)](https://www.transifex.com/authentik/authentik/)
 


### PR DESCRIPTION
Removed Docker pulls badge from README.

See: https://authentiksecurity.slack.com/archives/C047XJX5M7E/p1757012942421889