### PR TITLE
website/docs: remove reference to Go migration

### DIFF
--- a/website/docs/developer-docs/contributing.md
+++ b/website/docs/developer-docs/contributing.md
@@ -93,7 +93,7 @@ authentik
 └── tenants - Soft tenancy, configure defaults and branding per domain
 ```
 
-This Django project is running in gunicorn, which spawns multiple workers and threads. Gunicorn is run from a lightweight Go application which reverse-proxies it, handles static files and will eventually gain more functionality as more code is migrated to Go.
+This Django project is running in gunicorn, which spawns multiple workers and threads. Gunicorn is run from a lightweight Go application that reverse-proxies it and handles static files.
 
 There are also several background tasks that run in Dramatiq, via the `django-dramatiq-postgres` package, with some additional helpers in `authentik.tasks`.
 


### PR DESCRIPTION
This PR removes a sentence in our Contributing docs about the product eventually migrating to Go.

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
