### PR TITLE
website/docs: re-fix sentence about Go

### DIFF
--- a/website/docs/developer-docs/contributing.md
+++ b/website/docs/developer-docs/contributing.md
@@ -93,7 +93,7 @@ authentik
 └── tenants - Soft tenancy, configure defaults and branding per domain
 ```
 
-This Django project is running in gunicorn, which spawns multiple workers and threads. Gunicorn is run from a lightweight Go application that reverse-proxies it and handles static files.
+This Django project is running in gunicorn, which spawns multiple workers and threads. Gunicorn is run from a lightweight Go application that reverse-proxies the application and handles static files.
 
 There are also several background tasks that run in Dramatiq, via the `django-dramatiq-postgres` package, with some additional helpers in `authentik.tasks`.
 


### PR DESCRIPTION
An [older PR](https://github.com/goauthentik/authentik/pull/15246) that impacted this same content was never backported to 2025.8, so I did that, which overwrote the frst fix of the Go sentence. Good times.

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
