### PR TITLE
lib/logging: only show locals when in debug mode

### DIFF
--- a/authentik/lib/logging.py
+++ b/authentik/lib/logging.py
@@ -43,7 +43,9 @@ def structlog_configure():
             structlog.stdlib.PositionalArgumentsFormatter(),
             structlog.processors.TimeStamper(fmt="iso", utc=False),
             structlog.processors.StackInfoRenderer(),
-            structlog.processors.dict_tracebacks,
+            structlog.processors.ExceptionRenderer(
+                structlog.processors.ExceptionDictTransformer(show_locals=CONFIG.get_bool("debug"))
+            ),
             structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
         ],
         logger_factory=structlog.stdlib.LoggerFactory(),
@@ -65,7 +67,14 @@ def get_logger_config():
             "json": {
                 "()": structlog.stdlib.ProcessorFormatter,
                 "processor": structlog.processors.JSONRenderer(sort_keys=True),
-                "foreign_pre_chain": LOG_PRE_CHAIN + [structlog.processors.dict_tracebacks],
+                "foreign_pre_chain": LOG_PRE_CHAIN
+                + [
+                    structlog.processors.ExceptionRenderer(
+                        structlog.processors.ExceptionDictTransformer(
+                            show_locals=CONFIG.get_bool("debug")
+                        )
+                    ),
+                ],
             },
             "console": {
                 "()": structlog.stdlib.ProcessorFormatter,


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Only show locals in debug mode. Previous setup can be used in certain configurations to leak partial passwords in the log

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
