### PR TITLE
website/integrations: extends the example to include `jwt_config` for matrix synapse

### DIFF
--- a/website/integrations/chat-communication-collaboration/matrix-synapse/index.md
+++ b/website/integrations/chat-communication-collaboration/matrix-synapse/index.md
@@ -40,6 +40,9 @@ To support the integration of Matrix Synapse with authentik, you need to create 
 
 3. Click **Submit** to save the new application and provider.
 
+Note: RSA keys must be used for signing for Authentik, ECC keys do not work.
+Note: The provider must have a signing key set and must not use an encryption key.
+
 ## Matrix configuration
 
 Add the following block to your Matrix config
@@ -64,4 +67,9 @@ oidc_providers:
           config:
               localpart_template: "{{ user.preferred_username }}"
               display_name_template: "{{ user.name|capitalize }}"
+[...]
+jwt_config:
+    enabled: true
+    secret: "*client secret*" # (same as `client_secret` above)
+    algorithm: "RS256"
 ```

--- a/website/integrations/chat-communication-collaboration/matrix-synapse/index.md
+++ b/website/integrations/chat-communication-collaboration/matrix-synapse/index.md
@@ -35,13 +35,11 @@ To support the integration of Matrix Synapse with authentik, you need to create 
 - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
     - Note the **Client ID**, **Client Secret**, and **slug** values because they will be required later.
     - Set a `Strict` redirect URI to `https://matrix.company/_synapse/client/oidc/callback`.
-    - Select any available signing key.
+    - Select any available RSA signing key. Matrix Synapse doesn't support ECC keys.
+    - Do no set an encryption key because this is not supported by Matrix Synapse.
 - **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/flows-stages/bindings/) (policy, group, or user) to manage the listing and access to applications on a user's **My applications** page.
 
 3. Click **Submit** to save the new application and provider.
-
-Note: RSA keys must be used for signing for Authentik, ECC keys do not work.
-Note: The provider must have a signing key set and must not use an encryption key.
 
 ## Matrix configuration
 
@@ -57,8 +55,8 @@ oidc_providers:
       idp_name: authentik
       discover: true
       issuer: "https://authentik.company/application/o/<application_slug>/"
-      client_id: "*client id*"
-      client_secret: "*client secret*"
+      client_id: "*client_ID*"
+      client_secret: "*client_secret*"
       scopes:
           - "openid"
           - "profile"
@@ -70,6 +68,6 @@ oidc_providers:
 [...]
 jwt_config:
     enabled: true
-    secret: "*client secret*" # (same as `client_secret` above)
+    secret: "*client_secret*"
     algorithm: "RS256"
 ```


### PR DESCRIPTION
This is necessary to successfully connect Synapse to authentik.

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->

The documentation on how to connect authentik with Matrix/Synapse via OIDC was missing the `jwt_config` option, as discussed here: https://github.com/element-hq/synapse/issues/17896
I've also created a PR for the Synapse repository to update the documentation on the web page of Synapse as well: https://github.com/element-hq/synapse/pull/18931

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
  - I did not change anything code-wise, so I guess that all tests should pass.
-   [x] The code has been formatted (`make lint-fix`)
  - Same as with the local tests.

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
