### PR TITLE
web/flows: improvements for hCaptcha

### DIFF
--- a/web/src/flow/stages/captcha/CaptchaStage.ts
+++ b/web/src/flow/stages/captcha/CaptchaStage.ts
@@ -574,8 +574,8 @@ export class CaptchaStage extends BaseStage<CaptchaChallenge, CaptchaChallengeRe
                 theme: this.activeTheme,
             });
 
-            if (captchaProvider === CaptchaProvider.reCAPTCHA) {
-                // reCAPTCHA's domain verification can't seem to penetrate the true origin
+            if (captchaProvider === CaptchaProvider.reCAPTCHA || captchaProvider === CaptchaProvider.hCaptcha) {
+                // reCAPTCHA's & hCaptcha's domain verification can't seem to penetrate the true origin
                 // of the page when loaded from a blob URL, likely due to their double-nested
                 // iframe structure.
                 // We fallback to the deprecated `document.write` to get around this.

--- a/web/src/flow/stages/captcha/CaptchaStage.ts
+++ b/web/src/flow/stages/captcha/CaptchaStage.ts
@@ -574,7 +574,10 @@ export class CaptchaStage extends BaseStage<CaptchaChallenge, CaptchaChallengeRe
                 theme: this.activeTheme,
             });
 
-            if (captchaProvider === CaptchaProvider.reCAPTCHA || captchaProvider === CaptchaProvider.hCaptcha) {
+            if (
+                captchaProvider === CaptchaProvider.reCAPTCHA ||
+                captchaProvider === CaptchaProvider.hCaptcha
+            ) {
                 // reCAPTCHA's & hCaptcha's domain verification can't seem to penetrate the true origin
                 // of the page when loaded from a blob URL, likely due to their double-nested
                 // iframe structure.


### PR DESCRIPTION
## Details

Since hCaptcha recently updated its verification process to require the "host" parameter, requests without it are now rejected with a 403 Forbidden error see #16755. Although PR #16171 introduced this check for reCAPTCHA, hCaptcha also needs the same update. Without this change, hCaptcha blocks captcha verification and prevents user registrations.

This effectively blocks new user registrations through the registration flow that includes hCaptcha.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)