### PR TITLE
website/docs: add redirect for broken provider links

### DIFF
--- a/website/docs/static/_redirects
+++ b/website/docs/static/_redirects
@@ -53,6 +53,9 @@
 /outposts/*                                                 /add-secure-apps/outposts/:splat 301!
 #endregion
 
+#region Providers
+/providers/*                                                /add-secure-apps/providers/:splat 301!
+
 #region Sources
 /sources/*                                                  /users-sources/sources/:splat 301!
 /user-group-role/*                                          /users-sources/:splat 301!


### PR DESCRIPTION
## Details

The links under open source on the [pricing page](https://goauthentik.io/pricing/) are missing `/add-secure/apps/`. This PR updates the redirect file to fix this.

---

## Checklist

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
