### PR TITLE
providers/ldap: add include_children parameter to cached search mode

### DIFF
--- a/internal/outpost/ldap/search/memory/memory.go
+++ b/internal/outpost/ldap/search/memory/memory.go
@@ -57,7 +57,7 @@ func (ms *MemorySearcher) fetch() {
 		Logger:   ms.log,
 	})
 	ms.users = users
-	groups, _ := ak.Paginator(ms.si.GetAPIClient().CoreApi.CoreGroupsList(context.TODO()).IncludeUsers(true), ak.PaginatorOptions{
+	groups, _ := ak.Paginator(ms.si.GetAPIClient().CoreApi.CoreGroupsList(context.TODO()).IncludeUsers(true).IncludeChildren(true), ak.PaginatorOptions{
 		PageSize: 100,
 		Logger:   ms.log,
 	})


### PR DESCRIPTION
## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
In #14974 I made some changes that added parent/child groups to the results from the LDAP provider. However, when changing the default value of `include_children` from `true` to `false` following review I forgot to add `.IncludeChildren(true)` to the cached search mode. Thus, it currently only works when using direct search mode. This PR fixes that oversight.

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
