### PR TITLE
website: Fix broken schema links v2

### DIFF
--- a/website/api/clients/golang.md
+++ b/website/api/clients/golang.md
@@ -4,7 +4,7 @@ sidebar_label: Golang
 description: A Golang client for the authentik API.
 ---
 
-The [Go API client](https://pkg.go.dev/goauthentik.io/api/v3) is generated using the [OpenAPI Generator](https://openapi-generator.tech/) and the [OpenAPI v3 schema](https://docs.goauthentik.io/schema.yml).
+The [Go API client](https://pkg.go.dev/goauthentik.io/api/v3) is generated using the [OpenAPI Generator](https://openapi-generator.tech/) and the [OpenAPI v3 schema](https://api.goauthentik.io/schema.yml).
 
 ```shell
 go get goauthentik.io/api/v3

--- a/website/api/clients/node.md
+++ b/website/api/clients/node.md
@@ -4,7 +4,7 @@ sidebar_label: Node.js
 description: A TypeScript client for the authentik API.
 ---
 
-The [Node.js API client](https://www.npmjs.com/package/@goauthentik/api) is generated using the [OpenAPI Generator](https://openapi-generator.tech/) and the [OpenAPI v3 schema](https://docs.goauthentik.io/schema.yml).
+The [Node.js API client](https://www.npmjs.com/package/@goauthentik/api) is generated using the [OpenAPI Generator](https://openapi-generator.tech/) and the [OpenAPI v3 schema](https://api.goauthentik.io/schema.yml).
 
 ```shell
 npm install @goauthentik/api

--- a/website/api/clients/python.md
+++ b/website/api/clients/python.md
@@ -4,7 +4,7 @@ sidebar_label: Python
 description: A Python client for the authentik API.
 ---
 
-The [Python API client](https://pypi.org/project/authentik-client/) is generated using the [OpenAPI Generator](https://openapi-generator.tech/) and the [OpenAPI v3 schema](https://docs.goauthentik.io/schema.yml).
+The [Python API client](https://pypi.org/project/authentik-client/) is generated using the [OpenAPI Generator](https://openapi-generator.tech/) and the [OpenAPI v3 schema](https://api.goauthentik.io/schema.yml).
 
 ```shell
 pip install authentik-client

--- a/website/api/index.md
+++ b/website/api/index.md
@@ -3,7 +3,7 @@ title: API Overview
 sidebar_label: Overview
 ---
 
-Our API reference documentation is generated from the [OpenAPI v3 schema](https://docs.goauthentik.io/schema.yml).
+Our API reference documentation is generated from the [OpenAPI v3 schema](https://api.goauthentik.io/schema.yml).
 
 You can also access your installation's own, instance-specific API Browser. Starting with 2021.3.5, every authentik instance has a built-in API browser, which can be accessed at <code>https://<em>authentik.company</em>/api/v3/</code>.
 

--- a/website/api/static/_redirects
+++ b/website/api/static/_redirects
@@ -5,6 +5,9 @@
 # Note: The order of the rules defines the priority of the redirect.
 #       i.e. The first rule that matches the URL will take precedence.
 
+#region OpenAPI
+/schema.yaml                                              /schema.yml 301!
+#endregion
 
 #region api prefix
 /api/*                                                     /:splat 301!

--- a/website/docs/static/_redirects
+++ b/website/docs/static/_redirects
@@ -6,13 +6,15 @@
 #       i.e. The first rule that matches the URL will take precedence.
 
 #region API
-/api                                                        https://api.goauthentik.io  301!
-/docs/api                                                   https://api.goauthentik.io  301!
-/docs/developer-docs/api/                                   https://api.goauthentik.io  301!
-/api/*                                                      https://api.goauthentik.io/:splat  301!
-/docs/api/*                                                 https://api.goauthentik.io/:splat  301!
-/docs/developer-docs/api/*                                  https://api.goauthentik.io/:splat  301!
-/developer-docs/api/*                                       https://api.goauthentik.io/:splat  301!
+/schema.yml                                                 https://api.goauthentik.io/schema.yml 301!
+/schema.yaml                                                https://api.goauthentik.io/schema.yml 301!
+/api                                                        https://api.goauthentik.io 301!
+/docs/api                                                   https://api.goauthentik.io 301!
+/docs/developer-docs/api/                                   https://api.goauthentik.io 301!
+/api/*                                                      https://api.goauthentik.io/:splat 301!
+/docs/api/*                                                 https://api.goauthentik.io/:splat 301!
+/docs/developer-docs/api/*                                  https://api.goauthentik.io/:splat 301!
+/developer-docs/api/*                                       https://api.goauthentik.io/:splat 301!
 #endregion
 
 #region Applications


### PR DESCRIPTION
## Details

A slimmed-down version of #16900. This PR retains the schema link updates and includes redirects for the links prior to the API docs split.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
