### PR TITLE
providers/plex: Add provider_type to PlexSource

### DIFF
--- a/authentik/sources/plex/models.py
+++ b/authentik/sources/plex/models.py
@@ -42,6 +42,7 @@ class PlexAuthenticationChallengeResponse(ChallengeResponse):
 class PlexSource(ScheduledModel, Source):
     """Authenticate against plex.tv"""
 
+    provider_type = "plex"
     client_id = models.TextField(
         default=generate_id,
         help_text=_("Client identifier used to talk to Plex."),


### PR DESCRIPTION
This will allow the Plex source to work with policies written against OAuth.  Closes #16951


## Details

This is a minor enhancement to add a property to the PlexSource that the OAuth source already has, and is used in example policies.

---

## Checklist

-   [X] Local tests pass (`ak test authentik/`)
-   [X] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
