### PR TITLE
blueprints: fix typo in sources-google-ldap-mappings

### DIFF
--- a/blueprints/example/sources-google-ldap-mappings.yaml
+++ b/blueprints/example/sources-google-ldap-mappings.yaml
@@ -215,7 +215,7 @@ entries:
       expression: |
         return {
           "attributes": {
-            "homeDirectoy": ldap.get("homeDirectory"),
+            "homeDirectory": ldap.get("homeDirectory"),
           },
         }
   - identifiers:


### PR DESCRIPTION
## Details

In the identifier for Google Secure LDAP Mapping: homeDirectory, there is a typo in the returned attribute property title. This PR corrects it.

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)