### PR TITLE
website/docs: random typo fixes

### DIFF
--- a/website/docs/add-secure-apps/flows-stages/bindings/index.md
+++ b/website/docs/add-secure-apps/flows-stages/bindings/index.md
@@ -12,7 +12,7 @@ Bindings are an important part of authentik; the majority of configuration optio
 
 Bindings are analyzed by authentik's Flow Plan, which starts with the flow, then assesses all of the bound policies, and then runs them in order to build out the plan.
 
-The two most common types of bindings in authentik are:
+The three most common types of bindings in authentik are:
 
 - stage bindings
 - policy bindings

--- a/website/docs/add-secure-apps/providers/proxy/_traefik_ingress.md
+++ b/website/docs/add-secure-apps/providers/proxy/_traefik_ingress.md
@@ -26,7 +26,7 @@ spec:
 ```
 
 :::info
-Traefik changed the apiVersion of the middleware CRD in version 3.0, for older versions please subsititue "apiVersion: traefik.containo.us/v1alpha1"
+Traefik changed the apiVersion of the middleware CRD in version 3.0, for older versions please substitute "apiVersion: traefik.containo.us/v1alpha1"
 :::
 
 Add the following settings to your IngressRoute

--- a/website/docs/add-secure-apps/providers/rac/rac_credentials_prompt.md
+++ b/website/docs/add-secure-apps/providers/rac/rac_credentials_prompt.md
@@ -4,7 +4,7 @@ title: RAC Credentials Prompt
 
 ## About the RAC credentials prompt
 
-You can configure the RAC provider to prompt users for their credentials when connecting to RAC endpoints. This is particulalry useful for establishing RDP connections to modern Windows systems that often require credentials to establish a connection.
+You can configure the RAC provider to prompt users for their credentials when connecting to RAC endpoints. This is particularly useful for establishing RDP connections to modern Windows systems that often require credentials to establish a connection.
 
 After implementing this configuration, when connecting to an RAC endpoint users are prompted to enter their credentials which are then passed to the RAC endpoint. This means that static credentials do not need to be set in the RAC provider, property mapping, or endpoint.
 

--- a/website/docs/customize/blueprints/index.mdx
+++ b/website/docs/customize/blueprints/index.mdx
@@ -30,7 +30,7 @@ Any additional `.yaml` file in `/blueprints` will be discovered and automaticall
 
 To disable existing blueprints, an empty file can be mounted over the existing blueprint.
 
-File-based blueprints are automatically removed once they become unavailable, however none of the objects created by those blueprints afre affected by this.
+File-based blueprints are automatically removed once they become unavailable, however none of the objects created by those blueprints are affected by this.
 
 :::info
 Please note that, by default, blueprint discovery and evaluation is not guaranteed to follow any specific order.

--- a/website/docs/customize/policies/expression.mdx
+++ b/website/docs/customize/policies/expression.mdx
@@ -56,7 +56,7 @@ import Objects from "../../expressions/_objects.md";
     - `request.user`: The current user, against which the policy is applied. See [User](../../users-sources/user/index.mdx)
 
         :::caution
-        When a policy is executed in the context of a flow, this will be set to the user initiaing request, and will only be changed by a `user_login` stage. For that reason, using this value in authentication flow policies may not return the expected user. Use `context['pending_user']` instead; User Identification and other stages update this value during flow execution.
+        When a policy is executed in the context of a flow, this will be set to the user initiating the request, and will only be changed by a `user_login` stage. For that reason, using this value in authentication flow policies may not return the expected user. Use `context['pending_user']` instead; User Identification and other stages update this value during flow execution.
 
         If the user is not authenticated, this will be set to a user called _AnonymousUser_, which is an instance of [authentik.core.models.User](https://docs.djangoproject.com/en/4.1/ref/contrib/auth/#django.contrib.auth.models.User) (authentik uses django-guardian for per-object permissions, [see](https://django-guardian.readthedocs.io/en/stable/)).
         :::

--- a/website/docs/developer-docs/docs/templates/index.md
+++ b/website/docs/developer-docs/docs/templates/index.md
@@ -12,7 +12,7 @@ The most common types are:
 
 - [**Conceptual**](./conceptual.md): these docs provide the WHY information, and explain when to use a feature (or when not to!), and general concepts behind the feature or functionality.
 
-- [**Reference**](./reference.md): this is typically tables or lists of reference information, such as configuration values, or functions, or most commmonly APIs.
+- [**Reference**](./reference.md): this is typically tables or lists of reference information, such as configuration values, or functions, or most commonly APIs.
 
 ### Add a new integration
 

--- a/website/docs/developer-docs/docs/templates/reference.tmpl.md
+++ b/website/docs/developer-docs/docs/templates/reference.tmpl.md
@@ -2,7 +2,7 @@
 title: "Markdown template: reference"
 ---
 
-Write a few sentences introducing the feature/component/technology, and state that this page contains refeerence materials.
+Write a few sentences introducing the feature/component/technology, and state that this page contains reference materials.
 
 :::info
 if needed, use this syntax to add a note (info) or warning (warning)


### PR DESCRIPTION
## Details

Fixes random mistakes.

---

## Checklist

If applicable
-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)