### PR TITLE
web/admin: Fix dissapearing "Create" button in service account modal

### DIFF
--- a/web/src/admin/users/ServiceAccountForm.ts
+++ b/web/src/admin/users/ServiceAccountForm.ts
@@ -54,6 +54,7 @@ export class ServiceAccountForm extends Form<UserServiceAccountRequest> {
     reset(): void {
         super.reset();
         this.result = null;
+        (this.parentElement as ModalForm).showSubmitButton = true;
     }
 
     renderForm(): TemplateResult {


### PR DESCRIPTION
Reproduction:

1. Attempt to create a service account: fill out the username and click Create.
2. There's a popup giving you your username and token. Click Close
3. Attempt to click Create Service Account again, the Create button should be here this time.

Root Cause: When the form is reset (it happens when the modal is closed), it was resetting the form data and clearing the result but not restoring the showSubmitButton property back to true.

Closes: https://github.com/goauthentik/authentik/issues/15948
