### PR TITLE
website/docs: oauth provider: Add 'device' and 'introspect' to reserved slugs

### DIFF
--- a/website/docs/add-secure-apps/providers/oauth2/index.mdx
+++ b/website/docs/add-secure-apps/providers/oauth2/index.mdx
@@ -59,7 +59,7 @@ sequenceDiagram
 | OpenID Configuration | `/application/o/<application slug>/.well-known/openid-configuration` |
 
 :::caution Reserved application slugs
-Due to how the OAuth2 provider endpoints are structured, you cannot create applications that use the slugs `authorize`, `token`, `userinfo`, or `revoke` as these would conflict with the global OAuth2 endpoints.
+Due to how the OAuth2 provider endpoints are structured, you cannot create applications that use the slugs `authorize`, `token`, `device`, `userinfo`, `introspect`, or `revoke` as these would conflict with the global OAuth2 endpoints.
 :::
 
 ### Additional configuration options with Redirect URIs


### PR DESCRIPTION
Updated the list of reserved application slugs for OAuth2 endpoints.

Closes: AUTH-1317
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
