### PR TITLE
webiste/docs: add missing oauth endpoints

### DIFF
--- a/website/docs/add-secure-apps/providers/oauth2/index.mdx
+++ b/website/docs/add-secure-apps/providers/oauth2/index.mdx
@@ -54,6 +54,8 @@ sequenceDiagram
 | Token                | `/application/o/token/`                                              |
 | User Info            | `/application/o/userinfo/`                                           |
 | Token Revoke         | `/application/o/revoke/`                                             |
+| Token Introspection  | `/application/o/introspect/`                                         |
+| Device Authorization | `/application/o/device/`                                             |
 | End Session          | `/application/o/<application slug>/end-session/`                     |
 | JWKS                 | `/application/o/<application slug>/jwks/`                            |
 | OpenID Configuration | `/application/o/<application slug>/.well-known/openid-configuration` |


### PR DESCRIPTION
## Details

Adds the device and introspection endpoints to the doc

---

## Checklist

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
