### PR TITLE
rbac: optimize rbac assigned by users query

### DIFF
--- a/authentik/rbac/api/rbac_assigned_by_users.py
+++ b/authentik/rbac/api/rbac_assigned_by_users.py
@@ -1,5 +1,6 @@
 """common RBAC serializers"""
 
+from django.contrib.auth.models import Permission
 from django.db.models import Q, QuerySet
 from django.db.transaction import atomic
 from django_filters.filters import CharFilter, ChoiceFilter
@@ -17,7 +18,7 @@ from rest_framework.viewsets import GenericViewSet
 
 from authentik.core.api.groups import GroupMemberSerializer
 from authentik.core.api.utils import ModelSerializer
-from authentik.core.models import User, UserTypes
+from authentik.core.models import Group, User, UserTypes
 from authentik.policies.event_matcher.models import model_choices
 from authentik.rbac.api.rbac import PermissionAssignResultSerializer, PermissionAssignSerializer
 from authentik.rbac.decorators import permission_required
@@ -54,26 +55,56 @@ class UserAssignedPermissionFilter(FilterSet):
     model = ChoiceFilter(choices=model_choices(), method="filter_model", required=True)
     object_pk = CharFilter(method="filter_object_pk")
 
+    def filter_queryset(self, queryset):
+        queryset = super().filter_queryset(queryset)
+        data = self.form.cleaned_data
+        model: str = data["model"]
+        object_pk: str | None = data.get("object_pk", None)
+        app, _, model = model.partition(".")
+
+        superuser_pks = (
+            Group.objects.filter(is_superuser=True).values_list("users", flat=True).distinct()
+        )
+
+        permissions = Permission.objects.filter(
+            content_type__app_label=app,
+            content_type__model=model,
+        )
+
+        user_pks_with_model_permission = (
+            permissions.order_by().values_list("user", flat=True).distinct()
+        )
+        user_pks_with_object_permission = []
+        if object_pk:
+            user_pks_with_object_permission = (
+                UserObjectPermission.objects.filter(
+                    permission__in=permissions,
+                    object_pk=object_pk,
+                )
+                .order_by()
+                .values_list("user", flat=True)
+                .distinct()
+            )
+
+        return queryset.filter(
+            Q(pk__in=superuser_pks)
+            | Q(pk__in=user_pks_with_model_permission)
+            | Q(pk__in=user_pks_with_object_permission)
+        )
+
     def filter_model(self, queryset: QuerySet, name, value: str) -> QuerySet:
         """Filter by object type"""
-        app, _, model = value.partition(".")
-        return queryset.filter(
-            Q(
-                user_permissions__content_type__app_label=app,
-                user_permissions__content_type__model=model,
-            )
-            | Q(
-                userobjectpermission__permission__content_type__app_label=app,
-                userobjectpermission__permission__content_type__model=model,
-            )
-            | Q(ak_groups__is_superuser=True)
-        ).distinct()
+        # Actual filtering is handled by the above method where both `model` and `object_pk` are
+        # available. Don't do anything here, this method is only left here to avoid overriding too
+        # much of filter_queryset.
+        return queryset
 
     def filter_object_pk(self, queryset: QuerySet, name, value: str) -> QuerySet:
         """Filter by object primary key"""
-        return queryset.filter(
-            Q(userobjectpermission__object_pk=value) | Q(ak_groups__is_superuser=True),
-        ).distinct()
+        # Actual filtering is handled by the above method where both `model` and `object_pk` are
+        # available. Don't do anything here, this method is only left here to avoid overriding too
+        # much of filter_queryset.
+        return queryset
 
 
 class UserAssignedPermissionViewSet(ListModelMixin, GenericViewSet):
@@ -83,7 +114,7 @@ class UserAssignedPermissionViewSet(ListModelMixin, GenericViewSet):
     ordering = ["username"]
     # The filtering is done in the filterset,
     # which has a required filter that does the heavy lifting
-    queryset = User.objects.all()
+    queryset = User.objects.all().prefetch_related("userobjectpermission_set")
     filterset_class = UserAssignedPermissionFilter
 
     @permission_required("authentik_core.assign_user_permissions")


### PR DESCRIPTION
This query was quite badly optimised. The previous query does 11 (!) joins:
```sql
SELECT DISTINCT "authentik_core_user"."id",
                "authentik_core_user"."password",
                "authentik_core_user"."last_login",
                "authentik_core_user"."username",
                "authentik_core_user"."first_name",
                "authentik_core_user"."last_name",
                "authentik_core_user"."email",
                "authentik_core_user"."is_active",
                "authentik_core_user"."date_joined",
                "authentik_core_user"."attributes",
                "authentik_core_user"."uuid",
                "authentik_core_user"."name",
                "authentik_core_user"."path",
                "authentik_core_user"."type",
                "authentik_core_user"."password_change_date",
                "authentik_core_user"."last_updated"
FROM "authentik_core_user"
LEFT OUTER JOIN "authentik_core_user_user_permissions" ON ("authentik_core_user"."id" = "authentik_core_user_user_permissions"."user_id")
LEFT OUTER JOIN "auth_permission" ON ("authentik_core_user_user_permissions"."permission_id" = "auth_permission"."id")
LEFT OUTER JOIN "django_content_type" ON ("auth_permission"."content_type_id" = "django_content_type"."id")
LEFT OUTER JOIN "guardian_userobjectpermission" ON ("authentik_core_user"."id" = "guardian_userobjectpermission"."user_id")
LEFT OUTER JOIN "auth_permission" T6 ON ("guardian_userobjectpermission"."permission_id" = T6."id")
LEFT OUTER JOIN "django_content_type" T7 ON (T6."content_type_id" = T7."id")
LEFT OUTER JOIN "authentik_core_user_ak_groups" ON ("authentik_core_user"."id" = "authentik_core_user_ak_groups"."user_id")
LEFT OUTER JOIN "authentik_core_group" ON ("authentik_core_user_ak_groups"."group_id" = "authentik_core_group"."group_uuid")
LEFT OUTER JOIN "guardian_userobjectpermission" T10 ON ("authentik_core_user"."id" = T10."user_id")
LEFT OUTER JOIN "authentik_core_user_ak_groups" T11 ON ("authentik_core_user"."id" = T11."user_id")
LEFT OUTER JOIN "authentik_core_group" T12 ON (T11."group_id" = T12."group_uuid")
WHERE ((("django_content_type"."app_label" = 'authentik_providers_proxy'
         AND "django_content_type"."model" = 'proxyprovider')
        OR (T7."app_label" = 'authentik_providers_proxy'
            AND T7."model" = 'proxyprovider')
        OR "authentik_core_group"."is_superuser")
       AND (T10."object_pk" = '1'
            OR T12."is_superuser"))
ORDER BY "authentik_core_user"."username" ASC
```
which ends up in 80 rows to be processed for a user table with 4 rows (numbers here must also take into account the quantity of rows in the joined tables, but you get the idea):
```
                                                                                                                                                                                                                                                     QUERY PLAN                                                                                                                                                                                                                                                      
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=1471.26..1471.46 rows=80 width=1925) (actual time=0.252..0.255 rows=2 loops=1)
   Sort Key: authentik_core_user.username
   Sort Method: quicksort  Memory: 25kB
   ->  HashAggregate  (cost=1467.93..1468.73 rows=80 width=1925) (actual time=0.233..0.236 rows=2 loops=1)
         Group Key: authentik_core_user.username, authentik_core_user.id, authentik_core_user.password, authentik_core_user.last_login, authentik_core_user.first_name, authentik_core_user.last_name, authentik_core_user.email, authentik_core_user.is_active, authentik_core_user.date_joined, authentik_core_user.attributes, authentik_core_user.uuid, authentik_core_user.name, authentik_core_user.path, authentik_core_user.type, authentik_core_user.password_change_date, authentik_core_user.last_updated
         Batches: 1  Memory Usage: 48kB
         ->  Hash Right Join  (cost=85.38..235.49 rows=30811 width=1925) (actual time=0.175..0.191 rows=65 loops=1)
               Hash Cond: (t11.user_id = authentik_core_user.id)
               Filter: (((t10.object_pk)::text = '1'::text) OR t12.is_superuser)
               Rows Removed by Filter: 1
               ->  Hash Left Join  (cost=1.07..30.98 rows=1570 width=5) (actual time=0.015..0.016 rows=4 loops=1)
                     Hash Cond: (t11.group_id = t12.group_uuid)
                     ->  Seq Scan on authentik_core_user_ak_groups t11  (cost=0.00..25.70 rows=1570 width=20) (actual time=0.001..0.001 rows=4 loops=1)
                     ->  Hash  (cost=1.03..1.03 rows=3 width=17) (actual time=0.003..0.003 rows=4 loops=1)
                           Buckets: 1024  Batches: 1  Memory Usage: 9kB
                           ->  Seq Scan on authentik_core_group t12  (cost=0.00..1.03 rows=3 width=17) (actual time=0.001..0.001 rows=4 loops=1)
               ->  Hash  (cost=74.50..74.50 rows=785 width=1962) (actual time=0.151..0.152 rows=33 loops=1)
                     Buckets: 1024  Batches: 1  Memory Usage: 14kB
                     ->  Hash Left Join  (cost=32.34..74.50 rows=785 width=1962) (actual time=0.129..0.144 rows=33 loops=1)
                           Hash Cond: (authentik_core_user.id = t10.user_id)
                           ->  Hash Left Join  (cost=31.32..70.33 rows=785 width=1925) (actual time=0.114..0.125 rows=17 loops=1)
                                 Hash Cond: (authentik_core_user_ak_groups.group_id = authentik_core_group.group_uuid)
                                 Filter: ((((django_content_type.app_label)::text = 'authentik_providers_proxy'::text) AND ((django_content_type.model)::text = 'proxyprovider'::text)) OR (((t7.app_label)::text = 'authentik_providers_proxy'::text) AND ((t7.model)::text = 'proxyprovider'::text)) OR authentik_core_group.is_superuser)
                                 Rows Removed by Filter: 3
                                 ->  Hash Right Join  (cost=30.25..64.98 rows=1570 width=2021) (actual time=0.095..0.102 rows=20 loops=1)
                                       Hash Cond: (authentik_core_user_ak_groups.user_id = authentik_core_user.id)
                                       ->  Seq Scan on authentik_core_user_ak_groups  (cost=0.00..25.70 rows=1570 width=20) (actual time=0.004..0.004 rows=4 loops=1)
                                       ->  Hash  (cost=29.75..29.75 rows=40 width=2005) (actual time=0.082..0.083 rows=11 loops=1)
                                             Buckets: 1024  Batches: 1  Memory Usage: 11kB
                                             ->  Hash Left Join  (cost=19.03..29.75 rows=40 width=2005) (actual time=0.073..0.078 rows=11 loops=1)
                                                   Hash Cond: (authentik_core_user.id = authentik_core_user_user_permissions.user_id)
                                                   ->  Hash Left Join  (cost=9.51..20.07 rows=40 width=1965) (actual time=0.044..0.047 rows=5 loops=1)
                                                         Hash Cond: (authentik_core_user.id = guardian_userobjectpermission.user_id)
                                                         ->  Seq Scan on authentik_core_user  (cost=0.00..10.40 rows=40 width=1925) (actual time=0.005..0.006 rows=4 loops=1)
                                                         ->  Hash  (cost=9.50..9.50 rows=1 width=44) (actual time=0.027..0.028 rows=3 loops=1)
                                                               Buckets: 1024  Batches: 1  Memory Usage: 9kB
                                                               ->  Nested Loop Left Join  (cost=0.42..9.50 rows=1 width=44) (actual time=0.018..0.025 rows=3 loops=1)
                                                                     ->  Seq Scan on guardian_userobjectpermission  (cost=0.00..1.01 rows=1 width=8) (actual time=0.005..0.005 rows=3 loops=1)
                                                                     ->  Nested Loop Left Join  (cost=0.42..8.48 rows=1 width=44) (actual time=0.005..0.006 rows=1 loops=3)
                                                                           ->  Index Scan using auth_permission_pkey on auth_permission t6  (cost=0.28..8.29 rows=1 width=8) (actual time=0.003..0.003 rows=1 loops=3)
                                                                                 Index Cond: (id = guardian_userobjectpermission.permission_id)
                                                                           ->  Index Scan using django_content_type_pkey on django_content_type t7  (cost=0.14..0.19 rows=1 width=44) (actual time=0.002..0.002 rows=1 loops=3)
                                                                                 Index Cond: (id = t6.content_type_id)
                                                   ->  Hash  (cost=9.50..9.50 rows=1 width=44) (actual time=0.020..0.020 rows=5 loops=1)
                                                         Buckets: 1024  Batches: 1  Memory Usage: 9kB
                                                         ->  Nested Loop Left Join  (cost=0.42..9.50 rows=1 width=44) (actual time=0.011..0.018 rows=5 loops=1)
                                                               ->  Seq Scan on authentik_core_user_user_permissions  (cost=0.00..1.01 rows=1 width=8) (actual time=0.002..0.002 rows=5 loops=1)
                                                               ->  Nested Loop Left Join  (cost=0.42..8.48 rows=1 width=44) (actual time=0.003..0.003 rows=1 loops=5)
                                                                     ->  Index Scan using auth_permission_pkey on auth_permission  (cost=0.28..8.29 rows=1 width=8) (actual time=0.001..0.001 rows=1 loops=5)
                                                                           Index Cond: (id = authentik_core_user_user_permissions.permission_id)
                                                                     ->  Index Scan using django_content_type_pkey on django_content_type  (cost=0.14..0.19 rows=1 width=44) (actual time=0.001..0.001 rows=1 loops=5)
                                                                           Index Cond: (id = auth_permission.content_type_id)
                                 ->  Hash  (cost=1.03..1.03 rows=3 width=17) (actual time=0.009..0.009 rows=4 loops=1)
                                       Buckets: 1024  Batches: 1  Memory Usage: 9kB
                                       ->  Seq Scan on authentik_core_group  (cost=0.00..1.03 rows=3 width=17) (actual time=0.005..0.006 rows=4 loops=1)
                           ->  Hash  (cost=1.01..1.01 rows=1 width=41) (actual time=0.003..0.003 rows=3 loops=1)
                                 Buckets: 1024  Batches: 1  Memory Usage: 9kB
                                 ->  Seq Scan on guardian_userobjectpermission t10  (cost=0.00..1.01 rows=1 width=41) (actual time=0.001..0.002 rows=3 loops=1)
 Planning Time: 2.075 ms
 Execution Time: 0.457 ms
(60 rows)
```
Because the `DISTINCT` operates on all authentik_core_user columns, rows get sorted by all of the columns first, then they get filtered, and only then does the distinct happen. This causes a massive sort to happen. For big installations, this can result in the query exceeding postgres' `work_mem`, thus overflowing on disk.
We can halve the number of rows with a `DISTINCT ON (username)`:
```sql
EXPLAIN ANALYZE SELECT DISTINCT ON ("authentik_core_user"."username") "authentik_core_user"."id",
                   "authentik_core_user"."password",
                   "authentik_core_user"."last_login",
                   "authentik_core_user"."username",
                   "authentik_core_user"."first_name",
                   "authentik_core_user"."last_name",
                   "authentik_core_user"."email",
                   "authentik_core_user"."is_active",
                   "authentik_core_user"."date_joined",
                   "authentik_core_user"."attributes",
                   "authentik_core_user"."uuid",
                   "authentik_core_user"."name",
                   "authentik_core_user"."path",
                   "authentik_core_user"."type",
                   "authentik_core_user"."password_change_date",
                   "authentik_core_user"."last_updated"
FROM "authentik_core_user"
LEFT OUTER JOIN "authentik_core_user_user_permissions" ON ("authentik_core_user"."id" = "authentik_core_user_user_permissions"."user_id")
LEFT OUTER JOIN "auth_permission" ON ("authentik_core_user_user_permissions"."permission_id" = "auth_permission"."id")
LEFT OUTER JOIN "django_content_type" ON ("auth_permission"."content_type_id" = "django_content_type"."id")
LEFT OUTER JOIN "guardian_userobjectpermission" ON ("authentik_core_user"."id" = "guardian_userobjectpermission"."user_id")
LEFT OUTER JOIN "auth_permission" T6 ON ("guardian_userobjectpermission"."permission_id" = T6."id")
LEFT OUTER JOIN "django_content_type" T7 ON (T6."content_type_id" = T7."id")
LEFT OUTER JOIN "authentik_core_user_ak_groups" ON ("authentik_core_user"."id" = "authentik_core_user_ak_groups"."user_id")
LEFT OUTER JOIN "authentik_core_group" ON ("authentik_core_user_ak_groups"."group_id" = "authentik_core_group"."group_uuid")
LEFT OUTER JOIN "guardian_userobjectpermission" T10 ON ("authentik_core_user"."id" = T10."user_id")
LEFT OUTER JOIN "authentik_core_user_ak_groups" T11 ON ("authentik_core_user"."id" = T11."user_id")
LEFT OUTER JOIN "authentik_core_group" T12 ON (T11."group_id" = T12."group_uuid")
WHERE ((("django_content_type"."app_label" ='authentik_providers_proxy'
         AND "django_content_type"."model" = 'proxyprovider')
        OR (T7."app_label" = 'authentik_providers_proxy'
            AND T7."model" = 'proxyprovider')
        OR "authentik_core_group"."is_superuser")
       AND (T10."object_pk" = '1'
            OR T12."is_superuser"))
ORDER BY "authentik_core_user"."username" ASC
```
which is still not great:
```
                                                                                                                                                           QUERY PLAN                                                                                                                                                            
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Unique  (cost=2.35..1488.26 rows=40 width=1925) (actual time=0.106..0.177 rows=2 loops=1)
   ->  Nested Loop Left Join  (cost=2.35..1411.23 rows=30811 width=1925) (actual time=0.106..0.173 rows=65 loops=1)
         Filter: (((t10.object_pk)::text = '1'::text) OR t12.is_superuser)
         Rows Removed by Filter: 1
         ->  Nested Loop Left Join  (cost=1.13..263.12 rows=785 width=1962) (actual time=0.086..0.116 rows=33 loops=1)
               Join Filter: (authentik_core_user.id = t10.user_id)
               Rows Removed by Join Filter: 19
               ->  Nested Loop Left Join  (cost=1.13..250.34 rows=785 width=1925) (actual time=0.081..0.103 rows=17 loops=1)
                     Join Filter: (authentik_core_user_ak_groups.group_id = authentik_core_group.group_uuid)
                     Rows Removed by Join Filter: 34
                     Filter: ((((django_content_type.app_label)::text = 'authentik_providers_proxy'::text) AND ((django_content_type.model)::text = 'proxyprovider'::text)) OR (((t7.app_label)::text = 'authentik_providers_proxy'::text) AND ((t7.model)::text = 'proxyprovider'::text)) OR authentik_core_group.is_superuser)
                     Rows Removed by Filter: 3
                     ->  Nested Loop Left Join  (cost=1.13..131.85 rows=1570 width=2021) (actual time=0.070..0.085 rows=20 loops=1)
                           ->  Nested Loop Left Join  (cost=0.98..68.95 rows=40 width=2005) (actual time=0.062..0.069 rows=11 loops=1)
                                 Join Filter: (authentik_core_user.id = authentik_core_user_user_permissions.user_id)
                                 Rows Removed by Join Filter: 16
                                 ->  Nested Loop Left Join  (cost=0.56..58.84 rows=40 width=1965) (actual time=0.041..0.044 rows=5 loops=1)
                                       Join Filter: (authentik_core_user.id = guardian_userobjectpermission.user_id)
                                       Rows Removed by Join Filter: 9
                                       ->  Index Scan using authentik_core_user_username_key on authentik_core_user  (cost=0.14..48.74 rows=40 width=1925) (actual time=0.011..0.012 rows=4 loops=1)
                                       ->  Materialize  (cost=0.42..9.51 rows=1 width=44) (actual time=0.006..0.007 rows=3 loops=4)
                                             ->  Nested Loop Left Join  (cost=0.42..9.50 rows=1 width=44) (actual time=0.020..0.026 rows=3 loops=1)
                                                   ->  Seq Scan on guardian_userobjectpermission  (cost=0.00..1.01 rows=1 width=8) (actual time=0.006..0.006 rows=3 loops=1)
                                                   ->  Nested Loop Left Join  (cost=0.42..8.48 rows=1 width=44) (actual time=0.005..0.006 rows=1 loops=3)
                                                         ->  Index Scan using auth_permission_pkey on auth_permission t6  (cost=0.28..8.29 rows=1 width=8) (actual time=0.003..0.003 rows=1 loops=3)
                                                               Index Cond: (id = guardian_userobjectpermission.permission_id)
                                                         ->  Index Scan using django_content_type_pkey on django_content_type t7  (cost=0.14..0.19 rows=1 width=44) (actual time=0.002..0.002 rows=1 loops=3)
                                                               Index Cond: (id = t6.content_type_id)
                                 ->  Materialize  (cost=0.42..9.51 rows=1 width=44) (actual time=0.003..0.004 rows=5 loops=5)
                                       ->  Nested Loop Left Join  (cost=0.42..9.50 rows=1 width=44) (actual time=0.010..0.017 rows=5 loops=1)
                                             ->  Seq Scan on authentik_core_user_user_permissions  (cost=0.00..1.01 rows=1 width=8) (actual time=0.002..0.002 rows=5 loops=1)
                                             ->  Nested Loop Left Join  (cost=0.42..8.48 rows=1 width=44) (actual time=0.003..0.003 rows=1 loops=5)
                                                   ->  Index Scan using auth_permission_pkey on auth_permission  (cost=0.28..8.29 rows=1 width=8) (actual time=0.001..0.001 rows=1 loops=5)
                                                         Index Cond: (id = authentik_core_user_user_permissions.permission_id)
                                                   ->  Index Scan using django_content_type_pkey on django_content_type  (cost=0.14..0.19 rows=1 width=44) (actual time=0.001..0.001 rows=1 loops=5)
                                                         Index Cond: (id = auth_permission.content_type_id)
                           ->  Index Scan using authentik_core_user_pb_groups_user_id_5ce7c1dc on authentik_core_user_ak_groups  (cost=0.15..1.49 rows=8 width=20) (actual time=0.001..0.001 rows=2 loops=11)
                                 Index Cond: (user_id = authentik_core_user.id)
                     ->  Materialize  (cost=0.00..1.04 rows=3 width=17) (actual time=0.001..0.001 rows=3 loops=20)
                           ->  Seq Scan on authentik_core_group  (cost=0.00..1.03 rows=3 width=17) (actual time=0.004..0.005 rows=4 loops=1)
               ->  Materialize  (cost=0.00..1.01 rows=1 width=41) (actual time=0.000..0.000 rows=3 loops=17)
                     ->  Seq Scan on guardian_userobjectpermission t10  (cost=0.00..1.01 rows=1 width=41) (actual time=0.001..0.001 rows=3 loops=1)
         ->  Hash Left Join  (cost=1.22..2.58 rows=8 width=5) (actual time=0.001..0.001 rows=2 loops=33)
               Hash Cond: (t11.group_id = t12.group_uuid)
               ->  Index Scan using authentik_core_user_pb_groups_user_id_5ce7c1dc on authentik_core_user_ak_groups t11  (cost=0.15..1.49 rows=8 width=20) (actual time=0.000..0.001 rows=2 loops=33)
                     Index Cond: (user_id = authentik_core_user.id)
               ->  Hash  (cost=1.03..1.03 rows=3 width=17) (actual time=0.004..0.004 rows=4 loops=1)
                     Buckets: 1024  Batches: 1  Memory Usage: 9kB
                     ->  Seq Scan on authentik_core_group t12  (cost=0.00..1.03 rows=3 width=17) (actual time=0.001..0.001 rows=4 loops=1)
 Planning Time: 2.176 ms
 Execution Time: 0.322 ms
(51 rows)
```
Now only half the rows get sorted, but as the total row number grows exponentially compared to the number of base rows in the initial table and joined tables, we need to do more optimisation.

The first step was to rewrite the queries to avoid any kind of join. We do this by instead going to the N+1 table, do a select there and use the result to filter. We thus end up with sub-queries instead of joins:
```sql
EXPLAIN ANALYZE SELECT DISTINCT
    "authentik_core_user"."id",
    "authentik_core_user"."password",
    "authentik_core_user"."last_login",
    "authentik_core_user"."username",
    "authentik_core_user"."first_name",
    "authentik_core_user"."last_name",
    "authentik_core_user"."email",
    "authentik_core_user"."is_active",
    "authentik_core_user"."date_joined",
    "authentik_core_user"."attributes",
    "authentik_core_user"."uuid",
    "authentik_core_user"."name",
    "authentik_core_user"."path",
    "authentik_core_user"."type",
    "authentik_core_user"."password_change_date",
    "authentik_core_user"."last_updated"
FROM "authentik_core_user"
LEFT OUTER JOIN
    "authentik_core_user_ak_groups"
    ON ("authentik_core_user"."id" = "authentik_core_user_ak_groups"."user_id")
WHERE (
    "authentik_core_user_ak_groups"."group_id" IN
    (
        SELECT U0."group_uuid"
        FROM "authentik_core_group" AS U0
        WHERE U0."is_superuser"
    )
    OR "authentik_core_user"."id" IN
    (
        SELECT DISTINCT U2."user_id"
        FROM "auth_permission" AS U0
        INNER JOIN
            "django_content_type" AS U1
            ON (U0."content_type_id" = U1."id")
        LEFT OUTER JOIN
            "authentik_core_user_user_permissions" AS U2
            ON (U0."id" = U2."permission_id")
        WHERE (
            U1."app_label" = 'authentik_providers_proxy'
            AND U1."model" = 'proxyprovider'
        )
    )
    OR "authentik_core_user"."id" IN
    (
        SELECT DISTINCT V0."user_id"
        FROM "guardian_userobjectpermission" AS V0
        WHERE (
            V0."object_pk" = '1'
            AND V0."permission_id" IN
            (
                SELECT U0."id"
                FROM "auth_permission" AS U0
                INNER JOIN
                    "django_content_type" AS U1
                    ON (U0."content_type_id" = U1."id")
                WHERE (
                    U1."app_label" = 'authentik_providers_proxy'
                    AND U1."model" = 'proxyprovider'
                )
            )
        )
    )
)
ORDER BY "authentik_core_user"."username" ASC
```
We still have one join, because for some reason I either forgot to remove it here, or because it was easier to write group filtering like this.
```
                                                                                                                                                                                                                                                     QUERY PLAN                                                                                                                                                                                                                                                      
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=130.21..130.41 rows=80 width=1925) (actual time=0.147..0.149 rows=2 loops=1)
   Sort Key: authentik_core_user.username
   Sort Method: quicksort  Memory: 25kB
   ->  HashAggregate  (cost=126.88..127.68 rows=80 width=1925) (actual time=0.124..0.126 rows=2 loops=1)
         Group Key: authentik_core_user.username, authentik_core_user.id, authentik_core_user.password, authentik_core_user.last_login, authentik_core_user.first_name, authentik_core_user.last_name, authentik_core_user.email, authentik_core_user.is_active, authentik_core_user.date_joined, authentik_core_user.attributes, authentik_core_user.uuid, authentik_core_user.name, authentik_core_user.path, authentik_core_user.type, authentik_core_user.password_change_date, authentik_core_user.last_updated
         Batches: 1  Memory Usage: 48kB
         ->  Hash Right Join  (cost=41.95..71.92 rows=1374 width=1925) (actual time=0.038..0.116 rows=3 loops=1)
               Hash Cond: (authentik_core_user_ak_groups.user_id = authentik_core_user.id)
               Filter: ((hashed SubPlan 1) OR (hashed SubPlan 2) OR (hashed SubPlan 3))
               Rows Removed by Filter: 3
               ->  Seq Scan on authentik_core_user_ak_groups  (cost=0.00..25.70 rows=1570 width=20) (actual time=0.004..0.005 rows=4 loops=1)
               ->  Hash  (cost=10.40..10.40 rows=40 width=1925) (actual time=0.013..0.013 rows=4 loops=1)
                     Buckets: 1024  Batches: 1  Memory Usage: 9kB
                     ->  Seq Scan on authentik_core_user  (cost=0.00..10.40 rows=40 width=1925) (actual time=0.005..0.006 rows=4 loops=1)
               SubPlan 1
                 ->  Seq Scan on authentik_core_group u0  (cost=0.00..1.03 rows=2 width=16) (actual time=0.005..0.005 rows=2 loops=1)
                       Filter: is_superuser
                       Rows Removed by Filter: 2
               SubPlan 2
                 ->  Unique  (cost=13.30..13.32 rows=1 width=4) (actual time=0.039..0.040 rows=1 loops=1)
                       ->  Sort  (cost=13.30..13.31 rows=4 width=4) (actual time=0.039..0.039 rows=4 loops=1)
                             Sort Key: u2.user_id
                             Sort Method: quicksort  Memory: 25kB
                             ->  Nested Loop Left Join  (cost=0.28..13.26 rows=4 width=4) (actual time=0.017..0.024 rows=4 loops=1)
                                   ->  Nested Loop  (cost=0.15..12.57 rows=4 width=4) (actual time=0.008..0.014 rows=4 loops=1)
                                         ->  Seq Scan on django_content_type u1  (cost=0.00..4.31 rows=1 width=4) (actual time=0.004..0.009 rows=1 loops=1)
                                               Filter: (((app_label)::text = 'authentik_providers_proxy'::text) AND ((model)::text = 'proxyprovider'::text))
                                               Rows Removed by Filter: 155
                                         ->  Index Scan using auth_permission_content_type_id_2f476e4b on auth_permission u0_1  (cost=0.15..8.22 rows=4 width=8) (actual time=0.003..0.004 rows=4 loops=1)
                                               Index Cond: (content_type_id = u1.id)
                                   ->  Index Scan using authentik_core_user_user_permissions_permission_id_67859147 on authentik_core_user_user_permissions u2  (cost=0.12..0.16 rows=1 width=8) (actual time=0.002..0.002 rows=0 loops=4)
                                         Index Cond: (permission_id = u0_1.id)
               SubPlan 3
                 ->  Unique  (cost=0.55..16.69 rows=1 width=4) (actual time=0.028..0.029 rows=0 loops=1)
                       ->  Nested Loop Semi Join  (cost=0.55..16.69 rows=1 width=4) (actual time=0.028..0.028 rows=0 loops=1)
                             ->  Index Scan using guardian_userobjectpermission_user_id_d5c1e964 on guardian_userobjectpermission v0  (cost=0.12..8.14 rows=1 width=8) (actual time=0.010..0.011 rows=2 loops=1)
                                   Filter: ((object_pk)::text = '1'::text)
                                   Rows Removed by Filter: 1
                             ->  Nested Loop  (cost=0.42..8.53 rows=1 width=4) (actual time=0.008..0.008 rows=0 loops=2)
                                   ->  Index Scan using auth_permission_pkey on auth_permission u0_2  (cost=0.28..8.29 rows=1 width=8) (actual time=0.005..0.005 rows=1 loops=2)
                                         Index Cond: (id = v0.permission_id)
                                   ->  Index Scan using django_content_type_pkey on django_content_type u1_1  (cost=0.14..0.19 rows=1 width=4) (actual time=0.003..0.003 rows=0 loops=2)
                                         Index Cond: (id = u0_2.content_type_id)
                                         Filter: (((app_label)::text = 'authentik_providers_proxy'::text) AND ((model)::text = 'proxyprovider'::text))
                                         Rows Removed by Filter: 1
 Planning Time: 1.515 ms
 Execution Time: 0.312 ms
(47 rows)
```
Much better, but we still have a sort going on, because of the distinct. We can try the previous trick with `DISTINCT ON (username)`:
```sql
EXPLAIN ANALYZE SELECT DISTINCT ON ("authentik_core_user"."username") "authentik_core_user"."id",
                   "authentik_core_user"."password",
                   "authentik_core_user"."last_login",
                   "authentik_core_user"."username",
                   "authentik_core_user"."first_name",
                   "authentik_core_user"."last_name",
                   "authentik_core_user"."email",
                   "authentik_core_user"."is_active",
                   "authentik_core_user"."date_joined",
                   "authentik_core_user"."attributes",
                   "authentik_core_user"."uuid",
                   "authentik_core_user"."name",
                   "authentik_core_user"."path",
                   "authentik_core_user"."type",
                   "authentik_core_user"."password_change_date",
                   "authentik_core_user"."last_updated"
FROM "authentik_core_user"
LEFT OUTER JOIN "authentik_core_user_ak_groups" ON ("authentik_core_user"."id" = "authentik_core_user_ak_groups"."user_id")
WHERE ("authentik_core_user_ak_groups"."group_id" IN
         (SELECT U0."group_uuid"
          FROM "authentik_core_group" U0
          WHERE U0."is_superuser")
       OR "authentik_core_user"."id" IN
         (SELECT DISTINCT U2."user_id"
          FROM "auth_permission" U0
          INNER JOIN "django_content_type" U1 ON (U0."content_type_id" = U1."id")
          LEFT OUTER JOIN "authentik_core_user_user_permissions" U2 ON (U0."id" = U2."permission_id")
          WHERE (U1."app_label" = 'authentik_providers_proxy'
                 AND U1."model" = 'proxyprovider'))
       OR "authentik_core_user"."id" IN
         (SELECT DISTINCT V0."user_id"
          FROM "guardian_userobjectpermission" V0
          WHERE (V0."object_pk" = '1'
                 AND V0."permission_id" IN
                   (SELECT U0."id"
                    FROM "auth_permission" U0
                    INNER JOIN "django_content_type" U1 ON (U0."content_type_id" = U1."id")
                    WHERE (U1."app_label" = 'authentik_providers_proxy'
                           AND U1."model" = 'proxyprovider')))))
ORDER BY "authentik_core_user"."username" ASC
```
which gives:
```
                                                                                                             QUERY PLAN                                                                                                              
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Unique  (cost=31.34..148.52 rows=40 width=1925) (actual time=0.039..0.130 rows=2 loops=1)
   ->  Nested Loop Left Join  (cost=31.34..145.09 rows=1374 width=1925) (actual time=0.038..0.128 rows=3 loops=1)
         Filter: ((hashed SubPlan 1) OR (hashed SubPlan 2) OR (hashed SubPlan 3))
         Rows Removed by Filter: 3
         ->  Index Scan using authentik_core_user_username_key on authentik_core_user  (cost=0.14..48.74 rows=40 width=1925) (actual time=0.013..0.015 rows=4 loops=1)
         ->  Index Scan using authentik_core_user_pb_groups_user_id_5ce7c1dc on authentik_core_user_ak_groups  (cost=0.15..1.49 rows=8 width=20) (actual time=0.003..0.003 rows=1 loops=4)
               Index Cond: (user_id = authentik_core_user.id)
         SubPlan 1
           ->  Seq Scan on authentik_core_group u0  (cost=0.00..1.03 rows=2 width=16) (actual time=0.006..0.007 rows=2 loops=1)
                 Filter: is_superuser
                 Rows Removed by Filter: 2
         SubPlan 2
           ->  Unique  (cost=13.30..13.32 rows=1 width=4) (actual time=0.045..0.046 rows=1 loops=1)
                 ->  Sort  (cost=13.30..13.31 rows=4 width=4) (actual time=0.044..0.045 rows=4 loops=1)
                       Sort Key: u2.user_id
                       Sort Method: quicksort  Memory: 25kB
                       ->  Nested Loop Left Join  (cost=0.28..13.26 rows=4 width=4) (actual time=0.017..0.025 rows=4 loops=1)
                             ->  Nested Loop  (cost=0.15..12.57 rows=4 width=4) (actual time=0.008..0.014 rows=4 loops=1)
                                   ->  Seq Scan on django_content_type u1  (cost=0.00..4.31 rows=1 width=4) (actual time=0.005..0.011 rows=1 loops=1)
                                         Filter: (((app_label)::text = 'authentik_providers_proxy'::text) AND ((model)::text = 'proxyprovider'::text))
                                         Rows Removed by Filter: 155
                                   ->  Index Scan using auth_permission_content_type_id_2f476e4b on auth_permission u0_1  (cost=0.15..8.22 rows=4 width=8) (actual time=0.001..0.002 rows=4 loops=1)
                                         Index Cond: (content_type_id = u1.id)
                             ->  Index Scan using authentik_core_user_user_permissions_permission_id_67859147 on authentik_core_user_user_permissions u2  (cost=0.12..0.16 rows=1 width=8) (actual time=0.002..0.002 rows=0 loops=4)
                                   Index Cond: (permission_id = u0_1.id)
         SubPlan 3
           ->  Unique  (cost=0.55..16.69 rows=1 width=4) (actual time=0.030..0.030 rows=0 loops=1)
                 ->  Nested Loop Semi Join  (cost=0.55..16.69 rows=1 width=4) (actual time=0.030..0.030 rows=0 loops=1)
                       ->  Index Scan using guardian_userobjectpermission_user_id_d5c1e964 on guardian_userobjectpermission v0  (cost=0.12..8.14 rows=1 width=8) (actual time=0.012..0.012 rows=2 loops=1)
                             Filter: ((object_pk)::text = '1'::text)
                             Rows Removed by Filter: 1
                       ->  Nested Loop  (cost=0.42..8.53 rows=1 width=4) (actual time=0.008..0.008 rows=0 loops=2)
                             ->  Index Scan using auth_permission_pkey on auth_permission u0_2  (cost=0.28..8.29 rows=1 width=8) (actual time=0.005..0.005 rows=1 loops=2)
                                   Index Cond: (id = v0.permission_id)
                             ->  Index Scan using django_content_type_pkey on django_content_type u1_1  (cost=0.14..0.19 rows=1 width=4) (actual time=0.003..0.003 rows=0 loops=2)
                                   Index Cond: (id = u0_2.content_type_id)
                                   Filter: (((app_label)::text = 'authentik_providers_proxy'::text) AND ((model)::text = 'proxyprovider'::text))
                                   Rows Removed by Filter: 1
 Planning Time: 1.471 ms
 Execution Time: 0.282 ms
(40 rows)
```
Yay, no more sort! However, having that `DISTINCT` here puts a restriction on what can be used in `ORDER BY`, preventing custom ordering, notably for the frontend and the tests. So we convert the group filtering to a subquery as well, removing all joins:
```sql
EXPLAIN ANALYZE SELECT
    "authentik_core_user"."id",
    "authentik_core_user"."password",
    "authentik_core_user"."last_login",
    "authentik_core_user"."username",
    "authentik_core_user"."first_name",
    "authentik_core_user"."last_name",
    "authentik_core_user"."email",
    "authentik_core_user"."is_active",
    "authentik_core_user"."date_joined",
    "authentik_core_user"."attributes",
    "authentik_core_user"."uuid",
    "authentik_core_user"."name",
    "authentik_core_user"."path",
    "authentik_core_user"."type",
    "authentik_core_user"."password_change_date",
    "authentik_core_user"."last_updated"
FROM "authentik_core_user"
WHERE (
    "authentik_core_user"."id" IN
    (
        SELECT DISTINCT U1."user_id"
        FROM "authentik_core_group" AS U0
        LEFT OUTER JOIN
            "authentik_core_user_ak_groups" AS U1
            ON (U0."group_uuid" = U1."group_id")
        WHERE U0."is_superuser"
    )
    OR "authentik_core_user"."id" IN
    (
        SELECT DISTINCT U2."user_id"
        FROM "auth_permission" AS U0
        INNER JOIN
            "django_content_type" AS U1
            ON (U0."content_type_id" = U1."id")
        LEFT OUTER JOIN
            "authentik_core_user_user_permissions" AS U2
            ON (U0."id" = U2."permission_id")
        WHERE (
            U1."app_label" = 'authentik_providers_proxy'
            AND U1."model" = 'proxyprovider'
        )
    )
    OR "authentik_core_user"."id" IN
    (
        SELECT DISTINCT V0."user_id"
        FROM "guardian_userobjectpermission" AS V0
        WHERE (
            V0."object_pk" = '1'
            AND V0."permission_id" IN
            (
                SELECT U0."id"
                FROM "auth_permission" AS U0
                INNER JOIN
                    "django_content_type" AS U1
                    ON (U0."content_type_id" = U1."id")
                WHERE (
                    U1."app_label" = 'authentik_providers_proxy'
                    AND U1."model" = 'proxyprovider'
                )
            )
        )
    )
)
ORDER BY "authentik_core_user"."username" ASC
```
which gives:
```
                                                                                                             QUERY PLAN                                                                                                              
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=75.33..75.42 rows=35 width=1925) (actual time=0.126..0.128 rows=2 loops=1)
   Sort Key: authentik_core_user.username
   Sort Method: quicksort  Memory: 25kB
   ->  Seq Scan on authentik_core_user  (cost=63.74..74.44 rows=35 width=1925) (actual time=0.108..0.110 rows=2 loops=1)
         Filter: ((hashed SubPlan 1) OR (hashed SubPlan 2) OR (hashed SubPlan 3))
         Rows Removed by Filter: 2
         SubPlan 1
           ->  HashAggregate  (cost=31.22..33.22 rows=200 width=4) (actual time=0.026..0.026 rows=2 loops=1)
                 Group Key: u1.user_id
                 Batches: 1  Memory Usage: 40kB
                 ->  Nested Loop Left Join  (cost=4.21..28.61 rows=1047 width=4) (actual time=0.017..0.021 rows=3 loops=1)
                       ->  Seq Scan on authentik_core_group u0  (cost=0.00..1.03 rows=2 width=16) (actual time=0.005..0.006 rows=2 loops=1)
                             Filter: is_superuser
                             Rows Removed by Filter: 2
                       ->  Bitmap Heap Scan on authentik_core_user_ak_groups u1  (cost=4.21..13.71 rows=8 width=20) (actual time=0.006..0.006 rows=2 loops=2)
                             Recheck Cond: (u0.group_uuid = group_id)
                             Heap Blocks: exact=2
                             ->  Bitmap Index Scan on authentik_core_user_pb_groups_group_id_344046d2  (cost=0.00..4.21 rows=8 width=0) (actual time=0.003..0.003 rows=2 loops=2)
                                   Index Cond: (group_id = u0.group_uuid)
         SubPlan 2
           ->  Unique  (cost=13.30..13.32 rows=1 width=4) (actual time=0.035..0.036 rows=1 loops=1)
                 ->  Sort  (cost=13.30..13.31 rows=4 width=4) (actual time=0.034..0.035 rows=4 loops=1)
                       Sort Key: u2.user_id
                       Sort Method: quicksort  Memory: 25kB
                       ->  Nested Loop Left Join  (cost=0.28..13.26 rows=4 width=4) (actual time=0.014..0.021 rows=4 loops=1)
                             ->  Nested Loop  (cost=0.15..12.57 rows=4 width=4) (actual time=0.006..0.012 rows=4 loops=1)
                                   ->  Seq Scan on django_content_type u1_1  (cost=0.00..4.31 rows=1 width=4) (actual time=0.004..0.009 rows=1 loops=1)
                                         Filter: (((app_label)::text = 'authentik_providers_proxy'::text) AND ((model)::text = 'proxyprovider'::text))
                                         Rows Removed by Filter: 155
                                   ->  Index Scan using auth_permission_content_type_id_2f476e4b on auth_permission u0_1  (cost=0.15..8.22 rows=4 width=8) (actual time=0.002..0.002 rows=4 loops=1)
                                         Index Cond: (content_type_id = u1_1.id)
                             ->  Index Scan using authentik_core_user_user_permissions_permission_id_67859147 on authentik_core_user_user_permissions u2  (cost=0.12..0.16 rows=1 width=8) (actual time=0.002..0.002 rows=0 loops=4)
                                   Index Cond: (permission_id = u0_1.id)
         SubPlan 3
           ->  Unique  (cost=0.55..16.69 rows=1 width=4) (actual time=0.025..0.026 rows=0 loops=1)
                 ->  Nested Loop Semi Join  (cost=0.55..16.69 rows=1 width=4) (actual time=0.025..0.025 rows=0 loops=1)
                       ->  Index Scan using guardian_userobjectpermission_user_id_d5c1e964 on guardian_userobjectpermission v0  (cost=0.12..8.14 rows=1 width=8) (actual time=0.011..0.011 rows=2 loops=1)
                             Filter: ((object_pk)::text = '1'::text)
                             Rows Removed by Filter: 1
                       ->  Nested Loop  (cost=0.42..8.53 rows=1 width=4) (actual time=0.007..0.007 rows=0 loops=2)
                             ->  Index Scan using auth_permission_pkey on auth_permission u0_2  (cost=0.28..8.29 rows=1 width=8) (actual time=0.004..0.004 rows=1 loops=2)
                                   Index Cond: (id = v0.permission_id)
                             ->  Index Scan using django_content_type_pkey on django_content_type u1_2  (cost=0.14..0.19 rows=1 width=4) (actual time=0.003..0.003 rows=0 loops=2)
                                   Index Cond: (id = u0_2.content_type_id)
                                   Filter: (((app_label)::text = 'authentik_providers_proxy'::text) AND ((model)::text = 'proxyprovider'::text))
                                   Rows Removed by Filter: 1
 Planning Time: 1.494 ms
 Execution Time: 0.267 ms
(48 rows)
```
Hey, we still have a sort here. Yes, but it's not as bad as it looks, because that field is indexed, and because there aren't any joins, postgres can take advantage of the index to do the sorting.