### PR TITLE
web: Report unregistered elements.

### DIFF
--- a/web/src/elements/Base.ts
+++ b/web/src/elements/Base.ts
@@ -13,7 +13,7 @@ import {
 import { UiThemeEnum } from "@goauthentik/api";
 
 import { localized } from "@lit/localize";
-import { CSSResult, CSSResultGroup, CSSResultOrNative, LitElement } from "lit";
+import { CSSResult, CSSResultGroup, CSSResultOrNative, LitElement, PropertyValues } from "lit";
 import { property } from "lit/decorators.js";
 
 export interface AKElementProps {
@@ -53,6 +53,25 @@ export class AKElement extends LitElement implements AKElementProps {
         this.#customCSSStyleSheet = brand?.brandingCustomCss
             ? createStyleSheetUnsafe(brand.brandingCustomCss)
             : null;
+
+        if (process.env.NODE_ENV === "development") {
+            const updatedCallback = this.updated;
+
+            this.updated = function (args: PropertyValues) {
+                updatedCallback?.call(this, args);
+
+                const unregisteredElements = this.renderRoot.querySelectorAll(":not(:defined)");
+
+                if (!unregisteredElements.length) return;
+
+                for (const element of unregisteredElements) {
+                    console.debug("Unregistered custom element found in the DOM", element);
+                }
+                throw new TypeError(
+                    `${unregisteredElements.length} unregistered custom elements found in the DOM. See console for details.`,
+                );
+            };
+        }
     }
 
     public override disconnectedCallback(): void {


### PR DESCRIPTION
## Details

This comes up occasionally while in development - a custom element is written in a template but isn't imported.

The fix here is to observe child elements and report any that haven't been registered. 

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
