### PR TITLE
web/a11y: Notifications drawer

### DIFF
--- a/web/e2e/fixtures/PointerFixture.ts
+++ b/web/e2e/fixtures/PointerFixture.ts
@@ -27,6 +27,7 @@ export class PointerFixture extends PageFixture {
         }
 
         const options = {
+            exact: typeof name === "string",
             ...optionsOrRole,
             name,
         };

--- a/web/src/common/labels.ts
+++ b/web/src/common/labels.ts
@@ -57,6 +57,16 @@ export const severityEnumToLabel = new Map<SeverityEnum | null | undefined, stri
 export const severityToLabel = (severity: SeverityEnum | null | undefined) =>
     severityEnumToLabel.get(severity) ?? msg("Unknown severity");
 
+export function severityToLevel(severity?: SeverityEnum | null): string {
+    switch (severity) {
+        case SeverityEnum.Warning:
+            return "pf-m-warning";
+        case SeverityEnum.Alert:
+            return "pf-m-danger";
+    }
+    return "pf-m-info";
+}
+
 // TODO: Add verbose_name field to now vendored OTP devices
 export const deviceTypeToLabel = new Map<string, string>([
     ["authentik_stages_authenticator_static.StaticDevice", msg("Static tokens")],

--- a/web/src/elements/notifications/APIDrawer.ts
+++ b/web/src/elements/notifications/APIDrawer.ts
@@ -1,7 +1,8 @@
+import "#elements/timestamp/ak-timestamp";
+
 import { RequestInfo } from "#common/api/middleware";
 import { EVENT_API_DRAWER_TOGGLE, EVENT_REQUEST_POST } from "#common/constants";
 import { globalAK } from "#common/global";
-import { formatElapsedTime } from "#common/temporal";
 
 import { AKElement } from "#elements/Base";
 
@@ -14,6 +15,32 @@ import PFContent from "@patternfly/patternfly/components/Content/content.css";
 import PFDropdown from "@patternfly/patternfly/components/Dropdown/dropdown.css";
 import PFNotificationDrawer from "@patternfly/patternfly/components/NotificationDrawer/notification-drawer.css";
 import PFBase from "@patternfly/patternfly/patternfly-base.css";
+
+function renderItem(item: RequestInfo, idx: number): TemplateResult {
+    const subheading = `${item.method}: ${item.status}`;
+
+    const label = URL.canParse(item.path) ? new URL(item.path).pathname : null;
+
+    return html`<li
+        class="pf-c-notification-drawer__list-item pf-m-read"
+        aria-label=${label ?? subheading}
+    >
+        <div class="pf-c-notification-drawer__list-item-header">
+            <h2
+                class="pf-c-notification-drawer__list-item-header-title"
+                id="notification-list-item-${idx}"
+            >
+                ${item.method}: ${item.status}
+            </h2>
+        </div>
+        <a class="pf-c-notification-drawer__list-item-description" target="_blank" href=${item.path}
+            >${label ?? item.path}</a
+        >
+        <div class="pf-c-notification-drawer__list-item-timestamp">
+            <ak-timestamp .timestamp=${item.time} refresh datetime></ak-timestamp>
+        </div>
+    </li>`;
+}
 
 @customElement("ak-api-drawer")
 export class APIDrawer extends AKElement {
@@ -41,7 +68,7 @@ export class APIDrawer extends AKElement {
             }
             .pf-c-notification-drawer__list-item-description {
                 white-space: pre-wrap;
-                font-family: monospace;
+                font-family: var(--pf-global--FontFamily--monospace);
             }
             .pf-c-notification-drawer__body {
                 overflow-x: hidden;
@@ -64,27 +91,13 @@ export class APIDrawer extends AKElement {
         }) as EventListener);
     }
 
-    renderItem(item: RequestInfo): TemplateResult {
-        return html`<li class="pf-c-notification-drawer__list-item pf-m-read">
-            <div class="pf-c-notification-drawer__list-item-header">
-                <h2 class="pf-c-notification-drawer__list-item-header-title">
-                    ${item.method}: ${item.status}
-                </h2>
-            </div>
-            <a
-                class="pf-c-notification-drawer__list-item-description"
-                target="_blank"
-                href=${item.path}
-                >${item.path}</a
-            >
-            <div class="pf-c-notification-drawer__list-item-timestamp">
-                ${formatElapsedTime(new Date(item.time))}
-            </div>
-        </li>`;
-    }
-
     render(): TemplateResult {
-        return html`<div class="pf-c-drawer__body pf-m-no-padding">
+        return html`<div
+            class="pf-c-drawer__body pf-m-no-padding"
+            aria-label=${msg("API drawer")}
+            role="region"
+            tabindex="0"
+        >
             <div class="pf-c-notification-drawer">
                 <div class="pf-c-notification-drawer__header">
                     <div class="text">
@@ -108,7 +121,7 @@ export class APIDrawer extends AKElement {
                                 }}
                                 class="pf-c-button pf-m-plain"
                                 type="button"
-                                aria-label=${msg("Close")}
+                                aria-label=${msg("Close API drawer")}
                             >
                                 <i class="fas fa-times" aria-hidden="true"></i>
                             </button>
@@ -117,7 +130,7 @@ export class APIDrawer extends AKElement {
                 </div>
                 <div class="pf-c-notification-drawer__body">
                     <ul class="pf-c-notification-drawer__list">
-                        ${this.requests.map((n) => this.renderItem(n))}
+                        ${this.requests.map(renderItem)}
                     </ul>
                 </div>
             </div>

--- a/web/src/elements/timestamp/ak-timestamp.ts
+++ b/web/src/elements/timestamp/ak-timestamp.ts
@@ -15,7 +15,7 @@ export class AKTimestamp extends AKElement {
         return this.#timestamp;
     }
 
-    public set timestamp(value: string | Date | null) {
+    public set timestamp(value: string | Date | number | null) {
         this.#timestamp = value ? (value instanceof Date ? value : new Date(value)) : null;
     }
 


### PR DESCRIPTION
## Details

A first pass at the notifications drawer. This is mostly focused on presenting the drawer as its own ARIA region. 

## Sample ARIA Tree


<img width="454" height="183" alt="Screenshot 2025-09-25 at 20 39 25" src="https://github.com/user-attachments/assets/8918e0e0-4d42-43df-84ab-9d820fd5f642" />
