### PR TITLE
tests/e2e: less hardcoded names

### DIFF
--- a/authentik/crypto/tests.py
+++ b/authentik/crypto/tests.py
@@ -27,7 +27,7 @@ class TestCrypto(APITestCase):
     def test_model_private(self):
         """Test model private key"""
         cert = CertificateKeyPair.objects.create(
-            name="test",
+            name=generate_id(),
             certificate_data="foo",
             key_data="foo",
         )
@@ -271,7 +271,7 @@ class TestCrypto(APITestCase):
         keypair = create_test_cert()
         provider = OAuth2Provider.objects.create(
             name=generate_id(),
-            client_id="test",
+            client_id=generate_id(),
             client_secret=generate_key(),
             authorization_flow=create_test_flow(),
             redirect_uris=[RedirectURI(RedirectURIMatchingMode.STRICT, "http://localhost")],
@@ -303,7 +303,7 @@ class TestCrypto(APITestCase):
         keypair = create_test_cert()
         OAuth2Provider.objects.create(
             name=generate_id(),
-            client_id="test",
+            client_id=generate_id(),
             client_secret=generate_key(),
             authorization_flow=create_test_flow(),
             redirect_uris=[RedirectURI(RedirectURIMatchingMode.STRICT, "http://localhost")],

--- a/tests/e2e/test_provider_oauth2_github.py
+++ b/tests/e2e/test_provider_oauth2_github.py
@@ -220,7 +220,7 @@ class TestProviderOAuth2Github(SeleniumTestCase):
         )
 
         negative_policy = ExpressionPolicy.objects.create(
-            name="negative-static", expression="return False"
+            name=generate_id(), expression="return False"
         )
         PolicyBinding.objects.create(target=app, policy=negative_policy, order=0)
 

--- a/tests/e2e/test_provider_oauth2_grafana.py
+++ b/tests/e2e/test_provider_oauth2_grafana.py
@@ -400,7 +400,7 @@ class TestProviderOAuth2OAuth(SeleniumTestCase):
         )
 
         negative_policy = ExpressionPolicy.objects.create(
-            name="negative-static", expression="return False"
+            name=generate_id(), expression="return False"
         )
         PolicyBinding.objects.create(target=app, policy=negative_policy, order=0)
         self.driver.get("http://localhost:3000")

--- a/tests/e2e/test_provider_oidc.py
+++ b/tests/e2e/test_provider_oidc.py
@@ -290,7 +290,7 @@ class TestProviderOAuth2OIDC(SeleniumTestCase):
         )
 
         negative_policy = ExpressionPolicy.objects.create(
-            name="negative-static", expression="return False"
+            name=generate_id(), expression="return False"
         )
         PolicyBinding.objects.create(target=app, policy=negative_policy, order=0)
 

--- a/tests/e2e/test_provider_oidc_implicit.py
+++ b/tests/e2e/test_provider_oidc_implicit.py
@@ -270,7 +270,7 @@ class TestProviderOAuth2OIDCImplicit(SeleniumTestCase):
         )
 
         negative_policy = ExpressionPolicy.objects.create(
-            name="negative-static", expression="return False"
+            name=generate_id(), expression="return False"
         )
         PolicyBinding.objects.create(target=app, policy=negative_policy, order=0)
 

--- a/tests/e2e/test_provider_radius.py
+++ b/tests/e2e/test_provider_radius.py
@@ -41,7 +41,7 @@ class TestProviderRadius(SeleniumTestCase):
             shared_secret=self.shared_secret,
         )
         # we need to create an application to actually access radius
-        Application.objects.create(name="radius", slug=generate_id(), provider=radius)
+        Application.objects.create(name=generate_id(), slug=generate_id(), provider=radius)
         outpost: Outpost = Outpost.objects.create(
             name=generate_id(),
             type=OutpostType.RADIUS,

--- a/tests/e2e/test_provider_saml.py
+++ b/tests/e2e/test_provider_saml.py
@@ -10,6 +10,7 @@ from authentik.blueprints.tests import apply_blueprint, reconcile_app
 from authentik.core.models import Application
 from authentik.core.tests.utils import create_test_cert
 from authentik.flows.models import Flow
+from authentik.lib.generators import generate_id
 from authentik.policies.apps import BufferedPolicyAccessViewFlag
 from authentik.policies.expression.models import ExpressionPolicy
 from authentik.policies.models import PolicyBinding
@@ -65,7 +66,7 @@ class TestProviderSAML(SeleniumTestCase):
             slug="default-provider-authorization-implicit-consent"
         )
         provider: SAMLProvider = SAMLProvider.objects.create(
-            name="saml-test",
+            name=generate_id(),
             acs_url="http://localhost:9009/saml/acs",
             audience="authentik-e2e",
             issuer="authentik-e2e",
@@ -77,7 +78,7 @@ class TestProviderSAML(SeleniumTestCase):
         provider.save()
         Application.objects.create(
             name="SAML",
-            slug="authentik-saml",
+            slug=generate_id(),
             provider=provider,
         )
         self.setup_client(provider)
@@ -133,7 +134,7 @@ class TestProviderSAML(SeleniumTestCase):
             slug="default-provider-authorization-implicit-consent"
         )
         provider: SAMLProvider = SAMLProvider.objects.create(
-            name="saml-test",
+            name=generate_id(),
             acs_url="http://localhost:9009/saml/acs",
             audience="authentik-e2e",
             issuer="authentik-e2e",
@@ -145,7 +146,7 @@ class TestProviderSAML(SeleniumTestCase):
         provider.save()
         Application.objects.create(
             name="SAML",
-            slug="authentik-saml",
+            slug=generate_id(),
             provider=provider,
         )
         self.setup_client(provider, True)
@@ -201,7 +202,7 @@ class TestProviderSAML(SeleniumTestCase):
             slug="default-provider-authorization-explicit-consent"
         )
         provider: SAMLProvider = SAMLProvider.objects.create(
-            name="saml-test",
+            name=generate_id(),
             acs_url="http://localhost:9009/saml/acs",
             audience="authentik-e2e",
             issuer="authentik-e2e",
@@ -213,7 +214,7 @@ class TestProviderSAML(SeleniumTestCase):
         provider.save()
         app = Application.objects.create(
             name="SAML",
-            slug="authentik-saml",
+            slug=generate_id(),
             provider=provider,
         )
         self.setup_client(provider)
@@ -284,7 +285,7 @@ class TestProviderSAML(SeleniumTestCase):
             slug="default-provider-authorization-explicit-consent"
         )
         provider: SAMLProvider = SAMLProvider.objects.create(
-            name="saml-test",
+            name=generate_id(),
             acs_url="http://localhost:9009/saml/acs",
             audience="authentik-e2e",
             issuer="authentik-e2e",
@@ -296,7 +297,7 @@ class TestProviderSAML(SeleniumTestCase):
         provider.save()
         app = Application.objects.create(
             name="SAML",
-            slug="authentik-saml",
+            slug=generate_id(),
             provider=provider,
         )
         self.setup_client(provider, True)
@@ -367,7 +368,7 @@ class TestProviderSAML(SeleniumTestCase):
             slug="default-provider-authorization-implicit-consent"
         )
         provider: SAMLProvider = SAMLProvider.objects.create(
-            name="saml-test",
+            name=generate_id(),
             acs_url="http://localhost:9009/saml/acs",
             audience="authentik-e2e",
             issuer="authentik-e2e",
@@ -379,7 +380,7 @@ class TestProviderSAML(SeleniumTestCase):
         provider.save()
         Application.objects.create(
             name="SAML",
-            slug="authentik-saml",
+            slug=generate_id(),
             provider=provider,
         )
         self.setup_client(provider)
@@ -444,7 +445,7 @@ class TestProviderSAML(SeleniumTestCase):
             name="negative-static", expression="return False"
         )
         provider: SAMLProvider = SAMLProvider.objects.create(
-            name="saml-test",
+            name=generate_id(),
             acs_url="http://localhost:9009/saml/acs",
             audience="authentik-e2e",
             issuer="authentik-e2e",
@@ -456,7 +457,7 @@ class TestProviderSAML(SeleniumTestCase):
         provider.save()
         app = Application.objects.create(
             name="SAML",
-            slug="authentik-saml",
+            slug=generate_id(),
             provider=provider,
         )
         PolicyBinding.objects.create(target=app, policy=negative_policy, order=0)
@@ -491,7 +492,7 @@ class TestProviderSAML(SeleniumTestCase):
         )
         invalidation_flow = Flow.objects.get(slug="default-provider-invalidation-flow")
         provider: SAMLProvider = SAMLProvider.objects.create(
-            name="saml-test",
+            name=generate_id(),
             acs_url="http://localhost:9009/saml/acs",
             audience="authentik-e2e",
             issuer="authentik-e2e",
@@ -504,7 +505,7 @@ class TestProviderSAML(SeleniumTestCase):
         provider.save()
         Application.objects.create(
             name="SAML",
-            slug="authentik-saml",
+            slug=generate_id(),
             provider=provider,
         )
         self.setup_client(provider)
@@ -542,7 +543,7 @@ class TestProviderSAML(SeleniumTestCase):
             slug="default-provider-authorization-implicit-consent"
         )
         provider: SAMLProvider = SAMLProvider.objects.create(
-            name="saml-test",
+            name=generate_id(),
             acs_url=f"http://{self.host}:9009/saml/acs",
             audience="authentik-e2e",
             issuer="authentik-e2e",
@@ -554,7 +555,7 @@ class TestProviderSAML(SeleniumTestCase):
         provider.save()
         Application.objects.create(
             name="SAML",
-            slug="authentik-saml",
+            slug=generate_id(),
             provider=provider,
         )
         self.setup_client(provider, True, SP_ROOT_URL=f"http://{self.host}:9009")


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Reduce issues when retrying e2e tests internally by not re-using db names

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
