### PR TITLE
storages: s3 custom domain signature fix

### DIFF
--- a/authentik/root/storages.py
+++ b/authentik/root/storages.py
@@ -3,13 +3,13 @@
 import os
 from urllib.parse import parse_qsl, urlsplit
 
+from botocore.awsrequest import AWSRequest
 from django.conf import settings
 from django.core.exceptions import SuspiciousOperation
 from django.core.files.storage import FileSystemStorage
 from django.db import connection
 from storages.backends.s3 import S3Storage as BaseS3Storage
 from storages.utils import clean_name, safe_join
-import botocore
 
 from authentik.lib.config import CONFIG
 
@@ -99,8 +99,10 @@ class S3Storage(BaseS3Storage):
 
         if self.custom_domain:
             custom_url = f"{self.url_protocol}//{self.custom_domain}/{name}"
-            request = botocore.awsrequest.AWSRequest(http_method or "GET", custom_url)
-            self.bucket.meta.client._request_signer.sign("GetObject", request, signing_type="presign-url", expires_in=expire)
+            request = AWSRequest(http_method or "GET", custom_url)
+            self.bucket.meta.client._request_signer.sign(
+                "GetObject", request, signing_type="presign-url", expires_in=expire
+            )
             prepared_request = request.prepare()
             url = prepared_request.url
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

- #13463

Effectively this fixes s3 signatures for custom domains.
The solution for this is somewhat hacky, however it does apply cleanly on *version/2025.2.4* and I have tested it and can confirm that it works.
I'll set this to draft state because I do not currently have the capacity to finish the testing and linting, so if anyone wants to pick this up, please go ahead.
To be perfectly honest, I just copied the stuff I use to generate such links personally straight out of my shell history into the source code.
It is however the only solution that I have managed to find which actually works.
**NB**: this has *only* been tested when cherry-picked onto *2025.2.3* and *2025.8.3*!
**NB**: this is more or less a bandaid, a proper rewrite of the method to generate the URl would be desirable IMHO, especially since it will compute the signature even when it is not needed. Using the proper class for the URl would also be good, to avoid any weirdnesses for edge-cases. Right now the onus of providing a working string is put on the admin.

The commit message is included verbatim below.

---

S3 signatures are fickle since there are several hashes of components which must ultimately be correct for the signature to match with no room for error.
Since both the *host* header as well as the path, the former by default, the latter necessarily.
The issue with custom domains is therefore that the *host* header mismatches unless the signature was created for that specific domain.
This is complicated further by *boto3* making it incredibly difficult to actually sign a link with the path *not* containing the bucket prefix.
Therefore setting the endpoint alone does not work with a truly custom domain (i.e. one where the data resides on the root of the domain).

Changing this to a rather hacky workaround accessing fields of the internal data structures and grabbing the signer directly allows for signing the request.
This comes with several caveats such as the parameters going largely untouched, however in preliminary testing it works fine.
There are no superfluous slashes (i.e. no `https://example.com//file.svg`), no superfluous prefixes (i.e. `https://example.com/example.com/example.com/file.svg`), and there are no signature errors in general.
Uploads still work.
Reminder that the application cache may need clearing before the changes reflect in the non-admin UI.

Relates:

- [issue 13463](https://redirect.github.com/goauthentik/authentik/issues/13463)
- [pr 14706 ](https://redirect.github.com/goauthentik/authentik/pull/14706)

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
