### PR TITLE
web: Fix table child alignment

### DIFF
--- a/web/src/admin/applications/ApplicationListPage.ts
+++ b/web/src/admin/applications/ApplicationListPage.ts
@@ -130,12 +130,17 @@ export class ApplicationListPage extends WithBrandConfig(TablePage<Application>)
                   </a>`
                 : html`-`,
             html`${item.providerObj?.verboseName || msg("-")}`,
-            html`<ak-forms-modal>
+            html`<div>
+                <ak-forms-modal>
                     <span slot="submit">${msg("Update")}</span>
                     <span slot="header">${msg("Update Application")}</span>
                     <ak-application-form slot="form" .instancePk=${item.slug}>
                     </ak-application-form>
-                    <button slot="trigger" class="pf-c-button pf-m-plain" aria-label=${msg("Edit")}>
+                    <button
+                        slot="trigger"
+                        class="pf-c-button pf-m-plain"
+                        aria-label=${msg(str`Edit "${item.name}"`)}
+                    >
                         <pf-tooltip position="top" content=${msg("Edit")}>
                             <i class="fas fa-edit" aria-hidden="true"></i>
                         </pf-tooltip>
@@ -146,13 +151,14 @@ export class ApplicationListPage extends WithBrandConfig(TablePage<Application>)
                           href=${item.launchUrl}
                           target="_blank"
                           class="pf-c-button pf-m-plain"
-                          aria-label=${msg("Open")}
+                          aria-label=${msg(str`Open "${item.name}"`)}
                       >
                           <pf-tooltip position="top" content=${msg("Open")}>
                               <i class="fas fa-share-square" aria-hidden="true"></i>
                           </pf-tooltip>
                       </a>`
-                    : nothing}`,
+                    : nothing}
+            </div>`,
         ];
     }
 

--- a/web/src/admin/blueprints/BlueprintListPage.ts
+++ b/web/src/admin/blueprints/BlueprintListPage.ts
@@ -151,7 +151,8 @@ export class BlueprintListPage extends TablePage<BlueprintInstance> {
             html`${BlueprintStatus(item)}`,
             Timestamp(item.lastApplied),
             html`<ak-status-label ?good=${item.enabled}></ak-status-label>`,
-            html`<ak-forms-modal>
+            html`<div>
+                <ak-forms-modal>
                     <span slot="submit">${msg("Update")}</span>
                     <span slot="header">${msg("Update Blueprint")}</span>
                     <ak-blueprint-form slot="form" .instancePk=${item.pk}> </ak-blueprint-form>
@@ -192,7 +193,8 @@ export class BlueprintListPage extends TablePage<BlueprintInstance> {
                     <pf-tooltip position="top" content=${msg("Apply")}>
                         <i class="fas fa-play" aria-hidden="true"></i>
                     </pf-tooltip>
-                </ak-action-button>`,
+                </ak-action-button>
+            </div>`,
         ];
     }
 

--- a/web/src/admin/brands/BrandListPage.ts
+++ b/web/src/admin/brands/BrandListPage.ts
@@ -76,7 +76,8 @@ export class BrandListPage extends TablePage<Brand> {
             html`${item.domain}`,
             html`${item.brandingTitle}`,
             html`<ak-status-label ?good=${item._default}></ak-status-label>`,
-            html`<ak-forms-modal>
+            html`<div>
+                <ak-forms-modal>
                     <span slot="submit">${msg("Update")}</span>
                     <span slot="header">${msg("Update Brand")}</span>
                     <ak-brand-form slot="form" .instancePk=${item.brandUuid}> </ak-brand-form>
@@ -91,7 +92,8 @@ export class BrandListPage extends TablePage<Brand> {
                     model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikBrandsBrand}
                     objectPk=${item.brandUuid}
                 >
-                </ak-rbac-object-permission-modal>`,
+                </ak-rbac-object-permission-modal>
+            </div>`,
         ];
     }
 

--- a/web/src/admin/crypto/CertificateKeyPairListPage.ts
+++ b/web/src/admin/crypto/CertificateKeyPairListPage.ts
@@ -112,7 +112,8 @@ export class CertificateKeyPairListPage extends TablePage<CertificateKeyPair> {
             >
             </ak-status-label>`,
             html`<ak-label color=${color}> ${item.certExpiry?.toLocaleString()} </ak-label>`,
-            html`<ak-forms-modal>
+            html`<div>
+                <ak-forms-modal>
                     <span slot="submit">${msg("Update")}</span>
                     <span slot="header">${msg("Update Certificate-Key Pair")}</span>
                     <ak-crypto-certificate-form slot="form" .instancePk=${item.pk}>
@@ -127,7 +128,8 @@ export class CertificateKeyPairListPage extends TablePage<CertificateKeyPair> {
                     model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikCryptoCertificatekeypair}
                     objectPk=${item.pk}
                 >
-                </ak-rbac-object-permission-modal>`,
+                </ak-rbac-object-permission-modal>
+            </div>`,
         ];
     }
 

--- a/web/src/admin/enterprise/EnterpriseLicenseListPage.ts
+++ b/web/src/admin/enterprise/EnterpriseLicenseListPage.ts
@@ -207,7 +207,8 @@ export class EnterpriseLicenseListPage extends TablePage<License> {
             html`<div>${msg(str`Internal: ${item.internalUsers}`)}</div>
                 <div>${msg(str`External: ${item.externalUsers}`)}</div>`,
             html`<ak-label color=${color}> ${item.expiry?.toLocaleString()} </ak-label>`,
-            html`<ak-forms-modal>
+            html`<div>
+                <ak-forms-modal>
                     <span slot="submit">${msg("Update")}</span>
                     <span slot="header">${msg("Update License")}</span>
                     <ak-enterprise-license-form slot="form" .instancePk=${item.licenseUuid}>
@@ -222,7 +223,8 @@ export class EnterpriseLicenseListPage extends TablePage<License> {
                     model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikEnterpriseLicense}
                     objectPk=${item.licenseUuid}
                 >
-                </ak-rbac-object-permission-modal> `,
+                </ak-rbac-object-permission-modal>
+            </div>`,
         ];
     }
 

--- a/web/src/admin/events/RuleListPage.ts
+++ b/web/src/admin/events/RuleListPage.ts
@@ -87,7 +87,8 @@ export class RuleListPage extends TablePage<NotificationRule> {
                       >${item.destinationGroupObj.name}</a
                   >`
                 : msg("-")}`,
-            html`<ak-forms-modal>
+            html`<div>
+                <ak-forms-modal>
                     <span slot="submit">${msg("Update")}</span>
                     <span slot="header">${msg("Update Notification Rule")}</span>
                     <ak-event-rule-form slot="form" .instancePk=${item.pk}> </ak-event-rule-form>
@@ -102,7 +103,8 @@ export class RuleListPage extends TablePage<NotificationRule> {
                     model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikEventsNotificationrule}
                     objectPk=${item.pk}
                 >
-                </ak-rbac-object-permission-modal>`,
+                </ak-rbac-object-permission-modal>
+            </div>`,
         ];
     }
 

--- a/web/src/admin/events/TransportListPage.ts
+++ b/web/src/admin/events/TransportListPage.ts
@@ -78,7 +78,8 @@ export class TransportListPage extends TablePage<NotificationTransport> {
         return [
             html`${item.name}`,
             html`${item.modeVerbose}`,
-            html`<ak-forms-modal>
+            html`<div>
+                <ak-forms-modal>
                     <span slot="submit">${msg("Update")}</span>
                     <span slot="header">${msg("Update Notification Transport")}</span>
                     <ak-event-transport-form slot="form" .instancePk=${item.pk}>
@@ -106,7 +107,8 @@ export class TransportListPage extends TablePage<NotificationTransport> {
                     <pf-tooltip position="top" content=${msg("Test")}>
                         <i class="fas fa-vial" aria-hidden="true"></i>
                     </pf-tooltip>
-                </ak-action-button>`,
+                </ak-action-button>
+            </div>`,
         ];
     }
 

--- a/web/src/admin/groups/GroupListPage.ts
+++ b/web/src/admin/groups/GroupListPage.ts
@@ -74,16 +74,18 @@ export class GroupListPage extends TablePage<Group> {
             html`${item.parentName || msg("-")}`,
             html`${Array.from(item.users || []).length}`,
             html`<ak-status-label type="neutral" ?good=${item.isSuperuser}></ak-status-label>`,
-            html`<ak-forms-modal>
-                <span slot="submit">${msg("Update")}</span>
-                <span slot="header">${msg("Update Group")}</span>
-                <ak-group-form slot="form" .instancePk=${item.pk}> </ak-group-form>
-                <button slot="trigger" class="pf-c-button pf-m-plain">
-                    <pf-tooltip position="top" content=${msg("Edit")}>
-                        <i class="fas fa-edit" aria-hidden="true"></i>
-                    </pf-tooltip>
-                </button>
-            </ak-forms-modal>`,
+            html`<div>
+                <ak-forms-modal>
+                    <span slot="submit">${msg("Update")}</span>
+                    <span slot="header">${msg("Update Group")}</span>
+                    <ak-group-form slot="form" .instancePk=${item.pk}> </ak-group-form>
+                    <button slot="trigger" class="pf-c-button pf-m-plain">
+                        <pf-tooltip position="top" content=${msg("Edit")}>
+                            <i class="fas fa-edit" aria-hidden="true"></i>
+                        </pf-tooltip>
+                    </button>
+                </ak-forms-modal>
+            </div>`,
         ];
     }
 

--- a/web/src/admin/groups/RelatedUserList.ts
+++ b/web/src/admin/groups/RelatedUserList.ts
@@ -191,7 +191,8 @@ export class RelatedUserList extends WithBrandConfig(WithCapabilitiesConfig(Tabl
             html`<ak-status-label ?good=${item.isActive}></ak-status-label>`,
             Timestamp(item.lastLogin),
 
-            html`<ak-forms-modal>
+            html`<div>
+                <ak-forms-modal>
                     <span slot="submit">${msg("Update")}</span>
                     <span slot="header">${msg("Update User")}</span>
                     <ak-user-form slot="form" .instancePk=${item.pk}> </ak-user-form>
@@ -220,7 +221,8 @@ export class RelatedUserList extends WithBrandConfig(WithCapabilitiesConfig(Tabl
                               </button>
                           </ak-forms-modal>
                       `
-                    : nothing}`,
+                    : nothing}
+            </div>`,
         ];
     }
 

--- a/web/src/admin/outposts/OutpostListPage.ts
+++ b/web/src/admin/outposts/OutpostListPage.ts
@@ -124,7 +124,8 @@ export class OutpostListPage extends TablePage<Outpost> {
             html`<ak-outpost-health-simple
                 outpostId=${ifDefined(item.pk)}
             ></ak-outpost-health-simple>`,
-            html`<ak-forms-modal>
+            html`<div>
+                <ak-forms-modal>
                     <span slot="submit">${msg("Update")}</span>
                     <span slot="header">${msg("Update Outpost")}</span>
                     <ak-outpost-form
@@ -150,7 +151,8 @@ export class OutpostListPage extends TablePage<Outpost> {
                               ${msg("View Deployment Info")}
                           </button>
                       </ak-outpost-deployment-modal>`
-                    : nothing}`,
+                    : nothing}
+            </div>`,
         ];
     }
 

--- a/web/src/admin/providers/ProviderListPage.ts
+++ b/web/src/admin/providers/ProviderListPage.ts
@@ -111,27 +111,29 @@ export class ProviderListPage extends TablePage<Provider> {
             html`<a href="#/core/providers/${item.pk}">${item.name}</a>`,
             this.#rowApp(item),
             html`${item.verboseName}`,
-            html`<ak-forms-modal>
-                <span slot="submit">${msg("Update")}</span>
-                <span slot="header">${msg(str`Update ${item.verboseName}`)}</span>
-                <ak-proxy-form
-                    slot="form"
-                    .args=${{
-                        instancePk: item.pk,
-                    }}
-                    type=${item.component}
-                >
-                </ak-proxy-form>
-                <button
-                    aria-label=${msg(str`Edit "${item.name}" provider`)}
-                    slot="trigger"
-                    class="pf-c-button pf-m-plain"
-                >
-                    <pf-tooltip position="top" content=${msg("Edit")}>
-                        <i aria-hidden="true" class="fas fa-edit"></i>
-                    </pf-tooltip>
-                </button>
-            </ak-forms-modal>`,
+            html`<div>
+                <ak-forms-modal>
+                    <span slot="submit">${msg("Update")}</span>
+                    <span slot="header">${msg(str`Update ${item.verboseName}`)}</span>
+                    <ak-proxy-form
+                        slot="form"
+                        .args=${{
+                            instancePk: item.pk,
+                        }}
+                        type=${item.component}
+                    >
+                    </ak-proxy-form>
+                    <button
+                        aria-label=${msg(str`Edit "${item.name}" provider`)}
+                        slot="trigger"
+                        class="pf-c-button pf-m-plain"
+                    >
+                        <pf-tooltip position="top" content=${msg("Edit")}>
+                            <i aria-hidden="true" class="fas fa-edit"></i>
+                        </pf-tooltip>
+                    </button>
+                </ak-forms-modal>
+            </div>`,
         ];
     }
 

--- a/web/src/admin/providers/rac/EndpointList.ts
+++ b/web/src/admin/providers/rac/EndpointList.ts
@@ -86,7 +86,8 @@ export class EndpointListPage extends Table<Endpoint> {
         return [
             html`${item.name}`,
             html`${item.host}`,
-            html`<ak-forms-modal>
+            html`<div>
+                <ak-forms-modal>
                     <span slot="submit">${msg("Update")}</span>
                     <span slot="header">${msg("Update Endpoint")}</span>
                     <ak-rac-endpoint-form slot="form" .instancePk=${item.pk}>
@@ -101,7 +102,8 @@ export class EndpointListPage extends Table<Endpoint> {
                     model=${RbacPermissionsAssignedByUsersListModelEnum.AuthentikProvidersRacEndpoint}
                     objectPk=${item.pk}
                 >
-                </ak-rbac-object-permission-modal>`,
+                </ak-rbac-object-permission-modal>
+            </div>`,
         ];
     }
 

--- a/web/src/admin/rbac/InitialPermissionsListPage.ts
+++ b/web/src/admin/rbac/InitialPermissionsListPage.ts
@@ -73,17 +73,19 @@ export class InitialPermissionsListPage extends TablePage<InitialPermissions> {
     row(item: InitialPermissions): SlottedTemplateResult[] {
         return [
             html`${item.name}`,
-            html`<ak-forms-modal>
-                <span slot="submit">${msg("Update")}</span>
-                <span slot="header">${msg("Update Initial Permissions")}</span>
-                <ak-initial-permissions-form slot="form" .instancePk=${item.pk}>
-                </ak-initial-permissions-form>
-                <button slot="trigger" class="pf-c-button pf-m-plain">
-                    <pf-tooltip position="top" content=${msg("Edit")}>
-                        <i class="fas fa-edit" aria-hidden="true"></i>
-                    </pf-tooltip>
-                </button>
-            </ak-forms-modal>`,
+            html`<div>
+                <ak-forms-modal>
+                    <span slot="submit">${msg("Update")}</span>
+                    <span slot="header">${msg("Update Initial Permissions")}</span>
+                    <ak-initial-permissions-form slot="form" .instancePk=${item.pk}>
+                    </ak-initial-permissions-form>
+                    <button slot="trigger" class="pf-c-button pf-m-plain">
+                        <pf-tooltip position="top" content=${msg("Edit")}>
+                            <i class="fas fa-edit" aria-hidden="true"></i>
+                        </pf-tooltip>
+                    </button>
+                </ak-forms-modal>
+            </div>`,
         ];
     }
 

--- a/web/src/admin/roles/RoleListPage.ts
+++ b/web/src/admin/roles/RoleListPage.ts
@@ -73,16 +73,18 @@ export class RoleListPage extends TablePage<Role> {
     row(item: Role): SlottedTemplateResult[] {
         return [
             html`<a href="#/identity/roles/${item.pk}">${item.name}</a>`,
-            html`<ak-forms-modal>
-                <span slot="submit">${msg("Update")}</span>
-                <span slot="header">${msg("Update Role")}</span>
-                <ak-role-form slot="form" .instancePk=${item.pk}> </ak-role-form>
-                <button slot="trigger" class="pf-c-button pf-m-plain">
-                    <pf-tooltip position="top" content=${msg("Edit")}>
-                        <i class="fas fa-edit" aria-hidden="true"></i>
-                    </pf-tooltip>
-                </button>
-            </ak-forms-modal>`,
+            html`<div>
+                <ak-forms-modal>
+                    <span slot="submit">${msg("Update")}</span>
+                    <span slot="header">${msg("Update Role")}</span>
+                    <ak-role-form slot="form" .instancePk=${item.pk}> </ak-role-form>
+                    <button slot="trigger" class="pf-c-button pf-m-plain">
+                        <pf-tooltip position="top" content=${msg("Edit")}>
+                            <i class="fas fa-edit" aria-hidden="true"></i>
+                        </pf-tooltip>
+                    </button>
+                </ak-forms-modal>
+            </div>`,
         ];
     }
 

--- a/web/src/admin/stages/StageListPage.ts
+++ b/web/src/admin/stages/StageListPage.ts
@@ -123,7 +123,8 @@ export class StageListPage extends TablePage<Stage> {
                     </li>`;
                 })}
             </ul>`,
-            html`<ak-forms-modal>
+            html`<div>
+                <ak-forms-modal>
                     <span slot="submit">${msg("Update")}</span>
                     <span slot="header">${msg(str`Update ${item.verboseName}`)}</span>
                     <ak-proxy-form
@@ -142,7 +143,8 @@ export class StageListPage extends TablePage<Stage> {
                 </ak-forms-modal>
                 <ak-rbac-object-permission-modal model=${item.metaModelName} objectPk=${item.pk}>
                 </ak-rbac-object-permission-modal>
-                ${this.renderStageActions(item)}`,
+                ${this.renderStageActions(item)}
+            </div>`,
         ];
     }
 

--- a/web/src/admin/users/UserApplicationTable.ts
+++ b/web/src/admin/users/UserApplicationTable.ts
@@ -52,7 +52,8 @@ export class UserApplicationTable extends Table<Application> {
                   </a>`
                 : html`-`,
             html`${item.providerObj?.verboseName || msg("-")}`,
-            html`<ak-forms-modal>
+            html`<div>
+                <ak-forms-modal>
                     <span slot="submit">${msg("Update")}</span>
                     <span slot="header">${msg("Update Application")}</span>
                     <ak-application-form slot="form" .instancePk=${item.slug}>
@@ -69,7 +70,8 @@ export class UserApplicationTable extends Table<Application> {
                               <i class="fas fa-share-square" aria-hidden="true"></i>
                           </pf-tooltip>
                       </a>`
-                    : nothing}`,
+                    : nothing}
+            </div>`,
         ];
     }
 }

--- a/web/src/admin/users/UserListPage.ts
+++ b/web/src/admin/users/UserListPage.ts
@@ -248,7 +248,8 @@ export class UserListPage extends WithBrandConfig(WithCapabilitiesConfig(TablePa
             html`<ak-status-label ?good=${item.isActive}></ak-status-label>`,
             Timestamp(item.lastLogin),
             html`${userTypeToLabel(item.type)}`,
-            html`<ak-forms-modal>
+            html`<div>
+                <ak-forms-modal>
                     <span slot="submit">${msg("Update")}</span>
                     <span slot="header">${msg("Update User")}</span>
                     <ak-user-form slot="form" .instancePk=${item.pk}> </ak-user-form>
@@ -277,7 +278,8 @@ export class UserListPage extends WithBrandConfig(WithCapabilitiesConfig(TablePa
                               </button>
                           </ak-forms-modal>
                       `
-                    : nothing}`,
+                    : nothing}
+            </div>`,
         ];
     }
 

--- a/web/src/elements/table/Table.ts
+++ b/web/src/elements/table/Table.ts
@@ -79,13 +79,6 @@ export abstract class Table<T extends object>
                 }
             }
 
-            td,
-            th {
-                &:last-child {
-                    white-space: nowrap;
-                }
-            }
-
             /**
              * TODO: Row actions need a better approach to alignment,
              * but this will at least get the buttons in a grid-like layout.

--- a/web/src/elements/table/Table.ts
+++ b/web/src/elements/table/Table.ts
@@ -74,7 +74,7 @@ export abstract class Table<T extends object>
                 .presentational {
                     --pf-c-table--cell--MinWidth: 0;
                 }
-                @container (width > 600px) {
+                @container (width > 1200px) {
                     --pf-c-table--cell--MinWidth: 9em;
                 }
             }


### PR DESCRIPTION
## Details

This PR fixes two issues stemming from table styles:

- Modals are subject to CSS inheritance of a parent table row
- Table action columns wrap awkwardly on smaller viewports

The fix here is a stop gap while modals get migrated to `<dialog>`
