### PR TITLE
web/a11y: Table header -- Search input

### DIFF
--- a/web/src/admin/applications/ApplicationListPage.ts
+++ b/web/src/admin/applications/ApplicationListPage.ts
@@ -80,7 +80,7 @@ export class ApplicationListPage extends WithBrandConfig(TablePage<Application>)
     protected renderSidebarAfter(): TemplateResult {
         return html`<aside
             aria-label=${msg("Applications Documentation")}
-            class="pf-c-sidebar__panel pf-m-width-25"
+            class="pf-c-sidebar__panel"
         >
             <div class="pf-c-card">
                 <div class="pf-c-card__body">

--- a/web/src/admin/users/UserListPage.ts
+++ b/web/src/admin/users/UserListPage.ts
@@ -91,6 +91,9 @@ export class UserListPage extends WithBrandConfig(WithCapabilitiesConfig(TablePa
     supportsQL = true;
 
     protected override searchEnabled = true;
+    public override searchPlaceholder = msg("Search by username, email, etc...");
+    public override searchLabel = msg("User Search");
+
     public pageTitle = msg("Users");
     public pageDescription = "";
     public pageIcon = "pf-icon pf-icon-user";
@@ -207,34 +210,33 @@ export class UserListPage extends WithBrandConfig(WithCapabilitiesConfig(TablePa
     }
 
     renderToolbarAfter(): TemplateResult {
-        return html`&nbsp;
-            <div class="pf-c-toolbar__group pf-m-filter-group">
-                <div class="pf-c-toolbar__item pf-m-search-filter">
-                    <div class="pf-c-input-group">
-                        <label class="pf-c-switch">
-                            <input
-                                class="pf-c-switch__input"
-                                type="checkbox"
-                                ?checked=${this.hideDeactivated}
-                                @change=${() => {
-                                    this.hideDeactivated = !this.hideDeactivated;
-                                    this.page = 1;
-                                    this.fetch();
-                                    updateURLParams({
-                                        hideDeactivated: this.hideDeactivated,
-                                    });
-                                }}
-                            />
-                            <span class="pf-c-switch__toggle">
-                                <span class="pf-c-switch__toggle-icon">
-                                    <i class="fas fa-check" aria-hidden="true"></i>
-                                </span>
+        return html` <div class="pf-c-toolbar__group pf-m-filter-group">
+            <div class="pf-c-toolbar__item pf-m-search-filter">
+                <div class="pf-c-input-group">
+                    <label class="pf-c-switch">
+                        <input
+                            class="pf-c-switch__input"
+                            type="checkbox"
+                            ?checked=${!this.hideDeactivated}
+                            @change=${() => {
+                                this.hideDeactivated = !this.hideDeactivated;
+                                this.page = 1;
+                                this.fetch();
+                                updateURLParams({
+                                    hideDeactivated: this.hideDeactivated,
+                                });
+                            }}
+                        />
+                        <span class="pf-c-switch__toggle">
+                            <span class="pf-c-switch__toggle-icon">
+                                <i class="fas fa-check" aria-hidden="true"></i>
                             </span>
-                            <span class="pf-c-switch__label">${msg("Hide deactivated user")}</span>
-                        </label>
-                    </div>
+                        </span>
+                        <span class="pf-c-switch__label">${msg("Show deactivated users")}</span>
+                    </label>
                 </div>
-            </div>`;
+            </div>
+        </div>`;
     }
 
     row(item: User): SlottedTemplateResult[] {
@@ -392,27 +394,24 @@ export class UserListPage extends WithBrandConfig(WithCapabilitiesConfig(TablePa
     renderObjectCreate(): TemplateResult {
         return html`
             <ak-forms-modal>
-                <span slot="submit">${msg("Create")}</span>
-                <span slot="header">${msg("Create User")}</span>
+                <span slot="submit">${msg("Create User")}</span>
+                <span slot="header">${msg("New User")}</span>
                 <ak-user-form defaultPath=${this.activePath} slot="form"> </ak-user-form>
-                <button slot="trigger" class="pf-c-button pf-m-primary">${msg("Create")}</button>
+                <button slot="trigger" class="pf-c-button pf-m-primary">${msg("New User")}</button>
             </ak-forms-modal>
             <ak-forms-modal .closeAfterSuccessfulSubmit=${false} .cancelText=${msg("Close")}>
-                <span slot="submit">${msg("Create")}</span>
-                <span slot="header">${msg("Create Service account")}</span>
+                <span slot="submit">${msg("Create Service Account")}</span>
+                <span slot="header">${msg("New Service Account")}</span>
                 <ak-user-service-account-form slot="form"> </ak-user-service-account-form>
                 <button slot="trigger" class="pf-c-button pf-m-secondary">
-                    ${msg("Create Service account")}
+                    ${msg("New Service Account")}
                 </button>
             </ak-forms-modal>
         `;
     }
 
     protected renderSidebarBefore(): TemplateResult {
-        return html`<aside
-            aria-labelledby="sidebar-left-panel-header"
-            class="pf-c-sidebar__panel pf-m-width-25"
-        >
+        return html`<aside aria-labelledby="sidebar-left-panel-header" class="pf-c-sidebar__panel">
             <div class="pf-c-card">
                 <div
                     role="heading"

--- a/web/src/elements/table/Table.ts
+++ b/web/src/elements/table/Table.ts
@@ -17,6 +17,7 @@ import { AKElement } from "#elements/Base";
 import { WithLicenseSummary } from "#elements/mixins/license";
 import { getURLParam, updateURLParams } from "#elements/router/RouteMatch";
 import { SlottedTemplateResult } from "#elements/types";
+import { ifPresent } from "#elements/utils/attributes";
 
 import { Pagination } from "@goauthentik/api";
 
@@ -122,11 +123,8 @@ export abstract class Table<T extends object>
                 }
             }
 
-            .pf-c-toolbar__group.pf-m-search-filter.ql {
-                flex-grow: 1;
-            }
-            ak-table-search.ql {
-                width: 100% !important;
+            .pf-m-search-filter {
+                flex: 1 1 auto;
             }
             .pf-c-table thead .pf-c-table__check {
                 min-width: 3rem;
@@ -134,11 +132,13 @@ export abstract class Table<T extends object>
             .pf-c-table tbody .pf-c-table__check input {
                 margin-top: calc(var(--pf-c-table__check--input--MarginTop) + 1px);
             }
+
             .pf-c-toolbar__content {
-                row-gap: var(--pf-global--spacer--sm);
+                justify-content: space-between;
+                gap: var(--pf-global--spacer--sm);
             }
-            .pf-c-toolbar__item .pf-c-input-group {
-                padding: 0 var(--pf-global--spacer--sm);
+            .pf-c-toolbar__group {
+                gap: var(--pf-global--spacer--sm);
             }
 
             .pf-c-table {
@@ -154,6 +154,10 @@ export abstract class Table<T extends object>
             thead,
             .pf-c-table tr.pf-m-hoverable {
                 user-select: none;
+            }
+
+            time {
+                text-transform: capitalize;
             }
         `,
     ];
@@ -173,7 +177,8 @@ export abstract class Table<T extends object>
      */
     protected abstract row(item: T): SlottedTemplateResult[];
 
-    #loading = false;
+    @state()
+    protected loading = false;
 
     #pageParam = `${this.tagName.toLowerCase()}-page`;
     #searchParam = `${this.tagName.toLowerCase()}-search`;
@@ -329,11 +334,11 @@ export abstract class Table<T extends object>
     }
 
     public fetch(): Promise<void> {
-        if (this.#loading) {
+        if (this.loading) {
             return Promise.resolve();
         }
 
-        this.#loading = true;
+        this.loading = true;
 
         return this.apiEndpoint()
             .then((data) => {
@@ -364,7 +369,7 @@ export abstract class Table<T extends object>
                 this.error = await parseAPIResponseError(error);
             })
             .finally(() => {
-                this.#loading = false;
+                this.loading = false;
                 this.requestUpdate();
             });
     }
@@ -438,7 +443,7 @@ export abstract class Table<T extends object>
             return this.renderEmpty(this.renderError());
         }
 
-        if (!this.data || this.#loading) {
+        if (!this.data || this.loading) {
             return this.renderLoading();
         }
 
@@ -673,26 +678,24 @@ export abstract class Table<T extends object>
         return nothing;
     }
 
-    protected renderToolbarAfter(): SlottedTemplateResult {
-        return nothing;
-    }
+    protected renderToolbarAfter?(): SlottedTemplateResult;
 
     protected renderToolbarContainer(): SlottedTemplateResult {
         const label = this.toolbarLabel ?? msg(str`${this.label ?? "Table"} actions`);
 
         return html`<header class="pf-c-toolbar" role="toolbar" aria-label="${label}">
-            <div role="presentation" class="pf-c-toolbar__content">
+            <div class="pf-c-toolbar__content">
                 ${this.renderSearch()}
-                <div role="presentation" class="pf-c-toolbar__bulk-select">
-                    ${this.renderToolbar()}
+                ${this.renderToolbarAfter
+                    ? html`<div class="pf-c-toolbar__group">${this.renderToolbarAfter()}</div>`
+                    : nothing}
+            </div>
+
+            <div class="pf-c-toolbar__content">
+                <div class="pf-c-toolbar__group">
+                    ${this.renderToolbar()} ${this.renderToolbarSelected()}
                 </div>
-                <div role="presentation" class="pf-c-toolbar__group">
-                    ${this.renderToolbarAfter()}
-                </div>
-                <div role="presentation" class="pf-c-toolbar__group">
-                    ${this.renderToolbarSelected()}
-                </div>
-                ${this.paginated ? this.renderTablePagination() : nothing}
+                ${this.renderTablePagination()}
             </div>
         </header>`;
     }
@@ -716,18 +719,16 @@ export abstract class Table<T extends object>
 
         const isQL = this.supportsQL && this.hasEnterpriseLicense;
 
-        return html`<div class="pf-c-toolbar__group pf-m-search-filter ${isQL ? "ql" : ""}">
-            <ak-table-search
-                class="pf-c-toolbar__item pf-m-search-filter ${isQL ? "ql" : ""}"
-                .defaultValue=${this.search}
-                label=${ifDefined(this.searchLabel)}
-                placeholder=${ifDefined(this.searchPlaceholder)}
-                .onSearch=${this.#searchListener}
-                .supportsQL=${this.supportsQL}
-                .apiResponse=${this.data}
-            >
-            </ak-table-search>
-        </div>`;
+        return html` <ak-table-search
+            class="pf-c-toolbar__item pf-m-search-filter ${isQL ? "ql" : ""}"
+            .defaultValue=${this.search}
+            label=${ifDefined(this.searchLabel)}
+            placeholder=${ifDefined(this.searchPlaceholder)}
+            .onSearch=${this.#searchListener}
+            .supportsQL=${this.supportsQL}
+            .apiResponse=${this.data}
+        >
+        </ak-table-search>`;
     }
 
     //#endregion
@@ -816,6 +817,8 @@ export abstract class Table<T extends object>
      * A simple pagination display, shown at both the top and bottom of the page.
      */
     protected renderTablePagination(): SlottedTemplateResult {
+        if (!this.paginated) return nothing;
+
         const handler = (page: number) => {
             this.page = page;
             this.fetch();
@@ -823,7 +826,8 @@ export abstract class Table<T extends object>
 
         return html`
             <ak-table-pagination
-                label=${ifDefined(this.label || undefined)}
+                ?loading=${this.loading}
+                label=${ifPresent(this.label)}
                 class="pf-c-toolbar__item pf-m-pagination"
                 .pages=${this.data?.pagination}
                 .onPageChange=${handler}

--- a/web/src/elements/table/TablePage.ts
+++ b/web/src/elements/table/TablePage.ts
@@ -5,7 +5,7 @@ import { SlottedTemplateResult } from "#elements/types";
 import { setPageDetails } from "#components/ak-page-navbar";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, nothing, PropertyValues, TemplateResult } from "lit";
+import { css, CSSResult, html, nothing, PropertyValues, TemplateResult } from "lit";
 
 import PFContent from "@patternfly/patternfly/components/Content/content.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
@@ -18,6 +18,14 @@ export abstract class TablePage<T extends object> extends Table<T> {
         PFPage,
         PFContent,
         PFSidebar,
+        css`
+            .pf-c-sidebar__panel {
+                flex: 0 1 25%;
+            }
+            .pf-c-sidebar__content {
+                flex: 1 1 75%;
+            }
+        `,
     ];
 
     //#region Abstract properties

--- a/web/src/elements/table/TablePagination.ts
+++ b/web/src/elements/table/TablePagination.ts
@@ -20,6 +20,9 @@ export class TablePagination extends AKElement {
     @property({ attribute: false })
     public pages?: Pagination;
 
+    @property({ type: Boolean })
+    public loading = false;
+
     @property({ attribute: false })
     public onPageChange?: TablePageChangeListener;
 
@@ -28,12 +31,25 @@ export class TablePagination extends AKElement {
         PFButton,
         PFPagination,
         css`
-            :host([theme="dark"]) .pf-c-pagination__nav-control .pf-c-button {
-                color: var(--pf-c-button--m-plain--disabled--Color);
-                --pf-c-button--disabled--Color: var(--pf-c-button--m-plain--Color);
+            .pf-c-pagination {
+                min-width: 8rem;
+
+                &[inert] {
+                    opacity: 0.5;
+                }
             }
-            :host([theme="dark"]) .pf-c-pagination__nav-control .pf-c-button:disabled {
-                color: var(--pf-c-button--disabled--Color);
+
+            :host([theme="dark"]) {
+                .pf-c-pagination__nav-control {
+                    .pf-c-button {
+                        color: var(--pf-c-button--m-plain--disabled--Color);
+                        --pf-c-button--disabled--Color: var(--pf-c-button--m-plain--Color);
+
+                        &:disabled {
+                            color: var(--pf-c-button--disabled--Color);
+                        }
+                    }
+                }
             }
         `,
     ];
@@ -47,21 +63,24 @@ export class TablePagination extends AKElement {
     };
 
     render() {
-        if (!this.pages) {
+        if (!this.pages && !this.loading) {
             return nothing;
         }
+
+        const startIndex = this.pages?.startIndex || 1;
+        const endIndex = this.pages?.endIndex || 1;
+        const pageCount = this.pages?.count || 1;
 
         return html` <nav
             aria-label=${msg(str`${this.label || ""} table pagination`)}
             class="pf-c-pagination pf-m-compact pf-m-hidden pf-m-visible-on-md"
+            ?inert=${this.loading}
         >
             <div class="pf-c-pagination pf-m-compact pf-m-compact pf-m-hidden pf-m-visible-on-md">
                 <div class="pf-c-options-menu">
                     <div class="pf-c-options-menu__toggle pf-m-text pf-m-plain">
                         <span role="heading" aria-level="4" class="pf-c-options-menu__toggle-text">
-                            ${msg(
-                                str`${this.pages?.startIndex} - ${this.pages?.endIndex} of ${this.pages?.count}`,
-                            )}
+                            ${msg(str`${startIndex} - ${endIndex} of ${pageCount}`)}
                         </span>
                     </div>
                 </div>

--- a/web/src/elements/table/TableSearch.ts
+++ b/web/src/elements/table/TableSearch.ts
@@ -3,11 +3,11 @@ import "#components/ak-search-ql/index";
 import { AKElement } from "#elements/Base";
 import { WithLicenseSummary } from "#elements/mixins/license";
 import { PaginatedResponse } from "#elements/table/Table";
+import { ifPresent } from "#elements/utils/attributes";
 
 import { msg } from "@lit/localize";
 import { css, CSSResult, html, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
-import { ifDefined } from "lit/directives/if-defined.js";
 import { createRef, ref } from "lit/directives/ref.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
@@ -43,11 +43,32 @@ export class TableSearchForm extends WithLicenseSummary(AKElement) {
         PFInputGroup,
         PFFormControl,
         css`
-            ::-webkit-search-cancel-button {
-                display: none;
+            form.pf-c-input-group {
+                position: relative;
             }
+
             ak-search-ql {
                 width: 100%;
+            }
+
+            button[type="reset"] {
+                position: absolute;
+                inset-inline-end: 0.25em;
+                inset-block-start: 0.25em;
+                appearance: none;
+                border: none;
+                background: none;
+                line-height: 1;
+                font-family: ui-monospace, monospace;
+                color: initial;
+                color: ButtonText;
+                z-index: var(--pf-global--ZIndex--xs);
+                cursor: pointer;
+                display: none;
+            }
+
+            ak-search-ql:state(present) + button[type="reset"] {
+                display: block;
             }
         `,
     ];
@@ -58,6 +79,20 @@ export class TableSearchForm extends WithLicenseSummary(AKElement) {
         this.#formRef.value?.reset();
 
         this.onSearch?.("");
+    };
+
+    #searchListener = (event: InputEvent) => {
+        const target = event.target;
+
+        if (!(target instanceof HTMLInputElement) || !this.onSearch) return;
+
+        // The search event is dispatched by either pressing enter
+        // or clearing the input (e.g. via the "x" button or pressing escape).
+
+        // The submit listener handles the enter key, so we only need to handle the clearing here.
+        if (target.value) return;
+
+        this.onSearch("");
     };
 
     #submitListener = (event: SubmitEvent) => {
@@ -76,25 +111,27 @@ export class TableSearchForm extends WithLicenseSummary(AKElement) {
         this.onSearch(value);
     };
 
-    renderInput(): TemplateResult {
+    protected renderInput(): TemplateResult {
         if (this.supportsQL && this.hasEnterpriseLicense) {
             return html`<ak-search-ql
-                aria-label=${ifDefined(this.label)}
-                name="search"
-                required
-                placeholder=${ifDefined(this.placeholder)}
-                value=${ifDefined(this.defaultValue)}
-                .apiResponse=${this.apiResponse}
-            ></ak-search-ql>`;
+                    label=${ifPresent(this.label)}
+                    role="presentation"
+                    name="search"
+                    placeholder=${ifPresent(this.placeholder)}
+                    value=${ifPresent(this.defaultValue)}
+                    .apiResponse=${this.apiResponse}
+                ></ak-search-ql>
+                <button type="reset" aria-label=${msg("Clear search")}>&times;</button>`;
         }
 
         return html`<input
-            aria-label=${ifDefined(this.label)}
+            aria-label=${ifPresent(this.label)}
             name="search"
-            required
-            placeholder=${ifDefined(this.placeholder)}
-            value=${ifDefined(this.defaultValue)}
+            type="search"
+            placeholder=${ifPresent(this.placeholder)}
+            value=${ifPresent(this.defaultValue)}
             class="pf-c-form-control"
+            @search=${this.#searchListener}
         />`;
     }
 
@@ -103,19 +140,9 @@ export class TableSearchForm extends WithLicenseSummary(AKElement) {
             ${ref(this.#formRef)}
             class="pf-c-input-group"
             @submit=${this.#submitListener}
+            @reset=${this.reset}
         >
             ${this.renderInput()}
-            <button
-                aria-label=${msg("Clear search")}
-                class="pf-c-button pf-m-control"
-                type="reset"
-                @click=${this.reset}
-            >
-                <i class="fas fa-times" aria-hidden="true"></i>
-            </button>
-            <button aria-label=${msg("Search")} type="submit" class="pf-c-button pf-m-control">
-                <i class="fas fa-search" aria-hidden="true"></i>
-            </button>
         </form>`;
     }
 }


### PR DESCRIPTION
## Depends on

- #17116 

## Details

Both the basic table search and QL search inputs have improved keyboard access, as well a more consistent layout on smaller screens. QL search inputs now announce suggestions according to the ARIA combobox role.


<img width="1470" height="560" alt="Screenshot 2025-09-29 at 21 56 16" src="https://github.com/user-attachments/assets/5a581ff4-6290-46c5-adb9-103fcfcdbb6a" />
