### PR TITLE
web: Fix native icon colors when using dark theme.

### DIFF
--- a/web/src/common/styles/theme-dark.css
+++ b/web/src/common/styles/theme-dark.css
@@ -18,6 +18,7 @@
 
 body {
     background-color: var(--ak-dark-background) !important;
+    color-scheme: dark;
 }
 
 .pf-c-radio {
@@ -224,10 +225,6 @@ select.pf-c-form-control {
 
 .pf-c-switch__input:checked ~ .pf-c-switch__label {
     --pf-c-switch__input--checked__label--Color: var(--ak-dark-foreground);
-}
-input[type="datetime-local"]::-webkit-calendar-picker-indicator,
-input[type="date"]::-webkit-calendar-picker-indicator {
-    filter: invert(1);
 }
 
 /* select toggle */


### PR DESCRIPTION
## Details

This PR fixes a collection of dark theme icon issues that occur when a user's preferred _color scheme_ doesn't align with the app's _color theme_. 

### Date icon visibility on dark theme


<img width="1152" height="361" alt="Screenshot 2025-09-29 at 22 15 45" src="https://github.com/user-attachments/assets/03c6fc37-6e0e-4567-801e-8ae325b8e108" />

## Date icon visibility on light theme

<img width="1135" height="338" alt="Screenshot 2025-09-29 at 22 15 05" src="https://github.com/user-attachments/assets/95fffd07-c2cd-486c-8821-8949d50011ee" />
