### PR TITLE
website/docs: updates to say use info not note

### DIFF
--- a/website/docs/developer-docs/docs/style-guide.mdx
+++ b/website/docs/developer-docs/docs/style-guide.mdx
@@ -194,7 +194,7 @@ We only use Info, Warning, and Danger boxes, but not Notes. For an Info box, you
 
 Use the following syntax for these components:
 
-**Info notes**:
+**Info**:
 
 ```md
 ::: info add-title-here

--- a/website/docs/developer-docs/docs/style-guide.mdx
+++ b/website/docs/developer-docs/docs/style-guide.mdx
@@ -205,7 +205,7 @@ This is a tip or general note.
 **Warnings**:
 
 ```md
-::: warning
+:::warning
 This level is for more serious situations: an action cannot be undone, a process might be canceled, etc..
 :::
 ```

--- a/website/docs/developer-docs/docs/style-guide.mdx
+++ b/website/docs/developer-docs/docs/style-guide.mdx
@@ -188,6 +188,36 @@ Add a period at the end of a bulleted item if it is a complete sentence. Try not
 
 If there is a [colon](#following-a-colon) used in a bulleted list item, follow the capitalization rules.
 
+### Notes and warnings
+
+We only use Info, Warning, and Danger boxes, but not Notes. For an Info box, you can optionally add a title, but do not use a title with Warning or Danger boxes.
+
+Use the following syntax for these components:
+
+**Info notes**:
+
+```md
+::: info add-title-here
+This is a tip or general note.
+:::
+```
+
+**Warnings**:
+
+```md
+::: warning
+This level is for more serious situations: an action cannot be undone, a process might be canceled, etc..
+:::
+```
+
+**Critical warnings** (for irreversible actions):
+
+```md
+:::danger
+This level is for extremely serious situations, such as an action permanently removing data.
+:::
+```
+
 ### URLs
 
     - When mentioning URLs in text or within procedural instructions, omit code formatting. For instance: "In your browser, go to https://example.com."
@@ -345,36 +375,6 @@ When documenting errors, follow this structure:
 - **Descriptive link text**: Provide descriptive link text. Avoid using generic terms like "Click here". Be specific about where the link will take the user.
     - **DON'T:** "Click here."
     - **DO:** "See the [Authentication Settings](/) for more details."
-
----
-
-## Notes and warnings
-
-Use the following components to highlight important information:
-
-**Info notes**:
-
-```md
-:::info
-This is a tip or general note.
-:::
-```
-
-**Warnings**:
-
-```md
-:::warning
-This level is for more serious situations: an action cannot be undone, a process might be canceled, etc..
-:::
-```
-
-**Critical warnings** (for irreversible actions):
-
-```md
-:::danger
-This level is for extremely serious situations, such as an action permanently removing data.
-:::
-```
 
 ---
 

--- a/website/docs/developer-docs/docs/style-guide.mdx
+++ b/website/docs/developer-docs/docs/style-guide.mdx
@@ -206,7 +206,7 @@ This is a tip or general note.
 
 ```md
 :::warning
-This level is for more serious situations: an action cannot be undone, a process might be canceled, etc..
+This level is for more serious situations: an action cannot be undone, a process might be canceled, etc.
 :::
 ```
 

--- a/website/docs/developer-docs/docs/style-guide.mdx
+++ b/website/docs/developer-docs/docs/style-guide.mdx
@@ -190,7 +190,7 @@ If there is a [colon](#following-a-colon) used in a bulleted list item, follow t
 
 ### Notes and warnings
 
-We only use Info, Warning, and Danger boxes, but not Notes. For an Info box, you can optionally add a title, but do not use a title with Warning or Danger boxes.
+We use Info, Warning, and Danger boxes, to provide supplemental information. Info boxes can optionally have a title, but do not use a title with Warning or Danger boxes.
 
 Use the following syntax for these components:
 

--- a/website/docs/developer-docs/docs/style-guide.mdx
+++ b/website/docs/developer-docs/docs/style-guide.mdx
@@ -14,7 +14,6 @@ We appreciate all contributions to our documentation — whether it's fixing a t
 - [Component-Based Formatting](#component-based-formatting)
 - [Error Message Formatting and Troubleshooting](#error-message-formatting-and-troubleshooting)
 - [Accessibility Best Practices](#accessibility-best-practices)
-- [Notes and Warnings](#notes-and-warnings)
 - [Inclusive Language](#inclusive-language)
 - [Images and Media](#images-and-media)
 - [Document Structure and Metadata](#document-structure-and-metadata)

--- a/website/docs/developer-docs/docs/templates/combo.md
+++ b/website/docs/developer-docs/docs/templates/combo.md
@@ -1,9 +1,9 @@
 ---
-title: "Combination topic"
+title: "Combination topic (most common)"
 ---
 
-:::info
-**How to use this template**: start with the markdown version of the template, either by copying the [`combo.tmpl.md`](https://github.com/goauthentik/authentik/tree/main/website/docs/developer-docs/docs/templates) file from our GitHub repo or downloading the template file using the following command:
+:::info How to use this template
+Start with the markdown version of the template, either by copying the [`combo.tmpl.md`](https://github.com/goauthentik/authentik/tree/main/website/docs/developer-docs/docs/templates) file from our GitHub repo or downloading the template file using the following command:
 
 ```shell
 wget https://raw.githubusercontent.com/goauthentik/authentik/main/website/docs/developer-docs/docs/templates/combo.tmpl.md

--- a/website/docs/developer-docs/docs/templates/combo.tmpl.md
+++ b/website/docs/developer-docs/docs/templates/combo.tmpl.md
@@ -8,8 +8,8 @@ add brief description of the feature/functionality
 
 In this section, go into a deeper explanation of the feature, provide typical use cases, etc.
 
-:::info
-if needed, use this syntax to add a note (info) or warning (warning).
+:::info Add a title here
+If needed, use this syntax to add a note (info) or warning (warning) anywhere in the document that is appropriate.
 :::
 
 ### More info about the feature, a sub-category of info

--- a/website/docs/developer-docs/docs/templates/conceptual.md
+++ b/website/docs/developer-docs/docs/templates/conceptual.md
@@ -2,8 +2,8 @@
 title: "Conceptual topic"
 ---
 
-:::info
-**How to use this template**: start with the markdown version of the template, either by copying the [`conceptual.tmpl.md`](https://github.com/goauthentik/authentik/tree/main/website/docs/developer-docs/docs/templates) file from our GitHub repo or downloading the template file using the following command:
+:::info How to use this template
+Start with the markdown version of the template, either by copying the [`conceptual.tmpl.md`](https://github.com/goauthentik/authentik/tree/main/website/docs/developer-docs/docs/templates) file from our GitHub repo or downloading the template file using the following command:
 
 ```shell
 wget https://raw.githubusercontent.com/goauthentik/authentik/main/website/docs/developer-docs/docs/templates/conceptual.tmpl.md

--- a/website/docs/developer-docs/docs/templates/conceptual.tmpl.md
+++ b/website/docs/developer-docs/docs/templates/conceptual.tmpl.md
@@ -4,8 +4,8 @@ title: "Markdown template: conceptual"
 
 Write a few sentences introducing the feature/component/technology.
 
-:::info
-if needed, use this syntax to add a note (info) or warning (warning)
+:::info Add a title here
+If needed, use this syntax to add a note (info) or warning (warning) anywhere in the document that is appropriate.
 :::
 
 ## Common use cases

--- a/website/docs/developer-docs/docs/templates/index.md
+++ b/website/docs/developer-docs/docs/templates/index.md
@@ -2,11 +2,11 @@
 title: "Templates"
 ---
 
-In technical documentation, there are document "types" (similar to how there are data types). We have templates for the different types, to make it super-easy for whomever wants to contribute some documentation!
+In technical documentation, there are document "types" (similar to how there are data types). We have templates for the different types, to make it super-easy to divide longer topics into separate pages (one for each content type) if needed. And templates in general make it easy for whomever wants to contribute some documentation!
 
 The most common types are:
 
-- [**Combo**](./combo.md): For most topics (unless they are very large and complex), we can combine the procedural and conceptual information into a single document. A handy guideline to follow is: "If the actual 1., 2., 3. steps are buried at the bottom, and a reader has to scroll multiple times to find them, then the combo approach is _not_ the right one".
+- [**Combo**](./combo.md): For most topics (unless they are very large and complex), we can combine the procedural and conceptual information into a single document. A handy guideline to follow is: "If the actual 1., 2., 3. steps are buried at the bottom, and a reader has to scroll multiple times to find them, then the combo approach is _not_ the right one. Use separate topics.".
 
 - [**Procedural**](./procedural.md): these are How To docs, the HOW information, with step-by-step instructions for accomplishing a task. This is what most people are looking for when they open the docs... and best practice is to separate the procedural docs from long, lengthy conceptual or reference docs.
 

--- a/website/docs/developer-docs/docs/templates/procedural.md
+++ b/website/docs/developer-docs/docs/templates/procedural.md
@@ -2,8 +2,8 @@
 title: "Procedural topic"
 ---
 
-:::info
-**How to use this template**: start with the markdown version of the template, either by copying the [`procedural.tmpl.md`](https://github.com/goauthentik/authentik/tree/main/website/docs/developer-docs/docs/templates) file from our GitHub repo or downloading the template file using the following command:
+:::info How to use this template
+Start with the markdown version of the template, either by copying the [`procedural.tmpl.md`](https://github.com/goauthentik/authentik/tree/main/website/docs/developer-docs/docs/templates) file from our GitHub repo or downloading the template file using the following command:
 
 ```shell
 wget https://raw.githubusercontent.com/goauthentik/authentik/main/website/docs/developer-docs/docs/templates/procedural.tmpl.md

--- a/website/docs/developer-docs/docs/templates/procedural.tmpl.md
+++ b/website/docs/developer-docs/docs/templates/procedural.tmpl.md
@@ -4,8 +4,8 @@ title: "Markdown template: procedural"
 
 add brief description of the feature/functionality
 
-:::info
-if needed, use this syntax to add a note (info) or warning (warning)
+:::info Add a title here
+If needed, use this syntax to add a note (info) or warning (warning) anywhere in the document that is appropriate.
 :::
 
 ## Prerequisites

--- a/website/docs/developer-docs/docs/templates/reference.md
+++ b/website/docs/developer-docs/docs/templates/reference.md
@@ -2,8 +2,8 @@
 title: "Reference topic"
 ---
 
-:::info
-**How to use this template**: start with the markdown version of the template, either by copying the [`reference.tmpl.md`](https://github.com/goauthentik/authentik/tree/main/website/docs/developer-docs/docs/templates) file from our GitHub repo or downloading the template file using the following command:
+:::info How to use this template
+Start with the markdown version of the template, either by copying the [`reference.tmpl.md`](https://github.com/goauthentik/authentik/tree/main/website/docs/developer-docs/docs/templates) file from our GitHub repo or downloading the template file using the following command:
 
 ```shell
 wget https://raw.githubusercontent.com/goauthentik/authentik/main/website/docs/developer-docs/docs/templates/reference.tmpl.md

--- a/website/docs/developer-docs/docs/templates/reference.tmpl.md
+++ b/website/docs/developer-docs/docs/templates/reference.tmpl.md
@@ -5,7 +5,7 @@ title: "Markdown template: reference"
 Write a few sentences introducing the feature/component/technology, and state that this page contains reference materials.
 
 :::info Optionally add a title here
-If needed, use this syntax to add a note (info) or warning (warning) anywhere in the document that is appropriate.
+If needed, use this syntax to add a info, warning or danger box to the document.
 :::
 
 ## Head 2

--- a/website/docs/developer-docs/docs/templates/reference.tmpl.md
+++ b/website/docs/developer-docs/docs/templates/reference.tmpl.md
@@ -4,8 +4,8 @@ title: "Markdown template: reference"
 
 Write a few sentences introducing the feature/component/technology, and state that this page contains reference materials.
 
-:::info
-if needed, use this syntax to add a note (info) or warning (warning)
+:::info Add a title here
+If needed, use this syntax to add a note (info) or warning (warning) anywhere in the document that is appropriate.
 :::
 
 ## Head 2

--- a/website/docs/developer-docs/docs/templates/reference.tmpl.md
+++ b/website/docs/developer-docs/docs/templates/reference.tmpl.md
@@ -4,7 +4,7 @@ title: "Markdown template: reference"
 
 Write a few sentences introducing the feature/component/technology, and state that this page contains reference materials.
 
-:::info Add a title here
+:::info Optionally add a title here
 If needed, use this syntax to add a note (info) or warning (warning) anywhere in the document that is appropriate.
 :::
 

--- a/website/docs/sidebar.mjs
+++ b/website/docs/sidebar.mjs
@@ -688,10 +688,10 @@ const items = [
                             id: "developer-docs/docs/templates/index",
                         },
                         items: [
+                            "developer-docs/docs/templates/combo",
                             "developer-docs/docs/templates/procedural",
                             "developer-docs/docs/templates/conceptual",
                             "developer-docs/docs/templates/reference",
-                            "developer-docs/docs/templates/combo",
                         ],
                     },
                 ],


### PR DESCRIPTION
This PR updates the Style Guide and our templates to say we only use Info, Warning, and Danger boxes (not notes), and updates the syntax for adding a title to an Info box.

Dewi updated the integration guides and docs  in PR #17139 and PR #17138, respectively.

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
