### PR TITLE
web/a11y: Fix dark theme color contrast

### DIFF
--- a/web/src/common/styles/authentik.css
+++ b/web/src/common/styles/authentik.css
@@ -129,20 +129,55 @@ html > form > input {
     }
 }
 
+/* #endregion */
+
+/* #region Form controls */
+
 .pf-c-form-control {
     --pf-c-form-control--readonly--BackgroundColor: var(--pf-global--BackgroundColor--200);
     --pf-c-form-control--disabled--BackgroundColor: var(--pf-global--BackgroundColor--200);
 
+    /* #region Caps Lock */
+
     --pf-c-form-control--m-caps-lock--BackgroundUrl: url("data:image/svg+xml;charset=utf8,%3Csvg fill='%23aaabac' viewBox='0 0 56 56' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 20.7812 37.6211 L 35.2421 37.6211 C 38.5233 37.6211 40.2577 35.6992 40.2577 32.6055 L 40.2577 28.4570 L 49.1404 28.4570 C 51.0859 28.4570 52.6329 27.3086 52.6329 25.5039 C 52.6329 24.4024 52.0703 23.5351 51.0158 22.6211 L 30.9062 4.8789 C 29.9452 4.0351 29.0546 3.4727 27.9999 3.4727 C 26.9687 3.4727 26.0780 4.0351 25.1171 4.8789 L 4.9843 22.6445 C 3.8828 23.6055 3.3671 24.4024 3.3671 25.5039 C 3.3671 27.3086 4.9140 28.4570 6.8828 28.4570 L 15.7421 28.4570 L 15.7421 32.6055 C 15.7421 35.6992 17.4999 37.6211 20.7812 37.6211 Z M 21.1562 34.0820 C 20.2655 34.0820 19.6562 33.4961 19.6562 32.6055 L 19.6562 25.7149 C 19.6562 25.1524 19.4452 24.9180 18.8828 24.9180 L 8.6640 24.9180 C 8.4999 24.9180 8.4296 24.8476 8.4296 24.7305 C 8.4296 24.6367 8.4530 24.5430 8.5702 24.4492 L 27.5077 7.9961 C 27.7187 7.8086 27.8359 7.7383 27.9999 7.7383 C 28.1640 7.7383 28.3046 7.8086 28.4921 7.9961 L 47.4532 24.4492 C 47.5703 24.5430 47.5939 24.6367 47.5939 24.7305 C 47.5939 24.8476 47.4998 24.9180 47.3356 24.9180 L 37.1406 24.9180 C 36.5780 24.9180 36.3671 25.1524 36.3671 25.7149 L 36.3671 32.6055 C 36.3671 33.4727 35.7109 34.0820 34.8671 34.0820 Z M 19.7733 52.5273 L 36.0624 52.5273 C 38.7577 52.5273 40.3046 51.0273 40.3046 48.3086 L 40.3046 44.9336 C 40.3046 42.2148 38.7577 40.6680 36.0624 40.6680 L 19.7733 40.6680 C 17.0546 40.6680 15.5077 42.2383 15.5077 44.9336 L 15.5077 48.3086 C 15.5077 51.0039 17.0546 52.5273 19.7733 52.5273 Z M 20.3124 49.2227 C 19.4921 49.2227 19.0468 48.8008 19.0468 47.9805 L 19.0468 45.2617 C 19.0468 44.4414 19.4921 43.9727 20.3124 43.9727 L 35.5233 43.9727 C 36.3202 43.9727 36.7655 44.4414 36.7655 45.2617 L 36.7655 47.9805 C 36.7655 48.8008 36.3202 49.2227 35.5233 49.2227 Z'/%3E%3C/svg%3E");
+
+    &.pf-m-icon.pf-m-caps-lock {
+        --pf-c-form-control--m-icon--BackgroundUrl: var(
+            --pf-c-form-control--m-caps-lock--BackgroundUrl
+        );
+    }
+
+    /* #endregion */
 }
 
-.pf-c-form-control.pf-m-icon.pf-m-caps-lock {
-    --pf-c-form-control--m-icon--BackgroundUrl: var(
-        --pf-c-form-control--m-caps-lock--BackgroundUrl
-    );
+/* #region Buttons */
+
+.pf-c-button {
+    --pf-c-button--disabled--BackgroundColor: var(--pf-global--Color--light-200);
 }
 
 /* #endregion */
+
+/* #region Tables */
+
+.pf-c-table {
+    --pf-c-table__sort__button__text--Color: var(--pf-global--Color--100);
+    --pf-c-table__button--hover--Color: var(--pf-global--link--Color--hover);
+}
+
+.pf-c-table__sort.pf-m-selected {
+    text-decoration: underline;
+
+    .pf-c-table__button .pf-c-table__text {
+        --pf-c-table__sort__button__text--Color: var(--pf-global--Color--100);
+
+        --pf-c-table__button--hover--Color: var(--pf-global--link--Color--hover);
+    }
+}
+
+/* #endregion */
+
+/* #region Page layout */
 
 .pf-c-page__header {
     z-index: 0;
@@ -218,8 +253,28 @@ html > form > input {
 
 /* #region Fields */
 
+/* #region Switch  */
+.pf-c-switch {
+    --pf-c-switch__input--focus__toggle--OutlineWidth: 0;
+
+    &:hover {
+        --pf-c-switch__toggle--before--BackgroundColor: var(--pf-global--BackgroundColor--200);
+    }
+}
+
 .pf-c-switch__label {
+    --pf-c-switch__input--not-checked__label--Color: var(--pf-global--Color--100);
     user-select: none;
+}
+
+/* #endregion */
+
+.pf-c-form__helper-text {
+    text-wrap: pretty;
+}
+
+::placeholder {
+    font-style: italic;
 }
 
 /* #endregion */

--- a/web/src/common/styles/theme-dark.css
+++ b/web/src/common/styles/theme-dark.css
@@ -98,21 +98,11 @@ body {
     --pf-c-table--tr--m-hoverable--active--BackgroundColor: var(--ak-dark-background-lighter);
     --pf-global--link--Color: var(--pf-global--link--Color--light);
     --pf-global--link--Color--hover: var(--pf-global--link--Color--light--hover);
-    /* --pf-c-table__sort__button__text--Color: var(--pf-global--Color--light-200);
-    --pf-c-table__button--hover--Color: var(--pf-global--link--Color--light--hover); */
 }
 
 .pf-c-table__text {
     color: var(--ak-dark-foreground);
 }
-/*
-.pf-c-table__sort.pf-m-selected {
-    .pf-c-table__button .pf-c-table__text {
-        --pf-c-table__sort__button__text--Color: var(--pf-global--Color--light-200);
-
-        --pf-c-table__button--hover--Color: var(--pf-global--link--Color--light--hover);
-    }
-} */
 
 .pf-c-table__sort-indicator i {
     color: var(--ak-dark-foreground) !important;

--- a/web/src/common/styles/theme-dark.css
+++ b/web/src/common/styles/theme-dark.css
@@ -14,6 +14,9 @@
     --ak-global--Color--100: var(--ak-dark-foreground) !important;
     --pf-c-page__main-section--m-light--BackgroundColor: var(--ak-dark-background-darker);
     --pf-global--BorderColor--100: var(--ak-dark-background-lighter) !important;
+    --pf-global--danger-color--100: #e6190a;
+    --pf-global--link--Color: var(--pf-global--link--Color--light);
+    --pf-global--link--Color--hover: var(--pf-global--link--Color--light--hover);
 }
 
 body {
@@ -86,21 +89,31 @@ body {
 }
 
 /* #region Tables */
+
 .pf-c-table {
+    --pf-global--Color--100: var(--ak-dark-foreground);
     --pf-c-table--BackgroundColor: var(--ak-dark-background-light);
     --pf-c-table--BorderColor: var(--ak-dark-background-lighter);
     --pf-c-table--cell--Color: var(--ak-dark-foreground);
     --pf-c-table--tr--m-hoverable--hover--BackgroundColor: var(--ak-dark-background-light-ish);
     --pf-c-table--tr--m-hoverable--active--BackgroundColor: var(--ak-dark-background-lighter);
+    --pf-global--link--Color: var(--pf-global--link--Color--light);
+    --pf-global--link--Color--hover: var(--pf-global--link--Color--light--hover);
+    /* --pf-c-table__sort__button__text--Color: var(--pf-global--Color--light-200);
+    --pf-c-table__button--hover--Color: var(--pf-global--link--Color--light--hover); */
 }
 
 .pf-c-table__text {
     color: var(--ak-dark-foreground);
 }
+/*
+.pf-c-table__sort.pf-m-selected {
+    .pf-c-table__button .pf-c-table__text {
+        --pf-c-table__sort__button__text--Color: var(--pf-global--Color--light-200);
 
-.pf-c-table__sort:not(.pf-m-selected) .pf-c-table__button .pf-c-table__text {
-    color: var(--ak-dark-foreground) !important;
-}
+        --pf-c-table__button--hover--Color: var(--pf-global--link--Color--light--hover);
+    }
+} */
 
 .pf-c-table__sort-indicator i {
     color: var(--ak-dark-foreground) !important;
@@ -254,16 +267,18 @@ select.pf-c-form-control {
     --pf-c-select__menu-item--focus--BackgroundColor: var(--ak-dark-background-light-ish);
 }
 
-.pf-c-button:disabled {
-    color: var(--ak-dark-background-lighter);
-}
+/* #region Buttons */
 
-.pf-c-button.pf-m-plain {
-    --pf-c-button--m-plain--focus--Color: var(--pf-global--Color--200);
-    --pf-c-button--m-plain--hover--Color: var(--ak-dark-foreground);
+.pf-c-button {
+    --pf-c-button--disabled--BackgroundColor: var(--pf-global--Color--300);
 
-    &:focus:hover {
-        color: var(--pf-c-button--m-plain--hover--Color);
+    &.pf-m-plain {
+        --pf-c-button--m-plain--focus--Color: var(--pf-global--Color--200);
+        --pf-c-button--m-plain--hover--Color: var(--ak-dark-foreground);
+
+        &:focus:hover {
+            color: var(--pf-c-button--m-plain--hover--Color);
+        }
     }
 }
 
@@ -287,6 +302,8 @@ select.pf-c-form-control {
         --pf-c-button--after--BorderColor: var(--ak-dark-foreground);
     }
 }
+
+/* #endregion */
 
 .pf-c-form__label-text {
     color: var(--ak-dark-foreground);
@@ -326,11 +343,6 @@ select.pf-c-form-control {
 .pf-c-toggle-group__button.pf-m-selected {
     color: var(--ak-dark-foreground) !important;
     background-color: var(--pf-global--primary-color--100) !important;
-}
-
-/* inputs help text */
-.pf-c-form__helper-text:not(.pf-m-error) {
-    color: var(--ak-dark-foreground);
 }
 
 /* #endregion */

--- a/web/src/common/styles/theme-dark.css
+++ b/web/src/common/styles/theme-dark.css
@@ -14,7 +14,6 @@
     --ak-global--Color--100: var(--ak-dark-foreground) !important;
     --pf-c-page__main-section--m-light--BackgroundColor: var(--ak-dark-background-darker);
     --pf-global--BorderColor--100: var(--ak-dark-background-lighter) !important;
-    --pf-global--danger-color--100: #e6190a;
     --pf-global--link--Color: var(--pf-global--link--Color--light);
     --pf-global--link--Color--hover: var(--pf-global--link--Color--light--hover);
 }

--- a/web/src/elements/buttons/SpinnerButton/BaseTaskButton.ts
+++ b/web/src/elements/buttons/SpinnerButton/BaseTaskButton.ts
@@ -26,6 +26,16 @@ const buttonStyles = [
         #spinner-button.working {
             pointer-events: none;
         }
+
+        .pf-c-button {
+            &.pf-m-primary.pf-m-success {
+                color: var(--pf-c-button--m-primary--Color) !important;
+            }
+
+            &.pf-m-secondary.pf-m-success {
+                color: var(--pf-c-button--m-secondary--Color) !important;
+            }
+        }
     `,
 ];
 

--- a/web/src/elements/table/Table.ts
+++ b/web/src/elements/table/Table.ts
@@ -129,7 +129,12 @@ export abstract class Table<T extends object>
             .pf-c-toolbar__content {
                 justify-content: space-between;
                 gap: var(--pf-global--spacer--sm);
+
+                .pf-c-switch {
+                    --pf-c-switch--ColumnGap: var(--pf-c-toolbar__item--m-search-filter--spacer);
+                }
             }
+
             .pf-c-toolbar__group {
                 gap: var(--pf-global--spacer--sm);
             }
@@ -552,7 +557,7 @@ export abstract class Table<T extends object>
 
         if (selectAllCheckbox) {
             selectAllCheckbox.checked = pageItemCount !== 0 && selectedCount !== 0;
-            selectAllCheckbox.indeterminate = pageItemCount !== 0 && selectedCount < pageItemCount;
+            selectAllCheckbox.indeterminate = selectedCount !== 0 && selectedCount < pageItemCount;
         }
 
         this.requestUpdate();


### PR DESCRIPTION
## Details

This PR covers a few situations where the dark theme doesn't apply colors that can be read with low-contrast backgrounds. Some CSS rules may appear twice to take precedence when combined with certain elements.
