### PR TITLE
web/a11y: Tree view

### DIFF
--- a/web/src/admin/users/UserListPage.ts
+++ b/web/src/admin/users/UserListPage.ts
@@ -425,6 +425,7 @@ export class UserListPage extends WithBrandConfig(WithCapabilitiesConfig(TablePa
                 </div>
                 <div class="pf-c-card__body">
                     <ak-treeview
+                        label=${msg("User paths")}
                         .items=${this.userPaths?.paths || []}
                         activePath=${this.activePath}
                         @ak-refresh=${(ev: CustomEvent<{ path: string }>) => {

--- a/web/src/elements/TreeView.ts
+++ b/web/src/elements/TreeView.ts
@@ -2,8 +2,9 @@ import { EVENT_REFRESH } from "#common/constants";
 
 import { AKElement } from "#elements/Base";
 import { setURLParams } from "#elements/router/RouteMatch";
+import { ifPresent } from "#elements/utils/attributes";
 
-import { msg } from "@lit/localize";
+import { msg, str } from "@lit/localize";
 import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
@@ -68,38 +69,51 @@ export class TreeViewNode extends AKElement {
         }
     }
 
+    #selectionListener = () => {
+        if (this.host) {
+            this.host.activeNode = this;
+        }
+        setURLParams({ path: this.fullPath });
+        this.dispatchEvent(
+            new CustomEvent(EVENT_REFRESH, {
+                bubbles: true,
+                composed: true,
+                detail: {
+                    path: this.fullPath,
+                },
+            }),
+        );
+    };
+
     render(): TemplateResult {
         const shouldRenderChildren = (this.item?.childItems || []).length > 0 && this.open;
+        const itemLabel = this.item?.label || msg("Unnamed");
+        const current = this.host?.activeNode === this;
+
         return html`
             <li
                 class="pf-c-tree-view__list-item ${this.open ? "pf-m-expanded" : ""}"
                 role="treeitem"
+                aria-expanded=${ifPresent(this.openable, this.open ? "true" : "false")}
+                aria-label=${itemLabel}
+                aria-selected=${current ? "true" : "false"}
                 tabindex="0"
             >
                 <div class="pf-c-tree-view__content">
-                    <button
-                        class="pf-c-tree-view__node ${this.host?.activeNode === this
-                            ? "pf-m-current"
-                            : ""}"
-                        @click=${() => {
-                            if (this.host) {
-                                this.host.activeNode = this;
-                            }
-                            setURLParams({ path: this.fullPath });
-                            this.dispatchEvent(
-                                new CustomEvent(EVENT_REFRESH, {
-                                    bubbles: true,
-                                    composed: true,
-                                    detail: {
-                                        path: this.fullPath,
-                                    },
-                                }),
-                            );
-                        }}
+                    <div
+                        class="pf-c-tree-view__node ${current ? "pf-m-current" : ""}"
+                        @click=${this.#selectionListener}
                     >
                         <div class="pf-c-tree-view__node-container">
                             ${this.openable
                                 ? html` <button
+                                      type="button"
+                                      aria-label=${ifPresent(
+                                          this.openable,
+                                          this.open
+                                              ? msg(str`Collapse "${itemLabel}"`)
+                                              : msg(str`Expand "${itemLabel}"`),
+                                      )}
                                       class="pf-c-tree-view__node-toggle"
                                       @click=${(e: Event) => {
                                           if (this.openable) {
@@ -119,11 +133,23 @@ export class TreeViewNode extends AKElement {
                                     aria-hidden="true"
                                 ></i>
                             </span>
-                            <span class="pf-c-tree-view__node-text">${this.item?.label}</span>
+                            <button
+                                type="button"
+                                aria-label=${msg(str`Select "${itemLabel}"`)}
+                                @click=${this.#selectionListener}
+                                class="pf-c-tree-view__node-text"
+                            >
+                                ${itemLabel}
+                            </button>
                         </div>
-                    </button>
+                    </div>
                 </div>
-                <ul class="pf-c-tree-view__list" role="group" ?hidden=${!shouldRenderChildren}>
+                <ul
+                    class="pf-c-tree-view__list"
+                    ?hidden=${!shouldRenderChildren}
+                    role="group"
+                    aria-label=${msg(str`Items of "${itemLabel}"`)}
+                >
                     ${this.item?.childItems.map((item) => {
                         return html`<ak-treeview-node
                             .item=${item}
@@ -141,6 +167,9 @@ export class TreeViewNode extends AKElement {
 @customElement("ak-treeview")
 export class TreeView extends AKElement {
     static styles: CSSResult[] = [PFBase, PFTreeView];
+
+    @property({ type: String })
+    public label: string | null = null;
 
     @property({ type: Array })
     items: string[] = [];
@@ -194,7 +223,7 @@ export class TreeView extends AKElement {
     render(): TemplateResult {
         const rootItem = this.parse(this.items);
         return html`<div class="pf-c-tree-view pf-m-guides">
-            <ul class="pf-c-tree-view__list" role="tree">
+            <ul class="pf-c-tree-view__list" role="tree" aria-label=${ifPresent(this.label)}>
                 <ak-treeview-node
                     .item=${rootItem}
                     activePath=${this.activePath}


### PR DESCRIPTION
## Details

A first pass at ARIA fixes for the tree element. This started as the necessary fixes to get Playwright to target the buttons correctly. The visual layout is left as is:

## ARIA

<img width="653" height="457" alt="Screenshot 2025-09-30 at 19 10 52" src="https://github.com/user-attachments/assets/c80ffdc0-f80d-4643-8805-63971c8707e4" />
