### PR TITLE
web: Fix default RADIUS EAP-TLS cert without license.

### DIFF
--- a/web/src/admin/common/ak-crypto-certificate-search.ts
+++ b/web/src/admin/common/ak-crypto-certificate-search.ts
@@ -13,6 +13,7 @@ import {
     CryptoCertificatekeypairsListRequest,
 } from "@goauthentik/api";
 
+import { msg } from "@lit/localize";
 import { html } from "lit";
 import { customElement, property, query } from "lit/decorators.js";
 
@@ -43,10 +44,10 @@ export class AkCryptoCertificateSearch extends CustomListenerElement(AKElement) 
     public name?: string | null;
 
     @property({ type: String })
-    public label: string | null = null;
+    public label: string | null = msg("Certificate");
 
     @property({ type: String })
-    public placeholder: string | null = null;
+    public placeholder: string | null = msg("Select a certificate...");
 
     /**
      * Set to `true` to allow certificates without private key to show up. When set to `false`,

--- a/web/src/admin/providers/radius/RadiusProviderFormForm.ts
+++ b/web/src/admin/providers/radius/RadiusProviderFormForm.ts
@@ -12,6 +12,8 @@ import { propertyMappingsProvider, propertyMappingsSelector } from "./RadiusProv
 
 import { ascii_letters, digits, randomString } from "#common/utils";
 
+import { ifPresent } from "#elements/utils/attributes";
+
 import {
     CurrentBrand,
     FlowsInstancesListDesignationEnum,
@@ -101,10 +103,8 @@ export function renderForm({ provider = {}, errors = {}, brand }: RADIUSProvider
                     input-hint="code"
                 ></ak-text-input>
                 <ak-form-element-horizontal label=${msg("Certificate")} name="certificate">
-                    <!-- NOTE: 'null' cast to 'undefined' on signingKey to satisfy Lit requirements -->
                     <ak-crypto-certificate-search
-                        certificate=${ifDefined(provider?.certificate ?? undefined)}
-                        singleton
+                        certificate=${ifPresent(provider?.certificate)}
                     ></ak-crypto-certificate-search>
                     <p class="pf-c-form__helper-text">
                         ${msg(

--- a/web/test/browser/providers.test.ts
+++ b/web/test/browser/providers.test.ts
@@ -200,7 +200,7 @@ test.describe("Provider Wizard", () => {
 
     test("Complete RADIUS Provider", async ({ page, pointer, form }, testInfo) => {
         const providerName = providerNames.get(testInfo.testId)!;
-        const { fill, selectSearchValue } = form;
+        const { fill, selectSearchValue, setFormGroup } = form;
         const { click } = pointer;
 
         await series(
@@ -208,6 +208,8 @@ test.describe("Provider Wizard", () => {
             [click, "Next"],
             [fill, "Provider name", providerName],
             [selectSearchValue, "Authentication flow", /default-authentication-flow/],
+            [setFormGroup, "Protocol settings", true],
+            [selectSearchValue, "Certificate", /------/],
             [click, "Finish", "button", page.getByRole("dialog", { name: "New Provider" })],
         );
     });


### PR DESCRIPTION
## Details

Given a user is creating a provider and doesn't have a license, an error occurs when submitting the form with default values:

<img width="1257" height="671" alt="Screenshot 2025-09-30 at 22 15 57" src="https://github.com/user-attachments/assets/7af352fb-59f3-48be-a51c-78d4a6a3ffe1" />
