### PR TITLE
web/a11y: Admin overview regions.

### DIFF
--- a/web/src/admin/admin-overview/AdminOverviewPage.ts
+++ b/web/src/admin/admin-overview/AdminOverviewPage.ts
@@ -79,7 +79,7 @@ export class AdminOverviewPage extends AdminOverviewBase {
     }
 
     render(): TemplateResult {
-        return html` <section class="pf-c-page__main-section">
+        return html` <main class="pf-c-page__main-section" aria-label=${msg("Overview")}>
             <div class="pf-l-grid pf-m-gutter">
                 <!-- row 1 -->
                 <div
@@ -92,14 +92,14 @@ export class AdminOverviewPage extends AdminOverviewBase {
                     <div class="pf-l-grid__item pf-m-12-col pf-m-6-col-on-xl pf-m-4-col-on-2xl">
                         <ak-aggregate-card
                             icon="pf-icon pf-icon-zone"
-                            header=${msg("Outpost status")}
+                            label=${msg("Outpost status")}
                             headerLink="#/outpost/outposts"
                         >
                             <ak-admin-status-chart-outpost></ak-admin-status-chart-outpost>
                         </ak-aggregate-card>
                     </div>
                     <div class="pf-l-grid__item pf-m-12-col pf-m-12-col-on-xl pf-m-4-col-on-2xl">
-                        <ak-aggregate-card icon="fa fa-sync-alt" header=${msg("Sync status")}>
+                        <ak-aggregate-card icon="fa fa-sync-alt" label=${msg("Sync status")}>
                             <ak-admin-status-chart-sync></ak-admin-status-chart-sync>
                         </ak-aggregate-card>
                     </div>
@@ -120,7 +120,7 @@ export class AdminOverviewPage extends AdminOverviewBase {
                 >
                     <ak-aggregate-card
                         icon="pf-icon pf-icon-server"
-                        header=${msg("Logins and authorizations over the last week (per 8 hours)")}
+                        label=${msg("Logins and authorizations over the last week (per 8 hours)")}
                     >
                         <ak-charts-admin-login-authorization></ak-charts-admin-login-authorization>
                     </ak-aggregate-card>
@@ -130,13 +130,13 @@ export class AdminOverviewPage extends AdminOverviewBase {
                 >
                     <ak-aggregate-card
                         icon="pf-icon pf-icon-server"
-                        header=${msg("Apps with most usage")}
+                        label=${msg("Apps with most usage")}
                     >
                         <ak-top-applications-table></ak-top-applications-table>
                     </ak-aggregate-card>
                 </div>
             </div>
-        </section>`;
+        </main>`;
     }
 
     renderCards() {

--- a/web/src/admin/admin-overview/DashboardUserPage.ts
+++ b/web/src/admin/admin-overview/DashboardUserPage.ts
@@ -42,7 +42,7 @@ export class DashboardUserPage extends AKElement {
                     <div
                         class="pf-l-grid__item pf-m-12-col pf-m-12-col-on-xl pf-m-12-col-on-2xl big-graph-container"
                     >
-                        <ak-aggregate-card header=${msg("Users created per day in the last month")}>
+                        <ak-aggregate-card label=${msg("Users created per day in the last month")}>
                             <ak-charts-admin-model-per-day
                                 .query=${{
                                     contextModelApp: "authentik_core",
@@ -60,7 +60,7 @@ export class DashboardUserPage extends AKElement {
                     <div
                         class="pf-l-grid__item pf-m-12-col pf-m-6-col-on-xl pf-m-6-col-on-2xl big-graph-container"
                     >
-                        <ak-aggregate-card header=${msg("Logins per day in the last month")}>
+                        <ak-aggregate-card label=${msg("Logins per day in the last month")}>
                             <ak-charts-admin-model-per-day
                                 action=${EventActions.Login}
                                 label=${msg("Logins")}
@@ -71,7 +71,7 @@ export class DashboardUserPage extends AKElement {
                     <div
                         class="pf-l-grid__item pf-m-12-col pf-m-6-col-on-xl pf-m-6-col-on-2xl big-graph-container"
                     >
-                        <ak-aggregate-card header=${msg("Failed Logins per day in the last month")}>
+                        <ak-aggregate-card label=${msg("Failed Logins per day in the last month")}>
                             <ak-charts-admin-model-per-day
                                 action=${EventActions.LoginFailed}
                                 label=${msg("Failed logins")}

--- a/web/src/admin/admin-overview/cards/AdminStatusCard.ts
+++ b/web/src/admin/admin-overview/cards/AdminStatusCard.ts
@@ -107,10 +107,12 @@ export abstract class AdminStatusCard<T> extends AggregateCard {
      * @returns TemplateResult for status display
      */
     private renderStatus(status: AdminStatus): SlottedTemplateResult {
-        return html`
-            <p><i class="${status.icon}" aria-hidden="true"></i>${this.renderValue()}</p>
+        return html` <div class="status-container">
+            <h2 class="status-heading">
+                <i class="${status.icon}" aria-hidden="true"></i>${this.renderValue()}
+            </h2>
             ${status.message ? html`<p class="subtext">${status.message}</p>` : nothing}
-        `;
+        </div>`;
     }
 
     /**
@@ -121,7 +123,9 @@ export abstract class AdminStatusCard<T> extends AggregateCard {
      */
     private renderError(error: string): SlottedTemplateResult {
         return html`
-            <p><i aria-hidden="true" class="fa fa-times"></i>${msg("Failed to fetch")}</p>
+            <h2 role="alert" aria-live="assertive">
+                <i aria-hidden="true" class="fa fa-times"></i>${msg("Failed to fetch")}
+            </h2>
             <p class="subtext">${error}</p>
         `;
     }
@@ -141,16 +145,10 @@ export abstract class AdminStatusCard<T> extends AggregateCard {
      * @returns TemplateResult for current component state
      */
     renderInner(): SlottedTemplateResult {
-        return html`
-            <p class="center-value">
-                ${
-                    this.status
-                        ? this.renderStatus(this.status) // Status available
-                        : this.error
-                          ? this.renderError(pluckErrorDetail(this.error)) // Error state
-                          : this.renderLoading() // Loading state
-                }
-            </p>
-        `;
+        return this.status
+            ? this.renderStatus(this.status) // Status available
+            : this.error
+              ? this.renderError(pluckErrorDetail(this.error)) // Error state
+              : this.renderLoading(); // Loading state
     }
 }

--- a/web/src/admin/admin-overview/cards/AdminStatusCard.ts
+++ b/web/src/admin/admin-overview/cards/AdminStatusCard.ts
@@ -108,7 +108,7 @@ export abstract class AdminStatusCard<T> extends AggregateCard {
      */
     private renderStatus(status: AdminStatus): SlottedTemplateResult {
         return html`
-            <p><i class="${status.icon}" aria-hidden="true"></i>&nbsp;${this.renderValue()}</p>
+            <p><i class="${status.icon}" aria-hidden="true"></i>${this.renderValue()}</p>
             ${status.message ? html`<p class="subtext">${status.message}</p>` : nothing}
         `;
     }
@@ -121,7 +121,7 @@ export abstract class AdminStatusCard<T> extends AggregateCard {
      */
     private renderError(error: string): SlottedTemplateResult {
         return html`
-            <p><i aria-hidden="true" class="fa fa-times"></i>&nbsp;${msg("Failed to fetch")}</p>
+            <p><i aria-hidden="true" class="fa fa-times"></i>${msg("Failed to fetch")}</p>
             <p class="subtext">${error}</p>
         `;
     }

--- a/web/src/admin/admin-overview/cards/FipsStatusCard.ts
+++ b/web/src/admin/admin-overview/cards/FipsStatusCard.ts
@@ -12,10 +12,11 @@ type StatusContent = { icon: string; message: TemplateResult };
 
 @customElement("ak-admin-fips-status-system")
 export class FipsStatusCard extends AdminStatusCard<SystemInfo> {
-    icon = "pf-icon pf-icon-server";
+    public override icon = "pf-icon pf-icon-server";
+    public override label = msg("FIPS Status");
 
     @state()
-    statusSummary?: string;
+    protected statusSummary?: string;
 
     async getPrimaryValue(): Promise<SystemInfo> {
         return await new AdminApi(DEFAULT_CONFIG).adminSystemRetrieve();
@@ -36,10 +37,6 @@ export class FipsStatusCard extends AdminStatusCard<SystemInfo> {
                   icon: "fa fa-info-circle pf-m-warning",
                   message: html`${msg("FIPS compliance: unverified")}`,
               });
-    }
-
-    renderHeader(): TemplateResult {
-        return html`${msg("FIPS Status")}`;
     }
 
     renderValue(): TemplateResult {

--- a/web/src/admin/admin-overview/cards/RecentEventsCard.ts
+++ b/web/src/admin/admin-overview/cards/RecentEventsCard.ts
@@ -66,7 +66,8 @@ export class RecentEventsCard extends Table<Event> {
 
     renderToolbar(): TemplateResult {
         return html`<h1 class="pf-c-card__title">
-            <i class="pf-icon pf-icon-catalog" aria-hidden="true"></i>&nbsp;${msg("Recent events")}
+            <i class="pf-icon pf-icon-catalog" aria-hidden="true"></i>
+            ${msg("Recent events")}
         </h1>`;
     }
 

--- a/web/src/admin/admin-overview/cards/RecentEventsCard.ts
+++ b/web/src/admin/admin-overview/cards/RecentEventsCard.ts
@@ -1,5 +1,6 @@
 import "#components/ak-event-info";
 import "#elements/Tabs";
+import "#elements/timestamp/ak-timestamp";
 import "#elements/buttons/Dropdown";
 import "#elements/buttons/ModalButton";
 import "#elements/buttons/SpinnerButton/index";
@@ -8,7 +9,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { EventWithContext } from "#common/events";
 import { actionToLabel } from "#common/labels";
 
-import { PaginatedResponse, Table, TableColumn, Timestamp } from "#elements/table/Table";
+import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
 import { SlottedTemplateResult } from "#elements/types";
 
 import { EventGeo, renderEventUser } from "#admin/events/utils";
@@ -23,6 +24,10 @@ import PFCard from "@patternfly/patternfly/components/Card/card.css";
 
 @customElement("ak-recent-events")
 export class RecentEventsCard extends Table<Event> {
+    public override role = "region";
+    public override ariaLabel = msg("Recent events");
+    public override label = msg("Events");
+
     @property()
     order = "-created";
 
@@ -45,9 +50,6 @@ export class RecentEventsCard extends Table<Event> {
                 --pf-c-card__title--FontSize: var(--pf-global--FontSize--md);
                 --pf-c-card__title--FontWeight: var(--pf-global--FontWeight--bold);
             }
-            * {
-                word-break: break-all;
-            }
         `,
     ];
 
@@ -63,9 +65,9 @@ export class RecentEventsCard extends Table<Event> {
     ];
 
     renderToolbar(): TemplateResult {
-        return html`<div class="pf-c-card__title">
+        return html`<h1 class="pf-c-card__title">
             <i class="pf-icon pf-icon-catalog" aria-hidden="true"></i>&nbsp;${msg("Recent events")}
-        </div>`;
+        </h1>`;
     }
 
     row(item: EventWithContext): SlottedTemplateResult[] {
@@ -73,7 +75,7 @@ export class RecentEventsCard extends Table<Event> {
             html`<div><a href="${`#/events/log/${item.pk}`}">${actionToLabel(item.action)}</a></div>
                 <small>${item.app}</small>`,
             renderEventUser(item),
-            Timestamp(item.created),
+            html`<ak-timestamp .timestamp=${item.created}></ak-timestamp>`,
             html` <div>${item.clientIp || msg("-")}</div>
                 <small>${EventGeo(item)}</small>`,
         ];

--- a/web/src/admin/admin-overview/cards/SystemStatusCard.ts
+++ b/web/src/admin/admin-overview/cards/SystemStatusCard.ts
@@ -14,7 +14,8 @@ import { customElement, state } from "lit/decorators.js";
 export class SystemStatusCard extends AdminStatusCard<SystemInfo> {
     now?: Date;
 
-    icon = "pf-icon pf-icon-server";
+    public override icon = "pf-icon pf-icon-server";
+    public override label = msg("System Status");
 
     @state()
     statusSummary?: string;
@@ -82,10 +83,6 @@ export class SystemStatusCard extends AdminStatusCard<SystemInfo> {
             icon: "fa fa-check-circle pf-m-success",
             message: html`${msg("Everything is ok.")}`,
         });
-    }
-
-    renderHeader(): SlottedTemplateResult {
-        return msg("System status");
     }
 
     renderValue(): SlottedTemplateResult {

--- a/web/src/admin/admin-overview/cards/VersionStatusCard.ts
+++ b/web/src/admin/admin-overview/cards/VersionStatusCard.ts
@@ -10,7 +10,8 @@ import { customElement } from "lit/decorators.js";
 
 @customElement("ak-admin-status-version")
 export class VersionStatusCard extends AdminStatusCard<Version> {
-    icon = "pf-icon pf-icon-bundle";
+    public override icon = "pf-icon pf-icon-bundle";
+    public override label = msg("Version");
 
     getPrimaryValue(): Promise<Version> {
         return new AdminApi(DEFAULT_CONFIG).adminVersionRetrieve();
@@ -46,10 +47,6 @@ export class VersionStatusCard extends AdminStatusCard<Version> {
             icon: "fa fa-question-circle",
             message: html`${msg("Latest version unknown")}`,
         });
-    }
-
-    renderHeader(): TemplateResult {
-        return html`${msg("Version")}`;
     }
 
     renderValue(): TemplateResult {

--- a/web/src/admin/admin-overview/cards/WorkerStatusCard.ts
+++ b/web/src/admin/admin-overview/cards/WorkerStatusCard.ts
@@ -5,19 +5,16 @@ import { AdminStatus, AdminStatusCard } from "#admin/admin-overview/cards/AdminS
 import { TasksApi, Worker } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { html, TemplateResult } from "lit";
+import { html } from "lit";
 import { customElement } from "lit/decorators.js";
 
 @customElement("ak-admin-status-card-workers")
 export class WorkersStatusCard extends AdminStatusCard<Worker[]> {
-    icon = "pf-icon pf-icon-server";
+    public override icon = "pf-icon pf-icon-server";
+    public override label = msg("Workers");
 
     getPrimaryValue(): Promise<Worker[]> {
         return new TasksApi(DEFAULT_CONFIG).tasksWorkersList();
-    }
-
-    renderHeader(): TemplateResult {
-        return html`${msg("Workers")}`;
     }
 
     getStatus(value: Worker[]): Promise<AdminStatus> {

--- a/web/src/admin/admin-overview/charts/OutpostStatusChart.ts
+++ b/web/src/admin/admin-overview/charts/OutpostStatusChart.ts
@@ -16,6 +16,8 @@ import { customElement } from "lit/decorators.js";
 
 @customElement("ak-admin-status-chart-outpost")
 export class OutpostStatusChart extends AKChart<SummarizedSyncStatus[]> {
+    public override ariaLabel = msg("Outpost status chart");
+
     getChartType(): string {
         return "doughnut";
     }

--- a/web/src/admin/admin-overview/charts/SyncStatusChart.ts
+++ b/web/src/admin/admin-overview/charts/SyncStatusChart.ts
@@ -29,6 +29,8 @@ export interface SummarizedSyncStatus {
 
 @customElement("ak-admin-status-chart-sync")
 export class SyncStatusChart extends AKChart<SummarizedSyncStatus[]> {
+    public override ariaLabel = msg("Synchronization status chart");
+
     getChartType(): string {
         return "doughnut";
     }

--- a/web/src/admin/enterprise/EnterpriseLicenseListPage.ts
+++ b/web/src/admin/enterprise/EnterpriseLicenseListPage.ts
@@ -148,7 +148,7 @@ export class EnterpriseLicenseListPage extends TablePage<License> {
                     <ak-aggregate-card
                         class="pf-l-grid__item"
                         icon="pf-icon pf-icon-user"
-                        header=${msg("Forecast internal users")}
+                        label=${msg("Forecast internal users")}
                         subtext=${msg(
                             str`Estimated user count one year from now based on ${this.forecast?.internalUsers} current internal users and ${this.forecast?.forecastedInternalUsers} forecasted internal users.`,
                         )}
@@ -159,7 +159,7 @@ export class EnterpriseLicenseListPage extends TablePage<License> {
                     <ak-aggregate-card
                         class="pf-l-grid__item"
                         icon="pf-icon pf-icon-user"
-                        header=${msg("Forecast external users")}
+                        label=${msg("Forecast external users")}
                         subtext=${msg(
                             str`Estimated user count one year from now based on ${this.forecast?.externalUsers} current external users and ${this.forecast?.forecastedExternalUsers} forecasted external users.`,
                         )}
@@ -170,7 +170,7 @@ export class EnterpriseLicenseListPage extends TablePage<License> {
                     <ak-aggregate-card
                         class="pf-l-grid__item"
                         icon="pf-icon pf-icon-user"
-                        header=${msg("Expiry")}
+                        label=${msg("Expiry")}
                         subtext=${msg("Cumulative license expiry")}
                     >
                         ${this.summary &&

--- a/web/src/elements/cards/AggregateCard.ts
+++ b/web/src/elements/cards/AggregateCard.ts
@@ -4,17 +4,16 @@ import { AKElement } from "#elements/Base";
 
 import { css, CSSResult, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
-import { ifDefined } from "lit/directives/if-defined.js";
 
 import PFCard from "@patternfly/patternfly/components/Card/card.css";
 import PFFlex from "@patternfly/patternfly/layouts/Flex/flex.css";
 import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 export interface IAggregateCard {
-    icon?: string;
-    header?: string;
-    headerLink?: string;
-    subtext?: string;
+    icon?: string | null;
+    label?: string | null;
+    headerLink?: string | null;
+    subtext?: string | null;
     leftJustified?: boolean;
 }
 
@@ -34,32 +33,32 @@ export class AggregateCard extends AKElement implements IAggregateCard {
      *
      * @attr
      */
-    @property()
-    icon?: string;
+    @property({ type: String })
+    public icon: string | null = null;
 
     /**
      * The title of the card.
      *
      * @attr
      */
-    @property()
-    header?: string;
+    @property({ type: String })
+    public label: string | null = null;
 
     /**
      * If this is non-empty, a link icon will be shown in the upper-right corner of the card.
      *
      * @attr
      */
-    @property()
-    headerLink?: string;
+    @property({ type: String })
+    public headerLink: string | null = null;
 
     /**
      * If this is non-empty, a small-text footer will be shown at the bottom of the card
      *
      * @attr
      */
-    @property()
-    subtext?: string;
+    @property({ type: String })
+    public subtext: string | null = null;
 
     /**
      * If this is set, the contents of the card will be left-justified; otherwise they will be
@@ -68,7 +67,7 @@ export class AggregateCard extends AKElement implements IAggregateCard {
      * @attr
      */
     @property({ type: Boolean, attribute: "left-justified" })
-    leftJustified = false;
+    public leftJustified = false;
 
     static styles: CSSResult[] = [
         PFBase,
@@ -79,8 +78,14 @@ export class AggregateCard extends AKElement implements IAggregateCard {
                 height: 100%;
             }
             .pf-c-card__header {
-                flex-wrap: nowrap;
+                padding-inline: var(--pf-global--spacer--md);
             }
+            .pf-c-card__title {
+                display: flex;
+                align-items: center;
+                gap: var(--pf-global--spacer--md);
+            }
+
             .center-value {
                 font-size: var(--pf-global--icon--FontSize--lg);
                 text-align: center;
@@ -100,6 +105,10 @@ export class AggregateCard extends AKElement implements IAggregateCard {
             .pf-c-card__footer {
                 padding-bottom: 0;
             }
+
+            .pf-c-card__footer {
+                min-height: 1ex;
+            }
         `,
     ];
 
@@ -117,30 +126,20 @@ export class AggregateCard extends AKElement implements IAggregateCard {
         </a>`;
     }
 
-    renderHeader(): SlottedTemplateResult {
-        return this.header ?? nothing;
-    }
-
     render(): SlottedTemplateResult {
-        return html`<div
-            aria-label="${ifDefined(this.header)}"
-            role="region"
-            class="pf-c-card pf-c-card-aggregate"
-        >
-            <div class="pf-c-card__header pf-l-flex pf-m-justify-content-space-between">
-                <div class="pf-c-card__title">
-                    ${this.icon
-                        ? html`<i aria-hidden="true" class="${this.icon}"></i>&nbsp;`
-                        : nothing}${this.renderHeader()}
-                </div>
-                ${this.renderHeaderLink()}
-            </div>
+        return html`<section class="pf-c-card pf-c-card-aggregate" aria-labelledby="card-title">
+            <header class="pf-c-card__header pf-l-flex pf-m-justify-content-space-between">
+                <h1 class="pf-c-card__title" id="card-title">
+                    ${this.icon ? html`<i aria-hidden="true" class="${this.icon}"></i>` : nothing}
+                    ${this.label || nothing} ${this.renderHeaderLink()}
+                </h1>
+            </header>
             <div class="pf-c-card__body ${this.leftJustified ? "" : "center-value"}">
                 ${this.renderInner()}
                 ${this.subtext ? html`<p class="subtext">${this.subtext}</p>` : nothing}
             </div>
-            <div class="pf-c-card__footer">&nbsp;</div>
-        </div>`;
+            <div class="pf-c-card__footer"></div>
+        </section>`;
     }
 }
 

--- a/web/src/elements/cards/AggregateCard.ts
+++ b/web/src/elements/cards/AggregateCard.ts
@@ -14,7 +14,6 @@ export interface IAggregateCard {
     label?: string | null;
     headerLink?: string | null;
     subtext?: string | null;
-    leftJustified?: boolean;
 }
 
 /**
@@ -60,36 +59,32 @@ export class AggregateCard extends AKElement implements IAggregateCard {
     @property({ type: String })
     public subtext: string | null = null;
 
-    /**
-     * If this is set, the contents of the card will be left-justified; otherwise they will be
-     * centered by default.
-     *
-     * @attr
-     */
-    @property({ type: Boolean, attribute: "left-justified" })
-    public leftJustified = false;
-
     static styles: CSSResult[] = [
         PFBase,
         PFCard,
         PFFlex,
         css`
+            .pf-c-card {
+                container-type: inline-size;
+            }
+
             .pf-c-card.pf-c-card-aggregate {
                 height: 100%;
             }
             .pf-c-card__header {
-                padding-inline: var(--pf-global--spacer--md);
+                padding: var(--pf-global--spacer--md);
             }
             .pf-c-card__title {
                 display: flex;
                 align-items: center;
-                gap: var(--pf-global--spacer--md);
+                gap: var(--pf-global--spacer--sm);
+                flex: 1 1 auto;
+
+                @container (width < 200px) {
+                    font-size: var(--pf-global--FontSize--sm);
+                }
             }
 
-            .center-value {
-                font-size: var(--pf-global--icon--FontSize--lg);
-                text-align: center;
-            }
             .subtext {
                 margin-top: var(--pf-global--spacer--sm);
                 font-size: var(--pf-global--FontSize--sm);
@@ -98,6 +93,21 @@ export class AggregateCard extends AKElement implements IAggregateCard {
                 overflow-x: auto;
                 padding-left: calc(var(--pf-c-card--child--PaddingLeft) / 2);
                 padding-right: calc(var(--pf-c-card--child--PaddingRight) / 2);
+            }
+            .status-container {
+                font-size: var(--pf-global--icon--FontSize--lg);
+                text-align: center;
+
+                @container (width < 200px) {
+                    font-size: var(--pf-global--icon--FontSize--md);
+                }
+
+                .status-heading {
+                    display: flex;
+                    gap: var(--pf-global--spacer--sm);
+                    justify-content: center;
+                    align-items: baseline;
+                }
             }
             .pf-c-card__header,
             .pf-c-card__title,
@@ -122,21 +132,30 @@ export class AggregateCard extends AKElement implements IAggregateCard {
         }
 
         return html`<a href="${this.headerLink}">
-            <i aria-hidden="true" class="fa fa-link"> </i>
+            <i aria-hidden="true" class="fa fa-link"></i>
         </a>`;
     }
 
     render(): SlottedTemplateResult {
-        return html`<section class="pf-c-card pf-c-card-aggregate" aria-labelledby="card-title">
-            <header class="pf-c-card__header pf-l-flex pf-m-justify-content-space-between">
-                <h1 class="pf-c-card__title" id="card-title">
+        return html`<section
+            class="pf-c-card pf-c-card-aggregate"
+            aria-labelledby="card-title"
+            part="card"
+        >
+            <header
+                part="card-header"
+                class="pf-c-card__header pf-l-flex pf-m-justify-content-space-between"
+            >
+                <h1 part="card-title" class="pf-c-card__title" id="card-title">
                     ${this.icon ? html`<i aria-hidden="true" class="${this.icon}"></i>` : nothing}
-                    ${this.label || nothing} ${this.renderHeaderLink()}
+                    <span>${this.label || nothing}</span>${this.renderHeaderLink()}
                 </h1>
             </header>
-            <div class="pf-c-card__body ${this.leftJustified ? "" : "center-value"}">
+            <div part="card-body" class="pf-c-card__body">
                 ${this.renderInner()}
-                ${this.subtext ? html`<p class="subtext">${this.subtext}</p>` : nothing}
+                ${this.subtext
+                    ? html`<p part="card-subtext" class="subtext">${this.subtext}</p>`
+                    : nothing}
             </div>
             <div class="pf-c-card__footer"></div>
         </section>`;

--- a/web/src/elements/cards/AggregatePromiseCard.ts
+++ b/web/src/elements/cards/AggregatePromiseCard.ts
@@ -58,9 +58,9 @@ export class AggregatePromiseCard extends AggregateCard implements IAggregatePro
     }
 
     renderInner(): TemplateResult {
-        return html`<p class="center-value">
+        return html`
             ${until(this.promiseProxy(), html`<ak-spinner size="${PFSize.Large}"></ak-spinner>`)}
-        </p>`;
+        `;
     }
 }
 

--- a/web/src/elements/cards/QuickActionsCard.ts
+++ b/web/src/elements/cards/QuickActionsCard.ts
@@ -59,7 +59,7 @@ export class QuickActionsCard extends AKElement implements IQuickActionsCard {
     actions: QuickAction[] = [];
 
     render() {
-        return html` <ak-aggregate-card icon="fa fa-share" label=${this.title} left-justified>
+        return html` <ak-aggregate-card icon="fa fa-share" label=${this.title}>
             <ul aria-label="${msg("Quick actions")}" class="pf-c-list">
                 ${map(this.actions, renderItem)}
             </ul>

--- a/web/src/elements/cards/QuickActionsCard.ts
+++ b/web/src/elements/cards/QuickActionsCard.ts
@@ -59,7 +59,7 @@ export class QuickActionsCard extends AKElement implements IQuickActionsCard {
     actions: QuickAction[] = [];
 
     render() {
-        return html` <ak-aggregate-card icon="fa fa-share" header=${this.title} left-justified>
+        return html` <ak-aggregate-card icon="fa fa-share" label=${this.title} left-justified>
             <ul aria-label="${msg("Quick actions")}" class="pf-c-list">
                 ${map(this.actions, renderItem)}
             </ul>

--- a/web/src/elements/cards/stories/AggregateCard.stories.ts
+++ b/web/src/elements/cards/stories/AggregateCard.stories.ts
@@ -39,7 +39,6 @@ import "#elements/cards/AggregateCard";
         label: { control: "text" },
         headerLink: { control: "text" },
         subtext: { control: "text" },
-        leftJustified: { control: "boolean" },
     },
 };
 
@@ -51,9 +50,8 @@ export const DefaultStory: StoryObj = {
         label: "Default",
         headerLink: null,
         subtext: null,
-        leftJustified: false,
     },
-    render: ({ icon, label, headerLink, subtext, leftJustified }: IAggregateCard) => {
+    render: ({ icon, label, headerLink, subtext }: IAggregateCard) => {
         return html`
             <style>
                 ak-aggregate-card {
@@ -67,7 +65,6 @@ export const DefaultStory: StoryObj = {
                 headerLink=${ifPresent(headerLink)}
                 subtext=${ifPresent(subtext)}
                 icon=${ifPresent(icon)}
-                ?left-justified=${leftJustified}
             >
                 <p>
                     Form without content style without meaning quick-win, for that is a good problem

--- a/web/src/elements/cards/stories/AggregateCard.stories.ts
+++ b/web/src/elements/cards/stories/AggregateCard.stories.ts
@@ -2,10 +2,11 @@ import "../AggregateCard.js";
 
 import { AggregateCard, type IAggregateCard } from "../AggregateCard.js";
 
+import { ifPresent } from "#elements/utils/attributes";
+
 import type { Meta, StoryObj } from "@storybook/web-components";
 
 import { html } from "lit";
-import { ifDefined } from "lit/directives/if-defined.js";
 
 const metadata: Meta<AggregateCard> = {
     title: "Elements/<ak-aggregate-card>",
@@ -35,7 +36,7 @@ import "#elements/cards/AggregateCard";
     },
     argTypes: {
         icon: { control: "text" },
-        header: { control: "text" },
+        label: { control: "text" },
         headerLink: { control: "text" },
         subtext: { control: "text" },
         leftJustified: { control: "boolean" },
@@ -46,13 +47,13 @@ export default metadata;
 
 export const DefaultStory: StoryObj = {
     args: {
-        icon: undefined,
-        header: "Default",
-        headerLink: undefined,
-        subtext: undefined,
+        icon: null,
+        label: "Default",
+        headerLink: null,
+        subtext: null,
         leftJustified: false,
     },
-    render: ({ icon, header, headerLink, subtext, leftJustified }: IAggregateCard) => {
+    render: ({ icon, label, headerLink, subtext, leftJustified }: IAggregateCard) => {
         return html`
             <style>
                 ak-aggregate-card {
@@ -62,10 +63,10 @@ export const DefaultStory: StoryObj = {
                 }
             </style>
             <ak-aggregate-card
-                header=${ifDefined(header)}
-                headerLink=${ifDefined(headerLink)}
-                subtext=${ifDefined(subtext)}
-                icon=${ifDefined(icon)}
+                label=${ifPresent(label)}
+                headerLink=${ifPresent(headerLink)}
+                subtext=${ifPresent(subtext)}
+                icon=${ifPresent(icon)}
                 ?left-justified=${leftJustified}
             >
                 <p>

--- a/web/src/elements/cards/stories/AggregatePromiseCard.stories.ts
+++ b/web/src/elements/cards/stories/AggregatePromiseCard.stories.ts
@@ -40,7 +40,7 @@ import "#elements/cards/AggregatePromiseCard";
     },
     argTypes: {
         icon: { control: "text" },
-        header: { control: "text" },
+        label: { control: "text" },
         headerLink: { control: "text" },
         subtext: { control: "text" },
         leftJustified: { control: "boolean" },
@@ -64,7 +64,13 @@ export const DefaultStory: StoryObj = {
         subtext: `Demo has a ${EXAMPLE_TIMEOUT / MILLIS_PER_SECOND} second delay until resolution`,
         leftJustified: false,
     },
-    render: ({ icon, header, headerLink, subtext, leftJustified }: IAggregatePromiseCard) => {
+    render: ({
+        icon,
+        label: header,
+        headerLink,
+        subtext,
+        leftJustified,
+    }: IAggregatePromiseCard) => {
         const runThis = (timeout: number, value: string) =>
             new Promise((resolve) => setTimeout(resolve, timeout, value));
 
@@ -99,7 +105,7 @@ export const PromiseRejected: StoryObj = {
     },
     render: ({
         icon,
-        header,
+        label: header,
         headerLink,
         subtext,
         leftJustified,

--- a/web/src/elements/cards/stories/AggregatePromiseCard.stories.ts
+++ b/web/src/elements/cards/stories/AggregatePromiseCard.stories.ts
@@ -43,7 +43,6 @@ import "#elements/cards/AggregatePromiseCard";
         label: { control: "text" },
         headerLink: { control: "text" },
         subtext: { control: "text" },
-        leftJustified: { control: "boolean" },
         failureMessage: { control: "text" },
     },
 };
@@ -62,15 +61,8 @@ export const DefaultStory: StoryObj = {
         header: "Default",
         headerLink: undefined,
         subtext: `Demo has a ${EXAMPLE_TIMEOUT / MILLIS_PER_SECOND} second delay until resolution`,
-        leftJustified: false,
     },
-    render: ({
-        icon,
-        label: header,
-        headerLink,
-        subtext,
-        leftJustified,
-    }: IAggregatePromiseCard) => {
+    render: ({ icon, label: header, headerLink, subtext }: IAggregatePromiseCard) => {
         const runThis = (timeout: number, value: string) =>
             new Promise((resolve) => setTimeout(resolve, timeout, value));
 
@@ -87,7 +79,6 @@ export const DefaultStory: StoryObj = {
                 headerLink=${ifDefined(headerLink)}
                 subtext=${ifDefined(subtext)}
                 icon=${ifDefined(icon)}
-                ?left-justified=${leftJustified}
                 .promise=${runThis(EXAMPLE_TIMEOUT, text)}
             >
             </ak-aggregate-card-promise> `;
@@ -100,7 +91,6 @@ export const PromiseRejected: StoryObj = {
         header: "Default",
         headerLink: undefined,
         subtext: `Demo has a ${EXAMPLE_TIMEOUT / MILLIS_PER_SECOND} second delay until resolution`,
-        leftJustified: false,
         failureMessage: undefined,
     },
     render: ({
@@ -108,7 +98,6 @@ export const PromiseRejected: StoryObj = {
         label: header,
         headerLink,
         subtext,
-        leftJustified,
         failureMessage,
     }: IAggregatePromiseCard) => {
         const runThis = (timeout: number, value: string) =>
@@ -128,7 +117,6 @@ export const PromiseRejected: StoryObj = {
                 subtext=${ifDefined(subtext)}
                 icon=${ifDefined(icon)}
                 failureMessage=${ifDefined(failureMessage)}
-                ?left-justified=${leftJustified}
                 .promise=${runThis(EXAMPLE_TIMEOUT, text)}
             >
             </ak-aggregate-card-promise>

--- a/web/src/elements/cards/stories/AggregatePromiseCard.stories.ts
+++ b/web/src/elements/cards/stories/AggregatePromiseCard.stories.ts
@@ -2,10 +2,11 @@ import "../AggregatePromiseCard.js";
 
 import { AggregatePromiseCard, type IAggregatePromiseCard } from "../AggregatePromiseCard.js";
 
+import { ifPresent } from "#elements/utils/attributes";
+
 import type { Meta, StoryObj } from "@storybook/web-components";
 
 import { html } from "lit";
-import { ifDefined } from "lit/directives/if-defined.js";
 
 const metadata: Meta<AggregatePromiseCard> = {
     title: "Elements/<ak-aggregate-card-promise>",
@@ -75,10 +76,10 @@ export const DefaultStory: StoryObj = {
                 }
             </style>
             <ak-aggregate-card-promise
-                header=${ifDefined(header)}
-                headerLink=${ifDefined(headerLink)}
-                subtext=${ifDefined(subtext)}
-                icon=${ifDefined(icon)}
+                header=${ifPresent(header)}
+                headerLink=${ifPresent(headerLink)}
+                subtext=${ifPresent(subtext)}
+                icon=${ifPresent(icon)}
                 .promise=${runThis(EXAMPLE_TIMEOUT, text)}
             >
             </ak-aggregate-card-promise> `;
@@ -112,11 +113,11 @@ export const PromiseRejected: StoryObj = {
                 }
             </style>
             <ak-aggregate-card-promise
-                header=${ifDefined(header)}
-                headerLink=${ifDefined(headerLink)}
-                subtext=${ifDefined(subtext)}
-                icon=${ifDefined(icon)}
-                failureMessage=${ifDefined(failureMessage)}
+                header=${ifPresent(header)}
+                headerLink=${ifPresent(headerLink)}
+                subtext=${ifPresent(subtext)}
+                icon=${ifPresent(icon)}
+                failureMessage=${ifPresent(failureMessage)}
                 .promise=${runThis(EXAMPLE_TIMEOUT, text)}
             >
             </ak-aggregate-card-promise>

--- a/web/src/elements/charts/Chart.ts
+++ b/web/src/elements/charts/Chart.ts
@@ -44,6 +44,8 @@ export const FONT_COLOUR_DARK_MODE = "#fafafa";
 export const FONT_COLOUR_LIGHT_MODE = "#151515";
 
 export abstract class AKChart<T> extends AKElement {
+    public role = "figure";
+
     abstract apiRequest(): Promise<T>;
     abstract getChartData(data: T): ChartData;
 
@@ -210,7 +212,11 @@ export abstract class AKChart<T> extends AKElement {
                       `
                     : html`${this.chart ? nothing : html`<ak-empty-state loading></ak-empty-state>`}`}
                 ${this.centerText ? html` <span>${this.centerText}</span> ` : nothing}
-                <canvas style="${this.chart === undefined ? "display: none;" : ""}"></canvas>
+                <canvas
+                    role="img"
+                    aria-label=${msg("Chart")}
+                    style="${!this.chart ? "display: none;" : ""}"
+                ></canvas>
             </div>
         `;
     }

--- a/web/src/elements/charts/EventChart.ts
+++ b/web/src/elements/charts/EventChart.ts
@@ -6,6 +6,8 @@ import { EventActions, EventVolume } from "@goauthentik/api";
 
 import { ChartData, ChartDataset } from "chart.js";
 
+import { msg } from "@lit/localize";
+
 export function actionToColor(action: EventActions): string {
     switch (action) {
         case EventActions.AuthorizeApplication:
@@ -65,6 +67,8 @@ export function actionToColor(action: EventActions): string {
 }
 
 export abstract class EventChart extends AKChart<EventVolume[]> {
+    public override ariaLabel = msg("Event volume chart");
+
     eventVolume(
         data: EventVolume[],
         options?: {


### PR DESCRIPTION
## Details

This PR refines the ARIA region detection when viewing the admin overview page. The contents within each region need additional attributes, but this revision allows Playwright to traverse the page with more granularity.

### ARIA Tree Before

<img width="822" height="590" alt="Screenshot 2025-10-01 at 14 43 56" src="https://github.com/user-attachments/assets/670b6c52-b24e-473e-84f1-491a15f353cc" />

### ARIA Tree After

<img width="800" height="493" alt="Screenshot 2025-10-01 at 14 43 14" src="https://github.com/user-attachments/assets/9492c4c7-92f7-42c4-a2f5-91c2d2161017" />
After


