### PR TITLE
web: Remove brand column.

### DIFF
--- a/web/src/admin/admin-overview/cards/RecentEventsCard.ts
+++ b/web/src/admin/admin-overview/cards/RecentEventsCard.ts
@@ -60,7 +60,6 @@ export class RecentEventsCard extends Table<Event> {
         [msg("User"), "user"],
         [msg("Creation Date"), "created"],
         [msg("Client IP"), "client_ip"],
-        [msg("Brand"), "brand_name"],
     ];
 
     renderToolbar(): TemplateResult {
@@ -77,7 +76,6 @@ export class RecentEventsCard extends Table<Event> {
             Timestamp(item.created),
             html` <div>${item.clientIp || msg("-")}</div>
                 <small>${EventGeo(item)}</small>`,
-            html`<span>${item.brand?.name || msg("-")}</span>`,
         ];
     }
 


### PR DESCRIPTION
## Details

A follow-up from a design session, this PR removes the brand column from the recent events card to ease the width requirements on the admin overview page.

## Screenshot


<img width="584" height="519" alt="Screenshot 2025-10-01 at 15 47 01" src="https://github.com/user-attachments/assets/3d456b46-f277-42e8-ba49-e7b66fd04eb8" />
