### PR TITLE
web: Fix nested table column span behavior.

### DIFF
--- a/web/src/admin/applications/entitlements/ApplicationEntitlementPage.ts
+++ b/web/src/admin/applications/entitlements/ApplicationEntitlementPage.ts
@@ -99,26 +99,14 @@ export class ApplicationEntitlementsPage extends Table<ApplicationEntitlement> {
     }
 
     renderExpanded(item: ApplicationEntitlement): TemplateResult {
-        return html`<td></td>
-            <td colspan="4">
-                <div class="pf-c-table__expandable-row-content">
-                    <div class="pf-c-content">
-                        <p>
-                            ${msg(
-                                "These bindings control which users have access to this entitlement.",
-                            )}
-                        </p>
-                        <ak-bound-policies-list
-                            .target=${item.pbmUuid}
-                            .allowedTypes=${[
-                                PolicyBindingCheckTarget.group,
-                                PolicyBindingCheckTarget.user,
-                            ]}
-                        >
-                        </ak-bound-policies-list>
-                    </div>
-                </div>
-            </td>`;
+        return html`<div class="pf-c-content">
+            <p>${msg("These bindings control which users have access to this entitlement.")}</p>
+            <ak-bound-policies-list
+                .target=${item.pbmUuid}
+                .allowedTypes=${[PolicyBindingCheckTarget.group, PolicyBindingCheckTarget.user]}
+            >
+            </ak-bound-policies-list>
+        </div>`;
     }
 
     renderEmpty(): TemplateResult {

--- a/web/src/admin/blueprints/BlueprintListPage.ts
+++ b/web/src/admin/blueprints/BlueprintListPage.ts
@@ -101,38 +101,35 @@ export class BlueprintListPage extends TablePage<BlueprintInstance> {
 
     renderExpanded(item: BlueprintInstance): TemplateResult {
         const [appLabel, modelName] = ModelEnum.AuthentikBlueprintsBlueprintinstance.split(".");
-        return html`<td colspan="5">
-            <div class="pf-c-table__expandable-row-content">
-                <dl class="pf-c-description-list pf-m-horizontal">
-                    <div class="pf-c-description-list__group">
-                        <dt class="pf-c-description-list__term">
-                            <span class="pf-c-description-list__text">${msg("Path")}</span>
-                        </dt>
-                        <dd class="pf-c-description-list__description">
-                            <div class="pf-c-description-list__text">
-                                <pre>${item.path}</pre>
-                            </div>
-                        </dd>
-                    </div>
-                </dl>
-                <dl class="pf-c-description-list pf-m-horizontal">
-                    <div class="pf-c-description-list__group">
-                        <dt class="pf-c-description-list__term">
-                            <span class="pf-c-description-list__text">${msg("Tasks")}</span>
-                        </dt>
-                        <dd class="pf-c-description-list__description">
-                            <div class="pf-c-description-list__text">
-                                <ak-task-list
-                                    .relObjAppLabel=${appLabel}
-                                    .relObjModel=${modelName}
-                                    .relObjId="${item.pk}"
-                                ></ak-task-list>
-                            </div>
-                        </dd>
-                    </div>
-                </dl>
-            </div>
-        </td>`;
+
+        return html`<dl class="pf-c-description-list pf-m-horizontal">
+                <div class="pf-c-description-list__group">
+                    <dt class="pf-c-description-list__term">
+                        <span class="pf-c-description-list__text">${msg("Path")}</span>
+                    </dt>
+                    <dd class="pf-c-description-list__description">
+                        <div class="pf-c-description-list__text">
+                            <pre>${item.path}</pre>
+                        </div>
+                    </dd>
+                </div>
+            </dl>
+            <dl class="pf-c-description-list pf-m-horizontal">
+                <div class="pf-c-description-list__group">
+                    <dt class="pf-c-description-list__term">
+                        <span class="pf-c-description-list__text">${msg("Tasks")}</span>
+                    </dt>
+                    <dd class="pf-c-description-list__description">
+                        <div class="pf-c-description-list__text">
+                            <ak-task-list
+                                .relObjAppLabel=${appLabel}
+                                .relObjModel=${modelName}
+                                .relObjId="${item.pk}"
+                            ></ak-task-list>
+                        </div>
+                    </dd>
+                </div>
+            </dl>`;
     }
 
     row(item: BlueprintInstance): SlottedTemplateResult[] {

--- a/web/src/admin/crypto/CertificateKeyPairListPage.ts
+++ b/web/src/admin/crypto/CertificateKeyPairListPage.ts
@@ -134,73 +134,61 @@ export class CertificateKeyPairListPage extends TablePage<CertificateKeyPair> {
     }
 
     renderExpanded(item: CertificateKeyPair): TemplateResult {
-        return html`<td colspan="4">
-                <div class="pf-c-table__expandable-row-content">
-                    <dl class="pf-c-description-list pf-m-horizontal">
-                        <div class="pf-c-description-list__group">
-                            <dt class="pf-c-description-list__term">
-                                <span class="pf-c-description-list__text"
-                                    >${msg("Certificate Fingerprint (SHA1)")}</span
-                                >
-                            </dt>
-                            <dd class="pf-c-description-list__description">
-                                <div class="pf-c-description-list__text">
-                                    ${item.fingerprintSha1}
-                                </div>
-                            </dd>
-                        </div>
-                        <div class="pf-c-description-list__group">
-                            <dt class="pf-c-description-list__term">
-                                <span class="pf-c-description-list__text"
-                                    >${msg("Certificate Fingerprint (SHA256)")}</span
-                                >
-                            </dt>
-                            <dd class="pf-c-description-list__description">
-                                <div class="pf-c-description-list__text">
-                                    ${item.fingerprintSha256}
-                                </div>
-                            </dd>
-                        </div>
-                        <div class="pf-c-description-list__group">
-                            <dt class="pf-c-description-list__term">
-                                <span class="pf-c-description-list__text"
-                                    >${msg("Certificate Subject")}</span
-                                >
-                            </dt>
-                            <dd class="pf-c-description-list__description">
-                                <div class="pf-c-description-list__text">${item.certSubject}</div>
-                            </dd>
-                        </div>
-                        <div class="pf-c-description-list__group">
-                            <dt class="pf-c-description-list__term">
-                                <span class="pf-c-description-list__text">${msg("Download")}</span>
-                            </dt>
-                            <dd class="pf-c-description-list__description">
-                                <div class="pf-c-description-list__text">
-                                    <a
-                                        class="pf-c-button pf-m-secondary"
-                                        target="_blank"
-                                        href=${item.certificateDownloadUrl}
-                                    >
-                                        ${msg("Download Certificate")}
-                                    </a>
-                                    ${item.privateKeyAvailable
-                                        ? html`<a
-                                              class="pf-c-button pf-m-secondary"
-                                              target="_blank"
-                                              href=${item.privateKeyDownloadUrl}
-                                          >
-                                              ${msg("Download Private key")}
-                                          </a>`
-                                        : nothing}
-                                </div>
-                            </dd>
-                        </div>
-                    </dl>
-                </div>
-            </td>
-            <td></td>
-            <td></td>`;
+        return html`<dl class="pf-c-description-list pf-m-horizontal">
+            <div class="pf-c-description-list__group">
+                <dt class="pf-c-description-list__term">
+                    <span class="pf-c-description-list__text"
+                        >${msg("Certificate Fingerprint (SHA1)")}</span
+                    >
+                </dt>
+                <dd class="pf-c-description-list__description">
+                    <div class="pf-c-description-list__text">${item.fingerprintSha1}</div>
+                </dd>
+            </div>
+            <div class="pf-c-description-list__group">
+                <dt class="pf-c-description-list__term">
+                    <span class="pf-c-description-list__text"
+                        >${msg("Certificate Fingerprint (SHA256)")}</span
+                    >
+                </dt>
+                <dd class="pf-c-description-list__description">
+                    <div class="pf-c-description-list__text">${item.fingerprintSha256}</div>
+                </dd>
+            </div>
+            <div class="pf-c-description-list__group">
+                <dt class="pf-c-description-list__term">
+                    <span class="pf-c-description-list__text">${msg("Certificate Subject")}</span>
+                </dt>
+                <dd class="pf-c-description-list__description">
+                    <div class="pf-c-description-list__text">${item.certSubject}</div>
+                </dd>
+            </div>
+            <div class="pf-c-description-list__group">
+                <dt class="pf-c-description-list__term">
+                    <span class="pf-c-description-list__text">${msg("Download")}</span>
+                </dt>
+                <dd class="pf-c-description-list__description">
+                    <div class="pf-c-description-list__text">
+                        <a
+                            class="pf-c-button pf-m-secondary"
+                            target="_blank"
+                            href=${item.certificateDownloadUrl}
+                        >
+                            ${msg("Download Certificate")}
+                        </a>
+                        ${item.privateKeyAvailable
+                            ? html`<a
+                                  class="pf-c-button pf-m-secondary"
+                                  target="_blank"
+                                  href=${item.privateKeyDownloadUrl}
+                              >
+                                  ${msg("Download Private key")}
+                              </a>`
+                            : nothing}
+                    </div>
+                </dd>
+            </div>
+        </dl>`;
     }
 
     renderObjectCreate(): TemplateResult {

--- a/web/src/admin/events/EventListPage.ts
+++ b/web/src/admin/events/EventListPage.ts
@@ -116,14 +116,7 @@ export class EventListPage extends WithLicenseSummary(TablePage<Event>) {
     }
 
     renderExpanded(item: Event): TemplateResult {
-        return html` <td colspan="5">
-                <div class="pf-c-table__expandable-row-content">
-                    <ak-event-info .event=${item as EventWithContext}></ak-event-info>
-                </div>
-            </td>
-            <td></td>
-            <td></td>
-            <td></td>`;
+        return html`<ak-event-info .event=${item as EventWithContext}></ak-event-info>`;
     }
 }
 

--- a/web/src/admin/events/RuleListPage.ts
+++ b/web/src/admin/events/RuleListPage.ts
@@ -121,33 +121,29 @@ export class RuleListPage extends TablePage<NotificationRule> {
 
     renderExpanded(item: NotificationRule): TemplateResult {
         const [appLabel, modelName] = ModelEnum.AuthentikEventsNotificationrule.split(".");
-        return html` <td colspan="4">
-            <div class="pf-c-table__expandable-row-content">
-                <p>
-                    ${msg(
-                        `These bindings control upon which events this rule triggers.
+        return html`<p>
+                ${msg(
+                    `These bindings control upon which events this rule triggers.
 Bindings to groups/users are checked against the user of the event.`,
-                    )}
-                </p>
-                <ak-bound-policies-list .target=${item.pk}> </ak-bound-policies-list>
-                <dl class="pf-c-description-list pf-m-horizontal">
-                    <div class="pf-c-description-list__group">
-                        <dt class="pf-c-description-list__term">
-                            <span class="pf-c-description-list__text">${msg("Tasks")}</span>
-                        </dt>
-                        <dd class="pf-c-description-list__description">
-                            <div class="pf-c-description-list__text">
-                                <ak-task-list
-                                    .relObjAppLabel=${appLabel}
-                                    .relObjModel=${modelName}
-                                    .relObjId="${item.pk}"
-                                ></ak-task-list>
-                            </div>
-                        </dd>
-                    </div>
-                </dl>
-            </div>
-        </td>`;
+                )}
+            </p>
+            <ak-bound-policies-list .target=${item.pk}> </ak-bound-policies-list>
+            <dl class="pf-c-description-list pf-m-horizontal">
+                <div class="pf-c-description-list__group">
+                    <dt class="pf-c-description-list__term">
+                        <span class="pf-c-description-list__text">${msg("Tasks")}</span>
+                    </dt>
+                    <dd class="pf-c-description-list__description">
+                        <div class="pf-c-description-list__text">
+                            <ak-task-list
+                                .relObjAppLabel=${appLabel}
+                                .relObjModel=${modelName}
+                                .relObjId="${item.pk}"
+                            ></ak-task-list>
+                        </div>
+                    </dd>
+                </div>
+            </dl>`;
     }
 }
 

--- a/web/src/admin/events/TransportListPage.ts
+++ b/web/src/admin/events/TransportListPage.ts
@@ -114,26 +114,22 @@ export class TransportListPage extends TablePage<NotificationTransport> {
 
     renderExpanded(item: NotificationTransport): TemplateResult {
         const [appLabel, modelName] = ModelEnum.AuthentikEventsNotificationtransport.split(".");
-        return html`<td colspan="5">
-            <div class="pf-c-table__expandable-row-content">
-                <dl class="pf-c-description-list pf-m-horizontal">
-                    <div class="pf-c-description-list__group">
-                        <dt class="pf-c-description-list__term">
-                            <span class="pf-c-description-list__text">${msg("Tasks")}</span>
-                        </dt>
-                        <dd class="pf-c-description-list__description">
-                            <div class="pf-c-description-list__text">
-                                <ak-task-list
-                                    .relObjAppLabel=${appLabel}
-                                    .relObjModel=${modelName}
-                                    .relObjId="${item.pk}"
-                                ></ak-task-list>
-                            </div>
-                        </dd>
+        return html`<dl class="pf-c-description-list pf-m-horizontal">
+            <div class="pf-c-description-list__group">
+                <dt class="pf-c-description-list__term">
+                    <span class="pf-c-description-list__text">${msg("Tasks")}</span>
+                </dt>
+                <dd class="pf-c-description-list__description">
+                    <div class="pf-c-description-list__text">
+                        <ak-task-list
+                            .relObjAppLabel=${appLabel}
+                            .relObjModel=${modelName}
+                            .relObjId="${item.pk}"
+                        ></ak-task-list>
                     </div>
-                </dl>
+                </dd>
             </div>
-        </td>`;
+        </dl>`;
     }
 
     renderObjectCreate(): TemplateResult {

--- a/web/src/admin/flows/BoundStagesList.ts
+++ b/web/src/admin/flows/BoundStagesList.ts
@@ -118,23 +118,14 @@ export class BoundStagesList extends Table<FlowStageBinding> {
     }
 
     renderExpanded(item: FlowStageBinding): TemplateResult {
-        return html` <td></td>
-            <td colspan="4">
-                <div class="pf-c-table__expandable-row-content">
-                    <div class="pf-c-content">
-                        <p>
-                            ${msg(
-                                "These bindings control if this stage will be applied to the flow.",
-                            )}
-                        </p>
-                        <ak-bound-policies-list
-                            .target=${item.policybindingmodelPtrId}
-                            .policyEngineMode=${item.policyEngineMode}
-                        >
-                        </ak-bound-policies-list>
-                    </div>
-                </div>
-            </td>`;
+        return html`<div class="pf-c-content">
+            <p>${msg("These bindings control if this stage will be applied to the flow.")}</p>
+            <ak-bound-policies-list
+                .target=${item.policybindingmodelPtrId}
+                .policyEngineMode=${item.policyEngineMode}
+            >
+            </ak-bound-policies-list>
+        </div>`;
     }
 
     renderEmpty(): TemplateResult {

--- a/web/src/admin/groups/RelatedUserList.ts
+++ b/web/src/admin/groups/RelatedUserList.ts
@@ -250,151 +250,127 @@ export class RelatedUserList extends WithBrandConfig(WithCapabilitiesConfig(Tabl
     }
 
     renderExpanded(item: User): TemplateResult {
-        return html`<td colspan="3">
-                <div class="pf-c-table__expandable-row-content">
-                    <dl class="pf-c-description-list pf-m-horizontal">
-                        <div class="pf-c-description-list__group">
-                            <dt class="pf-c-description-list__term">
-                                <span class="pf-c-description-list__text"
-                                    >${msg("User status")}</span
-                                >
-                            </dt>
-                            <dd class="pf-c-description-list__description">
-                                <div class="pf-c-description-list__text">
-                                    ${item.isActive ? msg("Active") : msg("Inactive")}
-                                </div>
-                                <div class="pf-c-description-list__text">
-                                    ${item.isSuperuser ? msg("Superuser") : msg("Regular user")}
-                                </div>
-                            </dd>
-                        </div>
-                        <div class="pf-c-description-list__group">
-                            <dt class="pf-c-description-list__term">
-                                <span class="pf-c-description-list__text"
-                                    >${msg("Change status")}</span
-                                >
-                            </dt>
-                            <dd class="pf-c-description-list__description">
-                                <div class="pf-c-description-list__text">
-                                    <ak-user-active-form
-                                        .obj=${item}
-                                        objectLabel=${msg("User")}
-                                        .delete=${() => {
-                                            return new CoreApi(
-                                                DEFAULT_CONFIG,
-                                            ).coreUsersPartialUpdate({
-                                                id: item.pk || 0,
-                                                patchedUserRequest: {
-                                                    isActive: !item.isActive,
-                                                },
-                                            });
-                                        }}
-                                    >
-                                        <button slot="trigger" class="pf-c-button pf-m-warning">
-                                            ${item.isActive ? msg("Deactivate") : msg("Activate")}
-                                        </button>
-                                    </ak-user-active-form>
-                                </div>
-                            </dd>
-                        </div>
-                        <div class="pf-c-description-list__group">
-                            <dt class="pf-c-description-list__term">
-                                <span class="pf-c-description-list__text">${msg("Recovery")}</span>
-                            </dt>
-                            <dd class="pf-c-description-list__description">
-                                <div class="pf-c-description-list__text">
-                                    <ak-forms-modal>
-                                        <span slot="submit">${msg("Update password")}</span>
-                                        <span slot="header">
-                                            ${msg(
-                                                str`Update ${item.name || item.username}'s password`,
-                                            )}
-                                        </span>
-                                        <ak-user-password-form
-                                            username=${item.username}
-                                            email=${ifDefined(item.email)}
-                                            slot="form"
-                                            .instancePk=${item.pk}
-                                        ></ak-user-password-form>
-                                        <button slot="trigger" class="pf-c-button pf-m-secondary">
-                                            ${msg("Set password")}
-                                        </button>
-                                    </ak-forms-modal>
-                                    ${this.brand.flowRecovery
-                                        ? html`
-                                              <ak-action-button
-                                                  class="pf-m-secondary"
-                                                  .apiRequest=${() => {
-                                                      return new CoreApi(DEFAULT_CONFIG)
-                                                          .coreUsersRecoveryCreate({
-                                                              id: item.pk,
-                                                          })
-                                                          .then((rec) => {
-                                                              showMessage({
-                                                                  level: MessageLevel.success,
-                                                                  message: msg(
-                                                                      "Successfully generated recovery link",
-                                                                  ),
-                                                                  description: rec.link,
-                                                              });
-                                                          })
-                                                          .catch(async (error: unknown) => {
-                                                              const parsedError =
-                                                                  await parseAPIResponseError(
-                                                                      error,
-                                                                  );
+        return html`<dl class="pf-c-description-list pf-m-horizontal">
+            <div class="pf-c-description-list__group">
+                <dt class="pf-c-description-list__term">
+                    <span class="pf-c-description-list__text">${msg("User status")}</span>
+                </dt>
+                <dd class="pf-c-description-list__description">
+                    <div class="pf-c-description-list__text">
+                        ${item.isActive ? msg("Active") : msg("Inactive")}
+                    </div>
+                    <div class="pf-c-description-list__text">
+                        ${item.isSuperuser ? msg("Superuser") : msg("Regular user")}
+                    </div>
+                </dd>
+            </div>
+            <div class="pf-c-description-list__group">
+                <dt class="pf-c-description-list__term">
+                    <span class="pf-c-description-list__text">${msg("Change status")}</span>
+                </dt>
+                <dd class="pf-c-description-list__description">
+                    <div class="pf-c-description-list__text">
+                        <ak-user-active-form
+                            .obj=${item}
+                            objectLabel=${msg("User")}
+                            .delete=${() => {
+                                return new CoreApi(DEFAULT_CONFIG).coreUsersPartialUpdate({
+                                    id: item.pk || 0,
+                                    patchedUserRequest: {
+                                        isActive: !item.isActive,
+                                    },
+                                });
+                            }}
+                        >
+                            <button slot="trigger" class="pf-c-button pf-m-warning">
+                                ${item.isActive ? msg("Deactivate") : msg("Activate")}
+                            </button>
+                        </ak-user-active-form>
+                    </div>
+                </dd>
+            </div>
+            <div class="pf-c-description-list__group">
+                <dt class="pf-c-description-list__term">
+                    <span class="pf-c-description-list__text">${msg("Recovery")}</span>
+                </dt>
+                <dd class="pf-c-description-list__description">
+                    <div class="pf-c-description-list__text">
+                        <ak-forms-modal>
+                            <span slot="submit">${msg("Update password")}</span>
+                            <span slot="header">
+                                ${msg(str`Update ${item.name || item.username}'s password`)}
+                            </span>
+                            <ak-user-password-form
+                                username=${item.username}
+                                email=${ifDefined(item.email)}
+                                slot="form"
+                                .instancePk=${item.pk}
+                            ></ak-user-password-form>
+                            <button slot="trigger" class="pf-c-button pf-m-secondary">
+                                ${msg("Set password")}
+                            </button>
+                        </ak-forms-modal>
+                        ${this.brand.flowRecovery
+                            ? html`
+                                  <ak-action-button
+                                      class="pf-m-secondary"
+                                      .apiRequest=${() => {
+                                          return new CoreApi(DEFAULT_CONFIG)
+                                              .coreUsersRecoveryCreate({
+                                                  id: item.pk,
+                                              })
+                                              .then((rec) => {
+                                                  showMessage({
+                                                      level: MessageLevel.success,
+                                                      message: msg(
+                                                          "Successfully generated recovery link",
+                                                      ),
+                                                      description: rec.link,
+                                                  });
+                                              })
+                                              .catch(async (error: unknown) => {
+                                                  const parsedError =
+                                                      await parseAPIResponseError(error);
 
-                                                              showMessage({
-                                                                  level: MessageLevel.error,
-                                                                  message:
-                                                                      pluckErrorDetail(parsedError),
-                                                              });
-                                                          });
-                                                  }}
-                                              >
-                                                  ${msg("Copy recovery link")}
-                                              </ak-action-button>
-                                              ${item.email
-                                                  ? html`<ak-forms-modal
-                                                        .closeAfterSuccessfulSubmit=${false}
-                                                    >
-                                                        <span slot="submit">
-                                                            ${msg("Send link")}
-                                                        </span>
-                                                        <span slot="header">
-                                                            ${msg("Send recovery link to user")}
-                                                        </span>
-                                                        <ak-user-reset-email-form
-                                                            slot="form"
-                                                            .user=${item}
-                                                        >
-                                                        </ak-user-reset-email-form>
-                                                        <button
-                                                            slot="trigger"
-                                                            class="pf-c-button pf-m-secondary"
-                                                        >
-                                                            ${msg("Email recovery link")}
-                                                        </button>
-                                                    </ak-forms-modal>`
-                                                  : html`<span
-                                                        >${msg(
-                                                            "Recovery link cannot be emailed, user has no email address saved.",
-                                                        )}</span
-                                                    >`}
-                                          `
-                                        : html` <p>
-                                              ${msg(
-                                                  "To let a user directly reset a their password, configure a recovery flow on the currently active brand.",
-                                              )}
-                                          </p>`}
-                                </div>
-                            </dd>
-                        </div>
-                    </dl>
-                </div>
-            </td>
-            <td></td>
-            <td></td>`;
+                                                  showMessage({
+                                                      level: MessageLevel.error,
+                                                      message: pluckErrorDetail(parsedError),
+                                                  });
+                                              });
+                                      }}
+                                  >
+                                      ${msg("Copy recovery link")}
+                                  </ak-action-button>
+                                  ${item.email
+                                      ? html`<ak-forms-modal .closeAfterSuccessfulSubmit=${false}>
+                                            <span slot="submit"> ${msg("Send link")} </span>
+                                            <span slot="header">
+                                                ${msg("Send recovery link to user")}
+                                            </span>
+                                            <ak-user-reset-email-form slot="form" .user=${item}>
+                                            </ak-user-reset-email-form>
+                                            <button
+                                                slot="trigger"
+                                                class="pf-c-button pf-m-secondary"
+                                            >
+                                                ${msg("Email recovery link")}
+                                            </button>
+                                        </ak-forms-modal>`
+                                      : html`<span
+                                            >${msg(
+                                                "Recovery link cannot be emailed, user has no email address saved.",
+                                            )}</span
+                                        >`}
+                              `
+                            : html` <p>
+                                  ${msg(
+                                      "To let a user directly reset a their password, configure a recovery flow on the currently active brand.",
+                                  )}
+                              </p>`}
+                    </div>
+                </dd>
+            </div>
+        </dl>`;
     }
 
     renderToolbar(): TemplateResult {

--- a/web/src/admin/outposts/OutpostListPage.ts
+++ b/web/src/admin/outposts/OutpostListPage.ts
@@ -158,58 +158,54 @@ export class OutpostListPage extends TablePage<Outpost> {
 
     renderExpanded(item: Outpost): TemplateResult {
         const [appLabel, modelName] = ModelEnum.AuthentikOutpostsOutpost.split(".");
-        return html`<td colspan="7">
-            <div class="pf-c-table__expandable-row-content">
-                <h3>
-                    ${msg(
-                        "Detailed health (one instance per column, data is cached so may be out of date)",
-                    )}
-                </h3>
-                <dl class="pf-c-description-list pf-m-3-col-on-lg">
-                    ${this.health[item.pk].map((h) => {
-                        return html`<div class="pf-c-description-list__group">
-                            <dd class="pf-c-description-list__description">
-                                <div class="pf-c-description-list__text">
-                                    <ak-outpost-health .outpostHealth=${h}></ak-outpost-health>
-                                </div>
-                            </dd>
-                        </div>`;
-                    })}
-                </dl>
-                <dl class="pf-c-description-list pf-m-horizontal">
-                    <div class="pf-c-description-list__group">
-                        <dt class="pf-c-description-list__term">
-                            <span class="pf-c-description-list__text">${msg("Schedules")}</span>
-                        </dt>
+        return html` <h3>
+                ${msg(
+                    "Detailed health (one instance per column, data is cached so may be out of date)",
+                )}
+            </h3>
+            <dl class="pf-c-description-list pf-m-3-col-on-lg">
+                ${this.health[item.pk].map((h) => {
+                    return html`<div class="pf-c-description-list__group">
                         <dd class="pf-c-description-list__description">
                             <div class="pf-c-description-list__text">
-                                <ak-schedule-list
-                                    .relObjAppLabel=${appLabel}
-                                    .relObjModel=${modelName}
-                                    .relObjId="${item.pk}"
-                                ></ak-schedule-list>
+                                <ak-outpost-health .outpostHealth=${h}></ak-outpost-health>
                             </div>
                         </dd>
-                    </div>
-                </dl>
-                <dl class="pf-c-description-list pf-m-horizontal">
-                    <div class="pf-c-description-list__group">
-                        <dt class="pf-c-description-list__term">
-                            <span class="pf-c-description-list__text">${msg("Tasks")}</span>
-                        </dt>
-                        <dd class="pf-c-description-list__description">
-                            <div class="pf-c-description-list__text">
-                                <ak-task-list
-                                    .relObjAppLabel=${appLabel}
-                                    .relObjModel=${modelName}
-                                    .relObjId="${item.pk}"
-                                ></ak-task-list>
-                            </div>
-                        </dd>
-                    </div>
-                </dl>
-            </div>
-        </td>`;
+                    </div>`;
+                })}
+            </dl>
+            <dl class="pf-c-description-list pf-m-horizontal">
+                <div class="pf-c-description-list__group">
+                    <dt class="pf-c-description-list__term">
+                        <span class="pf-c-description-list__text">${msg("Schedules")}</span>
+                    </dt>
+                    <dd class="pf-c-description-list__description">
+                        <div class="pf-c-description-list__text">
+                            <ak-schedule-list
+                                .relObjAppLabel=${appLabel}
+                                .relObjModel=${modelName}
+                                .relObjId="${item.pk}"
+                            ></ak-schedule-list>
+                        </div>
+                    </dd>
+                </div>
+            </dl>
+            <dl class="pf-c-description-list pf-m-horizontal">
+                <div class="pf-c-description-list__group">
+                    <dt class="pf-c-description-list__term">
+                        <span class="pf-c-description-list__text">${msg("Tasks")}</span>
+                    </dt>
+                    <dd class="pf-c-description-list__description">
+                        <div class="pf-c-description-list__text">
+                            <ak-task-list
+                                .relObjAppLabel=${appLabel}
+                                .relObjModel=${modelName}
+                                .relObjId="${item.pk}"
+                            ></ak-task-list>
+                        </div>
+                    </dd>
+                </div>
+            </dl>`;
     }
 
     renderToolbarSelected(): TemplateResult {

--- a/web/src/admin/outposts/ServiceConnectionListPage.ts
+++ b/web/src/admin/outposts/ServiceConnectionListPage.ts
@@ -107,42 +107,38 @@ export class OutpostServiceConnectionListPage extends TablePage<ServiceConnectio
 
     renderExpanded(item: ServiceConnection): TemplateResult {
         const [appLabel, modelName] = item.metaModelName.split(".");
-        return html` <td colspan="5">
-            <div class="pf-c-table__expandable-row-content">
-                <dl class="pf-c-description-list pf-m-horizontal">
-                    <div class="pf-c-description-list__group">
-                        <dt class="pf-c-description-list__term">
-                            <span class="pf-c-description-list__text">${msg("Schedules")}</span>
-                        </dt>
-                        <dd class="pf-c-description-list__description">
-                            <div class="pf-c-description-list__text">
-                                <ak-schedule-list
-                                    .relObjAppLabel=${appLabel}
-                                    .relObjModel=${modelName}
-                                    .relObjId="${item.pk}"
-                                ></ak-schedule-list>
-                            </div>
-                        </dd>
-                    </div>
-                </dl>
-                <dl class="pf-c-description-list pf-m-horizontal">
-                    <div class="pf-c-description-list__group">
-                        <dt class="pf-c-description-list__term">
-                            <span class="pf-c-description-list__text">${msg("Tasks")}</span>
-                        </dt>
-                        <dd class="pf-c-description-list__description">
-                            <div class="pf-c-description-list__text">
-                                <ak-task-list
-                                    .relObjAppLabel=${appLabel}
-                                    .relObjModel=${modelName}
-                                    .relObjId="${item.pk}"
-                                ></ak-task-list>
-                            </div>
-                        </dd>
-                    </div>
-                </dl>
-            </div>
-        </td>`;
+        return html`<dl class="pf-c-description-list pf-m-horizontal">
+                <div class="pf-c-description-list__group">
+                    <dt class="pf-c-description-list__term">
+                        <span class="pf-c-description-list__text">${msg("Schedules")}</span>
+                    </dt>
+                    <dd class="pf-c-description-list__description">
+                        <div class="pf-c-description-list__text">
+                            <ak-schedule-list
+                                .relObjAppLabel=${appLabel}
+                                .relObjModel=${modelName}
+                                .relObjId="${item.pk}"
+                            ></ak-schedule-list>
+                        </div>
+                    </dd>
+                </div>
+            </dl>
+            <dl class="pf-c-description-list pf-m-horizontal">
+                <div class="pf-c-description-list__group">
+                    <dt class="pf-c-description-list__term">
+                        <span class="pf-c-description-list__text">${msg("Tasks")}</span>
+                    </dt>
+                    <dd class="pf-c-description-list__description">
+                        <div class="pf-c-description-list__text">
+                            <ak-task-list
+                                .relObjAppLabel=${appLabel}
+                                .relObjModel=${modelName}
+                                .relObjId="${item.pk}"
+                            ></ak-task-list>
+                        </div>
+                    </dd>
+                </div>
+            </dl>`;
     }
 
     renderToolbarSelected(): TemplateResult {

--- a/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderGroupList.ts
+++ b/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderGroupList.ts
@@ -94,11 +94,7 @@ export class GoogleWorkspaceProviderGroupList extends Table<GoogleWorkspaceProvi
     }
 
     renderExpanded(item: GoogleWorkspaceProviderGroup): TemplateResult {
-        return html`<td colspan="4">
-            <div class="pf-c-table__expandable-row-content">
-                <pre>${JSON.stringify(item.attributes, null, 4)}</pre>
-            </div>
-        </td>`;
+        return html` <pre>${JSON.stringify(item.attributes, null, 4)}</pre>`;
     }
 }
 

--- a/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderUserList.ts
+++ b/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderUserList.ts
@@ -95,11 +95,7 @@ export class GoogleWorkspaceProviderUserList extends Table<GoogleWorkspaceProvid
     }
 
     renderExpanded(item: GoogleWorkspaceProviderUser): TemplateResult {
-        return html`<td colspan="4">
-            <div class="pf-c-table__expandable-row-content">
-                <pre>${JSON.stringify(item.attributes, null, 4)}</pre>
-            </div>
-        </td>`;
+        return html`<pre>${JSON.stringify(item.attributes, null, 4)}</pre>`;
     }
 }
 

--- a/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderGroupList.ts
+++ b/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderGroupList.ts
@@ -91,11 +91,7 @@ export class MicrosoftEntraProviderGroupList extends Table<MicrosoftEntraProvide
     }
 
     renderExpanded(item: MicrosoftEntraProviderGroup): TemplateResult {
-        return html`<td colspan="4">
-            <div class="pf-c-table__expandable-row-content">
-                <pre>${JSON.stringify(item.attributes, null, 4)}</pre>
-            </div>
-        </td>`;
+        return html` <pre>${JSON.stringify(item.attributes, null, 4)}</pre>`;
     }
 }
 

--- a/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderUserList.ts
+++ b/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderUserList.ts
@@ -95,11 +95,7 @@ export class MicrosoftEntraProviderUserList extends Table<MicrosoftEntraProvider
     }
 
     renderExpanded(item: MicrosoftEntraProviderUser): TemplateResult {
-        return html`<td colspan="4">
-            <div class="pf-c-table__expandable-row-content">
-                <pre>${JSON.stringify(item.attributes, null, 4)}</pre>
-            </div>
-        </td>`;
+        return html`<pre>${JSON.stringify(item.attributes, null, 4)}</pre>`;
     }
 }
 

--- a/web/src/admin/providers/rac/EndpointList.ts
+++ b/web/src/admin/providers/rac/EndpointList.ts
@@ -108,19 +108,14 @@ export class EndpointListPage extends Table<Endpoint> {
     }
 
     renderExpanded(item: Endpoint): TemplateResult {
-        return html` <td></td>
-            <td colspan="4">
-                <div class="pf-c-table__expandable-row-content">
-                    <div class="pf-c-content">
-                        <p>
-                            ${msg(
-                                "These bindings control which users will have access to this endpoint. Users must also have access to the application.",
-                            )}
-                        </p>
-                        <ak-bound-policies-list .target=${item.pk}> </ak-bound-policies-list>
-                    </div>
-                </div>
-            </td>`;
+        return html`<div class="pf-c-content">
+            <p>
+                ${msg(
+                    "These bindings control which users will have access to this endpoint. Users must also have access to the application.",
+                )}
+            </p>
+            <ak-bound-policies-list .target=${item.pk}></ak-bound-policies-list>
+        </div>`;
     }
 
     renderObjectCreate(): TemplateResult {

--- a/web/src/admin/providers/scim/SCIMProviderGroupList.ts
+++ b/web/src/admin/providers/scim/SCIMProviderGroupList.ts
@@ -90,11 +90,7 @@ export class SCIMProviderGroupList extends Table<SCIMProviderGroup> {
         ];
     }
     renderExpanded(item: SCIMProviderGroup): TemplateResult {
-        return html`<td colspan="4">
-            <div class="pf-c-table__expandable-row-content">
-                <pre>${JSON.stringify(item.attributes, null, 4)}</pre>
-            </div>
-        </td>`;
+        return html`<pre>${JSON.stringify(item.attributes, null, 4)}</pre>`;
     }
 }
 

--- a/web/src/admin/providers/scim/SCIMProviderUserList.ts
+++ b/web/src/admin/providers/scim/SCIMProviderUserList.ts
@@ -91,11 +91,7 @@ export class SCIMProviderUserList extends Table<SCIMProviderUser> {
         ];
     }
     renderExpanded(item: SCIMProviderUser): TemplateResult {
-        return html`<td colspan="4">
-            <div class="pf-c-table__expandable-row-content">
-                <pre>${JSON.stringify(item.attributes, null, 4)}</pre>
-            </div>
-        </td>`;
+        return html`<pre>${JSON.stringify(item.attributes, null, 4)}</pre>`;
     }
 }
 

--- a/web/src/admin/sources/scim/SCIMSourceGroups.ts
+++ b/web/src/admin/sources/scim/SCIMSourceGroups.ts
@@ -35,11 +35,7 @@ export class SCIMSourceGroupList extends Table<SCIMSourceGroup> {
     ];
 
     renderExpanded(item: SCIMSourceGroup): TemplateResult {
-        return html`<td colspan="4">
-            <div class="pf-c-table__expandable-row-content">
-                <pre>${JSON.stringify(item.attributes, null, 4)}</pre>
-            </div>
-        </td>`;
+        return html`<pre>${JSON.stringify(item.attributes, null, 4)}</pre>`;
     }
 
     row(item: SCIMSourceGroup): SlottedTemplateResult[] {

--- a/web/src/admin/sources/scim/SCIMSourceUsers.ts
+++ b/web/src/admin/sources/scim/SCIMSourceUsers.ts
@@ -35,11 +35,7 @@ export class SCIMSourceUserList extends Table<SCIMSourceUser> {
     ];
 
     renderExpanded(item: SCIMSourceUser): TemplateResult {
-        return html`<td colspan="4">
-            <div class="pf-c-table__expandable-row-content">
-                <pre>${JSON.stringify(item.attributes, null, 4)}</pre>
-            </div>
-        </td>`;
+        return html`<pre>${JSON.stringify(item.attributes, null, 4)}</pre>`;
     }
 
     row(item: SCIMSourceUser): SlottedTemplateResult[] {

--- a/web/src/admin/stages/invitation/InvitationListPage.ts
+++ b/web/src/admin/stages/invitation/InvitationListPage.ts
@@ -140,16 +140,9 @@ export class InvitationListPage extends TablePage<Invitation> {
     }
 
     renderExpanded(item: Invitation): TemplateResult {
-        return html` <td colspan="3">
-                <div class="pf-c-table__expandable-row-content">
-                    <ak-stage-invitation-list-link
-                        .invitation=${item}
-                    ></ak-stage-invitation-list-link>
-                </div>
-            </td>
-            <td></td>
-            <td></td>
-            <td></td>`;
+        return html`<ak-stage-invitation-list-link
+            .invitation=${item}
+        ></ak-stage-invitation-list-link>`;
     }
 
     renderObjectCreate(): TemplateResult {

--- a/web/src/admin/users/UserListPage.ts
+++ b/web/src/admin/users/UserListPage.ts
@@ -293,111 +293,91 @@ export class UserListPage extends WithBrandConfig(WithCapabilitiesConfig(TablePa
     }
 
     renderExpanded(item: User): TemplateResult {
-        return html`<td colspan="3">
-                <div class="pf-c-table__expandable-row-content">
-                    <dl class="pf-c-description-list pf-m-horizontal">
-                        <div class="pf-c-description-list__group">
-                            <dt class="pf-c-description-list__term">
-                                <span class="pf-c-description-list__text"
-                                    >${msg("User status")}</span
-                                >
-                            </dt>
-                            <dd class="pf-c-description-list__description">
-                                <div class="pf-c-description-list__text">
-                                    ${item.isActive ? msg("Active") : msg("Inactive")}
-                                </div>
-                                <div class="pf-c-description-list__text">
-                                    ${item.isSuperuser ? msg("Superuser") : msg("Regular user")}
-                                </div>
-                            </dd>
-                        </div>
-                        <div class="pf-c-description-list__group">
-                            <dt class="pf-c-description-list__term">
-                                <span class="pf-c-description-list__text"
-                                    >${msg("Change status")}</span
-                                >
-                            </dt>
-                            <dd class="pf-c-description-list__description">
-                                <div class="pf-c-description-list__text">
-                                    <ak-user-active-form
-                                        .obj=${item}
-                                        objectLabel=${msg("User")}
-                                        .delete=${() => {
-                                            return new CoreApi(
-                                                DEFAULT_CONFIG,
-                                            ).coreUsersPartialUpdate({
-                                                id: item.pk,
-                                                patchedUserRequest: {
-                                                    isActive: !item.isActive,
-                                                },
-                                            });
-                                        }}
-                                    >
-                                        <button slot="trigger" class="pf-c-button pf-m-warning">
-                                            ${item.isActive ? msg("Deactivate") : msg("Activate")}
-                                        </button>
-                                    </ak-user-active-form>
-                                </div>
-                            </dd>
-                        </div>
-                        <div class="pf-c-description-list__group">
-                            <dt class="pf-c-description-list__term">
-                                <span class="pf-c-description-list__text">${msg("Recovery")}</span>
-                            </dt>
-                            <dd class="pf-c-description-list__description">
-                                <div
-                                    class="pf-c-description-list__text"
-                                    id="recovery-request-buttons"
-                                >
-                                    <ak-forms-modal
-                                        size=${PFSize.Medium}
-                                        id="update-password-request"
-                                    >
-                                        <span slot="submit">${msg("Update password")}</span>
-                                        <span slot="header">
-                                            ${msg(
-                                                str`Update ${item.name || item.username}'s password`,
-                                            )}
-                                        </span>
-                                        <ak-user-password-form
-                                            username=${item.username}
-                                            email=${ifDefined(item.email)}
-                                            slot="form"
-                                            .instancePk=${item.pk}
-                                        ></ak-user-password-form>
-                                        <button slot="trigger" class="pf-c-button pf-m-secondary">
-                                            ${msg("Set password")}
-                                        </button>
-                                    </ak-forms-modal>
-                                    ${this.brand.flowRecovery
-                                        ? html`
-                                              <ak-action-button
-                                                  class="pf-m-secondary"
-                                                  .apiRequest=${() => requestRecoveryLink(item)}
-                                              >
-                                                  ${msg("Create recovery link")}
-                                              </ak-action-button>
-                                              ${item.email
-                                                  ? renderRecoveryEmailRequest(item)
-                                                  : html`<span
-                                                        >${msg(
-                                                            "Recovery link cannot be emailed, user has no email address saved.",
-                                                        )}</span
-                                                    >`}
-                                          `
-                                        : html` <p>
-                                              ${msg(
-                                                  "To let a user directly reset their password, configure a recovery flow on the currently active brand.",
-                                              )}
-                                          </p>`}
-                                </div>
-                            </dd>
-                        </div>
-                    </dl>
-                </div>
-            </td>
-            <td></td>
-            <td></td>`;
+        return html`<dl class="pf-c-description-list pf-m-horizontal">
+            <div class="pf-c-description-list__group">
+                <dt class="pf-c-description-list__term">
+                    <span class="pf-c-description-list__text">${msg("User status")}</span>
+                </dt>
+                <dd class="pf-c-description-list__description">
+                    <div class="pf-c-description-list__text">
+                        ${item.isActive ? msg("Active") : msg("Inactive")}
+                    </div>
+                    <div class="pf-c-description-list__text">
+                        ${item.isSuperuser ? msg("Superuser") : msg("Regular user")}
+                    </div>
+                </dd>
+            </div>
+            <div class="pf-c-description-list__group">
+                <dt class="pf-c-description-list__term">
+                    <span class="pf-c-description-list__text">${msg("Change status")}</span>
+                </dt>
+                <dd class="pf-c-description-list__description">
+                    <div class="pf-c-description-list__text">
+                        <ak-user-active-form
+                            .obj=${item}
+                            objectLabel=${msg("User")}
+                            .delete=${() => {
+                                return new CoreApi(DEFAULT_CONFIG).coreUsersPartialUpdate({
+                                    id: item.pk,
+                                    patchedUserRequest: {
+                                        isActive: !item.isActive,
+                                    },
+                                });
+                            }}
+                        >
+                            <button slot="trigger" class="pf-c-button pf-m-warning">
+                                ${item.isActive ? msg("Deactivate") : msg("Activate")}
+                            </button>
+                        </ak-user-active-form>
+                    </div>
+                </dd>
+            </div>
+            <div class="pf-c-description-list__group">
+                <dt class="pf-c-description-list__term">
+                    <span class="pf-c-description-list__text">${msg("Recovery")}</span>
+                </dt>
+                <dd class="pf-c-description-list__description">
+                    <div class="pf-c-description-list__text" id="recovery-request-buttons">
+                        <ak-forms-modal size=${PFSize.Medium} id="update-password-request">
+                            <span slot="submit">${msg("Update password")}</span>
+                            <span slot="header">
+                                ${msg(str`Update ${item.name || item.username}'s password`)}
+                            </span>
+                            <ak-user-password-form
+                                username=${item.username}
+                                email=${ifDefined(item.email)}
+                                slot="form"
+                                .instancePk=${item.pk}
+                            ></ak-user-password-form>
+                            <button slot="trigger" class="pf-c-button pf-m-secondary">
+                                ${msg("Set password")}
+                            </button>
+                        </ak-forms-modal>
+                        ${this.brand.flowRecovery
+                            ? html`
+                                  <ak-action-button
+                                      class="pf-m-secondary"
+                                      .apiRequest=${() => requestRecoveryLink(item)}
+                                  >
+                                      ${msg("Create recovery link")}
+                                  </ak-action-button>
+                                  ${item.email
+                                      ? renderRecoveryEmailRequest(item)
+                                      : html`<span
+                                            >${msg(
+                                                "Recovery link cannot be emailed, user has no email address saved.",
+                                            )}</span
+                                        >`}
+                              `
+                            : html` <p>
+                                  ${msg(
+                                      "To let a user directly reset their password, configure a recovery flow on the currently active brand.",
+                                  )}
+                              </p>`}
+                    </div>
+                </dd>
+            </div>
+        </dl>`;
     }
 
     renderObjectCreate(): TemplateResult {

--- a/web/src/components/events/ObjectChangelog.ts
+++ b/web/src/components/events/ObjectChangelog.ts
@@ -83,14 +83,7 @@ export class ObjectChangelog extends Table<Event> {
     }
 
     renderExpanded(item: Event): TemplateResult {
-        return html` <td colspan="4">
-                <div class="pf-c-table__expandable-row-content">
-                    <ak-event-info .event=${item as EventWithContext}></ak-event-info>
-                </div>
-            </td>
-            <td></td>
-            <td></td>
-            <td></td>`;
+        return html`<ak-event-info .event=${item as EventWithContext}></ak-event-info>`;
     }
 
     renderEmpty(): TemplateResult {

--- a/web/src/components/events/UserEvents.ts
+++ b/web/src/components/events/UserEvents.ts
@@ -57,14 +57,7 @@ export class UserEvents extends Table<Event> {
     }
 
     renderExpanded(item: Event): TemplateResult {
-        return html` <td colspan="4">
-                <div class="pf-c-table__expandable-row-content">
-                    <ak-event-info .event=${item as EventWithContext}></ak-event-info>
-                </div>
-            </td>
-            <td></td>
-            <td></td>
-            <td></td>`;
+        return html`<ak-event-info .event=${item as EventWithContext}></ak-event-info>`;
     }
 
     renderEmpty(): TemplateResult {

--- a/web/src/elements/events/LogViewer.ts
+++ b/web/src/elements/events/LogViewer.ts
@@ -46,32 +46,28 @@ export class LogViewer extends Table<LogEvent> {
     }
 
     renderExpanded(item: LogEvent): TemplateResult {
-        return html`<td colspan="4">
-            <div class="pf-c-table__expandable-row-content">
-                <dl class="pf-c-description-list pf-m-horizontal">
-                    <div class="pf-c-description-list__group">
-                        <dt class="pf-c-description-list__term">
-                            <span class="pf-c-description-list__text">${msg("Timestamp")}</span>
-                        </dt>
-                        <dd class="pf-c-description-list__description">
-                            <div class="pf-c-description-list__text">
-                                ${item.timestamp.toLocaleString()}
-                            </div>
-                        </dd>
+        return html`<dl class="pf-c-description-list pf-m-horizontal">
+            <div class="pf-c-description-list__group">
+                <dt class="pf-c-description-list__term">
+                    <span class="pf-c-description-list__text">${msg("Timestamp")}</span>
+                </dt>
+                <dd class="pf-c-description-list__description">
+                    <div class="pf-c-description-list__text">
+                        ${item.timestamp.toLocaleString()}
                     </div>
-                    <div class="pf-c-description-list__group">
-                        <dt class="pf-c-description-list__term">
-                            <span class="pf-c-description-list__text">${msg("Attributes")}</span>
-                        </dt>
-                        <dd class="pf-c-description-list__description">
-                            <div class="pf-c-description-list__text">
-                                <pre>${JSON.stringify(item.attributes, null, 4)}</pre>
-                            </div>
-                        </dd>
-                    </div>
-                </dl>
+                </dd>
             </div>
-        </td>`;
+            <div class="pf-c-description-list__group">
+                <dt class="pf-c-description-list__term">
+                    <span class="pf-c-description-list__text">${msg("Attributes")}</span>
+                </dt>
+                <dd class="pf-c-description-list__description">
+                    <div class="pf-c-description-list__text">
+                        <pre>${JSON.stringify(item.attributes, null, 4)}</pre>
+                    </div>
+                </dd>
+            </div>
+        </dl>`;
     }
 
     renderToolbarContainer(): SlottedTemplateResult {

--- a/web/src/elements/forms/DeleteBulkForm.ts
+++ b/web/src/elements/forms/DeleteBulkForm.ts
@@ -84,13 +84,9 @@ export class DeleteObjectsTable<T extends object> extends Table<T> {
             }
             return this.renderUsedBy(this.usedByData.get(item) || []);
         };
-        return html`<td colspan="2">
-            <div class="pf-c-table__expandable-row-content">
-                ${this.usedBy
-                    ? until(handler(), html`<ak-spinner size=${PFSize.Large}></ak-spinner>`)
-                    : nothing}
-            </div>
-        </td>`;
+        return html`${this.usedBy
+            ? until(handler(), html`<ak-spinner size=${PFSize.Large}></ak-spinner>`)
+            : nothing}`;
     }
 
     renderUsedBy(usedBy: UsedBy[]): TemplateResult {

--- a/web/src/elements/oauth/UserAccessTokenList.ts
+++ b/web/src/elements/oauth/UserAccessTokenList.ts
@@ -47,18 +47,12 @@ export class UserOAuthAccessTokenList extends Table<TokenModel> {
     ];
 
     renderExpanded(item: TokenModel): TemplateResult {
-        return html` <td colspan="4">
-                <div class="pf-c-table__expandable-row-content">
-                    <div class="pf-l-flex">
-                        <div class="pf-l-flex__item">
-                            <h3>${msg("ID Token")}</h3>
-                            <pre>${item.idToken}</pre>
-                        </div>
-                    </div>
-                </div>
-            </td>
-            <td></td>
-            <td></td>`;
+        return html`<div class="pf-l-flex">
+            <div class="pf-l-flex__item">
+                <h3>${msg("ID Token")}</h3>
+                <pre>${item.idToken}</pre>
+            </div>
+        </div>`;
     }
 
     renderToolbarSelected(): TemplateResult {

--- a/web/src/elements/oauth/UserRefreshTokenList.ts
+++ b/web/src/elements/oauth/UserRefreshTokenList.ts
@@ -48,18 +48,12 @@ export class UserOAuthRefreshTokenList extends Table<TokenModel> {
     ];
 
     renderExpanded(item: TokenModel): TemplateResult {
-        return html` <td colspan="4">
-                <div class="pf-c-table__expandable-row-content">
-                    <div class="pf-l-flex">
-                        <div class="pf-l-flex__item">
-                            <h3>${msg("ID Token")}</h3>
-                            <pre>${item.idToken}</pre>
-                        </div>
-                    </div>
-                </div>
-            </td>
-            <td></td>
-            <td></td>`;
+        return html`<div class="pf-l-flex">
+            <div class="pf-l-flex__item">
+                <h3>${msg("ID Token")}</h3>
+                <pre>${item.idToken}</pre>
+            </div>
+        </div>`;
     }
 
     renderToolbarSelected(): TemplateResult {

--- a/web/src/elements/table/Table.ts
+++ b/web/src/elements/table/Table.ts
@@ -54,6 +54,16 @@ export function hasPrimaryKey<T extends string | number = string | number>(
     return Object.hasOwn(item, "pk");
 }
 
+/**
+ * An instance of a Table component.
+ *
+ * This is necessary to work around limitations in Lit's typing system
+ * not recognizing abstract properties.
+ */
+export type TableInstance = InstanceType<typeof Table> & {
+    columns: TableColumn[];
+};
+
 export abstract class Table<T extends object>
     extends WithLicenseSummary(AKElement)
     implements TableLike
@@ -203,6 +213,20 @@ export abstract class Table<T extends object>
      */
     protected abstract row(item: T): SlottedTemplateResult[];
 
+    /**
+     * The total number of defined and additional columns in the table.
+     */
+    #columnCount = 0;
+
+    #synchronizeColumnCount() {
+        let nextColumnCount = this.columns.length;
+
+        if (this.checkbox) nextColumnCount += 1;
+        if (this.expandable) nextColumnCount += 1;
+
+        this.#columnCount = nextColumnCount;
+    }
+
     @state()
     protected loading = false;
 
@@ -347,6 +371,16 @@ export abstract class Table<T extends object>
         }
     }
 
+    protected override updated(changedProperties: PropertyValues<this>): void {
+        if (
+            (changedProperties as PropertyValues<TableInstance>).has("columns") ||
+            changedProperties.has("checkbox") ||
+            changedProperties.has("expandable")
+        ) {
+            this.#synchronizeColumnCount();
+        }
+    }
+
     firstUpdated(): void {
         this.fetch();
     }
@@ -408,7 +442,7 @@ export abstract class Table<T extends object>
 
     protected renderLoading(): TemplateResult {
         return html`<tr role="presentation">
-            <td role="presentation" colspan="25">
+            <td role="presentation" colspan=${this.#columnCount}>
                 <div class="pf-l-bullseye">
                     <ak-empty-state default-label></ak-empty-state>
                 </div>
@@ -419,7 +453,7 @@ export abstract class Table<T extends object>
     protected renderEmpty(inner?: SlottedTemplateResult): TemplateResult {
         return html`
             <tr role="presentation">
-                <td role="presentation" colspan="8">
+                <td role="presentation" colspan=${this.#columnCount}>
                     <div class="pf-l-bullseye">
                         ${inner ??
                         html`<ak-empty-state
@@ -495,14 +529,12 @@ export abstract class Table<T extends object>
             }
         }
 
-        const columnCount = this.columns.length + (this.checkbox ? 1 : 0);
-
         return groups.map(([group, items], groupIndex) => {
             const groupHeaderID = `table-group-${groupIndex}`;
 
             return html`<thead>
                     <tr>
-                        <th id=${groupHeaderID} scope="colgroup" colspan=${columnCount}>
+                        <th id=${groupHeaderID} scope="colgroup" colspan=${this.#columnCount}>
                             ${group}
                         </th>
                     </tr>
@@ -521,13 +553,7 @@ export abstract class Table<T extends object>
         return [["", items]];
     }
 
-    protected renderExpanded(_item: T): SlottedTemplateResult {
-        if (this.expandable) {
-            throw new TypeError("Expandable is enabled but renderExpanded is not overridden!");
-        }
-
-        return nothing;
-    }
+    protected renderExpanded?(item: T): SlottedTemplateResult;
 
     #toggleExpansion = (itemKey?: string | number, event?: PointerEvent) => {
         // An unlikely scenario but possible if items shift between fetches
@@ -644,6 +670,27 @@ export abstract class Table<T extends object>
             </td>`;
         };
 
+        let expansionContent: SlottedTemplateResult = nothing;
+
+        if (this.expandable) {
+            if (!this.renderExpanded) {
+                throw new TypeError("Expandable is enabled but renderExpanded is not overridden!");
+            }
+
+            expansionContent = html`<tr
+                class="pf-c-table__expandable-row ${classMap({
+                    "pf-m-expanded": expanded,
+                })}"
+            >
+                <td aria-hidden="true"></td>
+                <td colspan=${this.#columnCount - 1}>
+                    <div class="pf-c-table__expandable-row-content">
+                        ${this.renderExpanded(item)}
+                    </div>
+                </td>
+            </tr>`;
+        }
+
         return html`
             <tr
                 aria-selected=${selected ? "true" : "false"}
@@ -674,16 +721,7 @@ export abstract class Table<T extends object>
                     </td>`;
                 })}
             </tr>
-            ${this.expandable
-                ? html` <tr
-                      class="pf-c-table__expandable-row ${classMap({
-                          "pf-m-expanded": expanded,
-                      })}"
-                  >
-                      <td aria-hidden="true"></td>
-                      ${expanded ? this.renderExpanded(item) : nothing}
-                  </tr>`
-                : nothing}
+            ${expansionContent}
         `;
     }
 

--- a/web/src/elements/tasks/ScheduleList.ts
+++ b/web/src/elements/tasks/ScheduleList.ts
@@ -151,17 +151,13 @@ export class ScheduleList extends Table<Schedule> {
 
     renderExpanded(item: Schedule): TemplateResult {
         const [appLabel, modelName] = ModelEnum.AuthentikTasksSchedulesSchedule.split(".");
-        return html` <td colspan="5">
-            <div class="pf-c-table__expandable-row-content">
-                <div class="pf-c-content">
-                    <ak-task-list
-                        .relObjAppLabel=${appLabel}
-                        .relObjModel=${modelName}
-                        .relObjId="${item.id}"
-                    ></ak-task-list>
-                </div>
-            </div>
-        </td>`;
+        return html`<div class="pf-c-content">
+            <ak-task-list
+                .relObjAppLabel=${appLabel}
+                .relObjModel=${modelName}
+                .relObjId="${item.id}"
+            ></ak-task-list>
+        </div>`;
     }
 }
 

--- a/web/src/elements/tasks/TaskList.ts
+++ b/web/src/elements/tasks/TaskList.ts
@@ -184,18 +184,12 @@ export class TaskList extends Table<Task> {
     }
 
     renderExpanded(item: Task): TemplateResult {
-        return html` <td colspan="5">
-            <div class="pf-c-table__expandable-row-content">
-                <div class="pf-c-content">
-                    <p class="pf-c-title pf-u-mb-md">${msg("Current execution logs")}</p>
-                    <ak-log-viewer .logs=${item?.messages}></ak-log-viewer>
-                    <p class="pf-c-title pf-u-mt-xl pf-u-mb-md">
-                        ${msg("Previous executions logs")}
-                    </p>
-                    <ak-log-viewer .logs=${item?.previousMessages}></ak-log-viewer>
-                </div>
-            </div>
-        </td>`;
+        return html`<div class="pf-c-content">
+            <p class="pf-c-title pf-u-mb-md">${msg("Current execution logs")}</p>
+            <ak-log-viewer .logs=${item?.messages}></ak-log-viewer>
+            <p class="pf-c-title pf-u-mt-xl pf-u-mb-md">${msg("Previous executions logs")}</p>
+            <ak-log-viewer .logs=${item?.previousMessages}></ak-log-viewer>
+        </div>`;
     }
 }
 

--- a/web/src/user/user-settings/tokens/UserTokenList.ts
+++ b/web/src/user/user-settings/tokens/UserTokenList.ts
@@ -80,60 +80,53 @@ export class UserTokenList extends Table<Token> {
     }
 
     renderExpanded(item: Token): TemplateResult {
-        return html` <td colspan="3">
-                <div class="pf-c-table__expandable-row-content">
-                    <dl class="pf-c-description-list pf-m-horizontal">
-                        <div class="pf-c-description-list__group">
-                            <dt class="pf-c-description-list__term">
-                                <span class="pf-c-description-list__text">${msg("User")}</span>
-                            </dt>
-                            <dd class="pf-c-description-list__description">
-                                <div class="pf-c-description-list__text">
-                                    ${item.userObj?.username}
-                                </div>
-                            </dd>
-                        </div>
-                        <div class="pf-c-description-list__group">
-                            <dt class="pf-c-description-list__term">
-                                <span class="pf-c-description-list__text">${msg("Expiring")}</span>
-                            </dt>
-                            <dd class="pf-c-description-list__description">
-                                <div class="pf-c-description-list__text">
-                                    <ak-status-label ?good=${item.expiring}></ak-status-label>
-                                </div>
-                            </dd>
-                        </div>
-                        <div class="pf-c-description-list__group">
-                            <dt class="pf-c-description-list__term">
-                                <span class="pf-c-description-list__text">${msg("Expiring")}</span>
-                            </dt>
-                            <dd class="pf-c-description-list__description">
-                                <div class="pf-c-description-list__text">
-                                    ${item.expiring
-                                        ? html`<pf-tooltip
-                                              position="top"
-                                              .content=${item.expires?.toLocaleString()}
-                                          >
-                                              ${formatElapsedTime(item.expires!)}
-                                          </pf-tooltip>`
-                                        : msg("-")}
-                                </div>
-                            </dd>
-                        </div>
-                        <div class="pf-c-description-list__group">
-                            <dt class="pf-c-description-list__term">
-                                <span class="pf-c-description-list__text">${msg("Intent")}</span>
-                            </dt>
-                            <dd class="pf-c-description-list__description">
-                                <div class="pf-c-description-list__text">
-                                    ${intentToLabel(item.intent ?? IntentEnum.Api)}
-                                </div>
-                            </dd>
-                        </div>
-                    </dl>
-                </div>
-            </td>
-            <td></td>`;
+        return html`<dl class="pf-c-description-list pf-m-horizontal">
+            <div class="pf-c-description-list__group">
+                <dt class="pf-c-description-list__term">
+                    <span class="pf-c-description-list__text">${msg("User")}</span>
+                </dt>
+                <dd class="pf-c-description-list__description">
+                    <div class="pf-c-description-list__text">${item.userObj?.username}</div>
+                </dd>
+            </div>
+            <div class="pf-c-description-list__group">
+                <dt class="pf-c-description-list__term">
+                    <span class="pf-c-description-list__text">${msg("Expiring")}</span>
+                </dt>
+                <dd class="pf-c-description-list__description">
+                    <div class="pf-c-description-list__text">
+                        <ak-status-label ?good=${item.expiring}></ak-status-label>
+                    </div>
+                </dd>
+            </div>
+            <div class="pf-c-description-list__group">
+                <dt class="pf-c-description-list__term">
+                    <span class="pf-c-description-list__text">${msg("Expiring")}</span>
+                </dt>
+                <dd class="pf-c-description-list__description">
+                    <div class="pf-c-description-list__text">
+                        ${item.expiring
+                            ? html`<pf-tooltip
+                                  position="top"
+                                  .content=${item.expires?.toLocaleString()}
+                              >
+                                  ${formatElapsedTime(item.expires!)}
+                              </pf-tooltip>`
+                            : msg("-")}
+                    </div>
+                </dd>
+            </div>
+            <div class="pf-c-description-list__group">
+                <dt class="pf-c-description-list__term">
+                    <span class="pf-c-description-list__text">${msg("Intent")}</span>
+                </dt>
+                <dd class="pf-c-description-list__description">
+                    <div class="pf-c-description-list__text">
+                        ${intentToLabel(item.intent ?? IntentEnum.Api)}
+                    </div>
+                </dd>
+            </div>
+        </dl>`;
     }
 
     renderToolbarSelected(): TemplateResult {


### PR DESCRIPTION
## Details

This PR fixes a common issue among expandable table rows which contain sub-tables. Often, the row contents do not span across the entire parent table. This is caused by a combination of uncoupled column counting and a gradual drift from the initial number without a means to keep them in sync.


The line-count of this PR is large but is achieved with a series of codemods:

1. Find table cells with a defined `colspan`
2. Move the cell and parent `<div class="pf-c-table__expandable-row-content" .../>` element into the Table `renderExpansionRow`
3. Calculate the column count on property changes.

## Screenshots

### Before

<img width="1183" height="690" alt="Screenshot 2025-10-01 at 19 44 11" src="https://github.com/user-attachments/assets/3d9cff0d-22bb-423e-b18f-249999b35676" />

### After

<img width="1176" height="738" alt="Screenshot 2025-10-01 at 19 43 53" src="https://github.com/user-attachments/assets/44e4eb8d-9f97-4267-adb7-9e24354cfd80" />



