### PR TITLE
core: bump jsii from 1.114.1 to v1.115.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1748,7 +1748,7 @@ wheels = [
 
 [[package]]
 name = "jsii"
-version = "1.114.1"
+version = "1.115.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -1759,9 +1759,9 @@ dependencies = [
     { name = "typeguard" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/f7/6c3763ee3b88f07d0de3c7ed11aa8492a83801b9b2360bb3ee9065829e60/jsii-1.114.1.tar.gz", hash = "sha256:bd3a9ab7aa3f3971aea638e02ae079599f70ff2fe80a0bd8a6e38759f1235d78", size = 625605, upload-time = "2025-09-04T13:16:17.279Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/ad/2a7e98e88980f4a75750fbc2500ab3b56b2b07d5467d98c24891649acf70/jsii-1.115.0.tar.gz", hash = "sha256:4e32200d6fc3f71ee42fe8b1d817bb3ce8119b157f167a5e014c52171700ca2b", size = 625493, upload-time = "2025-09-29T13:33:03.637Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/f0/b7c5488c8f8628a2e468d63583f0a0aab490cbba1c1e143e990a49e4795b/jsii-1.114.1-py3-none-any.whl", hash = "sha256:e8e6a2fb6117af734803b709cbbb74745548e4d70248417f14724c9f6d4945dd", size = 601796, upload-time = "2025-09-04T13:16:15.936Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/4b/e0ae36e5357973cdf9b3ae621f573319632a02c454a9eedf450e1e847539/jsii-1.115.0-py3-none-any.whl", hash = "sha256:f7ef91e39954c6c10db859ca90cfe1bb978c457a5fcaf5fba4303cbdefff8619", size = 601724, upload-time = "2025-09-29T13:33:02.323Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
See https://pypi.org/project/jsii/ for package information