### PR TITLE
ci: don't log postgres always

### DIFF
--- a/.github/actions/test-results/action.yml
+++ b/.github/actions/test-results/action.yml
@@ -20,7 +20,9 @@ runs:
     - name: PostgreSQL Logs
       shell: bash
       run: |
-        docker stop setup-postgresql-1
-        echo "::group::PostgreSQL Logs"
-        docker logs setup-postgresql-1
-        echo "::endgroup::"
+        if [[ $ACTIONS_RUNNER_DEBUG == 'true' || $ACTIONS_STEP_DEBUG == 'true' ]]; then
+          docker stop setup-postgresql-1
+          echo "::group::PostgreSQL Logs"
+          docker logs setup-postgresql-1
+          echo "::endgroup::"
+        fi


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Ok so sometimes postgres logging causes the job to fail & timeout, so only debug log when we enable GHA debug logging

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
