### PR TITLE
web: Fix tab theme consistency, table overflow.

### DIFF
--- a/web/src/common/styles/authentik.css
+++ b/web/src/common/styles/authentik.css
@@ -158,6 +158,56 @@ html > form > input {
 
 /* #endregion */
 
+/* #region Tabs */
+
+.pf-c-tabs {
+    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--lg);
+
+    background-color: transparent;
+
+    &.pf-m-box.pf-m-vertical {
+        .pf-c-tabs__list::before {
+            border-color: transparent;
+        }
+    }
+
+    &.pf-m-box .pf-c-tabs__item.pf-m-current:first-child .pf-c-tabs__link::before {
+        border-color: transparent;
+    }
+
+    &.pf-m-vertical {
+        .pf-c-tabs__link {
+            background-color: transparent;
+        }
+    }
+
+    &:not(.pf-m-vertical) .pf-c-tabs__item {
+        &.pf-m-current {
+            --pf-c-tabs__link--after--BorderColor: var(--ak-accent);
+        }
+    }
+}
+
+ak-tabs[vertical] {
+    [role="tabpanel"] {
+        padding-inline-start: 0 !important;
+    }
+
+    .pf-c-card__body > *::part(table-container) {
+        overflow-x: auto;
+    }
+}
+
+.pf-c-tabs__link {
+    --pf-c-tabs__link--Color: var(--pf-global--Color--100);
+
+    &::before {
+        border-color: transparent;
+    }
+}
+
+/* #endregion */
+
 /* #region Tables */
 
 .pf-c-table {

--- a/web/src/common/styles/theme-dark.css
+++ b/web/src/common/styles/theme-dark.css
@@ -114,38 +114,6 @@ body {
 
 /* #endregion  */
 
-/* #region Tabs */
-
-.pf-c-tabs {
-    background-color: transparent;
-}
-
-.pf-c-tabs.pf-m-box.pf-m-vertical .pf-c-tabs__list::before {
-    border-color: transparent;
-}
-
-.pf-c-tabs.pf-m-box .pf-c-tabs__item.pf-m-current:first-child .pf-c-tabs__link::before {
-    border-color: transparent;
-}
-
-.pf-c-tabs__link::before {
-    border-color: transparent;
-}
-
-.pf-c-tabs__item.pf-m-current {
-    --pf-c-tabs__link--after--BorderColor: var(--ak-accent);
-}
-
-.pf-c-tabs__link {
-    --pf-c-tabs__link--Color: var(--ak-dark-foreground);
-}
-
-.pf-c-tabs.pf-m-vertical .pf-c-tabs__link {
-    background-color: transparent;
-}
-
-/* #endregion */
-
 /* #Region Mobile Tables */
 @media screen and (max-width: 1200px) {
     .pf-m-grid-xl.pf-c-table tbody:first-of-type {

--- a/web/src/elements/Tabs.ts
+++ b/web/src/elements/Tabs.ts
@@ -27,20 +27,21 @@ export class Tabs extends AKElement {
         PFGlobal,
         PFTabs,
         css`
-            ::slotted(*) {
-                flex-grow: 2;
-            }
             :host([vertical]) {
-                display: flex;
-            }
-            :host([vertical]) .pf-c-tabs {
-                width: auto !important;
-            }
-            :host([vertical]) .pf-c-tabs__list {
-                height: 100%;
-            }
-            :host([vertical]) .pf-c-tabs .pf-c-tabs__list::before {
-                border-color: transparent;
+                display: grid;
+                grid-template-columns: auto 1fr;
+
+                .pf-c-tabs {
+                    width: auto !important;
+                }
+
+                .pf-c-tabs__list {
+                    height: 100%;
+                }
+
+                .pf-c-tabs .pf-c-tabs__list::before {
+                    border-color: transparent;
+                }
             }
         `,
     ];
@@ -75,6 +76,7 @@ export class Tabs extends AKElement {
         updateURLParams(params);
         const page = this.querySelector(`[slot='${this.currentPage}']`);
         if (!page) return;
+
         page.dispatchEvent(new CustomEvent(EVENT_REFRESH));
         page.dispatchEvent(new CustomEvent("activate"));
     }

--- a/web/src/elements/table/Table.ts
+++ b/web/src/elements/table/Table.ts
@@ -932,28 +932,30 @@ export abstract class Table<T extends object>
 
         return html`${this.needChipGroup ? this.renderChipGroup() : nothing}
             ${this.renderToolbarContainer()}
-            <table
-                aria-label=${this.label ? msg(str`${this.label} table`) : msg("Table content")}
-                aria-rowcount=${totalItemCount}
-                class="pf-c-table pf-m-compact pf-m-grid-md pf-m-expandable"
-            >
-                <thead aria-label=${msg("Column actions")}>
-                    <tr class="pf-c-table__header-row">
-                        ${this.checkbox ? this.renderAllOnThisPageCheckbox() : nothing}
-                        ${this.expandable ? html`<td aria-hidden="true"></td>` : nothing}
-                        ${this.columns.map(([label, orderBy, ariaLabel], idx) =>
-                            renderTableColumn({
-                                label,
-                                ariaLabel,
-                                orderBy,
-                                table: this,
-                                columnIndex: idx,
-                            }),
-                        )}
-                    </tr>
-                </thead>
-                ${this.renderRows()}
-            </table>
+            <div part="table-container">
+                <table
+                    aria-label=${this.label ? msg(str`${this.label} table`) : msg("Table content")}
+                    aria-rowcount=${totalItemCount}
+                    class="pf-c-table pf-m-compact pf-m-grid-md pf-m-expandable"
+                >
+                    <thead aria-label=${msg("Column actions")}>
+                        <tr class="pf-c-table__header-row">
+                            ${this.checkbox ? this.renderAllOnThisPageCheckbox() : nothing}
+                            ${this.expandable ? html`<td aria-hidden="true"></td>` : nothing}
+                            ${this.columns.map(([label, orderBy, ariaLabel], idx) =>
+                                renderTableColumn({
+                                    label,
+                                    ariaLabel,
+                                    orderBy,
+                                    table: this,
+                                    columnIndex: idx,
+                                }),
+                            )}
+                        </tr>
+                    </thead>
+                    ${this.renderRows()}
+                </table>
+            </div>
             ${this.paginated ? renderBottomPagination() : nothing}`;
     }
 


### PR DESCRIPTION
## Details

This PR fixes a few visual discrepancies on vertical tabs when switching themes. Also included is a fix for table overflow when rendering within a tab panel.

### Before

<img width="805" height="654" alt="Screenshot 2025-10-02 at 18 34 21" src="https://github.com/user-attachments/assets/06dda049-a7b4-4c51-9558-b870333b7f9d" />

### After

<img width="1186" height="628" alt="Screenshot 2025-10-02 at 18 38 45" src="https://github.com/user-attachments/assets/46928ca9-8e70-4414-a0b0-758f9c64805b" />
