### PR TITLE
Makefile: Fix kerberos tests for brew users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,21 +17,20 @@ pg_user := $(shell uv run python -m authentik.lib.config postgresql.user 2>/dev/
 pg_host := $(shell uv run python -m authentik.lib.config postgresql.host 2>/dev/null)
 pg_name := $(shell uv run python -m authentik.lib.config postgresql.name 2>/dev/null)
 
-UNAME := $(shell uname)
-
 # For macOS users, add the libxml2 installed from brew libxmlsec1 to the build path
 # to prevent SAML-related tests from failing and ensure correct pip dependency compilation
-ifeq ($(UNAME), Darwin)
-# Only add for brew users who installed libxmlsec1
-	BREW_EXISTS := $(shell command -v brew 2> /dev/null)
-	ifdef BREW_EXISTS
-		LIBXML2_EXISTS := $(shell brew list libxml2 2> /dev/null)
-		ifdef LIBXML2_EXISTS
-			BREW_LDFLAGS := -L$(shell brew --prefix libxml2)/lib $(LDFLAGS)
-			BREW_CPPFLAGS := -I$(shell brew --prefix libxml2)/include $(CPPFLAGS)
-			BREW_PKG_CONFIG_PATH := $(shell brew --prefix libxml2)/lib/pkgconfig:$(PKG_CONFIG_PATH)
-		endif
-	endif
+# These functions are only evaluated when called in specific targets
+LIBXML2_EXISTS = $(shell brew list libxml2 2> /dev/null)
+KRB5_EXISTS = $(shell brew list krb5 2> /dev/null)
+
+LIBXML2_LDFLAGS = -L$(shell brew --prefix libxml2)/lib $(LDFLAGS)
+LIBXML2_CPPFLAGS = -I$(shell brew --prefix libxml2)/include $(CPPFLAGS)
+LIBXML2_PKG_CONFIG = $(shell brew --prefix libxml2)/lib/pkgconfig:$(PKG_CONFIG_PATH)
+
+KRB_PATH =
+
+ifneq ($(KRB5_EXISTS),)
+	KRB_PATH = PATH="$(shell brew --prefix krb5)/sbin:$(shell brew --prefix krb5)/bin:$$PATH"
 endif
 
 all: lint-fix lint gen web test  ## Lint, build, and test everything
@@ -50,7 +49,7 @@ go-test:
 	go test -timeout 0 -v -race -cover ./...
 
 test: ## Run the server tests and produce a coverage report (locally)
-	uv run coverage run manage.py test --keepdb authentik
+	$(KRB_PATH) uv run coverage run manage.py test --keepdb $(or $(filter-out $@,$(MAKECMDGOALS)),authentik)
 	uv run coverage html
 	uv run coverage report
 
@@ -66,11 +65,11 @@ lint: ## Lint the python and golang sources
 	golangci-lint run -v
 
 core-install:
-ifdef LIBXML2_EXISTS
+ifneq ($(LIBXML2_EXISTS),)
 # Clear cache to ensure fresh compilation
 	uv cache clean
 # Force compilation from source for lxml and xmlsec with correct environment
-	LDFLAGS="$(BREW_LDFLAGS)" CPPFLAGS="$(BREW_CPPFLAGS)" PKG_CONFIG_PATH="$(BREW_PKG_CONFIG_PATH)" uv sync --frozen --reinstall-package lxml --reinstall-package xmlsec --no-binary-package lxml --no-binary-package xmlsec
+	LDFLAGS="$(LIBXML2_LDFLAGS)" CPPFLAGS="$(LIBXML2_CPPFLAGS)" PKG_CONFIG_PATH="$(LIBXML2_PKG_CONFIG)" uv sync --frozen --reinstall-package lxml --reinstall-package xmlsec --no-binary-package lxml --no-binary-package xmlsec
 else
 	uv sync --frozen
 endif


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
We tell people to install krb5 with brew on dev env setup. The output from running `brew install krb5` tells people they have to update their path to add krb5 manually. This is very easy to miss, and without it in your path, the tests in `authentik/sources/kerberos` will hang infinitely.

This PR automatically updates your path to add the brew install of krb5 when the test suite is run via `make test` or `make all`

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
