### PR TITLE
Fixed CORS requests failing with forward auth via proxy provider

### DIFF
--- a/authentik/policies/views.py
+++ b/authentik/policies/views.py
@@ -68,13 +68,20 @@ class PolicyAccessView(AccessMixin, View):
         is not caught, and will return directly"""
         raise NotImplementedError
 
+    def supports_cors_preflight_requests(self) -> bool:
+        """If true, OPTIONS requests will be answered without authentication or permission checks.
+        This is useful for CORS preflight requests."""
+        return hasattr(self, "options") and callable(self.options)
+
     def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
+        # Validate request before doing anything else
         try:
             self.pre_permission_check()
         except RequestValidationError as exc:
             if exc.response:
                 return exc.response
             return self.handle_no_permission()
+
         try:
             self.resolve_provider_application()
         except (Application.DoesNotExist, Provider.DoesNotExist) as exc:
@@ -82,14 +89,19 @@ class PolicyAccessView(AccessMixin, View):
             return self.handle_no_permission_authenticated(
                 PolicyResult(False, _("Failed to resolve application"))
             )
-        # Check if user is unauthenticated, so we pass the application
-        # for the identification stage
-        if not request.user.is_authenticated:
-            return self.handle_no_permission()
-        # Check permissions
-        result = self.user_has_access()
-        if not result.passing:
-            return self.handle_no_permission_authenticated(result)
+
+        # CORS preflight requests should not require authentication
+        if request.method != "OPTIONS" or not self.supports_cors_preflight_requests():
+            # Check if user is unauthenticated, so we pass the application
+            # for the identification stage
+            if not request.user.is_authenticated:
+                return self.handle_no_permission()
+
+            # Check permissions
+            result = self.user_has_access()
+            if not result.passing:
+                return self.handle_no_permission_authenticated(result)
+
         return super().dispatch(request, *args, **kwargs)
 
     def handle_no_permission(self) -> HttpResponse:

--- a/authentik/providers/oauth2/views/authorize.py
+++ b/authentik/providers/oauth2/views/authorize.py
@@ -427,9 +427,10 @@ class AuthorizationFlowInitView(BufferedPolicyAccessView):
                     parsed_url._replace(query=urlencode(args, quote_via=quote, doseq=True))
                 )
 
-        # Add CORS headers based on the provider's redirect URIs
+        # Add CORS headers based on the provider's redirect URIs, if a provider exists and has
+        # redirect URIs configured
         allowed_origins = []
-        if self.provider and hasattr(self.provider, "redirect_uris"):
+        if hasattr(self, "provider") and self.provider and hasattr(self.provider, "redirect_uris"):
             allowed_origins = [x.url for x in self.provider.redirect_uris]
         cors_allow(self.request, response, *allowed_origins)
 

--- a/authentik/providers/oauth2/views/authorize.py
+++ b/authentik/providers/oauth2/views/authorize.py
@@ -62,7 +62,7 @@ from authentik.providers.oauth2.models import (
     ResponseTypes,
     ScopeMapping,
 )
-from authentik.providers.oauth2.utils import HttpResponseRedirectScheme
+from authentik.providers.oauth2.utils import HttpResponseRedirectScheme, TokenResponse, cors_allow
 from authentik.providers.oauth2.views.userinfo import UserInfoView
 from authentik.stages.consent.models import ConsentMode, ConsentStage
 from authentik.stages.consent.stage import (
@@ -347,6 +347,10 @@ class AuthorizationFlowInitView(BufferedPolicyAccessView):
     def pre_permission_check(self):
         """Check prompt parameter before checking permission/authentication,
         see https://openid.net/specs/openid-connect-core-1_0.html#rfc.section.3.1.2.6"""
+        # Allow unauthenticated CORS preflight requests
+        if self.request.method == "OPTIONS":
+            return
+
         # Quick sanity check at the beginning to prevent event spamming
         if len(self.request.GET) < 1:
             raise Http404
@@ -422,14 +426,30 @@ class AuthorizationFlowInitView(BufferedPolicyAccessView):
                 response["Location"] = urlunparse(
                     parsed_url._replace(query=urlencode(args, quote_via=quote, doseq=True))
                 )
+
+        # Add CORS headers based on the provider's redirect URIs
+        allowed_origins = []
+        if self.provider and hasattr(self.provider, "redirect_uris"):
+            allowed_origins = [x.url for x in self.provider.redirect_uris]
+        cors_allow(self.request, response, *allowed_origins)
+
+        # Override Access-Control-Allow-Methods to only allow GET and OPTIONS
+        # POST is not defined for this endpoint
+        if "Access-Control-Allow-Methods" in response:
+            response["Access-Control-Allow-Methods"] = "GET, OPTIONS"
+
         return response
 
     def dispatch(self, request: HttpRequest, *args, **kwargs):
         # Activate language before parsing params (error messages should be localised)
         return self.dispatch_with_language(request, *args, **kwargs)
 
+    def options(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        # Return an empty response. The dispatch method will add the CORS headers.
+        return TokenResponse({})
+
     def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
-        """Start FlowPLanner, return to flow executor shell"""
+        """Start FlowPlanner, return to flow executor shell"""
         # Require a login event to be set, otherwise make the user re-login
         login_event = get_login_event(request)
         if not login_event:

--- a/internal/outpost/proxyv2/application/oauth.go
+++ b/internal/outpost/proxyv2/application/oauth.go
@@ -21,6 +21,13 @@ func (a *Application) handleAuthStart(rw http.ResponseWriter, r *http.Request, f
 		a.log.WithError(err).Warning("failed to create state")
 		return
 	}
+
+	// Add CORS headers if origin is allowed
+	if a.isOriginAllowed(r) {
+		a.addCORSHeaders(rw, r)
+		return
+	}
+
 	http.Redirect(rw, r, a.oauthConfig.AuthCodeURL(state), http.StatusFound)
 }
 

--- a/internal/outpost/proxyv2/application/oauth_callback.go
+++ b/internal/outpost/proxyv2/application/oauth_callback.go
@@ -13,6 +13,13 @@ import (
 )
 
 func (a *Application) handleAuthCallback(rw http.ResponseWriter, r *http.Request) {
+	// Check for CORS preflight request and allow it to pass through unauthenticated
+	if a.isCORSPreflightRequest(r) {
+		a.sendCORSPreflightResponse(rw, r)
+		a.log.Trace("responding to CORS preflight request on callback endpoint")
+		return
+	}
+
 	state := a.stateFromRequest(r)
 	if state == nil {
 		a.log.Warning("invalid state")

--- a/internal/outpost/proxyv2/application/utils.go
+++ b/internal/outpost/proxyv2/application/utils.go
@@ -1,9 +1,12 @@
 package application
 
 import (
+	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 )
 
 func urlJoin(originalUrl string, newPath string) string {
@@ -25,6 +28,7 @@ func (a *Application) redirect(rw http.ResponseWriter, r *http.Request) {
 		state.Redirect = fallbackRedirect
 	}
 	a.log.WithField("redirect", state.Redirect).Trace("final redirect")
+	a.addCORSHeaders(rw, r)
 	http.Redirect(rw, r, state.Redirect, http.StatusFound)
 }
 
@@ -58,4 +62,34 @@ func cleanseHeaders(headers http.Header) map[string]string {
 		}
 	}
 	return h
+}
+
+// setUrlPort sets the port of a URL if it is missing, based on the scheme. This is
+// useful for URL comparisons, specifically when comparing against the Origin header.
+// If the port is already set, or the scheme is unknown, no changes are made.
+// If the scheme is unknown, an error is returned.
+func setUrlPort(u *url.URL) error {
+	if u.Port() != "" {
+		return nil
+	}
+
+	// This is designed to support the schemes listed here specifically: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Origin#description
+	switch strings.ToLower(u.Scheme) {
+	case "http":
+		u.Host = net.JoinHostPort(u.Host, "80")
+	case "https":
+		u.Host = net.JoinHostPort(u.Host, "443")
+	case "ftp":
+		u.Host = net.JoinHostPort(u.Host, "21")
+	case "ws":
+		u.Host = net.JoinHostPort(u.Host, "80")
+	case "wss":
+		u.Host = net.JoinHostPort(u.Host, "443")
+	case "gopher":
+		u.Host = net.JoinHostPort(u.Host, "70")
+	default:
+		return &url.Error{Op: "setUrlPort", URL: u.String(), Err: fmt.Errorf("unknown scheme: %s", u.Scheme)}
+	}
+
+	return nil
 }

--- a/website/docs/add-secure-apps/providers/proxy/_envoy_istio.md
+++ b/website/docs/add-secure-apps/providers/proxy/_envoy_istio.md
@@ -16,15 +16,17 @@ spec:
                   port: "9000"
                   pathPrefix: "/outpost.goauthentik.io/auth/envoy"
                   headersToDownstreamOnAllow:
-                      - cookie
-                  headersToUpstreamOnAllow:
                       - set-cookie
+                  headersToUpstreamOnAllow:
+                      - cookie
                       - x-authentik-*
                       # Add authorization headers to the allow list if you need proxy providers which
                       # send a custom HTTP-Basic Authentication header based on values from authentik
                       # - authorization
                   includeRequestHeadersInCheck:
                       - cookie
+                      # Needed for CORS requests to work properly when renewing a proxy ticket
+                      - origin
 ```
 
 Afterwards, you can create _AuthorizationPolicy_ resources to protect your applications like this:


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->

This allows CORS requests to go through the proxy provider forward auth "plan" (not sure if this is the right word), fixing XHR and fetch requests, as well as WebSockets when the forward auth plan needs to be ran again.

I'm not really familiar with this codebase and I don't do much front end web dev, so there may be issues (including security vulnerabilities) introduced by this. Please review this carefully and assume that I don't know what I'm doing.

I've tested this patch against a branch based off of the latest release, and I have it working with Radarr, an app that uses credentialed XMLHTTPRequests and SignalR over WebSockets. It's working great, and renewing the proxy cookie is 100% transparent to me as a user. Note that I have _only_ tested with Envoy/Istio. I don't have (or plan on having) traefik, caddy, or nginx deployed as a reverse proxy, so I'll be unable to test the changes that are specific to these reverse proxies.

One new requirement of this is that front-end application requests must set `XMLHTTPRequest.withCredentials = true`. Without this, the browser won't send the authentik session cookie to the authentik callback endpoint, making authentik think that every request needs to go through the application's configured auth flow. This needs to be set even if the application otherwise does not use credentials for these requests. I don't think that there is a way around this with how forward auth is handled with the proxy cookie. I'm not sure where to document this.

Closes https://github.com/goauthentik/authentik/issues/10057

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`) - These take like an hour to run locally. If they're not ran automatically in CI then I'll run them overnight.
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated - Please see above note about application needing `XMLHTTPRequest.withCredentials = true`
-   [ ] The documentation has been formatted (`make docs`)

Closes #25263
