### PR TITLE
web: change locale order

### DIFF
--- a/web/src/elements/ak-locale-context/helpers.ts
+++ b/web/src/elements/ak-locale-context/helpers.ts
@@ -51,8 +51,8 @@ export function autoDetectLanguage(userReq = TOMBSTONE, brandReq = TOMBSTONE): s
     const localeCandidates: string[] = [
         localeCodeFromUrl("locale"),
         //userReq,
-        brandReq,
         window.navigator?.language ?? TOMBSTONE,
+        brandReq,
         globalAK()?.locale ?? TOMBSTONE,
         DEFAULT_LOCALE,
     ].filter(isLocaleCandidate);

--- a/web/src/elements/ak-locale-context/helpers.ts
+++ b/web/src/elements/ak-locale-context/helpers.ts
@@ -50,7 +50,7 @@ const isLocaleCandidate = (v: unknown): v is string =>
 export function autoDetectLanguage(userReq = TOMBSTONE, brandReq = TOMBSTONE): string {
     const localeCandidates: string[] = [
         localeCodeFromUrl("locale"),
-        userReq,
+        //userReq,
         window.navigator?.language ?? TOMBSTONE,
         brandReq,
         globalAK()?.locale ?? TOMBSTONE,

--- a/web/src/elements/ak-locale-context/helpers.ts
+++ b/web/src/elements/ak-locale-context/helpers.ts
@@ -51,8 +51,8 @@ export function autoDetectLanguage(userReq = TOMBSTONE, brandReq = TOMBSTONE): s
     const localeCandidates: string[] = [
         localeCodeFromUrl("locale"),
         userReq,
-        brandReq,
         window.navigator?.language ?? TOMBSTONE,
+        brandReq,
         globalAK()?.locale ?? TOMBSTONE,
         DEFAULT_LOCALE,
     ].filter(isLocaleCandidate);

--- a/web/src/elements/ak-locale-context/helpers.ts
+++ b/web/src/elements/ak-locale-context/helpers.ts
@@ -51,8 +51,8 @@ export function autoDetectLanguage(userReq = TOMBSTONE, brandReq = TOMBSTONE): s
     const localeCandidates: string[] = [
         localeCodeFromUrl("locale"),
         //userReq,
-        window.navigator?.language ?? TOMBSTONE,
         brandReq,
+        window.navigator?.language ?? TOMBSTONE,
         globalAK()?.locale ?? TOMBSTONE,
         DEFAULT_LOCALE,
     ].filter(isLocaleCandidate);

--- a/web/src/elements/ak-locale-context/helpers.ts
+++ b/web/src/elements/ak-locale-context/helpers.ts
@@ -18,9 +18,7 @@ export const LOCALES = RAW_LOCALES.map((locale) =>
 );
 
 export function getBestMatchLocale(locale: string): AkLocale | undefined {
-    // Normalize "en-gb" and "en-us" to "en"
-    const normalizedLocale = locale.toLowerCase().startsWith("en-") ? "en" : locale;
-    return LOCALES.find((l) => l.match.test(normalizedLocale));
+    return LOCALES.find((l) => l.match.test(locale));
 }
 
 // This looks weird, but it's sensible: we have several candidates, and we want to find the first

--- a/web/src/elements/ak-locale-context/helpers.ts
+++ b/web/src/elements/ak-locale-context/helpers.ts
@@ -38,10 +38,11 @@ export function localeCodeFromUrl(param = "locale") {
 }
 
 // Get all locales we can, in order
-// - Global authentik settings (contains user settings)
 // - URL parameter
-// - A requested code passed in, if any
-// - Navigator
+// - User settings
+// - Brand settings
+// - Navigator (browser locale)
+// - authentik global locale
 // - Fallback (en)
 
 const isLocaleCandidate = (v: unknown): v is string =>

--- a/web/src/elements/ak-locale-context/helpers.ts
+++ b/web/src/elements/ak-locale-context/helpers.ts
@@ -50,7 +50,7 @@ const isLocaleCandidate = (v: unknown): v is string =>
 export function autoDetectLanguage(userReq = TOMBSTONE, brandReq = TOMBSTONE): string {
     const localeCandidates: string[] = [
         localeCodeFromUrl("locale"),
-        //userReq,
+        userReq,
         brandReq,
         window.navigator?.language ?? TOMBSTONE,
         globalAK()?.locale ?? TOMBSTONE,

--- a/web/src/elements/ak-locale-context/helpers.ts
+++ b/web/src/elements/ak-locale-context/helpers.ts
@@ -18,7 +18,9 @@ export const LOCALES = RAW_LOCALES.map((locale) =>
 );
 
 export function getBestMatchLocale(locale: string): AkLocale | undefined {
-    return LOCALES.find((l) => l.match.test(locale));
+    // Normalize "en-gb" and "en-us" to "en"
+    const normalizedLocale = locale.toLowerCase().startsWith("en-") ? "en" : locale;
+    return LOCALES.find((l) => l.match.test(normalizedLocale));
 }
 
 // This looks weird, but it's sensible: we have several candidates, and we want to find the first

--- a/web/src/elements/ak-locale-context/helpers.ts
+++ b/web/src/elements/ak-locale-context/helpers.ts
@@ -51,8 +51,8 @@ export function autoDetectLanguage(userReq = TOMBSTONE, brandReq = TOMBSTONE): s
     const localeCandidates: string[] = [
         localeCodeFromUrl("locale"),
         userReq,
-        window.navigator?.language ?? TOMBSTONE,
         brandReq,
+        window.navigator?.language ?? TOMBSTONE,
         globalAK()?.locale ?? TOMBSTONE,
         DEFAULT_LOCALE,
     ].filter(isLocaleCandidate);


### PR DESCRIPTION
## Details

Moves the brand locale above browser locale because the brand locale wasn't being applied in most situations. It was only applying when a non-supported browser locale was detected.

---

## Checklist

-   [x] The code has been formatted (`make web`)
