### PR TITLE
flows: redirect to next when accessing an unapplicable authentication flow while already authenticated

### DIFF
--- a/authentik/flows/tests/test_executor.py
+++ b/authentik/flows/tests/test_executor.py
@@ -188,6 +188,7 @@ class TestFlowExecutor(FlowTestCase):
         flow.designation = FlowDesignation.AUTHENTICATION
         flow.authentication = FlowAuthenticationRequirement.REQUIRE_UNAUTHENTICATED
         flow.save()
+        self.client.force_login(create_test_user())
 
         dest = "/unique-string"
         url = reverse("authentik_api:flow-executor", kwargs={"flow_slug": flow.slug})

--- a/authentik/flows/tests/test_executor.py
+++ b/authentik/flows/tests/test_executor.py
@@ -13,6 +13,7 @@ from authentik.core.models import Group, User
 from authentik.core.tests.utils import create_test_flow, create_test_user
 from authentik.flows.markers import ReevaluateMarker, StageMarker
 from authentik.flows.models import (
+    FlowAuthenticationRequirement,
     FlowDeniedAction,
     FlowDesignation,
     FlowStageBinding,
@@ -169,6 +170,24 @@ class TestFlowExecutor(FlowTestCase):
     def test_valid_flow_redirect(self):
         """Test valid flow with valid redirect destination"""
         flow = create_test_flow()
+
+        dest = "/unique-string"
+        url = reverse("authentik_api:flow-executor", kwargs={"flow_slug": flow.slug})
+
+        response = self.client.get(url + f"?{QS_QUERY}={urlencode({NEXT_ARG_NAME: dest})}")
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, "/unique-string")
+
+    @patch(
+        "authentik.flows.views.executor.to_stage_response",
+        TO_STAGE_RESPONSE_MOCK,
+    )
+    def test_valid_flow_redirect_authenticated(self):
+        """Test valid flow with valid redirect destination, authenticated already"""
+        flow = create_test_flow()
+        flow.designation = FlowDesignation.AUTHENTICATION
+        flow.authentication = FlowAuthenticationRequirement.REQUIRE_UNAUTHENTICATED
+        flow.save()
 
         dest = "/unique-string"
         url = reverse("authentik_api:flow-executor", kwargs={"flow_slug": flow.slug})

--- a/authentik/flows/views/executor.py
+++ b/authentik/flows/views/executor.py
@@ -184,6 +184,13 @@ class FlowExecutorView(APIView):
                 try:
                     self.plan = self._initiate_plan()
                 except FlowNonApplicableException as exc:
+                    # If we're this flow is for authentication and the user is already authenticated
+                    # continue to the next URL
+                    if (
+                        self.flow.designation == FlowDesignation.AUTHENTICATION
+                        and self.request.user.is_authenticated
+                    ):
+                        return self._flow_done()
                     self._logger.warning("f(exec): Flow not applicable to current user", exc=exc)
                     return self.handle_invalid_flow(exc)
                 except EmptyFlowException as exc:


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

related to #15034

if a user attempts to authenticate in multiple browsers (their session expired and a browser restart reloaded all tabs for example), this changes the behaviour to allow them to refresh other tabs after signing in on one tab

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
