### PR TITLE
website/integrations: fix mealie

### DIFF
--- a/website/integrations/documentation/mealie/index.md
+++ b/website/integrations/documentation/mealie/index.md
@@ -35,6 +35,7 @@ To support the integration of Mealie with authentik, you need to create an appli
 - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
     - Note the **Client ID**, **Client Secret**, , and **slug** values because they will be required later.
     - Create two `Strict` redirect URIs and set to `https://mealie.company/login` and `https://mealie.company/login?direct=1`.
+    - Select any available signing key.
 - **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/flows-stages/bindings/) (policy, group, or user) to manage the listing and access to applications on a user's **My applications** page.
 
 3. Click **Submit** to save the new application and provider.


### PR DESCRIPTION
## Details

Adds mention of signing key because mealie requires it

---

## Checklist

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
