### PR TITLE
web: Fix low DPI on QR Codes.

### DIFF
--- a/web/src/flow/stages/authenticator_totp/AuthenticatorTOTPStage.ts
+++ b/web/src/flow/stages/authenticator_totp/AuthenticatorTOTPStage.ts
@@ -69,7 +69,12 @@ export class AuthenticatorTOTPStage extends BaseStage<
 
                 <div class="pf-c-form__group">
                     <div class="qr-container">
-                        <qr-code data="${this.challenge.configUrl}"></qr-code>
+                        <qr-code
+                            role="img"
+                            aria-label=${msg("QR-Code to setup a time-based one-time password")}
+                            format="svg"
+                            data="${this.challenge.configUrl}"
+                        ></qr-code>
                         <button
                             type="button"
                             class="pf-c-button pf-m-secondary pf-m-progress pf-m-in-progress"


### PR DESCRIPTION
## Details

A small fix, switching our QR component's render result from raster based PNG to vector based SVG for infinitely sharp codes at any DPI.

### Before


<img width="909" height="518" alt="Screenshot 2025-10-05 at 20 46 25" src="https://github.com/user-attachments/assets/86aa6c18-270a-4d1c-a357-678b34e83540" />


### After

<img width="887" height="509" alt="Screenshot 2025-10-05 at 20 46 34" src="https://github.com/user-attachments/assets/9db28dd8-aad7-4829-a427-5940100c105b" />
