### PR TITLE
web/a11y: Accessible scrollbars.

### DIFF
--- a/web/src/admin/AdminInterface/index.entrypoint.ts
+++ b/web/src/admin/AdminInterface/index.entrypoint.ts
@@ -84,6 +84,10 @@ export class AdminInterface extends WithCapabilitiesConfig(AuthenticatedInterfac
         PFDrawer,
         PFNav,
         css`
+            .pf-c-page__main {
+                scrollbar-gutter: stable;
+            }
+
             .pf-c-page__main,
             .pf-c-drawer__content,
             .pf-c-page__drawer {
@@ -216,17 +220,15 @@ export class AdminInterface extends WithCapabilitiesConfig(AuthenticatedInterfac
                         <div class="pf-c-drawer__main">
                             <div class="pf-c-drawer__content">
                                 <div class="pf-c-drawer__body">
-                                    <div class="pf-c-page__main">
-                                        <ak-router-outlet
-                                            role="presentation"
-                                            class="pf-c-page__main"
-                                            tabindex="-1"
-                                            id="main-content"
-                                            defaultUrl="/administration/overview"
-                                            .routes=${ROUTES}
-                                        >
-                                        </ak-router-outlet>
-                                    </div>
+                                    <ak-router-outlet
+                                        role="presentation"
+                                        class="pf-c-page__main"
+                                        tabindex="-1"
+                                        id="main-content"
+                                        defaultUrl="/administration/overview"
+                                        .routes=${ROUTES}
+                                    >
+                                    </ak-router-outlet>
                                 </div>
                             </div>
                             <ak-notification-drawer

--- a/web/src/admin/rbac/ObjectPermissionsPage.ts
+++ b/web/src/admin/rbac/ObjectPermissionsPage.ts
@@ -104,21 +104,20 @@ export class ObjectPermissionPage extends AKElement {
                 slot="page-assigned-global-permissions"
                 id="page-assigned-global-permissions"
                 aria-label="${msg("Assigned global permissions")}"
+                class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
-                <div class="pf-c-page__main-section pf-m-no-padding-mobile">
-                    <div class="pf-c-card">
-                        <div class="pf-c-card__title">${msg("Assigned global permissions")}</div>
-                        <div class="pf-c-card__body">
-                            ${msg(
-                                "Permissions assigned to this user which affect all object instances of a given type.",
-                            )}
-                        </div>
-                        <div class="pf-c-card__body">
-                            <ak-user-assigned-global-permissions-table
-                                userId=${this.objectPk as number}
-                            >
-                            </ak-user-assigned-global-permissions-table>
-                        </div>
+                <div class="pf-c-card">
+                    <div class="pf-c-card__title">${msg("Assigned global permissions")}</div>
+                    <div class="pf-c-card__body">
+                        ${msg(
+                            "Permissions assigned to this user which affect all object instances of a given type.",
+                        )}
+                    </div>
+                    <div class="pf-c-card__body">
+                        <ak-user-assigned-global-permissions-table
+                            userId=${this.objectPk as number}
+                        >
+                        </ak-user-assigned-global-permissions-table>
                     </div>
                 </div>
             </div>
@@ -128,21 +127,20 @@ export class ObjectPermissionPage extends AKElement {
                 slot="page-assigned-object-permissions"
                 id="page-assigned-object-permissions"
                 aria-label="${msg("Assigned object permissions")}"
+                class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
-                <div class="pf-c-page__main-section pf-m-no-padding-mobile">
-                    <div class="pf-c-card">
-                        <div class="pf-c-card__title">${msg("Assigned object permissions")}</div>
-                        <div class="pf-c-card__body">
-                            ${msg(
-                                "Permissions assigned to this user affecting specific object instances.",
-                            )}
-                        </div>
-                        <div class="pf-c-card__body">
-                            <ak-user-assigned-object-permissions-table
-                                userId=${this.objectPk as number}
-                            >
-                            </ak-user-assigned-object-permissions-table>
-                        </div>
+                <div class="pf-c-card">
+                    <div class="pf-c-card__title">${msg("Assigned object permissions")}</div>
+                    <div class="pf-c-card__body">
+                        ${msg(
+                            "Permissions assigned to this user affecting specific object instances.",
+                        )}
+                    </div>
+                    <div class="pf-c-card__body">
+                        <ak-user-assigned-object-permissions-table
+                            userId=${this.objectPk as number}
+                        >
+                        </ak-user-assigned-object-permissions-table>
                     </div>
                 </div>
             </div>
@@ -157,21 +155,20 @@ export class ObjectPermissionPage extends AKElement {
                 slot="page-assigned-global-permissions"
                 id="page-assigned-global-permissions"
                 aria-label="${msg("Assigned global permissions")}"
+                class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
-                <div class="pf-c-page__main-section pf-m-no-padding-mobile">
-                    <div class="pf-c-card">
-                        <div class="pf-c-card__title">${msg("Assigned global permissions")}</div>
-                        <div class="pf-c-card__body">
-                            ${msg(
-                                "Permissions assigned to this role which affect all object instances of a given type.",
-                            )}
-                        </div>
-                        <div class="pf-c-card__body">
-                            <ak-role-assigned-global-permissions-table
-                                roleUuid=${this.objectPk as string}
-                            >
-                            </ak-role-assigned-global-permissions-table>
-                        </div>
+                <div class="pf-c-card">
+                    <div class="pf-c-card__title">${msg("Assigned global permissions")}</div>
+                    <div class="pf-c-card__body">
+                        ${msg(
+                            "Permissions assigned to this role which affect all object instances of a given type.",
+                        )}
+                    </div>
+                    <div class="pf-c-card__body">
+                        <ak-role-assigned-global-permissions-table
+                            roleUuid=${this.objectPk as string}
+                        >
+                        </ak-role-assigned-global-permissions-table>
                     </div>
                 </div>
             </div>
@@ -181,21 +178,20 @@ export class ObjectPermissionPage extends AKElement {
                 slot="page-assigned-object-permissions"
                 id="page-assigned-object-permissions"
                 aria-label="${msg("Assigned object permissions")}"
+                class="pf-c-page__main-section pf-m-no-padding-mobile"
             >
-                <div class="pf-c-page__main-section pf-m-no-padding-mobile">
-                    <div class="pf-c-card">
-                        <div class="pf-c-card__title">${msg("Assigned object permissions")}</div>
-                        <div class="pf-c-card__body">
-                            ${msg(
-                                "Permissions assigned to this user affecting specific object instances.",
-                            )}
-                        </div>
-                        <div class="pf-c-card__body">
-                            <ak-role-assigned-object-permissions-table
-                                roleUuid=${this.objectPk as string}
-                            >
-                            </ak-role-assigned-object-permissions-table>
-                        </div>
+                <div class="pf-c-card">
+                    <div class="pf-c-card__title">${msg("Assigned object permissions")}</div>
+                    <div class="pf-c-card__body">
+                        ${msg(
+                            "Permissions assigned to this user affecting specific object instances.",
+                        )}
+                    </div>
+                    <div class="pf-c-card__body">
+                        <ak-role-assigned-object-permissions-table
+                            roleUuid=${this.objectPk as string}
+                        >
+                        </ak-role-assigned-object-permissions-table>
                     </div>
                 </div>
             </div>

--- a/web/src/common/styles/authentik.css
+++ b/web/src/common/styles/authentik.css
@@ -39,6 +39,96 @@
     --pf-global--disabled-color--300: color-mix(in srgb, GrayText 100%, CanvasText 100%);
 }
 
+/* #endregion */
+
+/* #region Scrollbars */
+
+/**
+ * Scrollbar colors derived from default user agent styles.
+ *
+ * @remarks
+ *
+ * Scrollbar colors may be ignored by the browser depending on a few factors:
+ *
+ * - A preference for increased contrast
+ * - A preference for scrollbar visibility
+ * - The pointer precision available
+ * - Operating system differences
+ */
+:root {
+    --ak-scrollbar-background-color: hsl(0 0% 98%);
+    --ak-scrollbar-thumb-background-color: hsl(0 0% 76%);
+}
+
+/* Applicable to browsers with a WebKit lineage (Chrome, Edge, Safari) */
+::-webkit-scrollbar {
+    background: var(--ak-scrollbar-background-color);
+
+    /* Emulate thin scrollbar sizing. */
+    @media (pointer: fine) {
+        max-height: 12px;
+        max-width: 12px;
+    }
+}
+
+/* Necessary to avoid background color mismatch. */
+::-webkit-scrollbar-track {
+    background: var(--ak-scrollbar-background-color);
+}
+
+::-webkit-scrollbar-thumb {
+    background: var(--ak-scrollbar-thumb-background-color);
+    /* Applies consistent shape across browsers and platforms */
+    border: 3px solid transparent;
+    border-radius: 8px;
+    background-clip: content-box;
+
+    /* Emulate thin scrollbar sizing. */
+    @media (pointer: fine) {
+        border: 3px solid transparent;
+        border-radius: 8px;
+    }
+}
+
+/**
+ * Hides arrow buttons on the scrollbar.
+ * Not applicable to Edge when scrollbars are set to always visible.
+ */
+::-webkit-scrollbar-button {
+    display: none;
+    height: 0;
+    width: 0;
+}
+
+@supports (scrollbar-color: auto) {
+    :root {
+        /**
+         * Applies consistent colors across browsers and platforms.
+         * Not applicable when thin scrollbars are preferred.
+         */
+        scrollbar-color: var(--ak-scrollbar-thumb-background-color)
+            var(--ak-scrollbar-background-color);
+    }
+}
+
+@supports (scrollbar-width: thin) {
+    .pf-c-page__main,
+    .pf-c-nav__list,
+    .pf-c-card__body {
+        scrollbar-width: thin;
+
+        @media (pointer: coarse) {
+            /**
+             * Avoids issues on touch devices where thin scrollbars
+             * are difficult to interact with.
+             */
+            scrollbar-width: auto;
+        }
+    }
+}
+
+/* #endregion */
+
 .pf-c-form__group {
     column-gap: var(--pf-global--spacer--md);
 }
@@ -61,29 +151,6 @@
     margin-left: var(--pf-c-form__label-required--MarginLeft);
     font-size: var(--pf-c-form__label-required--FontSize);
     color: var(--pf-c-form__label-required--Color);
-}
-
-@supports selector(::-webkit-scrollbar) {
-    ::-webkit-scrollbar {
-        width: 5px;
-        height: 5px;
-        background-color: transparent;
-    }
-    ::-webkit-scrollbar-thumb {
-        background-color: var(--ak-accent);
-    }
-    ::-webkit-scrollbar-track {
-        background-color: transparent;
-    }
-    ::-webkit-scrollbar-corner {
-        background-color: transparent;
-    }
-}
-
-@supports not selector(::-webkit-scrollbar) {
-    :root {
-        scrollbar-color: var(--ak-accent) transparent;
-    }
 }
 
 html {

--- a/web/src/common/styles/theme-dark.css
+++ b/web/src/common/styles/theme-dark.css
@@ -23,6 +23,18 @@ body {
     color-scheme: dark;
 }
 
+/* #region Scrollbars */
+
+:root {
+    /**
+     * Scrollbar colors derived from default user agent styles.
+     */
+    --ak-scrollbar-background-color: hsl(0 0% 18%);
+    --ak-scrollbar-thumb-background-color: hsl(0 0% 42%);
+}
+
+/* #endregion */
+
 .pf-c-radio {
     --pf-c-radio__label--Color: var(--ak-dark-foreground);
 }

--- a/web/src/user/index.entrypoint.ts
+++ b/web/src/user/index.entrypoint.ts
@@ -222,16 +222,14 @@ class UserInterfacePresentation extends WithBrandConfig(AKElement) {
                         <div class="pf-c-drawer__main">
                             <div class="pf-c-drawer__content">
                                 <div class="pf-c-drawer__body">
-                                    <div class="pf-c-page__main">
-                                        <ak-router-outlet
-                                            class="pf-l-bullseye__item pf-c-page__main"
-                                            tabindex="-1"
-                                            id="main-content"
-                                            defaultUrl="/library"
-                                            .routes=${ROUTES}
-                                        >
-                                        </ak-router-outlet>
-                                    </div>
+                                    <ak-router-outlet
+                                        class="pf-l-bullseye__item pf-c-page__main"
+                                        tabindex="-1"
+                                        id="main-content"
+                                        defaultUrl="/library"
+                                        .routes=${ROUTES}
+                                    >
+                                    </ak-router-outlet>
                                 </div>
                             </div>
                             <ak-notification-drawer

--- a/web/src/user/user-settings/UserSettingsPage.ts
+++ b/web/src/user/user-settings/UserSettingsPage.ts
@@ -62,15 +62,20 @@ export class UserSettingsPage extends AKElement {
             :host([theme="dark"]) .pf-c-page__main-section {
                 --pf-c-page__main-section--BackgroundColor: transparent;
             }
+
             .pf-c-page__main {
                 min-height: 100vh;
-                overflow-y: auto;
             }
+            .pf-c-page__main,
+            .pf-c-page__main {
+                overflow: unset;
+            }
+
             @media screen and (min-width: 1200px) {
                 :host {
                     width: 90rem;
-                    margin-left: auto;
-                    margin-right: auto;
+                    width: 90rem;
+                    align-self: center;
                 }
             }
         `,


### PR DESCRIPTION
## Details

This PR fixes several layout and accessibility issues that appear in scrollbars across the app such as:

- Significant style variation across browsers and platforms
- Overriding of the user's preferred visual style
- Potential mixing of mixed theme/scheme colors when enforced at the brand level
- Conflicting levels of overflow-y applied to element containers 

## Sample screenshots

### Firefox

<img width="1470" height="746" alt="Screenshot 2025-10-06 at 05 05 44" 
src="https://github.com/user-attachments/assets/054ac02b-fc78-4fb8-a3c0-9cbbc22e91b2" />


#### Visible scrollbars

<img width="1470" height="722" alt="Screenshot 2025-10-06 at 05 06 15" src="https://github.com/user-attachments/assets/c55ef94b-7d51-4ca3-83b8-b2d9283ec1e7" />


### Chromium

<img width="1470" height="782" alt="Screenshot 2025-10-06 at 05 04 35" src="https://github.com/user-attachments/assets/29e93a92-bbab-4fd1-a672-005f27e2b6c8" />

#### Visible scrollbars

<img width="1470" height="746" alt="Screenshot 2025-10-06 at 05 06 32" src="https://github.com/user-attachments/assets/38f2a5c2-0ba4-4307-a6aa-eb6234186060" />

### Edge

<img width="1470" height="777" alt="Screenshot 2025-10-06 at 05 04 06" src="https://github.com/user-attachments/assets/5d799b6e-1333-4072-af53-18b29df9858c" />


### Safari 

<img width="1470" height="579" alt="Screenshot 2025-10-06 at 05 03 39" src="https://github.com/user-attachments/assets/99bd2f66-7e95-499e-a2f5-4d0130c59dcc" />

#### Visible scrollbars
<img width="1470" height="576" alt="Screenshot 2025-10-06 at 05 07 09" src="https://github.com/user-attachments/assets/d1a78b16-4ee3-4505-ab70-6da9bb9f2733" />

