### PR TITLE
web: Fix flow autofocus element targeting.

### DIFF
--- a/web/src/elements/decorators/intersection-observer.ts
+++ b/web/src/elements/decorators/intersection-observer.ts
@@ -1,0 +1,95 @@
+/**
+ * @file Intersection Observer Decorator for LitElement
+ */
+
+import { LitElement } from "lit";
+import { property } from "lit/decorators.js";
+
+/**
+ * Type for the decorator
+ */
+export type IntersectionDecorator = <T extends LitElement>(target: T, propertyKey: keyof T) => void;
+
+/**
+ * A decorator that applies an IntersectionObserver to the element.
+ * This is useful for lazy-loading elements that are not visible on the screen.
+ *
+ * @param init Configuration options for the IntersectionObserver
+ *
+ * ```ts
+ * class MyElement extends LitElement {
+ *     \@intersectionObserver()
+ *     protected visible!: boolean;
+ *
+ *     \@intersectionObserver({ threshold: 0.5, rootMargin: '50px' })
+ *     protected halfVisible!: boolean;
+ *
+ *     render() {
+ *         if (!this.visible) return nothing;
+ *
+ *         return html`
+ *             <div>
+ *                 Content is visible!
+ *                 ${this.halfVisible ? html`<p>More than 50% visible</p>` : ''}
+ *             </div>
+ *         `;
+ *     }
+ * }
+ * ```
+ */
+export function intersectionObserver(init: IntersectionObserverInit = {}): IntersectionDecorator {
+    return <T extends LitElement, K extends keyof T>(target: T, key: K) => {
+        //#region Prepare observer
+
+        property({ attribute: false, useDefault: false })(target, key);
+
+        const observerCallback: IntersectionObserverCallback = (entries) => {
+            for (const entry of entries) {
+                const currentTarget = entry.target as T;
+                const cachedIntersecting = currentTarget[key];
+
+                if (cachedIntersecting !== entry.isIntersecting) {
+                    Object.assign(currentTarget, {
+                        [key]: entry.isIntersecting,
+                    });
+
+                    currentTarget.requestUpdate(key, cachedIntersecting);
+                }
+            }
+        };
+
+        //#endregion
+
+        //#region Lifecycle
+
+        const observer = new IntersectionObserver(observerCallback, {
+            root: null,
+            rootMargin: "0px",
+            threshold: 0,
+            ...init,
+        });
+
+        const { connectedCallback, disconnectedCallback } = target;
+
+        target.connectedCallback = function (this: T) {
+            connectedCallback?.call(this);
+
+            if (this.hasUpdated) {
+                observer.observe(this);
+            } else {
+                this.updateComplete.then(() => {
+                    observer.observe(this);
+                });
+            }
+        };
+
+        target.disconnectedCallback = function (this: LitElement) {
+            disconnectedCallback?.call(this);
+
+            if (observer) {
+                observer.disconnect();
+            }
+        };
+        //#endregion
+    };
+}

--- a/web/src/elements/utils/focus.ts
+++ b/web/src/elements/utils/focus.ts
@@ -48,19 +48,38 @@ export class FocusTarget<T extends HTMLElement = HTMLElement> {
     public focus = (options?: FocusOptions): void => {
         const { target } = this;
 
-        if (!target) return;
-        if (document.activeElement === target) return;
+        if (!target) {
+            console.debug("FocusTarget: Skipping focus, no target", target);
+            return;
+        }
+
+        if (document.activeElement === target) {
+            console.debug("FocusTarget: Target is already focused", target);
+            return;
+        }
 
         // Despite our type definitions, this method isn't available in all browsers,
         // so we fallback to assuming the element is visible.
         const visible = target.checkVisibility?.() ?? true;
 
-        if (!visible) return;
+        if (!visible) {
+            console.debug("FocusTarget: Skipping focus, target is not visible", target);
+            return;
+        }
 
-        target.focus?.(options);
+        if (typeof target.focus !== "function") {
+            console.debug("FocusTarget: Skipping focus, target has no focus method", target);
+            return;
+        }
+
+        target.focus(options);
     };
 
     public toRef() {
         return ref(this.reference);
+    }
+
+    public toEventListener(options?: FocusOptions) {
+        return () => this.focus(options);
     }
 }

--- a/web/src/flow/providers/oauth2/DeviceCode.ts
+++ b/web/src/flow/providers/oauth2/DeviceCode.ts
@@ -1,8 +1,6 @@
 import "#flow/FormStatic";
 import "#flow/components/ak-flow-card";
 
-import { FocusTarget } from "#elements/utils/focus";
-
 import { AKFormErrors } from "#components/ak-field-errors";
 import { AKLabel } from "#components/ak-label";
 
@@ -42,12 +40,6 @@ export class OAuth2DeviceCode extends BaseStage<
         PFInputGroup,
     ];
 
-    #focusTarget = new FocusTarget<HTMLInputElement>();
-
-    protected override firstUpdated(): void {
-        this.#focusTarget.focus();
-    }
-
     render(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>
             <form class="pf-c-form" @submit=${this.submitForm}>
@@ -55,7 +47,7 @@ export class OAuth2DeviceCode extends BaseStage<
                     ${AKLabel({ required: true, htmlFor: "device-code-input" }, msg("Device Code"))}
 
                     <input
-                        ${this.#focusTarget.toRef()}
+                        ${this.autofocusTarget.toRef()}
                         id="device-code-input"
                         type="text"
                         name="code"

--- a/web/src/flow/stages/RedirectStage.ts
+++ b/web/src/flow/stages/RedirectStage.ts
@@ -5,7 +5,7 @@ import { BaseStage } from "#flow/stages/base";
 import { FlowChallengeResponseRequest, RedirectChallenge } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { css, CSSResult, html, TemplateResult } from "lit";
+import { css, CSSResult, html, PropertyValues, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
@@ -41,7 +41,9 @@ export class RedirectStage extends BaseStage<RedirectChallenge, FlowChallengeRes
         return new URL(this.challenge.to, document.baseURI).toString();
     }
 
-    firstUpdated(): void {
+    firstUpdated(changed: PropertyValues<this>): void {
+        super.firstUpdated(changed);
+
         if (this.promptUser) {
             document.addEventListener("keydown", (ev) => {
                 if (ev.key === "Enter") {

--- a/web/src/flow/stages/authenticator_duo/AuthenticatorDuoStage.ts
+++ b/web/src/flow/stages/authenticator_duo/AuthenticatorDuoStage.ts
@@ -32,6 +32,8 @@ export class AuthenticatorDuoStage extends BaseStage<
     static styles: CSSResult[] = [PFBase, PFLogin, PFForm, PFFormControl, PFTitle, PFButton];
 
     updated(changedProperties: PropertyValues<this>) {
+        super.updated(changedProperties);
+
         if (changedProperties.has("challenge") && this.challenge !== undefined) {
             const i = setInterval(() => {
                 this.checkEnrollStatus().then((shouldStop) => {

--- a/web/src/flow/stages/authenticator_totp/AuthenticatorTOTPStage.ts
+++ b/web/src/flow/stages/authenticator_totp/AuthenticatorTOTPStage.ts
@@ -78,6 +78,7 @@ export class AuthenticatorTOTPStage extends BaseStage<
                         <button
                             type="button"
                             class="pf-c-button pf-m-secondary pf-m-progress pf-m-in-progress"
+                            aria-label=${msg("Copy time-based one-time password configuration")}
                             @click=${(e: Event) => {
                                 e.preventDefault();
                                 if (!this.challenge?.configUrl) return;
@@ -104,7 +105,7 @@ export class AuthenticatorTOTPStage extends BaseStage<
                             <span class="pf-c-button__progress"
                                 ><i class="fas fa-copy" aria-hidden="true"></i
                             ></span>
-                            ${msg("Copy")}
+                            ${msg("Copy TOTP Config")}
                         </button>
                     </div>
                 </div>
@@ -114,15 +115,22 @@ export class AuthenticatorTOTPStage extends BaseStage<
                     )}
                 </p>
                 <div class="pf-c-form__group">
-                    ${AKLabel({ required: true, htmlFor: "totp-code-input" }, msg("Code"))}
+                    ${AKLabel(
+                        {
+                            "required": true,
+                            "htmlFor": "totp-code-input",
+                            "aria-label": msg("Time-based one-time password"),
+                        },
+                        msg("TOTP Code"),
+                    )}
                     <input
                         id="totp-code-input"
                         type="text"
                         name="code"
                         inputmode="numeric"
                         pattern="[0-9]*"
-                        placeholder="${msg("Please enter your TOTP Code")}"
-                        autofocus=""
+                        placeholder="${msg("Type your TOTP code...")}"
+                        aria-placeholder=${msg("Type your time-based one-time password code.")}
                         autocomplete="one-time-code"
                         class="pf-c-form-control pf-m-monospace"
                         spellcheck="false"

--- a/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStageCode.ts
+++ b/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStageCode.ts
@@ -1,7 +1,5 @@
 import "#flow/components/ak-flow-card";
 
-import { FocusTarget } from "#elements/utils/focus";
-
 import { AKFormErrors } from "#components/ak-field-errors";
 import { AKLabel } from "#components/ak-label";
 
@@ -39,12 +37,6 @@ export class AuthenticatorValidateStageWebCode extends BaseDeviceStage<
             }
         `,
     ];
-
-    #focusTarget = new FocusTarget<HTMLInputElement>();
-
-    protected override firstUpdated(): void {
-        this.#focusTarget.focus();
-    }
 
     deviceMessage(): string {
         switch (this.deviceChallenge?.deviceClass) {
@@ -95,7 +87,7 @@ export class AuthenticatorValidateStageWebCode extends BaseDeviceStage<
                         : msg("Authentication code"),
                 )}
                 <input
-                    ${this.#focusTarget.toRef()}
+                    ${this.autofocusTarget.toRef()}
                     id="validation-code-input"
                     type="text"
                     name="code"
@@ -107,6 +99,7 @@ export class AuthenticatorValidateStageWebCode extends BaseDeviceStage<
                         : "[0-9]*"}"
                     placeholder="${msg("Please enter your code")}"
                     autofocus
+                    spellcheck="false"
                     autocomplete="one-time-code"
                     class="pf-c-form-control"
                     value="${PasswordManagerPrefill.totp || ""}"

--- a/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStageDuo.ts
+++ b/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStageDuo.ts
@@ -27,6 +27,8 @@ export class AuthenticatorValidateStageWebDuo extends BaseDeviceStage<
     authenticating = false;
 
     updated(changedProperties: PropertyValues<this>) {
+        super.updated(changedProperties);
+
         if (changedProperties.has("challenge") && this.challenge !== undefined) {
             this.authenticating = true;
             this.host

--- a/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStageWebAuthn.ts
+++ b/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStageWebAuthn.ts
@@ -75,6 +75,8 @@ export class AuthenticatorValidateStageWebAuthn extends BaseDeviceStage<
     }
 
     updated(changedProperties: PropertyValues<this>) {
+        super.updated(changedProperties);
+
         if (changedProperties.has("challenge") && this.challenge !== undefined) {
             // convert certain members of the PublicKeyCredentialRequestOptions into
             // byte arrays as expected by the spec.

--- a/web/src/flow/stages/autosubmit/AutosubmitStage.ts
+++ b/web/src/flow/stages/autosubmit/AutosubmitStage.ts
@@ -6,7 +6,7 @@ import { BaseStage } from "#flow/stages/base";
 import { AutosubmitChallenge, AutoSubmitChallengeResponseRequest } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, PropertyValues, TemplateResult } from "lit";
 import { customElement, query } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
@@ -26,7 +26,9 @@ export class AutosubmitStage extends BaseStage<
 
     static styles: CSSResult[] = [PFBase, PFLogin, PFForm, PFFormControl, PFButton, PFTitle];
 
-    updated(): void {
+    updated(changed: PropertyValues<this>): void {
+        super.updated(changed);
+
         if (this.challenge.url !== undefined) {
             this.form?.submit();
         }

--- a/web/src/flow/stages/captcha/CaptchaStage.ts
+++ b/web/src/flow/stages/captcha/CaptchaStage.ts
@@ -315,6 +315,7 @@ export class CaptchaStage extends BaseStage<CaptchaChallenge, CaptchaChallengeRe
         if (this.challenge?.interactive) {
             return html`
                 <iframe
+                    aria-label=${msg("CAPTCHA challenge")}
                     ${ref(this.#iframeRef)}
                     style="height: ${this.iframeHeight}px;"
                     data-ready="${this.#iframeLoaded ? "ready" : "loading"}"
@@ -383,7 +384,9 @@ export class CaptchaStage extends BaseStage<CaptchaChallenge, CaptchaChallengeRe
 
     //#endregion
 
-    public firstUpdated(changedProperties: PropertyValues<this>) {
+    public override firstUpdated(changedProperties: PropertyValues<this>) {
+        super.firstUpdated(changedProperties);
+
         if (!(changedProperties.has("challenge") && typeof this.challenge !== "undefined")) {
             return;
         }
@@ -392,6 +395,8 @@ export class CaptchaStage extends BaseStage<CaptchaChallenge, CaptchaChallengeRe
     }
 
     public updated(changedProperties: PropertyValues<this>) {
+        super.updated(changedProperties);
+
         if (!changedProperties.has("refreshedAt") || !this.challenge) {
             return;
         }

--- a/web/src/flow/stages/identification/IdentificationStage.ts
+++ b/web/src/flow/stages/identification/IdentificationStage.ts
@@ -139,6 +139,8 @@ export class IdentificationStage extends BaseStage<
     //#region Lifecycle
 
     public updated(changedProperties: PropertyValues<this>) {
+        super.updated(changedProperties);
+
         if (changedProperties.has("challenge") && this.challenge !== undefined) {
             this.#autoRedirect();
             this.#createHelperForm();
@@ -378,6 +380,7 @@ export class IdentificationStage extends BaseStage<
                           >
                           </ak-stage-captcha>
                           <input
+                              aria-hidden="true"
                               class="faux-input"
                               ${ref(this.#captchaInputRef)}
                               name="captchaToken"


### PR DESCRIPTION
## Details

This PR refines #16739 with additional autofocus fixes such as when...

- Autofocus is lost after switching tabs
- A stage element intercepts a focus target before rendering completes
- Compatibility mode delays the visibility of nested custom elements between Lit lifecycle callbacks