### PR TITLE
web/a11y: Flow inspector.

### DIFF
--- a/web/src/common/styles/authentik.css
+++ b/web/src/common/styles/authentik.css
@@ -415,6 +415,8 @@ fieldset {
         --ak-legend-margin-inline-end: calc(
             var(--pf-c-card--child--PaddingRight) - var(--ak-legend-padding-inline-base)
         );
+        --pf-c-card--BoxShadow: none;
+        --pf-c-card--BackgroundColor: transparent;
     }
 
     &.pf-c-card,
@@ -440,6 +442,16 @@ fieldset {
         border-block-end: none;
     }
 }
+
+/* #endregion */
+
+/* #region Notifications */
+
+.pf-c-notification-drawer {
+    --pf-c-notification-drawer--BackgroundColor: var(--pf-global--BackgroundColor--150);
+}
+
+/* #endregion */
 
 /* #region Switch  */
 .pf-c-switch {

--- a/web/src/common/styles/authentik.css
+++ b/web/src/common/styles/authentik.css
@@ -372,6 +372,14 @@ ak-tabs[vertical] {
 
 /* #region Fields */
 
+fieldset.pf-c-card {
+    & > legend.pf-c-card__title {
+        padding: 0.5em;
+        margin-inline-start: calc(var(--pf-c-card--child--PaddingLeft) - 0.5em);
+        margin-inline-end: calc(var(--pf-c-card--child--PaddingRight) - 0.5em);
+    }
+}
+
 fieldset[name="actions"] {
     border: none;
     display: flex;

--- a/web/src/common/styles/authentik.css
+++ b/web/src/common/styles/authentik.css
@@ -372,18 +372,73 @@ ak-tabs[vertical] {
 
 /* #region Fields */
 
-fieldset.pf-c-card {
-    & > legend.pf-c-card__title {
-        padding: 0.5em;
-        margin-inline-start: calc(var(--pf-c-card--child--PaddingLeft) - 0.5em);
-        margin-inline-end: calc(var(--pf-c-card--child--PaddingRight) - 0.5em);
-    }
-}
+fieldset {
+    --ak-fieldset-border-width: thin;
+    --ak-fieldset-border-color: var(--pf-global--BackgroundColor--light-100);
+    --ak-legend-margin-inline-base: var(--pf-global--spacer--sm);
+    --ak-legend-padding-inline-base: var(--pf-global--spacer--sm);
 
-fieldset[name="actions"] {
-    border: none;
-    display: flex;
-    gap: var(--pf-global--spacer--sm);
+    border-color: var(--ak-fieldset-border-color);
+    border-width: var(--ak-fieldset-border-width);
+
+    padding: var(--ak-legend-padding-inline-base) !important;
+
+    @media (prefers-contrast: more) {
+        --ak-fieldset-border-color: var(--pf-global--BorderColor--200);
+    }
+
+    @media (prefers-contrast: less) {
+        --ak-fieldset-border-color: transparent;
+    }
+
+    & > legend {
+        line-height: 1;
+        padding: var(--ak-legend-padding-inline-base) !important;
+        margin-inline-start: var(
+            --ak-legend-margin-inline-start,
+            var(--ak-legend-margin-inline-base)
+        ) !important;
+        margin-inline-end: var(
+            --ak-legend-margin-inline-end,
+            var(--ak-legend-margin-inline-base)
+        ) !important;
+    }
+
+    &:has(legend.sr-only) {
+        border-width: 0;
+    }
+
+    &.pf-c-card {
+        --ak-legend-margin-inline-start: calc(
+            var(--pf-c-card--child--PaddingLeft) - var(--ak-legend-padding-inline-base)
+        );
+        --ak-legend-margin-inline-end: calc(
+            var(--pf-c-card--child--PaddingRight) - var(--ak-legend-padding-inline-base)
+        );
+    }
+
+    &.pf-c-card,
+    &.pf-c-form__group {
+        border-radius: var(--pf-global--BorderRadius--sm);
+    }
+
+    &.pf-c-form__group {
+        display: flex;
+        flex-wrap: wrap;
+
+        &.pf-m-action {
+            gap: var(--pf-global--spacer--md) var(--pf-global--spacer--sm);
+            margin-block-start: 0;
+            margin-block-end: calc(var(--pf-c-form__group--m-action--MarginTop) / 2);
+        }
+    }
+
+    &.pf-c-modal-box__footer {
+        --ak-legend-padding-inline-base: var(--pf-global--spacer--md);
+        padding-block: calc(var(--ak-legend-padding-inline-base) / 2);
+        border-inline: none;
+        border-block-end: none;
+    }
 }
 
 /* #region Switch  */

--- a/web/src/common/styles/theme-dark.css
+++ b/web/src/common/styles/theme-dark.css
@@ -91,6 +91,18 @@ body {
 
 /* #endregion */
 
+/* #region Fields */
+
+fieldset {
+    --ak-fieldset-border-color: var(--pf-global--BackgroundColor--dark-transparent-200);
+
+    @media (prefers-contrast: more) {
+        --ak-fieldset-border-color: var(--pf-global--BorderColor--300);
+    }
+}
+
+/* #endregion */
+
 .pf-c-toolbar {
     --pf-c-toolbar--BackgroundColor: var(--ak-dark-background-light);
 }

--- a/web/src/flow/FlowExecutor.ts
+++ b/web/src/flow/FlowExecutor.ts
@@ -564,7 +564,10 @@ export class FlowExecutor
                             <div class="pf-c-drawer__body">
                                 <div class="pf-c-login ${this.getLayout()}">
                                     <div class="${this.getLayoutClass()}">
-                                        <div class="pf-c-login__main">
+                                        <main
+                                            class="pf-c-login__main"
+                                            aria-label=${msg("Authentication form")}
+                                        >
                                             ${this.loading && this.challenge
                                                 ? html`<ak-loading-overlay></ak-loading-overlay>`
                                                 : nothing}
@@ -574,11 +577,14 @@ export class FlowExecutor
                                                 <img
                                                     src="${themeImage(this.brandingLogo)}"
                                                     alt="${msg("authentik Logo")}"
+                                                    role="presentation"
                                                 />
                                             </div>
                                             ${until(this.renderChallenge())}
-                                        </div>
+                                        </main>
                                         <ak-brand-links
+                                            role="contentinfo"
+                                            aria-label=${msg("Site footer")}
                                             class="pf-c-login__footer"
                                             .links=${this.brandingFooterLinks}
                                         ></ak-brand-links>
@@ -588,6 +594,10 @@ export class FlowExecutor
                         </div>
                         ${this.inspectorAvailable && !this.inspectorOpen
                             ? html`<button
+                                  aria-label=${this.inspectorOpen
+                                      ? msg("Close inspector")
+                                      : msg("Open inspector")}
+                                  aria-expanded=${this.inspectorOpen ? "true" : "false"}
                                   class="inspector-toggle pf-c-button pf-m-primary"
                                   @click=${() => {
                                       this.inspectorOpen = true;

--- a/web/src/flow/FlowInspector.ts
+++ b/web/src/flow/FlowInspector.ts
@@ -21,6 +21,10 @@ import PFProgressStepper from "@patternfly/patternfly/components/ProgressStepper
 import PFStack from "@patternfly/patternfly/layouts/Stack/stack.css";
 import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
+function stringify(obj: unknown): string {
+    return JSON.stringify(obj, null, 4);
+}
+
 @customElement("ak-flow-inspector")
 export class FlowInspector extends AKElement {
     @property()
@@ -42,8 +46,7 @@ export class FlowInspector extends AKElement {
         PFProgressStepper,
         css`
             .pf-c-drawer__body {
-                min-height: 100vh;
-                max-height: 100vh;
+                height: 100dvh;
             }
 
             .pf-c-notification-drawer__body {
@@ -101,8 +104,8 @@ export class FlowInspector extends AKElement {
         return stage;
     }
 
-    renderHeader() {
-        return html` <div class="pf-c-notification-drawer__header">
+    protected renderHeader() {
+        return html`<div class="pf-c-notification-drawer__header">
             <div class="text">
                 <h1 class="pf-c-notification-drawer__header-title">${msg("Flow inspector")}</h1>
             </div>
@@ -128,7 +131,7 @@ export class FlowInspector extends AKElement {
         </div>`;
     }
 
-    renderAccessDenied(): TemplateResult {
+    protected renderAccessDenied(): TemplateResult {
         return html`<aside
             aria-label=${msg("Flow inspector")}
             class="pf-c-drawer__body pf-m-no-padding"
@@ -148,7 +151,135 @@ export class FlowInspector extends AKElement {
         </aside>`;
     }
 
-    render(): TemplateResult {
+    protected renderNextStage({ currentPlan, isCompleted }: FlowInspection): TemplateResult {
+        return html`<fieldset class="pf-c-card">
+            <legend class="pf-c-card__title">${msg("Next stage")}</legend>
+            <div class="pf-c-card__body">
+                <dl class="pf-c-description-list">
+                    <div class="pf-c-description-list__group">
+                        <dt class="pf-c-description-list__term">
+                            <span class="pf-c-description-list__text">${msg("Stage name")}</span>
+                        </dt>
+                        <dd class="pf-c-description-list__description">
+                            <div class="pf-c-description-list__text">
+                                ${currentPlan?.nextPlannedStage?.stageObj?.name || "-"}
+                            </div>
+                        </dd>
+                    </div>
+                    <div class="pf-c-description-list__group">
+                        <dt class="pf-c-description-list__term">
+                            <span class="pf-c-description-list__text">${msg("Stage kind")}</span>
+                        </dt>
+                        <dd class="pf-c-description-list__description">
+                            <div class="pf-c-description-list__text">
+                                ${currentPlan?.nextPlannedStage?.stageObj?.verboseName || "-"}
+                            </div>
+                        </dd>
+                    </div>
+                    <div class="pf-c-description-list__group">
+                        <dt class="pf-c-description-list__term">
+                            <span class="pf-c-description-list__text">${msg("Stage object")}</span>
+                        </dt>
+                        <dd class="pf-c-description-list__description">
+                            ${isCompleted
+                                ? html`<div class="pf-c-description-list__text">
+                                      ${msg("This flow is completed.")}
+                                  </div>`
+                                : html`<ak-expand>
+                                      <pre class="pf-c-description-list__text">
+${stringify(this.getStage(currentPlan?.nextPlannedStage?.stageObj))}</pre
+                                      >
+                                  </ak-expand>`}
+                        </dd>
+                    </div>
+                </dl>
+            </div>
+        </fieldset>`;
+    }
+
+    protected renderPlanHistory({
+        plans,
+        isCompleted,
+        currentPlan,
+    }: FlowInspection): TemplateResult {
+        return html`<fieldset class="pf-c-card">
+            <legend class="pf-c-card__title">${msg("Plan history")}</legend>
+            <div class="pf-c-card__body">
+                <ol class="pf-c-progress-stepper pf-m-vertical">
+                    ${plans.map((plan) => {
+                        return html`<li class="pf-c-progress-stepper__step pf-m-success">
+                            <div class="pf-c-progress-stepper__step-connector">
+                                <span class="pf-c-progress-stepper__step-icon">
+                                    <i class="fas fa-check-circle" aria-hidden="true"></i>
+                                </span>
+                            </div>
+                            <div class="pf-c-progress-stepper__step-main">
+                                <div class="pf-c-progress-stepper__step-title">
+                                    ${plan.currentStage.stageObj?.name}
+                                </div>
+                                <div class="pf-c-progress-stepper__step-description">
+                                    ${plan.currentStage.stageObj?.verboseName}
+                                </div>
+                            </div>
+                        </li> `;
+                    })}
+                    ${currentPlan?.currentStage && !isCompleted
+                        ? html`<li class="pf-c-progress-stepper__step pf-m-current pf-m-info">
+                              <div class="pf-c-progress-stepper__step-connector">
+                                  <span class="pf-c-progress-stepper__step-icon">
+                                      <i
+                                          class="pficon pf-icon-resources-full"
+                                          aria-hidden="true"
+                                      ></i>
+                                  </span>
+                              </div>
+                              <div class="pf-c-progress-stepper__step-main">
+                                  <div class="pf-c-progress-stepper__step-title">
+                                      ${currentPlan?.currentStage?.stageObj?.name}
+                                  </div>
+                                  <div class="pf-c-progress-stepper__step-description">
+                                      ${currentPlan?.currentStage?.stageObj?.verboseName}
+                                  </div>
+                              </div>
+                          </li>`
+                        : nothing}
+                    ${currentPlan?.nextPlannedStage && !isCompleted
+                        ? html`<li class="pf-c-progress-stepper__step pf-m-pending">
+                              <div class="pf-c-progress-stepper__step-connector">
+                                  <span class="pf-c-progress-stepper__step-icon"></span>
+                              </div>
+                              <div class="pf-c-progress-stepper__step-main">
+                                  <div class="pf-c-progress-stepper__step-title">
+                                      ${currentPlan.nextPlannedStage.stageObj?.name}
+                                  </div>
+                                  <div class="pf-c-progress-stepper__step-description">
+                                      ${currentPlan?.nextPlannedStage?.stageObj?.verboseName}
+                                  </div>
+                              </div>
+                          </li>`
+                        : nothing}
+                </ol>
+            </div>
+        </fieldset>`;
+    }
+
+    protected renderCurrentPlan({ currentPlan }: FlowInspection): TemplateResult {
+        return html`<fieldset class="pf-c-card">
+            <legend class="pf-c-card__title">${msg("Current plan context")}</legend>
+            <pre class="pf-c-card__body"><code>${stringify(currentPlan?.planContext)}</code></pre>
+        </fieldset>`;
+    }
+
+    protected renderSession({ currentPlan }: FlowInspection): TemplateResult {
+        return html`<fieldset class="pf-c-card">
+            <legend class="pf-c-card__title">${msg("Session ID")}</legend>
+            <div class="pf-c-card__body">
+                <code class="break"> ${currentPlan?.sessionId} </code>
+            </div>
+        </fieldset>`;
+    }
+
+    protected render(): TemplateResult {
         if (this.error) {
             return this.renderAccessDenied();
         }
@@ -163,8 +294,9 @@ export class FlowInspector extends AKElement {
                     <div class="pf-c-notification-drawer__body"></div>
                     <ak-empty-state loading> </ak-empty-state>
                 </div>
-            </div>`;
+            </aside>`;
         }
+
         return html`<aside
             aria-label=${msg("Flow inspector")}
             class="pf-c-drawer__body pf-m-no-padding"
@@ -173,175 +305,10 @@ export class FlowInspector extends AKElement {
                 ${this.renderHeader()}
                 <div class="pf-c-notification-drawer__body">
                     <div class="pf-l-stack pf-m-gutter">
-                        <div class="pf-l-stack__item">
-                            <fieldset class="pf-c-card">
-                                <legend class="pf-c-card__title">${msg("Next stage")}</legend>
-                                <div class="pf-c-card__body">
-                                    <dl class="pf-c-description-list">
-                                        <div class="pf-c-description-list__group">
-                                            <dt class="pf-c-description-list__term">
-                                                <span class="pf-c-description-list__text"
-                                                    >${msg("Stage name")}</span
-                                                >
-                                            </dt>
-                                            <dd class="pf-c-description-list__description">
-                                                <div class="pf-c-description-list__text">
-                                                    ${this.state.currentPlan?.nextPlannedStage
-                                                        ?.stageObj?.name || "-"}
-                                                </div>
-                                            </dd>
-                                        </div>
-                                        <div class="pf-c-description-list__group">
-                                            <dt class="pf-c-description-list__term">
-                                                <span class="pf-c-description-list__text"
-                                                    >${msg("Stage kind")}</span
-                                                >
-                                            </dt>
-                                            <dd class="pf-c-description-list__description">
-                                                <div class="pf-c-description-list__text">
-                                                    ${this.state.currentPlan?.nextPlannedStage
-                                                        ?.stageObj?.verboseName || "-"}
-                                                </div>
-                                            </dd>
-                                        </div>
-                                        <div class="pf-c-description-list__group">
-                                            <dt class="pf-c-description-list__term">
-                                                <span class="pf-c-description-list__text"
-                                                    >${msg("Stage object")}</span
-                                                >
-                                            </dt>
-                                            <dd class="pf-c-description-list__description">
-                                                ${this.state.isCompleted
-                                                    ? html` <div
-                                                          class="pf-c-description-list__text"
-                                                      >
-                                                          ${msg("This flow is completed.")}
-                                                      </div>`
-                                                    : html`<ak-expand>
-                                                          <pre class="pf-c-description-list__text">
-${JSON.stringify(this.getStage(this.state.currentPlan?.nextPlannedStage?.stageObj), null, 4)}</pre
-                                                          >
-                                                      </ak-expand>`}
-                                            </dd>
-                                        </div>
-                                    </dl>
-                                </div>
-                            </fieldset>
-                        </div>
-                        <div class="pf-l-stack__item">
-                            <fieldset class="pf-c-card">
-                                <legend class="pf-c-card__title">${msg("Plan history")}</legend>
-                                <div class="pf-c-card__body">
-                                    <ol class="pf-c-progress-stepper pf-m-vertical">
-                                        ${this.state.plans.map((plan) => {
-                                            return html`<li
-                                                class="pf-c-progress-stepper__step pf-m-success"
-                                            >
-                                                <div class="pf-c-progress-stepper__step-connector">
-                                                    <span class="pf-c-progress-stepper__step-icon">
-                                                        <i
-                                                            class="fas fa-check-circle"
-                                                            aria-hidden="true"
-                                                        ></i>
-                                                    </span>
-                                                </div>
-                                                <div class="pf-c-progress-stepper__step-main">
-                                                    <div class="pf-c-progress-stepper__step-title">
-                                                        ${plan.currentStage.stageObj?.name}
-                                                    </div>
-                                                    <div
-                                                        class="pf-c-progress-stepper__step-description"
-                                                    >
-                                                        ${plan.currentStage.stageObj?.verboseName}
-                                                    </div>
-                                                </div>
-                                            </li> `;
-                                        })}
-                                        ${this.state.currentPlan?.currentStage &&
-                                        !this.state.isCompleted
-                                            ? html` <li
-                                                  class="pf-c-progress-stepper__step pf-m-current pf-m-info"
-                                              >
-                                                  <div
-                                                      class="pf-c-progress-stepper__step-connector"
-                                                  >
-                                                      <span
-                                                          class="pf-c-progress-stepper__step-icon"
-                                                      >
-                                                          <i
-                                                              class="pficon pf-icon-resources-full"
-                                                              aria-hidden="true"
-                                                          ></i>
-                                                      </span>
-                                                  </div>
-                                                  <div class="pf-c-progress-stepper__step-main">
-                                                      <div
-                                                          class="pf-c-progress-stepper__step-title"
-                                                      >
-                                                          ${this.state.currentPlan?.currentStage
-                                                              ?.stageObj?.name}
-                                                      </div>
-                                                      <div
-                                                          class="pf-c-progress-stepper__step-description"
-                                                      >
-                                                          ${this.state.currentPlan?.currentStage
-                                                              ?.stageObj?.verboseName}
-                                                      </div>
-                                                  </div>
-                                              </li>`
-                                            : nothing}
-                                        ${this.state.currentPlan?.nextPlannedStage &&
-                                        !this.state.isCompleted
-                                            ? html`<li
-                                                  class="pf-c-progress-stepper__step pf-m-pending"
-                                              >
-                                                  <div
-                                                      class="pf-c-progress-stepper__step-connector"
-                                                  >
-                                                      <span
-                                                          class="pf-c-progress-stepper__step-icon"
-                                                      ></span>
-                                                  </div>
-                                                  <div class="pf-c-progress-stepper__step-main">
-                                                      <div
-                                                          class="pf-c-progress-stepper__step-title"
-                                                      >
-                                                          ${this.state.currentPlan.nextPlannedStage
-                                                              .stageObj?.name}
-                                                      </div>
-                                                      <div
-                                                          class="pf-c-progress-stepper__step-description"
-                                                      >
-                                                          ${this.state.currentPlan?.nextPlannedStage
-                                                              ?.stageObj?.verboseName}
-                                                      </div>
-                                                  </div>
-                                              </li>`
-                                            : nothing}
-                                    </ol>
-                                </div>
-                            </fieldset>
-                        </div>
-                        <div class="pf-l-stack__item">
-                            <fieldset class="pf-c-card">
-                                <legend class="pf-c-card__title">
-                                    ${msg("Current plan context")}
-                                </legend>
-                                <div class="pf-c-card__body">
-                                    <pre>
-${JSON.stringify(this.state.currentPlan?.planContext, null, 4)}</pre
-                                    >
-                                </div>
-                            </fieldset>
-                        </div>
-                        <div class="pf-l-stack__item">
-                            <fieldset class="pf-c-card">
-                                <legend class="pf-c-card__title">${msg("Session ID")}</legend>
-                                <div class="pf-c-card__body">
-                                    <code class="break">${this.state.currentPlan?.sessionId}</code>
-                                </div>
-                            </fieldset>
-                        </div>
+                        <div class="pf-l-stack__item">${this.renderNextStage(this.state)}</div>
+                        <div class="pf-l-stack__item">${this.renderPlanHistory(this.state)}</div>
+                        <div class="pf-l-stack__item">${this.renderCurrentPlan(this.state)}</div>
+                        <div class="pf-l-stack__item">${this.renderSession(this.state)}</div>
                     </div>
                 </div>
             </div>

--- a/web/src/flow/FlowInspector.ts
+++ b/web/src/flow/FlowInspector.ts
@@ -45,9 +45,19 @@ export class FlowInspector extends AKElement {
                 min-height: 100vh;
                 max-height: 100vh;
             }
+
+            .pf-c-notification-drawer__body {
+                padding-inline: var(--pf-global--spacer--md);
+
+                .pf-l-stack__item:last-child {
+                    padding-block-end: var(--pf-global--spacer--md);
+                }
+            }
+
             code.break {
                 word-break: break-all;
             }
+
             pre {
                 word-break: break-all;
                 overflow-x: hidden;
@@ -109,7 +119,7 @@ export class FlowInspector extends AKElement {
                         }}
                         class="pf-c-button pf-m-plain"
                         type="button"
-                        aria-label=${msg("Close")}
+                        aria-label=${msg("Close flow inspector")}
                     >
                         <i class="fas fa-times" aria-hidden="true"></i>
                     </button>
@@ -119,7 +129,10 @@ export class FlowInspector extends AKElement {
     }
 
     renderAccessDenied(): TemplateResult {
-        return html`<div class="pf-c-drawer__body pf-m-no-padding">
+        return html`<aside
+            aria-label=${msg("Flow inspector")}
+            class="pf-c-drawer__body pf-m-no-padding"
+        >
             <div class="pf-c-notification-drawer">
                 ${this.renderHeader()}
                 <div class="pf-c-notification-drawer__body">
@@ -132,7 +145,7 @@ export class FlowInspector extends AKElement {
                     </div>
                 </div>
             </div>
-        </div>`;
+        </aside>`;
     }
 
     render(): TemplateResult {
@@ -141,7 +154,10 @@ export class FlowInspector extends AKElement {
         }
         if (!this.state) {
             this.advanceHandler();
-            return html`<div class="pf-c-drawer__body pf-m-no-padding">
+            return html`<aside
+                aria-label=${msg("Flow inspector loading")}
+                class="pf-c-drawer__body pf-m-no-padding"
+            >
                 <div class="pf-c-notification-drawer">
                     ${this.renderHeader()}
                     <div class="pf-c-notification-drawer__body"></div>
@@ -149,16 +165,17 @@ export class FlowInspector extends AKElement {
                 </div>
             </div>`;
         }
-        return html`<div class="pf-c-drawer__body pf-m-no-padding">
+        return html`<aside
+            aria-label=${msg("Flow inspector")}
+            class="pf-c-drawer__body pf-m-no-padding"
+        >
             <div class="pf-c-notification-drawer">
                 ${this.renderHeader()}
                 <div class="pf-c-notification-drawer__body">
                     <div class="pf-l-stack pf-m-gutter">
                         <div class="pf-l-stack__item">
-                            <div class="pf-c-card">
-                                <div class="pf-c-card__header">
-                                    <div class="pf-c-card__title">${msg("Next stage")}</div>
-                                </div>
+                            <fieldset class="pf-c-card">
+                                <legend class="pf-c-card__title">${msg("Next stage")}</legend>
                                 <div class="pf-c-card__body">
                                     <dl class="pf-c-description-list">
                                         <div class="pf-c-description-list__group">
@@ -209,13 +226,11 @@ ${JSON.stringify(this.getStage(this.state.currentPlan?.nextPlannedStage?.stageOb
                                         </div>
                                     </dl>
                                 </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <div class="pf-l-stack__item">
-                            <div class="pf-c-card">
-                                <div class="pf-c-card__header">
-                                    <div class="pf-c-card__title">${msg("Plan history")}</div>
-                                </div>
+                            <fieldset class="pf-c-card">
+                                <legend class="pf-c-card__title">${msg("Plan history")}</legend>
                                 <div class="pf-c-card__body">
                                     <ol class="pf-c-progress-stepper pf-m-vertical">
                                         ${this.state.plans.map((plan) => {
@@ -305,36 +320,32 @@ ${JSON.stringify(this.getStage(this.state.currentPlan?.nextPlannedStage?.stageOb
                                             : nothing}
                                     </ol>
                                 </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <div class="pf-l-stack__item">
-                            <div class="pf-c-card">
-                                <div class="pf-c-card__header">
-                                    <div class="pf-c-card__title">
-                                        ${msg("Current plan context")}
-                                    </div>
-                                </div>
+                            <fieldset class="pf-c-card">
+                                <legend class="pf-c-card__title">
+                                    ${msg("Current plan context")}
+                                </legend>
                                 <div class="pf-c-card__body">
                                     <pre>
 ${JSON.stringify(this.state.currentPlan?.planContext, null, 4)}</pre
                                     >
                                 </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <div class="pf-l-stack__item">
-                            <div class="pf-c-card">
-                                <div class="pf-c-card__header">
-                                    <div class="pf-c-card__title">${msg("Session ID")}</div>
-                                </div>
+                            <fieldset class="pf-c-card">
+                                <legend class="pf-c-card__title">${msg("Session ID")}</legend>
                                 <div class="pf-c-card__body">
                                     <code class="break">${this.state.currentPlan?.sessionId}</code>
                                 </div>
-                            </div>
+                            </fieldset>
                         </div>
                     </div>
                 </div>
             </div>
-        </div>`;
+        </aside>`;
     }
 }
 

--- a/web/src/flow/FormStatic.ts
+++ b/web/src/flow/FormStatic.ts
@@ -1,6 +1,6 @@
 import { AKElement } from "#elements/Base";
 
-import { msg } from "@lit/localize";
+import { msg, str } from "@lit/localize";
 import { css, CSSResult, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
@@ -8,6 +8,9 @@ import PFAvatar from "@patternfly/patternfly/components/Avatar/avatar.css";
 
 @customElement("ak-form-static")
 export class FormStatic extends AKElement {
+    public override role = "banner";
+    public override ariaLabel = msg("User information");
+
     @property()
     userAvatar?: string;
 
@@ -33,7 +36,7 @@ export class FormStatic extends AKElement {
                 display: flex;
                 align-items: center;
                 flex: 1 1 auto;
-                gap: 1rem;
+                gap: var(--pf-global--spacer--md);
             }
 
             .username {
@@ -70,10 +73,10 @@ export class FormStatic extends AKElement {
                     ? html`<img
                           class="pf-c-avatar"
                           src=${this.userAvatar}
-                          alt=${msg("User's avatar")}
+                          alt=${this.user ? msg(str`Avatar for ${this.user}`) : msg("User avatar")}
                       />`
                     : nothing}
-                <div class="username" aria-label=${msg("Username")}>${this.user}</div>
+                <div class="username" aria-description=${msg("Username")}>${this.user}</div>
             </div>
             <div class="links">
                 <slot name="link"></slot>

--- a/web/src/flow/components/ak-brand-footer.ts
+++ b/web/src/flow/components/ak-brand-footer.ts
@@ -32,7 +32,7 @@ export class BrandLinks extends AKElement {
     render() {
         const links = [...(this.links ?? [])];
 
-        return html` <ul class="pf-c-list pf-m-inline">
+        return html` <ul aria-label=${msg("Site links")} class="pf-c-list pf-m-inline">
             ${map(links, (link) => {
                 const children = sanitizeHTML(BrandedHTMLPolicy, link.name);
 

--- a/web/src/flow/components/ak-flow-card.ts
+++ b/web/src/flow/components/ak-flow-card.ts
@@ -22,6 +22,8 @@ import PFBase from "@patternfly/patternfly/patternfly-base.css";
  */
 @customElement("ak-flow-card")
 export class FlowCard extends AKElement {
+    role = "presentation";
+
     @property({ type: Object })
     challenge?: ChallengeTypes;
 
@@ -61,9 +63,7 @@ export class FlowCard extends AKElement {
         } else if (this.challenge?.flowInfo?.title) {
             title = html`<h1 class="pf-c-title pf-m-3xl">${this.challenge.flowInfo.title}</h1>`;
         }
-        return html`${title
-                ? html`<header class="pf-c-login__main-header">${title}</header>`
-                : nothing}
+        return html`${title ? html`<div class="pf-c-login__main-header">${title}</div>` : nothing}
             <div class="pf-c-login__main-body">${inner}</div>
             ${this.hasSlotted("footer") || this.hasSlotted("footer-band")
                 ? html`<footer class="pf-c-login__main-footer">


### PR DESCRIPTION
## Details

This PR adds additional ARIA labeling to the flow-inspector. The current iteration aims to isolate its ARIA tree from Playwright while testing authentication flows.

# ARIA Tree Preview


<img width="1156" height="875" alt="Screenshot 2025-10-06 at 17 27 05" src="https://github.com/user-attachments/assets/51479b19-d995-42d8-be7d-4d0cf9d4b9bb" />
