### PR TITLE
website/integrations: sssd: Updating config template to include default shell

### DIFF
--- a/website/integrations/infrastructure/sssd/index.md
+++ b/website/integrations/infrastructure/sssd/index.md
@@ -85,11 +85,8 @@ ldap_group_name = cn
 ldap_default_bind_dn = cn=${sssd.serviceAccount},ou=users,${ldap.baseDN}
 ldap_default_authtok = ${sssd.serviceAccountToken}
 
-# Authentik doesnt provide a shell by default
-#  This can cause issues with certian applications 
-#  (like XRDP) not having a user's shell returned.
-#  Adjust to a shell present on the system.
-
+# authentik does not define a loginShell attribute by default.
+# Users without an explicit shell setting will be assigned the following default shell:
 default_shell = /bin/sh
 ```
 

--- a/website/integrations/infrastructure/sssd/index.md
+++ b/website/integrations/infrastructure/sssd/index.md
@@ -84,6 +84,13 @@ ldap_group_name = cn
 
 ldap_default_bind_dn = cn=${sssd.serviceAccount},ou=users,${ldap.baseDN}
 ldap_default_authtok = ${sssd.serviceAccountToken}
+
+# Authentik doesnt provide a shell by default
+#  This can cause issues with certian applications 
+#  (like XRDP) not having a user's shell returned.
+#  Adjust to a shell present on the system.
+
+default_shell = /bin/sh
 ```
 
 You should now be able to start sssd; however, the system may not yet be set up to use it. Depending on your platform, you might need to use `authconfig` or `pam-auth-update` to configure your system. See the additional resources section for details.


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details
Updating `sssd.conf` template to suggest `default_shell`. Without this, sssd wont necessarily return a shell for users looked up in Authentik, and cause certain applications (XRDP) to fail in non-obvious ways. 

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
