### PR TITLE
web: Fix behavior for modals configured with closeAfterSuccessfulSubmit

### DIFF
--- a/web/src/admin/property-mappings/PropertyMappingTestForm.ts
+++ b/web/src/admin/property-mappings/PropertyMappingTestForm.ts
@@ -82,6 +82,7 @@ export class PolicyTestForm extends Form<PropertyMappingTestRequest> {
     renderExampleLDAP(): TemplateResult {
         return html`
             <button
+                type="button"
                 class="pf-c-button pf-m-secondary"
                 role="button"
                 @click=${() => {
@@ -105,6 +106,7 @@ export class PolicyTestForm extends Form<PropertyMappingTestRequest> {
                 ${msg("Active Directory User")}
             </button>
             <button
+                type="button"
                 class="pf-c-button pf-m-secondary"
                 role="button"
                 @click=${() => {

--- a/web/src/elements/forms/ModalForm.ts
+++ b/web/src/elements/forms/ModalForm.ts
@@ -92,6 +92,14 @@ export class ModalForm extends ModalButton {
         }
     };
 
+    #refreshListener = (e: Event): void => {
+        // if the modal should stay open after successful submit, prevent EVENT_REFRESH from bubbling
+        // to the parent components (which would cause table refreshes that destroy the modal)
+        if (!this.closeAfterSuccessfulSubmit) {
+            e.stopPropagation();
+        }
+    };
+
     #scrollListener = () => {
         window.dispatchEvent(
             new CustomEvent("scroll", {
@@ -99,6 +107,16 @@ export class ModalForm extends ModalButton {
             }),
         );
     };
+
+    override connectedCallback(): void {
+        super.connectedCallback();
+        this.addEventListener(EVENT_REFRESH, this.#refreshListener);
+    }
+
+    override disconnectedCallback(): void {
+        super.disconnectedCallback();
+        this.removeEventListener(EVENT_REFRESH, this.#refreshListener);
+    }
 
     protected renderModalInner(): TemplateResult {
         return html`${this.loading


### PR DESCRIPTION
when a form inside a modal submits successfully, it dispatches an EVENT_REFRESH event that bubbles up through the DOM. Parent components like TablePage listen for this event to refresh their data. so, when the parent component refreshes/re-renders in response to EVENT_REFRESH, it destroys and recreates the entire row including the modal element and that causes the modal to disappear even though the ModalForm component never explicitly closed it.

closes:  https://github.com/goauthentik/authentik/issues/14321