### PR TITLE
web/a11y: Prefers more field contrast

### DIFF
--- a/web/src/admin/AdminInterface/index.entrypoint.ts
+++ b/web/src/admin/AdminInterface/index.entrypoint.ts
@@ -27,11 +27,12 @@ import { getURLParam, updateURLParams } from "#elements/router/RouteMatch";
 import { PageNavMenuToggle } from "#components/ak-page-navbar";
 
 import type { AboutModal } from "#admin/AdminInterface/AboutModal";
+import Styles from "#admin/AdminInterface/styles.css";
 import { ROUTES } from "#admin/Routes";
 
 import { CapabilitiesEnum, SessionUser, UiThemeEnum } from "@goauthentik/api";
 
-import { css, CSSResult, html, nothing, TemplateResult } from "lit";
+import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, property, query } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 
@@ -78,52 +79,13 @@ export class AdminInterface extends WithCapabilitiesConfig(AuthenticatedInterfac
     //#region Styles
 
     static styles: CSSResult[] = [
+        // ---
         PFBase,
         PFPage,
         PFButton,
         PFDrawer,
         PFNav,
-        // HACK: Fixes Lit Analyzer's outdated parser.
-        (css as typeof css) /*css*/ `
-            .pf-c-page__main {
-                scrollbar-gutter: stable;
-            }
-        `,
-        css`
-            .pf-c-page__main,
-            .pf-c-drawer__content,
-            .pf-c-page__drawer {
-                z-index: auto !important;
-                background-color: transparent;
-            }
-
-            .display-none {
-                display: none;
-            }
-
-            .pf-c-page {
-                background-color: var(--pf-c-page--BackgroundColor) !important;
-            }
-
-            :host([theme="dark"]) {
-                /* Global page background colour */
-                .pf-c-page {
-                    --pf-c-page--BackgroundColor: var(--ak-dark-background);
-                }
-            }
-
-            ak-page-navbar {
-                grid-area: header;
-            }
-
-            .ak-sidebar {
-                grid-area: nav;
-            }
-
-            .pf-c-drawer__panel {
-                z-index: var(--pf-global--ZIndex--xl);
-            }
-        `,
+        Styles,
     ];
 
     //#endregion

--- a/web/src/admin/AdminInterface/index.entrypoint.ts
+++ b/web/src/admin/AdminInterface/index.entrypoint.ts
@@ -83,11 +83,13 @@ export class AdminInterface extends WithCapabilitiesConfig(AuthenticatedInterfac
         PFButton,
         PFDrawer,
         PFNav,
-        css`
+        // HACK: Fixes Lit Analyzer's outdated parser.
+        (css as typeof css) /*css*/ `
             .pf-c-page__main {
                 scrollbar-gutter: stable;
             }
-
+        `,
+        css`
             .pf-c-page__main,
             .pf-c-drawer__content,
             .pf-c-page__drawer {

--- a/web/src/admin/AdminInterface/styles.css
+++ b/web/src/admin/AdminInterface/styles.css
@@ -1,0 +1,37 @@
+.pf-c-page__main {
+    scrollbar-gutter: stable;
+}
+
+.pf-c-page__main,
+.pf-c-drawer__content,
+.pf-c-page__drawer {
+    z-index: auto !important;
+    background-color: transparent;
+}
+
+.display-none {
+    display: none;
+}
+
+.pf-c-page {
+    background-color: var(--pf-c-page--BackgroundColor) !important;
+}
+
+:host([theme="dark"]) {
+    /* Global page background colour */
+    .pf-c-page {
+        --pf-c-page--BackgroundColor: var(--ak-dark-background);
+    }
+}
+
+ak-page-navbar {
+    grid-area: header;
+}
+
+.ak-sidebar {
+    grid-area: nav;
+}
+
+.pf-c-drawer__panel {
+    z-index: var(--pf-global--ZIndex--xl);
+}

--- a/web/src/admin/admin-overview/cards/RecentEventsCard.css
+++ b/web/src/admin/admin-overview/cards/RecentEventsCard.css
@@ -1,0 +1,5 @@
+.pf-c-card__title {
+    --pf-c-card__title--FontFamily: var(--pf-global--FontFamily--heading--sans-serif);
+    --pf-c-card__title--FontSize: var(--pf-global--FontSize--md);
+    --pf-c-card__title--FontWeight: var(--pf-global--FontWeight--bold);
+}

--- a/web/src/admin/admin-overview/cards/RecentEventsCard.ts
+++ b/web/src/admin/admin-overview/cards/RecentEventsCard.ts
@@ -12,12 +12,13 @@ import { actionToLabel } from "#common/labels";
 import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
 import { SlottedTemplateResult } from "#elements/types";
 
+import Styles from "#admin/admin-overview/cards/RecentEventsCard.css";
 import { EventGeo, renderEventUser } from "#admin/events/utils";
 
 import { Event, EventsApi } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { css, CSSResult, html, TemplateResult } from "lit";
+import { CSSResult, html, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import PFCard from "@patternfly/patternfly/components/Card/card.css";
@@ -42,15 +43,10 @@ export class RecentEventsCard extends Table<Event> {
     }
 
     static styles: CSSResult[] = [
+        // ---
         ...super.styles,
         PFCard,
-        css`
-            .pf-c-card__title {
-                --pf-c-card__title--FontFamily: var(--pf-global--FontFamily--heading--sans-serif);
-                --pf-c-card__title--FontSize: var(--pf-global--FontSize--md);
-                --pf-c-card__title--FontWeight: var(--pf-global--FontWeight--bold);
-            }
-        `,
+        Styles,
     ];
 
     protected override rowLabel(item: Event): string {

--- a/web/src/admin/admin-overview/cards/VersionStatusCard.css
+++ b/web/src/admin/admin-overview/cards/VersionStatusCard.css
@@ -1,0 +1,15 @@
+.pf-c-card {
+    container-type: inline-size;
+}
+
+.pf-c-card__title {
+    @container (width < 200px) {
+        font-size: var(--pf-global--FontSize--sm);
+    }
+}
+
+.status-container {
+    @container (width < 200px) {
+        font-size: var(--pf-global--icon--FontSize--md);
+    }
+}

--- a/web/src/admin/admin-overview/cards/VersionStatusCard.ts
+++ b/web/src/admin/admin-overview/cards/VersionStatusCard.ts
@@ -1,39 +1,20 @@
 import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { AdminStatus, AdminStatusCard } from "#admin/admin-overview/cards/AdminStatusCard";
+import Styles from "#admin/admin-overview/cards/VersionStatusCard.css";
 
 import { AdminApi, Version } from "@goauthentik/api";
 
 import { msg, str } from "@lit/localize";
-import { css, html, TemplateResult } from "lit";
+import { html, TemplateResult } from "lit";
 import { customElement } from "lit/decorators.js";
 
 @customElement("ak-admin-status-version")
 export class VersionStatusCard extends AdminStatusCard<Version> {
+    public static styles = [...super.styles, Styles];
+
     public override icon = "pf-icon pf-icon-bundle";
     public override label = msg("Version");
-
-    static styles = [
-        ...super.styles,
-        // HACK: Fixes Lit Analyzer's outdated parser.
-        (css as typeof css) /*css*/ `
-            .pf-c-card {
-                container-type: inline-size;
-            }
-
-            .pf-c-card__title {
-                @container (width < 200px) {
-                    font-size: var(--pf-global--FontSize--sm);
-                }
-            }
-
-            .status-container {
-                @container (width < 200px) {
-                    font-size: var(--pf-global--icon--FontSize--md);
-                }
-            }
-        `,
-    ];
 
     getPrimaryValue(): Promise<Version> {
         return new AdminApi(DEFAULT_CONFIG).adminVersionRetrieve();

--- a/web/src/admin/providers/ldap/LDAPProviderFormForm.ts
+++ b/web/src/admin/providers/ldap/LDAPProviderFormForm.ts
@@ -52,7 +52,8 @@ export function renderForm({ provider = {}, errors = {}, brand }: LDAPProviderFo
     return html`
         <ak-text-input
             name="name"
-            placeholder=${msg("Provider name...")}
+            placeholder=${msg("Type a provider name...")}
+            autocomplete="off"
             value=${ifDefined(provider.name)}
             label=${msg("Name")}
             .errorMessages=${errors.name}

--- a/web/src/admin/providers/oauth2/OAuth2ProviderFormForm.ts
+++ b/web/src/admin/providers/oauth2/OAuth2ProviderFormForm.ts
@@ -149,7 +149,8 @@ export function renderForm({
 }: OAuth2ProviderFormProps) {
     return html` <ak-text-input
             name="name"
-            placeholder=${msg("Provider name...")}
+            placeholder=${msg("Type a provider name...")}
+            autocomplete="off"
             label=${msg("Provider Name")}
             value=${ifDefined(provider.name)}
             .errorMessages=${errors.name}
@@ -231,6 +232,7 @@ export function renderForm({
                     name="logoutUri"
                     value="${provider?.logoutUri ?? ""}"
                     input-hint="code"
+                    inputmode="url"
                     placeholder="https://..."
                     .help=${msg(
                         "URI to send logout notifications to when users log out. Required for OpenID Connect Logout functionality.",

--- a/web/src/admin/providers/radius/RadiusProviderFormForm.ts
+++ b/web/src/admin/providers/radius/RadiusProviderFormForm.ts
@@ -51,7 +51,8 @@ export function renderForm({ provider = {}, errors = {}, brand }: RADIUSProvider
         <ak-text-input
             name="name"
             label=${msg("Provider Name")}
-            placeholder=${msg("Provider name...")}
+            placeholder=${msg("Type a provider name...")}
+            autocomplete="off"
             value=${ifDefined(provider.name)}
             .errorMessages=${errors.name}
             required

--- a/web/src/common/styles/authentik.css
+++ b/web/src/common/styles/authentik.css
@@ -226,8 +226,28 @@ html > form > input {
 /* #region Form controls */
 
 .pf-c-form-control {
-    --pf-c-form-control--readonly--BackgroundColor: var(--pf-global--BackgroundColor--200);
-    --pf-c-form-control--disabled--BackgroundColor: var(--pf-global--BackgroundColor--200);
+    /* !important is required to ensure priority when in compatibility mode. */
+
+    --pf-c-form-control--readonly--BackgroundColor: var(
+        --pf-global--BackgroundColor--200
+    ) !important;
+    --pf-c-form-control--disabled--BackgroundColor: var(
+        --pf-global--BackgroundColor--200
+    ) !important;
+
+    --pf-c-form-control--BorderTopColor: transparent !important;
+    --pf-c-form-control--BorderRightColor: transparent !important;
+    --pf-c-form-control--BorderLeftColor: transparent !important;
+
+    --pf-c-form-control--Color: FieldText !important;
+    --pf-c-form-control--BackgroundColor: transparent !important;
+
+    @media (prefers-contrast: more) {
+        --pf-c-text-input-group--placeholder--Color: GrayText !important;
+        --pf-c-form-control--placeholder--Color: GrayText !important;
+
+        --pf-c-form-control--BackgroundColor: Field !important;
+    }
 
     /* #region Caps Lock */
 
@@ -240,6 +260,33 @@ html > form > input {
     }
 
     /* #endregion */
+}
+
+input.pf-c-form-control {
+    &[type="text"],
+    &[type="email"],
+    &[type="password"],
+    &[type="search"],
+    textarea {
+        @media not (prefers-contrast: more) {
+            border-inline: 0;
+            border-block-start-color: transparent;
+        }
+
+        @media (prefers-contrast: more) {
+            border: 1px solid ButtonBorder !important;
+
+            &:focus {
+                border: 1px solid Highlight !important;
+            }
+        }
+    }
+}
+
+@media (prefers-contrast: less) {
+    input {
+        outline: none !important;
+    }
 }
 
 /* #region Buttons */

--- a/web/src/common/styles/authentik.css
+++ b/web/src/common/styles/authentik.css
@@ -225,6 +225,22 @@ html > form > input {
 
 /* #region Form controls */
 
+/* TODO: Move after PF5 */
+
+:root {
+    --ak-c-form-control-BackgroundColor: transparent;
+    --ak-c-form-control-BackgroundColor--hover: color-mix(in srgb, transparent 100%, Field 50%);
+    --ak-c-form-control-BackgroundColor--focus: color-mix(in srgb, transparent 100%, Field 75%);
+}
+
+@media (prefers-contrast: more) {
+    :root {
+        --ak-c-form-control-BackgroundColor: color-mix(in srgb, transparent 100%, Field 50%);
+        --ak-c-form-control-BackgroundColor--hover: color-mix(in srgb, transparent 100%, Field 75%);
+        --ak-c-form-control-BackgroundColor--focus: Field;
+    }
+}
+
 .pf-c-form-control {
     /* !important is required to ensure priority when in compatibility mode. */
 
@@ -235,18 +251,36 @@ html > form > input {
         --pf-global--BackgroundColor--200
     ) !important;
 
-    --pf-c-form-control--BorderTopColor: transparent !important;
-    --pf-c-form-control--BorderRightColor: transparent !important;
-    --pf-c-form-control--BorderLeftColor: transparent !important;
+    --pf-c-form-control--BorderTopColor: transparent;
+    --pf-c-form-control--BorderRightColor: transparent;
+    --pf-c-form-control--BorderLeftColor: transparent;
 
     --pf-c-form-control--Color: FieldText !important;
-    --pf-c-form-control--BackgroundColor: transparent !important;
+    --pf-c-form-control--BackgroundColor: var(--ak-c-form-control-BackgroundColor) !important;
+
+    &:hover {
+        --pf-c-form-control--BackgroundColor: var(
+            --ak-c-form-control-BackgroundColor--hover
+        ) !important;
+    }
+
+    &:focus {
+        --pf-c-form-control--BackgroundColor: var(
+            --ak-c-form-control-BackgroundColor--focus
+        ) !important;
+
+        @media not (prefers-contrast: more) {
+            outline: none;
+        }
+
+        @media (prefers-contrast: more) {
+            outline-offset: 0.25em;
+        }
+    }
 
     @media (prefers-contrast: more) {
-        --pf-c-text-input-group--placeholder--Color: GrayText !important;
-        --pf-c-form-control--placeholder--Color: GrayText !important;
-
-        --pf-c-form-control--BackgroundColor: Field !important;
+        --pf-c-text-input-group--placeholder--Color: GrayText;
+        --pf-c-form-control--placeholder--Color: GrayText;
     }
 
     /* #region Caps Lock */
@@ -289,10 +323,43 @@ input.pf-c-form-control {
     }
 }
 
+.pf-c-input-group {
+    --pf-c-input-group--BackgroundColor: transparent !important;
+}
+
 /* #region Buttons */
 
 .pf-c-button {
     --pf-c-button--disabled--BackgroundColor: var(--pf-global--Color--light-200);
+}
+
+/* #endregion */
+
+/* #region Select */
+
+.pf-c-select {
+    --pf-c-select__toggle--BackgroundColor: transparent;
+    --pf-c-select__toggle-typeahead--BackgroundColor: var(--ak-c-form-control-BackgroundColor);
+}
+
+.pf-c-select__toggle-typeahead {
+    &:hover {
+        --pf-c-select__toggle-typeahead--BackgroundColor: var(
+            --ak-c-form-control-BackgroundColor--hover
+        );
+    }
+
+    &:focus {
+        --pf-c-select__toggle-typeahead--BackgroundColor: var(
+            --ak-c-form-control-BackgroundColor--focus
+        );
+    }
+}
+
+.pf-c-select__toggle::before {
+    --pf-c-select__toggle--before--BorderTopColor: transparent;
+    --pf-c-select__toggle--before--BorderRightColor: transparent;
+    --pf-c-select__toggle--before--BorderLeftColor: transparent;
 }
 
 /* #endregion */
@@ -570,7 +637,23 @@ fieldset {
 
 /* #endregion */
 
-/* #region Switch  */
+/* #region Radio */
+
+.pf-c-radio {
+    cursor: pointer;
+    user-select: none;
+    --pf-c-radio__label--Color: FieldText;
+    --pf-c-radio__description--Color: GrayText;
+
+    @media (prefers-contrast: more) {
+        --pf-c-radio__description--Color: color-mix(in srgb, GrayText 100%, FieldText 75%);
+    }
+}
+
+/* #endregion */
+
+/* #region Switch */
+
 .pf-c-switch {
     --pf-c-switch__input--focus__toggle--OutlineWidth: 0;
 
@@ -599,7 +682,7 @@ fieldset {
 .pf-m-monospace {
     font-family: var(--pf-global--FontFamily--monospace);
 
-    &::placeholder {
+    &:not([inputmode="url"])::placeholder {
         font-family: var(--pf-global--FontFamily--sans-serif);
     }
 }

--- a/web/src/common/styles/theme-dark.css
+++ b/web/src/common/styles/theme-dark.css
@@ -319,6 +319,7 @@ select.pf-c-form-control {
 .pf-c-dropdown__toggle::before {
     border-color: transparent;
 }
+
 .pf-c-dropdown__menu {
     --pf-c-dropdown__menu--BackgroundColor: var(--pf-global--BackgroundColor--dark-100);
     --pf-c-dropdown__menu-item--Color: var(--pf-global--Color--light-100);

--- a/web/src/common/styles/theme-dark.css
+++ b/web/src/common/styles/theme-dark.css
@@ -223,13 +223,7 @@ select.pf-c-form-control {
 
 .pf-c-form-control {
     /* !important is required to ensure priority when in compatibility mode. */
-
-    --pf-c-form-control--BorderTopColor: transparent !important;
-    --pf-c-form-control--BorderRightColor: transparent !important;
-    --pf-c-form-control--BorderLeftColor: transparent !important;
-    --pf-global--BackgroundColor--100: var(--ak-dark-background-light) !important;
-    --pf-c-form-control--BackgroundColor: var(--ak-dark-background-light) !important;
-    --pf-c-form-control--Color: var(--ak-dark-foreground) !important;
+    /* --pf-global--BackgroundColor--100: var(--ak-dark-background-light) !important; */
 
     --pf-c-form-control--readonly--BackgroundColor: var(--ak-dark-background-light) !important;
     --pf-c-form-control--disabled--BackgroundColor: var(--ak-dark-background-light) !important;
@@ -253,7 +247,7 @@ select.pf-c-form-control {
 }
 
 .pf-c-select__toggle.pf-m-typeahead {
-    --pf-c-select__toggle--BackgroundColor: var(--ak-dark-background-light);
+    --pf-c-select__toggle--BackgroundColor: Field;
 }
 
 .pf-c-select__menu {

--- a/web/src/common/styles/theme-dark.css
+++ b/web/src/common/styles/theme-dark.css
@@ -223,7 +223,6 @@ select.pf-c-form-control {
 
 .pf-c-form-control {
     /* !important is required to ensure priority when in compatibility mode. */
-    /* --pf-global--BackgroundColor--100: var(--ak-dark-background-light) !important; */
 
     --pf-c-form-control--readonly--BackgroundColor: var(--ak-dark-background-light) !important;
     --pf-c-form-control--disabled--BackgroundColor: var(--ak-dark-background-light) !important;

--- a/web/src/common/styles/theme-dark.css
+++ b/web/src/common/styles/theme-dark.css
@@ -35,10 +35,6 @@ body {
 
 /* #endregion */
 
-.pf-c-radio {
-    --pf-c-radio__label--Color: var(--ak-dark-foreground);
-}
-
 /* Global page background colour */
 .pf-c-page {
     --pf-c-page--BackgroundColor: var(--ak-dark-background);
@@ -213,10 +209,6 @@ select[multiple] option:checked {
     color: var(--ak-dark-background);
 }
 
-.pf-c-input-group {
-    --pf-c-input-group--BackgroundColor: transparent;
-}
-
 select.pf-c-form-control {
     --pf-c-form-control__select--BackgroundUrl: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 320 512'%3E%3Cpath fill='%23fafafa' d='M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z'/%3E%3C/svg%3E");
 }
@@ -238,16 +230,7 @@ select.pf-c-form-control {
 
 /* #endregion */
 
-/* select toggle */
-.pf-c-select__toggle::before {
-    --pf-c-select__toggle--before--BorderTopColor: var(--ak-dark-background-lighter);
-    --pf-c-select__toggle--before--BorderRightColor: var(--ak-dark-background-lighter);
-    --pf-c-select__toggle--before--BorderLeftColor: var(--ak-dark-background-lighter);
-}
-
-.pf-c-select__toggle.pf-m-typeahead {
-    --pf-c-select__toggle--BackgroundColor: Field;
-}
+/* #region Select */
 
 .pf-c-select__menu {
     --pf-c-select__menu--BackgroundColor: var(--ak-dark-background-light-ish);

--- a/web/src/components/ak-hidden-text-input.ts
+++ b/web/src/components/ak-hidden-text-input.ts
@@ -133,7 +133,7 @@ export class AkHiddenTextInput<T extends InputLike = HTMLInputElement>
             this.value = (ev.target as T).value;
         };
 
-        return html` <div style="display: flex; gap: 0.25rem">
+        return html`<div style="display: flex;" part="control">
             ${this.renderInputField(setValue, code)}
             <ak-visibility-toggle
                 part="toggle"

--- a/web/src/components/ak-search-ql/index.ts
+++ b/web/src/components/ak-search-ql/index.ts
@@ -7,10 +7,12 @@ import { FormAssociated, FormAssociatedElement } from "#elements/forms/form-asso
 import { PaginatedResponse } from "#elements/table/Table";
 import { ifPresent } from "#elements/utils/attributes";
 
+import Styles from "#components/ak-search-ql/styles.css";
+
 import DjangoQL, { Introspections } from "@mrmarble/djangoql-completion";
 
 import { msg } from "@lit/localize";
-import { css, CSSResult, html, LitElement, nothing, PropertyValues, TemplateResult } from "lit";
+import { CSSResult, html, LitElement, nothing, PropertyValues, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { createRef, ref, Ref } from "lit/directives/ref.js";
@@ -52,82 +54,11 @@ export class QLSearch extends FormAssociatedElement<string> implements FormAssoc
     declare anchor: HTMLTextAreaElement | null;
 
     public static styles: CSSResult[] = [
+        // ---
         PFBase,
         PFFormControl,
         PFSearchInput,
-        css`
-            .ql.pf-c-form-control {
-                --input-height: 2.25em;
-
-                height: var(--input-height);
-                min-height: var(--input-height);
-                max-height: calc(var(--input-height) * 6);
-                resize: vertical;
-                outline: none;
-            }
-
-            .pf-c-search-input[aria-expanded="true"] {
-                .ql.pf-c-form-control {
-                    --pf-c-form-control--BorderBottomColor: var(
-                        --pf-c-form-control--focus--BorderBottomColor
-                    );
-                }
-                .pf-c-search-input__text::after {
-                    --pf-c-search-input__text--after--BorderBottomWidth: var(
-                        --pf-c-search-input__text--focus-within--after--BorderBottomWidth
-                    );
-                    --pf-c-search-input__text--after--BorderBottomColor: var(
-                        --pf-c-search-input__text--focus-within--after--BorderBottomColor
-                    );
-                }
-            }
-
-            .selected {
-                background-color: var(--pf-c-search-input__menu-item--hover--BackgroundColor);
-            }
-
-            .pf-c-search-input__menu-list {
-                user-select: none;
-            }
-
-            :host([theme="dark"]) {
-                .pf-c-search-input__menu {
-                    --pf-c-search-input__menu--BackgroundColor: var(--ak-dark-background-light-ish);
-                    color: var(--ak-dark-foreground);
-                }
-
-                .pf-c-search-input__menu-item {
-                    --pf-c-search-input__menu-item--Color: var(--ak-dark-foreground);
-                }
-
-                .pf-c-search-input__menu-item:hover {
-                    --pf-c-search-input__menu-item--BackgroundColor: var(
-                        --ak-dark-background-lighter
-                    );
-                }
-
-                .pf-c-search-input__menu-list-item.selected {
-                    --pf-c-search-input__menu-item--hover--BackgroundColor: var(
-                        --ak-dark-background-light
-                    );
-                }
-            }
-
-            .pf-c-search-input__menu {
-                position: fixed;
-                min-width: 0;
-                overflow-y: auto;
-                max-height: 50vh;
-            }
-        `,
-        // HACK: Fixes Lit Analyzer's outdated parser.
-        (css as typeof css) /*css*/ `
-            @media not (prefers-contrast: more) {
-                .pf-c-search-input__text::before {
-                    border: none;
-                }
-            }
-        `,
+        Styles,
     ];
 
     //#region Properties

--- a/web/src/components/ak-search-ql/index.ts
+++ b/web/src/components/ak-search-ql/index.ts
@@ -66,6 +66,12 @@ export class QLSearch extends FormAssociatedElement<string> implements FormAssoc
                 outline: none;
             }
 
+            @media not (prefers-contrast: more) {
+                .pf-c-search-input__text::before {
+                    border: none;
+                }
+            }
+
             .pf-c-search-input[aria-expanded="true"] {
                 .ql.pf-c-form-control {
                     --pf-c-form-control--BorderBottomColor: var(
@@ -110,10 +116,6 @@ export class QLSearch extends FormAssociatedElement<string> implements FormAssoc
                     --pf-c-search-input__menu-item--hover--BackgroundColor: var(
                         --ak-dark-background-light
                     );
-                }
-
-                .pf-c-search-input__text::before {
-                    border: 0;
                 }
             }
 

--- a/web/src/components/ak-search-ql/index.ts
+++ b/web/src/components/ak-search-ql/index.ts
@@ -66,12 +66,6 @@ export class QLSearch extends FormAssociatedElement<string> implements FormAssoc
                 outline: none;
             }
 
-            @media not (prefers-contrast: more) {
-                .pf-c-search-input__text::before {
-                    border: none;
-                }
-            }
-
             .pf-c-search-input[aria-expanded="true"] {
                 .ql.pf-c-form-control {
                     --pf-c-form-control--BorderBottomColor: var(
@@ -124,6 +118,14 @@ export class QLSearch extends FormAssociatedElement<string> implements FormAssoc
                 min-width: 0;
                 overflow-y: auto;
                 max-height: 50vh;
+            }
+        `,
+        // HACK: Fixes Lit Analyzer's outdated parser.
+        (css as typeof css) /*css*/ `
+            @media not (prefers-contrast: more) {
+                .pf-c-search-input__text::before {
+                    border: none;
+                }
             }
         `,
     ];

--- a/web/src/components/ak-search-ql/styles.css
+++ b/web/src/components/ak-search-ql/styles.css
@@ -1,0 +1,63 @@
+.ql.pf-c-form-control {
+    --input-height: 2.25em;
+
+    height: var(--input-height);
+    min-height: var(--input-height);
+    max-height: calc(var(--input-height) * 6);
+    resize: vertical;
+    outline: none;
+}
+
+.pf-c-search-input[aria-expanded="true"] {
+    .ql.pf-c-form-control {
+        --pf-c-form-control--BorderBottomColor: var(--pf-c-form-control--focus--BorderBottomColor);
+    }
+    .pf-c-search-input__text::after {
+        --pf-c-search-input__text--after--BorderBottomWidth: var(
+            --pf-c-search-input__text--focus-within--after--BorderBottomWidth
+        );
+        --pf-c-search-input__text--after--BorderBottomColor: var(
+            --pf-c-search-input__text--focus-within--after--BorderBottomColor
+        );
+    }
+}
+
+.selected {
+    background-color: var(--pf-c-search-input__menu-item--hover--BackgroundColor);
+}
+
+.pf-c-search-input__menu-list {
+    user-select: none;
+}
+
+:host([theme="dark"]) {
+    .pf-c-search-input__menu {
+        --pf-c-search-input__menu--BackgroundColor: var(--ak-dark-background-light-ish);
+        color: var(--ak-dark-foreground);
+    }
+
+    .pf-c-search-input__menu-item {
+        --pf-c-search-input__menu-item--Color: var(--ak-dark-foreground);
+    }
+
+    .pf-c-search-input__menu-item:hover {
+        --pf-c-search-input__menu-item--BackgroundColor: var(--ak-dark-background-lighter);
+    }
+
+    .pf-c-search-input__menu-list-item.selected {
+        --pf-c-search-input__menu-item--hover--BackgroundColor: var(--ak-dark-background-light);
+    }
+}
+
+.pf-c-search-input__menu {
+    position: fixed;
+    min-width: 0;
+    overflow-y: auto;
+    max-height: 50vh;
+}
+
+@media not (prefers-contrast: more) {
+    .pf-c-search-input__text::before {
+        border: none;
+    }
+}

--- a/web/src/components/ak-text-input.ts
+++ b/web/src/components/ak-text-input.ts
@@ -52,6 +52,7 @@ export class AkTextInput extends HorizontalLightComponent<string> {
             spellcheck=${ifPresent(code ? "false" : this.spellcheck)}
             aria-describedby=${this.helpID}
             placeholder=${ifPresent(this.placeholder)}
+            inputmode=${ifPresent(this.inputMode)}
             ?required=${this.required}
         />`;
     }

--- a/web/src/elements/ak-mdx/ak-mdx.tsx
+++ b/web/src/elements/ak-mdx/ak-mdx.tsx
@@ -57,13 +57,15 @@ export type Replacer = (input: string) => string;
 
 @customElement("ak-mdx")
 export class AKMDX extends AKElement {
-    @property({ type: String, reflect: true })
+    // HACK: Fixes Lit Analyzer's parsing of TSX files with decorators.
+
+    @((property as typeof property)({ type: String, reflect: true }))
     public url?: string;
 
-    @property()
+    @((property as typeof property)())
     public content?: string;
 
-    @property({ attribute: false })
+    @((property as typeof property)({ attribute: false }))
     public replacers: Replacer[] = [];
 
     #reactRoot: Root | null = null;

--- a/web/src/elements/ak-mdx/ak-mdx.tsx
+++ b/web/src/elements/ak-mdx/ak-mdx.tsx
@@ -9,6 +9,7 @@ import { fetchMDXModule, MDXModuleContext } from "#elements/ak-mdx/MDXModuleCont
 import { remarkAdmonition } from "#elements/ak-mdx/remark/remark-admonition";
 import { remarkHeadings } from "#elements/ak-mdx/remark/remark-headings";
 import { remarkLists } from "#elements/ak-mdx/remark/remark-lists";
+import Styles from "#elements/ak-mdx/styles.css";
 import { AKElement } from "#elements/Base";
 
 import { DistDirectoryName, StaticDirectoryName } from "#paths";
@@ -32,7 +33,6 @@ import remarkMdxFrontmatter from "remark-mdx-frontmatter";
 import remarkParse from "remark-parse";
 import type { MDXModule } from "~docs/types";
 
-import { css } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import PFContent from "@patternfly/patternfly/components/Content/content.css";
@@ -71,94 +71,13 @@ export class AKMDX extends AKElement {
     #reactRoot: Root | null = null;
 
     static styles = [
+        // ---
         PFBase,
         PFList,
         PFTable,
         PFContent,
         OneDark,
-        css`
-            :host {
-                --ak-mermaid-message-text: var(--pf-c-content--Color);
-                --ak-table-stripe-background: var(--pf-global--BackgroundColor--light-200);
-            }
-
-            :host([theme="dark"]) {
-                --ak-mermaid-message-text: var(--ak-dark-foreground);
-                --ak-mermaid-box-background-color: var(--ak-dark-background-lighter);
-                --ak-table-stripe-background: var(--pf-global--BackgroundColor--dark-200);
-            }
-
-            ak-alert + p {
-                margin-block-start: var(--pf-global--spacer--md);
-            }
-
-            a {
-                --pf-global--link--Color: var(--pf-global--link--Color--light);
-                --pf-global--link--Color--hover: var(--pf-global--link--Color--light--hover);
-                --pf-global--link--Color--visited: var(--pf-global--link--Color);
-            }
-
-            /*
-            Note that order of anchor pseudo-selectors must follow:
-                1. link
-                2. visited
-                3. hover
-                4. active
-            */
-            a:link {
-                color: var(--pf-global--link--Color);
-            }
-
-            a:visited {
-                color: var(--pf-global--link--Color--visited);
-            }
-
-            a:hover {
-                color: var(--pf-global--link--Color--hover);
-            }
-
-            a:active {
-                color: var(--pf-global--link--Color);
-            }
-
-            h2:first-of-type {
-                margin-top: 0;
-            }
-
-            table thead,
-            table tr:nth-child(2n) {
-                background-color: var(--ak-table-stripe-background,);
-            }
-
-            table td,
-            table th {
-                border: var(--pf-table-border-width) solid var(--ifm-table-border-color);
-                padding: var(--pf-global--spacer--md);
-            }
-
-            pre {
-                overflow-x: auto;
-            }
-
-            pre:has(.hljs) {
-                padding: var(--pf-global--spacer--md);
-            }
-
-            svg[id^="mermaid-svg-"] {
-                .rect {
-                    fill: var(
-                        --ak-mermaid-box-background-color,
-                        var(--pf-global--BackgroundColor--light-300)
-                    ) !important;
-                }
-
-                .messageText {
-                    stroke-width: 4;
-                    fill: var(--ak-mermaid-message-text) !important;
-                    paint-order: stroke;
-                }
-            }
-        `,
+        Styles,
     ];
 
     public async connectedCallback() {

--- a/web/src/elements/ak-mdx/styles.css
+++ b/web/src/elements/ak-mdx/styles.css
@@ -1,0 +1,81 @@
+:host {
+    --ak-mermaid-message-text: var(--pf-c-content--Color);
+    --ak-table-stripe-background: var(--pf-global--BackgroundColor--light-200);
+}
+
+:host([theme="dark"]) {
+    --ak-mermaid-message-text: var(--ak-dark-foreground);
+    --ak-mermaid-box-background-color: var(--ak-dark-background-lighter);
+    --ak-table-stripe-background: var(--pf-global--BackgroundColor--dark-200);
+}
+
+ak-alert + p {
+    margin-block-start: var(--pf-global--spacer--md);
+}
+
+a {
+    --pf-global--link--Color: var(--pf-global--link--Color--light);
+    --pf-global--link--Color--hover: var(--pf-global--link--Color--light--hover);
+    --pf-global--link--Color--visited: var(--pf-global--link--Color);
+}
+
+/*
+ * Note that order of anchor pseudo-selectors must follow:
+ *   1. link
+ *   2. visited
+ *   3. hover
+ *   4. active
+ */
+a:link {
+    color: var(--pf-global--link--Color);
+}
+
+a:visited {
+    color: var(--pf-global--link--Color--visited);
+}
+
+a:hover {
+    color: var(--pf-global--link--Color--hover);
+}
+
+a:active {
+    color: var(--pf-global--link--Color);
+}
+
+h2:first-of-type {
+    margin-top: 0;
+}
+
+table thead,
+table tr:nth-child(2n) {
+    background-color: var(--ak-table-stripe-background,);
+}
+
+table td,
+table th {
+    border: var(--pf-table-border-width) solid var(--ifm-table-border-color);
+    padding: var(--pf-global--spacer--md);
+}
+
+pre {
+    overflow-x: auto;
+}
+
+pre:has(.hljs) {
+    padding: var(--pf-global--spacer--md);
+}
+
+svg[id^="mermaid-svg-"] {
+    .rect {
+        fill: var(
+            --ak-mermaid-box-background-color,
+            var(--pf-global--BackgroundColor--light-300)
+        ) !important;
+    }
+
+    .messageText {
+        stroke-width: 4;
+        fill: var(--ak-mermaid-message-text) !important;
+        paint-order: stroke;
+    }
+}

--- a/web/src/elements/cards/AggregateCard.css
+++ b/web/src/elements/cards/AggregateCard.css
@@ -1,0 +1,52 @@
+.pf-c-card.pf-c-card-aggregate {
+    height: 100%;
+}
+
+.pf-c-card__header {
+    padding: var(--pf-global--spacer--md);
+}
+
+.pf-c-card__title {
+    display: flex;
+    align-items: center;
+    gap: var(--pf-global--spacer--sm);
+    flex: 1 1 auto;
+}
+
+.subtext {
+    margin-top: var(--pf-global--spacer--sm);
+    font-size: var(--pf-global--FontSize--sm);
+}
+
+.pf-c-card__body {
+    overflow-x: auto;
+    padding-left: calc(var(--pf-c-card--child--PaddingLeft) / 2);
+    padding-right: calc(var(--pf-c-card--child--PaddingRight) / 2);
+}
+
+.status-container {
+    font-size: var(--pf-global--icon--FontSize--lg);
+    text-align: center;
+
+    .status-heading {
+        display: flex;
+        gap: var(--pf-global--spacer--sm);
+        justify-content: center;
+        align-items: baseline;
+    }
+}
+
+.pf-c-card__header,
+.pf-c-card__title,
+.pf-c-card__body,
+.pf-c-card__footer {
+    padding-bottom: 0;
+}
+
+.pf-c-card__footer {
+    min-height: 1ex;
+}
+
+:host([role="status"]) {
+    text-align: center;
+}

--- a/web/src/elements/cards/AggregateCard.ts
+++ b/web/src/elements/cards/AggregateCard.ts
@@ -1,8 +1,8 @@
-import { SlottedTemplateResult } from "../types";
-
 import { AKElement } from "#elements/Base";
+import Styles from "#elements/cards/AggregateCard.css";
+import { SlottedTemplateResult } from "#elements/types";
 
-import { css, CSSResult, html, nothing } from "lit";
+import { CSSResult, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import PFCard from "@patternfly/patternfly/components/Card/card.css";
@@ -59,61 +59,7 @@ export class AggregateCard extends AKElement implements IAggregateCard {
     @property({ type: String })
     public subtext: string | null = null;
 
-    static styles: CSSResult[] = [
-        PFBase,
-        PFCard,
-        PFFlex,
-        css`
-            .pf-c-card.pf-c-card-aggregate {
-                height: 100%;
-            }
-            .pf-c-card__header {
-                padding: var(--pf-global--spacer--md);
-            }
-            .pf-c-card__title {
-                display: flex;
-                align-items: center;
-                gap: var(--pf-global--spacer--sm);
-                flex: 1 1 auto;
-            }
-
-            .subtext {
-                margin-top: var(--pf-global--spacer--sm);
-                font-size: var(--pf-global--FontSize--sm);
-            }
-            .pf-c-card__body {
-                overflow-x: auto;
-                padding-left: calc(var(--pf-c-card--child--PaddingLeft) / 2);
-                padding-right: calc(var(--pf-c-card--child--PaddingRight) / 2);
-            }
-
-            .status-container {
-                font-size: var(--pf-global--icon--FontSize--lg);
-                text-align: center;
-
-                .status-heading {
-                    display: flex;
-                    gap: var(--pf-global--spacer--sm);
-                    justify-content: center;
-                    align-items: baseline;
-                }
-            }
-            .pf-c-card__header,
-            .pf-c-card__title,
-            .pf-c-card__body,
-            .pf-c-card__footer {
-                padding-bottom: 0;
-            }
-
-            .pf-c-card__footer {
-                min-height: 1ex;
-            }
-
-            :host([role="status"]) {
-                text-align: center;
-            }
-        `,
-    ];
+    public static styles: CSSResult[] = [PFBase, PFCard, PFFlex, Styles];
 
     renderInner(): SlottedTemplateResult {
         if (this.role === "status") {

--- a/web/src/elements/forms/FormGroup.css
+++ b/web/src/elements/forms/FormGroup.css
@@ -31,7 +31,10 @@ details {
         user-select: none;
 
         font-weight: bold;
-        text-decoration: underline;
+
+        @media (prefers-contrast: more) {
+            text-decoration: underline;
+        }
 
         &::marker {
             color: var(--marker-color, var(--pf-global--Color--200));

--- a/web/src/elements/forms/FormGroup.css
+++ b/web/src/elements/forms/FormGroup.css
@@ -1,0 +1,56 @@
+:host([theme="dark"]) {
+    --marker-color: var(--pf-global--Color--200);
+    --marker-color-hover: var(--ak-dark-foreground-darker);
+
+    details {
+        @media (prefers-contrast: more) {
+            background: var(--ak-dark-background-light);
+        }
+    }
+}
+
+details {
+    @media (prefers-contrast: more) {
+        border: 1px solid var(--pf-global--BorderColor--200);
+        background: var(--pf-global--BackgroundColor--150);
+    }
+
+    &::details-content {
+        padding-inline-start: var(--pf-c-form__field-group--GridTemplateColumns--toggle);
+        padding-inline-end: var(--pf-global--spacer--md);
+        padding-block-end: var(--pf-global--spacer--md);
+    }
+
+    & > summary {
+        list-style-position: outside;
+        margin-inline-start: 2em;
+        padding-inline-start: calc(var(--pf-global--spacer--md) + 0.25rem);
+        padding: var(--pf-global--spacer--md);
+        list-style-type: "\f105";
+        cursor: pointer;
+        user-select: none;
+
+        font-weight: bold;
+        text-decoration: underline;
+
+        &::marker {
+            color: var(--marker-color, var(--pf-global--Color--200));
+            transition: var(--pf-c-form__field-group-toggle-icon--Transition);
+            font-family: "Font Awesome 5 Free";
+            font-weight: 900;
+        }
+
+        &:hover::marker {
+            outline: 1px dashed red;
+            color: var(--marker-color-hover, var(--pf-global--Color--100));
+        }
+    }
+
+    &[open] summary {
+        list-style-type: "\f107";
+    }
+}
+
+.pf-c-form__field-group-header-description {
+    text-wrap: balance;
+}

--- a/web/src/elements/forms/FormGroup.ts
+++ b/web/src/elements/forms/FormGroup.ts
@@ -25,7 +25,6 @@ export class AKFormGroup extends AKElement {
         PFForm,
         PFButton,
         PFFormControl,
-
         css`
             :host([theme="dark"]) {
                 --marker-color: var(--pf-global--Color--200);
@@ -36,10 +35,6 @@ export class AKFormGroup extends AKElement {
                         background: var(--ak-dark-background-light);
                     }
                 }
-            }
-
-            .pf-c-form__field-group-header-description {
-                text-wrap: balance;
             }
 
             details {
@@ -84,6 +79,12 @@ export class AKFormGroup extends AKElement {
                 &[open] summary {
                     list-style-type: "\\f107";
                 }
+            }
+        `,
+        // HACK: Fixes Lit Analyzer's outdated parser.
+        (css as typeof css) /*css*/ `
+            .pf-c-form__field-group-header-description {
+                text-wrap: balance;
             }
         `,
     ];

--- a/web/src/elements/forms/FormGroup.ts
+++ b/web/src/elements/forms/FormGroup.ts
@@ -30,6 +30,12 @@ export class AKFormGroup extends AKElement {
             :host([theme="dark"]) {
                 --marker-color: var(--pf-global--Color--200);
                 --marker-color-hover: var(--ak-dark-foreground-darker);
+
+                details {
+                    @media (prefers-contrast: more) {
+                        background: var(--ak-dark-background-light);
+                    }
+                }
             }
 
             .pf-c-form__field-group-header-description {
@@ -37,10 +43,17 @@ export class AKFormGroup extends AKElement {
             }
 
             details {
+                @media (prefers-contrast: more) {
+                    border: 1px solid var(--pf-global--BorderColor--200);
+                    background: var(--pf-global--BackgroundColor--150);
+                }
+
                 &::details-content {
                     padding-inline-start: var(
                         --pf-c-form__field-group--GridTemplateColumns--toggle
                     );
+                    padding-inline-end: var(--pf-global--spacer--md);
+                    padding-block-end: var(--pf-global--spacer--md);
                 }
 
                 & > summary {
@@ -51,6 +64,9 @@ export class AKFormGroup extends AKElement {
                     list-style-type: "\\f105";
                     cursor: pointer;
                     user-select: none;
+
+                    font-weight: bold;
+                    text-decoration: underline;
 
                     &::marker {
                         color: var(--marker-color, var(--pf-global--Color--200));

--- a/web/src/elements/forms/FormGroup.ts
+++ b/web/src/elements/forms/FormGroup.ts
@@ -1,7 +1,8 @@
 import { AKElement } from "#elements/Base";
+import Styles from "#elements/forms/FormGroup.css";
 
 import { msg } from "@lit/localize";
-import { css, CSSResult, html, PropertyValues, TemplateResult } from "lit";
+import { CSSResult, html, PropertyValues, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { createRef, ref } from "lit/directives/ref.js";
 
@@ -20,74 +21,7 @@ import PFBase from "@patternfly/patternfly/patternfly-base.css";
  */
 @customElement("ak-form-group")
 export class AKFormGroup extends AKElement {
-    static styles: CSSResult[] = [
-        PFBase,
-        PFForm,
-        PFButton,
-        PFFormControl,
-        css`
-            :host([theme="dark"]) {
-                --marker-color: var(--pf-global--Color--200);
-                --marker-color-hover: var(--ak-dark-foreground-darker);
-
-                details {
-                    @media (prefers-contrast: more) {
-                        background: var(--ak-dark-background-light);
-                    }
-                }
-            }
-
-            details {
-                @media (prefers-contrast: more) {
-                    border: 1px solid var(--pf-global--BorderColor--200);
-                    background: var(--pf-global--BackgroundColor--150);
-                }
-
-                &::details-content {
-                    padding-inline-start: var(
-                        --pf-c-form__field-group--GridTemplateColumns--toggle
-                    );
-                    padding-inline-end: var(--pf-global--spacer--md);
-                    padding-block-end: var(--pf-global--spacer--md);
-                }
-
-                & > summary {
-                    list-style-position: outside;
-                    margin-inline-start: 2em;
-                    padding-inline-start: calc(var(--pf-global--spacer--md) + 0.25rem);
-                    padding: var(--pf-global--spacer--md);
-                    list-style-type: "\\f105";
-                    cursor: pointer;
-                    user-select: none;
-
-                    font-weight: bold;
-                    text-decoration: underline;
-
-                    &::marker {
-                        color: var(--marker-color, var(--pf-global--Color--200));
-                        transition: var(--pf-c-form__field-group-toggle-icon--Transition);
-                        font-family: "Font Awesome 5 Free";
-                        font-weight: 900;
-                    }
-
-                    &:hover::marker {
-                        outline: 1px dashed red;
-                        color: var(--marker-color-hover, var(--pf-global--Color--100));
-                    }
-                }
-
-                &[open] summary {
-                    list-style-type: "\\f107";
-                }
-            }
-        `,
-        // HACK: Fixes Lit Analyzer's outdated parser.
-        (css as typeof css) /*css*/ `
-            .pf-c-form__field-group-header-description {
-                text-wrap: balance;
-            }
-        `,
-    ];
+    static styles: CSSResult[] = [PFBase, PFForm, PFButton, PFFormControl, Styles];
 
     //region Properties
 

--- a/web/src/elements/forms/Radio.css
+++ b/web/src/elements/forms/Radio.css
@@ -2,11 +2,6 @@
     padding-top: calc(var(--pf-c-form--m-horizontal__group-label--md--PaddingTop) * 1.3);
 }
 
-.pf-c-radio {
-    cursor: pointer;
-    user-select: none;
-}
-
 .pf-m-disabled {
     cursor: not-allowed;
 

--- a/web/src/elements/forms/Radio.css
+++ b/web/src/elements/forms/Radio.css
@@ -1,0 +1,21 @@
+.pf-c-form__group-control {
+    padding-top: calc(var(--pf-c-form--m-horizontal__group-label--md--PaddingTop) * 1.3);
+}
+
+.pf-c-radio {
+    cursor: pointer;
+    user-select: none;
+}
+
+.pf-m-disabled {
+    cursor: not-allowed;
+
+    .pf-c-radio__label {
+        cursor: not-allowed;
+        color: var(--pf-global--disabled-color--100);
+    }
+}
+
+.pf-c-radio__description {
+    text-wrap: balance;
+}

--- a/web/src/elements/forms/Radio.ts
+++ b/web/src/elements/forms/Radio.ts
@@ -56,7 +56,9 @@ export class Radio<T> extends CustomEmitterElement(AKElement) {
                     color: var(--pf-global--disabled-color--100);
                 }
             }
-
+        `,
+        // HACK: Fixes Lit Analyzer's outdated parser.
+        (css as typeof css) /*css*/ `
             .pf-c-radio__description {
                 text-wrap: balance;
             }

--- a/web/src/elements/forms/Radio.ts
+++ b/web/src/elements/forms/Radio.ts
@@ -1,9 +1,10 @@
 import { AKElement } from "#elements/Base";
+import Styles from "#elements/forms/Radio.css";
 import { CustomEmitterElement } from "#elements/utils/eventEmitter";
 
 import { IDGenerator } from "@goauthentik/core/id";
 
-import { css, CSSResult, html, nothing, TemplateResult } from "lit";
+import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { map } from "lit/directives/map.js";
 
@@ -34,35 +35,11 @@ export class Radio<T> extends CustomEmitterElement(AKElement) {
     #fieldID: string = this.name || IDGenerator.randomID();
 
     static styles: CSSResult[] = [
+        // ---
         PFBase,
         PFRadio,
         PFForm,
-        css`
-            .pf-c-form__group-control {
-                padding-top: calc(
-                    var(--pf-c-form--m-horizontal__group-label--md--PaddingTop) * 1.3
-                );
-            }
-            .pf-c-radio {
-                cursor: pointer;
-                user-select: none;
-            }
-
-            .pf-m-disabled {
-                cursor: not-allowed;
-
-                .pf-c-radio__label {
-                    cursor: not-allowed;
-                    color: var(--pf-global--disabled-color--100);
-                }
-            }
-        `,
-        // HACK: Fixes Lit Analyzer's outdated parser.
-        (css as typeof css) /*css*/ `
-            .pf-c-radio__description {
-                text-wrap: balance;
-            }
-        `,
+        Styles,
     ];
 
     // Set the value if it's not set already. Property changes inside the `willUpdate()` method do

--- a/web/src/elements/forms/SearchSelect/ak-search-select-view.ts
+++ b/web/src/elements/forms/SearchSelect/ak-search-select-view.ts
@@ -9,7 +9,7 @@ import type { GroupedOptions, SelectOption, SelectOptions } from "#elements/type
 import { randomId } from "#elements/utils/randomId";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, nothing, PropertyValues } from "lit";
+import { css, CSSResult, html, nothing, PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { createRef, ref, Ref } from "lit/directives/ref.js";
@@ -69,7 +69,17 @@ export interface ISearchSelectView {
  */
 @customElement("ak-search-select-view")
 export class SearchSelectView extends AKElement implements ISearchSelectView {
-    static styles: CSSResult[] = [PFBase, PFForm, PFFormControl, PFSelect];
+    static styles: CSSResult[] = [
+        PFBase,
+        PFForm,
+        PFFormControl,
+        PFSelect,
+        css`
+            .pf-c-select {
+                --pf-c-select__toggle-wrapper--MaxWidth: unset;
+            }
+        `,
+    ];
 
     //#region Properties
 

--- a/web/src/elements/forms/SearchSelect/ak-search-select-view.ts
+++ b/web/src/elements/forms/SearchSelect/ak-search-select-view.ts
@@ -76,7 +76,7 @@ export class SearchSelectView extends AKElement implements ISearchSelectView {
         PFSelect,
         css`
             .pf-c-select {
-                --pf-c-select__toggle-wrapper--MaxWidth: unset;
+                --pf-c-select__toggle-wrapper--MaxWidth: initial;
             }
         `,
     ];

--- a/web/src/elements/table/Table.css
+++ b/web/src/elements/table/Table.css
@@ -1,0 +1,142 @@
+[part="table-container"] {
+    @media (max-width: 1199px) {
+        overflow-x: auto;
+    }
+}
+
+.pf-c-table {
+    .presentational {
+        --pf-c-table--cell--MinWidth: 0;
+    }
+}
+
+/**
+ * TODO: Row actions need a better approach to alignment,
+ * but this will at least get the buttons in a grid-like layout.
+ */
+td:has(ak-action-button),
+td:has(ak-forms-modal),
+td:has(ak-rbac-object-permission-modal) {
+    & > .pf-c-button,
+    & > button[slot="trigger"]:has(i),
+    & > *::part(spinner-button),
+    & > *::part(button) {
+        --pf-global--spacer--form-element: 0;
+
+        padding-inline: 0.5em !important;
+    }
+
+    button[slot="trigger"]:has(i) {
+        padding-inline-start: 0 !important;
+        padding-inline-end: 0.25em !important;
+    }
+
+    *::part(spinner-button) {
+        padding-inline-start: 0.5em !important;
+    }
+
+    button.pf-m-tertiary {
+        margin-inline-start: 0.25em;
+    }
+
+    & > * {
+        display: inline-flex;
+        place-items: center;
+        justify-content: center;
+    }
+}
+
+.pf-m-search-filter {
+    flex: 1 1 auto;
+    margin-inline: 0;
+}
+
+.pf-c-table thead .pf-c-table__check {
+    min-width: 3rem;
+}
+
+.pf-c-table tbody .pf-c-table__check input {
+    margin-top: calc(var(--pf-c-table__check--input--MarginTop) + 1px);
+}
+
+.pf-c-toolbar {
+    display: flex;
+    flex-flow: row wrap;
+    padding-inline: var(--pf-global--spacer--md);
+    gap: var(--pf-global--spacer--sm);
+}
+
+.pf-c-toolbar__content {
+    flex: 1 1 auto;
+    flex-flow: row wrap;
+    margin: 0;
+    justify-content: space-between;
+    gap: var(--pf-global--spacer--sm);
+    padding-inline: 0;
+    .pf-c-switch {
+        --pf-c-switch--ColumnGap: var(--pf-c-toolbar__item--m-search-filter--spacer);
+    }
+}
+
+.pf-c-toolbar__group {
+    flex-flow: row wrap;
+    gap: var(--pf-global--spacer--sm);
+
+    .pf-c-card__title .pf-icon {
+        margin-inline-end: var(--pf-global--spacer--sm);
+    }
+}
+
+[part="toolbar-primary"] {
+    flex: 2 1 auto;
+}
+
+.pf-c-table {
+    --pf-c-table--m-striped__tr--BackgroundColor: var(--pf-global--BackgroundColor--dark-300);
+}
+
+/**
+ * Prevents text selection from interfering with click events
+ * when rapidly interacting with cells.
+ */
+thead,
+.pf-c-table tr.pf-m-hoverable {
+    user-select: none;
+}
+
+time {
+    text-transform: capitalize;
+}
+
+.pf-c-pagination {
+    ak-timestamp {
+        font-size: 0.75rem;
+        font-style: italic;
+        color: var(--pf-global--Color--200);
+
+        &::part(label) {
+            display: inline-block;
+        }
+
+        &::part(elapsed) {
+            display: inline-block;
+        }
+    }
+}
+
+/**
+ * TODO: Remove after <dialog> modals are implemented.
+ */
+.pf-c-dropdown__menu:has(ak-forms-modal) {
+    z-index: var(--pf-global--ZIndex--lg);
+}
+
+:host {
+    container-type: inline-size;
+}
+
+.pf-c-table {
+    @container (width > 1200px) {
+        --pf-c-table--cell--MinWidth: 9em;
+    }
+}

--- a/web/src/elements/table/Table.ts
+++ b/web/src/elements/table/Table.ts
@@ -81,10 +81,6 @@ export abstract class Table<T extends object>
         PFDropdown,
         PFPagination,
         css`
-            :host {
-                container-type: inline-size;
-            }
-
             [part="table-container"] {
                 @media (max-width: 1199px) {
                     overflow-x: auto;
@@ -94,9 +90,6 @@ export abstract class Table<T extends object>
             .pf-c-table {
                 .presentational {
                     --pf-c-table--cell--MinWidth: 0;
-                }
-                @container (width > 1200px) {
-                    --pf-c-table--cell--MinWidth: 9em;
                 }
             }
 
@@ -219,6 +212,18 @@ export abstract class Table<T extends object>
              */
             .pf-c-dropdown__menu:has(ak-forms-modal) {
                 z-index: var(--pf-global--ZIndex--lg);
+            }
+        `,
+        // HACK: Fixes Lit Analyzer's outdated parser.
+        (css as typeof css) /*css*/ `
+            :host {
+                container-type: inline-size;
+            }
+
+            .pf-c-table {
+                @container (width > 1200px) {
+                    --pf-c-table--cell--MinWidth: 9em;
+                }
             }
         `,
     ];

--- a/web/src/elements/table/Table.ts
+++ b/web/src/elements/table/Table.ts
@@ -17,6 +17,7 @@ import { GroupResult } from "#common/utils";
 import { AKElement } from "#elements/Base";
 import { WithLicenseSummary } from "#elements/mixins/license";
 import { getURLParam, updateURLParams } from "#elements/router/RouteMatch";
+import Styles from "#elements/table/Table.css";
 import { SlottedTemplateResult } from "#elements/types";
 import { ifPresent } from "#elements/utils/attributes";
 
@@ -25,7 +26,7 @@ import { Pagination } from "@goauthentik/api";
 import { kebabCase } from "change-case";
 
 import { msg, str } from "@lit/localize";
-import { css, CSSResult, html, nothing, PropertyValues, TemplateResult } from "lit";
+import { CSSResult, html, nothing, PropertyValues, TemplateResult } from "lit";
 import { property, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -80,152 +81,7 @@ export abstract class Table<T extends object>
         PFToolbar,
         PFDropdown,
         PFPagination,
-        css`
-            [part="table-container"] {
-                @media (max-width: 1199px) {
-                    overflow-x: auto;
-                }
-            }
-
-            .pf-c-table {
-                .presentational {
-                    --pf-c-table--cell--MinWidth: 0;
-                }
-            }
-
-            /**
-             * TODO: Row actions need a better approach to alignment,
-             * but this will at least get the buttons in a grid-like layout.
-             */
-            td:has(ak-action-button),
-            td:has(ak-forms-modal),
-            td:has(ak-rbac-object-permission-modal) {
-                & > .pf-c-button,
-                & > button[slot="trigger"]:has(i),
-                & > *::part(spinner-button),
-                & > *::part(button) {
-                    --pf-global--spacer--form-element: 0;
-
-                    padding-inline: 0.5em !important;
-                }
-
-                button[slot="trigger"]:has(i) {
-                    padding-inline-start: 0 !important;
-                    padding-inline-end: 0.25em !important;
-                }
-
-                *::part(spinner-button) {
-                    padding-inline-start: 0.5em !important;
-                }
-
-                button.pf-m-tertiary {
-                    margin-inline-start: 0.25em;
-                }
-
-                & > * {
-                    display: inline-flex;
-                    place-items: center;
-                    justify-content: center;
-                }
-            }
-
-            .pf-m-search-filter {
-                flex: 1 1 auto;
-                margin-inline: 0;
-            }
-            .pf-c-table thead .pf-c-table__check {
-                min-width: 3rem;
-            }
-            .pf-c-table tbody .pf-c-table__check input {
-                margin-top: calc(var(--pf-c-table__check--input--MarginTop) + 1px);
-            }
-
-            .pf-c-toolbar {
-                display: flex;
-                flex-flow: row wrap;
-                padding-inline: var(--pf-global--spacer--md);
-                gap: var(--pf-global--spacer--sm);
-            }
-
-            .pf-c-toolbar__content {
-                flex: 1 1 auto;
-                flex-flow: row wrap;
-                margin: 0;
-                justify-content: space-between;
-                gap: var(--pf-global--spacer--sm);
-                padding-inline: 0;
-                .pf-c-switch {
-                    --pf-c-switch--ColumnGap: var(--pf-c-toolbar__item--m-search-filter--spacer);
-                }
-            }
-
-            .pf-c-toolbar__group {
-                flex-flow: row wrap;
-                gap: var(--pf-global--spacer--sm);
-
-                .pf-c-card__title .pf-icon {
-                    margin-inline-end: var(--pf-global--spacer--sm);
-                }
-            }
-
-            [part="toolbar-primary"] {
-                flex: 2 1 auto;
-            }
-
-            .pf-c-table {
-                --pf-c-table--m-striped__tr--BackgroundColor: var(
-                    --pf-global--BackgroundColor--dark-300
-                );
-            }
-
-            /**
-             * Prevents text selection from interfering with click events
-             * when rapidly interacting with cells.
-             */
-            thead,
-            .pf-c-table tr.pf-m-hoverable {
-                user-select: none;
-            }
-
-            time {
-                text-transform: capitalize;
-            }
-
-            .pf-c-pagination {
-                ak-timestamp {
-                    font-size: 0.75rem;
-                    font-style: italic;
-                    color: var(--pf-global--Color--200);
-
-                    &::part(label) {
-                        display: inline-block;
-                    }
-
-                    &::part(elapsed) {
-                        display: inline-block;
-                    }
-                }
-            }
-
-            /**
-             * TODO: Remove after <dialog> modals are implemented.
-             */
-            .pf-c-dropdown__menu:has(ak-forms-modal) {
-                z-index: var(--pf-global--ZIndex--lg);
-            }
-        `,
-        // HACK: Fixes Lit Analyzer's outdated parser.
-        (css as typeof css) /*css*/ `
-            :host {
-                container-type: inline-size;
-            }
-
-            .pf-c-table {
-                @container (width > 1200px) {
-                    --pf-c-table--cell--MinWidth: 9em;
-                }
-            }
-        `,
+        Styles,
     ];
 
     protected abstract apiEndpoint(): Promise<PaginatedResponse<T>>;

--- a/web/src/elements/table/Table.ts
+++ b/web/src/elements/table/Table.ts
@@ -20,6 +20,7 @@ import { getURLParam, updateURLParams } from "#elements/router/RouteMatch";
 import Styles from "#elements/table/Table.css";
 import { SlottedTemplateResult } from "#elements/types";
 import { ifPresent } from "#elements/utils/attributes";
+import { isEventTargetingListener } from "#elements/utils/pointer";
 
 import { Pagination } from "@goauthentik/api";
 
@@ -406,12 +407,7 @@ export abstract class Table<T extends object>
             return;
         }
 
-        const { target, currentTarget } = event ?? {};
-
-        if (
-            !(target instanceof HTMLElement) ||
-            (target.parentElement !== currentTarget && target !== currentTarget)
-        ) {
+        if (isEventTargetingListener(event)) {
             return;
         }
 

--- a/web/src/elements/utils/pointer.ts
+++ b/web/src/elements/utils/pointer.ts
@@ -1,0 +1,29 @@
+const InteractiveElementsQuery =
+    "[href],input,button,[role='button'],select,[tabindex]:not([tabindex='-1'])";
+
+/**
+ * Whether a pointer event is targeting the element itself or one of its children.
+ *
+ * @param event The pointer event to check.
+ * @returns Whether the event is targeting the element or one of its children.
+ */
+export function isEventTargetingListener(event?: Pick<Event, "target" | "currentTarget">): boolean {
+    const { target: triggerElement, currentTarget: listenerTarget } = event ?? {};
+
+    if (!triggerElement || !listenerTarget) {
+        return false;
+    }
+
+    if (!(triggerElement instanceof HTMLElement) || !(listenerTarget instanceof HTMLElement)) {
+        return false;
+    }
+
+    if (triggerElement === listenerTarget) {
+        return false;
+    }
+
+    return !!(
+        triggerElement.matches(InteractiveElementsQuery) ||
+        triggerElement.parentElement?.matches(InteractiveElementsQuery)
+    );
+}

--- a/web/src/flow/FlowInspector.ts
+++ b/web/src/flow/FlowInspector.ts
@@ -1,13 +1,13 @@
 import "#elements/EmptyState";
 import "#elements/Expand";
 
-import Styles from "./FlowInspector.css";
-
 import { DEFAULT_CONFIG } from "#common/api/config";
 import { EVENT_FLOW_ADVANCE, EVENT_FLOW_INSPECTOR_TOGGLE } from "#common/constants";
 import { APIError, parseAPIResponseError, pluckErrorDetail } from "#common/errors/network";
 
 import { AKElement } from "#elements/Base";
+
+import Styles from "#flow/FlowInspector.css";
 
 import { FlowInspection, FlowsApi, Stage } from "@goauthentik/api";
 


### PR DESCRIPTION
## Details

This PR adds additional support for a user's preferred level of contrast on inputs and fieldsets. The choice of field colors is deferred to the browser, allowing for default colors (with respect to our theme) to take effect.

## Screenshots

<img width="917" height="528" alt="Screenshot 2025-10-07 at 05 44 05" src="https://github.com/user-attachments/assets/31046283-7748-40b0-9825-a9f3df39cbeb" />

<img width="913" height="710" alt="Screenshot 2025-10-07 at 05 43 31" src="https://github.com/user-attachments/assets/0fbb1104-0d1a-4fd4-bfb6-7df89cc76f0a" />

