### PR TITLE
web/a11y: Fix missing screen reader class on fieldset legends.

### DIFF
--- a/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStageDuo.ts
+++ b/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStageDuo.ts
@@ -64,7 +64,7 @@ export class AuthenticatorValidateStageWebDuo extends BaseDeviceStage<
             </ak-empty-state>
             ${this.showBackButton
                 ? html`<fieldset class="pf-c-form__group pf-m-action">
-                      <legend>${msg("Form actions")}</legend>
+                      <legend class="sr-only">${msg("Form actions")}</legend>
                       ${this.renderReturnToDevicePicker()}
                   </fieldset>`
                 : nothing}

--- a/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStageWebAuthn.ts
+++ b/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStageWebAuthn.ts
@@ -118,7 +118,7 @@ export class AuthenticatorValidateStageWebAuthn extends BaseDeviceStage<
             </ak-empty-state>
             ${!this.authenticating || this.showBackButton
                 ? html`<fieldset class="pf-c-form__group pf-m-action">
-                      <legend>${msg("Form actions")}</legend>
+                      <legend class="sr-only">${msg("Form actions")}</legend>
                       ${!this.authenticating
                           ? html` <button
                                 class="pf-c-button pf-m-primary pf-m-block"

--- a/web/src/flow/stages/prompt/PromptStage.ts
+++ b/web/src/flow/stages/prompt/PromptStage.ts
@@ -299,7 +299,7 @@ ${prompt.initialValue}</textarea
 
     renderContinue(): TemplateResult {
         return html`<fieldset class="pf-c-form__group pf-m-action">
-            <legend>${msg("Form actions")}</legend>
+            <legend class="sr-only">${msg("Form actions")}</legend>
             <button type="submit" class="pf-c-button pf-m-primary pf-m-block">
                 ${msg("Continue")}
             </button>


### PR DESCRIPTION
## Details

Small fix to add missing screen reader classes for `<fieldset>` `<legend>` elements. Previously these fieldsets used their `name` attribute to indicate their legend is only visible to screen readers.