### PR TITLE
website: Enable legacy integrations redirects.

### DIFF
--- a/website/integrations/docusaurus.config.esm.mjs
+++ b/website/integrations/docusaurus.config.esm.mjs
@@ -9,6 +9,8 @@
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { legacyRedirects } from "./legacy-redirects.mjs";
+
 import { createDocusaurusConfig } from "@goauthentik/docusaurus-config";
 import {
     createAlgoliaConfig,
@@ -89,6 +91,12 @@ export default createDocusaurusConfig(
 
                         return redirects;
                     },
+                    redirects: Array.from(legacyRedirects, ([from, to]) => {
+                        return {
+                            from,
+                            to,
+                        };
+                    }),
                 }),
             ],
         ],


### PR DESCRIPTION
## Details

This PR enables our legacy redirects for integrations, allowing URLs such as `https://integrations.goauthentik.io/services/[some integration name]/` to redirect to their current path.

This functionality has existed for sometime but was disabled during the Netlify redirect clean up.