### PR TITLE
enterprise/providers/gws+entra: fix group integrity error during discovery

### DIFF
--- a/authentik/enterprise/providers/google_workspace/clients/groups.py
+++ b/authentik/enterprise/providers/google_workspace/clients/groups.py
@@ -208,11 +208,11 @@ class GoogleWorkspaceGroupClient(
         )
         if not matching_authentik_group:
             return
-        GoogleWorkspaceProviderGroup.objects.get_or_create(
+        GoogleWorkspaceProviderGroup.objects.update_or_create(
             provider=self.provider,
             group=matching_authentik_group,
             google_id=google_id,
-            attributes=group,
+            defaults={"attributes": group},
         )
 
     def update_single_attribute(self, connection: GoogleWorkspaceProviderUser):

--- a/authentik/enterprise/providers/google_workspace/tests/test_groups.py
+++ b/authentik/enterprise/providers/google_workspace/tests/test_groups.py
@@ -292,7 +292,7 @@ class GoogleWorkspaceGroupTests(TestCase):
                 ).exists()
             )
 
-    def test_sync_task(self):
+    def test_sync_discover(self):
         """Test group discovery"""
         uid = generate_id()
         http = MockHTTP()
@@ -332,3 +332,57 @@ class GoogleWorkspaceGroupTests(TestCase):
             )
             self.assertFalse(Event.objects.filter(action=EventAction.SYSTEM_EXCEPTION).exists())
             self.assertEqual(len(http.requests()), 5)
+
+    def test_sync_discover_multiple(self):
+        """Test group discovery"""
+        uid = generate_id()
+        http = MockHTTP()
+        http.add_response(
+            f"https://admin.googleapis.com/admin/directory/v1/customer/my_customer/domains?key={self.api_key}&alt=json",
+            domains_list_v1_mock,
+        )
+        http.add_response(
+            f"https://admin.googleapis.com/admin/directory/v1/users?customer=my_customer&maxResults=500&orderBy=email&key={self.api_key}&alt=json",
+            method="GET",
+            body={"users": []},
+        )
+        http.add_response(
+            f"https://admin.googleapis.com/admin/directory/v1/groups?customer=my_customer&maxResults=500&orderBy=email&key={self.api_key}&alt=json",
+            method="GET",
+            body={"groups": [{"id": uid, "name": uid}]},
+        )
+        http.add_response(
+            f"https://admin.googleapis.com/admin/directory/v1/groups/{uid}?key={self.api_key}&alt=json",
+            method="PUT",
+            body={"id": uid},
+        )
+        self.app.backchannel_providers.remove(self.provider)
+        different_group = Group.objects.create(
+            name=uid,
+        )
+        self.app.backchannel_providers.add(self.provider)
+        with patch(
+            "authentik.enterprise.providers.google_workspace.models.GoogleWorkspaceProvider.google_credentials",
+            MagicMock(return_value={"developerKey": self.api_key, "http": http}),
+        ):
+            google_workspace_sync.send(self.provider.pk).get_result()
+            self.assertTrue(
+                GoogleWorkspaceProviderGroup.objects.filter(
+                    group=different_group, provider=self.provider
+                ).exists()
+            )
+            self.assertFalse(Event.objects.filter(action=EventAction.SYSTEM_EXCEPTION).exists())
+            self.assertEqual(len(http.requests()), 5)
+            # Change response to trigger update
+            http.add_response(
+                f"https://admin.googleapis.com/admin/directory/v1/groups?customer=my_customer&maxResults=500&orderBy=email&key={self.api_key}&alt=json",
+                method="GET",
+                body={"groups": [{"id": uid, "name": uid, "bar": "baz"}]},
+            )
+            google_workspace_sync.send(self.provider.pk).get_result()
+            self.assertTrue(
+                GoogleWorkspaceProviderGroup.objects.filter(
+                    group=different_group, provider=self.provider
+                ).exists()
+            )
+            self.assertFalse(Event.objects.filter(action=EventAction.SYSTEM_EXCEPTION).exists())

--- a/authentik/enterprise/providers/microsoft_entra/clients/groups.py
+++ b/authentik/enterprise/providers/microsoft_entra/clients/groups.py
@@ -220,11 +220,11 @@ class MicrosoftEntraGroupClient(
         )
         if not matching_authentik_group:
             return
-        MicrosoftEntraProviderGroup.objects.get_or_create(
+        MicrosoftEntraProviderGroup.objects.update_or_create(
             provider=self.provider,
             group=matching_authentik_group,
             microsoft_id=group.id,
-            attributes=self.entity_as_dict(group),
+            defaults={"attributes": self.entity_as_dict(group)},
         )
 
     def update_single_attribute(self, connection: MicrosoftEntraProviderGroup):

--- a/authentik/enterprise/providers/microsoft_entra/tests/test_groups.py
+++ b/authentik/enterprise/providers/microsoft_entra/tests/test_groups.py
@@ -369,7 +369,7 @@ class MicrosoftEntraGroupTests(TestCase):
             group_create.assert_called_once()
             group_delete.assert_not_called()
 
-    def test_sync_task(self):
+    def test_sync_discover(self):
         """Test group discovery"""
         uid = generate_id()
         self.app.backchannel_providers.remove(self.provider)
@@ -430,3 +430,84 @@ class MicrosoftEntraGroupTests(TestCase):
             self.assertFalse(Event.objects.filter(action=EventAction.SYSTEM_EXCEPTION).exists())
             user_list.assert_called_once()
             group_list.assert_called_once()
+
+    def test_sync_discover_multiple(self):
+        """Test group discovery"""
+        uid = generate_id()
+        self.app.backchannel_providers.remove(self.provider)
+        different_group = Group.objects.create(
+            name=uid,
+        )
+        self.app.backchannel_providers.add(self.provider)
+        with (
+            patch(
+                "authentik.enterprise.providers.microsoft_entra.models.MicrosoftEntraProvider.microsoft_credentials",
+                MagicMock(return_value={"credentials": self.creds}),
+            ),
+            patch(
+                "msgraph.generated.organization.organization_request_builder.OrganizationRequestBuilder.get",
+                AsyncMock(
+                    return_value=OrganizationCollectionResponse(
+                        value=[
+                            Organization(verified_domains=[VerifiedDomain(name="goauthentik.io")])
+                        ]
+                    )
+                ),
+            ),
+            patch(
+                "msgraph.generated.users.item.user_item_request_builder.UserItemRequestBuilder.patch",
+                AsyncMock(return_value=MSUser(id=generate_id())),
+            ),
+            patch(
+                "msgraph.generated.groups.groups_request_builder.GroupsRequestBuilder.post",
+                AsyncMock(return_value=MSGroup(id=generate_id())),
+            ),
+            patch(
+                "msgraph.generated.groups.item.group_item_request_builder.GroupItemRequestBuilder.patch",
+                AsyncMock(return_value=MSGroup(id=uid)),
+            ),
+            patch(
+                "msgraph.generated.users.users_request_builder.UsersRequestBuilder.get",
+                AsyncMock(
+                    return_value=UserCollectionResponse(
+                        value=[MSUser(mail=f"{uid}@goauthentik.io", id=uid)]
+                    )
+                ),
+            ) as user_list,
+            patch(
+                "msgraph.generated.groups.groups_request_builder.GroupsRequestBuilder.get",
+                AsyncMock(
+                    return_value=GroupCollectionResponse(
+                        value=[MSGroup(display_name=uid, unique_name=uid, id=uid)]
+                    )
+                ),
+            ) as group_list,
+        ):
+            microsoft_entra_sync.send(self.provider.pk).get_result()
+            self.assertTrue(
+                MicrosoftEntraProviderGroup.objects.filter(
+                    group=different_group, provider=self.provider
+                ).exists()
+            )
+            self.assertFalse(Event.objects.filter(action=EventAction.SYSTEM_EXCEPTION).exists())
+            user_list.assert_called_once()
+            group_list.assert_called_once()
+
+            with patch(
+                "msgraph.generated.groups.groups_request_builder.GroupsRequestBuilder.get",
+                AsyncMock(
+                    return_value=GroupCollectionResponse(
+                        value=[
+                            MSGroup(display_name=uid, unique_name=uid, id=uid, description="foo")
+                        ]
+                    )
+                ),
+            ) as mod_group_list:
+                microsoft_entra_sync.send(self.provider.pk).get_result()
+                self.assertTrue(
+                    MicrosoftEntraProviderGroup.objects.filter(
+                        group=different_group, provider=self.provider
+                    ).exists()
+                )
+                self.assertFalse(Event.objects.filter(action=EventAction.SYSTEM_EXCEPTION).exists())
+                mod_group_list.assert_called_once()


### PR DESCRIPTION
I somehow missed this in #17341

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
