### PR TITLE
sources/saml: Set AuthnRequest ProtocolBinding to HTTP-POST instead of HTTP-Redirect

### DIFF
--- a/authentik/providers/saml/tests/test_auth_n_request.py
+++ b/authentik/providers/saml/tests/test_auth_n_request.py
@@ -21,7 +21,7 @@ from authentik.sources.saml.exceptions import MismatchedRequestID
 from authentik.sources.saml.models import SAMLSource
 from authentik.sources.saml.processors.constants import (
     NS_MAP,
-    SAML_BINDING_REDIRECT,
+    SAML_BINDING_POST,
     SAML_NAME_ID_FORMAT_EMAIL,
     SAML_NAME_ID_FORMAT_UNSPECIFIED,
 )
@@ -107,7 +107,7 @@ class TestAuthNRequest(TestCase):
         # First create an AuthNRequest
         request_proc = RequestProcessor(self.source, http_request, "test_state")
         auth_n = request_proc.get_auth_n()
-        self.assertEqual(auth_n.attrib["ProtocolBinding"], SAML_BINDING_REDIRECT)
+        self.assertEqual(auth_n.attrib["ProtocolBinding"], SAML_BINDING_POST)
 
         request = request_proc.build_auth_n()
         # Now we check the ID and signature

--- a/authentik/sources/saml/processors/request.py
+++ b/authentik/sources/saml/processors/request.py
@@ -11,14 +11,14 @@ from lxml.etree import Element  # nosec
 from authentik.providers.saml.utils import get_random_id
 from authentik.providers.saml.utils.encoding import deflate_and_base64_encode
 from authentik.providers.saml.utils.time import get_time_string
-from authentik.sources.saml.models import SAMLBindingTypes, SAMLSource
+from authentik.sources.saml.models import SAMLSource
 from authentik.sources.saml.processors.constants import (
     DIGEST_ALGORITHM_TRANSLATION_MAP,
     NS_MAP,
     NS_SAML_ASSERTION,
     NS_SAML_PROTOCOL,
-    SIGN_ALGORITHM_TRANSFORM_MAP,
     SAML_BINDING_POST,
+    SIGN_ALGORITHM_TRANSFORM_MAP,
 )
 
 SESSION_KEY_REQUEST_ID = "authentik/sources/saml/request_id"

--- a/authentik/sources/saml/processors/request.py
+++ b/authentik/sources/saml/processors/request.py
@@ -18,6 +18,7 @@ from authentik.sources.saml.processors.constants import (
     NS_SAML_ASSERTION,
     NS_SAML_PROTOCOL,
     SIGN_ALGORITHM_TRANSFORM_MAP,
+    SAML_BINDING_POST,
 )
 
 SESSION_KEY_REQUEST_ID = "authentik/sources/saml/request_id"
@@ -63,7 +64,7 @@ class RequestProcessor:
         auth_n_request.attrib["Destination"] = self.source.sso_url
         auth_n_request.attrib["ID"] = self.request_id
         auth_n_request.attrib["IssueInstant"] = self.issue_instant
-        auth_n_request.attrib["ProtocolBinding"] = SAMLBindingTypes(self.source.binding_type).uri
+        auth_n_request.attrib["ProtocolBinding"] = SAML_BINDING_POST
         auth_n_request.attrib["Version"] = "2.0"
         # Create issuer object
         auth_n_request.append(self.get_issuer())


### PR DESCRIPTION
## Details
This patch aligns authentik’s SAML Source implementation with the SAML 2.0 specification.

In the SAML Source configuration, the SP metadata always declares the
AssertionConsumerService (ACS) binding as HTTP-POST, regardless of the
SingleSignOnService (SSO) binding. However, the actual AuthnRequest message
used the SSO binding as its ProtocolBinding attribute, resulting in
HTTP-Redirect being sent.

According to the OASIS SAML 2.0 specification, the HTTP-Redirect binding
MUST NOT be used for delivering the <Response> from the IdP to the SP:

> Either the HTTP POST or HTTP Artifact binding can be used to transfer
> the message to the service provider through the user agent.  
> The HTTP Redirect binding MUST NOT be used.

While many IdPs will still prefer the ACS binding declared in the SP metadata,
this change aligns the AuthnRequest with the SAML 2.0 specification.

Hopefully close Hopefully close REDIRECT case issue at the step 1 of https://github.com/goauthentik/authentik/issues/16627

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
