### PR TITLE
sources/oauth: Add support for old ADFS

### DIFF
--- a/authentik/sources/oauth/apps.py
+++ b/authentik/sources/oauth/apps.py
@@ -9,6 +9,7 @@ from authentik.tasks.schedules.common import ScheduleSpec
 LOGGER = get_logger()
 
 AUTHENTIK_SOURCES_OAUTH_TYPES = [
+    "authentik.sources.oauth.types.adfs",
     "authentik.sources.oauth.types.apple",
     "authentik.sources.oauth.types.azure_ad",
     "authentik.sources.oauth.types.discord",

--- a/authentik/sources/oauth/models.py
+++ b/authentik/sources/oauth/models.py
@@ -269,8 +269,9 @@ class OpenIDConnectOAuthSource(CreatableType, OAuthSource):
         verbose_name = _("OpenID OAuth Source")
         verbose_name_plural = _("OpenID OAuth Sources")
 
-class AdfsOAuthSource(CreatableType, OAuthSource):
-    """Login using a Generic ADFS compliant provider."""
+
+class ADFSOAuthSource(CreatableType, OAuthSource):
+    """Login using a Active Directory Federation Services provider."""
 
     class Meta:
         abstract = True

--- a/authentik/sources/oauth/models.py
+++ b/authentik/sources/oauth/models.py
@@ -269,6 +269,14 @@ class OpenIDConnectOAuthSource(CreatableType, OAuthSource):
         verbose_name = _("OpenID OAuth Source")
         verbose_name_plural = _("OpenID OAuth Sources")
 
+class AdfsOAuthSource(CreatableType, OAuthSource):
+    """Login using a Generic ADFS compliant provider."""
+
+    class Meta:
+        abstract = True
+        verbose_name = _("ADFS OAuth Source")
+        verbose_name_plural = _("ADFS OAuth Sources")
+
 
 class AppleOAuthSource(CreatableType, OAuthSource):
     """Social Login using Apple."""

--- a/authentik/sources/oauth/types/adfs.py
+++ b/authentik/sources/oauth/types/adfs.py
@@ -1,0 +1,47 @@
+
+"""ADFS OAuth Views"""
+
+from typing import Any
+from jwt import decode
+
+from authentik.sources.oauth.models import AuthorizationCodeAuthMethod
+from authentik.sources.oauth.types.oidc import OpenIDConnectClient, OpenIDConnectOAuth2Callback, OpenIDConnectOAuthRedirect, OpenIDConnectType
+from authentik.sources.oauth.types.registry import SourceType, registry
+
+
+class AdfsConnectClient(OpenIDConnectClient):
+    
+    def get_profile_info(self, token):
+        id_token = token.get("id_token")
+        if id_token is None:
+            return None
+        return decode(id_token, options={"verify_signature": False})
+
+class AdfsOAuth2Callback(OpenIDConnectOAuth2Callback):
+    """ADFS OAuth2 Callback"""
+
+    client_class = AdfsConnectClient
+
+    def get_user_id(self, info):
+        return super().get_user_id(info) or info.get("upn")
+
+@registry.register()
+class AdfsConnectType(SourceType):
+    """Adfs Type definition"""
+
+    callback_view = AdfsOAuth2Callback
+    verbose_name = "ADFS Connect"
+    name = "adfs"
+
+    urls_customizable = True
+    authorization_code_auth_method = AuthorizationCodeAuthMethod.POST_BODY
+
+    redirect_view = OpenIDConnectOAuthRedirect
+
+    def get_base_user_properties(self, info: dict[str, Any], **kwargs) -> dict[str, Any]:
+        return {
+            "username": info.get("displayName"),
+            "email": info.get("email"),
+            "name": info.get("email"),
+            "groups": info.get("group", []),
+        }

--- a/authentik/sources/oauth/types/adfs.py
+++ b/authentik/sources/oauth/types/adfs.py
@@ -1,36 +1,41 @@
-
 """ADFS OAuth Views"""
 
 from typing import Any
+
 from jwt import decode
 
 from authentik.sources.oauth.models import AuthorizationCodeAuthMethod
-from authentik.sources.oauth.types.oidc import OpenIDConnectClient, OpenIDConnectOAuth2Callback, OpenIDConnectOAuthRedirect, OpenIDConnectType
+from authentik.sources.oauth.types.oidc import (
+    OpenIDConnectClient,
+    OpenIDConnectOAuth2Callback,
+    OpenIDConnectOAuthRedirect,
+)
 from authentik.sources.oauth.types.registry import SourceType, registry
 
 
-class AdfsConnectClient(OpenIDConnectClient):
-    
+class ADFSClient(OpenIDConnectClient):
     def get_profile_info(self, token):
         id_token = token.get("id_token")
         if id_token is None:
             return None
         return decode(id_token, options={"verify_signature": False})
 
-class AdfsOAuth2Callback(OpenIDConnectOAuth2Callback):
+
+class ADFSOAuth2Callback(OpenIDConnectOAuth2Callback):
     """ADFS OAuth2 Callback"""
 
-    client_class = AdfsConnectClient
+    client_class = ADFSClient
 
     def get_user_id(self, info):
         return super().get_user_id(info) or info.get("upn")
 
-@registry.register()
-class AdfsConnectType(SourceType):
-    """Adfs Type definition"""
 
-    callback_view = AdfsOAuth2Callback
-    verbose_name = "ADFS Connect"
+@registry.register()
+class ADFSType(SourceType):
+    """ADFS Type definition"""
+
+    callback_view = ADFSOAuth2Callback
+    verbose_name = "ADFS"
     name = "adfs"
 
     urls_customizable = True

--- a/blueprints/schema.json
+++ b/blueprints/schema.json
@@ -11318,8 +11318,9 @@
                 "provider_type": {
                     "type": "string",
                     "enum": [
-                        "apple",
                         "openidconnect",
+                        "adfs",
+                        "apple",
                         "entraid",
                         "azuread",
                         "discord",

--- a/schema.yml
+++ b/schema.yml
@@ -47340,8 +47340,9 @@ components:
       type: string
     ProviderTypeEnum:
       enum:
-      - apple
       - openidconnect
+      - adfs
+      - apple
       - entraid
       - azuread
       - discord

--- a/web/authentik/sources/adfs.svg
+++ b/web/authentik/sources/adfs.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 23 23">
+    <path fill="#000000" d="M1 1h10v10H1z"/>
+    <path fill="#000000" d="M12 1h10v10H12z"/>
+    <path fill="#000000" d="M1 12h10v10H1z"/>
+    <path fill="#000000" d="M12 12h10v10H12z"/>
+</svg>

--- a/web/src/admin/sources/oauth/OAuthSourceViewPage.ts
+++ b/web/src/admin/sources/oauth/OAuthSourceViewPage.ts
@@ -59,6 +59,8 @@ export function ProviderToLabel(provider?: ProviderTypeEnum): string {
             return "Mailcow";
         case ProviderTypeEnum.Openidconnect:
             return msg("Generic OpenID Connect");
+        case ProviderTypeEnum.Adfs:
+            return msg("Generic ADFS");
         case ProviderTypeEnum.Okta:
             return "Okta";
         case ProviderTypeEnum.Patreon:


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
This PR implements the OAuth logic for old self hosted ADFS login providers.
These providers can't use the generic OIDC flow because their userinfo endpoint requires a different token with an `aud` claim of `urn:microsoft:userinfo`. From what I have seen other IdPs such as keycloak therefore just ignore this endpoint and use the info from the user token.

closes #9973 
maybe also #5361 and some other issue when searching for adfs but many of the don't have enough info to tell

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [x] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
