### PR TITLE
ci: migrate npm publish to OIDC

### DIFF
--- a/.github/workflows/api-ts-publish.yml
+++ b/.github/workflows/api-ts-publish.yml
@@ -8,6 +8,11 @@ on:
       - "schema.yml"
   workflow_dispatch:
 
+permissions:
+  # Required for NPM OIDC trusted publisher
+  id-token: write
+  contents: read
+
 jobs:
   build:
     if: ${{ github.repository != 'goauthentik/authentik-internal' }}
@@ -32,8 +37,6 @@ jobs:
         run: |
           npm i
           npm publish --tag generated
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
       - name: Upgrade /web
         working-directory: web
         run: |

--- a/.github/workflows/packages-npm-publish.yml
+++ b/.github/workflows/packages-npm-publish.yml
@@ -12,6 +12,11 @@ on:
       - packages/esbuild-plugin-live-reload/**
   workflow_dispatch:
 
+permissions:
+  # Required for NPM OIDC trusted publisher
+  id-token: write
+  contents: read
+
 jobs:
   publish:
     if: ${{ github.repository != 'goauthentik/authentik-internal' }}
@@ -46,5 +51,3 @@ jobs:
           npm ci
           npm run build
           npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
https://github.blog/changelog/2025-09-29-strengthening-npm-security-important-changes-to-authentication-and-token-management/
https://docs.npmjs.com/trusted-publishers

Updated all npm packages from this repo to use the respective workflow as trusted publisher