### PR TITLE
website/docs: add a section about new param login_hint

### DIFF
--- a/website/docs/users-sources/sources/protocols/oauth/index.mdx
+++ b/website/docs/users-sources/sources/protocols/oauth/index.mdx
@@ -12,7 +12,7 @@ This source allows users to enroll themselves with an external OAuth-based Ident
 - Consumer key/Consumer secret: These values will be provided by the provider.
 - Scopes: Configure additional scopes to send to the provider.
 
-    Starting with authentik 2022.10, the default scopes can be replaced by prefix the value for scopes with `*`.
+    Starting with authentik 2022.10, the default scopes can be replaced by prefixing the value for scopes with `*`.
 
 ## OpenID Connect
 

--- a/website/docs/users-sources/sources/protocols/oauth/index.mdx
+++ b/website/docs/users-sources/sources/protocols/oauth/index.mdx
@@ -24,7 +24,7 @@ This URL is fetched upon saving the source, and all the URLs will be replaced by
 
 ### JWKS
 
-To simplify machine-to-machine authentication, you can create an OAuth Source as "trusted" source of JWTs. Create a source and configure either the Well-known URL or the OIDC JWKS URL, or you can manually enter the JWKS data if you so desire.
+To simplify machine-to-machine authentication, you can create an OAuth Source as a "trusted" source of JWTs. Create a source and configure either the Well-known URL or the OIDC JWKS URL, or you can manually enter the JWKS data if you so desire.
 
 Afterwards, this source can be selected in one or multiple OAuth2 providers, and any JWT issued by any of the configured sources' JWKS will be able to authenticate. To learn more about this, see [JWT-authentication](../../../../add-secure-apps/providers/oauth2/client_credentials#jwt-authentication).
 

--- a/website/docs/users-sources/sources/protocols/oauth/index.mdx
+++ b/website/docs/users-sources/sources/protocols/oauth/index.mdx
@@ -14,23 +14,23 @@ This source allows users to enroll themselves with an external OAuth-based Ident
 
     Starting with authentik 2022.10, the default scopes can be replaced by prefix the value for scopes with `*`.
 
-### OpenID Connect
+## OpenID Connect
 
-#### Well-known
+### Well-known
 
 Instead of configuring the URLs for a source manually, and the application you're configuring implements the [OpenID Connect Discovery Spec](https://openid.net/specs/openid-connect-discovery-1_0.html), you can configure the source with a single URL. The URL should always end with `.well-known/openid-configuration`. Many applications don't explicitly mention this URL, but for most of them it will be `https://application.company/.well-known/openid-configuration`.
 
 This URL is fetched upon saving the source, and all the URLs will be replaced by the ones from the Discovery document. No automatic re-fetching is done.
 
-#### JWKS
+### JWKS
 
 To simplify machine-to-machine authentication, you can create an OAuth Source as "trusted" source of JWTs. Create a source and configure either the Well-known URL or the OIDC JWKS URL, or you can manually enter the JWKS data if you so desire.
 
 Afterwards, this source can be selected in one or multiple OAuth2 providers, and any JWT issued by any of the configured sources' JWKS will be able to authenticate. To learn more about this, see [JWT-authentication](../../../../add-secure-apps/providers/oauth2/client_credentials#jwt-authentication).
 
-#### `Login_hint` parameter
+### `Login_hint` parameter
 
-If the Oauth authentication was started from within an authentik flow and the user has already identified themselves, authentik will set the `login_hint` parameter to the email address of the user. If the Identification stage has the ***Pretend user exists*** option enabled and a user could not be found, the `login_hint` value will be set to the identifier the user entered.
+If the Oauth authentication was started from within an authentik flow and the user has already identified themselves, authentik will set the `login_hint` parameter to the email address of the user. If the Identification stage has the **Pretend user exists** option enabled and a user could not be found, the `login_hint` value will be set to the identifier that the user entered.
 
 ## OAuth source property mappings
 

--- a/website/docs/users-sources/sources/protocols/oauth/index.mdx
+++ b/website/docs/users-sources/sources/protocols/oauth/index.mdx
@@ -30,7 +30,7 @@ Afterwards, this source can be selected in one or multiple OAuth2 providers, and
 
 ### `Login_hint` parameter
 
-If the Oauth authentication was started from within an authentik flow and the user has already identified themselves, authentik will set the `login_hint` parameter to the email address of the user. If the Identification stage has the **Pretend user exists** option enabled and a user could not be found, the `login_hint` value will be set to the identifier that the user entered.
+If the OAuth authentication was started from within an authentik flow and the user has already identified themselves, authentik will set the `login_hint` parameter to the email address of the user. If the Identification stage has the **Pretend user exists** option enabled and a user could not be found, the `login_hint` value will be set to the identifier that the user entered.
 
 ## OAuth source property mappings
 

--- a/website/docs/users-sources/sources/protocols/oauth/index.mdx
+++ b/website/docs/users-sources/sources/protocols/oauth/index.mdx
@@ -18,7 +18,7 @@ This source allows users to enroll themselves with an external OAuth-based Ident
 
 ### Well-known
 
-Instead of configuring the URLs for a source manually, and the application you're configuring implements the [OpenID Connect Discovery Spec](https://openid.net/specs/openid-connect-discovery-1_0.html), you can configure the source with a single URL. The URL should always end with `.well-known/openid-configuration`. Many applications don't explicitly mention this URL, but for most of them it will be `https://application.company/.well-known/openid-configuration`.
+Instead of configuring the URLs for a source manually, if the application you're configuring implements the [OpenID Connect Discovery Spec](https://openid.net/specs/openid-connect-discovery-1_0.html), you can configure the source with a single URL. The URL should always end with `.well-known/openid-configuration`. Many applications don't explicitly mention this URL, but for most of them it will be `https://application.company/.well-known/openid-configuration`.
 
 This URL is fetched upon saving the source, and all the URLs will be replaced by the ones from the Discovery document. No automatic re-fetching is done.
 

--- a/website/docs/users-sources/sources/protocols/oauth/index.mdx
+++ b/website/docs/users-sources/sources/protocols/oauth/index.mdx
@@ -28,7 +28,7 @@ To simplify machine-to-machine authentication, you can create an OAuth Source as
 
 Afterwards, this source can be selected in one or multiple OAuth2 providers, and any JWT issued by any of the configured sources' JWKS will be able to authenticate. To learn more about this, see [JWT-authentication](../../../../add-secure-apps/providers/oauth2/client_credentials#jwt-authentication).
 
-### `Login_hint` parameter
+### `login_hint` parameter
 
 If the OAuth authentication was started from within an authentik flow and the user has already identified themselves, authentik will set the `login_hint` parameter to the email address of the user. If the Identification stage has the **Pretend user exists** option enabled and a user could not be found, the `login_hint` value will be set to the identifier that the user entered.
 

--- a/website/docs/users-sources/sources/protocols/oauth/index.mdx
+++ b/website/docs/users-sources/sources/protocols/oauth/index.mdx
@@ -24,9 +24,13 @@ This URL is fetched upon saving the source, and all the URLs will be replaced by
 
 #### JWKS
 
-To simplify Machine-to-machine authentication, you can create an OAuth Source as "trusted" source of JWTs. Create a source and configure either the Well-known URL or the OIDC JWKS URL, or you can manually enter the JWKS data if you so desire.
+To simplify machine-to-machine authentication, you can create an OAuth Source as "trusted" source of JWTs. Create a source and configure either the Well-known URL or the OIDC JWKS URL, or you can manually enter the JWKS data if you so desire.
 
 Afterwards, this source can be selected in one or multiple OAuth2 providers, and any JWT issued by any of the configured sources' JWKS will be able to authenticate. To learn more about this, see [JWT-authentication](../../../../add-secure-apps/providers/oauth2/client_credentials#jwt-authentication).
+
+#### `Login_hint` parameter
+
+If the Oauth authentication was started from within an authentik flow and the user has already identified themselves, authentik will set the `login_hint` parameter to the email address of the user. If the Identification stage has the ***Pretend user exists*** option enabled and a user could not be found, the `login_hint` value will be set to the identifier the user entered.
 
 ## OAuth source property mappings
 


### PR DESCRIPTION
This PR adds a section about the `login_hint` parm being autotomatically used by authentik. Accompanies [PR 16982]( https://github.com/goauthentik/authentik/pull/16982.)

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
