### PR TITLE
core: fix application and source's fa:// icon

### DIFF
--- a/authentik/core/models.py
+++ b/authentik/core/models.py
@@ -577,6 +577,8 @@ class Application(SerializerModel, PolicyBindingModel):
             return None
         if self.meta_icon.name.startswith("http"):
             return self.meta_icon.name
+        if self.meta_icon.name.startswith("fa://"):
+            return self.meta_icon.name
         if self.meta_icon.name.startswith("/"):
             return CONFIG.get("web.path", "/")[:-1] + self.meta_icon.name
         return self.meta_icon.url
@@ -781,6 +783,8 @@ class Source(ManagedModel, SerializerModel, PolicyBindingModel):
         if not self.icon:
             return None
         if self.icon.name.startswith("http"):
+            return self.icon.name
+        if self.icon.name.startswith("fa://"):
             return self.icon.name
         if self.icon.name.startswith("/"):
             return CONFIG.get("web.path", "/")[:-1] + self.icon.name

--- a/authentik/core/tests/test_applications_api.py
+++ b/authentik/core/tests/test_applications_api.py
@@ -127,6 +127,21 @@ class TestApplicationsAPI(APITestCase):
         self.allowed.refresh_from_db()
         self.assertEqual(self.allowed.get_meta_icon, "https://authentik.company/img.png")
 
+    def test_set_icon_fa(self):
+        """Test set_icon (url)"""
+        self.client.force_login(self.user)
+        response = self.client.post(
+            reverse(
+                "authentik_api:application-set-icon-url",
+                kwargs={"slug": self.allowed.slug},
+            ),
+            data={"url": "fa://fa-check-circle"},
+        )
+        self.assertEqual(response.status_code, 200)
+
+        self.allowed.refresh_from_db()
+        self.assertEqual(self.allowed.get_meta_icon, "fa://fa-check-circle")
+
     def test_check_access(self):
         """Test check_access operation"""
         self.client.force_login(self.user)

--- a/web/src/user/LibraryPage/ak-library-application-list.css
+++ b/web/src/user/LibraryPage/ak-library-application-list.css
@@ -99,7 +99,7 @@
 
 [part="card-header-icon"] {
     --icon-height: 50%;
-    --icon-font-size: calc(var(--app-card-min-width) / 1.5);
+    --icon-font-size: calc(var(--app-card-min-width) / 2.3);
 
     &::part(icon) {
         --app-icon--shadow-background-color: var(--pf-c-card--BackgroundColor);


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Fixes `fa://<whatever>` icons not being returned by the API correctly
Also slightly decrease fallback font size for app icon

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
