### PR TITLE
website/docs: add more RADIUS EAP-TLS docs

### DIFF
--- a/website/docs/add-secure-apps/flows-stages/stages/mtls/index.md
+++ b/website/docs/add-secure-apps/flows-stages/stages/mtls/index.md
@@ -115,3 +115,7 @@ When using authentik without a reverse proxy, select the certificate authorities
         - **User attribute**: Select the attribute of the user the certificate should be compared against.
 
 4. Click **Finish**.
+
+:::info Use PKI for certificates
+For certificates, we recommend using Public Key Infrastructure (PKI) with the mTLS stage. The PKI issues digital certificates to authenticate both the user and the server.
+:::

--- a/website/docs/add-secure-apps/flows-stages/stages/mtls/index.md
+++ b/website/docs/add-secure-apps/flows-stages/stages/mtls/index.md
@@ -8,7 +8,7 @@ toc_max_heading_level: 5
 
 The Mutual TLS stage enables authentik to use client certificates to enroll and authenticate users. These certificates can be local to the device or available via PIV Smart Cards, Yubikeys, etc.
 
-import Eap from "../../../../expressions/_eap.md";
+import Eap from "../../../../expressions/\_eap.md";
 
 <Eap />
 

--- a/website/docs/add-secure-apps/flows-stages/stages/mtls/index.md
+++ b/website/docs/add-secure-apps/flows-stages/stages/mtls/index.md
@@ -8,7 +8,9 @@ toc_max_heading_level: 5
 
 The Mutual TLS stage enables authentik to use client certificates to enroll and authenticate users. These certificates can be local to the device or available via PIV Smart Cards, Yubikeys, etc.
 
-Management of client certificates is out of the scope of this document.
+import Eap from "../../../../expressions/_eap.md";
+
+<Eap />
 
 ## Reverse-proxy configuration
 
@@ -115,7 +117,3 @@ When using authentik without a reverse proxy, select the certificate authorities
         - **User attribute**: Select the attribute of the user the certificate should be compared against.
 
 4. Click **Finish**.
-
-:::info Use certificates from trusted certificate authority
-For certificates, we strongly recommend that you use a certificate created by a known certificate authority, not a self-generated certificate.
-:::

--- a/website/docs/add-secure-apps/flows-stages/stages/mtls/index.md
+++ b/website/docs/add-secure-apps/flows-stages/stages/mtls/index.md
@@ -116,6 +116,6 @@ When using authentik without a reverse proxy, select the certificate authorities
 
 4. Click **Finish**.
 
-:::info Use PKI for certificates
-For certificates, we recommend using Public Key Infrastructure (PKI) with the mTLS stage. The PKI issues digital certificates to authenticate both the user and the server.
+:::info Use certificates from trusted certificate authority
+For certificates, we strongly recommend that you use a certificate created by a known certificate authority, not a self-generated certificate.
 :::

--- a/website/docs/add-secure-apps/providers/radius/index.mdx
+++ b/website/docs/add-secure-apps/providers/radius/index.mdx
@@ -33,20 +33,15 @@ The following stages are supported:
 - [Deny](../../flows-stages/stages/deny.md)
 - [Mutual TLS stage](../../flows-stages/stages/mtls/index.md)
 
-### EAP
+### EAP :ak-enterprise :ak-version[2025.10]
 
-<div className="badge-group">
-
-:ak-version[2025.10]
-:ak-enterprise
-
-</div>
-
-authentik supports EAP with TLS as the inner protocol. To set this up, a certificate authority needs to be available and client certificates need to be installed on machines, the configuration of which is outside of the scope of this document.
+authentik supports EAP with TLS as the inner protocol, between the application and transport layers to encrypt and secure communications. To set this up, a certificate authority needs to be available and client certificates need to be installed on machines, the configuration of which is outside of the scope of this document.
 
 #### EAP-TLS
 
-Create an authentication flow with a [Mutual TLS stage](../../flows-stages/stages/mtls/index.md) as its first stage. This stage should be configured to use your certificate authority. Afterwards a certificate needs to be generated for the RADIUS outpost, which can be configured in the RADIUS provider. Once the certificate and the authentication flow are configured in the provider, authentication via EAP-TLS is possible.
+Create an authentication flow with a [Mutual TLS stage](../../flows-stages/stages/mtls/index.md) as its first stage. This stage should be configured to use your certificate authority. Afterwards a certificate needs to be generated for the RADIUS outpost, which can be configured in the RADIUS provider. After the certificate and the authentication flow are configured in the provider, authentication via EAP-TLS is possible.
+
+For certificates, we recommend using Public Key Infrastructure (PKI) to enable the EAP-TLS method. The PKI issues digital certificates to authenticate both the user and the server.
 
 ### RADIUS attributes
 

--- a/website/docs/add-secure-apps/providers/radius/index.mdx
+++ b/website/docs/add-secure-apps/providers/radius/index.mdx
@@ -45,6 +45,10 @@ Create an authentication flow with a [Mutual TLS stage](../../flows-stages/stage
 
 For certificates, ensure that you use a client certificate and a server certificate that are created by a certificate authority, not a self-generated certificate.
 
+import Eap from "../../../expressions/_eap.md";
+
+<Eap />
+
 ### RADIUS attributes
 
 Starting with authentik 2024.8, you can create RADIUS provider property mappings, which make it possible to add custom attributes to the RADIUS response packets.
@@ -70,7 +74,7 @@ After creation, make sure to select the RADIUS property mapping in the RADIUS pr
 The RADIUS provider supports EAP-TLS and [PAP](https://en.wikipedia.org/wiki/Password_Authentication_Protocol) (Password Authentication Protocol) protocol. For password-based authentication, only [PAP](https://en.wikipedia.org/wiki/Password_Authentication_Protocol) (Password Authentication Protocol) protocol is supported due to other password hashing methods requiring reversible password hashes, which we don’t support for security reasons.
 
 <details>
-  <summary>RADIUS protocol support for password-based authentication</summary>
+  <summary>RADIUS protocol support for password-based authentication (PAP):</summary>
 
 <HashSupport />
 </details>

--- a/website/docs/add-secure-apps/providers/radius/index.mdx
+++ b/website/docs/add-secure-apps/providers/radius/index.mdx
@@ -41,9 +41,9 @@ authentik supports EAP with TLS as the inner protocol, between the application a
 
 #### EAP-TLS
 
-Create an authentication flow with a [Mutual TLS stage](../../flows-stages/stages/mtls/index.md) as its first stage. This stage should be configured to use your certificate authority. Afterwards a certificate needs to be generated for the RADIUS outpost, which can be configured in the RADIUS provider. After the certificate and the authentication flow are configured in the provider, authentication via EAP-TLS is possible.
+Create an authentication flow with a [Mutual TLS stage](../../flows-stages/stages/mtls/index.md) as its first stage. This stage should be configured to use your CA's certificate. Afterwards a server certificate needs to be selected in the RADIUS provider (which serves as an outpost). Then, configure your RADIUS provider to use this authentication flow to enable EAP-TLS authentication. After the certificate and the authentication flow are configured in the provider, authentication via EAP-TLS is possible.
 
-For certificates, we recommend using Public Key Infrastructure (PKI) to enable the EAP-TLS method. The PKI issues digital certificates to authenticate both the user and the server.
+For certificates, ensure that you use a client certificate and a server certificate that are created by a certificate authority, not a self-generated certificate.
 
 ### RADIUS attributes
 

--- a/website/docs/add-secure-apps/providers/radius/index.mdx
+++ b/website/docs/add-secure-apps/providers/radius/index.mdx
@@ -7,7 +7,7 @@ import { HashSupport } from "./HashSupport";
 You can configure a Radius provider for applications that don't support any other protocols or that require Radius.
 
 :::info
-This provider requires the deployment of the [RADIUS outpost](../../outposts/index.mdx).
+This provider requires the deployment of a [RADIUS outpost](../../outposts/index.mdx).
 :::
 
 Currently, only authentication requests are supported.
@@ -23,7 +23,7 @@ The following stages are supported:
     - [Authenticator validation](../../flows-stages/stages/authenticator_validate/index.mdx)
 
     :::info
-    Authenticator validation currently only supports DUO, TOTP, and static auNothenticators.
+    Authenticator validation currently only supports DUO, TOTP, and static authenticator.
     :::
 
     For code-based authenticators, the code must be given as part of the bind password, separated by a semicolon. For example for the password `example-password` and the MFA token `123456`, the input must be `example-password;123456`.
@@ -65,8 +65,12 @@ return packet
 
 After creation, make sure to select the RADIUS property mapping in the RADIUS provider.
 
-### Limitations
+### Protocol support
 
-The RADIUS provider only supports the [PAP](https://en.wikipedia.org/wiki/Password_Authentication_Protocol) (Password Authentication Protocol) protocol:
+The RADIUS provider supports EAP-TLS and [PAP](https://en.wikipedia.org/wiki/Password_Authentication_Protocol) (Password Authentication Protocol) protocol. For password-based authentication, only [PAP](https://en.wikipedia.org/wiki/Password_Authentication_Protocol) (Password Authentication Protocol) protocol is supported due to other password hashing methods requiring reversible password hashes, which we don’t support for security reasons.
+
+<details>
+  <summary>RADIUS protocol support for password-based authentication</summary>
 
 <HashSupport />
+</details>

--- a/website/docs/add-secure-apps/providers/radius/index.mdx
+++ b/website/docs/add-secure-apps/providers/radius/index.mdx
@@ -7,7 +7,7 @@ import { HashSupport } from "./HashSupport";
 You can configure a Radius provider for applications that don't support any other protocols or that require Radius.
 
 :::info
-This provider requires the deployment of the [RADIUS outpost](../../outposts/index.mdx)
+This provider requires the deployment of the [RADIUS outpost](../../outposts/index.mdx).
 :::
 
 Currently, only authentication requests are supported.
@@ -18,11 +18,13 @@ Authentication requests against the Radius Server use a flow in the background. 
 
 The following stages are supported:
 
-- [Identification](../../flows-stages/stages/identification/index.mdx)
-- [Password](../../flows-stages/stages/password/index.md)
-- [Authenticator validation](../../flows-stages/stages/authenticator_validate/index.mdx)
+    - [Identification](../../flows-stages/stages/identification/index.mdx)
+    - [Password](../../flows-stages/stages/password/index.md)
+    - [Authenticator validation](../../flows-stages/stages/authenticator_validate/index.mdx)
 
-    Note: Authenticator validation currently only supports DUO, TOTP, and static authenticators.
+    :::info
+    Authenticator validation currently only supports DUO, TOTP, and static auNothenticators.
+    :::
 
     For code-based authenticators, the code must be given as part of the bind password, separated by a semicolon. For example for the password `example-password` and the MFA token `123456`, the input must be `example-password;123456`.
 

--- a/website/docs/expressions/_eap.md
+++ b/website/docs/expressions/_eap.md
@@ -1,0 +1,4 @@
+:::warning Use of trusted Certificate Authority
+For EAP-TLS, note that you should NOT use a globally known CA.
+For example, using a Verisign cert as a "known CA" means that ANYONE who has a certificate signed by them can authenticate via EAP-TLS. Using private PKI certificates that are trusted by the end-device is best practise to distribute client certificates.
+:::

--- a/website/docs/sys-mgmt/brands.md
+++ b/website/docs/sys-mgmt/brands.md
@@ -67,7 +67,7 @@ The **Web Certificate** option can be used to configure which certificate authen
 
 #### Client Certificates:ak-version[2025.4]
 
-When using the [Mutual TLS Stage](../add-secure-apps/flows-stages/stages/mtls/index.md) and accessing authentik directly, this option configures which certificate authorities clients' certificates can be issued by.
+When using the [Mutual TLS Stage](../add-secure-apps/flows-stages/stages/mtls/index.md) and accessing authentik directly, this option configures which certificate authorities can issue client certificates.
 
 #### Attributes
 

--- a/website/docs/sys-mgmt/brands.md
+++ b/website/docs/sys-mgmt/brands.md
@@ -67,7 +67,7 @@ The **Web Certificate** option can be used to configure which certificate authen
 
 #### Client Certificates:ak-version[2025.4]
 
-When using the [Mutual TLS Stage](../add-secure-apps/flows-stages/stages/mtls/index.md) and accessing authentik directly, this option configures which certificate authorities can issue client certificates.
+When using the [Mutual TLS Stage](../add-secure-apps/flows-stages/stages/mtls/index.md) and accessing authentik directly, this setting specifies which certificate authorities are trusted to issue client certificates.
 
 #### Attributes
 


### PR DESCRIPTION
This PR adds more content to the Docs about EAP [PR 15702](https://github.com/goauthentik/authentik/pull/15702), adds mention of needing to use a proper CA certificate with EAP-TLS and the mTLS stage. Also a few random cleanups.

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
