### PR TITLE
api: add decorator to validate serializer in @action endpoints

### DIFF
--- a/authentik/api/validation.py
+++ b/authentik/api/validation.py
@@ -1,0 +1,27 @@
+from collections.abc import Callable
+from functools import wraps
+
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.serializers import Serializer
+from rest_framework.viewsets import ViewSet
+
+
+def validate(serializer_type: type[Serializer]):
+
+    def wrapper_outer(func: Callable):
+
+        @wraps(func)
+        def wrapper(self: ViewSet, request: Request, *args, **kwargs) -> Response:
+            instance = serializer_type(
+                data=request.data,
+                context={
+                    "request": request,
+                },
+            )
+            instance.is_valid(raise_exception=True)
+            return func(self, request, *args, instance=instance, **kwargs)
+
+        return wrapper
+
+    return wrapper_outer

--- a/authentik/api/validation.py
+++ b/authentik/api/validation.py
@@ -9,6 +9,20 @@ from rest_framework.viewsets import ViewSet
 
 
 def validate(serializer_type: type[Serializer], location: Literal["body", "query"] = "body"):
+    """Validate incoming data with the specified serializer. Raw data can either be taken
+    from request body or query string, defaulting to body.
+
+    Validated data is added to the function this decorator is used on with a named parameter
+    based on the location of the data.
+
+    Example:
+
+        @validate(MySerializer)
+        @validate(MyQuerySerializer, location="query")
+        def my_action(self, request, *, body: MySerializer, query: MyQuerySerializer):
+            ...
+
+    """
 
     def wrapper_outer(func: Callable):
 

--- a/authentik/api/validation.py
+++ b/authentik/api/validation.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable
 from functools import wraps
+from typing import Literal
 
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -7,20 +8,28 @@ from rest_framework.serializers import Serializer
 from rest_framework.viewsets import ViewSet
 
 
-def validate(serializer_type: type[Serializer]):
+def validate(serializer_type: type[Serializer], location: Literal["body", "query"] = "body"):
 
     def wrapper_outer(func: Callable):
 
         @wraps(func)
         def wrapper(self: ViewSet, request: Request, *args, **kwargs) -> Response:
+            data = {}
+            if location == "body":
+                data = request.data
+            elif location == "query":
+                data = request.query_params
+            else:
+                raise ValueError(f"Invalid data location '{location}'")
             instance = serializer_type(
-                data=request.data,
+                data=data,
                 context={
                     "request": request,
                 },
             )
             instance.is_valid(raise_exception=True)
-            return func(self, request, *args, instance=instance, **kwargs)
+            kwargs[location] = instance
+            return func(self, request, *args, **kwargs)
 
         return wrapper
 

--- a/authentik/core/api/devices.py
+++ b/authentik/core/api/devices.py
@@ -13,6 +13,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
+from authentik.api.validation import validate
 from authentik.core.api.users import ParamUserSerializer
 from authentik.core.api.utils import MetaNameSerializer
 from authentik.enterprise.stages.authenticator_endpoint_gdtc.models import EndpointDevice
@@ -85,6 +86,7 @@ class AdminDeviceViewSet(ViewSet):
         parameters=[ParamUserSerializer],
         responses={200: DeviceSerializer(many=True)},
     )
+    @validate(ParamUserSerializer, "query")
     def list(self, request: Request) -> Response:
         """Get all devices for current user"""
         args = ParamUserSerializer(data=request.query_params)

--- a/authentik/core/api/devices.py
+++ b/authentik/core/api/devices.py
@@ -87,8 +87,6 @@ class AdminDeviceViewSet(ViewSet):
         responses={200: DeviceSerializer(many=True)},
     )
     @validate(ParamUserSerializer, "query")
-    def list(self, request: Request) -> Response:
+    def list(self, request: Request, query: ParamUserSerializer) -> Response:
         """Get all devices for current user"""
-        args = ParamUserSerializer(data=request.query_params)
-        args.is_valid(raise_exception=True)
-        return Response(DeviceSerializer(self.get_devices(**args.validated_data), many=True).data)
+        return Response(DeviceSerializer(self.get_devices(**query.validated_data), many=True).data)

--- a/authentik/core/api/groups.py
+++ b/authentik/core/api/groups.py
@@ -22,6 +22,7 @@ from rest_framework.serializers import ListSerializer, ValidationError
 from rest_framework.validators import UniqueValidator
 from rest_framework.viewsets import ModelViewSet
 
+from authentik.api.validation import validate
 from authentik.core.api.used_by import UsedByMixin
 from authentik.core.api.utils import JSONDictField, ModelSerializer, PassiveSerializer
 from authentik.core.models import Group, User
@@ -289,13 +290,14 @@ class GroupViewSet(UsedByMixin, ModelViewSet):
         filter_backends=[],
         permission_classes=[],
     )
-    def add_user(self, request: Request, pk: str) -> Response:
+    @validate(UserAccountSerializer)
+    def add_user(self, request: Request, body: UserAccountSerializer, pk: str) -> Response:
         """Add user to group"""
         group: Group = self.get_object()
         user: User = (
             get_objects_for_user(request.user, "authentik_core.view_user")
             .filter(
-                pk=request.data.get("pk"),
+                pk=body.validated_data.get("pk"),
             )
             .first()
         )
@@ -319,13 +321,14 @@ class GroupViewSet(UsedByMixin, ModelViewSet):
         filter_backends=[],
         permission_classes=[],
     )
-    def remove_user(self, request: Request, pk: str) -> Response:
+    @validate(UserAccountSerializer)
+    def remove_user(self, request: Request, body: UserAccountSerializer, pk: str) -> Response:
         """Remove user from group"""
         group: Group = self.get_object()
         user: User = (
             get_objects_for_user(request.user, "authentik_core.view_user")
             .filter(
-                pk=request.data.get("pk"),
+                pk=body.validated_data.get("pk"),
             )
             .first()
         )

--- a/authentik/core/api/property_mappings.py
+++ b/authentik/core/api/property_mappings.py
@@ -130,7 +130,7 @@ class PropertyMappingViewSet(
     )
     @action(detail=True, pagination_class=None, filter_backends=[], methods=["POST"])
     @validate(PropertyMappingTestSerializer)
-    def test(self, request: Request, pk: str, instance: PropertyMappingTestSerializer) -> Response:
+    def test(self, request: Request, pk: str, body: PropertyMappingTestSerializer) -> Response:
         """Test Property Mapping"""
         _mapping: PropertyMapping = self.get_object()
         # Use `get_subclass` to get correct class and correct `.evaluate` implementation
@@ -139,10 +139,10 @@ class PropertyMappingViewSet(
         # and ones for providers, we need to make the user field optional for the source mapping
         format_result = str(request.GET.get("format_result", "false")).lower() == "true"
 
-        context: dict = instance.validated_data.get("context", {})
+        context: dict = body.validated_data.get("context", {})
         context.setdefault("user", None)
 
-        if user := instance.validated_data.get("user"):
+        if user := body.validated_data.get("user"):
             # User permission check, only allow mapping testing for users that are readable
             users = get_objects_for_user(request.user, "authentik_core.view_user").filter(
                 pk=user.pk
@@ -150,7 +150,7 @@ class PropertyMappingViewSet(
             if not users.exists():
                 raise PermissionDenied()
             context["user"] = user
-        if group := instance.validated_data.get("group"):
+        if group := body.validated_data.get("group"):
             # Group permission check, only allow mapping testing for groups that are readable
             groups = get_objects_for_user(request.user, "authentik_core.view_group").filter(
                 pk=group.pk

--- a/authentik/core/api/tokens.py
+++ b/authentik/core/api/tokens.py
@@ -12,6 +12,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
+from authentik.api.validation import validate
 from authentik.blueprints.api import ManagedSerializer
 from authentik.blueprints.v1.importer import SERIALIZER_CONTEXT_BLUEPRINT
 from authentik.core.api.used_by import UsedByMixin
@@ -182,6 +183,7 @@ class TokenViewSet(UsedByMixin, ModelViewSet):
         },
     )
     @action(detail=True, pagination_class=None, filter_backends=[], methods=["POST"])
+    @validate(TokenSetKeySerializer)
     def set_key(self, request: Request, identifier: str, body: TokenSetKeySerializer) -> Response:
         """Set token key. Action is logged as event. `authentik_core.set_token_key` permission
         is required."""

--- a/authentik/core/api/transactional_applications.py
+++ b/authentik/core/api/transactional_applications.py
@@ -12,6 +12,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from yaml import ScalarNode
 
+from authentik.api.validation import validate
 from authentik.blueprints.v1.common import (
     Blueprint,
     BlueprintEntry,
@@ -160,11 +161,10 @@ class TransactionalApplicationView(APIView):
             200: TransactionApplicationResponseSerializer(),
         },
     )
-    def put(self, request: Request) -> Response:
+    @validate(TransactionApplicationSerializer)
+    def put(self, request: Request, instance: TransactionApplicationSerializer) -> Response:
         """Convert data into a blueprint, validate it and apply it"""
-        data = TransactionApplicationSerializer(data=request.data)
-        data.is_valid(raise_exception=True)
-        blueprint: Blueprint = data.validated_data
+        blueprint: Blueprint = instance.validated_data
         for entry in blueprint.entries:
             full_model = entry.get_model(blueprint)
             app, __, model = full_model.partition(".")

--- a/authentik/core/api/transactional_applications.py
+++ b/authentik/core/api/transactional_applications.py
@@ -162,9 +162,9 @@ class TransactionalApplicationView(APIView):
         },
     )
     @validate(TransactionApplicationSerializer)
-    def put(self, request: Request, instance: TransactionApplicationSerializer) -> Response:
+    def put(self, request: Request, body: TransactionApplicationSerializer) -> Response:
         """Convert data into a blueprint, validate it and apply it"""
-        blueprint: Blueprint = instance.validated_data
+        blueprint: Blueprint = body.validated_data
         for entry in blueprint.entries:
             full_model = entry.get_model(blueprint)
             app, __, model = full_model.partition(".")

--- a/authentik/crypto/api.py
+++ b/authentik/crypto/api.py
@@ -278,15 +278,15 @@ class CertificateKeyPairViewSet(UsedByMixin, ModelViewSet):
     )
     @action(detail=False, methods=["POST"])
     @validate(CertificateGenerationSerializer)
-    def generate(self, request: Request, instance: CertificateGenerationSerializer) -> Response:
+    def generate(self, request: Request, body: CertificateGenerationSerializer) -> Response:
         """Generate a new, self-signed certificate-key pair"""
-        raw_san = instance.validated_data.get("subject_alt_name", "")
+        raw_san = body.validated_data.get("subject_alt_name", "")
         sans = raw_san.split(",") if raw_san != "" else []
-        builder = CertificateBuilder(instance.validated_data["name"])
-        builder.alg = instance.validated_data["alg"]
+        builder = CertificateBuilder(body.validated_data["name"])
+        builder.alg = body.validated_data["alg"]
         builder.build(
             subject_alt_names=sans,
-            validity_days=int(instance.validated_data["validity_days"]),
+            validity_days=int(body.validated_data["validity_days"]),
         )
         instance = builder.save()
         serializer = self.get_serializer(instance)

--- a/authentik/enterprise/providers/ssf/views/stream.py
+++ b/authentik/enterprise/providers/ssf/views/stream.py
@@ -6,6 +6,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from structlog.stdlib import get_logger
 
+from authentik.api.validation import validate
 from authentik.core.api.utils import ModelSerializer, PassiveSerializer
 from authentik.enterprise.providers.ssf.models import (
     DeliveryMethods,
@@ -101,14 +102,13 @@ class StreamResponseSerializer(PassiveSerializer):
 
 
 class StreamView(SSFView):
-    def post(self, request: Request, *args, **kwargs) -> Response:
-        stream = StreamSerializer(data=request.data, context={"request": request})
-        stream.is_valid(raise_exception=True)
+    @validate(StreamSerializer)
+    def post(self, request: Request, *args, body: StreamSerializer, **kwargs) -> Response:
         if not request.user.has_perm("authentik_providers_ssf.add_stream", self.provider):
             raise PermissionDenied(
                 "User does not have permission to create stream for this provider."
             )
-        instance: Stream = stream.save(provider=self.provider)
+        instance: Stream = body.save(provider=self.provider)
         send_ssf_events(
             EventTypes.SET_VERIFICATION,
             {

--- a/authentik/policies/api/policies.py
+++ b/authentik/policies/api/policies.py
@@ -131,12 +131,12 @@ class PolicyViewSet(
     )
     @action(detail=True, pagination_class=None, filter_backends=[], methods=["POST"])
     @validate(PolicyTestSerializer)
-    def test(self, request: Request, pk: str, instance: PolicyTestSerializer) -> Response:
+    def test(self, request: Request, pk: str, body: PolicyTestSerializer) -> Response:
         """Test policy"""
         policy = self.get_object()
         # User permission check, only allow policy testing for users that are readable
         users = get_objects_for_user(request.user, "authentik_core.view_user").filter(
-            pk=instance.validated_data["user"].pk
+            pk=body.validated_data["user"].pk
         )
         if not users.exists():
             return Response(status=400)
@@ -144,7 +144,7 @@ class PolicyViewSet(
         p_request = PolicyRequest(users.first())
         p_request.debug = True
         p_request.set_http_request(self.request)
-        p_request.context = instance.validated_data.get("context", {})
+        p_request.context = body.validated_data.get("context", {})
 
         proc = PolicyProcess(PolicyBinding(policy=policy), p_request, None)
         with capture_logs() as logs:

--- a/authentik/policies/api/policies.py
+++ b/authentik/policies/api/policies.py
@@ -12,6 +12,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 from structlog.stdlib import get_logger
 
+from authentik.api.validation import validate
 from authentik.core.api.applications import user_app_cache_key
 from authentik.core.api.object_types import TypesMixin
 from authentik.core.api.used_by import UsedByMixin
@@ -129,16 +130,13 @@ class PolicyViewSet(
         },
     )
     @action(detail=True, pagination_class=None, filter_backends=[], methods=["POST"])
-    def test(self, request: Request, pk: str) -> Response:
+    @validate(PolicyTestSerializer)
+    def test(self, request: Request, pk: str, instance: PolicyTestSerializer) -> Response:
         """Test policy"""
         policy = self.get_object()
-        test_params = PolicyTestSerializer(data=request.data)
-        if not test_params.is_valid():
-            return Response(test_params.errors, status=400)
-
         # User permission check, only allow policy testing for users that are readable
         users = get_objects_for_user(request.user, "authentik_core.view_user").filter(
-            pk=test_params.validated_data["user"].pk
+            pk=instance.validated_data["user"].pk
         )
         if not users.exists():
             return Response(status=400)
@@ -146,7 +144,7 @@ class PolicyViewSet(
         p_request = PolicyRequest(users.first())
         p_request.debug = True
         p_request.set_http_request(self.request)
-        p_request.context = test_params.validated_data.get("context", {})
+        p_request.context = instance.validated_data.get("context", {})
 
         proc = PolicyProcess(PolicyBinding(policy=policy), p_request, None)
         with capture_logs() as logs:

--- a/authentik/providers/saml/api/providers.py
+++ b/authentik/providers/saml/api/providers.py
@@ -319,9 +319,9 @@ class SAMLProviderViewSet(UsedByMixin, ModelViewSet):
     )
     @action(detail=False, methods=["POST"], parser_classes=(MultiPartParser,))
     @validate(SAMLProviderImportSerializer)
-    def import_metadata(self, request: Request, instance: SAMLProviderImportSerializer) -> Response:
+    def import_metadata(self, request: Request, body: SAMLProviderImportSerializer) -> Response:
         """Create provider from SAML Metadata"""
-        file = instance.validated_data["file"]
+        file = body.validated_data["file"]
         # Validate syntax first
         try:
             fromstring(file.read())
@@ -331,9 +331,9 @@ class SAMLProviderViewSet(UsedByMixin, ModelViewSet):
         try:
             metadata = ServiceProviderMetadataParser().parse(file.read().decode())
             metadata.to_provider(
-                instance.validated_data["name"],
-                instance.validated_data["authorization_flow"],
-                instance.validated_data["invalidation_flow"],
+                body.validated_data["name"],
+                body.validated_data["authorization_flow"],
+                body.validated_data["invalidation_flow"],
             )
         except ValueError as exc:  # pragma: no cover
             LOGGER.warning(str(exc))

--- a/authentik/providers/saml/api/providers.py
+++ b/authentik/providers/saml/api/providers.py
@@ -23,6 +23,7 @@ from rest_framework.serializers import PrimaryKeyRelatedField, ValidationError
 from rest_framework.viewsets import ModelViewSet
 from structlog.stdlib import get_logger
 
+from authentik.api.validation import validate
 from authentik.core.api.providers import ProviderSerializer
 from authentik.core.api.used_by import UsedByMixin
 from authentik.core.api.utils import PassiveSerializer, PropertyMappingPreviewSerializer
@@ -317,12 +318,10 @@ class SAMLProviderViewSet(UsedByMixin, ModelViewSet):
         },
     )
     @action(detail=False, methods=["POST"], parser_classes=(MultiPartParser,))
-    def import_metadata(self, request: Request) -> Response:
+    @validate(SAMLProviderImportSerializer)
+    def import_metadata(self, request: Request, instance: SAMLProviderImportSerializer) -> Response:
         """Create provider from SAML Metadata"""
-        data = SAMLProviderImportSerializer(data=request.data)
-        if not data.is_valid():
-            raise ValidationError(data.errors)
-        file = data.validated_data["file"]
+        file = instance.validated_data["file"]
         # Validate syntax first
         try:
             fromstring(file.read())
@@ -332,9 +331,9 @@ class SAMLProviderViewSet(UsedByMixin, ModelViewSet):
         try:
             metadata = ServiceProviderMetadataParser().parse(file.read().decode())
             metadata.to_provider(
-                data.validated_data["name"],
-                data.validated_data["authorization_flow"],
-                data.validated_data["invalidation_flow"],
+                instance.validated_data["name"],
+                instance.validated_data["authorization_flow"],
+                instance.validated_data["invalidation_flow"],
             )
         except ValueError as exc:  # pragma: no cover
             LOGGER.warning(str(exc))

--- a/authentik/sources/plex/api/source.py
+++ b/authentik/sources/plex/api/source.py
@@ -150,7 +150,9 @@ class PlexSourceViewSet(UsedByMixin, ModelViewSet):
         permission_classes=[IsAuthenticated],
     )
     @validate(PlexTokenRedeemSerializer)
-    def redeem_token_authenticated(self, request: Request, body: PlexTokenRedeemSerializer) -> Response:
+    def redeem_token_authenticated(
+        self, request: Request, body: PlexTokenRedeemSerializer
+    ) -> Response:
         """Redeem a plex token for an authenticated user, creating a connection"""
         source: PlexSource = get_object_or_404(
             PlexSource, slug=request.query_params.get("slug", "")

--- a/authentik/tenants/api/tenants.py
+++ b/authentik/tenants/api/tenants.py
@@ -109,8 +109,7 @@ class TenantViewSet(ModelViewSet):
         tenant = self.get_object()
         with tenant:
             data = TenantAdminGroupRequestSerializer(data=request.data)
-            if not data.is_valid():
-                return Response(data.errors, status=400)
+            data.is_valid(raise_exception=True)
             user = User.objects.filter(username=data.validated_data.get("user")).first()
             if not user:
                 return Response(status=404)
@@ -131,8 +130,7 @@ class TenantViewSet(ModelViewSet):
         tenant = self.get_object()
         with tenant:
             data = TenantRecoveryKeyRequestSerializer(data=request.data)
-            if not data.is_valid():
-                return Response(data.errors, status=400)
+            data.is_valid(raise_exception=True)
             user = User.objects.filter(username=data.validated_data.get("user")).first()
             if not user:
                 return Response(status=404)


### PR DESCRIPTION
Instead of having to manually create the serializer and validate it, do that from the decorator

we've done this in the past where we just took the raw data without validating it, so this makes it easier

Example:

```py
@validate(MySerializer)
@validate(MyQuerySerializer, location="query")
def my_action(self, request, *, body: MySerializer, query: MyQuerySerializer):
    ...
```