### PR TITLE
web/admin: Add link to the docs in the import flow dialog

### DIFF
--- a/web/src/admin/flows/FlowImportForm.ts
+++ b/web/src/admin/flows/FlowImportForm.ts
@@ -68,9 +68,16 @@ export class FlowImportForm extends Form<Flow> {
         return html`<ak-form-element-horizontal label=${msg("Flow")} name="flow">
                 <input type="file" value="" class="pf-c-form-control" />
                 <p class="pf-c-form__helper-text">
-                    ${msg(
-                        ".yaml files, which can be found on goauthentik.io and can be exported by authentik.",
-                    )}
+                    ${msg(".yaml files, which can be found on")}
+                    <a
+                        rel="noopener noreferrer"
+                        target="_blank"
+                        href="https://docs.goauthentik.io/add-secure-apps/flows-stages/flow/examples/flows/"
+                        )}
+                    >
+                        ${msg("Example flows section")}
+                    </a>
+                    ${msg(" in the official documentation, can be exported by authentik.")}
                 </p>
             </ak-form-element-horizontal>
             ${this.result ? this.renderResult() : nothing}`;

--- a/web/src/admin/flows/FlowImportForm.ts
+++ b/web/src/admin/flows/FlowImportForm.ts
@@ -3,6 +3,7 @@ import "#elements/events/LogViewer";
 import "#elements/forms/HorizontalFormElement";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
+import { docLink } from "#common/global";
 import { SentryIgnoredError } from "#common/sentry/index";
 
 import { Form } from "#elements/forms/Form";
@@ -68,16 +69,16 @@ export class FlowImportForm extends Form<Flow> {
         return html`<ak-form-element-horizontal label=${msg("Flow")} name="flow">
                 <input type="file" value="" class="pf-c-form-control" />
                 <p class="pf-c-form__helper-text">
-                    ${msg(".yaml files, which can be found in the ")}
+                    ${msg(".yaml files, which can be found in the Example Flows documentation")}
+                </p>
+                <p class="pf-c-form__helper-text">
+                    ${msg("See more here:")}&nbsp;
                     <a
-                        rel="noopener noreferrer"
                         target="_blank"
-                        href="https://docs.goauthentik.io/add-secure-apps/flows-stages/flow/examples/flows/"
-                        )}
+                        rel="noopener noreferrer"
+                        href=${docLink("/add-secure-apps/flows-stages/flow/examples/flows/")}
+                        >${msg("Documentation")}</a
                     >
-                        ${msg("Example Flows documentation")}
-                    </a>
-                    ${msg(", can be imported by authentik.")}
                 </p>
             </ak-form-element-horizontal>
             ${this.result ? this.renderResult() : nothing}`;

--- a/web/src/admin/flows/FlowImportForm.ts
+++ b/web/src/admin/flows/FlowImportForm.ts
@@ -68,16 +68,16 @@ export class FlowImportForm extends Form<Flow> {
         return html`<ak-form-element-horizontal label=${msg("Flow")} name="flow">
                 <input type="file" value="" class="pf-c-form-control" />
                 <p class="pf-c-form__helper-text">
-                    ${msg(".yaml files, which can be found on")}
+                    ${msg(".yaml files, which can be found in the ")}
                     <a
                         rel="noopener noreferrer"
                         target="_blank"
                         href="https://docs.goauthentik.io/add-secure-apps/flows-stages/flow/examples/flows/"
                         )}
                     >
-                        ${msg("Example flows section")}
+                        ${msg("Example Flows documentation")}
                     </a>
-                    ${msg(" in the official documentation, can be exported by authentik.")}
+                    ${msg(", can be imported by authentik.")}
                 </p>
             </ak-form-element-horizontal>
             ${this.result ? this.renderResult() : nothing}`;


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

From

<img width="2460" height="1428" alt="image" src="https://github.com/user-attachments/assets/7c8e4f14-5f0f-4686-a985-389175aef94e" />


To

<img width="2424" height="1606" alt="image" src="https://github.com/user-attachments/assets/035ab47f-b09e-42e5-a82d-295c8cf4b7aa" />


link to https://docs.goauthentik.io/add-secure-apps/flows-stages/flow/examples/flows/

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
