### PR TITLE
sources/oauth: Fallback user id to sub field

### DIFF
--- a/authentik/sources/oauth/views/callback.py
+++ b/authentik/sources/oauth/views/callback.py
@@ -94,6 +94,8 @@ class OAuthCallback(OAuthClientMixin, View):
         """Return unique identifier from the profile info."""
         if "id" in info:
             return info["id"]
+        if "sub" in info:
+            return info["sub"]
         return None
 
     def handle_login_failure(self, reason: str) -> HttpResponse:


### PR DESCRIPTION

## Details

Adding a fallback for OAuth Sources IDs via the sub field. 
I encountered some problems where external OAuth Providers did not have any id field on the callback request. 

closes #16115 