### PR TITLE
web/a11y: Fix "skip to content" target.

### DIFF
--- a/web/src/elements/a11y/ak-skip-to-content.ts
+++ b/web/src/elements/a11y/ak-skip-to-content.ts
@@ -3,8 +3,47 @@ import { AKElement } from "#elements/Base";
 import { msg } from "@lit/localize";
 import { css, html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators.js";
+import { ref, RefOrCallback } from "lit/directives/ref.js";
 
 import PFBase from "@patternfly/patternfly/patternfly-base.css";
+
+/**
+ * Finds the main content element within a given context.
+ *
+ * @param context - The element to start searching from
+ * @returns The main content element, if any.
+ */
+export function findMainContent(context: HTMLElement): HTMLElement | null {
+    const renderRoot = context instanceof LitElement ? context.renderRoot : context;
+
+    const mainContent = renderRoot.querySelector<HTMLElement>("main,[role=main]");
+
+    if (mainContent) {
+        return mainContent;
+    }
+
+    for (const element of renderRoot.children) {
+        if (!(element instanceof HTMLElement)) continue;
+
+        if (element.role === "presentation" || element.role === "status") continue;
+
+        if (!element.checkVisibility?.()) continue;
+
+        if (element.inert) continue;
+
+        if (element instanceof LitElement && element.renderRoot !== element) {
+            const child = findMainContent(element);
+
+            if (child) return child;
+
+            continue;
+        }
+
+        return element;
+    }
+
+    return null;
+}
 
 @customElement("ak-skip-to-content")
 export class AKSkipToContent extends AKElement {
@@ -35,6 +74,18 @@ export class AKSkipToContent extends AKElement {
         `,
     ];
 
+    protected static delegate: RefOrCallback<Element> = (nextTarget) => {
+        if (!(nextTarget instanceof HTMLElement)) return;
+
+        const skipToContentElement = document.getElementsByTagName("ak-skip-to-content");
+
+        for (const skipElement of skipToContentElement) {
+            skipElement.targetElement = nextTarget;
+        }
+    };
+
+    public static ref = ref(AKSkipToContent.delegate);
+
     #targetElement: WeakRef<HTMLElement> | null = null;
 
     @property({ attribute: false })
@@ -42,8 +93,24 @@ export class AKSkipToContent extends AKElement {
         return this.#targetElement?.deref() ?? null;
     }
 
-    public set targetElement(value: HTMLElement | null) {
-        this.#targetElement = value ? new WeakRef(value) : null;
+    public set targetElement(nextTargetElement: HTMLElement | null | undefined) {
+        const previousTarget = this.targetElement;
+
+        if (previousTarget === nextTargetElement) return;
+
+        if (previousTarget) {
+            previousTarget.removeAttribute("tabindex");
+            previousTarget.removeAttribute("data-ak-skip-to-content-target");
+        }
+
+        if (nextTargetElement) {
+            this.#targetElement = new WeakRef(nextTargetElement);
+            nextTargetElement.tabIndex = -1;
+
+            nextTargetElement.setAttribute("data-ak-skip-to-content-target", "true");
+        } else {
+            this.#targetElement = null;
+        }
     }
 
     public activate = () => {

--- a/web/src/elements/a11y/ak-skip-to-content.ts
+++ b/web/src/elements/a11y/ak-skip-to-content.ts
@@ -74,7 +74,12 @@ export class AKSkipToContent extends AKElement {
         `,
     ];
 
-    protected static delegate: RefOrCallback<Element> = (nextTarget) => {
+    /**
+     * Assign a target element to all skip to content buttons.
+     *
+     * @see {@linkcode AKSkipToContent.ref} for more information on Lit's ref directive.
+     */
+    protected static assign: RefOrCallback<Element> = (nextTarget) => {
         if (!(nextTarget instanceof HTMLElement)) return;
 
         const skipToContentElement = document.getElementsByTagName("ak-skip-to-content");
@@ -84,7 +89,18 @@ export class AKSkipToContent extends AKElement {
         }
     };
 
-    public static ref = ref(AKSkipToContent.delegate);
+    /**
+     * Assign a target element to the skip to content button via Lit's directive system.
+     *
+     * ```ts
+     * function render() {
+     *   return html`<main ${AKSkipToContent.ref}></main>`;
+     * }
+     * ```
+     *
+     * @see {@linkcode ref} for more information on Lit's ref directive.
+     */
+    public static ref = ref(AKSkipToContent.assign);
 
     #targetElement: WeakRef<HTMLElement> | null = null;
 

--- a/web/src/elements/router/RouterOutlet.ts
+++ b/web/src/elements/router/RouterOutlet.ts
@@ -3,7 +3,7 @@ import "#elements/a11y/ak-skip-to-content";
 
 import { ROUTE_SEPARATOR } from "#common/constants";
 
-import type { AKSkipToContent } from "#elements/a11y/ak-skip-to-content";
+import { type AKSkipToContent, findMainContent } from "#elements/a11y/ak-skip-to-content";
 import { AKElement } from "#elements/Base";
 import { Route } from "#elements/router/Route";
 import { RouteMatch } from "#elements/router/RouteMatch";
@@ -106,18 +106,10 @@ export class RouterOutlet extends AKElement {
     #synchronizeContentTarget = () => {
         if (!this.#skipToContentElement) return;
 
-        for (const element of this.renderRoot.children) {
-            if (!(element instanceof HTMLElement)) continue;
+        const element = findMainContent(this);
 
-            if (element.role === "presentation" || element.role === "status") continue;
-
-            if (!element.checkVisibility?.()) continue;
-
-            if (element.inert) continue;
-
+        if (element) {
             this.#skipToContentElement.targetElement = element;
-            element.tabIndex = -1;
-            return;
         }
     };
 

--- a/web/src/elements/utils/focus.ts
+++ b/web/src/elements/utils/focus.ts
@@ -29,6 +29,45 @@ export function isActiveElement(
 }
 
 /**
+ * Type predicate to check if an element is focusable.
+ *
+ * @param target The element to check.
+ *
+ * @category DOM
+ */
+export function isFocusable(target: Element | null | undefined): target is HTMLElement {
+    if (!target) {
+        console.debug("FocusTarget: Skipping focus, no target", target);
+        return false;
+    }
+    if (!(target instanceof HTMLElement)) {
+        console.debug("FocusTarget: Skipping focus, target is not an HTMLElement", target);
+        return false;
+    }
+
+    if (document.activeElement === target) {
+        console.debug("FocusTarget: Target is already focused", target);
+        return false;
+    }
+
+    // Despite our type definitions, this method isn't available in all browsers,
+    // so we fallback to assuming the element is visible.
+    const visible = target.checkVisibility?.() ?? true;
+
+    if (!visible) {
+        console.debug("FocusTarget: Skipping focus, target is not visible", target);
+        return false;
+    }
+
+    if (typeof target.focus !== "function") {
+        console.debug("FocusTarget: Skipping focus, target has no focus method", target);
+        return false;
+    }
+
+    return true;
+}
+
+/**
  * A combination reference and focus target.
  *
  * @category DOM
@@ -46,33 +85,9 @@ export class FocusTarget<T extends HTMLElement = HTMLElement> {
     }
 
     public focus = (options?: FocusOptions): void => {
-        const { target } = this;
-
-        if (!target) {
-            console.debug("FocusTarget: Skipping focus, no target", target);
-            return;
+        if (isFocusable(this.target)) {
+            this.target.focus(options);
         }
-
-        if (document.activeElement === target) {
-            console.debug("FocusTarget: Target is already focused", target);
-            return;
-        }
-
-        // Despite our type definitions, this method isn't available in all browsers,
-        // so we fallback to assuming the element is visible.
-        const visible = target.checkVisibility?.() ?? true;
-
-        if (!visible) {
-            console.debug("FocusTarget: Skipping focus, target is not visible", target);
-            return;
-        }
-
-        if (typeof target.focus !== "function") {
-            console.debug("FocusTarget: Skipping focus, target has no focus method", target);
-            return;
-        }
-
-        target.focus(options);
     };
 
     public toRef() {

--- a/web/src/user/LibraryPage/ak-library-impl.ts
+++ b/web/src/user/LibraryPage/ak-library-impl.ts
@@ -17,6 +17,7 @@ import type { PageUIConfig } from "./types.js";
 
 import { groupBy } from "#common/utils";
 
+import { AKSkipToContent } from "#elements/a11y/ak-skip-to-content";
 import { AKElement } from "#elements/Base";
 import { bound } from "#elements/decorators/bound";
 import { ifPresent } from "#elements/utils/attributes";
@@ -201,17 +202,19 @@ export class LibraryPage extends AKElement {
     }
 
     render() {
-        return html`<main
-            aria-label=${msg("Applications library")}
-            class="pf-c-page__main"
-            tabindex="-1"
-            id="main-content"
-        >
+        return html`<div class="pf-c-page__main">
             <div class="pf-c-page__header pf-c-content">
                 <h1 class="pf-c-page__title">${msg("My applications")}</h1>
                 ${this.uiConfig.searchEnabled ? this.renderSearch() : nothing}
             </div>
-            <section class="pf-c-page__main-section">${this.renderState()}</section>
-        </main>`;
+            <main
+                ${AKSkipToContent.ref}
+                tabindex="-1"
+                id="main-content"
+                class="pf-c-page__main-section"
+            >
+                ${this.renderState()}
+            </main>
+        </div>`;
     }
 }

--- a/web/src/user/LibraryPage/ak-library.ts
+++ b/web/src/user/LibraryPage/ak-library.ts
@@ -34,6 +34,10 @@ const coreApi = () => new CoreApi(DEFAULT_CONFIG);
 @localized()
 @customElement("ak-library")
 export class LibraryPage extends AKElement {
+    protected createRenderRoot(): HTMLElement | DocumentFragment {
+        return this;
+    }
+
     @state()
     protected ready = false;
 

--- a/web/src/user/user-settings/UserSettingsPage.ts
+++ b/web/src/user/user-settings/UserSettingsPage.ts
@@ -11,6 +11,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { EVENT_REFRESH } from "#common/constants";
 import { rootInterface } from "#common/theme";
 
+import { AKSkipToContent } from "#elements/a11y/ak-skip-to-content";
 import { AKElement } from "#elements/Base";
 
 import type { UserInterface } from "#user/index.entrypoint";
@@ -100,8 +101,13 @@ export class UserSettingsPage extends AKElement {
             this.userSettings?.filter((stage) => stage.component === "ak-user-settings-password") ||
             [];
         return html`<div class="pf-c-page">
-            <main class="pf-c-page__main" tabindex="-1">
-                <ak-tabs vertical>
+            <div class="pf-c-page__main">
+                <ak-tabs
+                    vertical
+                    role="main"
+                    aria-label=${msg("User settings")}
+                    ${AKSkipToContent.ref}
+                >
                     <div
                         id="page-details"
                         role="tabpanel"
@@ -207,7 +213,7 @@ export class UserSettingsPage extends AKElement {
                         </div>
                     </div>
                 </ak-tabs>
-            </main>
+            </div>
         </div>`;
     }
 }


### PR DESCRIPTION
## Details

A small fix for user-driven focus targets. This PR resolves some issues that arise when focus targets exist within nested Shadow DOMs and/or slots.
