### PR TITLE
lib: import ExceptionDictTransformer from structlog.tracebacks

### DIFF
--- a/authentik/lib/logging.py
+++ b/authentik/lib/logging.py
@@ -44,7 +44,7 @@ def structlog_configure():
             structlog.processors.TimeStamper(fmt="iso", utc=False),
             structlog.processors.StackInfoRenderer(),
             structlog.processors.ExceptionRenderer(
-                structlog.processors.ExceptionDictTransformer(show_locals=CONFIG.get_bool("debug"))
+                structlog.tracebacks.ExceptionDictTransformer(show_locals=CONFIG.get_bool("debug"))
             ),
             structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
         ],
@@ -70,7 +70,7 @@ def get_logger_config():
                 "foreign_pre_chain": LOG_PRE_CHAIN
                 + [
                     structlog.processors.ExceptionRenderer(
-                        structlog.processors.ExceptionDictTransformer(
+                        structlog.tracebacks.ExceptionDictTransformer(
                             show_locals=CONFIG.get_bool("debug")
                         )
                     ),

--- a/authentik/lib/utils/errors.py
+++ b/authentik/lib/utils/errors.py
@@ -1,6 +1,7 @@
 """error utils"""
 
 from traceback import extract_tb
+from typing import Any
 
 from structlog.tracebacks import ExceptionDictTransformer
 
@@ -23,6 +24,6 @@ def exception_to_string(exc: Exception) -> str:
     )
 
 
-def exception_to_dict(exc: Exception) -> dict:
+def exception_to_dict(exc: Exception) -> list[dict[str, Any]]:
     """Format exception as a dictionary"""
     return _exception_transformer((type(exc), exc, exc.__traceback__))


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
structlog has moved `ExceptionDictTransformer` to `structlog.tracebacks`. Secondly, I noticed a type hint error in the `exception_to_dict` function

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
