### PR TITLE
providers/proxy: fix missing postgres import

### DIFF
--- a/internal/outpost/proxyv2/postgresstore/postgresstore.go
+++ b/internal/outpost/proxyv2/postgresstore/postgresstore.go
@@ -15,6 +15,7 @@ import (
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/mitchellh/mapstructure"
 	log "github.com/sirupsen/logrus"
+	_ "gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 	"gorm.io/gorm/logger"


### PR DESCRIPTION
Missing from https://github.com/goauthentik/authentik/pull/17511