### PR TITLE
website: fix active menu link background overlap

### DIFF
--- a/website/docusaurus-theme/theme/DocSidebarItems/styles.css
+++ b/website/docusaurus-theme/theme/DocSidebarItems/styles.css
@@ -90,4 +90,8 @@
     .theme-doc-sidebar-item-category:has(> .menu__list-item-collapsible:hover) .menu__list {
         --ak-menu-item-border-color: var(--ak-menu-item-color-hover);
     }
+
+    .menu__link.menu__link--active {
+        background-color: transparent;
+    }
 }


### PR DESCRIPTION
The Docusaurus theme applied a default background color to elements w the  .menu__link--active class class.

That created a a dark blue box under selected tabs in the documentation sidebar which looked out of place.

Before:
<img width="480" height="212" alt="image" src="https://github.com/user-attachments/assets/5926c429-0187-40f3-8d4d-e106e4a2f663" />

After:
<img width="338" height="194" alt="image" src="https://github.com/user-attachments/assets/9c21d1a7-49a6-414a-bd61-b49d357aa22b" />
