### PR TITLE
Install curl for server healthchecks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -157,7 +157,7 @@ RUN apt-get update && \
     # Required for runtime
     apt-get install -y --no-install-recommends libpq5 libmaxminddb0 ca-certificates libkrb5-3 libkadm5clnt-mit12 libkdb5-10 libltdl7 libxslt1.1 && \
     # Required for bootstrap & healtcheck
-    apt-get install -y --no-install-recommends runit && \
+    apt-get install -y --no-install-recommends runit curl && \
     pip3 install --no-cache-dir --upgrade pip && \
     apt-get clean && \
     rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/ && \


### PR DESCRIPTION
## Details

The [monitoring docs](https://docs.goauthentik.io/sys-mgmt/ops/monitoring/) mention two ways to health check the worker and the server: `ak healthcheck` for the worker, and issue a HTTP request to `/-/health/live/` for the server. Unfortunately, the Docker image does not ship a CLI tool to do that request: neither `curl`, nor `wget`.

This PR adds the CLI tool `curl` to the Docker image (~300kb), to enable health-checking the server.

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [x] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
