### PR TITLE
ci: use forked release action to deal with large release notes

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -87,7 +87,7 @@ jobs:
           git tag "version/${{ inputs.version }}" HEAD -m "version/${{ inputs.version }}"
           git push --follow-tags
       - name: Create Release
-        uses: goauthentik/action-gh-release@b754223f5f981b859af97bf5a142f31c11684571
+        uses: goauthentik/action-gh-release@84da137b91a625a58fe8a34f3bd6bdb034a49138
         with:
           token: "${{ steps.app-token.outputs.token }}"
           tag_name: "version/${{ inputs.version }}"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -87,7 +87,7 @@ jobs:
           git tag "version/${{ inputs.version }}" HEAD -m "version/${{ inputs.version }}"
           git push --follow-tags
       - name: Create Release
-        uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090 # v2
+        uses: goauthentik/action-gh-release@b754223f5f981b859af97bf5a142f31c11684571
         with:
           token: "${{ steps.app-token.outputs.token }}"
           tag_name: "version/${{ inputs.version }}"


### PR DESCRIPTION
See https://github.com/softprops/action-gh-release/pull/684 and https://github.com/goauthentik/authentik/actions/runs/18667483449/job/53223267647