### PR TITLE
website/docs: eap add info about custom validation

### DIFF
--- a/website/docs/add-secure-apps/flows-stages/stages/mtls/index.md
+++ b/website/docs/add-secure-apps/flows-stages/stages/mtls/index.md
@@ -10,7 +10,7 @@ The Mutual TLS stage enables authentik to use client certificates to enroll and 
 
 :::warning Use of trusted Certificate Authority
 
-- For mTLS, note that you should NOT use a globally known CA.
+For mTLS, note that you should NOT use a globally known CA.
 
 Using private PKI certificates that are trusted by the end-device is best practise. For example, using a Verisign certificate as a "known CA" means that ANYONE who has a certificate signed by them can authenticate via mTLS, and in addition you should implement [custom validation](../../flow/context/index.mdx#auth_method-string) to prevent unauthorized access.
 :::

--- a/website/docs/add-secure-apps/flows-stages/stages/mtls/index.md
+++ b/website/docs/add-secure-apps/flows-stages/stages/mtls/index.md
@@ -8,9 +8,12 @@ toc_max_heading_level: 5
 
 The Mutual TLS stage enables authentik to use client certificates to enroll and authenticate users. These certificates can be local to the device or available via PIV Smart Cards, Yubikeys, etc.
 
-import Eap from "../../../../expressions/\_eap.md";
+:::warning Use of trusted Certificate Authority
 
-<Eap />
+- For mTLS, note that you should NOT use a globally known CA.
+
+Using private PKI certificates that are trusted by the end-device is best practise. For example, using a Verisign certificate as a "known CA" means that ANYONE who has a certificate signed by them can authenticate via mTLS, and in addition you should implement [custom validation](../../flow/context/index.mdx#auth_method-string) to prevent unauthorized access.
+:::
 
 ## Reverse-proxy configuration
 

--- a/website/docs/add-secure-apps/providers/radius/index.mdx
+++ b/website/docs/add-secure-apps/providers/radius/index.mdx
@@ -59,7 +59,7 @@ For certificates, ensure that you use a client certificate and a server certific
 
 :::warning Use of trusted Certificate Authority
 
-- For EAP-TLS, note that you should NOT use a globally known CA.
+For EAP-TLS, note that you should NOT use a globally known CA.
 
 Using private PKI certificates that are trusted by the end-device is best practise. For example, using a Verisign certificate as a "known CA" means that ANYONE who has a certificate signed by them can authenticate via EAP-TLS, and in addition you should implement [custom validation](../../flows-stages/flow/context/index.mdx#auth_method-string) to prevent unauthorized access.
 :::

--- a/website/docs/add-secure-apps/providers/radius/index.mdx
+++ b/website/docs/add-secure-apps/providers/radius/index.mdx
@@ -35,6 +35,18 @@ The following stages are supported:
 - [Deny](../../flows-stages/stages/deny.md)
 - [Mutual TLS stage](../../flows-stages/stages/mtls/index.md)
 
+### Protocol support
+
+The RADIUS provider supports EAP-TLS and [PAP](https://en.wikipedia.org/wiki/Password_Authentication_Protocol) (Password Authentication Protocol) protocol. For password-based authentication, only PAP protocol is supported due to other password hashing methods requiring reversible password hashes, which we don’t support for security reasons.
+
+<details>
+  <summary>RADIUS compatibility matrix for password-based authentication:</summary>
+
+This table represents the password-hash compatibillity with various RADIUS protocols.
+
+<HashSupport />
+</details>
+
 ### EAP :ak-enterprise :ak-version[2025.10]
 
 authentik supports EAP with TLS as the inner protocol, between the application and transport layers to encrypt and secure communications. To set this up, a certificate authority needs to be available and client certificates need to be installed on machines, the configuration of which is outside of the scope of this document.
@@ -45,9 +57,12 @@ Create an authentication flow with a [Mutual TLS stage](../../flows-stages/stage
 
 For certificates, ensure that you use a client certificate and a server certificate that are created by a certificate authority, not a self-generated certificate.
 
-import Eap from "../../../expressions/_eap.md";
+:::warning Use of trusted Certificate Authority
 
-<Eap />
+- For EAP-TLS, note that you should NOT use a globally known CA.
+
+Using private PKI certificates that are trusted by the end-device is best practise. For example, using a Verisign certificate as a "known CA" means that ANYONE who has a certificate signed by them can authenticate via EAP-TLS, and in addition you should implement [custom validation](../../flows-stages/flow/context/index.mdx#auth_method-string) to prevent unauthorized access.
+:::
 
 ### RADIUS attributes
 
@@ -68,13 +83,3 @@ return packet
 ```
 
 After creation, make sure to select the RADIUS property mapping in the RADIUS provider.
-
-### Protocol support
-
-The RADIUS provider supports EAP-TLS and [PAP](https://en.wikipedia.org/wiki/Password_Authentication_Protocol) (Password Authentication Protocol) protocol. For password-based authentication, only [PAP](https://en.wikipedia.org/wiki/Password_Authentication_Protocol) (Password Authentication Protocol) protocol is supported due to other password hashing methods requiring reversible password hashes, which we don’t support for security reasons.
-
-<details>
-  <summary>RADIUS protocol support for password-based authentication (PAP):</summary>
-
-<HashSupport />
-</details>

--- a/website/docs/expressions/_eap.md
+++ b/website/docs/expressions/_eap.md
@@ -1,6 +1,0 @@
-:::warning Use of trusted Certificate Authority
-
-- For EAP-TLS, note that you should NOT use a globally known CA.
-
-Using private PKI certificates that are trusted by the end-device is best practise. For example, using a Verisign certificate as a "known CA" means that ANYONE who has a certificate signed by them can authenticate via EAP-TLS, and in addition you should implement [custom validation](https://docs.goauthentik.io/add-secure-apps/flows-stages/flow/context/#auth_method-string) to prevent unauthorized access.
-:::

--- a/website/docs/expressions/_eap.md
+++ b/website/docs/expressions/_eap.md
@@ -1,4 +1,6 @@
 :::warning Use of trusted Certificate Authority
-For EAP-TLS, note that you should NOT use a globally known CA.
-For example, using a Verisign cert as a "known CA" means that ANYONE who has a certificate signed by them can authenticate via EAP-TLS. Using private PKI certificates that are trusted by the end-device is best practise to distribute client certificates.
+
+- For EAP-TLS, note that you should NOT use a globally known CA.
+
+Using private PKI certificates that are trusted by the end-device is best practise. For example, using a Verisign certificate as a "known CA" means that ANYONE who has a certificate signed by them can authenticate via EAP-TLS, and in addition you should implement [custom validation](https://docs.goauthentik.io/add-secure-apps/flows-stages/flow/context/#auth_method-string) to prevent unauthorized access.
 :::


### PR DESCRIPTION
This PR:
-   [x] adds a sentence to the EAP Note about certs, saying that users should also implement custom validation options as well as a good cert. (I had a dreadful fight with my relative links, so caved and used full link. Will try to fix later.)
-   [x] updates the table on RADIUS provider page, to seaprate PAP from non-PAP.
---
-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
