### PR TITLE
website/docs: add note about invite link not bound

### DIFF
--- a/website/docs/users-sources/user/invitations.md
+++ b/website/docs/users-sources/user/invitations.md
@@ -49,5 +49,5 @@ Click **Save** to save the new invitation and close the box and return to the **
 On the **Invitations** page, click the chevron beside your new invitation, to expand the details. The **Link to use the invitation** displays with the URL. Copy the URL and send it in an email to the people you want to invite to enroll.
 
 :::info Invitation links validity
-Be aware that when an authentik administrator creates an invitation link, that link remains valid even if the administrator is removed from the authentik system with all rights revoked. That is because the invite is not bound to any user, including the administrator who created it. So theoretically the ex-administrator could use that link to gain access again.
+Be aware that when an authentik administrator creates an invitation link, that link remains valid even if the administrator is deactivated or has permissionss revoked. However, if the adrministrator who created the link is deleted and removed from the authentik system, the link is also deleted.
 :::

--- a/website/docs/users-sources/user/invitations.md
+++ b/website/docs/users-sources/user/invitations.md
@@ -47,3 +47,7 @@ Click **Save** to save the new invitation and close the box and return to the **
 **Step 3. Email the invitation**
 
 On the **Invitations** page, click the chevron beside your new invitation, to expand the details. The **Link to use the invitation** displays with the URL. Copy the URL and send it in an email to the people you want to invite to enroll.
+
+:::info Invitation links validity
+Be aware that when an authentik administrator creates an invitation link, that link remains valid even if the administrator is removed from the authentik system with all rights revoked. That is because the invite is not bound to any user, including the administrator who created it. So theoretically the ex-administrator could use that link to gain access again.
+:::

--- a/website/docs/users-sources/user/invitations.md
+++ b/website/docs/users-sources/user/invitations.md
@@ -49,5 +49,5 @@ Click **Save** to save the new invitation and close the box and return to the **
 On the **Invitations** page, click the chevron beside your new invitation, to expand the details. The **Link to use the invitation** displays with the URL. Copy the URL and send it in an email to the people you want to invite to enroll.
 
 :::info Invitation links validity
-Be aware that when an authentik administrator creates an invitation link, that link remains valid even if the administrator is deactivated or has permissionss revoked. However, if the adrministrator who created the link is deleted and removed from the authentik system, the link is also deleted.
+Be aware that when an authentik administrator or any other user creates an invitation link, that link remains valid even if the administrator is deactivated or has permissionss revoked. However, if the user who created the link is deleted and removed from the authentik system, the link is also deleted.
 :::


### PR DESCRIPTION
This PR adds a Note to the Invitations docs saying that because invitation links are not bound to the Admin who created them, the link is still valid even if the Admin is removed/rights revoked.

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
