### PR TITLE
web:  Abstract Wizard Lifecycle

### DIFF
--- a/web/src/admin/outposts/ServiceConnectionWizard.ts
+++ b/web/src/admin/outposts/ServiceConnectionWizard.ts
@@ -63,7 +63,7 @@ export class ServiceConnectionWizard extends AKElement {
                     return html`
                         <ak-wizard-page-form
                             slot=${`type-${type.component}-${type.modelName}`}
-                            .sidebarLabel=${() => msg(str`Create ${type.name}`)}
+                            label=${msg(str`Create ${type.name}`)}
                         >
                             <ak-proxy-form type=${type.component}></ak-proxy-form>
                         </ak-wizard-page-form>

--- a/web/src/admin/policies/PolicyWizard.ts
+++ b/web/src/admin/policies/PolicyWizard.ts
@@ -87,7 +87,7 @@ export class PolicyWizard extends AKElement {
                     return html`
                         <ak-wizard-page-form
                             slot=${`type-${type.component}-${type.modelName}`}
-                            .sidebarLabel=${() => msg(str`Create ${type.name}`)}
+                            label=${msg(str`Create ${type.name}`)}
                         >
                             <ak-proxy-form type=${type.component}></ak-proxy-form>
                         </ak-wizard-page-form>
@@ -96,7 +96,7 @@ export class PolicyWizard extends AKElement {
                 ${this.showBindingPage
                     ? html`<ak-wizard-page-form
                           slot="create-binding"
-                          .sidebarLabel=${() => msg("Create Binding")}
+                          label=${msg("Create Binding")}
                           .activePageCallback=${async (context: FormWizardPage) => {
                               const createSlot = context.host.steps[1];
                               const bindingForm =

--- a/web/src/admin/property-mappings/PropertyMappingWizard.ts
+++ b/web/src/admin/property-mappings/PropertyMappingWizard.ts
@@ -74,7 +74,7 @@ export class PropertyMappingWizard extends AKElement {
                     return html`
                         <ak-wizard-page-form
                             slot=${`type-${type.component}-${type.modelName}`}
-                            .sidebarLabel=${() => msg(str`Create ${type.name}`)}
+                            label=${msg(str`Create ${type.name}`)}
                         >
                             <ak-proxy-form type=${type.component}></ak-proxy-form>
                         </ak-wizard-page-form>

--- a/web/src/admin/providers/ProviderWizard.ts
+++ b/web/src/admin/providers/ProviderWizard.ts
@@ -72,7 +72,7 @@ export class ProviderWizard extends AKElement {
                     return html`
                         <ak-wizard-page-form
                             slot=${`type-${type.component}`}
-                            .sidebarLabel=${() => msg(str`Create ${type.name}`)}
+                            label=${msg(str`Create ${type.name}`)}
                         >
                             <ak-proxy-form type=${type.component}></ak-proxy-form>
                         </ak-wizard-page-form>

--- a/web/src/admin/sources/SourceWizard.ts
+++ b/web/src/admin/sources/SourceWizard.ts
@@ -66,7 +66,7 @@ export class SourceWizard extends AKElement {
                     return html`
                         <ak-wizard-page-form
                             slot=${`type-${type.component}-${type.modelName}`}
-                            .sidebarLabel=${() => msg(str`Create ${type.name}`)}
+                            label=${msg(str`Create ${type.name}`)}
                         >
                             <ak-proxy-form
                                 .args=${{

--- a/web/src/admin/stages/StageWizard.ts
+++ b/web/src/admin/stages/StageWizard.ts
@@ -101,7 +101,7 @@ export class StageWizard extends AKElement {
                     return html`
                         <ak-wizard-page-form
                             slot=${`type-${type.component}-${type.modelName}`}
-                            .sidebarLabel=${() => msg(str`Create ${type.name}`)}
+                            label=${msg(str`Create ${type.name}`)}
                         >
                             <ak-proxy-form type=${type.component}></ak-proxy-form>
                         </ak-wizard-page-form>
@@ -110,7 +110,7 @@ export class StageWizard extends AKElement {
                 ${this.showBindingPage
                     ? html`<ak-wizard-page-form
                           slot="create-binding"
-                          .sidebarLabel=${() => msg("Create Binding")}
+                          label=${msg("Create Binding")}
                           .activePageCallback=${async (context: FormWizardPage) => {
                               const createSlot = context.host.steps[1];
                               const bindingForm =

--- a/web/src/elements/wizard/ActionWizardPage.ts
+++ b/web/src/elements/wizard/ActionWizardPage.ts
@@ -58,7 +58,7 @@ export class ActionWizardPage extends WizardPage {
         this.host.isValid = true;
     };
 
-    sidebarLabel = () => msg("Apply changes");
+    public label = msg("Apply changes");
 
     async run(): Promise<void> {
         this.currentStep = this.states[0];

--- a/web/src/elements/wizard/TypeCreateWizardPage.ts
+++ b/web/src/elements/wizard/TypeCreateWizardPage.ts
@@ -60,7 +60,7 @@ export class TypeCreateWizardPage extends WithLicenseSummary(WizardPage) {
 
     //#endregion
 
-    public sidebarLabel = () => msg("Select type");
+    public override label = msg("Select type");
 
     public reset = () => {
         super.reset();

--- a/web/src/elements/wizard/Wizard.ts
+++ b/web/src/elements/wizard/Wizard.ts
@@ -104,19 +104,6 @@ export class Wizard extends ModalButton {
             this.steps.push(ApplyActionsSlot);
         }
 
-        for (const step of this._steps) {
-            const existingStepElement = this.getStepElementByName(step);
-
-            if (existingStepElement) continue;
-
-            const stepElement = document.createElement(step);
-
-            stepElement.slot = step;
-            stepElement.dataset.wizardmanaged = "true";
-
-            this.appendChild(stepElement);
-        }
-
         this.requestUpdate();
     }
 

--- a/web/src/elements/wizard/Wizard.ts
+++ b/web/src/elements/wizard/Wizard.ts
@@ -301,8 +301,6 @@ export class Wizard extends ModalButton {
 
                                 if (!stepEl) return html`<p>Unexpected missing step: ${step}</p>`;
 
-                                const sidebarLabel = stepEl.sidebarLabel();
-
                                 return html`
                                     <li role="presentation" class="pf-c-wizard__nav-item">
                                         <button
@@ -316,7 +314,7 @@ export class Wizard extends ModalButton {
                                                 this.activeStepElement = stepEl;
                                             }}
                                         >
-                                            ${sidebarLabel}
+                                            ${stepEl.label ?? msg("UNNAMED")}
                                         </button>
                                     </li>
                                 `;

--- a/web/src/elements/wizard/WizardPage.ts
+++ b/web/src/elements/wizard/WizardPage.ts
@@ -1,8 +1,8 @@
 import { AKElement } from "#elements/Base";
 import { Wizard } from "#elements/wizard/Wizard";
 
-import { CSSResult, html, PropertyDeclaration, TemplateResult } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import { CSSResult, html, LitElement, PropertyDeclaration, TemplateResult } from "lit";
+import { property } from "lit/decorators.js";
 
 import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
@@ -18,22 +18,17 @@ export type WizardPageActiveCallback = () => void | Promise<void>;
  */
 export type WizardPageNextCallback = () => boolean | Promise<boolean>;
 
-@customElement("ak-wizard-page")
-export class WizardPage extends AKElement {
+export abstract class WizardPage extends AKElement {
     static styles: CSSResult[] = [PFBase];
 
     /**
      * The label to display in the sidebar for this page.
      *
-     * Override this to provide a custom label.
-     * @todo: Should this be a getter or static property?
      */
-    @property()
-    sidebarLabel = (): string => {
-        return "UNNAMED";
-    };
+    @property({ type: String })
+    public label: string | null = null;
 
-    get host(): Wizard {
+    public get host(): Wizard {
         return this.parentElement as Wizard;
     }
 
@@ -49,7 +44,7 @@ export class WizardPage extends AKElement {
     /**
      * Called when this is the page brought into view.
      */
-    activeCallback: WizardPageActiveCallback = () => {
+    public activeCallback: WizardPageActiveCallback = () => {
         this.host.isValid = false;
     };
 
@@ -60,20 +55,21 @@ export class WizardPage extends AKElement {
      *
      * @returns `true` if the wizard can proceed to the next page, `false` otherwise.
      */
-    nextCallback: WizardPageNextCallback = () => {
+    public nextCallback: WizardPageNextCallback = () => {
         return Promise.resolve(true);
     };
 
-    requestUpdate(
+    public override requestUpdate(
         name?: PropertyKey,
         oldValue?: unknown,
         options?: PropertyDeclaration<unknown, unknown>,
     ): void {
-        this.querySelectorAll("*").forEach((el) => {
-            if ("requestUpdate" in el) {
-                (el as AKElement).requestUpdate();
+        for (const element of this.querySelectorAll("*")) {
+            if (element instanceof LitElement) {
+                element.requestUpdate();
             }
-        });
+        }
+
         return super.requestUpdate(name, oldValue, options);
     }
 


### PR DESCRIPTION
## Details

This PR removes `document.createElement(step)` side effect when a wizard `steps` setter is applied. AFAICT, this isn't necessary since the slot is always occupied by an existing element -- the `steps` setter only tracks the slot names.

Also included is a fix for some properties which better reflect the wizard page's use as an abstract element.