### PR TITLE
web: Table row refinements

### DIFF
--- a/web/src/elements/table/Table.ts
+++ b/web/src/elements/table/Table.ts
@@ -459,7 +459,17 @@ export abstract class Table<T extends object>
                 this.expandedElements = nextExpanded;
 
                 if (this.clearOnRefresh) {
-                    this.#selectedElements.clear();
+                    if (this.#selectedElements.size) {
+                        this.#selectedElements.clear();
+
+                        const selectAllCheckbox = this.#selectAllCheckboxRef.value;
+
+                        if (selectAllCheckbox) {
+                            selectAllCheckbox.checked = false;
+                            selectAllCheckbox.indeterminate = false;
+                        }
+                    }
+
                     this.requestUpdate();
                 }
             })

--- a/web/src/elements/table/Table.ts
+++ b/web/src/elements/table/Table.ts
@@ -736,7 +736,7 @@ export abstract class Table<T extends object>
 
         let expansionContent: SlottedTemplateResult = nothing;
 
-        if (this.expandable) {
+        if (this.expandable && expanded) {
             if (!this.renderExpanded) {
                 throw new TypeError("Expandable is enabled but renderExpanded is not overridden!");
             }

--- a/web/src/user/LibraryApplication/RACLaunchEndpointModal.ts
+++ b/web/src/user/LibraryApplication/RACLaunchEndpointModal.ts
@@ -15,16 +15,15 @@ export class RACLaunchEndpointModal extends TableModal<Endpoint> {
     clickable = true;
     protected override searchEnabled = true;
 
-    clickHandler = (item: Endpoint) => {
+    protected override rowClickListener(item: Endpoint, event?: InputEvent | PointerEvent) {
         if (!item.launchUrl) {
-            return;
+            return super.rowClickListener(item, event);
         }
-        if (this.app?.openInNewTab) {
-            window.open(item.launchUrl);
-        } else {
-            window.location.assign(item.launchUrl);
-        }
-    };
+
+        const target = this.app?.openInNewTab ? `ak-rac-endpoint-${item.name}` : "_self";
+
+        window.open(item.launchUrl, target);
+    }
 
     @property({ attribute: false })
     app?: Application;
@@ -35,7 +34,7 @@ export class RACLaunchEndpointModal extends TableModal<Endpoint> {
             provider: this.app?.provider || 0,
         });
         if (this.open && endpoints.pagination.count === 1) {
-            this.clickHandler(endpoints.results[0]);
+            this.rowClickListener(endpoints.results[0]);
             this.open = false;
         }
         return endpoints;


### PR DESCRIPTION
## Details

This PR fixes several issues that occur when rendering table rows:

- The "select all" checkbox now respects the `clearOnRefresh` property.
- Selectable rows with expandable content now prefers expansion over selection when clicking a text cell.
- Expandable content is now lazy-rendered
- Lit's `repeat` directive is now used to have a more stable/performant rendering.  
