### PR TITLE
website/integrations: grafana: replace deprecated redirect_uris usage by allowed_redirect_uris

### DIFF
--- a/website/integrations/monitoring/grafana/index.mdx
+++ b/website/integrations/monitoring/grafana/index.mdx
@@ -70,8 +70,12 @@ resource "authentik_provider_oauth2" "grafana" {
 
   authorization_flow  = data.authentik_flow.default-provider-authorization-implicit-consent.id
 
-  redirect_uris = ["https://grafana.company/login/generic_oauth"]
-
+  allowed_redirect_uris = [
+    {
+      matching_mode = "strict",
+      url           = "https://grafana.company/login/generic_oauth",
+    }
+  ]
   property_mappings = [
     data.authentik_property_mapping_provider_scope.scope-email.id,
     data.authentik_property_mapping_provider_scope.scope-profile.id,

--- a/website/integrations/monitoring/grafana/index.mdx
+++ b/website/integrations/monitoring/grafana/index.mdx
@@ -76,6 +76,7 @@ resource "authentik_provider_oauth2" "grafana" {
       url           = "https://grafana.company/login/generic_oauth",
     }
   ]
+
   property_mappings = [
     data.authentik_property_mapping_provider_scope.scope-email.id,
     data.authentik_property_mapping_provider_scope.scope-profile.id,


### PR DESCRIPTION
## Details

Hello,
Quick fix in the oidc grafana documentation example named "Integrate with Grafana"

