### PR TITLE
website/integrations: fixed paperless-ngx yml syntax issue and added additional info

### DIFF
--- a/website/integrations/documentation/paperless-ngx/index.mdx
+++ b/website/integrations/documentation/paperless-ngx/index.mdx
@@ -43,7 +43,7 @@ To support the integration of Paperless-ngx with authentik, you need to create a
 
 3. Click **Submit** to save the new application and provider.
 
-## Paperless Configuration
+## Paperless-ngx Configuration
 
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
@@ -84,9 +84,9 @@ environment:
     PAPERLESS_LOGOUT_REDIRECT_URL: "https://authentik.company/application/o/<application_slug>/end-session/"
 ```
 
-OR if you would rather have the settings in the `docker-compose.env` file:
+Alternatively, add the variables directly to your environment file:
 
-```env
+```sh
 PAPERLESS_ENABLE_ALLAUTH=true
 PAPERLESS_APPS=allauth.socialaccount.providers.openid_connect
 PAPERLESS_SOCIALACCOUNT_PROVIDERS={"openid_connect": {"APPS": [{"provider_id": "authentik", "name": "authentik", "client_id": "<client_id>", "secret": "<client_secret>", "settings": {"server_url": "https://authentik.company/application/o/<application_slug>/.well-known/openid-configuration", "claims": {"username": "email"}}}], "OAUTH_PKCE_ENABLED": "True"}}
@@ -95,13 +95,17 @@ PAPERLESS_AUTO_CREATE=true
 PAPERLESS_LOGOUT_REDIRECT_URL=https://authentik.company/application/o/<application_slug>/end-session/
 ```
 
+To add authentik authentication to an existing Paperless-ngx user, log in to Paperless-ngx with local authentication, click the profile icon in the top-right, click **My Profile**, then **Connect new social account**.
+
+If you want to be able to automatically sign up authentik users, set [PAPERLESS_SOCIAL_AUTO_SIGNUP](https://docs.paperless-ngx.com/configuration/#PAPERLESS_SOCIAL_AUTO_SIGNUP) and/or [PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS](https://docs.paperless-ngx.com/configuration/#PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS).
+
 Now restart your container:
 `docker compose down && docker compose up -d`
 
   </TabItem>
   <TabItem value="standalone">
 
-You need to update your `paperless.conf` configuration file. Paperless will search for this configuration file in the following locations and use the first one it finds:
+You need to update your `paperless.conf` configuration file. Paperless-ngx will search for this configuration file in the following locations and use the first one it finds:
 
 - The environment variable `PAPERLESS_CONFIGURATION_PATH`
 - `/path/to/paperless/paperless.conf`
@@ -116,14 +120,15 @@ PAPERLESS_APPS=allauth.socialaccount.providers.openid_connect
 PAPERLESS_SOCIALACCOUNT_PROVIDERS={"openid_connect":{"OAUTH_PKCE_ENABLED":true,"APPS":[{"provider_id":"authentik","name":"authentik","client_id":"<Client ID>","secret":"<Client Secret>","settings":{"server_url":"https://authentik.company/application/o/paperless/.well-known/openid-configuration"}}]}}
 ```
 
-Now restart your Paperless services using `sudo systemctl restart paperless-*`
+To add authentik authentication to an existing Paperless-ngx user, log in to Paperless-ngx with local authentication, click the profile icon in the top-right, click **My Profile**, then **Connect new social account**.
+
+If you want to be able to automatically sign up authentik users, set [PAPERLESS_SOCIAL_AUTO_SIGNUP](https://docs.paperless-ngx.com/configuration/#PAPERLESS_SOCIAL_AUTO_SIGNUP) and/or [PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS](https://docs.paperless-ngx.com/configuration/#PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS).
+
+Now restart your Paperless-ngx services using `sudo systemctl restart paperless-*`
 
   </TabItem>
 </Tabs>
-## Finished
 
-Now you can access Paperless-ngx by logging in with authentik.
+## Configuration verification
 
-If you also want to be able to automatically sign users up based on authentik, you will also have to set [PAPERLESS_SOCIAL_AUTO_SIGNUP](https://docs.paperless-ngx.com/configuration/#PAPERLESS_SOCIAL_AUTO_SIGNUP) and/or [PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS](https://docs.paperless-ngx.com/configuration/#PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS).
-
-To add authentik authentication to an existing user, log in to Paperless with local authentication, click the profile icon in the top-right, click My Profile, then Connect new social account.
+To confirm that authentik is properly configured with Paperless-ngx, log out and click the **authentik** button. You will be redirected to authentik and once authenticated, you will be signed in to Paperless-ngx.

--- a/website/integrations/documentation/paperless-ngx/index.mdx
+++ b/website/integrations/documentation/paperless-ngx/index.mdx
@@ -97,7 +97,7 @@ PAPERLESS_LOGOUT_REDIRECT_URL=https://authentik.company/application/o/<applicati
 
 To add authentik authentication to an existing Paperless-ngx user, the user can log in to Paperless-ngx with local authentication, click the profile icon in the top-right, click **My Profile**, then **Connect new social account**.
 
-If you want to be able to automatically sign up authentik users, set [PAPERLESS_SOCIAL_AUTO_SIGNUP](https://docs.paperless-ngx.com/configuration/#PAPERLESS_SOCIAL_AUTO_SIGNUP) and/or [PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS](https://docs.paperless-ngx.com/configuration/#PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS).
+If you want to be able to automatically sign up authentik users, set [PAPERLESS_SOCIAL_AUTO_SIGNUP](https://docs.paperless-ngx.com/configuration/#PAPERLESS_SOCIAL_AUTO_SIGNUP) and/or [PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS](https://docs.paperless-ngx.com/configuration/#PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS) to true, either in your compose or environment file.
 
 Now restart your container:
 `docker compose down && docker compose up -d`
@@ -120,9 +120,9 @@ PAPERLESS_APPS=allauth.socialaccount.providers.openid_connect
 PAPERLESS_SOCIALACCOUNT_PROVIDERS={"openid_connect":{"OAUTH_PKCE_ENABLED":true,"APPS":[{"provider_id":"authentik","name":"authentik","client_id":"<Client ID>","secret":"<Client Secret>","settings":{"server_url":"https://authentik.company/application/o/paperless/.well-known/openid-configuration"}}]}}
 ```
 
-To add authentik authentication to an existing Paperless-ngx user, log in to Paperless-ngx with local authentication, click the profile icon in the top-right, click **My Profile**, then **Connect new social account**.
+To add authentik authentication to an existing Paperless-ngx user, the user can log in to Paperless-ngx with local authentication, click the profile icon in the top-right, click **My Profile**, then **Connect new social account**.
 
-If you want to be able to automatically sign up authentik users, set [PAPERLESS_SOCIAL_AUTO_SIGNUP](https://docs.paperless-ngx.com/configuration/#PAPERLESS_SOCIAL_AUTO_SIGNUP) and/or [PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS](https://docs.paperless-ngx.com/configuration/#PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS) to true, either in your compose or environment file.
+If you want to be able to automatically sign up authentik users, set [PAPERLESS_SOCIAL_AUTO_SIGNUP](https://docs.paperless-ngx.com/configuration/#PAPERLESS_SOCIAL_AUTO_SIGNUP) and/or [PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS](https://docs.paperless-ngx.com/configuration/#PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS) to true in your `paperless.conf` file.
 
 Now restart your Paperless-ngx services using `sudo systemctl restart paperless-*`
 

--- a/website/integrations/documentation/paperless-ngx/index.mdx
+++ b/website/integrations/documentation/paperless-ngx/index.mdx
@@ -95,7 +95,7 @@ PAPERLESS_AUTO_CREATE=true
 PAPERLESS_LOGOUT_REDIRECT_URL=https://authentik.company/application/o/<application_slug>/end-session/
 ```
 
-To add authentik authentication to an existing Paperless-ngx user, log in to Paperless-ngx with local authentication, click the profile icon in the top-right, click **My Profile**, then **Connect new social account**.
+To add authentik authentication to an existing Paperless-ngx user, the user can log in to Paperless-ngx with local authentication, click the profile icon in the top-right, click **My Profile**, then **Connect new social account**.
 
 If you want to be able to automatically sign up authentik users, set [PAPERLESS_SOCIAL_AUTO_SIGNUP](https://docs.paperless-ngx.com/configuration/#PAPERLESS_SOCIAL_AUTO_SIGNUP) and/or [PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS](https://docs.paperless-ngx.com/configuration/#PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS).
 
@@ -122,7 +122,7 @@ PAPERLESS_SOCIALACCOUNT_PROVIDERS={"openid_connect":{"OAUTH_PKCE_ENABLED":true,"
 
 To add authentik authentication to an existing Paperless-ngx user, log in to Paperless-ngx with local authentication, click the profile icon in the top-right, click **My Profile**, then **Connect new social account**.
 
-If you want to be able to automatically sign up authentik users, set [PAPERLESS_SOCIAL_AUTO_SIGNUP](https://docs.paperless-ngx.com/configuration/#PAPERLESS_SOCIAL_AUTO_SIGNUP) and/or [PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS](https://docs.paperless-ngx.com/configuration/#PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS).
+If you want to be able to automatically sign up authentik users, set [PAPERLESS_SOCIAL_AUTO_SIGNUP](https://docs.paperless-ngx.com/configuration/#PAPERLESS_SOCIAL_AUTO_SIGNUP) and/or [PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS](https://docs.paperless-ngx.com/configuration/#PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS) to true, either in your compose or environment file.
 
 Now restart your Paperless-ngx services using `sudo systemctl restart paperless-*`
 

--- a/website/integrations/documentation/paperless-ngx/index.mdx
+++ b/website/integrations/documentation/paperless-ngx/index.mdx
@@ -59,7 +59,7 @@ If you have Paperless-ngx setup in Docker, add the following environment variabl
 
 ```yaml
 environment:
-    PAPERLESS_ENABLE_ALLAUTH=true
+    PAPERLESS_ENABLE_ALLAUTH: true
     PAPERLESS_APPS: allauth.socialaccount.providers.openid_connect
     PAPERLESS_SOCIALACCOUNT_PROVIDERS: >
         {
@@ -79,9 +79,20 @@ environment:
             "OAUTH_PKCE_ENABLED": "True"
           }
         }
-    PAPERLESS_AUTO_LOGIN=true
-    PAPERLESS_AUTO_CREATE=true
+    PAPERLESS_AUTO_LOGIN: true
+    PAPERLESS_AUTO_CREATE: true
     PAPERLESS_LOGOUT_REDIRECT_URL: "https://authentik.company/application/o/<application_slug>/end-session/"
+```
+
+OR if you would rather have the settings in the `docker-compose.env` file:
+
+```env
+PAPERLESS_ENABLE_ALLAUTH=true
+PAPERLESS_APPS=allauth.socialaccount.providers.openid_connect
+PAPERLESS_SOCIALACCOUNT_PROVIDERS={"openid_connect": {"APPS": [{"provider_id": "authentik", "name": "authentik", "client_id": "<client_id>", "secret": "<client_secret>", "settings": {"server_url": "https://authentik.company/application/o/<application_slug>/.well-known/openid-configuration", "claims": {"username": "email"}}}], "OAUTH_PKCE_ENABLED": "True"}}
+PAPERLESS_AUTO_LOGIN=true
+PAPERLESS_AUTO_CREATE=true
+PAPERLESS_LOGOUT_REDIRECT_URL=https://authentik.company/application/o/<application_slug>/end-session/
 ```
 
 Now restart your container:
@@ -112,5 +123,7 @@ Now restart your Paperless services using `sudo systemctl restart paperless-*`
 ## Finished
 
 Now you can access Paperless-ngx by logging in with authentik.
+
+If you also want to be able to automatically sign users up based on authentik, you will also have to set [PAPERLESS_SOCIAL_AUTO_SIGNUP](https://docs.paperless-ngx.com/configuration/#PAPERLESS_SOCIAL_AUTO_SIGNUP) and/or [PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS](https://docs.paperless-ngx.com/configuration/#PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS).
 
 To add authentik authentication to an existing user, log in to Paperless with local authentication, click the profile icon in the top-right, click My Profile, then Connect new social account.


### PR DESCRIPTION
## Details

There was a syntax issue in the `yml` example, using `=` as key/value separators.
This PR also adds an example for configuring the dedicated config file `docker-compose.env` for the use with authentik as well as adding a note about two useful config fields that may be added.

---

## Checklist

~~-   [ ] Local tests pass (`ak test authentik/`)~~ (skipped due to purely a mdx docs change)
-   [x] The code has been formatted (`make lint-fix`)

~~If an API change has been made~~

~~-   [ ] The API schema has been updated (`make gen-build`)~~

~~If changes to the frontend have been made~~

~~-   [ ] The code has been formatted (`make web`)~~

~~If applicable~~

~~-   [ ] The documentation has been updated~~
~~-   [ ] The documentation has been formatted (`make docs`)~~
