### PR TITLE
sources/oauth: Make PKCE verifier 128 characters

### DIFF
--- a/authentik/sources/oauth/clients/oauth2.py
+++ b/authentik/sources/oauth/clients/oauth2.py
@@ -143,7 +143,7 @@ class OAuth2Client(BaseOAuthClient):
         if self.source.source_type.urls_customizable and self.source.pkce:
             pkce_mode = self.source.pkce
         if pkce_mode != PKCEMethod.NONE:
-            verifier = generate_id()
+            verifier = generate_id(length=128)
             self.request.session[SESSION_KEY_OAUTH_PKCE] = verifier
             # https://datatracker.ietf.org/doc/html/rfc7636#section-4.2
             if pkce_mode == PKCEMethod.PLAIN:

--- a/authentik/sources/oauth/tests/test_views.py
+++ b/authentik/sources/oauth/tests/test_views.py
@@ -205,6 +205,7 @@ class TestOAuthSource(APITestCase):
         session = self.client.session
         state = session[f"oauth-client-{self.source.name}-request-state"]
         verifier = session[SESSION_KEY_OAUTH_PKCE]
+        self.assertEqual(len(verifier), 128)
         challenge = pkce_s256_challenge(verifier)
 
         self.assertEqual(qs["redirect_uri"], ["http://testserver/source/oauth/callback/test/"])


### PR DESCRIPTION
## Details

The PKCE spec requires the code verifier to be 43-128 characters[^1].

The default `length` argument to `generate_id` is 40 characters, which meant the verifier is always shorter than required by the spec. This could cause issues integrating authentik with PKCE-compliant OIDC providers.

For transparency, I work on GOV.UK One Login (an OIDC OP) and am looking at @brendanarnold's integration with us which is also being discussed in issue #17491.

I would like to add a test to this PR that the generated verifier is of the correct length, but it wasn't clear to be where that should go. If you can point me to the right place I'll add it.

[^1]: https://datatracker.ietf.org/doc/html/rfc7636#section-4.1

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

