### PR TITLE
tasks: delay startup signals

### DIFF
--- a/authentik/root/settings.py
+++ b/authentik/root/settings.py
@@ -429,6 +429,7 @@ DRAMATIQ = {
             },
         ),
         ("dramatiq.results.middleware.Results", {"store_results": True}),
+        ("authentik.tasks.middleware.StartupSignalsMiddleware", {}),
         ("authentik.tasks.middleware.CurrentTask", {}),
         ("authentik.tasks.middleware.TenantMiddleware", {}),
         ("authentik.tasks.middleware.ModelDataMiddleware", {}),

--- a/authentik/tasks/middleware.py
+++ b/authentik/tasks/middleware.py
@@ -23,6 +23,7 @@ from authentik import authentik_full_version
 from authentik.events.models import Event, EventAction
 from authentik.lib.sentry import should_ignore_exception
 from authentik.lib.utils.reflection import class_to_path
+from authentik.root.signals import post_startup, pre_startup, startup
 from authentik.tasks.models import Task, TaskLog, TaskStatus, WorkerStatus
 from authentik.tenants.models import Tenant
 from authentik.tenants.utils import get_current_tenant
@@ -30,6 +31,14 @@ from authentik.tenants.utils import get_current_tenant
 LOGGER = get_logger()
 HEALTHCHECK_LOGGER = get_logger("authentik.worker").bind()
 DB_ERRORS = (OperationalError, Error)
+
+
+class StartupSignalsMiddleware(Middleware):
+    def after_process_boot(self, broker: Broker):
+        _startup_sender = type("WorkerStartup", (object,), {})
+        pre_startup.send(sender=_startup_sender)
+        startup.send(sender=_startup_sender)
+        post_startup.send(sender=_startup_sender)
 
 
 class CurrentTask(BaseCurrentTask):

--- a/authentik/tasks/setup.py
+++ b/authentik/tasks/setup.py
@@ -5,10 +5,3 @@ setup()
 import django  # noqa: E402
 
 django.setup()
-
-from authentik.root.signals import post_startup, pre_startup, startup  # noqa: E402
-
-_startup_sender = type("WorkerStartup", (object,), {})
-pre_startup.send(sender=_startup_sender)
-startup.send(sender=_startup_sender)
-post_startup.send(sender=_startup_sender)

--- a/packages/django-dramatiq-postgres/django_dramatiq_postgres/broker.py
+++ b/packages/django-dramatiq-postgres/django_dramatiq_postgres/broker.py
@@ -94,6 +94,7 @@ class PostgresBroker(Broker):
 
     @property
     def consumer_class(self) -> "type[_PostgresConsumer]":
+        time.sleep(2)
         return _PostgresConsumer
 
     @cached_property

--- a/packages/django-dramatiq-postgres/django_dramatiq_postgres/broker.py
+++ b/packages/django-dramatiq-postgres/django_dramatiq_postgres/broker.py
@@ -94,7 +94,6 @@ class PostgresBroker(Broker):
 
     @property
     def consumer_class(self) -> "type[_PostgresConsumer]":
-        time.sleep(2)
         return _PostgresConsumer
 
     @cached_property


### PR DESCRIPTION
There somehow is a race condition when starting up the worker, that makes some tasks inexistent even though they actually have been inserted. Here we simply delay the start of the consumers so we can completely finish the startup and only then grab tasks and process them.

Closes #17749
