### PR TITLE
internal: fix go deprecation for +build

### DIFF
--- a/web/static_outpost.go
+++ b/web/static_outpost.go
@@ -1,5 +1,4 @@
 //go:build outpost_static_embed
-// +build outpost_static_embed
 
 package web
 


### PR DESCRIPTION
Fixes golangci-lint too.

See: https://stackoverflow.com/questions/68360688/whats-the-difference-between-gobuild-and-build-directives