### PR TITLE
website/integrations: miniflux: existing users must link accounts manually first

### DIFF
--- a/website/integrations/media/miniflux/index.md
+++ b/website/integrations/media/miniflux/index.md
@@ -58,8 +58,9 @@ The trailing `.well-known/openid-configuration` is not required for `OAUTH2_OIDC
 
 Restart the Miniflux service for the changes to take effect.
 
-Existing Miniflux accounts must be first linked to your Authentik account.
-To do that, log in using your existing Miniflux credentials, go to Settings and click on Link my OpenID Connect account.
+:::info Existing Miniflux accounts
+Existing Miniflux accounts must first be linked to a matching authentik account. To do this, log in using your existing Miniflux credentials, go to **Settings** and click on **Link my OpenID Connect account**.
+:::
 
 ## Configuration verification
 

--- a/website/integrations/media/miniflux/index.md
+++ b/website/integrations/media/miniflux/index.md
@@ -58,6 +58,9 @@ The trailing `.well-known/openid-configuration` is not required for `OAUTH2_OIDC
 
 Restart the Miniflux service for the changes to take effect.
 
+Existing Miniflux accounts must be first linked to your Authentik account.
+To do that, log in using your existing Miniflux credentials, go to Settings and click on Link my OpenID Connect account.
+
 ## Configuration verification
 
 To confirm that authentik is properly configured with Miniflux, log out of Miniflux, locate the "Sign in with OpenID Connect" button on the login page, click on it, and ensure you can successfully log in using Single Sign-On.


### PR DESCRIPTION
## Details

If a user already exists in Miniflux, trying to log in using Authentik will throw an error saying: "This user already exists". To enable logging in, the user must first log in using their existing credentials and manually link the account.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
