### PR TITLE
outpost: revert breaking signals change

### DIFF
--- a/authentik/outposts/signals.py
+++ b/authentik/outposts/signals.py
@@ -77,9 +77,10 @@ def outpost_m2m_changed(sender, instance: Outpost | Provider, action: str, **_):
 
 
 @receiver(post_save, sender=Outpost)
-def outpost_post_save(sender, instance: Outpost, **_):
-    LOGGER.info("Outpost saved, ensuring token and user are created and permissions are set")
-    _ = instance.token
+def outpost_post_save(sender, instance: Outpost, created: bool, **_):
+    if created:
+        LOGGER.info("New outpost saved, ensuring initial token and user are created")
+        _ = instance.token
     outpost_controller.send_with_options(
         args=(instance.pk,),
         rel_obj=instance.service_connection,

--- a/authentik/tenants/tests/test_recovery.py
+++ b/authentik/tenants/tests/test_recovery.py
@@ -5,7 +5,8 @@ from json import loads
 from django.urls import reverse
 from django_tenants.utils import get_public_schema_name
 
-from authentik.core.models import Token, TokenIntents, User
+from authentik.core.models import Token, TokenIntents
+from authentik.core.tests.utils import create_test_user
 from authentik.lib.config import CONFIG
 from authentik.lib.generators import generate_id
 from authentik.tenants.models import Tenant
@@ -21,7 +22,7 @@ class TestRecovery(TenantAPITestCase):
     def setUp(self):
         super().setUp()
         self.tenant = Tenant.objects.get(schema_name=get_public_schema_name())
-        self.user: User = User.objects.create_user(username="recovery-test-user")
+        self.user = create_test_user()
 
     @CONFIG.patch("outposts.disable_embedded_outpost", True)
     @CONFIG.patch("tenants.enabled", True)


### PR DESCRIPTION
I have no idea why this breaks tests

rel #17783 (specifically, commit https://github.com/goauthentik/authentik/pull/17783/commits/c27c2b042bae75d80e574c9578d9d955c28ef26e)