### PR TITLE
stages/user_write: Fix user attributes are not sanitized under certains conditions

### DIFF
--- a/authentik/stages/user_write/stage.py
+++ b/authentik/stages/user_write/stage.py
@@ -13,7 +13,7 @@ from rest_framework.exceptions import ValidationError
 from authentik.core.middleware import SESSION_KEY_IMPERSONATE_USER
 from authentik.core.models import USER_ATTRIBUTE_SOURCES, User, UserSourceConnection, UserTypes
 from authentik.core.sources.stage import PLAN_CONTEXT_SOURCES_CONNECTION
-from authentik.events.utils import sanitize_item
+from authentik.events.utils import sanitize_dict, sanitize_item
 from authentik.flows.planner import PLAN_CONTEXT_PENDING_USER
 from authentik.flows.stage import StageView
 from authentik.flows.views.executor import FlowExecutorView
@@ -116,10 +116,9 @@ class UserWriteStageView(StageView):
             # For exact attributes match, update the dictionary in place
             elif key == "attributes":
                 if isinstance(value, dict):
-                    sanitized_values = {k: sanitize_item(v) for k, v in value.items()}
-                    user.attributes.update(sanitized_values)
+                    user.attributes.update(sanitize_dict(value))
                 else:
-                    user.attributes.update(value)
+                    raise ValidationError("Attempt to overwrite complete attributes")
             # If using dot notation, use the correct helper to update the nested value
             elif key.startswith("attributes.") or key.startswith("attributes_"):
                 UserWriteStageView.write_attribute(user, key, value)

--- a/authentik/stages/user_write/stage.py
+++ b/authentik/stages/user_write/stage.py
@@ -115,7 +115,11 @@ class UserWriteStageView(StageView):
                 continue
             # For exact attributes match, update the dictionary in place
             elif key == "attributes":
-                user.attributes.update(value)
+                if isinstance(value, dict):
+                    sanitized_values = {k: sanitize_item(v) for k, v in value.items()}
+                    user.attributes.update(sanitized_values)
+                else:
+                    user.attributes.update(value)
             # If using dot notation, use the correct helper to update the nested value
             elif key.startswith("attributes.") or key.startswith("attributes_"):
                 UserWriteStageView.write_attribute(user, key, value)


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
This PR fixes a case where certain prompt types (like the date prompt) lead to a failure in the user write stage, because of unsanitized attributes. The original issue was reported in #8708 and later fixed in #8926. However, the fix in #8926 only worked if the prompt would write to `attributes_foo` or `attributes.foo.bar`. If the normal syntax is used `attributes.foo` the stage would try to directly update the user attributes, which lead to unsanitized values. This PR fixes that case.

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
