### PR TITLE
web: Lit Session Context

### DIFF
--- a/web/src/admin/AdminInterface/index.entrypoint.ts
+++ b/web/src/admin/AdminInterface/index.entrypoint.ts
@@ -15,13 +15,14 @@ import {
     renderSidebarItems,
 } from "./AdminSidebar.js";
 
+import { isAPIResultReady } from "#common/api/responses";
 import { EVENT_API_DRAWER_TOGGLE, EVENT_NOTIFICATION_DRAWER_TOGGLE } from "#common/constants";
 import { configureSentry } from "#common/sentry/index";
-import { me } from "#common/users";
 import { WebsocketClient } from "#common/ws";
 
 import { AuthenticatedInterface } from "#elements/AuthenticatedInterface";
 import { WithCapabilitiesConfig } from "#elements/mixins/capabilities";
+import { canAccessAdmin, WithSession } from "#elements/mixins/session";
 import { getURLParam, updateURLParams } from "#elements/router/RouteMatch";
 
 import { PageNavMenuToggle } from "#components/ak-page-navbar";
@@ -30,9 +31,9 @@ import type { AboutModal } from "#admin/AdminInterface/AboutModal";
 import Styles from "#admin/AdminInterface/index.entrypoint.css";
 import { ROUTES } from "#admin/Routes";
 
-import { CapabilitiesEnum, SessionUser, UiThemeEnum } from "@goauthentik/api";
+import { CapabilitiesEnum, UiThemeEnum } from "@goauthentik/api";
 
-import { CSSResult, html, nothing, TemplateResult } from "lit";
+import { CSSResult, html, nothing, PropertyValues, TemplateResult } from "lit";
 import { customElement, property, query } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 
@@ -47,7 +48,7 @@ if (process.env.NODE_ENV === "development") {
 }
 
 @customElement("ak-interface-admin")
-export class AdminInterface extends WithCapabilitiesConfig(AuthenticatedInterface) {
+export class AdminInterface extends WithCapabilitiesConfig(WithSession(AuthenticatedInterface)) {
     //#region Properties
 
     @property({ type: Boolean })
@@ -55,9 +56,6 @@ export class AdminInterface extends WithCapabilitiesConfig(AuthenticatedInterfac
 
     @property({ type: Boolean })
     public apiDrawerOpen = getURLParam("apiDrawerOpen", false);
-
-    @property({ type: Object, attribute: false })
-    public user?: SessionUser;
 
     @query("ak-about-modal")
     public aboutModal?: AboutModal;
@@ -93,7 +91,7 @@ export class AdminInterface extends WithCapabilitiesConfig(AuthenticatedInterfac
     //#region Lifecycle
 
     constructor() {
-        configureSentry(true);
+        configureSentry();
 
         super();
 
@@ -135,22 +133,21 @@ export class AdminInterface extends WithCapabilitiesConfig(AuthenticatedInterfac
         WebsocketClient.close();
     }
 
-    async firstUpdated(): Promise<void> {
-        me().then((session) => {
-            this.user = session;
+    public override updated(changedProperties: PropertyValues<this>): void {
+        super.updated(changedProperties);
 
-            const canAccessAdmin =
-                this.user.user.isSuperuser ||
-                // TODO: somehow add `access_admin_interface` to the API schema
-                this.user.user.systemPermissions.includes("access_admin_interface");
-
-            if (!canAccessAdmin && this.user.user.pk > 0) {
+        if (changedProperties.has("session")) {
+            if (isAPIResultReady(this.session) && !canAccessAdmin(this.session.user)) {
                 window.location.assign("/if/user/");
             }
-        });
+        }
     }
 
     render(): TemplateResult {
+        if (!isAPIResultReady(this.session) || !canAccessAdmin(this.session.user)) {
+            return html`<slot></slot>`;
+        }
+
         const sidebarClasses = {
             "pf-c-page__sidebar": true,
             "pf-m-light": this.activeTheme === UiThemeEnum.Light,

--- a/web/src/admin/providers/ldap/LDAPProviderViewPage.ts
+++ b/web/src/admin/providers/ldap/LDAPProviderViewPage.ts
@@ -9,16 +9,15 @@ import "#elements/buttons/SpinnerButton/index";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
 import { EVENT_REFRESH } from "#common/constants";
-import { me } from "#common/users";
 
 import { AKElement } from "#elements/Base";
+import { WithSession } from "#elements/mixins/session";
 import { SlottedTemplateResult } from "#elements/types";
 
 import {
     LDAPProvider,
     ProvidersApi,
     RbacPermissionsAssignedByUsersListModelEnum,
-    SessionUser,
 } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
@@ -39,15 +38,12 @@ import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
 import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-provider-ldap-view")
-export class LDAPProviderViewPage extends AKElement {
+export class LDAPProviderViewPage extends WithSession(AKElement) {
     @property({ type: Number })
     providerID?: number;
 
     @state()
     provider?: LDAPProvider;
-
-    @state()
-    me?: SessionUser;
 
     static styles: CSSResult[] = [
         PFBase,
@@ -68,9 +64,6 @@ export class LDAPProviderViewPage extends AKElement {
         this.addEventListener(EVENT_REFRESH, () => {
             if (!this.provider?.pk) return;
             this.providerID = this.provider?.pk;
-        });
-        me().then((user) => {
-            this.me = user;
         });
     }
 
@@ -136,6 +129,7 @@ export class LDAPProviderViewPage extends AKElement {
         if (!this.provider) {
             return nothing;
         }
+
         return html`
             ${
                 this.provider?.outpostSet.length < 1
@@ -219,9 +213,7 @@ export class LDAPProviderViewPage extends AKElement {
                                     class="pf-c-form-control"
                                     readonly
                                     type="text"
-                                    value=${`cn=${
-                                        this.me?.user.username
-                                    },ou=users,${this.provider?.baseDn?.toLowerCase()}`}
+                                    value=${`cn=${this.currentUser?.username},ou=users,${this.provider?.baseDn?.toLowerCase()}`}
                                 />
                             </div>
                             <div class="pf-c-form__group">

--- a/web/src/admin/users/UserListPage.ts
+++ b/web/src/admin/users/UserListPage.ts
@@ -16,22 +16,19 @@ import { PFSize } from "#common/enums";
 import { parseAPIResponseError } from "#common/errors/network";
 import { userTypeToLabel } from "#common/labels";
 import { MessageLevel } from "#common/messages";
-import { rootInterface } from "#common/theme";
-import { DefaultUIConfig, uiConfig } from "#common/ui/config";
-import { me } from "#common/users";
+import { DefaultUIConfig } from "#common/ui/config";
 
 import { showAPIErrorMessage, showMessage } from "#elements/messages/MessageContainer";
 import { WithBrandConfig } from "#elements/mixins/branding";
 import { CapabilitiesEnum, WithCapabilitiesConfig } from "#elements/mixins/capabilities";
+import { WithSession } from "#elements/mixins/session";
 import { getURLParam, updateURLParams } from "#elements/router/RouteMatch";
 import { PaginatedResponse, TableColumn, Timestamp } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
 import { SlottedTemplateResult } from "#elements/types";
 import { writeToClipboard } from "#elements/utils/writeToClipboard";
 
-import type { AdminInterface } from "#admin/AdminInterface/index.entrypoint";
-
-import { CoreApi, SessionUser, User, UserPath } from "@goauthentik/api";
+import { CoreApi, User, UserPath } from "@goauthentik/api";
 
 import { msg, str } from "@lit/localize";
 import { css, CSSResult, html, nothing, TemplateResult } from "lit";
@@ -84,7 +81,9 @@ const recoveryButtonStyles = css`
 `;
 
 @customElement("ak-user-list")
-export class UserListPage extends WithBrandConfig(WithCapabilitiesConfig(TablePage<User>)) {
+export class UserListPage extends WithBrandConfig(
+    WithCapabilitiesConfig(WithSession(TablePage<User>)),
+) {
     expandable = true;
     checkbox = true;
     clearOnRefresh = true;
@@ -110,9 +109,6 @@ export class UserListPage extends WithBrandConfig(WithCapabilitiesConfig(TablePa
     @state()
     userPaths?: UserPath;
 
-    @state()
-    me?: SessionUser;
-
     static styles: CSSResult[] = [
         ...TablePage.styles,
         PFDescriptionList,
@@ -123,13 +119,11 @@ export class UserListPage extends WithBrandConfig(WithCapabilitiesConfig(TablePa
 
     constructor() {
         super();
-        const defaultPath = new DefaultUIConfig().defaults.userPath;
+        const defaultPath = DefaultUIConfig.defaults.userPath;
         this.activePath = getURLParam<string>("path", defaultPath);
-        uiConfig().then((c) => {
-            if (c.defaults.userPath !== defaultPath) {
-                this.activePath = c.defaults.userPath;
-            }
-        });
+        if (this.uiConfig.defaults.userPath !== defaultPath) {
+            this.activePath = this.uiConfig.defaults.userPath;
+        }
     }
 
     async apiEndpoint(): Promise<PaginatedResponse<User>> {
@@ -142,7 +136,6 @@ export class UserListPage extends WithBrandConfig(WithCapabilitiesConfig(TablePa
         this.userPaths = await new CoreApi(DEFAULT_CONFIG).coreUsersPathsRetrieve({
             search: this.search,
         });
-        this.me = await me();
         return users;
     }
 
@@ -164,9 +157,10 @@ export class UserListPage extends WithBrandConfig(WithCapabilitiesConfig(TablePa
 
     renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;
-        const currentUser = rootInterface<AdminInterface>()?.user;
+        const { currentUser, originalUser } = this;
+
         const shouldShowWarning = this.selectedElements.find((el) => {
-            return el.pk === currentUser?.user.pk || el.pk === currentUser?.original?.pk;
+            return el.pk === currentUser?.pk || el.pk === originalUser?.pk;
         });
         return html`<ak-forms-delete-bulk
             objectLabel=${msg("User(s)")}
@@ -247,8 +241,11 @@ export class UserListPage extends WithBrandConfig(WithCapabilitiesConfig(TablePa
     }
 
     row(item: User): SlottedTemplateResult[] {
-        const canImpersonate =
-            this.can(CapabilitiesEnum.CanImpersonate) && item.pk !== this.me?.user.pk;
+        const { currentUser } = this;
+
+        const impersionationVisible =
+            this.can(CapabilitiesEnum.CanImpersonate) && currentUser && item.pk !== currentUser.pk;
+
         return [
             html`<a href="#/identity/users/${item.pk}">
                 <div>${item.username}</div>
@@ -268,7 +265,7 @@ export class UserListPage extends WithBrandConfig(WithCapabilitiesConfig(TablePa
                         </pf-tooltip>
                     </button>
                 </ak-forms-modal>
-                ${canImpersonate
+                ${impersionationVisible
                     ? html`
                           <ak-forms-modal size=${PFSize.Medium} id="impersonate-request">
                               <span slot="submit">${msg("Impersonate")}</span>

--- a/web/src/common/api/responses.ts
+++ b/web/src/common/api/responses.ts
@@ -1,0 +1,28 @@
+/**
+ * @file Utilities for API requests
+ */
+
+import { APIError } from "#common/errors/network";
+
+export interface APIResultLoading {
+    loading: true;
+    error: null;
+}
+
+export interface APIResultError {
+    loading: false;
+    error: APIError;
+}
+
+export type APIResultSucccess<T extends object = object> = T & {
+    error?: null;
+    loading?: false;
+};
+
+export type APIResult<T extends object> = APIResultLoading | APIResultError | APIResultSucccess<T>;
+
+export function isAPIResultReady<T extends object>(
+    result: APIResult<T> | null | undefined,
+): result is APIResultSucccess<T> {
+    return !!(result && result.loading !== false && result.error !== null);
+}

--- a/web/src/common/sentry/index.ts
+++ b/web/src/common/sentry/index.ts
@@ -1,5 +1,4 @@
 import { globalAK } from "#common/global";
-import { me } from "#common/users";
 
 import { readInterfaceRouteParam } from "#elements/router/utils";
 
@@ -11,7 +10,6 @@ import {
     EventHint,
     init,
     setTag,
-    setUser,
     spotlightBrowserIntegration,
 } from "@sentry/browser";
 import { type Integration } from "@sentry/core";
@@ -92,12 +90,5 @@ export function configureSentry(canDoPpi = false): void {
         setTag(TAG_SENTRY_COMPONENT, `web/${readInterfaceRouteParam()}`);
     }
 
-    if (cfg.errorReporting.sendPii && canDoPpi) {
-        me().then((user) => {
-            setUser({ email: user.user.email });
-            console.debug("authentik/config: Sentry with PII enabled.");
-        });
-    } else {
-        console.debug("authentik/config: Sentry enabled.");
-    }
+    console.debug("authentik/config: Sentry enabled.");
 }

--- a/web/src/common/ui/config.ts
+++ b/web/src/common/ui/config.ts
@@ -1,8 +1,6 @@
-import { me } from "#common/users";
-
 import { isUserRoute } from "#elements/router/utils";
 
-import { CurrentBrand, UiThemeEnum, UserSelf } from "@goauthentik/api";
+import { CurrentBrand, UiThemeEnum } from "@goauthentik/api";
 
 import { deepmerge } from "deepmerge-ts";
 
@@ -66,54 +64,42 @@ export interface UIConfig {
     };
 }
 
-export class DefaultUIConfig implements UIConfig {
-    enabledFeatures = {
+export const DefaultUIConfig = {
+    enabledFeatures: {
         apiDrawer: true,
         notificationDrawer: true,
         settings: true,
         applicationEdit: true,
         search: true,
-    };
-    layout = {
+    },
+    layout: {
         type: LayoutType.row,
-    };
-    navbar = {
+    },
+    navbar: {
         userDisplay: UserDisplay.username,
-    };
-    theme = {
+    },
+    theme: {
         base: UiThemeEnum.Automatic,
         background: "",
         cardBackground: "",
-    };
-    pagination = {
+    },
+    pagination: {
         perPage: 20,
-    };
-    locale = "";
-    defaults = {
+    },
+    locale: "",
+    defaults: {
         userPath: "users",
-    };
+    },
+} as const satisfies UIConfig;
 
-    constructor() {
-        this.enabledFeatures.apiDrawer = !isUserRoute();
-    }
-}
-
-let globalUiConfig: Promise<UIConfig>;
-
-export function getConfigForUser(user: UserSelf): UIConfig {
-    const settings = user.settings as UIConfig;
-    const config = new DefaultUIConfig();
-    if (!settings) {
-        return config;
-    }
-    return deepmerge({ ...config }, settings);
-}
-
-export function uiConfig(): Promise<UIConfig> {
-    if (!globalUiConfig) {
-        globalUiConfig = me().then((user) => {
-            return getConfigForUser(user.user);
-        });
-    }
-    return globalUiConfig;
+export function createUIConfig(overrides: Partial<UIConfig> = {}): UIConfig {
+    return deepmerge(
+        { ...DefaultUIConfig },
+        {
+            enabledFeatures: {
+                apiDrawer: !isUserRoute(),
+            },
+        },
+        overrides,
+    );
 }

--- a/web/src/components/ak-nav-buttons.ts
+++ b/web/src/components/ak-nav-buttons.ts
@@ -3,16 +3,14 @@ import "#elements/buttons/ActionButton/ak-action-button";
 import { DEFAULT_CONFIG } from "#common/api/config";
 import { EVENT_API_DRAWER_TOGGLE, EVENT_NOTIFICATION_DRAWER_TOGGLE } from "#common/constants";
 import { globalAK } from "#common/global";
-import { uiConfig, UIConfig, UserDisplay } from "#common/ui/config";
-import { me } from "#common/users";
+import { formatUserDisplayName, isGuest } from "#common/users";
 
 import { AKElement } from "#elements/Base";
+import { WithSession } from "#elements/mixins/session";
 
 import Styles from "#components/ak-nav-button.css";
 
-import { CoreApi, EventsApi, SessionUser } from "@goauthentik/api";
-
-import { match } from "ts-pattern";
+import { CoreApi, EventsApi } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
 import { html, nothing } from "lit";
@@ -29,13 +27,7 @@ import PFBase from "@patternfly/patternfly/patternfly-base.css";
 import PFDisplay from "@patternfly/patternfly/utilities/Display/display.css";
 
 @customElement("ak-nav-buttons")
-export class NavigationButtons extends AKElement {
-    @property({ type: Object })
-    uiConfig?: UIConfig;
-
-    @property({ type: Object })
-    me?: SessionUser;
-
+export class NavigationButtons extends WithSession(AKElement) {
     @property({ type: Boolean, reflect: true })
     notificationDrawerOpen = false;
 
@@ -58,16 +50,21 @@ export class NavigationButtons extends AKElement {
         Styles,
     ];
 
-    async firstUpdated() {
-        this.me = await me();
+    protected async refreshNotifications(): Promise<void> {
+        const { currentUser } = this;
+
+        if (!currentUser || isGuest(currentUser)) {
+            return;
+        }
+
         const notifications = await new EventsApi(DEFAULT_CONFIG).eventsNotificationsList({
             seen: false,
             ordering: "-created",
             pageSize: 1,
-            user: this.me.user.pk,
+            user: currentUser.pk,
         });
+
         this.notificationsCount = notifications.pagination.count;
-        this.uiConfig = await uiConfig();
     }
 
     renderApiDrawerTrigger() {
@@ -143,7 +140,7 @@ export class NavigationButtons extends AKElement {
     }
 
     renderImpersonation() {
-        if (!this.me?.original) return nothing;
+        if (!this.impersonating) return nothing;
 
         const onClick = async () => {
             await new CoreApi(DEFAULT_CONFIG).coreUsersImpersonateEndRetrieve();
@@ -161,26 +158,24 @@ export class NavigationButtons extends AKElement {
     }
 
     renderAvatar() {
+        const { currentUser } = this;
+        if (!currentUser) {
+            return nothing;
+        }
+
         return html`<div
             class="pf-c-page__header-tools-item pf-c-avatar pf-m-hidden pf-m-visible-on-xl"
             aria-hidden="true"
         >
-            ${this.me?.user.avatar
-                ? html`<img src=${this.me.user.avatar} alt=${msg("Avatar image")} />`
+            ${currentUser.avatar
+                ? html`<img src=${currentUser.avatar} alt=${msg("Avatar image")} />`
                 : nothing}
         </div>`;
     }
 
-    get userDisplayName() {
-        return match<UserDisplay | undefined, string | undefined>(this.uiConfig?.navbar.userDisplay)
-            .with(UserDisplay.username, () => this.me?.user.username)
-            .with(UserDisplay.name, () => this.me?.user.name)
-            .with(UserDisplay.email, () => this.me?.user.email || "")
-            .with(UserDisplay.none, () => "")
-            .otherwise(() => this.me?.user.username);
-    }
-
     render() {
+        const displayName = formatUserDisplayName(this.currentUser, this.uiConfig);
+
         return html`<div role="presentation" class="pf-c-page__header-tools">
             <div class="pf-c-page__header-tools-group">
                 ${this.renderApiDrawerTrigger()}
@@ -201,10 +196,10 @@ export class NavigationButtons extends AKElement {
                 <slot name="extra"></slot>
             </div>
             ${this.renderImpersonation()}
-            ${this.userDisplayName
+            ${displayName
                 ? html`<div class="pf-c-page__header-tools-group pf-m-hidden">
                       <div class="pf-c-page__header-tools-item pf-m-visible-on-2xl">
-                          ${this.userDisplayName}
+                          ${displayName}
                       </div>
                   </div>`
                 : nothing}

--- a/web/src/components/ak-page-navbar.ts
+++ b/web/src/components/ak-page-navbar.ts
@@ -3,15 +3,13 @@ import "@patternfly/elements/pf-tooltip/pf-tooltip.js";
 
 import { EVENT_WS_MESSAGE } from "#common/constants";
 import { globalAK } from "#common/global";
-import { getConfigForUser, UIConfig, UserDisplay } from "#common/ui/config";
-import { me } from "#common/users";
+import { UserDisplay } from "#common/ui/config";
 
 import { AKElement } from "#elements/Base";
 import { WithBrandConfig } from "#elements/mixins/branding";
+import { WithSession } from "#elements/mixins/session";
 import { isAdminRoute } from "#elements/router/utils";
 import { themeImage } from "#elements/utils/images";
-
-import { SessionUser } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
 import { css, CSSResult, html, nothing, TemplateResult } from "lit";
@@ -40,7 +38,10 @@ export interface PageHeaderInit {
  * dispatched by the `ak-page-header` component.
  */
 @customElement("ak-page-navbar")
-export class AKPageNavbar extends WithBrandConfig(AKElement) implements PageHeaderInit {
+export class AKPageNavbar
+    extends WithBrandConfig(WithSession(AKElement))
+    implements PageHeaderInit
+{
     //#region Static Properties
 
     static styles: CSSResult[] = [
@@ -263,12 +264,6 @@ export class AKPageNavbar extends WithBrandConfig(AKElement) implements PageHead
     @property({ type: Boolean, reflect: true })
     public open?: boolean;
 
-    @state()
-    protected session?: SessionUser;
-
-    @state()
-    protected uiConfig!: UIConfig;
-
     //#endregion
 
     //#region Private Methods
@@ -325,8 +320,6 @@ export class AKPageNavbar extends WithBrandConfig(AKElement) implements PageHead
     }
 
     public async firstUpdated() {
-        this.session = await me();
-        this.uiConfig = getConfigForUser(this.session.user);
         this.uiConfig.navbar.userDisplay = UserDisplay.none;
     }
 
@@ -403,7 +396,7 @@ export class AKPageNavbar extends WithBrandConfig(AKElement) implements PageHead
 
                 <div class="items secondary">
                     <div class="pf-c-page__header-tools-group">
-                        <ak-nav-buttons .uiConfig=${this.uiConfig} .me=${this.session}>
+                        <ak-nav-buttons>
                             <a
                                 class="pf-c-button pf-m-secondary pf-m-small pf-u-display-none pf-u-display-block-on-md"
                                 href="${globalAK().api.base}if/user/"

--- a/web/src/elements/AuthenticatedInterface.ts
+++ b/web/src/elements/AuthenticatedInterface.ts
@@ -1,4 +1,5 @@
 import { LicenseContextController } from "#elements/controllers/LicenseContextController";
+import { SessionContextController } from "#elements/controllers/SessionContextController";
 import { VersionContextController } from "#elements/controllers/VersionContextController";
 import { Interface } from "#elements/Interface";
 
@@ -7,6 +8,7 @@ export class AuthenticatedInterface extends Interface {
         super();
 
         this.addController(new LicenseContextController(this));
+        this.addController(new SessionContextController(this));
         this.addController(new VersionContextController(this));
     }
 }

--- a/web/src/elements/controllers/LicenseContextController.ts
+++ b/web/src/elements/controllers/LicenseContextController.ts
@@ -1,8 +1,10 @@
 import { DEFAULT_CONFIG } from "#common/api/config";
 import { EVENT_REFRESH_ENTERPRISE } from "#common/constants";
 import { isCausedByAbortError } from "#common/errors/network";
+import { isGuest } from "#common/users";
 
 import { LicenseContext, LicenseMixin } from "#elements/mixins/license";
+import { SessionMixin } from "#elements/mixins/session";
 import type { ReactiveElementHost } from "#elements/types";
 
 import { EnterpriseApi, LicenseSummary } from "@goauthentik/api";
@@ -14,7 +16,7 @@ export class LicenseContextController implements ReactiveController {
     #log = console.debug.bind(console, `authentik/controller/license`);
     #abortController: null | AbortController = null;
 
-    #host: ReactiveElementHost<LicenseMixin>;
+    #host: ReactiveElementHost<SessionMixin & LicenseMixin>;
     #context: ContextProvider<LicenseContext>;
 
     constructor(host: ReactiveElementHost<LicenseMixin>, initialValue?: LicenseSummary) {
@@ -27,8 +29,6 @@ export class LicenseContextController implements ReactiveController {
 
     #fetch = () => {
         this.#log("Fetching license summary...");
-
-        this.#abortController?.abort();
 
         this.#abortController = new AbortController();
 
@@ -57,22 +57,30 @@ export class LicenseContextController implements ReactiveController {
             });
     };
 
-    public hostConnected() {
-        window.addEventListener(EVENT_REFRESH_ENTERPRISE, this.#fetch);
+    #refreshListener = (event: Event) => {
+        this.#abortController?.abort(event.type);
         this.#fetch();
+    };
+
+    public hostConnected() {
+        window.addEventListener(EVENT_REFRESH_ENTERPRISE, this.#refreshListener);
     }
 
     public hostDisconnected() {
-        window.removeEventListener(EVENT_REFRESH_ENTERPRISE, this.#fetch);
-        this.#abortController?.abort();
+        window.removeEventListener(EVENT_REFRESH_ENTERPRISE, this.#refreshListener);
     }
 
     public hostUpdate() {
-        // If the Interface changes its config information, we should notify all
-        // users of the context of that change, without creating an infinite
-        // loop of resets.
-        if (this.#host.licenseSummary && this.#host.licenseSummary !== this.#context.value) {
-            this.#context.setValue(this.#host.licenseSummary);
+        const { currentUser } = this.#host;
+
+        if (currentUser && !isGuest(currentUser) && !this.#abortController) {
+            this.#fetch();
+
+            return;
+        }
+
+        if (!currentUser && this.#abortController) {
+            this.#abortController.abort("session-invalidated");
         }
     }
 }

--- a/web/src/elements/controllers/SessionContextController.ts
+++ b/web/src/elements/controllers/SessionContextController.ts
@@ -1,0 +1,89 @@
+import type { APIResult } from "#common/api/responses";
+import { EVENT_WS_MESSAGE } from "#common/constants";
+import { isCausedByAbortError, parseAPIResponseError } from "#common/errors/network";
+import { me } from "#common/users";
+
+import { AKConfigMixin, kAKConfig } from "#elements/mixins/config";
+import { SessionContext, SessionMixin } from "#elements/mixins/session";
+import type { ReactiveElementHost } from "#elements/types";
+
+import { SessionUser } from "@goauthentik/api";
+
+import { setUser } from "@sentry/browser";
+
+import { ContextProvider } from "@lit/context";
+import type { ReactiveController } from "lit";
+
+/**
+ * A controller that provides the session information to the element.
+ *
+ * @see {@linkcode SessionMixin}
+ */
+export class SessionContextController implements ReactiveController {
+    #log = console.debug.bind(console, `authentik/controller/session`);
+    #abortController: null | AbortController = null;
+
+    #host: ReactiveElementHost<SessionMixin & AKConfigMixin>;
+    #context: ContextProvider<SessionContext>;
+
+    constructor(
+        host: ReactiveElementHost<SessionMixin & AKConfigMixin>,
+        initialValue?: APIResult<SessionUser>,
+    ) {
+        this.#host = host;
+
+        this.#context = new ContextProvider(this.#host, {
+            context: SessionContext,
+            initialValue: initialValue ?? { loading: true, error: null },
+        });
+    }
+
+    #fetch = () => {
+        this.#log("Fetching session...");
+
+        this.#abortController?.abort();
+
+        this.#abortController = new AbortController();
+
+        return me({
+            signal: this.#abortController.signal,
+        })
+            .then((session) => {
+                const config = this.#host[kAKConfig];
+
+                if (config?.errorReporting.sendPii) {
+                    console.debug("authentik/config: Sentry with PII enabled.");
+
+                    setUser({ email: session.user.email });
+                }
+
+                console.debug("authentik/controller/session: Fetched session", session);
+                this.#context.setValue(session);
+                this.#host.session = session;
+            })
+            .catch(async (error: unknown) => {
+                if (isCausedByAbortError(error)) {
+                    this.#log("Aborted fetching session");
+                    return;
+                }
+
+                const parsedError = parseAPIResponseError(error);
+                console.error("authentik/controller/session: Failed to fetch session", parsedError);
+
+                throw error;
+            })
+            .finally(() => {
+                this.#abortController = null;
+            });
+    };
+
+    public hostConnected() {
+        window.addEventListener(EVENT_WS_MESSAGE, this.#fetch);
+        this.#fetch();
+    }
+
+    public hostDisconnected() {
+        window.removeEventListener(EVENT_WS_MESSAGE, this.#fetch);
+        this.#abortController?.abort();
+    }
+}

--- a/web/src/elements/controllers/VersionContextController.ts
+++ b/web/src/elements/controllers/VersionContextController.ts
@@ -1,7 +1,9 @@
 import { DEFAULT_CONFIG } from "#common/api/config";
 import { EVENT_REFRESH } from "#common/constants";
 import { isCausedByAbortError } from "#common/errors/network";
+import { isGuest } from "#common/users";
 
+import { SessionMixin } from "#elements/mixins/session";
 import { VersionContext, VersionMixin } from "#elements/mixins/version";
 import type { ReactiveElementHost } from "#elements/types";
 
@@ -14,10 +16,10 @@ export class VersionContextController implements ReactiveController {
     #log = console.debug.bind(console, `authentik/controller/version`);
     #abortController: null | AbortController = null;
 
-    #host: ReactiveElementHost<VersionMixin>;
+    #host: ReactiveElementHost<SessionMixin & VersionMixin>;
     #context: ContextProvider<VersionContext>;
 
-    constructor(host: ReactiveElementHost<VersionMixin>, initialValue?: Version) {
+    constructor(host: ReactiveElementHost<VersionMixin & VersionMixin>, initialValue?: Version) {
         this.#host = host;
         this.#context = new ContextProvider(this.#host, {
             context: VersionContext,
@@ -27,8 +29,6 @@ export class VersionContextController implements ReactiveController {
 
     #fetch = () => {
         this.#log("Fetching latest version...");
-
-        this.#abortController?.abort();
 
         this.#abortController = new AbortController();
 
@@ -54,21 +54,30 @@ export class VersionContextController implements ReactiveController {
             });
     };
 
-    public hostConnected() {
-        window.addEventListener(EVENT_REFRESH, this.#fetch);
+    #refreshListener = (event: Event) => {
+        this.#abortController?.abort(event.type);
         this.#fetch();
+    };
+
+    public hostConnected() {
+        window.addEventListener(EVENT_REFRESH, this.#refreshListener);
     }
 
     public hostDisconnected() {
-        window.removeEventListener(EVENT_REFRESH, this.#fetch);
-        this.#abortController?.abort();
+        window.removeEventListener(EVENT_REFRESH, this.#refreshListener);
     }
 
     public hostUpdate() {
-        // If the Interface changes its version information for some reason,
-        // we should notify all users of the context of that change. doesn't
-        if (this.#host.version && this.#host.version !== this.#context.value) {
-            this.#context.setValue(this.#host.version);
+        const { currentUser } = this.#host;
+
+        if (currentUser && !isGuest(currentUser) && !this.#abortController) {
+            this.#fetch();
+
+            return;
+        }
+
+        if (!currentUser && this.#abortController) {
+            this.#abortController.abort("session-invalidated");
         }
     }
 }

--- a/web/src/elements/mixins/session.ts
+++ b/web/src/elements/mixins/session.ts
@@ -1,0 +1,133 @@
+import { APIResult, isAPIResultReady } from "#common/api/responses";
+import { createUIConfig, DefaultUIConfig, UIConfig } from "#common/ui/config";
+
+import { createMixin } from "#elements/types";
+
+import type { SessionUser, UserSelf } from "@goauthentik/api";
+
+import { consume, createContext } from "@lit/context";
+import { property } from "lit/decorators.js";
+
+/**
+ * The Lit context for the application configuration.
+ *
+ * @category Context
+ * @see {@linkcode SessionMixin}
+ * @see {@linkcode WithSession}
+ */
+export const SessionContext = createContext<APIResult<SessionUser>>(
+    Symbol.for("authentik-session-context"),
+);
+
+export type SessionContext = typeof SessionContext;
+/**
+ * A consumer that provides session information to the element.
+ *
+ * @category Mixin
+ * @see {@linkcode WithSession}
+ */
+export interface SessionMixin {
+    /**
+     * The current session information.
+     *
+     * @see {@linkcode currentUser} for access to the current user.
+     */
+    readonly session: APIResult<SessionUser>;
+
+    /**
+     *
+     * The current user of the session.
+     *
+     * If this user is impersonating another user, this will be the impersonated user.
+     */
+    readonly currentUser: Readonly<UserSelf> | null;
+
+    /**
+     * The original user of the session.
+     *
+     * If this user is impersonating another user, this will be the original user.
+     */
+    readonly originalUser: Readonly<UserSelf> | null;
+
+    /**
+     * The aggregate uiConfig, derived from user, brand, and instance data.
+     */
+    readonly uiConfig: Readonly<UIConfig>;
+
+    /**
+     * Whether the current session is impersonating another user.
+     */
+    readonly impersonating: boolean;
+}
+
+/**
+ * Whether the user can view the admin innterface.
+ */
+export function canAccessAdmin(user?: UserSelf | null) {
+    return (
+        user &&
+        (user.isSuperuser ||
+            user.systemPermissions.includes("access_admin_interface") ||
+            user.pk === 0)
+    );
+}
+
+// uiConfig.enabledFeatures.applicationEdit && currentUser?.isSuperuser
+
+/**
+ * A mixin that provides the session information to the element.
+ *
+ * @category Mixin
+ */
+export const WithSession = createMixin<SessionMixin>(
+    ({
+        // ---
+        SuperClass,
+        subscribe = true,
+    }) => {
+        abstract class SessionProvider extends SuperClass implements SessionMixin {
+            #data: APIResult<Readonly<SessionUser>> = {
+                loading: true,
+                error: null,
+            };
+
+            #uiConfig: Readonly<UIConfig> = DefaultUIConfig;
+
+            @consume({
+                context: SessionContext,
+                subscribe,
+            })
+            @property({ attribute: false })
+            public set session(nextResult: APIResult<SessionUser>) {
+                this.#data = nextResult;
+                if (isAPIResultReady(nextResult)) {
+                    const { settings = {} } = nextResult.user || {};
+
+                    this.#uiConfig = createUIConfig(settings);
+                }
+            }
+
+            public get session(): APIResult<Readonly<SessionUser>> {
+                return this.#data;
+            }
+
+            public get uiConfig(): Readonly<UIConfig> {
+                return this.#uiConfig;
+            }
+
+            public get currentUser(): Readonly<UserSelf> | null {
+                return (isAPIResultReady(this.#data) && this.#data.user) || null;
+            }
+
+            public get originalUser(): Readonly<UserSelf> | null {
+                return (isAPIResultReady(this.#data) && this.#data.original) || null;
+            }
+
+            public get impersonating(): boolean {
+                return !!this.originalUser;
+            }
+        }
+
+        return SessionProvider;
+    },
+);

--- a/web/src/elements/mixins/version.ts
+++ b/web/src/elements/mixins/version.ts
@@ -2,7 +2,8 @@ import { createMixin } from "#elements/types";
 
 import type { Version } from "@goauthentik/api";
 
-import { consume, Context, createContext } from "@lit/context";
+import { consume, createContext } from "@lit/context";
+import { property } from "lit/decorators.js";
 
 /**
  * The Lit context for application branding.
@@ -12,9 +13,11 @@ import { consume, Context, createContext } from "@lit/context";
  * @see {@linkcode WithVersion}
  */
 
-export const VersionContext = createContext<Version>(Symbol.for("authentik-version-context"));
+export const VersionContext = createContext<Version | null>(
+    Symbol.for("authentik-version-context"),
+);
 
-export type VersionContext = Context<symbol, Version>;
+export type VersionContext = typeof VersionContext;
 
 /**
  * A mixin that provides the current version to the element.
@@ -27,7 +30,7 @@ export interface VersionMixin {
      *
      * @format semver
      */
-    readonly version: Version;
+    readonly version: Version | null;
 }
 
 /**
@@ -46,7 +49,8 @@ export const WithVersion = createMixin<VersionMixin>(
                 context: VersionContext,
                 subscribe,
             })
-            public version!: Version;
+            @property({ attribute: false })
+            public version: Version | null = null;
         }
 
         return VersionProvider;

--- a/web/src/elements/notifications/NotificationDrawer.ts
+++ b/web/src/elements/notifications/NotificationDrawer.ts
@@ -7,10 +7,11 @@ import { globalAK } from "#common/global";
 import { actionToLabel, severityToLevel } from "#common/labels";
 import { MessageLevel } from "#common/messages";
 import { formatElapsedTime } from "#common/temporal";
-import { me } from "#common/users";
+import { isGuest } from "#common/users";
 
 import { AKElement } from "#elements/Base";
 import { showMessage } from "#elements/messages/MessageContainer";
+import { WithSession } from "#elements/mixins/session";
 import { PaginatedResponse } from "#elements/table/Table";
 import { SlottedTemplateResult } from "#elements/types";
 
@@ -27,7 +28,7 @@ import PFNotificationDrawer from "@patternfly/patternfly/components/Notification
 import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-notification-drawer")
-export class NotificationDrawer extends AKElement {
+export class NotificationDrawer extends WithSession(AKElement) {
     @property({ attribute: false })
     notifications?: PaginatedResponse<Notification>;
 
@@ -63,19 +64,28 @@ export class NotificationDrawer extends AKElement {
         `,
     ];
 
-    firstUpdated(): void {
-        me().then((user) => {
-            new EventsApi(DEFAULT_CONFIG)
-                .eventsNotificationsList({
-                    seen: false,
-                    ordering: "-created",
-                    user: user.user.pk,
-                })
-                .then((r) => {
-                    this.notifications = r;
-                    this.unread = r.results.length;
-                });
-        });
+    connectedCallback(): void {
+        super.connectedCallback();
+        this.refreshNotifications();
+    }
+
+    protected async refreshNotifications(): Promise<void> {
+        const { currentUser } = this;
+
+        if (!currentUser || isGuest(currentUser)) {
+            return Promise.resolve();
+        }
+
+        return new EventsApi(DEFAULT_CONFIG)
+            .eventsNotificationsList({
+                seen: false,
+                ordering: "-created",
+                user: currentUser.pk,
+            })
+            .then((r) => {
+                this.notifications = r;
+                this.unread = r.results.length;
+            });
     }
 
     #renderItem = (item: Notification): TemplateResult => {
@@ -114,7 +124,7 @@ export class NotificationDrawer extends AKElement {
                                 },
                             })
                             .then(() => {
-                                this.firstUpdated();
+                                this.refreshNotifications();
                                 this.dispatchEvent(
                                     new CustomEvent(EVENT_REFRESH, {
                                         bubbles: true,
@@ -143,7 +153,7 @@ export class NotificationDrawer extends AKElement {
                 level: MessageLevel.success,
                 message: msg("Successfully cleared notifications"),
             });
-            this.firstUpdated();
+            this.refreshNotifications();
             this.dispatchEvent(
                 new CustomEvent(EVENT_REFRESH, {
                     bubbles: true,

--- a/web/src/elements/table/Table.ts
+++ b/web/src/elements/table/Table.ts
@@ -11,11 +11,11 @@ import { renderTableColumn, TableColumn } from "./TableColumn.js";
 
 import { EVENT_REFRESH } from "#common/constants";
 import { APIError, parseAPIResponseError, pluckErrorDetail } from "#common/errors/network";
-import { uiConfig } from "#common/ui/config";
 import { GroupResult } from "#common/utils";
 
 import { AKElement } from "#elements/Base";
 import { WithLicenseSummary } from "#elements/mixins/license";
+import { WithSession } from "#elements/mixins/session";
 import { getURLParam, updateURLParams } from "#elements/router/RouteMatch";
 import Styles from "#elements/table/Table.css";
 import { SlottedTemplateResult } from "#elements/types";
@@ -71,7 +71,7 @@ export type TableInstance = InstanceType<typeof Table> & {
 };
 
 export abstract class Table<T extends object>
-    extends WithLicenseSummary(AKElement)
+    extends WithLicenseSummary(WithSession(AKElement))
     implements TableLike
 {
     static styles: CSSResult[] = [
@@ -294,7 +294,7 @@ export abstract class Table<T extends object>
         return {
             ordering: this.order,
             page: this.page,
-            pageSize: (await uiConfig()).pagination.perPage,
+            pageSize: this.uiConfig.pagination.perPage,
             search: this.searchEnabled ? this.search || "" : undefined,
         };
     }

--- a/web/src/user/LibraryPage/ApplicationList.ts
+++ b/web/src/user/LibraryPage/ApplicationList.ts
@@ -1,12 +1,10 @@
 import type { AppGroupEntry } from "./types.js";
 
-import { rootInterface } from "#common/theme";
 import { LayoutType } from "#common/ui/config";
 
 import { LitFC } from "#elements/types";
 import { ifPresent } from "#elements/utils/attributes";
 
-import { UserInterface } from "#user/index.entrypoint";
 import { AnchorPositionSupported } from "#user/LibraryApplication/CardMenu";
 import { AKLibraryApp } from "#user/LibraryApplication/index";
 
@@ -30,6 +28,7 @@ const LayoutColumnCount = {
 } as const satisfies Record<LayoutType, number>;
 
 export interface AKLibraryApplicationListProps extends HTMLAttributes<HTMLDivElement> {
+    editable?: boolean;
     groupedApps: AppGroupEntry[];
     layout: LayoutType;
     background?: string | null;
@@ -41,6 +40,7 @@ export interface AKLibraryApplicationListProps extends HTMLAttributes<HTMLDivEle
  * Renders the current library list of a User's Applications.
  */
 export const AKLibraryApplicationList: LitFC<AKLibraryApplicationListProps> = ({
+    editable,
     groupedApps,
     layout = LayoutType.row,
     background,
@@ -49,8 +49,6 @@ export const AKLibraryApplicationList: LitFC<AKLibraryApplicationListProps> = ({
     ...props
 }) => {
     const columnCount = LayoutColumnCount[layout] ?? 1;
-    const { me, uiConfig } = rootInterface<UserInterface>();
-    const canEdit = !!(uiConfig?.enabledFeatures.applicationEdit && me?.user.isSuperuser);
 
     return html`<div
         role="presentation"
@@ -86,7 +84,7 @@ export const AKLibraryApplicationList: LitFC<AKLibraryApplicationListProps> = ({
                         (application, appIndex) => {
                             const selected = selectedApp === application;
 
-                            const editURL = canEdit
+                            const editURL = editable
                                 ? ApplicationRoute.EditURL(application.slug)
                                 : null;
 

--- a/web/src/user/LibraryPage/ak-library.ts
+++ b/web/src/user/LibraryPage/ak-library.ts
@@ -1,19 +1,15 @@
 import "#elements/EmptyState";
 import "./ak-library-impl.js";
 
-import type { PageUIConfig } from "./types.js";
-
 import { DEFAULT_CONFIG } from "#common/api/config";
-import { rootInterface } from "#common/theme";
-import { me } from "#common/users";
+import { APIResult } from "#common/api/responses";
+import { parseAPIResponseError, pluckErrorDetail } from "#common/errors/network";
 
 import { AKElement } from "#elements/Base";
 
-import type { UserInterface } from "#user/index.entrypoint";
-
 import { Application, CoreApi } from "@goauthentik/api";
 
-import { localized, msg } from "@lit/localize";
+import { msg } from "@lit/localize";
 import { html } from "lit";
 import { customElement, state } from "lit/decorators.js";
 
@@ -31,7 +27,6 @@ import { customElement, state } from "lit/decorators.js";
 
 const coreApi = () => new CoreApi(DEFAULT_CONFIG);
 
-@localized()
 @customElement("ak-library")
 export class LibraryPage extends AKElement {
     static shadowRootOptions = { ...AKElement.shadowRootOptions, delegatesFocus: true };
@@ -40,41 +35,30 @@ export class LibraryPage extends AKElement {
         return this;
     }
 
-    @state()
-    protected ready = false;
-
-    @state()
-    protected admin = false;
-
     /**
      * The list of applications. This is the *complete* list; the constructor fetches as many pages
      * as the server announces when page one is accessed, and then concatenates them all together.
      */
     @state()
-    protected apps: Application[] = [];
+    protected apps: APIResult<Application[]> = {
+        loading: true,
+        error: null,
+    };
 
-    @state()
-    uiConfig: PageUIConfig;
+    public override connectedCallback(): void {
+        super.connectedCallback();
 
-    constructor() {
-        super();
-        const { uiConfig } = rootInterface<UserInterface>();
-
-        if (!uiConfig) {
-            throw new Error("Could not retrieve uiConfig. Reason: unknown. Check logs.");
-        }
-
-        this.uiConfig = {
-            layout: uiConfig.layout.type,
-            background: uiConfig.theme.cardBackground,
-            searchEnabled: uiConfig.enabledFeatures.search,
-        };
-
-        Promise.all([this.fetchApplications(), me()]).then(([applications, meStatus]) => {
-            this.apps = applications;
-            this.admin = meStatus.user.isSuperuser;
-            this.ready = true;
-        });
+        this.fetchApplications()
+            .then((apps) => {
+                this.apps = apps;
+            })
+            .catch(async (error: unknown) => {
+                const parsedError = await parseAPIResponseError(error);
+                this.apps = {
+                    loading: false,
+                    error: parsedError,
+                };
+            });
     }
 
     async fetchApplications(): Promise<Application[]> {
@@ -111,20 +95,19 @@ export class LibraryPage extends AKElement {
 
     public pageTitle = msg("My Applications");
 
-    loading() {
-        return html`<ak-empty-state default-label></ak-empty-state>`;
-    }
-
-    running() {
-        return html`<ak-library-impl
-            ?admin=${this.admin}
-            .apps=${this.apps}
-            .uiConfig=${this.uiConfig}
-        ></ak-library-impl>`;
-    }
-
     render() {
-        return this.ready ? this.running() : this.loading();
+        if (this.apps.loading) {
+            return html`<ak-empty-state default-label></ak-empty-state>`;
+        }
+
+        if (this.apps.error) {
+            return html`<ak-empty-state icon="fa-ban"
+                ><span>${msg("Failed to fetch applications.")}</span>
+                <div slot="body">${pluckErrorDetail(this.apps.error)}</div>
+            </ak-empty-state>`;
+        }
+
+        return html`<ak-library-impl .apps=${this.apps}></ak-library-impl>`;
     }
 }
 

--- a/web/src/user/index.entrypoint.ts
+++ b/web/src/user/index.entrypoint.ts
@@ -11,20 +11,16 @@ import "#elements/sidebar/SidebarItem";
 import "@patternfly/elements/pf-tooltip/pf-tooltip.js";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
-import {
-    EVENT_API_DRAWER_TOGGLE,
-    EVENT_NOTIFICATION_DRAWER_TOGGLE,
-    EVENT_WS_MESSAGE,
-} from "#common/constants";
+import { EVENT_API_DRAWER_TOGGLE, EVENT_NOTIFICATION_DRAWER_TOGGLE } from "#common/constants";
 import { globalAK } from "#common/global";
 import { configureSentry } from "#common/sentry/index";
-import { DefaultBrand, getConfigForUser, UIConfig } from "#common/ui/config";
-import { me } from "#common/users";
+import { isGuest } from "#common/users";
 import { WebsocketClient } from "#common/ws";
 
 import { AuthenticatedInterface } from "#elements/AuthenticatedInterface";
 import { AKElement } from "#elements/Base";
 import { WithBrandConfig } from "#elements/mixins/branding";
+import { canAccessAdmin, WithSession } from "#elements/mixins/session";
 import { getURLParam, updateURLParams } from "#elements/router/RouteMatch";
 import { ifPresent } from "#elements/utils/attributes";
 import { themeImage } from "#elements/utils/images";
@@ -32,10 +28,10 @@ import { themeImage } from "#elements/utils/images";
 import Styles from "#user/index.entrypoint.css";
 import { ROUTES } from "#user/Routes";
 
-import { EventsApi, SessionUser } from "@goauthentik/api";
+import { EventsApi } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { html, nothing } from "lit";
+import { html, nothing, PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
 import PFAvatar from "@patternfly/patternfly/components/Avatar/avatar.css";
@@ -66,7 +62,7 @@ if (process.env.NODE_ENV === "development") {
 
 @customElement("ak-interface-user-presentation")
 // @ts-ignore
-class UserInterfacePresentation extends WithBrandConfig(AKElement) {
+class UserInterfacePresentation extends WithBrandConfig(WithSession(AKElement)) {
     static styles = [
         PFDisplay,
         PFBrand,
@@ -79,12 +75,6 @@ class UserInterfacePresentation extends WithBrandConfig(AKElement) {
         Styles,
     ];
 
-    @property({ type: Object })
-    uiConfig!: UIConfig;
-
-    @property({ type: Object })
-    me!: SessionUser;
-
     @property({ type: Boolean, reflect: true })
     notificationDrawerOpen = false;
 
@@ -94,20 +84,8 @@ class UserInterfacePresentation extends WithBrandConfig(AKElement) {
     @property({ type: Number })
     notificationsCount = 0;
 
-    get canAccessAdmin() {
-        return (
-            this.me.user.isSuperuser ||
-            // TODO: somehow add `access_admin_interface` to the API schema
-            this.me.user.systemPermissions.includes("access_admin_interface")
-        );
-    }
-
-    get isFullyConfigured() {
-        return Boolean(this.uiConfig && this.me && this.brand);
-    }
-
     renderAdminInterfaceLink() {
-        if (!this.canAccessAdmin) {
+        if (!canAccessAdmin(this.currentUser)) {
             return nothing;
         }
 
@@ -128,12 +106,20 @@ class UserInterfacePresentation extends WithBrandConfig(AKElement) {
     }
 
     render() {
-        // The `!` in the field definitions above only re-assure typescript and eslint that the
-        // values *should* be available, not that they *are*. Thus this contract check; it asserts
-        // that the contract we promised is being honored, and the rest of the code that depends on
-        // `!` being truthful is not being lied to.
-        if (!this.isFullyConfigured) {
-            throw new Error("ak-interface-user-presentation misused; no valid values passed");
+        const { currentUser } = this;
+
+        if (!currentUser) {
+            console.debug(`authentik/user/UserInterface: waiting for user session to be available`);
+
+            return html`<slot></slot>`;
+        }
+
+        if (isGuest(currentUser)) {
+            // TODO: There might be a hidden feature here.
+            // Allowing guest users to see some parts of the interface?
+            // Maybe redirect to a flow?
+
+            return html`<slot></slot>`;
         }
 
         const backgroundStyles = this.uiConfig.theme.background;
@@ -156,9 +142,7 @@ class UserInterfacePresentation extends WithBrandConfig(AKElement) {
                             />
                         </a>
                     </div>
-                    <ak-nav-buttons .uiConfig=${this.uiConfig} .me=${this.me}
-                        >${this.renderAdminInterfaceLink()}</ak-nav-buttons
-                    >
+                    <ak-nav-buttons>${this.renderAdminInterfaceLink()}</ak-nav-buttons>
                 </header>
                 <div class="pf-c-page__drawer">
                     <div
@@ -207,7 +191,7 @@ class UserInterfacePresentation extends WithBrandConfig(AKElement) {
 //
 //
 @customElement("ak-interface-user")
-export class UserInterface extends WithBrandConfig(AuthenticatedInterface) {
+export class UserInterface extends WithBrandConfig(WithSession(AuthenticatedInterface)) {
     public static shadowRootOptions = { ...AKElement.shadowRootOptions, delegatesFocus: true };
 
     public override tabIndex = -1;
@@ -221,23 +205,15 @@ export class UserInterface extends WithBrandConfig(AuthenticatedInterface) {
     @state()
     notificationsCount = 0;
 
-    @state()
-    me: SessionUser | null = null;
-
-    @state()
-    uiConfig: UIConfig | null = null;
-
     constructor() {
-        configureSentry(true);
+        configureSentry();
 
         super();
 
         WebsocketClient.connect();
 
-        this.fetchConfigurationDetails();
         this.toggleNotificationDrawer = this.toggleNotificationDrawer.bind(this);
         this.toggleApiDrawer = this.toggleApiDrawer.bind(this);
-        this.fetchConfigurationDetails = this.fetchConfigurationDetails.bind(this);
     }
 
     async connectedCallback() {
@@ -245,7 +221,6 @@ export class UserInterface extends WithBrandConfig(AuthenticatedInterface) {
 
         window.addEventListener(EVENT_NOTIFICATION_DRAWER_TOGGLE, this.toggleNotificationDrawer);
         window.addEventListener(EVENT_API_DRAWER_TOGGLE, this.toggleApiDrawer);
-        window.addEventListener(EVENT_WS_MESSAGE, this.fetchConfigurationDetails);
     }
 
     disconnectedCallback() {
@@ -253,9 +228,35 @@ export class UserInterface extends WithBrandConfig(AuthenticatedInterface) {
 
         window.removeEventListener(EVENT_NOTIFICATION_DRAWER_TOGGLE, this.toggleNotificationDrawer);
         window.removeEventListener(EVENT_API_DRAWER_TOGGLE, this.toggleApiDrawer);
-        window.removeEventListener(EVENT_WS_MESSAGE, this.fetchConfigurationDetails);
 
         WebsocketClient.close();
+    }
+
+    public updated(changedProperties: PropertyValues<this>): void {
+        super.updated(changedProperties);
+
+        if (changedProperties.has("session")) {
+            this.refreshNotifications();
+        }
+    }
+
+    protected refreshNotifications(): Promise<void> {
+        const { currentUser } = this;
+
+        if (!currentUser || isGuest(currentUser)) {
+            return Promise.resolve();
+        }
+
+        return new EventsApi(DEFAULT_CONFIG)
+            .eventsNotificationsList({
+                seen: false,
+                ordering: "-created",
+                pageSize: 1,
+                user: currentUser.pk,
+            })
+            .then((notifications) => {
+                this.notificationsCount = notifications.pagination.count;
+            });
     }
 
     toggleNotificationDrawer() {
@@ -272,41 +273,16 @@ export class UserInterface extends WithBrandConfig(AuthenticatedInterface) {
         });
     }
 
-    fetchConfigurationDetails() {
-        me().then((session: SessionUser) => {
-            this.me = session;
-            this.uiConfig = getConfigForUser(session.user);
-
-            new EventsApi(DEFAULT_CONFIG)
-                .eventsNotificationsList({
-                    seen: false,
-                    ordering: "-created",
-                    pageSize: 1,
-                    user: this.me.user.pk,
-                })
-                .then((notifications) => {
-                    this.notificationsCount = notifications.pagination.count;
-                });
-        });
-    }
-
     render() {
-        if (!this.me) {
+        const { currentUser } = this;
+
+        if (!currentUser || isGuest(currentUser)) {
             console.debug(`authentik/user/UserInterface: waiting for user session to be available`);
 
-            return nothing;
-        }
-
-        if (!this.uiConfig) {
-            console.debug(`authentik/user/UserInterface: waiting for UI config to be available`);
-
-            return nothing;
+            return html`<slot></slot>`;
         }
 
         return html`<ak-interface-user-presentation
-            .uiConfig=${this.uiConfig}
-            .me=${this.me}
-            .brand=${this.brand ?? DefaultBrand}
             ?notificationDrawerOpen=${this.notificationDrawerOpen}
             ?apiDrawerOpen=${this.apiDrawerOpen}
             notificationsCount=${this.notificationsCount}

--- a/web/src/user/user-settings/UserSettingsPage.ts
+++ b/web/src/user/user-settings/UserSettingsPage.ts
@@ -9,18 +9,17 @@ import "#user/user-settings/tokens/UserTokenList";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
 import { EVENT_REFRESH } from "#common/constants";
-import { rootInterface } from "#common/theme";
 
 import { AKSkipToContent } from "#elements/a11y/ak-skip-to-content";
 import { AKElement } from "#elements/Base";
+import { WithSession } from "#elements/mixins/session";
 import { ifPresent } from "#elements/utils/attributes";
 
-import type { UserInterface } from "#user/index.entrypoint";
 import Styles from "#user/user-settings/styles.css";
 
 import { StagesApi, UserSetting } from "@goauthentik/api";
 
-import { localized, msg } from "@lit/localize";
+import { msg } from "@lit/localize";
 import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -36,9 +35,8 @@ import PFStack from "@patternfly/patternfly/layouts/Stack/stack.css";
 import PFDisplay from "@patternfly/patternfly/utilities/Display/display.css";
 import PFSizing from "@patternfly/patternfly/utilities/Sizing/sizing.css";
 
-@localized()
 @customElement("ak-user-settings")
-export class UserSettingsPage extends AKElement {
+export class UserSettingsPage extends WithSession(AKElement) {
     static styles: CSSResult[] = [
         PFPage,
         PFDisplay,
@@ -71,6 +69,9 @@ export class UserSettingsPage extends AKElement {
         const pwStage =
             this.userSettings?.filter((stage) => stage.component === "ak-user-settings-password") ||
             [];
+
+        const { currentUser } = this;
+
         return html`<div class="pf-c-page">
             <div class="pf-c-page__main">
                 <ak-tabs
@@ -111,9 +112,7 @@ export class UserSettingsPage extends AKElement {
                         <div class="pf-c-card">
                             <div class="pf-c-card__body">
                                 <ak-user-session-list
-                                    targetUser=${ifDefined(
-                                        rootInterface<UserInterface>()?.me?.user.username,
-                                    )}
+                                    targetUser=${ifPresent(currentUser?.username)}
                                 ></ak-user-session-list>
                             </div>
                         </div>
@@ -129,7 +128,7 @@ export class UserSettingsPage extends AKElement {
                         <div class="pf-c-card">
                             <div class="pf-c-card__body">
                                 <ak-user-consent-list
-                                    userId=${ifDefined(rootInterface<UserInterface>()?.me?.user.pk)}
+                                    userId=${ifPresent(currentUser?.pk)}
                                 ></ak-user-consent-list>
                             </div>
                         </div>
@@ -166,7 +165,7 @@ export class UserSettingsPage extends AKElement {
                             </div>
                             <ak-user-settings-source
                                 allow-configuration
-                                user-id=${ifPresent(rootInterface<UserInterface>()?.me?.user.pk)}
+                                userId=${ifPresent(currentUser?.pk)}
                             ></ak-user-settings-source>
                         </div>
                     </div>


### PR DESCRIPTION
## Details

This PR cleans up much of the client-side session fetching, allowing for fewer re-renders and a smoother recovery from stale sessions, i.e. less UI jank when navigating to a page that your user is no longer authorized to view.

Previously, this behavior was handled with a combination of `me()` calls and sentinel promises to ensure the page is ready. The core fix in this PR is a Lit context.

`SessionContext` handles most scenarios where you'd reach for `me()`, managing the loading, error, and what could be considered a _model view_ of the session. 

For page-level components the session state is available to determine whether to continue showing a loading spinner, or redirecting the user to a more appropriate route. "Smaller but still considered singleton-ish" elements can consume the session information at a higher-level via `this.currentUser`, as well as common variation properties like impersonation, whether the user is no longer authenticated, and the user's UI config.

### Fixes

- Authenticated API endpoints such as version, license, and notification information now wait until a session has been established, avoiding partial page rendering on slow connections and when credentials are stale.
- Several components no longer depend on `rootInterface` to reach up and through the DOM for session and UI config information. This function has slowly been replaced with more idiomatic Lit patterns and will likely be vanquished soon.
- Sentry's initialization is no longer dependent on calls to `me()`, detangling some odd code paths when session expires while debugging. 
- When impersonating a user without admin privileges, the admin UI no longer renders in a broken state, instead redirecting the user from a loading spinner to their library page.
- When fetching applications, the application library now parses and displays API errors, similar to our tabs and table components. 
