### PR TITLE
web: Hide avatars when set to "none"

### DIFF
--- a/web/src/components/ak-nav-buttons.ts
+++ b/web/src/components/ak-nav-buttons.ts
@@ -7,6 +7,7 @@ import { formatUserDisplayName, isGuest } from "#common/users";
 
 import { AKElement } from "#elements/Base";
 import { WithSession } from "#elements/mixins/session";
+import { isDefaultAvatar } from "#elements/utils/images";
 
 import Styles from "#components/ak-nav-button.css";
 
@@ -159,7 +160,14 @@ export class NavigationButtons extends WithSession(AKElement) {
 
     renderAvatar() {
         const { currentUser } = this;
+
         if (!currentUser) {
+            return nothing;
+        }
+
+        const { avatar } = currentUser;
+
+        if (!avatar || isDefaultAvatar(avatar)) {
             return nothing;
         }
 
@@ -167,9 +175,7 @@ export class NavigationButtons extends WithSession(AKElement) {
             class="pf-c-page__header-tools-item pf-c-avatar pf-m-hidden pf-m-visible-on-xl"
             aria-hidden="true"
         >
-            ${currentUser.avatar
-                ? html`<img src=${currentUser.avatar} alt=${msg("Avatar image")} />`
-                : nothing}
+            <img src=${avatar} alt=${msg("Avatar image")} />
         </div>`;
     }
 

--- a/web/src/elements/utils/images.ts
+++ b/web/src/elements/utils/images.ts
@@ -3,3 +3,7 @@ import { ResolvedUITheme } from "#common/theme";
 export function themeImage(rawPath: string, theme: ResolvedUITheme) {
     return rawPath.replaceAll("%(theme)s", theme);
 }
+
+export function isDefaultAvatar(path?: string | null): boolean {
+    return !!path?.endsWith("user_default.png");
+}

--- a/web/src/flow/FormStatic.ts
+++ b/web/src/flow/FormStatic.ts
@@ -1,4 +1,5 @@
 import { AKElement } from "#elements/Base";
+import { isDefaultAvatar } from "#elements/utils/images";
 
 import { msg, str } from "@lit/localize";
 import { css, CSSResult, html, nothing } from "lit";
@@ -70,7 +71,7 @@ export class FormStatic extends AKElement {
 
         return html`
             <div class="primary-content">
-                ${this.userAvatar
+                ${this.userAvatar && !isDefaultAvatar(this.userAvatar)
                     ? html`<img
                           class="pf-c-avatar"
                           src=${this.userAvatar}


### PR DESCRIPTION
## Details

This PR fixes a small UI regression affecting the navigation header's avatar.

Closes #17747