### PR TITLE
web/i18n: Locale message fixes

### DIFF
--- a/web/src/admin/AdminInterface/AdminSidebar.ts
+++ b/web/src/admin/AdminInterface/AdminSidebar.ts
@@ -11,7 +11,7 @@ import { repeat } from "lit/directives/repeat.js";
 
 // The second attribute type is of string[] to help with the 'activeWhen' control, which was
 // commonplace and singular enough to merit its own handler.
-type SidebarEntry = [
+export type SidebarEntry = [
     path: string | null,
     label: string,
     attributes?: LitPropertyRecord<SidebarItemProperties> | string[] | null,
@@ -48,7 +48,7 @@ export function renderSidebarItems(entries: readonly SidebarEntry[]) {
 }
 
 // prettier-ignore
-export const AdminSidebarEntries: readonly SidebarEntry[] = [
+export const createAdminSidebarEntries = (): readonly SidebarEntry[] => [
     [null, msg("Dashboards"), { "?expanded": true }, [
         ["/administration/overview", msg("Overview")],
         ["/administration/dashboard/users", msg("User Statistics")],
@@ -93,7 +93,7 @@ export const AdminSidebarEntries: readonly SidebarEntry[] = [
 ];
 
 // prettier-ignore
-export const AdminSidebarEnterpriseEntries: readonly SidebarEntry[] = [
+export const createAdminSidebarEnterpriseEntries = (): readonly SidebarEntry[] => [
     [null, msg("Enterprise"), null, [
         ["/enterprise/licenses", msg("Licenses"), null]
     ],

--- a/web/src/admin/AdminInterface/index.entrypoint.ts
+++ b/web/src/admin/AdminInterface/index.entrypoint.ts
@@ -10,8 +10,8 @@ import "#elements/sidebar/Sidebar";
 import "#elements/sidebar/SidebarItem";
 
 import {
-    AdminSidebarEnterpriseEntries,
-    AdminSidebarEntries,
+    createAdminSidebarEnterpriseEntries,
+    createAdminSidebarEntries,
     renderSidebarItems,
 } from "./AdminSidebar.js";
 
@@ -172,10 +172,10 @@ export class AdminInterface extends WithCapabilitiesConfig(AuthenticatedInterfac
                     <ak-enterprise-status interface="admin"></ak-enterprise-status>
                 </ak-page-navbar>
 
-                <ak-sidebar ?hidden=${!this.sidebarOpen} class="${classMap(sidebarClasses)}">
-                    ${renderSidebarItems(AdminSidebarEntries)}
+                <ak-sidebar ?hidden=${!this.sidebarOpen} class="${classMap(sidebarClasses)}"
+                    >${renderSidebarItems(createAdminSidebarEntries())}
                     ${this.can(CapabilitiesEnum.IsEnterprise)
-                        ? renderSidebarItems(AdminSidebarEnterpriseEntries)
+                        ? renderSidebarItems(createAdminSidebarEnterpriseEntries())
                         : nothing}
                 </ak-sidebar>
 

--- a/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStage.ts
+++ b/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStage.ts
@@ -38,43 +38,44 @@ interface DevicePickerProps {
     description?: string;
 }
 
-const DevicePickerPropMap = {
-    [DeviceClassesEnum.Duo]: {
-        icon: "fa-mobile-alt",
-        label: msg("Duo push-notifications"),
-        description: msg("Receive a push notification on your device."),
-    },
-    [DeviceClassesEnum.Webauthn]: {
-        icon: "fa-mobile-alt",
-        label: msg("Authenticator"),
-        description: msg("Use a security key to prove your identity."),
-    },
-    [DeviceClassesEnum.Totp]: {
-        icon: "fa-clock",
-        label: msg("Traditional authenticator"),
-        description: msg("Use a code-based authenticator."),
-    },
-    [DeviceClassesEnum.Static]: {
-        icon: "fa-key",
-        label: msg("Recovery keys"),
-        description: msg("In case you lose access to your primary authenticators."),
-    },
-    [DeviceClassesEnum.Sms]: {
-        icon: "fa-mobile-alt",
-        label: msg("SMS"),
-        description: msg("Tokens sent via SMS."),
-    },
-    [DeviceClassesEnum.Email]: {
-        icon: "fa-envelope",
-        label: msg("Email"),
-        description: msg("Tokens sent via email."),
-    },
-    [DeviceClassesEnum.UnknownDefaultOpenApi]: {
-        icon: "fa-question",
-        label: msg("Unknown device"),
-        description: msg("An unknown device class was provided."),
-    },
-} as const satisfies Record<DeviceClassesEnum, DevicePickerProps>;
+const createDevicePickerPropMap = () =>
+    ({
+        [DeviceClassesEnum.Duo]: {
+            icon: "fa-mobile-alt",
+            label: msg("Duo push-notifications"),
+            description: msg("Receive a push notification on your device."),
+        },
+        [DeviceClassesEnum.Webauthn]: {
+            icon: "fa-mobile-alt",
+            label: msg("Authenticator"),
+            description: msg("Use a security key to prove your identity."),
+        },
+        [DeviceClassesEnum.Totp]: {
+            icon: "fa-clock",
+            label: msg("Traditional authenticator"),
+            description: msg("Use a code-based authenticator."),
+        },
+        [DeviceClassesEnum.Static]: {
+            icon: "fa-key",
+            label: msg("Recovery keys"),
+            description: msg("In case you lose access to your primary authenticators."),
+        },
+        [DeviceClassesEnum.Sms]: {
+            icon: "fa-mobile-alt",
+            label: msg("SMS"),
+            description: msg("Tokens sent via SMS."),
+        },
+        [DeviceClassesEnum.Email]: {
+            icon: "fa-envelope",
+            label: msg("Email"),
+            description: msg("Tokens sent via email."),
+        },
+        [DeviceClassesEnum.UnknownDefaultOpenApi]: {
+            icon: "fa-question",
+            label: msg("Unknown device"),
+            description: msg("An unknown device class was provided."),
+        },
+    }) as const satisfies Record<DeviceClassesEnum, DevicePickerProps>;
 
 @customElement("ak-stage-authenticator-validate")
 export class AuthenticatorValidateStage
@@ -199,6 +200,8 @@ export class AuthenticatorValidateStage
 
         const { deviceChallenges } = this.challenge;
 
+        const devicePickerPropMap = createDevicePickerPropMap();
+
         const deviceChallengeButtons = repeat(
             deviceChallenges,
             (challenges) => challenges.deviceUid,
@@ -207,7 +210,7 @@ export class AuthenticatorValidateStage
                 const labelID = `${buttonID}-label`;
                 const descriptionID = `${buttonID}-description`;
 
-                const { icon, label, description } = DevicePickerPropMap[challenges.deviceClass];
+                const { icon, label, description } = devicePickerPropMap[challenges.deviceClass];
 
                 return html`
                     <button

--- a/web/src/flow/stages/captcha/CaptchaStage.ts
+++ b/web/src/flow/stages/captcha/CaptchaStage.ts
@@ -3,7 +3,9 @@ import "#flow/components/ak-flow-card";
 
 import { pluckErrorDetail } from "#common/errors/network";
 
+import autoDetectLanguage from "#elements/ak-locale-context/helpers";
 import { akEmptyState } from "#elements/EmptyState";
+import { ifPresent } from "#elements/utils/attributes";
 import { ListenerController } from "#elements/utils/listenerController";
 import { randomId } from "#elements/utils/randomId";
 
@@ -132,6 +134,8 @@ export class CaptchaStage extends BaseStage<CaptchaChallenge, CaptchaChallengeRe
     #captchaDocumentContainer?: HTMLDivElement;
     #listenController = new ListenerController();
 
+    #locale: string | null = null;
+
     //#endregion
 
     //#region Getters/Setters
@@ -191,6 +195,7 @@ export class CaptchaStage extends BaseStage<CaptchaChallenge, CaptchaChallengeRe
                     sitekey: this.challenge.siteKey,
                     callback: this.onTokenChange,
                     size: "invisible",
+                    hl: this.#locale ?? undefined,
                 }),
             );
         });
@@ -225,6 +230,7 @@ export class CaptchaStage extends BaseStage<CaptchaChallenge, CaptchaChallengeRe
                 sitekey: this.challenge.siteKey,
                 callback: this.onTokenChange,
                 size: "invisible",
+                hl: this.#locale ?? undefined,
             }),
         );
     }
@@ -250,6 +256,7 @@ export class CaptchaStage extends BaseStage<CaptchaChallenge, CaptchaChallengeRe
             data-theme="${this.activeTheme}"
             data-callback="callback"
             data-size="flexible"
+            data-language=${ifPresent(this.#locale)}
         ></div>`;
     };
 
@@ -368,6 +375,8 @@ export class CaptchaStage extends BaseStage<CaptchaChallenge, CaptchaChallengeRe
         window.addEventListener("message", this.#messageListener, {
             signal: this.#listenController.signal,
         });
+
+        this.#locale = autoDetectLanguage();
     }
 
     public disconnectedCallback(): void {


### PR DESCRIPTION
## Details

This PR includes a few small fixes to make translations work consistently:

- Pre-defined constants such as sidebar entries are lazy rendered, deferring their value to the current locale, rather than the locale at initial page loading.
- Captchas now respect the page locale, falling back to auto detection if no supported language is provided
