### PR TITLE
providers/radius: revert fix inverted message authenticator validation (#17855)

### DIFF
--- a/internal/outpost/radius/request.go
+++ b/internal/outpost/radius/request.go
@@ -1,6 +1,7 @@
 package radius
 
 import (
+	"bytes"
 	"crypto/hmac"
 	"crypto/md5"
 	"errors"
@@ -45,7 +46,7 @@ func (r *RadiusRequest) validateMessageAuthenticator() error {
 		return err
 	}
 	hash.Write(encode)
-	if !hmac.Equal(mauth, hash.Sum(nil)) {
+	if bytes.Equal(mauth, hash.Sum(nil)) {
 		return ErrInvalidMessageAuthenticator
 	}
 	return nil


### PR DESCRIPTION
This reverts commit 09e3301c8fae277adaa736ce700aa0010947af23.

closes #17901

something must be broken in the validation, so revert to the "broken" behaviour for now