### PR TITLE
web/admin: fixes capitalization in application wizard title

### DIFF
--- a/web/src/admin/applications/wizard/steps/ak-application-wizard-application-step.ts
+++ b/web/src/admin/applications/wizard/steps/ak-application-wizard-application-step.ts
@@ -115,7 +115,7 @@ export class ApplicationWizardApplicationStep extends ApplicationWizardStep {
     }
 
     renderForm(app: Partial<ApplicationRequest>, errors: ValidationRecord) {
-        return html` <ak-wizard-title>${msg("Configure The Application")}</ak-wizard-title>
+        return html` <ak-wizard-title>${msg("Configure the Application")}</ak-wizard-title>
             <form id="applicationform" class="pf-c-form pf-m-horizontal" slot="form">
                 <ak-text-input
                     name="name"


### PR DESCRIPTION
## Details

My most pernickety PR yet.

<img width="952" height="316" alt="image" src="https://github.com/user-attachments/assets/725e7f32-6e28-4283-886f-b9cad046059a" />

After:
<img width="754" height="210" alt="image" src="https://github.com/user-attachments/assets/bbdab85e-a0d1-47c1-b86d-892bb27bb996" />


---

## Checklist

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)
