### PR TITLE
website/docs: remove broken info box and fix sentence

### DIFF
--- a/website/docs/users-sources/user/user_ref.mdx
+++ b/website/docs/users-sources/user/user_ref.mdx
@@ -20,8 +20,8 @@ The User object has the following properties:
 - `ak_groups`: This is a queryset of all the user's direct groups.
 - `all_groups()`: This is a queryset of all the user's direct and indirect groups.
 
-:::note Clarifying direct vs indirect group membership
-:::infois a member of a group (direct member). If that group in turn has a parent group, then the user is an indirect member of that parent group.
+:::info Clarifying direct vs indirect group membership
+A user is a member of a group (direct member). If that group in turn has a parent group, then the user is an indirect member of that parent group.
 :::
 
 ## Examples


### PR DESCRIPTION
## Details

Fixes this mess 
<img width="322" height="140" alt="image" src="https://github.com/user-attachments/assets/8b77498a-28e6-4a28-bfd3-69cce4f63897" />


---

## Checklist

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
