### PR TITLE
core: bump django from 5.2.7 to 5.2.8

### DIFF
--- a/authentik/providers/oauth2/tests/test_authorize.py
+++ b/authentik/providers/oauth2/tests/test_authorize.py
@@ -6,6 +6,7 @@ from urllib.parse import parse_qs, urlparse
 from django.test import RequestFactory
 from django.urls import reverse
 from django.utils.timezone import now
+from structlog.stdlib import get_logger
 
 from authentik.blueprints.tests import apply_blueprint
 from authentik.core.models import Application
@@ -27,6 +28,8 @@ from authentik.providers.oauth2.models import (
 from authentik.providers.oauth2.tests.utils import OAuthTestCase
 from authentik.providers.oauth2.views.authorize import OAuthAuthorizationParams
 from authentik.stages.password.stage import PLAN_CONTEXT_METHOD
+
+logger = get_logger()
 
 
 class TestAuthorize(OAuthTestCase):
@@ -459,6 +462,10 @@ class TestAuthorize(OAuthTestCase):
                     "redirect_uri": "http://localhost",
                     "nonce": generate_id(),
                 },
+            )
+            print("\n\n$$$ RESPONSE:\n", response, response.url, response.content)
+            logger.warning(
+                "Response details", response=response, url=response.url, content=response.content
             )
             self.assertEqual(response.status_code, 302)
             token: AccessToken = AccessToken.objects.filter(user=user).first()

--- a/authentik/providers/oauth2/tests/test_authorize.py
+++ b/authentik/providers/oauth2/tests/test_authorize.py
@@ -6,7 +6,6 @@ from urllib.parse import parse_qs, urlparse
 from django.test import RequestFactory
 from django.urls import reverse
 from django.utils.timezone import now
-from structlog.stdlib import get_logger
 
 from authentik.blueprints.tests import apply_blueprint
 from authentik.core.models import Application
@@ -28,8 +27,6 @@ from authentik.providers.oauth2.models import (
 from authentik.providers.oauth2.tests.utils import OAuthTestCase
 from authentik.providers.oauth2.views.authorize import OAuthAuthorizationParams
 from authentik.stages.password.stage import PLAN_CONTEXT_METHOD
-
-logger = get_logger()
 
 
 class TestAuthorize(OAuthTestCase):
@@ -462,10 +459,6 @@ class TestAuthorize(OAuthTestCase):
                     "redirect_uri": "http://localhost",
                     "nonce": generate_id(),
                 },
-            )
-            print("\n\n$$$ RESPONSE:\n", response, response.url, response.content)
-            logger.warning(
-                "Response details", response=response, url=response.url, content=response.content
             )
             self.assertEqual(response.status_code, 302)
             token: AccessToken = AccessToken.objects.filter(user=user).first()

--- a/authentik/root/settings.py
+++ b/authentik/root/settings.py
@@ -6,7 +6,7 @@ from hashlib import sha512
 from pathlib import Path
 
 import orjson
-from django.utils import http
+from django.http import response as http_response
 from sentry_sdk import set_tag
 from xmlsec import enable_debug_trace
 
@@ -477,7 +477,7 @@ STORAGES = {
 # as the maximum for a URL to redirect to, mostly for running on windows.
 # However our URLs can easily exceed that with OAuth/SAML Query parameters or hash values
 # 8192 should cover most cases..
-http.MAX_URL_LENGTH = http.MAX_URL_LENGTH * 4
+http_response.MAX_URL_LENGTH = http_response.MAX_URL_LENGTH * 4
 
 
 # Media files

--- a/authentik/root/settings.py
+++ b/authentik/root/settings.py
@@ -6,6 +6,7 @@ from hashlib import sha512
 from pathlib import Path
 
 import orjson
+from django.utils import http
 from sentry_sdk import set_tag
 from xmlsec import enable_debug_trace
 
@@ -471,6 +472,12 @@ STORAGES = {
         "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
     },
 }
+
+# Django 5.2.8 and CVE-2025-64458 added a strong enforcement of 2048 characters
+# as the maximum for a URL to redirect to, mostly for running on windows.
+# However our URLs can easily exceed that with OAuth/SAML Query parameters or hash values
+# 8192 should cover most cases..
+http.MAX_URL_LENGTH = http.MAX_URL_LENGTH * 4
 
 
 # Media files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
   "dacite==1.9.2",
   "deepmerge==2.0",
   "defusedxml==0.7.1",
-  "django==5.2.7",
+  "django==5.2.8",
   "django-channels-postgres",
   "django-countries==7.6.1",
   "django-cte==2.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.13.*"
 
 [manifest]
@@ -284,7 +284,7 @@ requires-dist = [
     { name = "dacite", specifier = "==1.9.2" },
     { name = "deepmerge", specifier = "==2.0" },
     { name = "defusedxml", specifier = "==0.7.1" },
-    { name = "django", specifier = "==5.2.7" },
+    { name = "django", specifier = "==5.2.8" },
     { name = "django-channels-postgres", editable = "packages/django-channels-postgres" },
     { name = "django-countries", specifier = "==7.6.1" },
     { name = "django-cte", specifier = "==2.0.0" },
@@ -977,16 +977,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.2.7"
+version = "5.2.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/96/bd84e2bb997994de8bcda47ae4560991084e86536541d7214393880f01a8/django-5.2.7.tar.gz", hash = "sha256:e0f6f12e2551b1716a95a63a1366ca91bbcd7be059862c1b18f989b1da356cdd", size = 10865812, upload-time = "2025-10-01T14:22:12.081Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/a2/933dbbb3dd9990494960f6e64aca2af4c0745b63b7113f59a822df92329e/django-5.2.8.tar.gz", hash = "sha256:23254866a5bb9a2cfa6004e8b809ec6246eba4b58a7589bc2772f1bcc8456c7f", size = 10849032, upload-time = "2025-11-05T14:07:32.778Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/ef/81f3372b5dd35d8d354321155d1a38894b2b766f576d0abffac4d8ae78d9/django-5.2.7-py3-none-any.whl", hash = "sha256:59a13a6515f787dec9d97a0438cd2efac78c8aca1c80025244b0fe507fe0754b", size = 8307145, upload-time = "2025-10-01T14:22:49.476Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/3d/a035a4ee9b1d4d4beee2ae6e8e12fe6dee5514b21f62504e22efcbd9fb46/django-5.2.8-py3-none-any.whl", hash = "sha256:37e687f7bd73ddf043e2b6b97cfe02fcbb11f2dbb3adccc6a2b18c6daa054d7f", size = 8289692, upload-time = "2025-11-05T14:07:28.761Z" },
 ]
 
 [[package]]
@@ -1636,6 +1636,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
     { url = "https://files.pythonhosted.org/packages/a2/15/0d5e4e1a66fab130d98168fe984c509249c833c1a3c16806b90f253ce7b9/greenlet-3.2.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:d25c5091190f2dc0eaa3f950252122edbbadbb682aa7b1ef2f8af0f8c0afefae", size = 1149210, upload-time = "2025-08-07T13:18:24.072Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/53/f9c440463b3057485b8594d7a638bed53ba531165ef0ca0e6c364b5cc807/greenlet-3.2.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6e343822feb58ac4d0a1211bd9399de2b3a04963ddeec21530fc426cc121f19b", size = 1564759, upload-time = "2025-11-04T12:42:19.395Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e4/3bb4240abdd0a8d23f4f88adec746a3099f0d86bfedb623f063b2e3b4df0/greenlet-3.2.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ca7f6f1f2649b89ce02f6f229d7c19f680a6238af656f61e0115b24857917929", size = 1634288, upload-time = "2025-11-04T12:42:21.174Z" },
     { url = "https://files.pythonhosted.org/packages/0b/55/2321e43595e6801e105fcfdee02b34c0f996eb71e6ddffca6b10b7e1d771/greenlet-3.2.4-cp313-cp313-win_amd64.whl", hash = "sha256:554b03b6e73aaabec3745364d6239e9e012d64c68ccd0b8430c64ccc14939a8b", size = 299685, upload-time = "2025-08-07T13:24:38.824Z" },
 ]
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

https://docs.djangoproject.com/en/dev/releases/5.2.8/

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
