### PR TITLE
blueprints: new meta clean model

### DIFF
--- a/authentik/blueprints/apps.py
+++ b/authentik/blueprints/apps.py
@@ -132,6 +132,7 @@ class AuthentikBlueprintsConfig(ManagedAppConfig):
     def import_models(self):
         super().import_models()
         self.import_module("authentik.blueprints.v1.meta.apply_blueprint")
+        self.import_module("authentik.blueprints.v1.meta.clean_blueprint")
 
     @ManagedAppConfig.reconcile_global
     def tasks_middlewares(self):

--- a/authentik/blueprints/tests/fixtures/meta_clean.yaml
+++ b/authentik/blueprints/tests/fixtures/meta_clean.yaml
@@ -1,0 +1,5 @@
+version: 1
+entries:
+  - model: authentik_blueprints.metacleanblueprint
+    attrs:
+      model_name: authentik_core.application

--- a/authentik/blueprints/tests/test_v1_meta_clean.py
+++ b/authentik/blueprints/tests/test_v1_meta_clean.py
@@ -1,0 +1,36 @@
+"""Test blueprints v1"""
+
+from django.test import TransactionTestCase
+
+from authentik.blueprints.v1.importer import Importer
+from authentik.core.models import Application
+from authentik.lib.generators import generate_id
+from authentik.lib.tests.utils import load_fixture
+
+
+class TestBlueprintsV1MetaClean(TransactionTestCase):
+    """Test Blueprints meta clean model"""
+
+    def test_meta_clean(self):
+        """Test meta clean"""
+
+        num_apps = 5
+
+        for _ in range(num_apps):
+            Application.objects.create(name=generate_id(), slug=generate_id())
+
+        all_apps = Application.objects.all()
+
+        # Ensure all objects exist
+        self.assertEqual(len(all_apps), num_apps)
+
+        import_yaml = load_fixture("fixtures/meta_clean.yaml")
+
+        importer = Importer.from_string(import_yaml)
+        self.assertTrue(importer.validate()[0])
+        self.assertTrue(importer.apply())
+
+        all_apps = Application.objects.all()
+
+        # Ensure all objects removed
+        self.assertEqual(len(all_apps), 0)

--- a/authentik/blueprints/v1/meta/clean_blueprint.py
+++ b/authentik/blueprints/v1/meta/clean_blueprint.py
@@ -1,0 +1,48 @@
+"""Clean Blueprint meta model"""
+
+from rest_framework.exceptions import ValidationError
+from rest_framework.fields import CharField
+
+from authentik.blueprints.v1.meta.registry import BaseMetaModel, MetaResult, registry
+from authentik.core.api.utils import PassiveSerializer
+from authentik.lib.models import SerializerModel
+
+
+class CleanBlueprintMetaSerializer(PassiveSerializer):
+    """Serializer for meta clean blueprint model"""
+
+    model_name = CharField()
+
+    model: type[SerializerModel]
+
+    def validate(self, attrs):
+        model_attr = attrs["model_name"]
+
+        model_app_label, model_name = model_attr.split(".")
+        try:
+            mdl: type[SerializerModel] = registry.get_model(model_app_label, model_name)
+        except LookupError as exc:
+            raise ValidationError({"model_name": "Required model does not exist"}) from exc
+
+        self.model = mdl
+
+        return super().validate(attrs)
+
+    def create(self, validated_data: dict) -> MetaResult:
+        existing_objects = self.model.objects.all()
+
+        existing_objects.delete()
+
+        return MetaResult()
+
+
+@registry.register("metacleanblueprint")
+class MetaCleanBlueprint(BaseMetaModel):
+    """Meta model to delete all instances of another model"""
+
+    @staticmethod
+    def serializer() -> CleanBlueprintMetaSerializer:
+        return CleanBlueprintMetaSerializer
+
+    class Meta:
+        abstract = True

--- a/blueprints/schema.json
+++ b/blueprints/schema.json
@@ -139,6 +139,42 @@
                 {
                     "type": "object",
                     "required": [
+                        "model"
+                    ],
+                    "properties": {
+                        "model": {
+                            "const": "authentik_blueprints.metacleanblueprint"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "absent",
+                                "created",
+                                "must_created",
+                                "present"
+                            ],
+                            "default": "present"
+                        },
+                        "conditions": {
+                            "type": "array",
+                            "items": {
+                                "type": "boolean"
+                            }
+                        },
+                        "permissions": {
+                            "$ref": "#/$defs/model_authentik_blueprints.metacleanblueprint_permissions"
+                        },
+                        "attrs": {
+                            "$ref": "#/$defs/model_authentik_blueprints.metacleanblueprint"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
                         "model",
                         "identifiers"
                     ],
@@ -4502,6 +4538,43 @@
                             "change_metaapplyblueprint",
                             "delete_metaapplyblueprint",
                             "view_metaapplyblueprint"
+                        ]
+                    },
+                    "user": {
+                        "type": "integer"
+                    },
+                    "role": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "model_authentik_blueprints.metacleanblueprint": {
+            "type": "object",
+            "properties": {
+                "model_name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "title": "Model name"
+                }
+            },
+            "required": []
+        },
+        "model_authentik_blueprints.metacleanblueprint_permissions": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "permission"
+                ],
+                "properties": {
+                    "permission": {
+                        "type": "string",
+                        "enum": [
+                            "add_metacleanblueprint",
+                            "change_metacleanblueprint",
+                            "delete_metacleanblueprint",
+                            "view_metacleanblueprint"
                         ]
                     },
                     "user": {

--- a/website/docs/customize/blueprints/v1/meta.md
+++ b/website/docs/customize/blueprints/v1/meta.md
@@ -23,3 +23,18 @@ See [examples](https://github.com/search?q=repo%3Agoauthentik%2Fauthentik+path%3
 - `required`: (Default: `true`) Configure if the blueprint instance must exist
 
     If this is set to `true` and no blueprint instance matches the query above, an error will be thrown. Otherwise, execution will continue without applying anything extra.
+
+### `authentik_blueprints.metacleanblueprint`
+
+This meta model can be used to remove all objects of the given model from database. This allows setting up from the blueprint from scratch, ensuring nothing left in database.
+
+#### Attributes
+
+- `model_name`: Name of the model whose objects are to be removed
+
+    Example:
+
+    ```yaml
+    attrs:
+        model_name: authentik_providers_oauth2.oauth2provider
+    ```


### PR DESCRIPTION
## Details

This PR adds a new meta blueprint model — MetaCleanBlueprint.
This new meta-blueprint removes all objects of a given model name.
For example, run it with `model_name: authentik_providers_oauth2.oauth2provider` - all oauth2 providers will be deleted.
Or with `model_name: authentik_core.application` - all applications will be removed from the database.

**Motivation for this addition:**
I am developing a solution to dynamically set up applications and providers in a docker environment based on container discovery.
In particular, I want to automatically create a new provider and application when a container with specific labels spins up, and remove the corresponding provider and application when that container is destroyed.
To achieve this, I generate blueprint file with applications and providers based on the currently running containers.
To avoid figuring out which providers need to be deleted, I looked for a way to clean all existing providers and applications so they can be recreated from scratch according to the actual running containers.

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [x] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
