### PR TITLE
ci: fix migrate-from-stable for old versions

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -87,7 +87,7 @@ jobs:
           if [[ -n $current_version_family ]]; then
               prev_stable=$current_version_family
           fi
-          echo "Checking out ${prev_stable} as stable version..."
+          echo "::notice::Checking out ${prev_stable} as stable version..."
           git checkout $(prev_stable)
           rm -rf .github/ scripts/
           mv ../.github ../scripts .

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -83,7 +83,7 @@ jobs:
           # Previous stable tag
           prev_stable=$(git tag --sort=version:refname | grep '^version/' | grep -vE -- '-rc[0-9]+$' | tail -n1)
           # Current version family based on
-          current_version_family=$(uv version --short | grep -vE -- 'rc[0-9]+$')
+          current_version_family=$(python -c "from authentik import VERSION; print(VERSION)" | grep -vE -- 'rc[0-9]+$')
           if [[ -n $current_version_family ]]; then
               prev_stable=$current_version_family
           fi

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -80,7 +80,15 @@ jobs:
           cp authentik/lib/default.yml local.env.yml
           cp -R .github ..
           cp -R scripts ..
-          git checkout $(git tag --sort=version:refname | grep '^version/' | grep -vE -- '-rc[0-9]+$' | tail -n1)
+          # Previous stable tag
+          prev_stable=$(git tag --sort=version:refname | grep '^version/' | grep -vE -- '-rc[0-9]+$' | tail -n1)
+          # Current version family based on
+          current_version_family=$(uv version --short | grep -vE -- 'rc[0-9]+$')
+          if [[ -n $current_version_family ]]; then
+              prev_stable=$current_version_family
+          fi
+          echo "Checking out ${prev_stable} as stable version..."
+          git checkout $(prev_stable)
           rm -rf .github/ scripts/
           mv ../.github ../scripts .
       - name: Setup authentik env (stable)

--- a/proxy.Dockerfile
+++ b/proxy.Dockerfile
@@ -7,11 +7,11 @@ ENV NODE_ENV=production
 WORKDIR /static
 
 COPY package.json /
-RUN --mount=type=bind,target=/static/package.json,src=./web/package.json \
-    --mount=type=bind,target=/static/package-lock.json,src=./web/package-lock.json \
+RUN --mount=type=bind,rw,target=/static/package.json,src=./web/package.json \
+    --mount=type=bind,rw,target=/static/package-lock.json,src=./web/package-lock.json \
     --mount=type=bind,target=/static/scripts,src=./web/scripts \
     --mount=type=cache,target=/root/.npm \
-    npm ci
+    npm i
 
 COPY web .
 RUN npm run build-proxy

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -192,19 +192,6 @@
             "integrity": "sha512-VQKMkwriZbaOgVCby1UDY/LDk5fIjhQicCvVPFqfe+69fWaPWydbWJ3wRt59/YzIwda1I81loas3oCoHxnqvdA==",
             "license": "MIT"
         },
-        "node_modules/@ampproject/remapping": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-            "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-            "optional": true,
-            "dependencies": {
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.24"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
         "node_modules/@antfu/install-pkg": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-0.4.1.tgz",
@@ -249,38 +236,68 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.7.tgz",
-            "integrity": "sha512-9ickoLz+hcXCeh7jrcin+/SLWm+GkxE2kTvoYyp38p4WkdFXfQJxDFGWp/YHjiKLPx06z2A7W8XKuqbReXDzsw==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
+            "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
+            "license": "MIT",
             "optional": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.0.tgz",
-            "integrity": "sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
+            "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.27.0",
-                "@babel/types": "^7.27.0",
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.25",
+                "@babel/parser": "^7.28.5",
+                "@babel/types": "^7.28.5",
+                "@jridgewell/gen-mapping": "^0.3.12",
+                "@jridgewell/trace-mapping": "^0.3.28",
                 "jsesc": "^3.0.2"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@babel/generator/node_modules/@babel/parser": {
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
+            "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.28.5"
+            },
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/generator/node_modules/@babel/types": {
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+            "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.28.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.7.tgz",
-            "integrity": "sha512-DniTEax0sv6isaw6qSQSfV4gVRNtw2rte8HHM45t9ZR0xILaufBRNkpMifCRiAPyvL4ACD6v0gfCwCmtOQaV4A==",
+            "version": "7.27.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+            "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+            "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@babel/compat-data": "^7.25.7",
-                "@babel/helper-validator-option": "^7.25.7",
+                "@babel/compat-data": "^7.27.2",
+                "@babel/helper-validator-option": "^7.27.1",
                 "browserslist": "^4.24.0",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
@@ -313,48 +330,45 @@
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "optional": true
         },
+        "node_modules/@babel/helper-globals": {
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.7.tgz",
-            "integrity": "sha512-o0xCgpNmRohmnoWKQ0Ij8IdddjyBFE4T2kagL/x6M3+4zUgc+4qTOUBoNe4XxDskt1HPKO007ZPiMgLDq2s7Kw==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+            "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+            "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@babel/traverse": "^7.25.7",
-                "@babel/types": "^7.25.7"
+                "@babel/traverse": "^7.27.1",
+                "@babel/types": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.7.tgz",
-            "integrity": "sha512-k/6f8dKG3yDz/qCwSM+RKovjMix563SLxQFo0UhRNo239SP6n9u5/eLtKD6EAjwta2JHJ49CsD8pms2HdNiMMQ==",
+            "version": "7.28.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+            "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+            "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@babel/helper-module-imports": "^7.25.7",
-                "@babel/helper-simple-access": "^7.25.7",
-                "@babel/helper-validator-identifier": "^7.25.7",
-                "@babel/traverse": "^7.25.7"
+                "@babel/helper-module-imports": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.27.1",
+                "@babel/traverse": "^7.28.3"
             },
             "engines": {
                 "node": ">=6.9.0"
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0"
-            }
-        },
-        "node_modules/@babel/helper-simple-access": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.25.7.tgz",
-            "integrity": "sha512-FPGAkJmyoChQeM+ruBGIDyrT2tKfZJO8NcxdC+CWNJi7N8/rZpSxK7yvBJ5O/nF1gfu5KzN7VKG3YVSLFfRSxQ==",
-            "optional": true,
-            "dependencies": {
-                "@babel/traverse": "^7.25.7",
-                "@babel/types": "^7.25.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-string-parser": {
@@ -367,32 +381,47 @@
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-            "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.7.tgz",
-            "integrity": "sha512-ytbPLsm+GjArDYXJ8Ydr1c/KJuutjF2besPNbIZnZ6MKUxi/uTA22t2ymmA4WFjZFpjiAMO0xuuJPqK2nvDVfQ==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+            "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+            "license": "MIT",
             "optional": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.27.6",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
-            "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+            "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
                 "@babel/template": "^7.27.2",
-                "@babel/types": "^7.27.6"
+                "@babel/types": "^7.28.4"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helpers/node_modules/@babel/types": {
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+            "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.28.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -474,30 +503,49 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.0.tgz",
-            "integrity": "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
+            "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.26.2",
-                "@babel/generator": "^7.27.0",
-                "@babel/parser": "^7.27.0",
-                "@babel/template": "^7.27.0",
-                "@babel/types": "^7.27.0",
-                "debug": "^4.3.1",
-                "globals": "^11.1.0"
+                "@babel/code-frame": "^7.27.1",
+                "@babel/generator": "^7.28.5",
+                "@babel/helper-globals": "^7.28.0",
+                "@babel/parser": "^7.28.5",
+                "@babel/template": "^7.27.2",
+                "@babel/types": "^7.28.5",
+                "debug": "^4.3.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/traverse/node_modules/globals": {
-            "version": "11.12.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+        "node_modules/@babel/traverse/node_modules/@babel/parser": {
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
+            "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
             "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.28.5"
+            },
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
             "engines": {
-                "node": ">=4"
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/traverse/node_modules/@babel/types": {
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+            "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.28.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/types": {
@@ -2273,16 +2321,24 @@
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-            "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+            "version": "0.3.13",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+            "license": "MIT",
             "dependencies": {
-                "@jridgewell/set-array": "^1.2.1",
-                "@jridgewell/sourcemap-codec": "^1.4.10",
+                "@jridgewell/sourcemap-codec": "^1.5.0",
                 "@jridgewell/trace-mapping": "^0.3.24"
-            },
-            "engines": {
-                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/remapping": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.24"
             }
         },
         "node_modules/@jridgewell/resolve-uri": {
@@ -2293,23 +2349,16 @@
                 "node": ">=6.0.0"
             }
         },
-        "node_modules/@jridgewell/set-array": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-            "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
             "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.25",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+            "license": "MIT",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -7965,6 +8014,29 @@
                 "undici-types": "~6.21.0"
             }
         },
+        "node_modules/@wdio/runner/node_modules/webdriver": {
+            "version": "9.19.0",
+            "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.19.0.tgz",
+            "integrity": "sha512-o5ZUvy1IFrlkVuf9hnlwQQnTMVSkEurXQkREb9XXSfcGdzValQejw7vmIrROaPVTgmLcnCq17cNzvirRWkBmgw==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@types/node": "^20.1.0",
+                "@types/ws": "^8.5.3",
+                "@wdio/config": "9.19.0",
+                "@wdio/logger": "9.18.0",
+                "@wdio/protocols": "9.16.2",
+                "@wdio/types": "9.19.0",
+                "@wdio/utils": "9.19.0",
+                "deepmerge-ts": "^7.0.3",
+                "https-proxy-agent": "^7.0.6",
+                "undici": "^6.21.3",
+                "ws": "^8.8.0"
+            },
+            "engines": {
+                "node": ">=18.20.0"
+            }
+        },
         "node_modules/@wdio/spec-reporter": {
             "version": "9.19.0",
             "resolved": "https://registry.npmjs.org/@wdio/spec-reporter/-/spec-reporter-9.19.0.tgz",
@@ -8444,13 +8516,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@web/test-runner-core/node_modules/convert-source-map": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-            "license": "MIT",
-            "optional": true
-        },
         "node_modules/@web/test-runner-core/node_modules/globby": {
             "version": "11.1.0",
             "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -8550,13 +8615,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/@web/test-runner/node_modules/convert-source-map": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/@web/test-runner/node_modules/diff": {
             "version": "5.2.0",
@@ -9620,6 +9678,16 @@
                 }
             ]
         },
+        "node_modules/baseline-browser-mapping": {
+            "version": "2.8.25",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.25.tgz",
+            "integrity": "sha512-2NovHVesVF5TXefsGX1yzx1xgr7+m9JQenvz6FQY3qd+YXkKkYiv+vTCc7OriP9mcDZpTC5mAOYN4ocd29+erA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "bin": {
+                "baseline-browser-mapping": "dist/cli.js"
+            }
+        },
         "node_modules/basic-ftp": {
             "version": "5.0.5",
             "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
@@ -10202,9 +10270,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001716",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001716.tgz",
-            "integrity": "sha512-49/c1+x3Kwz7ZIWt+4DvK3aMJy9oYXXG6/97JKsnjdCk/6n9vVyWL8NAwVt95Lwt9eigI10Hl782kDfZUUlRXw==",
+            "version": "1.0.30001754",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001754.tgz",
+            "integrity": "sha512-x6OeBXueoAceOmotzx3PO4Zpt4rzpeIFsSr6AAePTZxSkXiYDUmpypEl7e2+8NCd9bD7bXjqyef8CJYPC1jfxg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -10943,6 +11011,13 @@
             "engines": {
                 "node": ">= 0.6"
             }
+        },
+        "node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/cookie": {
             "version": "0.7.2",
@@ -12512,9 +12587,10 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.32",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.32.tgz",
-            "integrity": "sha512-M+7ph0VGBQqqpTT2YrabjNKSQ2fEl9PVx6AK3N558gDH9NO8O6XN9SXXFWRo9u9PbEg/bWq+tjXQr+eXmxubCw==",
+            "version": "1.5.248",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.248.tgz",
+            "integrity": "sha512-zsur2yunphlyAO4gIubdJEXCK6KOVvtpiuDfCIqbM9FjcnMYiyn0ICa3hWfPr0nc41zcLWobgy1iL7VvoOyA2Q==",
+            "license": "ISC",
             "optional": true
         },
         "node_modules/emoji-regex": {
@@ -18130,12 +18206,6 @@
             "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
             "optional": true
         },
-        "node_modules/lodash.isequal": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-            "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-            "optional": true
-        },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -20344,9 +20414,10 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.18",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
-            "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
+            "version": "2.0.27",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+            "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+            "license": "MIT",
             "optional": true
         },
         "node_modules/normalize-package-data": {
@@ -25865,9 +25936,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
-            "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz",
+            "integrity": "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -25882,10 +25953,11 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "escalade": "^3.2.0",
-                "picocolors": "^1.1.0"
+                "picocolors": "^1.1.1"
             },
             "bin": {
                 "update-browserslist-db": "cli.js"
@@ -25947,13 +26019,6 @@
             "engines": {
                 "node": ">=10.12.0"
             }
-        },
-        "node_modules/v8-to-istanbul/node_modules/convert-source-map": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/validate-npm-package-license": {
             "version": "3.0.4",
@@ -26762,6 +26827,128 @@
                 "qrjs": "^0.2.0"
             }
         },
+        "node_modules/webdriver": {
+            "version": "9.20.0",
+            "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.20.0.tgz",
+            "integrity": "sha512-Kk+AGV1xWLNHVpzUynQJDULMzbcO3IjXo3s0BzfC30OpGxhpaNmoazMQodhtv0Lp242Mb1VYXD89dCb4oAHc4w==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@types/node": "^20.1.0",
+                "@types/ws": "^8.5.3",
+                "@wdio/config": "9.20.0",
+                "@wdio/logger": "9.18.0",
+                "@wdio/protocols": "9.16.2",
+                "@wdio/types": "9.20.0",
+                "@wdio/utils": "9.20.0",
+                "deepmerge-ts": "^7.0.3",
+                "https-proxy-agent": "^7.0.6",
+                "undici": "^6.21.3",
+                "ws": "^8.8.0"
+            },
+            "engines": {
+                "node": ">=18.20.0"
+            }
+        },
+        "node_modules/webdriver/node_modules/@types/node": {
+            "version": "20.19.24",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.24.tgz",
+            "integrity": "sha512-FE5u0ezmi6y9OZEzlJfg37mqqf6ZDSF2V/NLjUyGrR9uTZ7Sb9F7bLNZ03S4XVUNRWGA7Ck4c1kK+YnuWjl+DA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "undici-types": "~6.21.0"
+            }
+        },
+        "node_modules/webdriver/node_modules/@wdio/config": {
+            "version": "9.20.0",
+            "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.20.0.tgz",
+            "integrity": "sha512-ggwd3EMsVj/LTcbYw2h+hma+/7fQ1cTXMuy9B5WTkLjDlOtbLjsqs9QLt4BLIo1cdsxvAw/UVpRVUuYy7rTmtQ==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@wdio/logger": "9.18.0",
+                "@wdio/types": "9.20.0",
+                "@wdio/utils": "9.20.0",
+                "deepmerge-ts": "^7.0.3",
+                "glob": "^10.2.2",
+                "import-meta-resolve": "^4.0.0",
+                "jiti": "^2.5.1"
+            },
+            "engines": {
+                "node": ">=18.20.0"
+            }
+        },
+        "node_modules/webdriver/node_modules/@wdio/types": {
+            "version": "9.20.0",
+            "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.20.0.tgz",
+            "integrity": "sha512-zMmAtse2UMCSOW76mvK3OejauAdcFGuKopNRH7crI0gwKTZtvV89yXWRziz9cVXpFgfmJCjf9edxKFWdhuF5yw==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@types/node": "^20.1.0"
+            },
+            "engines": {
+                "node": ">=18.20.0"
+            }
+        },
+        "node_modules/webdriver/node_modules/@wdio/utils": {
+            "version": "9.20.0",
+            "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.20.0.tgz",
+            "integrity": "sha512-T1ze005kncUTocYImSBQc/FAVcOwP/vOU4MDJFgzz/RTcps600qcKX98sVdWM5/ukXCVkjOufWteDHIbX5/tEA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@puppeteer/browsers": "^2.2.0",
+                "@wdio/logger": "9.18.0",
+                "@wdio/types": "9.20.0",
+                "decamelize": "^6.0.0",
+                "deepmerge-ts": "^7.0.3",
+                "edgedriver": "^6.1.2",
+                "geckodriver": "^5.0.0",
+                "get-port": "^7.0.0",
+                "import-meta-resolve": "^4.0.0",
+                "locate-app": "^2.2.24",
+                "mitt": "^3.0.1",
+                "safaridriver": "^1.0.0",
+                "split2": "^4.2.0",
+                "wait-port": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=18.20.0"
+            }
+        },
+        "node_modules/webdriver/node_modules/glob": {
+            "version": "10.4.5",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/webdriver/node_modules/jiti": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+            "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+            "license": "MIT",
+            "optional": true,
+            "bin": {
+                "jiti": "lib/jiti-cli.mjs"
+            }
+        },
         "node_modules/webdriverio": {
             "version": "9.19.0",
             "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.19.0.tgz",
@@ -26815,6 +27002,29 @@
             "optional": true,
             "dependencies": {
                 "undici-types": "~6.21.0"
+            }
+        },
+        "node_modules/webdriverio/node_modules/webdriver": {
+            "version": "9.19.0",
+            "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.19.0.tgz",
+            "integrity": "sha512-o5ZUvy1IFrlkVuf9hnlwQQnTMVSkEurXQkREb9XXSfcGdzValQejw7vmIrROaPVTgmLcnCq17cNzvirRWkBmgw==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@types/node": "^20.1.0",
+                "@types/ws": "^8.5.3",
+                "@wdio/config": "9.19.0",
+                "@wdio/logger": "9.18.0",
+                "@wdio/protocols": "9.16.2",
+                "@wdio/types": "9.19.0",
+                "@wdio/utils": "9.19.0",
+                "deepmerge-ts": "^7.0.3",
+                "https-proxy-agent": "^7.0.6",
+                "undici": "^6.21.3",
+                "ws": "^8.8.0"
+            },
+            "engines": {
+                "node": ">=18.20.0"
             }
         },
         "node_modules/webidl-conversions": {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9678,16 +9678,6 @@
                 }
             ]
         },
-        "node_modules/baseline-browser-mapping": {
-            "version": "2.8.25",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.25.tgz",
-            "integrity": "sha512-2NovHVesVF5TXefsGX1yzx1xgr7+m9JQenvz6FQY3qd+YXkKkYiv+vTCc7OriP9mcDZpTC5mAOYN4ocd29+erA==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "bin": {
-                "baseline-browser-mapping": "dist/cli.js"
-            }
-        },
         "node_modules/basic-ftp": {
             "version": "5.0.5",
             "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
@@ -10268,27 +10258,6 @@
             "engines": {
                 "node": ">=6"
             }
-        },
-        "node_modules/caniuse-lite": {
-            "version": "1.0.30001754",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001754.tgz",
-            "integrity": "sha512-x6OeBXueoAceOmotzx3PO4Zpt4rzpeIFsSr6AAePTZxSkXiYDUmpypEl7e2+8NCd9bD7bXjqyef8CJYPC1jfxg==",
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/browserslist"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "CC-BY-4.0",
-            "optional": true
         },
         "node_modules/ccount": {
             "version": "2.0.1",
@@ -12585,13 +12554,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/electron-to-chromium": {
-            "version": "1.5.248",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.248.tgz",
-            "integrity": "sha512-zsur2yunphlyAO4gIubdJEXCK6KOVvtpiuDfCIqbM9FjcnMYiyn0ICa3hWfPr0nc41zcLWobgy1iL7VvoOyA2Q==",
-            "license": "ISC",
-            "optional": true
         },
         "node_modules/emoji-regex": {
             "version": "9.2.2",
@@ -20413,13 +20375,6 @@
                 "node-gyp-build-test": "build-test.js"
             }
         },
-        "node_modules/node-releases": {
-            "version": "2.0.27",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-            "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-            "license": "MIT",
-            "optional": true
-        },
         "node_modules/normalize-package-data": {
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -25933,37 +25888,6 @@
             "optional": true,
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
-            }
-        },
-        "node_modules/update-browserslist-db": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz",
-            "integrity": "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==",
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/browserslist"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/browserslist"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "escalade": "^3.2.0",
-                "picocolors": "^1.1.1"
-            },
-            "bin": {
-                "update-browserslist-db": "cli.js"
-            },
-            "peerDependencies": {
-                "browserslist": ">= 4.21.0"
             }
         },
         "node_modules/uri-js": {

--- a/web/static_outpost.go
+++ b/web/static_outpost.go
@@ -1,5 +1,4 @@
 //go:build outpost_static_embed
-// +build outpost_static_embed
 
 package web
 


### PR DESCRIPTION
should fix migrate-from-stable first installing the latest release (2025.10) and then downgrading