### PR TITLE
ci: fix migrate-from-stable for old versions (#18019)

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -80,7 +80,15 @@ jobs:
           cp authentik/lib/default.yml local.env.yml
           cp -R .github ..
           cp -R scripts ..
-          git checkout $(git tag --sort=version:refname | grep '^version/' | grep -vE -- '-rc[0-9]+$' | tail -n1)
+          # Previous stable tag
+          prev_stable=$(git tag --sort=version:refname | grep '^version/' | grep -vE -- '-rc[0-9]+$' | tail -n1)
+          # Current version family based on
+          current_version_family=$(python -c "from authentik import VERSION; print(VERSION)" | grep -vE -- 'rc[0-9]+$')
+          if [[ -n $current_version_family ]]; then
+              prev_stable=$current_version_family
+          fi
+          echo "::notice::Checking out ${prev_stable} as stable version..."
+          git checkout $(prev_stable)
           rm -rf .github/ scripts/
           mv ../.github ../scripts .
       - name: Setup authentik env (stable)


### PR DESCRIPTION
ci: better logic for picking previous stable version

backport of #18019, manual cause perms