### PR TITLE
web: Fix tab activation, blank provider URLs

### DIFF
--- a/web/src/elements/Tabs.ts
+++ b/web/src/elements/Tabs.ts
@@ -95,11 +95,17 @@ export class Tabs extends AKElement {
             childList: true,
             subtree: true,
         });
+
+        this.dispatchActivateEvent();
     }
 
     public override disconnectedCallback(): void {
         this.#observer?.disconnect();
         super.disconnectedCallback();
+    }
+
+    public findActiveTabPanel(): Element | null {
+        return this.querySelector(`[slot='${this.activeTabName}']`);
     }
 
     public activateTab(nextTabName: string): void {
@@ -125,11 +131,17 @@ export class Tabs extends AKElement {
 
         this.activeTabName = nextTabName;
 
-        const page = this.querySelector(`[slot='${this.activeTabName}']`);
-        if (!page) return;
+        this.dispatchActivateEvent();
+    }
 
-        page.dispatchEvent(new CustomEvent(EVENT_REFRESH));
-        page.dispatchEvent(new CustomEvent("activate"));
+    public dispatchActivateEvent(tabPanel = this.findActiveTabPanel()): void {
+        if (!tabPanel) {
+            console.warn("Cannot dispatch activate event, no tab panel found");
+            return;
+        }
+
+        tabPanel.dispatchEvent(new CustomEvent(EVENT_REFRESH));
+        tabPanel.dispatchEvent(new CustomEvent("activate"));
     }
 
     #delegateFocusListener = (event: FocusEvent) => {


### PR DESCRIPTION
## Details

This PR fixes a regression introduced in #17804. The removal of extra re-renders in the tab component still requires that a activation event is dispatched to the parent, such as when viewing a provider page.