### PR TITLE
ci: revert to upstream GHA for release

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -89,7 +89,7 @@ jobs:
           git tag "version/${{ inputs.version }}" HEAD -m "version/${{ inputs.version }}"
           git push --follow-tags
       - name: Create Release
-        uses: goauthentik/action-gh-release@84da137b91a625a58fe8a34f3bd6bdb034a49138
+        uses: softprops/action-gh-release@5be0e66d93ac7ed76da52eca8bb058f665c3a5fe # v2.4.2
         with:
           token: "${{ steps.app-token.outputs.token }}"
           tag_name: "version/${{ inputs.version }}"


### PR DESCRIPTION
https://github.com/softprops/action-gh-release/pull/684 is merged

see https://github.com/softprops/action-gh-release/releases/tag/v2.4.2
