### PR TITLE
outpost/proxyv2: revalidate auth if session fails to load

### DIFF
--- a/internal/outpost/proxyv2/application/oauth.go
+++ b/internal/outpost/proxyv2/application/oauth.go
@@ -1,6 +1,7 @@
 package application
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"strings"
@@ -19,8 +20,41 @@ func (a *Application) handleAuthStart(rw http.ResponseWriter, r *http.Request, f
 	state, err := a.createState(r, rw, fwd)
 	if err != nil {
 		a.log.WithError(err).Warning("failed to create state")
-		rw.WriteHeader(400)
-		return
+		if !strings.HasPrefix(err.Error(), "failed to get session") {
+			rw.WriteHeader(400)
+			return
+		}
+
+		// Client has a cookie but we're unable to load the session from
+		// storage (TMPDIR=/dev/shm). This can happen if the session file
+		// was deleted due to container restart or session invalidation
+		// (e.g., logout on auth server).
+		//
+		// Re-save an empty session and try again.
+
+		session, err := a.sessions.Get(r, a.SessionName())
+		if err != nil && !strings.HasSuffix(err.Error(), "no such file or directory") {
+			a.log.WithError(err).Warning("failed to get session")
+			rw.WriteHeader(400)
+			return
+		}
+		err = a.sessions.Save(r, rw, session)
+		if err != nil {
+			a.log.WithError(err).Warning("failed to save session")
+			rw.WriteHeader(400)
+			return
+		}
+
+		// The registry caches the previous attempt to open the session so it
+		// needs to be cleared in order to get the session in createState().
+		*r = *r.WithContext(context.Background())
+
+		state, err = a.createState(r, rw, fwd)
+		if err != nil {
+			a.log.WithError(err).Warning("failed to create state on retry")
+			rw.WriteHeader(400)
+			return
+		}
 	}
 	http.Redirect(rw, r, a.oauthConfig.AuthCodeURL(state), http.StatusFound)
 }


### PR DESCRIPTION
## Bug

The forward auth handler in the outpost does not properly handle a session load failure. When the session fails to load, it simply bails out, returning a `200` to the reverse proxy which then allows the request to proceed. Depending on the configuration of the upstream service, this can result in a 401, basic auth prompt, or simply allowing access. With one of my applications, the app set it's own cookies which still granted access despite the invalid authentik session.

Similar issue is mentioned in https://github.com/goauthentik/authentik/issues/2023#issuecomment-2962624284

Setup:
- https://auth.example.com
- https://app.example.com (using fwd auth to outpost [I'm using traefik but should apply to others])

Flow:
1. Visit https://app.example.com -> redir to auth, sign in -> redir to app
2. Visit https://auth.example.com -> sign out
3. Session is properly invalidated at the outpost, e.g.:

```json
{"event":"Logging out","level":"debug","logger":"authentik.outpost.proxyv2","provider":"app.example.com","timestamp":"2025-11-10T17:22:54Z"}
{"event":"deleting session","level":"trace","logger":"authentik.outpost.proxyv2.application","name":"provider-app","path":"/dev/shm/session_6JCRTWRRAVWIPWGLBIWZZPLTYUI27PYAVIEQKH5YSDQOMBNMMIWA","timestamp":"2025-11-10T17:22:54Z"}
```

4. Visit https://app.example.com - warning logged but fwd auth returns `200` - app returns 401

Step 2 can also be a restart of the outpost due to crash, reboot, or redeployment.

## Fix

After session validation falls through, fix the session/state setup so we can redirect to the auth server and complete the flow. User will either be prompted to log in or, if they had already logged back in again, they will be sent back and the new session will be established properly.