### PR TITLE
ci: attempt to fix integration tests using dind

### DIFF
--- a/tests/integration/test_outpost_docker.py
+++ b/tests/integration/test_outpost_docker.py
@@ -30,7 +30,7 @@ class OutpostDockerTests(DockerTestCase, ChannelsLiveServerTestCase):
         super().setUp()
         self.ssl_folder = mkdtemp()
         self.run_container(
-            image="library/docker:dind",
+            image="docker.io/library/docker:24.0.7-dind-alpine3.18",
             network_mode="host",
             privileged=True,
             healthcheck=Healthcheck(

--- a/tests/integration/test_outpost_docker.py
+++ b/tests/integration/test_outpost_docker.py
@@ -30,7 +30,7 @@ class OutpostDockerTests(DockerTestCase, ChannelsLiveServerTestCase):
         super().setUp()
         self.ssl_folder = mkdtemp()
         self.run_container(
-            image="docker.io/library/docker:24.0.7-dind-alpine3.18",
+            image="docker.io/library/docker:28.5.2-dind-alpine3.22",
             network_mode="host",
             privileged=True,
             healthcheck=Healthcheck(

--- a/tests/integration/test_proxy_docker.py
+++ b/tests/integration/test_proxy_docker.py
@@ -30,7 +30,7 @@ class TestProxyDocker(DockerTestCase, ChannelsLiveServerTestCase):
         super().setUp()
         self.ssl_folder = mkdtemp()
         self.run_container(
-            image="library/docker:dind",
+            image="docker.io/library/docker:24.0.7-dind-alpine3.18",
             network_mode="host",
             privileged=True,
             healthcheck=Healthcheck(

--- a/tests/integration/test_proxy_docker.py
+++ b/tests/integration/test_proxy_docker.py
@@ -30,7 +30,7 @@ class TestProxyDocker(DockerTestCase, ChannelsLiveServerTestCase):
         super().setUp()
         self.ssl_folder = mkdtemp()
         self.run_container(
-            image="docker.io/library/docker:24.0.7-dind-alpine3.18",
+            image="docker.io/library/docker:28.5.2-dind-alpine3.22",
             network_mode="host",
             privileged=True,
             healthcheck=Healthcheck(


### PR DESCRIPTION
I forgot we use dind in some integration tests, this uses a fixed version (currently an older one for testing)