### PR TITLE
events: fix timezone not set for log events

### DIFF
--- a/authentik/events/logs.py
+++ b/authentik/events/logs.py
@@ -1,7 +1,7 @@
 from collections.abc import Generator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from django.utils.timezone import now
@@ -28,7 +28,7 @@ class LogEvent:
     def from_event_dict(item: EventDict) -> "LogEvent":
         event = item.pop("event")
         log_level = item.pop("level").lower()
-        timestamp = datetime.fromisoformat(item.pop("timestamp"))
+        timestamp = datetime.fromisoformat(item.pop("timestamp")).replace(tzinfo=UTC)
         item.pop("pid", None)
         # Sometimes log entries have both `level` and `log_level` set, but `level` is always set
         item.pop("log_level", None)


### PR DESCRIPTION
should fix this 
<img width="1144" height="695" alt="image" src="https://github.com/user-attachments/assets/de609779-9f0c-4178-8996-c008f7f30870" />
