### PR TITLE
web: Disable library `<datalist>` on Firefox.

### DIFF
--- a/web/src/elements/utils/isSafari.ts
+++ b/web/src/elements/utils/isSafari.ts
@@ -1,4 +1,0 @@
-export const isSafari = () =>
-    navigator.userAgent.includes("Safari") && !navigator.userAgent.includes("Chrome");
-
-export default isSafari;

--- a/web/src/elements/utils/useragent.ts
+++ b/web/src/elements/utils/useragent.ts
@@ -1,0 +1,19 @@
+/**
+ * @file User agent utilities.
+ */
+
+/**
+ * Predicate to determine if the current browser is Safari.
+ */
+export function isSafari(): boolean {
+    const ua = navigator.userAgent.toLowerCase();
+    return ua.includes("safari") && !ua.includes("chrome") && !ua.includes("chromium");
+}
+
+/**
+ * Predicate to determine if the current browser is Firefox.
+ */
+export function isFirefox(): boolean {
+    const ua = navigator.userAgent.toLowerCase();
+    return ua.includes("firefox");
+}

--- a/web/src/elements/utils/writeToClipboard.ts
+++ b/web/src/elements/utils/writeToClipboard.ts
@@ -1,4 +1,4 @@
-import { isSafari } from "./isSafari.js";
+import { isSafari } from "./useragent.js";
 
 export async function writeToClipboard(message: string) {
     if (!navigator.clipboard) {

--- a/web/src/user/LibraryPage/ak-library-impl.ts
+++ b/web/src/user/LibraryPage/ak-library-impl.ts
@@ -17,6 +17,7 @@ import { getURLParam, updateURLParams } from "#elements/router/RouteMatch";
 import { ifPresent } from "#elements/utils/attributes";
 import { FocusTarget } from "#elements/utils/focus";
 import { isInteractiveElement } from "#elements/utils/interactivity";
+import { isFirefox } from "#elements/utils/useragent";
 
 import type { Application } from "@goauthentik/api";
 
@@ -26,7 +27,6 @@ import { msg, str } from "@lit/localize";
 import { html, nothing, PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { createRef } from "lit/directives/ref.js";
-import { repeat } from "lit/directives/repeat.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFCard from "@patternfly/patternfly/components/Card/card.css";
@@ -54,6 +54,18 @@ import PFSpacing from "@patternfly/patternfly/utilities/Spacing/spacing.css";
  */
 @customElement("ak-library-impl")
 export class LibraryPage extends WithSession(AKElement) {
+    /**
+     * Maximum number of items to show in the datalist for search suggestions.
+     */
+    static readonly MAX_DATA_LIST_ITEMS = 5;
+    /**
+     * Whether to enable the datalist for search suggestions.
+     *
+     * @remarks
+     * Disabled on Firefox due to performance issues between renders.
+     */
+    static DataListEnabled = !isFirefox();
+
     static styles = [
         // ---
         PFBase,
@@ -311,19 +323,23 @@ export class LibraryPage extends WithSession(AKElement) {
                     autofocus
                     placeholder=${msg("Search for an application by name...")}
                     value=${ifPresent(this.query)}
-                    list="application-search-options"
+                    list=${ifPresent(LibraryPage.DataListEnabled, "application-search-options")}
                 />
-                <datalist id="application-search-options">
-                    ${repeat(
-                        this.visibleApplications,
-                        (application) => application.pk,
-                        (app) => {
-                            return html`<option value=${app.name}></option>`;
-                        },
-                    )}
-                </datalist>
+                ${this.renderDataList()}
             </form>
         </search>`;
+    }
+
+    protected renderDataList() {
+        if (!LibraryPage.DataListEnabled) {
+            return nothing;
+        }
+
+        return html`<datalist id="application-search-options">
+            ${this.visibleApplications.slice(0, LibraryPage.MAX_DATA_LIST_ITEMS).map((app) => {
+                return html`<option value=${app.name}></option>`;
+            })}
+        </datalist>`;
     }
 
     protected renderNoAppsFound() {


### PR DESCRIPTION
## Details

This PR is a follow up on #17522, disabling the `<datalist>` element on Firefox. Unfortunately, datalists exhibit inconsistent performance characteristics when combined with web components in Firefox's implementation.

The Datalist was first introduced to help navigate app libraries with many results and serves as a supplemental feature. While we'd love to maintain feature parity across all browsers, Firefox users will have the best experience with this feature disabled until the following implementation issues are resolved:

- [Keystrokes on <datalist> fire keyboard events on associated <input>](https://bugzilla.mozilla.org/show_bug.cgi?id=1360755)
- [HTML Datalist field not working after last update](https://bugzilla.mozilla.org/show_bug.cgi?id=1880457)
- [Inconsistent behaviour of datalist + autocomplete="off" between Desktop and Mobile](https://bugzilla.mozilla.org/show_bug.cgi?id=1293664)
- https://bugzilla.mozilla.org/show_bug.cgi?id=1638433
- [Failing WPT html/semantics/forms/the-datalist-element/datalistoptions.html](https://bugzilla.mozilla.org/show_bug.cgi?id=1886914)