### PR TITLE
packages/django-channels-postgres/layer: fix query when subscribed to multiple channels

### DIFF
--- a/packages/django-channels-postgres/django_channels_postgres/layer.py
+++ b/packages/django-channels-postgres/django_channels_postgres/layer.py
@@ -473,7 +473,7 @@ class PostgresChannelLayerReceiver:
                     """
                     DELETE
                     FROM {table}
-                    WHERE {table}.{channel} IN (%s)
+                    WHERE {table}.{channel} = ANY(%s)
                       AND {table}.{expires} >= %s
                     RETURNING {table}.{id}, {table}.{channel}, {table}.{message}
                 """
@@ -484,7 +484,7 @@ class PostgresChannelLayerReceiver:
                     expires=sql.Identifier("expires"),
                     message=sql.Identifier("message"),
                 ),
-                (tuple(self._subscribed_to), now()),
+                (list(self._subscribed_to), now()),
             )
             async for row in cursor:
                 message_id, channel, message = row


### PR DESCRIPTION
didn't cause any issue until now, but might as well