### PR TITLE
website/integrations: ubuntu landscape: remove appendix

### DIFF
--- a/website/integrations/monitoring/ubuntu-landscape/index.md
+++ b/website/integrations/monitoring/ubuntu-landscape/index.md
@@ -57,19 +57,3 @@ oidc-client-secret = <client Secret of the provider you've created>
 ```
 
 Afterwards, run `sudo lsctl restart` to restart the Landscape services.
-
-## Appendix
-
-To make an OpenID-Connect User admin, you have to insert some rows into the database.
-
-First login with your authentik user, and make sure the user is created successfully.
-
-Run `sudo -u postgres psql landscape-standalone-main` on the Landscape server to open a PostgreSQL Prompt.
-Then run `select * from person;` to get a list of all users. Take note of the ID given to your new user.
-
-Run the following commands to make this user an administrator:
-
-```sql
-INSERT INTO person_account VALUES (<user id>, 1);
-INSERT INTO person_access VALUES (<user id>, 1, 1);
-```


### PR DESCRIPTION
## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
Removed the appendix section detailing how to make an OpenID-Connect User an admin. Roles are now managed in the UI when you invite a user or afterwards in the Roles tab. There is no need for database edits.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
