### PR TITLE
providers/saml: fix front-end saml binding defaults

### DIFF
--- a/web/src/admin/providers/saml/SAMLProviderFormForm.ts
+++ b/web/src/admin/providers/saml/SAMLProviderFormForm.ts
@@ -38,7 +38,6 @@ const serviceProviderBindingOptions: RadioOption<SAMLBindingsEnum>[] = [
     {
         label: msg("Post"),
         value: SAMLBindingsEnum.Post,
-        default: true,
     },
 ];
 
@@ -95,7 +94,7 @@ function renderHasSlsUrl(
             label=${msg("SLS Binding")}
             name="slsBinding"
             .options=${serviceProviderBindingOptions}
-            .value=${provider?.slsBinding}
+            .value=${provider?.slsBinding ?? SAMLBindingsEnum.Redirect}
             help=${msg(
                 "Determines how authentik sends the logout response back to the Service Provider.",
             )}
@@ -177,7 +176,7 @@ export function renderForm({
                     name="spBinding"
                     required
                     .options=${serviceProviderBindingOptions}
-                    .value=${provider.spBinding}
+                    .value=${provider.spBinding ?? SAMLBindingsEnum.Post}
                     help=${msg(
                         "Determines how authentik sends the response back to the Service Provider.",
                     )}


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
I accidentally replaced the front-end default for sls urls, so this PR fixes that issue

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
