### PR TITLE
website: Unlisted & Draft Release Notes

### DIFF
--- a/website/docusaurus-theme/components/VersionPicker/VersionDropdown.tsx
+++ b/website/docusaurus-theme/components/VersionPicker/VersionDropdown.tsx
@@ -2,9 +2,13 @@ import "./styles.css";
 
 import { createVersionURL, parseBranchSemVer } from "#components/VersionPicker/utils.ts";
 
+import type {
+    AKReleaseFrontMatter,
+    AKReleasesPluginEnvironment,
+} from "@goauthentik/docusaurus-theme/releases/common";
+
 import clsx from "clsx";
 import React, { memo } from "react";
-import { AKReleasesPluginEnvironment } from "releases/node.mjs";
 
 export interface VersionDropdownProps {
     /**
@@ -20,12 +24,19 @@ export interface VersionDropdownProps {
      * @format semver
      */
     releases: string[];
+
+    /**
+     * A possible record of parsed front-matter for each release.
+     */
+    frontMatterRecord: Record<string, AKReleaseFrontMatter>;
 }
 
 /**
  * A dropdown that shows the available versions of the documentation.
  */
-export const VersionDropdown = memo<VersionDropdownProps>(({ environment, releases }) => {
+export const VersionDropdown = memo<VersionDropdownProps>((props) => {
+    const { environment, releases, frontMatterRecord } = props;
+
     const { branch, preReleaseOrigin } = environment;
     const parsedSemVer = parseBranchSemVer(branch);
 
@@ -65,6 +76,11 @@ export const VersionDropdown = memo<VersionDropdownProps>(({ environment, releas
 
                 {visibleReleases.map((semVer, idx) => {
                     let label = semVer;
+                    const frontmatter = frontMatterRecord[semVer];
+
+                    if (frontmatter?.unlisted || frontmatter?.draft) {
+                        return null;
+                    }
 
                     if (idx === 0) {
                         label += " (Current Release)";

--- a/website/docusaurus-theme/package.json
+++ b/website/docusaurus-theme/package.json
@@ -14,6 +14,7 @@
         "./redirects/plugin": "./redirects/plugin.mjs",
         "./redirects/node": "./redirects/node.mjs",
         "./redirects": "./redirects/index.mjs",
+        "./releases/common": "./releases/common.mjs",
         "./releases/plugin": "./releases/plugin.mjs",
         "./releases/node": "./releases/node.mjs"
     },

--- a/website/docusaurus-theme/releases/common.mjs
+++ b/website/docusaurus-theme/releases/common.mjs
@@ -1,0 +1,41 @@
+/**
+ * @typedef {object} AKReleasesPluginEnvironment
+ * @property {string} [branch] The current branch name, if available.
+ * e.g. "main" `version-${year}.${month}`, "feature-branch"
+ * @property {string} currentReleaseOrigin The URL to the current release documentation.
+ * @property {string} preReleaseOrigin The URL to the pre-release documentation.
+ * @property {string} apiReferenceOrigin The URL to the API reference documentation.
+ */
+
+/**
+ * @typedef {object} AKReleaseFrontMatter
+ * @property {boolean} [draft] Whether the release is a draft.
+ * @property {boolean} [unlisted] Whether the release is unlisted.
+ */
+
+/**
+ * @typedef {object} AKReleaseFileMetadata
+ * @property {string} name The name of the release file.
+ * @property {string} path The relative path to the release file.
+ */
+
+/**
+ * @typedef {AKReleaseFileMetadata & { frontMatter?: AKReleaseFrontMatter }} AKReleaseFile
+ *
+ * Represents a release file with additional frontmatter properties.
+ */
+
+/**
+ * @typedef {object} AKReleasesPluginOptions
+ * @property {string} docsDirectory The path to the documentation directory.
+ * @property {AKReleasesPluginEnvironment} [environment] Optional environment variables overrides.
+ */
+
+/**
+ * @typedef {object} AKReleasesPluginData
+ * @property {string} publicPath URL to the plugin's public directory.
+ * @property {AKReleaseFile[]} releases Available versions of the documentation.
+ * @property {AKReleasesPluginEnvironment} env Environment variables
+ */
+
+export {};

--- a/website/docusaurus-theme/releases/plugin.mjs
+++ b/website/docusaurus-theme/releases/plugin.mjs
@@ -3,7 +3,7 @@
  * @file Docusaurus releases plugin.
  *
  * @import { LoadContext, Plugin } from "@docusaurus/types"
- * @import { AKReleasesPluginEnvironment } from "./node.mjs"
+ * @import { AKReleasesPluginOptions, AKReleasesPluginData } from "./common.mjs"
  */
 
 import * as fs from "node:fs/promises";
@@ -13,19 +13,6 @@ import { collectReleaseFiles, prepareReleaseEnvironment } from "./node.mjs";
 
 const PLUGIN_NAME = "ak-releases-plugin";
 const RELEASES_FILENAME = "releases.gen.json";
-
-/**
- * @typedef {object} AKReleasesPluginOptions
- * @property {string} docsDirectory The path to the documentation directory.
- * @property {AKReleasesPluginEnvironment} [environment] Optional environment variables overrides.
- */
-
-/**
- * @typedef {object} AKReleasesPluginData
- * @property {string} publicPath URL to the plugin's public directory.
- * @property {string[]} releases Available versions of the documentation.
- * @property {AKReleasesPluginEnvironment} env Environment variables
- */
 
 /**
  * @param {LoadContext} loadContext
@@ -44,14 +31,13 @@ async function akReleasesPlugin(loadContext, options) {
                 ...options.environment,
             };
 
-            const releases = collectReleaseFiles(options.docsDirectory).map(
-                (release) => release.name,
-            );
+            const releases = collectReleaseFiles(options.docsDirectory);
+            const releaseNames = releases.map((release) => release.name);
 
             const outputPath = path.join(loadContext.siteDir, "static", RELEASES_FILENAME);
 
             await fs.mkdir(path.dirname(outputPath), { recursive: true });
-            await fs.writeFile(outputPath, JSON.stringify(releases, null, 2), "utf-8");
+            await fs.writeFile(outputPath, JSON.stringify(releaseNames, null, 2), "utf-8");
             console.log(`✅ ${RELEASES_FILENAME} generated`);
 
             /**

--- a/website/docusaurus-theme/theme/ContentVisibility/Unlisted/index.tsx
+++ b/website/docusaurus-theme/theme/ContentVisibility/Unlisted/index.tsx
@@ -1,0 +1,60 @@
+import { useDoc } from "@docusaurus/plugin-content-docs/client";
+import {
+    ThemeClassNames,
+    UnlistedBannerMessage,
+    UnlistedBannerTitle,
+    UnlistedMetadata,
+} from "@docusaurus/theme-common";
+import Translate from "@docusaurus/Translate";
+import Admonition from "@theme/Admonition";
+import type { Props } from "@theme/ContentVisibility/Unlisted";
+import clsx from "clsx";
+import React, { type ReactNode } from "react";
+
+function UnlistedBanner({ className }: Props) {
+    const context = useDoc();
+
+    if (context.metadata.id?.startsWith("releases")) {
+        return (
+            <Admonition
+                type="note"
+                title={
+                    <Translate
+                        id="theme.contentVisibility.unlistedBanner.preRelease.title"
+                        description="The unlisted content banner title"
+                    >
+                        Pre-Release Documentation
+                    </Translate>
+                }
+                className={clsx(className, ThemeClassNames.common.unlistedBanner)}
+            >
+                <Translate
+                    id="theme.contentVisibility.unlistedBanner.preRelease.message"
+                    description="The unlisted content banner message"
+                >
+                    This documentation is for an upcoming version of authentik. It may be incomplete
+                    or subject to changes before the final release.
+                </Translate>
+            </Admonition>
+        );
+    }
+
+    return (
+        <Admonition
+            type="caution"
+            title={<UnlistedBannerTitle />}
+            className={clsx(className, ThemeClassNames.common.unlistedBanner)}
+        >
+            <UnlistedBannerMessage />
+        </Admonition>
+    );
+}
+
+export default function Unlisted(props: Props): ReactNode {
+    return (
+        <>
+            <UnlistedMetadata />
+            <UnlistedBanner {...props} />
+        </>
+    );
+}


### PR DESCRIPTION
## Details

This PR adds support for Docusaurus's `unlisted` and `draft` front-matter properties to the version selector. 

### How does it work?

Markdown files within Docusaurus can make use the `unlisted` front-matter property to hide an entry from the sidebar:
 
For example to unlist a future version of the release notes:

```md
---
title: Release 2025.11
slug: "/releases/2025.11"
unlisted: true
---

## Highlights

...etc
```

The result is a file which renders typically in development:

<img width="1894" height="848" alt="Screenshot 2025-11-19 at 16 48 24" src="https://github.com/user-attachments/assets/9f145d62-468a-4c96-9a8b-58c62ad1ca85" />


---

However in production the page will not be listed unless the URL is visited directly. In the case of a release page, the entry will not be visible in the sidebar. The warning banner is rendered automatically by Docusaurus.

- `draft`
  - ✅ [Visible in sidebar during development](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-pages#draft) 
  - 🚫 Not visible in sidebar when deployed to production
  - 🚫 Not published when deployed to production
- `unlisted`
  - ✅ [Visible in sidebar during development](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-pages#unlisted) 
  - ✅ Published in production, viewable with a direct link
  - 🚫 Not visible in sidebar when deployed to production

### When should I use `draft` instead of `unlisted`?

We don't yet have use-case for `draft`, but the effect on release files is similar to `unlisted`. Our support for `draft` is included to keep our version selector aligned with Docusaurus's Markdown parser.