### PR TITLE
web: Improve user display in modals by falling back to username

### DIFF
--- a/web/src/admin/users/UserActiveForm.ts
+++ b/web/src/admin/users/UserActiveForm.ts
@@ -3,18 +3,20 @@ import "#elements/buttons/SpinnerButton/index";
 import { parseAPIResponseError, pluckErrorDetail } from "#common/errors/network";
 import { MessageLevel } from "#common/messages";
 
-import { DeleteForm } from "#elements/forms/DeleteForm";
 import { showMessage } from "#elements/messages/MessageContainer";
+import { UserDeleteForm } from "#elements/user/utils";
 
 import { msg, str } from "@lit/localize";
 import { html, TemplateResult } from "lit";
 import { customElement } from "lit/decorators.js";
 
 @customElement("ak-user-active-form")
-export class UserActiveForm extends DeleteForm {
+export class UserActiveForm extends UserDeleteForm {
     onSuccess(): void {
         showMessage({
-            message: msg(str`Successfully updated ${this.objectLabel} ${this.obj?.name}`),
+            message: msg(
+                str`Successfully updated ${this.objectLabel} ${this.getObjectDisplayName()}`,
+            ),
             level: MessageLevel.success,
         });
     }
@@ -30,7 +32,8 @@ export class UserActiveForm extends DeleteForm {
         });
     }
 
-    renderModalInner(): TemplateResult {
+    override renderModalInner(): TemplateResult {
+        const objName = this.getFormattedObjectName();
         return html`<section class="pf-c-modal-box__header pf-c-page__main-section pf-m-light">
                 <div class="pf-c-content">
                     <h1 class="pf-c-title pf-m-2xl">${msg(str`Update ${this.objectLabel}`)}</h1>
@@ -39,9 +42,7 @@ export class UserActiveForm extends DeleteForm {
             <section class="pf-c-modal-box__body pf-m-light">
                 <form class="pf-c-form pf-m-horizontal">
                     <p>
-                        ${msg(
-                            str`Are you sure you want to update ${this.objectLabel} "${this.obj?.name}"?`,
-                        )}
+                        ${msg(str`Are you sure you want to update ${this.objectLabel}${objName}?`)}
                     </p>
                 </form>
             </section>

--- a/web/src/elements/forms/DeleteForm.ts
+++ b/web/src/elements/forms/DeleteForm.ts
@@ -41,11 +41,11 @@ export class DeleteForm extends ModalButton {
 
     /**
      * Get the formatted object name for display in messages.
-     * Returns empty string if no display name, otherwise returns ` displayName` with a leading space.
+     * Returns ` "displayName"` with quotes if display name exists, empty string otherwise.
      */
     protected getFormattedObjectName(): string {
         const displayName = this.getObjectDisplayName();
-        return displayName ? ` ${displayName}` : "";
+        return displayName ? ` "${displayName}"` : "";
     }
 
     confirm(): Promise<void> {

--- a/web/src/elements/forms/DeleteForm.ts
+++ b/web/src/elements/forms/DeleteForm.ts
@@ -32,6 +32,22 @@ export class DeleteForm extends ModalButton {
     @property({ attribute: false })
     delete!: () => Promise<unknown>;
 
+    /**
+     * Get the display name for the object being deleted/updated.
+     */
+    protected getObjectDisplayName(): string | undefined {
+        return this.obj?.name as string | undefined;
+    }
+
+    /**
+     * Get the formatted object name for display in messages.
+     * Returns empty string if no display name, otherwise returns ` displayName` with a leading space.
+     */
+    protected getFormattedObjectName(): string {
+        const displayName = this.getObjectDisplayName();
+        return displayName ? ` ${displayName}` : "";
+    }
+
     confirm(): Promise<void> {
         return this.delete()
             .then(() => {
@@ -54,7 +70,9 @@ export class DeleteForm extends ModalButton {
 
     onSuccess(): void {
         showMessage({
-            message: msg(str`Successfully deleted ${this.objectLabel} ${this.obj?.name}`),
+            message: msg(
+                str`Successfully deleted ${this.objectLabel} ${this.getObjectDisplayName()}`,
+            ),
             level: MessageLevel.success,
         });
     }
@@ -71,12 +89,7 @@ export class DeleteForm extends ModalButton {
     }
 
     renderModalInner(): TemplateResult {
-        let objName = this.obj?.name;
-        if (objName) {
-            objName = ` "${objName}"`;
-        } else {
-            objName = "";
-        }
+        const objName = this.getFormattedObjectName();
         return html`<section class="pf-c-modal-box__header pf-c-page__main-section pf-m-light">
                 <div class="pf-c-content">
                     <h1 class="pf-c-title pf-m-2xl">${msg(str`Delete ${this.objectLabel}`)}</h1>
@@ -85,7 +98,7 @@ export class DeleteForm extends ModalButton {
             <section class="pf-c-modal-box__body pf-m-light">
                 <form class="pf-c-form pf-m-horizontal">
                     <p>
-                        ${msg(str`Are you sure you want to delete ${this.objectLabel} ${objName}?`)}
+                        ${msg(str`Are you sure you want to delete ${this.objectLabel}${objName}?`)}
                     </p>
                 </form>
             </section>

--- a/web/src/elements/user/utils.ts
+++ b/web/src/elements/user/utils.ts
@@ -1,3 +1,5 @@
+import { DeleteForm } from "#elements/forms/DeleteForm";
+
 import { User } from "@goauthentik/api";
 
 export function UserOption(user: User): string {
@@ -16,4 +18,25 @@ export function UserOption(user: User): string {
         finalString += ")";
     }
     return finalString;
+}
+
+/**
+ * Get a display-friendly name for a user object.
+ * Falls back to username if no display name (name field) is set.
+ *
+ * @param user - The user object
+ * @returns The user's display name or username
+ */
+export function getUserDisplayName(user: User): string {
+    return user.name || user.username;
+}
+
+/**
+ * Base class for delete/update forms that work with User objects.
+ * Automatically uses username as fallback when user has no display name.
+ */
+export class UserDeleteForm extends DeleteForm {
+    protected override getObjectDisplayName(): string | undefined {
+        return this.obj ? getUserDisplayName(this.obj as User) : undefined;
+    }
 }

--- a/web/src/elements/user/utils.ts
+++ b/web/src/elements/user/utils.ts
@@ -37,6 +37,6 @@ export function getUserDisplayName(user: User): string {
  */
 export class UserDeleteForm extends DeleteForm {
     protected override getObjectDisplayName(): string | undefined {
-        return this.obj ? getUserDisplayName(this.obj as User) : undefined;
+        return this.obj ? getUserDisplayName(this.obj as unknown as User) : undefined;
     }
 }


### PR DESCRIPTION
Fixes UX issues in user-related modals where users without a display name would show empty text.

Previously:
* "Are you sure you want to update User ""?" (empty display name)
* "Successfully updated User undefined"

Now:
* "Are you sure you want to update User john_doe?" (falls back to username)
* "Successfully updated User john_doe"

Topics of discussion:
* Wether the object label should be lowercased to keep the sentence flowing (In this case, lowercasing User)<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
