### PR TITLE
ci: fix checkout stable

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -89,7 +89,7 @@ jobs:
               prev_stable=$current_version_family
           fi
           echo "::notice::Checking out ${prev_stable} as stable version..."
-          git checkout $(prev_stable)
+          git checkout ${prev_stable}
           rm -rf .github/ scripts/
           mv ../.github ../scripts .
       - name: Setup authentik env (stable)


### PR DESCRIPTION
If you don't happen to read the logs of this step, everything seems fine and `git checkout $(prev_stable)` is just interpreted as the no-op `git checkout`. That's because `$()` spawns a subshell and subshell errors don't stop execution on `set -eo pipefail`. In fact, a quick search didn't reveal any way to catch this typo with `set`.

I wonder how long this could have stayed hidden if I wasn't specifically looking at this workflow for a completely different reason.