### PR TITLE
sources/saml: Allow user matching via attributes when NameID is transient

### DIFF
--- a/authentik/sources/saml/models.py
+++ b/authentik/sources/saml/models.py
@@ -79,6 +79,20 @@ class SAMLNameIDPolicy(models.TextChoices):
     UNSPECIFIED = SAML_NAME_ID_FORMAT_UNSPECIFIED
 
 
+ATTRIBUTE_NAME_TRANSLATION_MAP = {
+    "urn:oid:0.9.2342.19200300.100.1.3": "email",
+    "urn:mace:dir:attribute-def:mail": "email",
+    "mail": "email",
+    "urn:oid:1.3.6.1.4.1.5923.1.1.1.6": "eppn",
+    "urn:mace:dir:attribute-def:eduPersonPrincipalName": "eppn",
+    "eduPersonPrincipalName": "eppn",
+    "urn:oid:1.3.6.1.4.1.5923.1.1.1.10": "eptid",
+    "eduPersonTargetedID": "eptid",
+    "urn:oid:0.9.2342.19200300.100.1.1": "uid",
+    "urn:mace:dir:attribute-def:uid": "uid",
+}
+
+
 class SAMLSource(Source):
     """Authenticate using an external SAML Identity Provider."""
 
@@ -224,16 +238,21 @@ class SAMLSource(Source):
     def property_mapping_type(self) -> type[PropertyMapping]:
         return SAMLSourcePropertyMapping
 
-    def get_base_user_properties(self, root: _Element, assertion: _Element, name_id: Any, **kwargs):
+    def extract_attributes(self, root: _Element, assertion: _Element | None = None) -> dict:
+        """Extract and normalize SAML attributes from an assertion."""
         attributes = {}
+        if assertion is None:
+            assertion = root.find(f"{{{NS_SAML_ASSERTION}}}Assertion")
         if assertion is None:
             raise ValueError("Assertion element not found")
         attribute_statement = assertion.find(f"{{{NS_SAML_ASSERTION}}}AttributeStatement")
         if attribute_statement is None:
-            raise ValueError("Attribute statement element not found")
+            return attributes
         # Get all attributes and their values into a dict
         for attribute in attribute_statement.iterchildren():
-            key = attribute.attrib["Name"]
+            key = ATTRIBUTE_NAME_TRANSLATION_MAP.get(
+                attribute.attrib["Name"], attribute.attrib["Name"]
+            )
             attributes.setdefault(key, [])
             for value in attribute.iterchildren():
                 attributes[key].append(get_element_text(value))
@@ -245,7 +264,19 @@ class SAMLSource(Source):
             if key == "groups":
                 continue
             attributes[key] = BaseEvaluator.expr_flatten(value)
-        attributes["username"] = get_element_text(name_id)
+        return attributes
+
+    def get_base_user_properties(
+        self,
+        root: _Element,
+        assertion: _Element,
+        name_id: Any,
+        saml_attributes: dict | None = None,
+        **kwargs,
+    ):
+        """Build base user properties from SAML attributes and NameID."""
+        attributes = dict(saml_attributes or self.extract_attributes(root, assertion))
+        attributes.setdefault("username", get_element_text(name_id))
 
         return attributes
 

--- a/authentik/sources/saml/processors/response.py
+++ b/authentik/sources/saml/processors/response.py
@@ -32,8 +32,7 @@ from authentik.core.models import (
     USER_ATTRIBUTE_EXPIRES,
     USER_ATTRIBUTE_GENERATED,
     USER_ATTRIBUTE_SOURCES,
-    USERNAME_MAX_LENGTH,
-    User,
+    SourceUserMatchingModes,
 )
 from authentik.core.sources.flow_manager import SourceFlowManager
 from authentik.lib.utils.time import timedelta_from_string
@@ -99,6 +98,7 @@ class ResponseProcessor:
         self._verify_request_id()
         self._verify_status()
         self._verify_conditions()
+        self._saml_attributes = self._source.extract_attributes(self._root, self.get_assertion())
 
     def _decrypt_response(self):
         """Decrypt SAMLResponse EncryptedAssertion Element"""
@@ -237,46 +237,6 @@ class ResponseProcessor:
         if message_text or detail_text:
             LOGGER.debug("SAML Status message", message=message_text, detail=detail_text)
 
-    def _handle_name_id_transient(self) -> SourceFlowManager:
-        """Handle a NameID with the Format of Transient. This is a bit more complex than other
-        formats, as we need to create a temporary User that is used in the session. This
-        user has an attribute that refers to our Source for cleanup. The user is also deleted
-        on logout and periodically."""
-        # Create a temporary User
-        name_id_el, name_id = self._get_name_id()
-        # trim username to ensure it is max 150 chars
-        username = f"ak-{name_id[: USERNAME_MAX_LENGTH - 14]}-transient"
-        expiry = mktime(
-            (now() + timedelta_from_string(self._source.temporary_user_delete_after)).timetuple()
-        )
-        user: User = User.objects.create(
-            username=username,
-            attributes={
-                USER_ATTRIBUTE_GENERATED: True,
-                USER_ATTRIBUTE_SOURCES: [
-                    self._source.name,
-                ],
-                USER_ATTRIBUTE_DELETE_ON_LOGOUT: True,
-                USER_ATTRIBUTE_EXPIRES: expiry,
-            },
-            path=self._source.get_user_path(),
-        )
-        LOGGER.debug("Created temporary user for NameID Transient", username=name_id)
-        user.set_unusable_password()
-        user.save()
-        UserSAMLSourceConnection.objects.create(source=self._source, user=user, identifier=name_id)
-        return SAMLSourceFlowManager(
-            source=self._source,
-            request=self._http_request,
-            identifier=str(name_id),
-            user_info={
-                "root": self._root,
-                "assertion": self.get_assertion(),
-                "name_id": name_id_el,
-            },
-            policy_context={},
-        )
-
     def get_assertion(self) -> Element | None:
         """Get assertion element, if we have a signed assertion"""
         if self._assertion is not None:
@@ -301,10 +261,12 @@ class ResponseProcessor:
         name_id_el, name_id = self._get_name_id()
         if not name_id:
             raise UnsupportedNameIDFormat("Subject's NameID is empty.")
-        _format = name_id_el.attrib["Format"]
+        _format = name_id_el.attrib.get("Format")
+        if not _format:
+            raise UnsupportedNameIDFormat("Subject's NameID has no Format attribute.")
         if _format == SAML_NAME_ID_FORMAT_EMAIL:
             return {"email": name_id}
-        if _format == SAML_NAME_ID_FORMAT_PERSISTENT:
+        if _format in [SAML_NAME_ID_FORMAT_PERSISTENT, SAML_NAME_ID_FORMAT_TRANSIENT]:
             return {"username": name_id}
         if _format == SAML_NAME_ID_FORMAT_X509:
             # This attribute is statically set by the LDAP source
@@ -327,22 +289,50 @@ class ResponseProcessor:
                 expected=self._source.name_id_policy,
                 got=name_id_el.attrib["Format"],
             )
-        # transient NameIDs are handled separately as they don't have to go through flows.
+        attributes = getattr(self, "_saml_attributes", None)
+        if attributes is None:
+            attributes = self._source.extract_attributes(self._root, self.get_assertion())
+
+        if self._source.user_matching_mode in [
+            SourceUserMatchingModes.USERNAME_LINK,
+            SourceUserMatchingModes.USERNAME_DENY,
+        ]:
+            if "eppn" in attributes:
+                attributes["username"] = attributes["eppn"]
+            elif "eptid" in attributes:
+                attributes["username"] = attributes["eptid"]
+
+        connection_id = name_id
         if name_id_el.attrib["Format"] == SAML_NAME_ID_FORMAT_TRANSIENT:
-            return self._handle_name_id_transient()
+            for key in ["eppn", "eptid", "email"]:
+                if key in attributes:
+                    connection_id = attributes[key]
+                    attributes["username"] = attributes[key]
+                    break
+            else:
+                expiry = mktime(
+                    (
+                        now() + timedelta_from_string(self._source.temporary_user_delete_after)
+                    ).timetuple()
+                )
+                attributes["attributes"] = {
+                    USER_ATTRIBUTE_GENERATED: True,
+                    USER_ATTRIBUTE_SOURCES: [self._source.name],
+                    USER_ATTRIBUTE_DELETE_ON_LOGOUT: True,
+                    USER_ATTRIBUTE_EXPIRES: expiry,
+                }
 
         return SAMLSourceFlowManager(
             source=self._source,
             request=self._http_request,
-            identifier=str(name_id),
+            identifier=connection_id,
             user_info={
                 "root": self._root,
                 "assertion": self.get_assertion(),
                 "name_id": name_id_el,
+                "saml_attributes": attributes,
             },
-            policy_context={
-                "saml_response": etree.tostring(self._root),
-            },
+            policy_context={"saml_response": etree.tostring(self._root)},
         )
 
 

--- a/authentik/sources/saml/tests/fixtures/response_persistent.xml
+++ b/authentik/sources/saml/tests/fixtures/response_persistent.xml
@@ -1,0 +1,113 @@
+<saml2p:Response xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol"
+                 Destination="https://sp.example.org:9443/source/saml/shibboleth-post/acs/"
+                 ID="_1f0aa41b3cbc5799f6b9cc3ffd361f00"
+                 InResponseTo="_c42dc05a9b6d40de825bf18a79662830"
+                 IssueInstant="2025-11-22T11:47:55.200Z"
+                 Version="2.0"
+                 >
+    <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">https://idp.example.org/idp/shibboleth</saml2:Issuer>
+    <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:SignedInfo>
+            <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
+            <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" />
+            <ds:Reference URI="#_1f0aa41b3cbc5799f6b9cc3ffd361f00">
+                <ds:Transforms>
+                    <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" />
+                    <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
+                </ds:Transforms>
+                <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" />
+                <ds:DigestValue>tCh2LEX0FlexYxmiT9WAzEXy7FA+9g/jvzR5IVB0z5M=</ds:DigestValue>
+            </ds:Reference>
+        </ds:SignedInfo>
+        <ds:SignatureValue>QyvJuug0eC+cVXICPZQYUXNgLKmd8Cq6ThUo7PhCdhDQIgI6QrOK6QO966OUcw2YI2mPnoDCJDInONycTrD+/37OWTBZZ9MR9q3xkGO5mfu6hKcd1pWPRxxrwHyB0PcJktkblvKE5nydJ4oVCt5QP82usJB6/M8OnJSyzWeUcnaJRJ8GSvqVv/1/R/YZSvt6MzoDJ/eRTdLRxG0cg5hLq1HMeN1lTOthlD8FAzRXdXpZpMVjlUX/gKMJg2fhZrK9DitYXXySeds6dKqF2d+jHIjhLqJVgtkeVhcickTef2W6Z66Q5WFb8G5oeBLNE1tO+H0ynFkzWFL9MzxcdaxZg4y+zuVbHEYBeKCmvSA8ZeHVQ/n0joYS6Xa/3tZ3GfQLurMoLKX3M0XY4GsB2aB9xXd+KPqtuXySZq9bDYadc9bjp6r9UY7r/vpEO6Qxq+dilPihOl2H8TnpugUM63N4v0+EoNGgaHK7ZdL1zgc+BYiRY2fVY8tP8D2nh2zw49sQ</ds:SignatureValue>
+        <ds:KeyInfo>
+            <ds:X509Data>
+                <ds:X509Certificate>MIIEJzCCAo+gAwIBAgIULkt8KW/m8IwdQ23HBongLnbONBUwDQYJKoZIhvcNAQELBQAwGjEYMBYG
+A1UEAwwPaWRwLmV4YW1wbGUub3JnMB4XDTI1MTAwODA4MjAzN1oXDTQ1MTAwODA4MjAzN1owGjEY
+MBYGA1UEAwwPaWRwLmV4YW1wbGUub3JnMIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEA
+luZ/lUn5ZZnuUGUMWSDzMNLOLCnS+vys2L7PYx50DqayRKTuV1IneHPHBfSp8+3SHDbSd6Ps1Bp+
+P9lhByIBf8daVMT3jlVqHte1lUGhLLrBwnvg8rd/TYHWT9gOxxOksRDzcbwVRvzXPy3YFZGN/QzT
+fpgeVG1kbxQ/74MG8oRcuqbuhe/mF9anAu59L8xhMn3CZQB4i02kQl/k45bdfNhVxwVc5roOBUZB
+GruoUf0JGUJpS72MtHWrnhgu6zBvUQxuLSdZWhvRD4wmalRGTkOxmU0iynE/4/Jghbjo7GPO5Nhe
+KjJFKoQKSbIjLsfmIN29+hds2t5oEhui//FQpUNGt3mDcE1wbVBG6YihPY9ziypt51rcuXOdrTsv
+Vht8jv9RVGJHVjqsWrjh49aFLXp43m6ML4DkZW1lFVeYU2XtQfTKxjPZDUF1haIQeCAyTofToUb1
+MuAiid6kWhoRHVj8uvyQ3RkgMp1GRAmubLU9P6YprTYb9W+gYj3HISadAgMBAAGjZTBjMB0GA1Ud
+DgQWBBTUfueUxuQucNVb9aVi05lSLuWGpTBCBgNVHREEOzA5gg9pZHAuZXhhbXBsZS5vcmeGJmh0
+dHBzOi8vaWRwLmV4YW1wbGUub3JnL2lkcC9zaGliYm9sZXRoMA0GCSqGSIb3DQEBCwUAA4IBgQCJ
+25bNYpyLkrtPf+kje1pJRZXbRXjOVbQ1CDevOFy9FBkgO4mL02jhpmQesQqKvzaZklA9YuMev6/X
+mL8wxa+5oVm9cSPh1eUiuhUq3PWvY+nXEy4vDbaGwGb6BK9IYDEZvCM52+1IyMenYmTM0AcUq3uq
+EipcTIMXC/EO818hvG+EEzdZRjb1mHrNAwZIgNuBmZKTkOXkcdFfcfXvYmBi7GxNrW0RfcRUI8xG
+F3yMhZriNl8vMaX8EsQuNY2wJNnRQozfHjp58TjatSbN8ltjK/dXq2dMog+y8thcADTCdWPcfYof
+Ka9ynWldilndxM03zO52McZbm7QT6Z2kWRyeabc3w44FaP5NbU8UQGVLQkXxqh8YJBVv/AnrMRRh
+WuE+eBb3Y0ssWRAc5XqTdNHgeRWtdt6AkntIK7SVlSrUXR2mkJMiVXATORX5/loDuLKKOswfPvtj
+37I6oQvrI/oLN8Klkhqp/putEHw8B3RY1Dnz5xrN1uk3Ue6m+FEjenQ=</ds:X509Certificate>
+            </ds:X509Data>
+        </ds:KeyInfo>
+    </ds:Signature>
+    <saml2p:Status>
+        <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success" />
+    </saml2p:Status>
+    <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+                     ID="_86e073e2da85dbd7b67312161530fa7f"
+                     IssueInstant="2025-11-22T11:47:55.200Z"
+                     Version="2.0"
+                     >
+        <saml2:Issuer>https://idp.example.org/idp/shibboleth</saml2:Issuer>
+        <saml2:Subject>
+            <saml2:NameID xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+                          Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"
+                          NameQualifier="https://idp.example.org/idp/shibboleth"
+                          SPNameQualifier="https://sp.example.org/source/saml/shibboleth-post/metadata/"
+                          >LHPJHTQTRBOHWQRFZIYHL7PASE67UJVM</saml2:NameID>
+            <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+                <saml2:SubjectConfirmationData Address="192.168.65.1"
+                                               InResponseTo="_c42dc05a9b6d40de825bf18a79662830"
+                                               NotOnOrAfter="2025-11-22T11:52:55.218Z"
+                                               Recipient="https://sp.example.org:9443/source/saml/shibboleth-post/acs/"
+                                               />
+            </saml2:SubjectConfirmation>
+        </saml2:Subject>
+        <saml2:Conditions NotBefore="2025-11-22T11:47:55.200Z"
+                          NotOnOrAfter="2025-11-22T11:52:55.200Z"
+                          >
+            <saml2:AudienceRestriction>
+                <saml2:Audience>https://sp.example.org/source/saml/shibboleth-post/metadata/</saml2:Audience>
+            </saml2:AudienceRestriction>
+        </saml2:Conditions>
+        <saml2:AuthnStatement AuthnInstant="2025-11-22T11:47:55.035Z"
+                              SessionIndex="_9ebbfb1a7afe0d8be4b3f639b1c5391f"
+                              >
+            <saml2:SubjectLocality Address="192.168.65.1" />
+            <saml2:AuthnContext>
+                <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml2:AuthnContextClassRef>
+            </saml2:AuthnContext>
+        </saml2:AuthnStatement>
+        <saml2:AttributeStatement>
+            <saml2:Attribute FriendlyName="schacHomeOrganization"
+                             Name="urn:oid:1.3.6.1.4.1.25178.1.2.9"
+                             NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
+                             >
+                <saml2:AttributeValue>example.org</saml2:AttributeValue>
+            </saml2:Attribute>
+            <saml2:Attribute FriendlyName="eduPersonPrincipalName"
+                             Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.6"
+                             NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
+                             >
+                <saml2:AttributeValue>test001@example.org</saml2:AttributeValue>
+            </saml2:Attribute>
+            <saml2:Attribute FriendlyName="mail"
+                             Name="urn:oid:0.9.2342.19200300.100.1.3"
+                             NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
+                             >
+                <saml2:AttributeValue>test001@example.org</saml2:AttributeValue>
+            </saml2:Attribute>
+            <saml2:Attribute FriendlyName="uid"
+                             Name="urn:oid:0.9.2342.19200300.100.1.1"
+                             NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
+                             >
+                <saml2:AttributeValue>test001</saml2:AttributeValue>
+                <saml2:AttributeValue>test001</saml2:AttributeValue>
+            </saml2:Attribute>
+        </saml2:AttributeStatement>
+    </saml2:Assertion>
+</saml2p:Response>

--- a/authentik/sources/saml/tests/fixtures/response_transient_simple.xml
+++ b/authentik/sources/saml/tests/fixtures/response_transient_simple.xml
@@ -1,0 +1,94 @@
+<saml2p:Response xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol"
+                 Destination="https://sp.example.org:9443/source/saml/shibboleth-post/acs/"
+                 ID="_adb79a9617e21b18c2d5d51311b1ba15"
+                 InResponseTo="_84535c4a5bbe430db1a58632afd60f64"
+                 IssueInstant="2025-11-22T11:52:41.790Z"
+                 Version="2.0"
+                 >
+    <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">https://idp.example.org/idp/shibboleth</saml2:Issuer>
+    <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:SignedInfo>
+            <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
+            <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" />
+            <ds:Reference URI="#_adb79a9617e21b18c2d5d51311b1ba15">
+                <ds:Transforms>
+                    <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" />
+                    <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
+                </ds:Transforms>
+                <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" />
+                <ds:DigestValue>v1ZejyRMDyf6r0jk/bs2i+xKy5PFZjarD2e1csZAdHA=</ds:DigestValue>
+            </ds:Reference>
+        </ds:SignedInfo>
+        <ds:SignatureValue>M7k5oYZkXw7yZ9JroDqELUzhLerDGsYWqM85tQciB3YA15yRrWHHL5XbDmCWPUhEAzMuVKVKcsRYucTkPDpp6eIRy4jMcOD5YBZR82kP9yVhYxSRvA2c1ZB2Mt3Yenhkx2T7IwpqrOPaCxM8iFUCUpkU652eebDYkXKO56h2zMvyHmAzg3+PSSmd424QHaGFXKc/0+/Gh0KRaceA5kYnpxxFs2OhYnlFTKB8GPftz4Jx55Cjf2w3c9FV5wpcC68tRwv3STZuvJi16nDW6WMU3QCFLaoaZpat5iNVJIhz/eXmymAGoxoPBE74DL++T+obyFm/t+JmHe71i/XxTdr4V4KgY5cIgl32gfwiaFmFCk+esWWZMXUdbjD0PnQfMl3re/YcT1aNxv98obAL+14pAilCO4cTSGj/KH6XngDOkr10F9muGcCp/QPS0pJYuXcjg26D+LDoGrF528uQ+SXfZmCkoEbni3oI7sN857txTskYoy6aDW6cR/DeIy2n613G</ds:SignatureValue>
+        <ds:KeyInfo>
+            <ds:X509Data>
+                <ds:X509Certificate>MIIEJzCCAo+gAwIBAgIULkt8KW/m8IwdQ23HBongLnbONBUwDQYJKoZIhvcNAQELBQAwGjEYMBYG
+A1UEAwwPaWRwLmV4YW1wbGUub3JnMB4XDTI1MTAwODA4MjAzN1oXDTQ1MTAwODA4MjAzN1owGjEY
+MBYGA1UEAwwPaWRwLmV4YW1wbGUub3JnMIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEA
+luZ/lUn5ZZnuUGUMWSDzMNLOLCnS+vys2L7PYx50DqayRKTuV1IneHPHBfSp8+3SHDbSd6Ps1Bp+
+P9lhByIBf8daVMT3jlVqHte1lUGhLLrBwnvg8rd/TYHWT9gOxxOksRDzcbwVRvzXPy3YFZGN/QzT
+fpgeVG1kbxQ/74MG8oRcuqbuhe/mF9anAu59L8xhMn3CZQB4i02kQl/k45bdfNhVxwVc5roOBUZB
+GruoUf0JGUJpS72MtHWrnhgu6zBvUQxuLSdZWhvRD4wmalRGTkOxmU0iynE/4/Jghbjo7GPO5Nhe
+KjJFKoQKSbIjLsfmIN29+hds2t5oEhui//FQpUNGt3mDcE1wbVBG6YihPY9ziypt51rcuXOdrTsv
+Vht8jv9RVGJHVjqsWrjh49aFLXp43m6ML4DkZW1lFVeYU2XtQfTKxjPZDUF1haIQeCAyTofToUb1
+MuAiid6kWhoRHVj8uvyQ3RkgMp1GRAmubLU9P6YprTYb9W+gYj3HISadAgMBAAGjZTBjMB0GA1Ud
+DgQWBBTUfueUxuQucNVb9aVi05lSLuWGpTBCBgNVHREEOzA5gg9pZHAuZXhhbXBsZS5vcmeGJmh0
+dHBzOi8vaWRwLmV4YW1wbGUub3JnL2lkcC9zaGliYm9sZXRoMA0GCSqGSIb3DQEBCwUAA4IBgQCJ
+25bNYpyLkrtPf+kje1pJRZXbRXjOVbQ1CDevOFy9FBkgO4mL02jhpmQesQqKvzaZklA9YuMev6/X
+mL8wxa+5oVm9cSPh1eUiuhUq3PWvY+nXEy4vDbaGwGb6BK9IYDEZvCM52+1IyMenYmTM0AcUq3uq
+EipcTIMXC/EO818hvG+EEzdZRjb1mHrNAwZIgNuBmZKTkOXkcdFfcfXvYmBi7GxNrW0RfcRUI8xG
+F3yMhZriNl8vMaX8EsQuNY2wJNnRQozfHjp58TjatSbN8ltjK/dXq2dMog+y8thcADTCdWPcfYof
+Ka9ynWldilndxM03zO52McZbm7QT6Z2kWRyeabc3w44FaP5NbU8UQGVLQkXxqh8YJBVv/AnrMRRh
+WuE+eBb3Y0ssWRAc5XqTdNHgeRWtdt6AkntIK7SVlSrUXR2mkJMiVXATORX5/loDuLKKOswfPvtj
+37I6oQvrI/oLN8Klkhqp/putEHw8B3RY1Dnz5xrN1uk3Ue6m+FEjenQ=</ds:X509Certificate>
+            </ds:X509Data>
+        </ds:KeyInfo>
+    </ds:Signature>
+    <saml2p:Status>
+        <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success" />
+    </saml2p:Status>
+    <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+                     ID="_6be4923c02a253c28d2b4bb4a302bd99"
+                     IssueInstant="2025-11-22T11:52:41.790Z"
+                     Version="2.0"
+                     >
+        <saml2:Issuer>https://idp.example.org/idp/shibboleth</saml2:Issuer>
+        <saml2:Subject>
+            <saml2:NameID xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+                          Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
+                          NameQualifier="https://idp.example.org/idp/shibboleth"
+                          SPNameQualifier="https://sp.example.org/source/saml/shibboleth-post/metadata/"
+                          >_ef5783d83c0d4147212322815d7e4064</saml2:NameID>
+            <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+                <saml2:SubjectConfirmationData Address="192.168.65.1"
+                                               InResponseTo="_84535c4a5bbe430db1a58632afd60f64"
+                                               NotOnOrAfter="2025-11-22T11:57:41.875Z"
+                                               Recipient="https://sp.example.org:9443/source/saml/shibboleth-post/acs/"
+                                               />
+            </saml2:SubjectConfirmation>
+        </saml2:Subject>
+        <saml2:Conditions NotBefore="2025-11-22T11:52:41.790Z"
+                          NotOnOrAfter="2025-11-22T11:57:41.790Z"
+                          >
+            <saml2:AudienceRestriction>
+                <saml2:Audience>https://sp.example.org/source/saml/shibboleth-post/metadata/</saml2:Audience>
+            </saml2:AudienceRestriction>
+        </saml2:Conditions>
+        <saml2:AuthnStatement AuthnInstant="2025-11-22T11:47:55.035Z"
+                              SessionIndex="_e707e7a4d277deb4952e2683c18ff943"
+                              >
+            <saml2:SubjectLocality Address="192.168.65.1" />
+            <saml2:AuthnContext>
+                <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml2:AuthnContextClassRef>
+            </saml2:AuthnContext>
+        </saml2:AuthnStatement>
+        <saml2:AttributeStatement>
+            <saml2:Attribute FriendlyName="schacHomeOrganization"
+                             Name="urn:oid:1.3.6.1.4.1.25178.1.2.9"
+                             NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
+                             >
+                <saml2:AttributeValue>example.org</saml2:AttributeValue>
+            </saml2:Attribute>
+        </saml2:AttributeStatement>
+    </saml2:Assertion>
+</saml2p:Response>

--- a/authentik/sources/saml/tests/test_response.py
+++ b/authentik/sources/saml/tests/test_response.py
@@ -355,7 +355,7 @@ class TestResponseProcessor(TestCase):
         full_name_id = "_ce3d2948b4cf20146dee0a0b3dd6f69b6cf86f62d7"
         # The text before the comment, which is what ``name_id.text`` returns.
         truncated_name_id = "_ce3d2948b4cf20146dee0a0b3dd6f"
-        commented_name_id = f"{truncated_name_id}<!--x-->{full_name_id[len(truncated_name_id):]}"
+        commented_name_id = f"{truncated_name_id}<!--x-->{full_name_id[len(truncated_name_id) :]}"
         fixture = load_fixture("fixtures/response_signed_assertion.xml").replace(
             full_name_id, commented_name_id
         )
@@ -419,7 +419,7 @@ class TestResponseProcessor(TestCase):
             root=parser._root, assertion=parser.get_assertion(), name_id=name_id_el
         )
         # The attribute value must not be truncated at the comment.
-        self.assertEqual(properties["mail"], "test@example.com")
+        self.assertEqual(properties["email"], "test@example.com")
 
     @freeze_time("2014-07-17T01:02:18Z")
     def test_verification_response(self):
@@ -566,7 +566,7 @@ class TestResponseProcessor(TestCase):
         parser = ResponseProcessor(self.source, request)
         parser.parse()
 
-    @freeze_time("2026-01-21T14:23")
+    @freeze_time("2026-01-21T14:23:00Z")
     def test_transient(self):
         """Test SAML transient NameID"""
         verification_key = load_fixture("fixtures/signature_cert2.pem")
@@ -588,4 +588,138 @@ class TestResponseProcessor(TestCase):
 
         parser = ResponseProcessor(self.source, request)
         parser.parse()
-        parser.prepare_flow_manager()
+        sfm = parser.prepare_flow_manager()
+
+        self.assertEqual(sfm.identifier, "test001@example.org")
+        self.assertEqual(
+            sfm.user_properties,
+            {
+                "username": "test001@example.org",
+                "path": self.source.get_user_path(),
+                "attributes": {},
+                "email": "test001@mail.example.org",
+                "eppn": "test001@example.org",
+                "uid": "test001",
+                "urn:oid:1.3.6.1.4.1.25178.1.2.9": "example.org",
+            },
+        )
+
+    @freeze_time("2025-11-22T11:53:00Z")
+    def test_transient_simple(self):
+        """Test SAML transient NameID without stable attributes."""
+        request = self.factory.post(
+            "/",
+            data={
+                "SAMLResponse": b64encode(
+                    load_fixture("fixtures/response_transient_simple.xml").encode()
+                ).decode()
+            },
+        )
+
+        parser = ResponseProcessor(self.source, request)
+        parser.parse()
+        sfm = parser.prepare_flow_manager()
+
+        username = "_ef5783d83c0d4147212322815d7e4064"
+        self.assertEqual(sfm.identifier, username)
+        self.assertEqual(
+            sfm.user_properties,
+            {
+                "username": username,
+                "path": self.source.get_user_path(),
+                "urn:oid:1.3.6.1.4.1.25178.1.2.9": "example.org",
+                "attributes": {
+                    "goauthentik.io/user/delete-on-logout": True,
+                    "goauthentik.io/user/expires": 1763898780.0,
+                    "goauthentik.io/user/generated": True,
+                    "goauthentik.io/user/sources": [self.source.name],
+                },
+            },
+        )
+
+    @freeze_time("2025-11-22T11:50:00Z")
+    def test_persistent(self):
+        """Test SAML persistent NameID."""
+        request = self.factory.post(
+            "/",
+            data={
+                "SAMLResponse": b64encode(
+                    load_fixture("fixtures/response_persistent.xml").encode()
+                ).decode()
+            },
+        )
+
+        parser = ResponseProcessor(self.source, request)
+        parser.parse()
+        sfm = parser.prepare_flow_manager()
+        self.assertEqual(
+            sfm.user_properties,
+            {
+                "email": "test001@example.org",
+                "eppn": "test001@example.org",
+                "urn:oid:1.3.6.1.4.1.25178.1.2.9": "example.org",
+                "uid": "test001",
+                "username": "LHPJHTQTRBOHWQRFZIYHL7PASE67UJVM",
+                "path": self.source.get_user_path(),
+                "attributes": {},
+            },
+        )
+
+    @freeze_time("2025-11-22T11:50:00Z")
+    def test_persistent_match_email(self):
+        """Test persistent NameID with email matching."""
+        request = self.factory.post(
+            "/",
+            data={
+                "SAMLResponse": b64encode(
+                    load_fixture("fixtures/response_persistent.xml").encode()
+                ).decode()
+            },
+        )
+
+        self.source.user_matching_mode = SourceUserMatchingModes.EMAIL_LINK
+        parser = ResponseProcessor(self.source, request)
+        parser.parse()
+        sfm = parser.prepare_flow_manager()
+        self.assertEqual(
+            sfm.user_properties,
+            {
+                "eppn": "test001@example.org",
+                "uid": "test001",
+                "urn:oid:1.3.6.1.4.1.25178.1.2.9": "example.org",
+                "email": "test001@example.org",
+                "username": "LHPJHTQTRBOHWQRFZIYHL7PASE67UJVM",
+                "path": self.source.get_user_path(),
+                "attributes": {},
+            },
+        )
+
+    @freeze_time("2025-11-22T11:50:00Z")
+    def test_persistent_match_eppn(self):
+        """Test persistent NameID with username matching."""
+        request = self.factory.post(
+            "/",
+            data={
+                "SAMLResponse": b64encode(
+                    load_fixture("fixtures/response_persistent.xml").encode()
+                ).decode()
+            },
+        )
+
+        self.source.user_matching_mode = SourceUserMatchingModes.USERNAME_LINK
+        parser = ResponseProcessor(self.source, request)
+        parser.parse()
+        sfm = parser.prepare_flow_manager()
+        self.assertEqual(sfm.identifier, "LHPJHTQTRBOHWQRFZIYHL7PASE67UJVM")
+        self.assertEqual(
+            sfm.user_properties,
+            {
+                "uid": "test001",
+                "email": "test001@example.org",
+                "urn:oid:1.3.6.1.4.1.25178.1.2.9": "example.org",
+                "eppn": "test001@example.org",
+                "username": "test001@example.org",
+                "path": self.source.get_user_path(),
+                "attributes": {},
+            },
+        )


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
This PR extends the behavior when handling SAML Assertions with a transient NameID, as discussed in https://github.com/goauthentik/authentik/issues/12766

In the current implementation, if the NameID is transient, the system immediately creates a temporary user without evaluating any SAML attributes. However, some Identity Providers (IdPs) expect that attribute-based user identification will still occur in such cases.

This patch introduces a proof-of-concept behavior in which, when NameID is transient, certain attributes are used to construct a provisional username, which is then passed to the user matching process according to the configured SourceUserMatchingModes. This approach is more aligned with how platforms like Authentik handle such scenarios.

Specifically:
- If SourceUserMatchingModes is EMAIL_LINK or DENY, and an email attribute is present, it is used as the provisional username.
- If USERNAME_LINK or DENY, and an ePPN attribute is present, it is used as the provisional username.
- In all other cases (e.g., modes including IDENTITY), the system falls back to the existing behavior, using the transient NameID as the username to create a temporary user, which will be deleted upon logout or after a timeout.

In addition, this patch changes the behavior so that if the user's `username` is explicitly set via property mapping, the user is no longer treated as temporary — even if the original NameID was transient.

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
