### PR TITLE
website/integrations: harbor: fix slashes in URLs and group claim name

### DIFF
--- a/website/integrations/infrastructure/harbor/index.md
+++ b/website/integrations/infrastructure/harbor/index.md
@@ -35,7 +35,7 @@ To support the integration of Harbor with authentik, you need to create an appli
 - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
     - **Protocol Settings**:
         - **Redirect URI**:
-            - Strict: `https://harbor.company/c/oidc/callback/`.
+            - Strict: `https://harbor.company/c/oidc/callback`.
         - **Signing Key**: select any available signing key.
     - **Advanced Protocol Settings**:
         - **Scopes**: add `authentik default OAuth Mapping: OpenID 'offline_access'` to **Selected Scopes**.
@@ -52,9 +52,10 @@ To support the integration of authentik with Harbor, you need to configure OIDC 
 2. Navigate to **Configuration** and select the **Authentication** tab.
 3. In the **Auth Mode** dropdown, select **OIDC** and provide the following required configurations.
     - **OIDC Provider Name**: `authentik`
-    - **OIDC Endpoint**: `https://authentik.company/application/o/harbor`
+    - **OIDC Endpoint**: `https://authentik.company/application/o/harbor/`
     - **OIDC Client ID**: client ID from authentik
     - **OIDC Client Secret**: client secret from authentik
+    - **Group Claim Name**: `groups`
     - **OIDC Scope**: `openid,profile,email,offline_access`
     - **Username Claim**: `preferred_username`
 


### PR DESCRIPTION
Hello!

When I configured the Harbor integration I ran into two issues and fixed them in the documentation.

Fixes:
- URI fix: The slash required in Harbor and not required in Authentik strict URL
- Group Claim Name fix: If provided Harbor fetches groups and admin group can be used.