### PR TITLE
core: Optimize list users and groups api

### DIFF
--- a/authentik/core/api/groups.py
+++ b/authentik/core/api/groups.py
@@ -98,13 +98,15 @@ class GroupSerializer(ModelSerializer):
     def get_users_obj(self, instance: Group) -> list[PartialUserSerializer] | None:
         if not self._should_include_users:
             return None
-        return PartialUserSerializer(instance.users, many=True).data
+        # Use .all() to access prefetched data instead of triggering new queries
+        return PartialUserSerializer(instance.users.all(), many=True).data
 
     @extend_schema_field(GroupChildSerializer(many=True))
     def get_children_obj(self, instance: Group) -> list[GroupChildSerializer] | None:
         if not self._should_include_children:
             return None
-        return GroupChildSerializer(instance.children, many=True).data
+        # Use .all() to access prefetched data instead of triggering new queries
+        return GroupChildSerializer(instance.children.all(), many=True).data
 
     def validate_parent(self, parent: Group | None):
         """Validate group parent (if set), ensuring the parent isn't itself"""
@@ -251,8 +253,18 @@ class GroupViewSet(UsedByMixin, ModelViewSet):
                 Prefetch("users", queryset=User.objects.all().only("id"))
             )
 
+        # Always prefetch children since the serializer includes 'children' field for PKs
+        # even when include_children=false
         if self.serializer_class(context={"request": self.request})._should_include_children:
-            base_qs = base_qs.prefetch_related("children")
+            # When including full children data, prefetch with parent selected
+            base_qs = base_qs.prefetch_related(
+                Prefetch("children", queryset=Group.objects.select_related("parent"))
+            )
+        else:
+            # When only needing PKs, just prefetch IDs
+            base_qs = base_qs.prefetch_related(
+                Prefetch("children", queryset=Group.objects.all().only("group_uuid"))
+            )
 
         return base_qs
 

--- a/authentik/core/api/users.py
+++ b/authentik/core/api/users.py
@@ -147,7 +147,8 @@ class UserSerializer(ModelSerializer):
     def get_groups_obj(self, instance: User) -> list[PartialGroupSerializer] | None:
         if not self._should_include_groups:
             return None
-        return PartialGroupSerializer(instance.ak_groups, many=True).data
+        # Use .all() to access prefetched data instead of triggering new queries
+        return PartialGroupSerializer(instance.ak_groups.all(), many=True).data
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -452,9 +453,31 @@ class UserViewSet(UsedByMixin, ModelViewSet):
         ]
 
     def get_queryset(self):
+        from django.db.models import Exists, OuterRef, Prefetch, Q
+
+        from authentik.core.models import Group
+
         base_qs = User.objects.all().exclude_anonymous()
+
+        # Annotate is_superuser to avoid expensive recursive CTE for each user
+        # This checks if user is in any superuser group
+        base_qs = base_qs.annotate(
+            is_superuser=Exists(
+                Group.objects.filter(Q(users=OuterRef("pk")) & Q(is_superuser=True))
+            )
+        )
+
+        # Always prefetch groups since UserSerializer includes 'groups' field for PKs
         if self.serializer_class(context={"request": self.request})._should_include_groups:
-            base_qs = base_qs.prefetch_related("ak_groups")
+            # When including full group data, prefetch with parent selected
+            base_qs = base_qs.prefetch_related(
+                Prefetch("ak_groups", queryset=Group.objects.select_related("parent"))
+            )
+        else:
+            # When only needing PKs, just prefetch minimal data
+            base_qs = base_qs.prefetch_related(
+                Prefetch("ak_groups", queryset=Group.objects.all().only("pk"))
+            )
         return base_qs
 
     @extend_schema(

--- a/authentik/core/api/users.py
+++ b/authentik/core/api/users.py
@@ -456,17 +456,6 @@ class UserViewSet(UsedByMixin, ModelViewSet):
     def get_queryset(self):
         base_qs = User.objects.all().exclude_anonymous()
 
-        # Annotate is_superuser to avoid expensive recursive CTE for each user
-        # This checks if user is in any superuser group
-        base_qs = base_qs.annotate(
-            is_superuser=Exists(
-                Group.objects.filter(
-                    users=OuterRef("pk"),
-                    is_superuser=True,
-                )
-            )
-        )
-
         # Always prefetch groups since UserSerializer includes 'groups' field for PKs
         if self.serializer_class(context={"request": self.request})._should_include_groups:
             # When including full group data, prefetch with parent selected


### PR DESCRIPTION
Attempt at optimizing users and groups api for users with a lot of groups

## Details

These changes reduced the response time by a factor of two or three when listing users and groups and reduced CPU load in pods and posgres. Most noticable improvement is when include_users=true or include_groups=true.

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
