### PR TITLE
stages/captcha: allow dynamic public/private key

### DIFF
--- a/authentik/stages/identification/stage.py
+++ b/authentik/stages/identification/stage.py
@@ -30,7 +30,11 @@ from authentik.lib.avatars import DEFAULT_AVATAR
 from authentik.lib.utils.reflection import all_subclasses
 from authentik.lib.utils.urls import reverse_with_qs
 from authentik.root.middleware import ClientIPMiddleware
-from authentik.stages.captcha.stage import CaptchaChallenge, verify_captcha_token
+from authentik.stages.captcha.stage import (
+    PLAN_CONTEXT_CAPTCHA_PRIVATE_KEY,
+    CaptchaChallenge,
+    verify_captcha_token,
+)
 from authentik.stages.identification.models import IdentificationStage
 from authentik.stages.identification.signals import identification_failed
 from authentik.stages.password.stage import authenticate
@@ -149,7 +153,12 @@ class IdentificationChallengeResponse(ChallengeResponse):
             if not captcha_token:
                 self.stage.logger.warning("Token not set for captcha attempt")
             try:
-                verify_captcha_token(captcha_stage, captcha_token, client_ip)
+                verify_captcha_token(
+                    captcha_stage,
+                    captcha_token,
+                    client_ip,
+                    key=self.stage.executor.plan.context.get(PLAN_CONTEXT_CAPTCHA_PRIVATE_KEY),
+                )
             except ValidationError:
                 raise ValidationError(_("Failed to authenticate.")) from None
 

--- a/website/docs/add-secure-apps/flows-stages/flow/context/index.mdx
+++ b/website/docs/add-secure-apps/flows-stages/flow/context/index.mdx
@@ -105,7 +105,7 @@ Key-value pairs of the data that is included in the form and will be submitted t
 
 ##### `captcha` (dictionary)
 
-When `error_on_invalid_score` (TODO) is set to false on a captcha stage, after the execution of the captcha stage, this object will be set in the flow context.
+When _Error on invalid score_ is set to false on a captcha stage, after the execution of the captcha stage, this object will be set in the flow context.
 
 It contains two keys, `response` which is the raw response from the specified captcha verification URL, and `stage`, which is a reference to the captcha stage that executed the test.
 

--- a/website/docs/add-secure-apps/flows-stages/flow/context/index.mdx
+++ b/website/docs/add-secure-apps/flows-stages/flow/context/index.mdx
@@ -109,9 +109,9 @@ When _Error on invalid score_ is set to false on a captcha stage, after the exec
 
 It contains two keys, `response` which is the raw response from the specified captcha verification URL, and `stage`, which is a reference to the captcha stage that executed the test.
 
-#### `goauthentik.io/stages/captcha/site_key` (string)
+#### `goauthentik.io/stages/captcha/site_key` (string):ak-version[2025.12]
 
-#### `goauthentik.io/stages/captcha/private_key` (string)
+#### `goauthentik.io/stages/captcha/private_key` (string):ak-version[2025.12]
 
 Optionally set captcha site and private keys dynamically through a policy, for example when using E2E testing with a captcha stage bound.
 

--- a/website/docs/add-secure-apps/flows-stages/flow/context/index.mdx
+++ b/website/docs/add-secure-apps/flows-stages/flow/context/index.mdx
@@ -109,6 +109,12 @@ When `error_on_invalid_score` (TODO) is set to false on a captcha stage, after t
 
 It contains two keys, `response` which is the raw response from the specified captcha verification URL, and `stage`, which is a reference to the captcha stage that executed the test.
 
+#### `goauthentik.io/stages/captcha/site_key` (string)
+
+#### `goauthentik.io/stages/captcha/private_key` (string)
+
+Optionally set captcha site and private keys dynamically through a policy, for example when using E2E testing with a captcha stage bound.
+
 #### Consent stage
 
 ##### `consent_header` (string)


### PR DESCRIPTION
ref https://github.com/goauthentik/internal-customer-ref/issues/2

allow setting captcha public/private keys dynamically more easily

closes #18159