### PR TITLE
policies: use flow planner directly in PolicyAccessView to directly set flow context

### DIFF
--- a/authentik/core/views/apps.py
+++ b/authentik/core/views/apps.py
@@ -40,7 +40,7 @@ class RedirectToAppLaunch(View):
         self.request.session[SESSION_KEY_APPLICATION_PRE] = app
         # otherwise, do a custom flow plan that includes the application that's
         # being accessed, to improve usability
-        flow = ToDefaultFlow(request=request, designation=FlowDesignation.AUTHENTICATION).get_flow()
+        flow = ToDefaultFlow.get_flow(request=request, designation=FlowDesignation.AUTHENTICATION)
         planner = FlowPlanner(flow)
         planner.allow_empty_flows = True
         try:

--- a/authentik/flows/planner.py
+++ b/authentik/flows/planner.py
@@ -143,10 +143,12 @@ class FlowPlan:
         self,
         request: HttpRequest,
         flow: Flow,
+        next: str | None = None,
         allowed_silent_types: list["StageView"] | None = None,
     ) -> HttpResponse:
         """Redirect to the flow executor for this flow plan"""
         from authentik.flows.views.executor import (
+            NEXT_ARG_NAME,
             SESSION_KEY_PLAN,
             FlowExecutorView,
         )
@@ -174,6 +176,8 @@ class FlowPlan:
             or request.user.has_perm("authentik_flows.inspect_flow")
         ):
             get_qs["inspector"] = "available"
+        if next:
+            get_qs[NEXT_ARG_NAME] = next
 
         return redirect_with_qs(
             "authentik_core:if-flow",

--- a/authentik/flows/planner.py
+++ b/authentik/flows/planner.py
@@ -39,6 +39,7 @@ PLAN_CONTEXT_REDIRECT = "redirect"
 PLAN_CONTEXT_APPLICATION = "application"
 PLAN_CONTEXT_SOURCE = "source"
 PLAN_CONTEXT_OUTPOST = "outpost"
+PLAN_CONTEXT_POST = "goauthentik.io/http/post"
 # Is set by the Flow Planner when a FlowToken was used, and the currently active flow plan
 # was restored.
 PLAN_CONTEXT_IS_RESTORED = "is_restored"

--- a/authentik/policies/tests/test_views.py
+++ b/authentik/policies/tests/test_views.py
@@ -55,6 +55,7 @@ class TestPolicyViews(TestCase):
 
     def test_pav_unauthenticated_no_flow(self):
         """Test simple policy access view (unauthenticated access, no authentication flow)"""
+        Flow.objects.filter(designation=FlowDesignation.AUTHENTICATION).delete()
         provider = Provider.objects.create(
             name=generate_id(),
         )

--- a/authentik/policies/tests/test_views.py
+++ b/authentik/policies/tests/test_views.py
@@ -4,9 +4,10 @@ from django.http import HttpResponse
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 
+from authentik.blueprints.tests import apply_blueprint
 from authentik.core.models import Application, Provider
-from authentik.core.tests.utils import create_test_flow, create_test_user
-from authentik.flows.models import FlowDesignation
+from authentik.core.tests.utils import create_test_brand, create_test_flow, create_test_user
+from authentik.flows.models import Flow, FlowDesignation
 from authentik.flows.planner import FlowPlan
 from authentik.flows.views.executor import SESSION_KEY_PLAN
 from authentik.lib.generators import generate_id
@@ -79,13 +80,14 @@ class TestPolicyViews(TestCase):
         self.assertTrue(res.url.startswith(reverse("authentik_policies:buffer")))
 
     @patch_flag(BufferedPolicyAccessViewFlag, True)
+    @apply_blueprint("default/flow-default-authentication-flow.yaml")
     def test_pav_buffer_skip(self):
         """Test simple policy access view (skip buffer)"""
         provider = Provider.objects.create(
             name=generate_id(),
         )
         app = Application.objects.create(name=generate_id(), slug=generate_id(), provider=provider)
-        flow = create_test_flow(FlowDesignation.AUTHENTICATION)
+        flow = Flow.objects.get(slug="default-authentication-flow")
 
         class TestView(BufferedPolicyAccessView):
             def resolve_provider_application(self):
@@ -97,13 +99,16 @@ class TestPolicyViews(TestCase):
 
         req = self.factory.get("/?skip_buffer=true")
         req.user = AnonymousUser()
+        req.brand = create_test_brand(flow_authentication=flow)
         middleware = SessionMiddleware(dummy_get_response)
         middleware.process_request(req)
         req.session[SESSION_KEY_PLAN] = FlowPlan(flow.pk)
         req.session.save()
         res = TestView.as_view()(req)
         self.assertEqual(res.status_code, 302)
-        self.assertTrue(res.url.startswith(reverse("authentik_flows:default-authentication")))
+        self.assertTrue(
+            res.url.startswith(reverse("authentik_core:if-flow", kwargs={"flow_slug": flow.slug}))
+        )
 
     def test_buffer(self):
         """Test buffer view"""

--- a/authentik/policies/views.py
+++ b/authentik/policies/views.py
@@ -122,7 +122,7 @@ class PolicyAccessView(AccessMixin, View):
         except (FlowNonApplicableException, EmptyFlowException) as exc:
             LOGGER.warning("Non-applicable authentication flow", exc=exc)
             raise Http404 from None
-        return plan.to_redirect(self.request, flow)
+        return plan.to_redirect(self.request, flow, next=self.request.get_full_path())
 
     def handle_no_permission_authenticated(
         self, result: PolicyResult | None = None

--- a/authentik/policies/views.py
+++ b/authentik/policies/views.py
@@ -5,8 +5,7 @@ from uuid import uuid4
 
 from django.contrib import messages
 from django.contrib.auth.mixins import AccessMixin
-from django.contrib.auth.views import redirect_to_login
-from django.http import HttpRequest, HttpResponse, QueryDict
+from django.http import Http404, HttpRequest, HttpResponse, QueryDict
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.http import urlencode
@@ -15,17 +14,25 @@ from django.views.generic.base import TemplateView, View
 from structlog.stdlib import get_logger
 
 from authentik.core.models import Application, Provider, User
+from authentik.flows.exceptions import FlowNonApplicableException
 from authentik.flows.models import Flow, FlowDesignation
-from authentik.flows.planner import FlowPlan
+from authentik.flows.planner import (
+    PLAN_CONTEXT_APPLICATION,
+    PLAN_CONTEXT_POST,
+    FlowPlan,
+    FlowPlanner,
+)
 from authentik.flows.views.executor import (
     SESSION_KEY_APPLICATION_PRE,
     SESSION_KEY_PLAN,
     SESSION_KEY_POST,
+    ToDefaultFlow,
 )
 from authentik.lib.sentry import SentryIgnoredException
 from authentik.policies.apps import BufferedPolicyAccessViewFlag
 from authentik.policies.denied import AccessDeniedResponse
 from authentik.policies.engine import PolicyEngine
+from authentik.policies.models import PolicyBindingModel
 from authentik.policies.types import PolicyRequest, PolicyResult
 
 LOGGER = get_logger()
@@ -55,8 +62,8 @@ class PolicyAccessView(AccessMixin, View):
     """Mixin class for usage in Authorization views.
     Provider functions to check application access, etc"""
 
-    provider: Provider
-    application: Application
+    provider: Provider | None = None
+    application: Application | None = None
 
     def pre_permission_check(self):
         """Optionally hook in before permission check to check if a request is valid.
@@ -96,17 +103,26 @@ class PolicyAccessView(AccessMixin, View):
         """User has no access and is not authenticated, so we remember the application
         they try to access and redirect to the login URL. The application is saved to show
         a hint on the Identification Stage what the user should login for."""
+        flow_context = {}
         if self.application:
             self.request.session[SESSION_KEY_APPLICATION_PRE] = self.application
+            flow_context[PLAN_CONTEXT_APPLICATION] = self.application
         # Because this view might get hit with a POST request, we need to preserve that data
         # since later views might need it (mostly SAML)
         if self.request.method.lower() == "post":
             self.request.session[SESSION_KEY_POST] = self.request.POST
-        return redirect_to_login(
-            self.request.get_full_path(),
-            self.get_login_url(),
-            self.get_redirect_field_name(),
-        )
+            flow_context[PLAN_CONTEXT_POST] = self.request.POST
+
+        flow = ToDefaultFlow.get_flow(self.request, FlowDesignation.AUTHENTICATION)
+        if not flow:
+            raise Http404
+        planner = FlowPlanner(flow)
+        try:
+            plan = planner.plan(self.request, self.modify_flow_context(flow, flow_context))
+        except FlowNonApplicableException as exc:
+            LOGGER.warning("Non-applicable authentication flow", exc=exc)
+            raise Http404 from None
+        return plan.to_redirect(self.request, flow)
 
     def handle_no_permission_authenticated(
         self, result: PolicyResult | None = None
@@ -121,19 +137,29 @@ class PolicyAccessView(AccessMixin, View):
         """optionally modify the policy request"""
         return request
 
-    def user_has_access(self, user: User | None = None) -> PolicyResult:
+    def modify_flow_context(self, flow: Flow, context: dict[str, Any]) -> dict[str, Any]:
+        """optionally modify the flow context which is used for the authentication flow"""
+        return context
+
+    def user_has_access(
+        self, user: User | None = None, pbm: PolicyBindingModel | None = None
+    ) -> PolicyResult:
         """Check if user has access to application."""
         user = user or self.request.user
-        policy_engine = PolicyEngine(self.application, user or self.request.user, self.request)
+        policy_engine = PolicyEngine(
+            pbm or self.application, user or self.request.user, self.request
+        )
         policy_engine.use_cache = False
         policy_engine.request = self.modify_policy_request(policy_engine.request)
         policy_engine.build()
         result = policy_engine.result
+        log_kwargs = {}
+        if pbm:
+            log_kwargs["pbm"] = pbm.pk
+        else:
+            log_kwargs["app"] = self.application.slug
         LOGGER.debug(
-            "PolicyAccessView user_has_access",
-            user=user.username,
-            app=self.application.slug,
-            result=result,
+            "PolicyAccessView user_has_access", user=user.username, result=result, **log_kwargs
         )
         if not result.passing:
             for message in result.messages:

--- a/authentik/policies/views.py
+++ b/authentik/policies/views.py
@@ -14,7 +14,7 @@ from django.views.generic.base import TemplateView, View
 from structlog.stdlib import get_logger
 
 from authentik.core.models import Application, Provider, User
-from authentik.flows.exceptions import FlowNonApplicableException
+from authentik.flows.exceptions import EmptyFlowException, FlowNonApplicableException
 from authentik.flows.models import Flow, FlowDesignation
 from authentik.flows.planner import (
     PLAN_CONTEXT_APPLICATION,
@@ -119,7 +119,7 @@ class PolicyAccessView(AccessMixin, View):
         planner = FlowPlanner(flow)
         try:
             plan = planner.plan(self.request, self.modify_flow_context(flow, flow_context))
-        except FlowNonApplicableException as exc:
+        except (FlowNonApplicableException, EmptyFlowException) as exc:
             LOGGER.warning("Non-applicable authentication flow", exc=exc)
             raise Http404 from None
         return plan.to_redirect(self.request, flow)

--- a/authentik/providers/oauth2/tests/test_authorize.py
+++ b/authentik/providers/oauth2/tests/test_authorize.py
@@ -672,6 +672,7 @@ class TestAuthorize(OAuthTestCase):
         parsed = OAuthAuthorizationParams.from_request(request)
         self.assertNotIn(SCOPE_OFFLINE_ACCESS, parsed.scope)
 
+    @apply_blueprint("default/flow-default-authentication-flow.yaml")
     def test_ui_locales(self):
         """Test OIDC ui_locales authorization"""
         flow = create_test_flow()
@@ -698,6 +699,7 @@ class TestAuthorize(OAuthTestCase):
         parsed = parse_qs(urlparse(response.url).query)
         self.assertEqual(parsed["locale"], ["fr"])
 
+    @apply_blueprint("default/flow-default-authentication-flow.yaml")
     def test_ui_locales_invalid(self):
         """Test OIDC ui_locales authorization"""
         flow = create_test_flow()


### PR DESCRIPTION
#6954

allows us to move more stuff out of the session and into the flow context