### PR TITLE
root: improve testing helpers

### DIFF
--- a/authentik/core/tests/test_source_flow_manager.py
+++ b/authentik/core/tests/test_source_flow_manager.py
@@ -100,7 +100,11 @@ class TestSourceFlowManager(TestCase):
     def test_unauthenticated_link(self):
         """Test un-authenticated user linking"""
         flow_manager = OAuthSourceFlowManager(
-            self.source, self.request_factory.get("/"), self.identifier, {"info": {}}, {}
+            self.source,
+            self.request_factory.get("/", user=get_anonymous_user()),
+            self.identifier,
+            {"info": {}},
+            {},
         )
         action, connection = flow_manager.get_action()
         self.assertEqual(action, Action.LINK)

--- a/authentik/core/tests/test_token_auth.py
+++ b/authentik/core/tests/test_token_auth.py
@@ -4,9 +4,9 @@ from django.test import TestCase
 
 from authentik.core.auth import TokenBackend
 from authentik.core.models import Token, TokenIntents, User
+from authentik.core.tests.utils import RequestFactory
 from authentik.flows.planner import FlowPlan
 from authentik.flows.views.executor import SESSION_KEY_PLAN
-from authentik.lib.tests.utils import get_request
 
 
 class TestTokenAuth(TestCase):
@@ -17,8 +17,9 @@ class TestTokenAuth(TestCase):
         self.token = Token.objects.create(
             expiring=False, user=self.user, intent=TokenIntents.INTENT_APP_PASSWORD
         )
+        self.request_factory = RequestFactory()
         # To test with session we need to create a request and pass it through all middlewares
-        self.request = get_request("/")
+        self.request = self.request_factory.get("/")
         self.request.session[SESSION_KEY_PLAN] = FlowPlan("test")
 
     def test_token_auth(self):

--- a/authentik/flows/tests/test_planner.py
+++ b/authentik/flows/tests/test_planner.py
@@ -10,7 +10,12 @@ from django.urls import reverse
 
 from authentik.blueprints.tests import reconcile_app
 from authentik.core.models import User
-from authentik.core.tests.utils import RequestFactory, create_test_admin_user, create_test_flow
+from authentik.core.tests.utils import (
+    RequestFactory,
+    create_test_admin_user,
+    create_test_flow,
+    dummy_get_response,
+)
 from authentik.flows.exceptions import EmptyFlowException, FlowNonApplicableException
 from authentik.flows.markers import ReevaluateMarker, StageMarker
 from authentik.flows.models import (
@@ -27,7 +32,6 @@ from authentik.flows.planner import (
 )
 from authentik.flows.stage import StageView
 from authentik.lib.generators import generate_id
-from authentik.lib.tests.utils import dummy_get_response
 from authentik.outposts.apps import MANAGED_OUTPOST
 from authentik.outposts.models import Outpost
 from authentik.policies.dummy.models import DummyPolicy

--- a/authentik/flows/tests/test_planner.py
+++ b/authentik/flows/tests/test_planner.py
@@ -2,18 +2,15 @@
 
 from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
-from django.contrib.auth.models import AnonymousUser
-from django.contrib.sessions.middleware import SessionMiddleware
 from django.core.cache import cache
 from django.http import HttpRequest
 from django.shortcuts import redirect
-from django.test import RequestFactory, TestCase
+from django.test import TestCase
 from django.urls import reverse
-from guardian.shortcuts import get_anonymous_user
 
 from authentik.blueprints.tests import reconcile_app
 from authentik.core.models import User
-from authentik.core.tests.utils import create_test_admin_user, create_test_flow
+from authentik.core.tests.utils import RequestFactory, create_test_admin_user, create_test_flow
 from authentik.flows.exceptions import EmptyFlowException, FlowNonApplicableException
 from authentik.flows.markers import ReevaluateMarker, StageMarker
 from authentik.flows.models import (
@@ -57,7 +54,6 @@ class TestFlowPlanner(TestCase):
         request = self.request_factory.get(
             reverse("authentik_api:flow-executor", kwargs={"flow_slug": flow.slug}),
         )
-        request.user = get_anonymous_user()
 
         with self.assertRaises(EmptyFlowException):
             planner = FlowPlanner(flow)
@@ -70,7 +66,6 @@ class TestFlowPlanner(TestCase):
         request = self.request_factory.get(
             reverse("authentik_api:flow-executor", kwargs={"flow_slug": flow.slug}),
         )
-        request.user = AnonymousUser()
         planner = FlowPlanner(flow)
         planner.allow_empty_flows = True
         planner.plan(request)
@@ -94,7 +89,6 @@ class TestFlowPlanner(TestCase):
         request = self.request_factory.get(
             reverse("authentik_api:flow-executor", kwargs={"flow_slug": flow.slug}),
         )
-        request.user = AnonymousUser()
         planner = FlowPlanner(flow)
         planner.allow_empty_flows = True
 
@@ -113,7 +107,6 @@ class TestFlowPlanner(TestCase):
         request = self.request_factory.get(
             reverse("authentik_api:flow-executor", kwargs={"flow_slug": flow.slug}),
         )
-        request.user = AnonymousUser()
         with self.assertRaises(FlowNonApplicableException):
             planner = FlowPlanner(flow)
             planner.allow_empty_flows = True
@@ -125,7 +118,6 @@ class TestFlowPlanner(TestCase):
             HTTP_X_AUTHENTIK_OUTPOST_TOKEN=outpost.token.key,
             HTTP_X_AUTHENTIK_REMOTE_IP="1.2.3.4",
         )
-        request.user = AnonymousUser()
         middleware = ClientIPMiddleware(dummy_get_response)
         middleware(request)
 
@@ -143,7 +135,6 @@ class TestFlowPlanner(TestCase):
         request = self.request_factory.get(
             reverse("authentik_api:flow-executor", kwargs={"flow_slug": flow.slug}),
         )
-        request.user = get_anonymous_user()
 
         with self.assertRaises(FlowNonApplicableException):
             planner = FlowPlanner(flow)
@@ -159,7 +150,6 @@ class TestFlowPlanner(TestCase):
         request = self.request_factory.get(
             reverse("authentik_api:flow-executor", kwargs={"flow_slug": flow.slug}),
         )
-        request.user = get_anonymous_user()
 
         planner = FlowPlanner(flow)
         planner.plan(request)
@@ -200,7 +190,6 @@ class TestFlowPlanner(TestCase):
         request = self.request_factory.get(
             reverse("authentik_api:flow-executor", kwargs={"flow_slug": flow.slug}),
         )
-        request.user = get_anonymous_user()
 
         planner = FlowPlanner(flow)
         plan = planner.plan(request)
@@ -230,11 +219,6 @@ class TestFlowPlanner(TestCase):
         request = self.request_factory.get(
             reverse("authentik_api:flow-executor", kwargs={"flow_slug": flow.slug}),
         )
-        request.user = get_anonymous_user()
-
-        middleware = SessionMiddleware(dummy_get_response)
-        middleware.process_request(request)
-        request.session.save()
 
         # Here we patch the dummy policy to evaluate to true so the stage is included
         with patch("authentik.policies.dummy.models.DummyPolicy.passes", POLICY_RETURN_TRUE):
@@ -256,11 +240,7 @@ class TestFlowPlanner(TestCase):
         request = self.request_factory.get(
             reverse("authentik_api:flow-executor", kwargs={"flow_slug": flow.slug}),
         )
-        middleware = SessionMiddleware(dummy_get_response)
-        middleware.process_request(request)
-        request.session.save()
 
-        request.user = AnonymousUser()
         planner = FlowPlanner(flow)
         planner.allow_empty_flows = True
         plan = planner.plan(request)
@@ -277,10 +257,6 @@ class TestFlowPlanner(TestCase):
         request = self.request_factory.get(
             reverse("authentik_api:flow-executor", kwargs={"flow_slug": flow.slug}),
         )
-        middleware = SessionMiddleware(dummy_get_response)
-        middleware.process_request(request)
-        request.session.save()
-        request.user = AnonymousUser()
         planner = FlowPlanner(flow)
         planner.allow_empty_flows = True
         plan = planner.plan(request)
@@ -309,7 +285,6 @@ class TestFlowPlanner(TestCase):
         request = self.request_factory.get(
             reverse("authentik_api:flow-executor", kwargs={"flow_slug": flow.slug}),
         )
-        request.user = AnonymousUser()
         planner = FlowPlanner(flow)
         planner.allow_empty_flows = True
         plan = planner.plan(request)
@@ -333,7 +308,6 @@ class TestFlowPlanner(TestCase):
         request = self.request_factory.get(
             reverse("authentik_api:flow-executor", kwargs={"flow_slug": flow.slug}),
         )
-        request.user = AnonymousUser()
         planner = FlowPlanner(flow)
         planner.allow_empty_flows = True
         plan = planner.plan(request)

--- a/authentik/lib/tests/utils.py
+++ b/authentik/lib/tests/utils.py
@@ -3,17 +3,6 @@
 from inspect import currentframe
 from pathlib import Path
 
-from django.contrib.messages.middleware import MessageMiddleware
-from django.contrib.sessions.middleware import SessionMiddleware
-from django.http import HttpRequest
-from django.test.client import RequestFactory
-from guardian.utils import get_anonymous_user
-
-
-def dummy_get_response(request: HttpRequest):  # pragma: no cover
-    """Dummy get_response for SessionMiddleware"""
-    return None
-
 
 def load_fixture(path: str, **kwargs) -> str:
     """Load fixture, optionally formatting it with kwargs"""
@@ -26,19 +15,3 @@ def load_fixture(path: str, **kwargs) -> str:
             return fixture % kwargs
         except (TypeError, ValueError):
             return fixture
-
-
-def get_request(*args, user=None, **kwargs):
-    """Get a request with usable session"""
-    request = RequestFactory().get(*args, **kwargs)
-    if user:
-        request.user = user
-    else:
-        request.user = get_anonymous_user()
-    middleware = SessionMiddleware(dummy_get_response)
-    middleware.process_request(request)
-    request.session.save()
-    middleware = MessageMiddleware(dummy_get_response)
-    middleware.process_request(request)
-    request.session.save()
-    return request

--- a/authentik/providers/saml/tests/test_auth_n_request.py
+++ b/authentik/providers/saml/tests/test_auth_n_request.py
@@ -8,11 +8,15 @@ from django.test import TestCase
 from lxml import etree  # nosec
 
 from authentik.blueprints.tests import apply_blueprint
-from authentik.core.tests.utils import create_test_admin_user, create_test_cert, create_test_flow
+from authentik.core.tests.utils import (
+    RequestFactory,
+    create_test_admin_user,
+    create_test_cert,
+    create_test_flow,
+)
 from authentik.crypto.models import CertificateKeyPair
 from authentik.events.models import Event, EventAction
 from authentik.lib.generators import generate_id
-from authentik.lib.tests.utils import get_request
 from authentik.lib.xml import lxml_from_string
 from authentik.providers.saml.models import SAMLPropertyMapping, SAMLProvider
 from authentik.providers.saml.processors.assertion import AssertionProcessor
@@ -82,6 +86,7 @@ class TestAuthNRequest(TestCase):
 
     @apply_blueprint("system/providers-saml.yaml")
     def setUp(self):
+        self.request_factory = RequestFactory()
         self.cert = create_test_cert()
         self.provider: SAMLProvider = SAMLProvider.objects.create(
             authorization_flow=create_test_flow(),
@@ -102,7 +107,7 @@ class TestAuthNRequest(TestCase):
 
     def test_signed_valid(self):
         """Test generated AuthNRequest with valid signature"""
-        http_request = get_request("/")
+        http_request = self.request_factory.get("/")
 
         # First create an AuthNRequest
         request_proc = RequestProcessor(self.source, http_request, "test_state")
@@ -123,7 +128,7 @@ class TestAuthNRequest(TestCase):
         self.provider.save()
         self.source.encryption_kp = self.cert
         self.source.save()
-        http_request = get_request("/")
+        http_request = self.request_factory.get("/")
 
         # First create an AuthNRequest
         request_proc = RequestProcessor(self.source, http_request, "test_state")
@@ -146,7 +151,7 @@ class TestAuthNRequest(TestCase):
 
     def test_request_signed(self):
         """Test full SAML Request/Response flow, fully signed"""
-        http_request = get_request("/")
+        http_request = self.request_factory.get("/")
 
         # First create an AuthNRequest
         request_proc = RequestProcessor(self.source, http_request, "test_state")
@@ -173,7 +178,7 @@ class TestAuthNRequest(TestCase):
         self.provider.sign_response = True
         self.provider.save()
         self.source.signed_response = True
-        http_request = get_request("/")
+        http_request = self.request_factory.get("/")
 
         # First create an AuthNRequest
         request_proc = RequestProcessor(self.source, http_request, "test_state")
@@ -213,7 +218,7 @@ class TestAuthNRequest(TestCase):
 
     def test_request_id_invalid(self):
         """Test generated AuthNRequest with invalid request ID"""
-        http_request = get_request("/")
+        http_request = self.request_factory.get("/")
 
         # First create an AuthNRequest
         request_proc = RequestProcessor(self.source, http_request, "test_state")
@@ -242,7 +247,7 @@ class TestAuthNRequest(TestCase):
 
     def test_signed_valid_detached(self):
         """Test generated AuthNRequest with valid signature (detached)"""
-        http_request = get_request("/")
+        http_request = self.request_factory.get("/")
 
         # First create an AuthNRequest
         request_proc = RequestProcessor(self.source, http_request, "test_state")
@@ -305,7 +310,7 @@ class TestAuthNRequest(TestCase):
         self.provider.authn_context_class_ref_mapping = mapping
         self.provider.save()
         user = create_test_admin_user()
-        http_request = get_request("/", user=user)
+        http_request = self.request_factory.get("/", user=user)
 
         # First create an AuthNRequest
         request_proc = RequestProcessor(self.source, http_request, "test_state")
@@ -327,7 +332,7 @@ class TestAuthNRequest(TestCase):
         self.provider.authn_context_class_ref_mapping = mapping
         self.provider.save()
         user = create_test_admin_user()
-        http_request = get_request("/", user=user)
+        http_request = self.request_factory.get("/", user=user)
 
         # First create an AuthNRequest
         request_proc = RequestProcessor(self.source, http_request, "test_state")
@@ -354,7 +359,7 @@ class TestAuthNRequest(TestCase):
     def test_request_attributes(self):
         """Test full SAML Request/Response flow, fully signed"""
         user = create_test_admin_user()
-        http_request = get_request("/", user=user)
+        http_request = self.request_factory.get("/", user=user)
 
         # First create an AuthNRequest
         request_proc = RequestProcessor(self.source, http_request, "test_state")
@@ -371,7 +376,7 @@ class TestAuthNRequest(TestCase):
     def test_request_attributes_invalid(self):
         """Test full SAML Request/Response flow, fully signed"""
         user = create_test_admin_user()
-        http_request = get_request("/", user=user)
+        http_request = self.request_factory.get("/", user=user)
 
         # First create an AuthNRequest
         request_proc = RequestProcessor(self.source, http_request, "test_state")

--- a/authentik/providers/saml/tests/test_auth_n_request.py
+++ b/authentik/providers/saml/tests/test_auth_n_request.py
@@ -5,6 +5,7 @@ from base64 import b64encode
 from defusedxml.lxml import fromstring
 from django.http.request import QueryDict
 from django.test import TestCase
+from guardian.utils import get_anonymous_user
 from lxml import etree  # nosec
 
 from authentik.blueprints.tests import apply_blueprint
@@ -128,7 +129,7 @@ class TestAuthNRequest(TestCase):
         self.provider.save()
         self.source.encryption_kp = self.cert
         self.source.save()
-        http_request = self.request_factory.get("/")
+        http_request = self.request_factory.get("/", user=get_anonymous_user())
 
         # First create an AuthNRequest
         request_proc = RequestProcessor(self.source, http_request, "test_state")
@@ -151,7 +152,7 @@ class TestAuthNRequest(TestCase):
 
     def test_request_signed(self):
         """Test full SAML Request/Response flow, fully signed"""
-        http_request = self.request_factory.get("/")
+        http_request = self.request_factory.get("/", user=get_anonymous_user())
 
         # First create an AuthNRequest
         request_proc = RequestProcessor(self.source, http_request, "test_state")
@@ -178,7 +179,7 @@ class TestAuthNRequest(TestCase):
         self.provider.sign_response = True
         self.provider.save()
         self.source.signed_response = True
-        http_request = self.request_factory.get("/")
+        http_request = self.request_factory.get("/", user=get_anonymous_user())
 
         # First create an AuthNRequest
         request_proc = RequestProcessor(self.source, http_request, "test_state")
@@ -218,7 +219,7 @@ class TestAuthNRequest(TestCase):
 
     def test_request_id_invalid(self):
         """Test generated AuthNRequest with invalid request ID"""
-        http_request = self.request_factory.get("/")
+        http_request = self.request_factory.get("/", user=get_anonymous_user())
 
         # First create an AuthNRequest
         request_proc = RequestProcessor(self.source, http_request, "test_state")

--- a/authentik/providers/saml/tests/test_schema.py
+++ b/authentik/providers/saml/tests/test_schema.py
@@ -3,6 +3,7 @@
 from base64 import b64encode
 
 from django.test import TestCase
+from guardian.shortcuts import get_anonymous_user
 from lxml import etree  # nosec
 
 from authentik.blueprints.tests import apply_blueprint
@@ -55,6 +56,7 @@ class TestSchema(TestCase):
     def test_response_schema(self):
         """Test generated AuthNRequest against Schema"""
         http_request = self.request_factory.get("/")
+        http_request.user = get_anonymous_user()
 
         # First create an AuthNRequest
         request_proc = RequestProcessor(self.source, http_request, "test_state")

--- a/authentik/providers/saml/tests/test_schema.py
+++ b/authentik/providers/saml/tests/test_schema.py
@@ -6,8 +6,7 @@ from django.test import TestCase
 from lxml import etree  # nosec
 
 from authentik.blueprints.tests import apply_blueprint
-from authentik.core.tests.utils import create_test_cert, create_test_flow
-from authentik.lib.tests.utils import get_request
+from authentik.core.tests.utils import RequestFactory, create_test_cert, create_test_flow
 from authentik.lib.xml import lxml_from_string
 from authentik.providers.saml.models import SAMLPropertyMapping, SAMLProvider
 from authentik.providers.saml.processors.assertion import AssertionProcessor
@@ -36,10 +35,11 @@ class TestSchema(TestCase):
             signing_kp=cert,
             pre_authentication_flow=create_test_flow(),
         )
+        self.request_factory = RequestFactory()
 
     def test_request_schema(self):
         """Test generated AuthNRequest against Schema"""
-        http_request = get_request("/")
+        http_request = self.request_factory.get("/")
 
         # First create an AuthNRequest
         request_proc = RequestProcessor(self.source, http_request, "test_state")
@@ -54,7 +54,7 @@ class TestSchema(TestCase):
 
     def test_response_schema(self):
         """Test generated AuthNRequest against Schema"""
-        http_request = get_request("/")
+        http_request = self.request_factory.get("/")
 
         # First create an AuthNRequest
         request_proc = RequestProcessor(self.source, http_request, "test_state")

--- a/authentik/sources/oauth/tests/test_property_mappings.py
+++ b/authentik/sources/oauth/tests/test_property_mappings.py
@@ -5,8 +5,8 @@ from copy import deepcopy
 from django.contrib.auth.models import AnonymousUser
 from django.test import TestCase
 
+from authentik.core.tests.utils import RequestFactory
 from authentik.lib.generators import generate_id
-from authentik.lib.tests.utils import get_request
 from authentik.sources.oauth.models import OAuthSource, OAuthSourcePropertyMapping
 from authentik.sources.oauth.views.callback import OAuthSourceFlowManager
 
@@ -33,6 +33,7 @@ class TestPropertyMappings(TestCase):
             profile_url="",
             consumer_key=generate_id(),
         )
+        self.request_factory = RequestFactory()
 
     def test_user_base_properties(self):
         """Test user base properties"""
@@ -64,7 +65,7 @@ class TestPropertyMappings(TestCase):
                 expression="return {'attributes': {'department': info.get('department')}}",
             )
         )
-        request = get_request("/", user=AnonymousUser())
+        request = self.request_factory.get("/", user=AnonymousUser())
         flow_manager = OAuthSourceFlowManager(self.source, request, IDENTIFIER, {"info": INFO}, {})
         self.assertEqual(
             flow_manager.user_properties,
@@ -88,7 +89,7 @@ class TestPropertyMappings(TestCase):
                 expression="return {'attributes': {'id': group_id}}",
             )
         )
-        request = get_request("/", user=AnonymousUser())
+        request = self.request_factory.get("/", user=AnonymousUser())
         flow_manager = OAuthSourceFlowManager(self.source, request, IDENTIFIER, {"info": info}, {})
         self.assertEqual(
             flow_manager.groups_properties,

--- a/authentik/sources/oauth/tests/test_type_apple.py
+++ b/authentik/sources/oauth/tests/test_type_apple.py
@@ -1,11 +1,10 @@
 """Apple Type tests"""
 
-from django.test import RequestFactory, TestCase
+from django.test import TestCase
 from guardian.shortcuts import get_anonymous_user
 
+from authentik.core.tests.utils import RequestFactory
 from authentik.lib.generators import generate_id
-from authentik.lib.tests.utils import dummy_get_response
-from authentik.root.middleware import SessionMiddleware
 from authentik.sources.oauth.models import OAuthSource
 from authentik.sources.oauth.types.registry import registry
 
@@ -29,9 +28,6 @@ class TestTypeApple(TestCase):
         request = self.factory.get("/")
         request.user = get_anonymous_user()
 
-        middleware = SessionMiddleware(dummy_get_response)
-        middleware.process_request(request)
-        request.session.save()
         oauth_type = registry.find_type("apple")
         challenge = oauth_type().login_challenge(self.source, request)
         self.assertTrue(challenge.is_valid(raise_exception=True))

--- a/authentik/sources/oauth/tests/test_type_google.py
+++ b/authentik/sources/oauth/tests/test_type_google.py
@@ -1,10 +1,8 @@
 """google Type tests"""
 
-from django.contrib.sessions.middleware import SessionMiddleware
 from django.test import TestCase
-from django.test.client import RequestFactory
 
-from authentik.lib.tests.utils import dummy_get_response
+from authentik.core.tests.utils import RequestFactory
 from authentik.sources.oauth.models import OAuthSource
 from authentik.sources.oauth.types.google import (
     GoogleOAuthRedirect,
@@ -47,9 +45,6 @@ class TestTypeGoogle(TestCase):
     def test_authorize_url(self):
         """Test authorize URL"""
         request = self.request_factory.get("/")
-        middleware = SessionMiddleware(dummy_get_response)
-        middleware.process_request(request)
-        request.session.save()
         redirect = GoogleOAuthRedirect(request=request).get_redirect_url(
             source_slug=self.source.slug
         )
@@ -66,9 +61,6 @@ class TestTypeGoogle(TestCase):
     def test_authorize_url_additional(self):
         """Test authorize URL"""
         request = self.request_factory.get("/")
-        middleware = SessionMiddleware(dummy_get_response)
-        middleware.process_request(request)
-        request.session.save()
         self.source.additional_scopes = "foo"
         self.source.save()
         redirect = GoogleOAuthRedirect(request=request).get_redirect_url(
@@ -87,9 +79,6 @@ class TestTypeGoogle(TestCase):
     def test_authorize_url_additional_replace(self):
         """Test authorize URL"""
         request = self.request_factory.get("/")
-        middleware = SessionMiddleware(dummy_get_response)
-        middleware.process_request(request)
-        request.session.save()
         self.source.additional_scopes = "*foo"
         self.source.save()
         redirect = GoogleOAuthRedirect(request=request).get_redirect_url(

--- a/authentik/sources/saml/tests/test_property_mappings.py
+++ b/authentik/sources/saml/tests/test_property_mappings.py
@@ -3,12 +3,11 @@
 from base64 import b64encode
 
 from defusedxml.lxml import fromstring
-from django.contrib.sessions.middleware import SessionMiddleware
-from django.test import RequestFactory, TestCase
+from django.test import TestCase
 
-from authentik.core.tests.utils import create_test_flow
+from authentik.core.tests.utils import RequestFactory, create_test_flow
 from authentik.lib.generators import generate_id
-from authentik.lib.tests.utils import dummy_get_response, load_fixture
+from authentik.lib.tests.utils import load_fixture
 from authentik.sources.saml.models import SAMLSource, SAMLSourcePropertyMapping
 from authentik.sources.saml.processors.constants import NS_SAML_ASSERTION
 from authentik.sources.saml.processors.response import ResponseProcessor
@@ -73,10 +72,6 @@ class TestPropertyMappings(TestCase):
             },
         )
 
-        middleware = SessionMiddleware(dummy_get_response)
-        middleware.process_request(request)
-        request.session.save()
-
         parser = ResponseProcessor(self.source, request)
         parser.parse()
         sfm = parser.prepare_flow_manager()
@@ -109,10 +104,6 @@ class TestPropertyMappings(TestCase):
                 ).decode()
             },
         )
-
-        middleware = SessionMiddleware(dummy_get_response)
-        middleware.process_request(request)
-        request.session.save()
 
         parser = ResponseProcessor(self.source, request)
         parser.parse()

--- a/authentik/sources/saml/tests/test_response.py
+++ b/authentik/sources/saml/tests/test_response.py
@@ -2,13 +2,12 @@
 
 from base64 import b64encode
 
-from django.contrib.sessions.middleware import SessionMiddleware
-from django.test import RequestFactory, TestCase
+from django.test import TestCase
 
-from authentik.core.tests.utils import create_test_cert, create_test_flow
+from authentik.core.tests.utils import RequestFactory, create_test_cert, create_test_flow
 from authentik.crypto.models import CertificateKeyPair
 from authentik.lib.generators import generate_id
-from authentik.lib.tests.utils import dummy_get_response, load_fixture
+from authentik.lib.tests.utils import load_fixture
 from authentik.sources.saml.exceptions import InvalidEncryption, InvalidSignature
 from authentik.sources.saml.models import SAMLSource
 from authentik.sources.saml.processors.response import ResponseProcessor
@@ -38,10 +37,6 @@ class TestResponseProcessor(TestCase):
             },
         )
 
-        middleware = SessionMiddleware(dummy_get_response)
-        middleware.process_request(request)
-        request.session.save()
-
         with self.assertRaisesMessage(
             ValueError,
             (
@@ -61,10 +56,6 @@ class TestResponseProcessor(TestCase):
                 ).decode()
             },
         )
-
-        middleware = SessionMiddleware(dummy_get_response)
-        middleware.process_request(request)
-        request.session.save()
 
         parser = ResponseProcessor(self.source, request)
         parser.parse()
@@ -98,10 +89,6 @@ class TestResponseProcessor(TestCase):
             },
         )
 
-        middleware = SessionMiddleware(dummy_get_response)
-        middleware.process_request(request)
-        request.session.save()
-
         parser = ResponseProcessor(self.source, request)
         parser.parse()
 
@@ -117,10 +104,6 @@ class TestResponseProcessor(TestCase):
                 ).decode()
             },
         )
-
-        middleware = SessionMiddleware(dummy_get_response)
-        middleware.process_request(request)
-        request.session.save()
 
         parser = ResponseProcessor(self.source, request)
         with self.assertRaises(InvalidEncryption):
@@ -145,10 +128,6 @@ class TestResponseProcessor(TestCase):
             },
         )
 
-        middleware = SessionMiddleware(dummy_get_response)
-        middleware.process_request(request)
-        request.session.save()
-
         parser = ResponseProcessor(self.source, request)
         parser.parse()
 
@@ -170,10 +149,6 @@ class TestResponseProcessor(TestCase):
                 ).decode()
             },
         )
-
-        middleware = SessionMiddleware(dummy_get_response)
-        middleware.process_request(request)
-        request.session.save()
 
         parser = ResponseProcessor(self.source, request)
         parser.parse()
@@ -197,10 +172,6 @@ class TestResponseProcessor(TestCase):
             },
         )
 
-        middleware = SessionMiddleware(dummy_get_response)
-        middleware.process_request(request)
-        request.session.save()
-
         parser = ResponseProcessor(self.source, request)
         parser.parse()
 
@@ -222,10 +193,6 @@ class TestResponseProcessor(TestCase):
                 ).decode()
             },
         )
-
-        middleware = SessionMiddleware(dummy_get_response)
-        middleware.process_request(request)
-        request.session.save()
 
         parser = ResponseProcessor(self.source, request)
 
@@ -249,10 +216,6 @@ class TestResponseProcessor(TestCase):
                 ).decode()
             },
         )
-
-        middleware = SessionMiddleware(dummy_get_response)
-        middleware.process_request(request)
-        request.session.save()
 
         parser = ResponseProcessor(self.source, request)
 

--- a/authentik/stages/authenticator_validate/tests/test_duo.py
+++ b/authentik/stages/authenticator_validate/tests/test_duo.py
@@ -2,14 +2,12 @@
 
 from unittest.mock import MagicMock, patch
 
-from django.contrib.sessions.middleware import SessionMiddleware
-from django.test.client import RequestFactory
 from django.urls import reverse
 from rest_framework.exceptions import ValidationError
 
 from authentik.brands.utils import get_brand_for_request
 from authentik.core.middleware import RESPONSE_HEADER_ID
-from authentik.core.tests.utils import create_test_admin_user, create_test_flow
+from authentik.core.tests.utils import RequestFactory, create_test_admin_user, create_test_flow
 from authentik.events.models import Event, EventAction
 from authentik.flows.models import FlowDesignation, FlowStageBinding
 from authentik.flows.planner import PLAN_CONTEXT_PENDING_USER, FlowPlan
@@ -17,7 +15,6 @@ from authentik.flows.stage import StageView
 from authentik.flows.tests import FlowTestCase
 from authentik.flows.views.executor import SESSION_KEY_PLAN, FlowExecutorView
 from authentik.lib.generators import generate_id, generate_key
-from authentik.lib.tests.utils import dummy_get_response
 from authentik.stages.authenticator_duo.models import AuthenticatorDuoStage, DuoDevice
 from authentik.stages.authenticator_validate.challenge import validate_challenge_duo
 from authentik.stages.authenticator_validate.models import AuthenticatorValidateStage, DeviceClasses
@@ -35,9 +32,6 @@ class AuthenticatorValidateStageDuoTests(FlowTestCase):
         """Test duo"""
         request = self.request_factory.get("/")
 
-        middleware = SessionMiddleware(dummy_get_response)
-        middleware.process_request(request)
-        request.session.save()
         request.brand = get_brand_for_request(request)
 
         stage = AuthenticatorDuoStage.objects.create(

--- a/authentik/stages/authenticator_validate/tests/test_webauthn.py
+++ b/authentik/stages/authenticator_validate/tests/test_webauthn.py
@@ -2,20 +2,18 @@
 
 from time import sleep
 
-from django.test.client import RequestFactory
 from django.urls.base import reverse
 from rest_framework.serializers import ValidationError
 from webauthn.helpers.base64url_to_bytes import base64url_to_bytes
 from webauthn.helpers.bytes_to_base64url import bytes_to_base64url
 
-from authentik.core.tests.utils import create_test_admin_user, create_test_flow
+from authentik.core.tests.utils import RequestFactory, create_test_admin_user, create_test_flow
 from authentik.flows.models import FlowStageBinding, NotConfiguredAction
 from authentik.flows.planner import PLAN_CONTEXT_PENDING_USER, FlowPlan
 from authentik.flows.stage import StageView
 from authentik.flows.tests import FlowTestCase
 from authentik.flows.views.executor import SESSION_KEY_PLAN, FlowExecutorView
 from authentik.lib.generators import generate_id
-from authentik.lib.tests.utils import get_request
 from authentik.stages.authenticator_validate.challenge import (
     get_challenge_for_device,
     get_webauthn_challenge_without_user,
@@ -86,7 +84,7 @@ class AuthenticatorValidateStageWebAuthnTests(FlowTestCase):
 
     def test_device_challenge_webauthn(self):
         """Test webauthn"""
-        request = get_request("/")
+        request = self.request_factory.get("/")
         request.user = self.user
 
         webauthn_device = WebAuthnDevice.objects.create(
@@ -135,7 +133,7 @@ class AuthenticatorValidateStageWebAuthnTests(FlowTestCase):
         """Test webauthn (getting device challenges with a webauthn
         device that is not allowed due to aaguid restrictions)"""
         webauthn_mds_import.send(force=True).get_result()
-        request = get_request("/")
+        request = self.request_factory.get("/")
         request.user = self.user
 
         WebAuthnDevice.objects.create(
@@ -179,7 +177,7 @@ class AuthenticatorValidateStageWebAuthnTests(FlowTestCase):
 
     def test_raw_get_challenge(self):
         """Test webauthn"""
-        request = get_request("/")
+        request = self.request_factory.get("/")
         request.user = self.user
 
         stage = AuthenticatorValidateStage.objects.create(
@@ -232,7 +230,7 @@ class AuthenticatorValidateStageWebAuthnTests(FlowTestCase):
 
     def test_get_challenge_userless(self):
         """Test webauthn (userless)"""
-        request = get_request("/")
+        request = self.request_factory.get("/")
         stage = AuthenticatorValidateStage.objects.create(
             name=generate_id(), webauthn_user_verification=UserVerification.PREFERRED
         )
@@ -493,7 +491,7 @@ class AuthenticatorValidateStageWebAuthnTests(FlowTestCase):
 
     def test_validate_challenge_invalid(self):
         """Test webauthn"""
-        request = get_request("/")
+        request = self.request_factory.get("/")
         request.user = self.user
 
         WebAuthnDevice.objects.create(
@@ -517,7 +515,7 @@ class AuthenticatorValidateStageWebAuthnTests(FlowTestCase):
         plan.context[PLAN_CONTEXT_WEBAUTHN_CHALLENGE] = base64url_to_bytes(
             "g98I51mQvZXo5lxLfhrD2zfolhZbLRyCgqkkYap1jwSaJ13BguoJWCF9_Lg3AgO4Wh-Bqa556JE20oKsYbl6RA"
         )
-        request = get_request("/")
+        request = self.request_factory.get("/")
 
         stage_view = AuthenticatorValidateStageView(
             FlowExecutorView(flow=flow, current_stage=stage, plan=plan), request=request

--- a/authentik/stages/email/tests/test_stage.py
+++ b/authentik/stages/email/tests/test_stage.py
@@ -7,12 +7,11 @@ from django.contrib import messages
 from django.core import mail
 from django.core.mail.backends.locmem import EmailBackend
 from django.core.mail.backends.smtp import EmailBackend as SMTPEmailBackend
-from django.test import RequestFactory
 from django.urls import reverse
 from django.utils.http import urlencode
 
 from authentik.brands.models import Brand
-from authentik.core.tests.utils import create_test_admin_user, create_test_flow
+from authentik.core.tests.utils import RequestFactory, create_test_admin_user, create_test_flow
 from authentik.flows.markers import StageMarker
 from authentik.flows.models import FlowDesignation, FlowStageBinding, FlowToken
 from authentik.flows.planner import PLAN_CONTEXT_PENDING_USER, FlowPlan
@@ -20,7 +19,6 @@ from authentik.flows.tests import FlowTestCase
 from authentik.flows.views.executor import QS_KEY_TOKEN, SESSION_KEY_PLAN, FlowExecutorView
 from authentik.lib.config import CONFIG
 from authentik.lib.generators import generate_id
-from authentik.lib.tests.utils import get_request
 from authentik.stages.consent.stage import SESSION_KEY_CONSENT_TOKEN
 from authentik.stages.email.models import EmailStage
 from authentik.stages.email.stage import PLAN_CONTEXT_EMAIL_OVERRIDE, EmailStageView
@@ -410,7 +408,7 @@ class TestEmailStage(FlowTestCase):
         session.save()
 
         url = reverse("authentik_api:flow-executor", kwargs={"flow_slug": self.flow.slug})
-        request = get_request(url, user=self.user)
+        request = self.factory.get(url, user=self.user)
         request.session = session
 
         request.brand = Brand.objects.create(domain="foo-domain.com", default=True)


### PR DESCRIPTION
- remove `authentik.lib.tests.utils.get_request`
- Remove explicit calls to SessionMiddleware
- Subclass RequestFactory