### PR TITLE
lib/sync/outgoing: check if there is a provider before creating tasks

### DIFF
--- a/authentik/enterprise/providers/ssf/tasks.py
+++ b/authentik/enterprise/providers/ssf/tasks.py
@@ -42,6 +42,8 @@ def send_ssf_events(
     for stream in Stream.objects.filter(**stream_filter):
         event_data = stream.prepare_event_payload(event_type, data, **extra_data)
         events_data[stream.uuid] = event_data
+    if not events_data:
+        return
     ssf_events_dispatch.send(events_data)
 
 

--- a/authentik/lib/sync/outgoing/signals.py
+++ b/authentik/lib/sync/outgoing/signals.py
@@ -28,6 +28,8 @@ def register_signals(
         # This primarily happens during user login
         if sender == User and update_fields == {"last_login"}:
             return
+        if not provider_type.objects.exists():
+            return
         task_sync_direct_dispatch.send(
             class_to_path(instance.__class__),
             instance.pk,
@@ -39,6 +41,8 @@ def register_signals(
 
     def model_pre_delete(sender: type[Model], instance: User | Group, **_):
         """Pre-delete handler"""
+        if not provider_type.objects.exists():
+            return
         task_sync_direct_dispatch.send(
             class_to_path(instance.__class__),
             instance.pk,
@@ -53,6 +57,8 @@ def register_signals(
     ):
         """Sync group membership"""
         if action not in ["post_add", "post_remove"]:
+            return
+        if not provider_type.objects.exists():
             return
         task_sync_m2m_dispatch.send(instance.pk, action, list(pk_set), reverse)
 

--- a/authentik/providers/oauth2/signals.py
+++ b/authentik/providers/oauth2/signals.py
@@ -109,7 +109,7 @@ def user_session_deleted_oauth_backchannel_logout_and_tokens_removal(
     """Revoke tokens upon user logout"""
     LOGGER.debug("Sending back-channel logout notifications signal!", session=instance)
 
-    access_tokens = AccessToken.objects.filter(
+    access_tokens = AccessToken.objects.select_related("provider").filter(
         user=instance.user,
         session__session__session_key=instance.session.session_key,
     )
@@ -128,7 +128,8 @@ def user_session_deleted_oauth_backchannel_logout_and_tokens_removal(
         and token.provider.logout_method == OAuth2LogoutMethod.BACKCHANNEL
     ]
 
-    backchannel_logout_notification_dispatch.send(revocations=backchannel_tokens)
+    if backchannel_tokens:
+        backchannel_logout_notification_dispatch.send(revocations=backchannel_tokens)
 
     access_tokens.delete()
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Closes #18368
Closes #17648

Not checking is causing too many issues for small instances. Let's bite the bullet of the extra db queries and do it this way.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
