### PR TITLE
web: Fix row expansion on modal trigger buttons.

### DIFF
--- a/web/src/elements/buttons/ModalButton.ts
+++ b/web/src/elements/buttons/ModalButton.ts
@@ -91,7 +91,8 @@ export abstract class ModalButton extends AKElement {
     /**
      * Show the modal.
      */
-    public show = (): void => {
+    public show = (event?: PointerEvent): void => {
+        event?.preventDefault();
         this.open = true;
 
         this.dispatchEvent(new ModalShowEvent(this));


### PR DESCRIPTION
## Details

This PR fixes a small issue where table rows will expand after pressing a modal trigger button. 

Our accessible modals refactor should resolve this kind of issue in some more complex situations, such as modals which contain tables, but this PR fixes the most common situations where an expandable content is affected by buttons within the table row.

