### PR TITLE
website/integrations: add local browser setting to seafile

### DIFF
--- a/website/integrations/media/seafile/index.md
+++ b/website/integrations/media/seafile/index.md
@@ -75,7 +75,7 @@ OAUTH_ATTRIBUTE_MAP = {
 LOGIN_URL = 'https://seafile.company/oauth/login/'
 
 # Enable client to open an external browser for single sign on
-# When it is false, the old buitin browser is opened for single sign on
+# When it is false, the old builtin browser is opened for single sign on
 # When it is true, the default browser of the operation system is opened
 # The benefit of using system browser is that it can support hardware 2FA
 # Since 11.0.0, and sync client 9.0.5, drive client 3.0.8

--- a/website/integrations/media/seafile/index.md
+++ b/website/integrations/media/seafile/index.md
@@ -74,6 +74,13 @@ OAUTH_ATTRIBUTE_MAP = {
 # Optionally set the following variable to automatically redirect users to the login page
 LOGIN_URL = 'https://seafile.company/oauth/login/'
 
+# Enable client to open an external browser for single sign on
+# When it is false, the old buitin browser is opened for single sign on
+# When it is true, the default browser of the operation system is opened
+# The benefit of using system browser is that it can support hardware 2FA
+# Since 11.0.0, and sync client 9.0.5, drive client 3.0.8
+CLIENT_SSO_VIA_LOCAL_BROWSER = True   # default is False
+
 ```
 
 ## Configuration verification


### PR DESCRIPTION
## Details

Users reporting issue without this setting in place: https://github.com/goauthentik/authentik/issues/6717#issuecomment-3589669575

Added note directly ripped from [offical seafile docs](https://manual.seafile.com/latest/config/seahub_settings_py/#single-sign-on).

---

## Checklist

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
