### PR TITLE
providers/scim: compare users/groups before sending update request

### DIFF
--- a/authentik/providers/scim/clients/groups.py
+++ b/authentik/providers/scim/clients/groups.py
@@ -1,12 +1,15 @@
 """Group client"""
 
 from itertools import batched
+from typing import Any
 
 from django.db import transaction
+from orjson import dumps
 from pydantic import ValidationError
 from pydanticscim.group import GroupMember
 
 from authentik.core.models import Group
+from authentik.lib.merge import MERGE_LIST_UNIQUE
 from authentik.lib.sync.mapper import PropertyMappingManager
 from authentik.lib.sync.outgoing.base import Direction
 from authentik.lib.sync.outgoing.exceptions import (
@@ -114,10 +117,23 @@ class SCIMGroupClient(SCIMClient[Group, SCIMProviderGroup, SCIMGroupSchema]):
         self._patch_add_users(connection, users)
         return connection
 
+    def diff(self, local_created: dict[str, Any], connection: SCIMProviderUser):
+        """Check if a group is different than what we last wrote to the remote system.
+        Returns true if there is a difference in data."""
+        local_known = connection.attributes
+        local_updated = {}
+        MERGE_LIST_UNIQUE.merge(local_updated, local_known)
+        MERGE_LIST_UNIQUE.merge(local_updated, local_created)
+        return dumps(local_updated) != dumps(local_known)
+
     def update(self, group: Group, connection: SCIMProviderGroup):
         """Update existing group"""
         scim_group = self.to_schema(group, connection)
         scim_group.id = connection.scim_id
+        payload = scim_group.model_dump(mode="json", exclude_unset=True)
+        if not self.diff(payload, connection):
+            self.logger.debug("Skipping group write as data has not changed")
+            return self.patch_compare_users(group)
         try:
             if self._config.patch.supported:
                 return self._update_patch(group, scim_group, connection)

--- a/authentik/providers/scim/clients/users.py
+++ b/authentik/providers/scim/clients/users.py
@@ -1,10 +1,14 @@
 """User client"""
 
+from typing import Any
+
 from django.db import transaction
 from django.utils.http import urlencode
+from orjson import dumps
 from pydantic import ValidationError
 
 from authentik.core.models import User
+from authentik.lib.merge import MERGE_LIST_UNIQUE
 from authentik.lib.sync.mapper import PropertyMappingManager
 from authentik.lib.sync.outgoing.exceptions import ObjectExistsSyncException, StopSync
 from authentik.policies.utils import delete_none_values
@@ -92,17 +96,30 @@ class SCIMUserClient(SCIMClient[User, SCIMProviderUser, SCIMUserSchema]):
                     provider=self.provider, user=user, scim_id=scim_id, attributes=response
                 )
 
+    def diff(self, local_created: dict[str, Any], connection: SCIMProviderUser):
+        """Check if a user is different than what we last wrote to the remote system.
+        Returns true if there is a difference in data."""
+        local_known = connection.attributes
+        local_updated = {}
+        MERGE_LIST_UNIQUE.merge(local_updated, local_known)
+        MERGE_LIST_UNIQUE.merge(local_updated, local_created)
+        return dumps(local_updated) != dumps(local_known)
+
     def update(self, user: User, connection: SCIMProviderUser):
         """Update existing user"""
         scim_user = self.to_schema(user, connection)
         scim_user.id = connection.scim_id
+        payload = scim_user.model_dump(
+            mode="json",
+            exclude_unset=True,
+        )
+        if not self.diff(payload, connection):
+            self.logger.debug("Skipping user write as data has not changed")
+            return
         response = self._request(
             "PUT",
             f"/Users/{connection.scim_id}",
-            json=scim_user.model_dump(
-                mode="json",
-                exclude_unset=True,
-            ),
+            json=payload,
         )
         connection.attributes = response
         connection.save()

--- a/authentik/providers/scim/tests/test_user.py
+++ b/authentik/providers/scim/tests/test_user.py
@@ -10,7 +10,7 @@ from authentik.blueprints.tests import apply_blueprint
 from authentik.core.models import Application, Group, User
 from authentik.lib.generators import generate_id
 from authentik.lib.sync.outgoing.base import SAFE_METHODS
-from authentik.providers.scim.models import SCIMMapping, SCIMProvider
+from authentik.providers.scim.models import SCIMMapping, SCIMProvider, SCIMProviderUser
 from authentik.providers.scim.tasks import scim_sync, scim_sync_objects
 from authentik.tasks.models import Task
 from authentik.tenants.models import Tenant
@@ -273,6 +273,8 @@ class SCIMUserTests(TestCase):
                 "userName": uid,
             },
         )
+        # Update user
+        user.name = "foo bar"
         user.save()
         self.assertEqual(mock.call_count, 4)
         self.assertEqual(mock.request_history[0].method, "GET")
@@ -455,3 +457,85 @@ class SCIMUserTests(TestCase):
         self.assertIsNotNone(log.attributes["url"])
         self.assertIsNotNone(log.attributes["body"])
         self.assertIsNotNone(log.attributes["method"])
+
+    @Mocker()
+    def test_user_create_update_noop(self, mock: Mocker):
+        """Test user creation and update"""
+        scim_id = generate_id()
+        mock: Mocker
+        mock.get(
+            "https://localhost/ServiceProviderConfig",
+            json={},
+        )
+        mock.post(
+            "https://localhost/Users",
+            json={
+                "id": scim_id,
+            },
+        )
+        mock.put(
+            "https://localhost/Users",
+            json={
+                "id": scim_id,
+            },
+        )
+        uid = generate_id()
+        user = User.objects.create(
+            username=uid,
+            name=f"{uid} {uid}",
+            email=f"{uid}@goauthentik.io",
+        )
+        self.assertEqual(mock.call_count, 2)
+        self.assertEqual(mock.request_history[0].method, "GET")
+        self.assertEqual(mock.request_history[1].method, "POST")
+        body = loads(mock.request_history[1].body)
+        self.assertEqual(
+            body,
+            {
+                "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+                "active": True,
+                "emails": [
+                    {
+                        "primary": True,
+                        "type": "other",
+                        "value": f"{uid}@goauthentik.io",
+                    }
+                ],
+                "displayName": f"{uid} {uid}",
+                "externalId": user.uid,
+                "name": {
+                    "familyName": uid,
+                    "formatted": f"{uid} {uid}",
+                    "givenName": uid,
+                },
+                "userName": uid,
+            },
+        )
+        conn = SCIMProviderUser.objects.filter(user=user).first()
+        conn.attributes = {
+            "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+            "active": True,
+            "emails": [
+                {
+                    "primary": True,
+                    "type": "other",
+                    "value": f"{uid}@goauthentik.io",
+                }
+            ],
+            "displayName": f"{uid} {uid}",
+            "externalId": user.uid,
+            "name": {
+                "familyName": uid,
+                "formatted": f"{uid} {uid}",
+                "givenName": uid,
+            },
+            "userName": uid,
+            "id": scim_id,
+        }
+        conn.save()
+        user.save()
+        self.assertEqual(mock.call_count, 3)
+        self.assertEqual(mock.request_history[0].method, "GET")
+        self.assertEqual(mock.request_history[1].method, "POST")
+        self.assertEqual(mock.request_history[2].method, "GET")
+        # No PUT request


### PR DESCRIPTION
closes #17857

compare SCIM objects to our known state before sending patch/put requests