### PR TITLE
crypto: only generate managed keypair if non-existent

### DIFF
--- a/authentik/crypto/apps.py
+++ b/authentik/crypto/apps.py
@@ -1,7 +1,5 @@
 """authentik crypto app config"""
 
-from datetime import UTC, datetime
-
 from dramatiq.broker import get_broker
 
 from authentik.blueprints.apps import ManagedAppConfig
@@ -47,10 +45,7 @@ class AuthentikCryptoConfig(ManagedAppConfig):
         cert: CertificateKeyPair | None = CertificateKeyPair.objects.filter(
             managed=MANAGED_KEY
         ).first()
-        now = datetime.now(tz=UTC)
-        if not cert or (
-            now < cert.certificate.not_valid_after_utc or now > cert.certificate.not_valid_after_utc
-        ):
+        if not cert:
             self._create_update_cert()
 
     @ManagedAppConfig.reconcile_tenant

--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -35,7 +35,7 @@ msgstr "Atualizar informações da versão mais recente."
 #: authentik/admin/tasks.py
 #, python-brace-format
 msgid "New version {version} available!"
-msgstr "Nova versão {versão} disponível!"
+msgstr "Nova versão {version} disponível!"
 
 #: authentik/api/v3/schema/query.py
 msgid "Which field to use when ordering the results."


### PR DESCRIPTION
since we only use this keypair for JWT/JWEs, we only use its private/public keys and not the cert, hence we don't need to replace it (and we don't have a good system for that yet anyways)

closes #8887