### PR TITLE
enterprise/endpoints/connectors/agent: fix Apple JWE encryption when FIPS is enabled

### DIFF
--- a/authentik/enterprise/endpoints/connectors/agent/tests/test_apple_jwe.py
+++ b/authentik/enterprise/endpoints/connectors/agent/tests/test_apple_jwe.py
@@ -1,3 +1,5 @@
+from base64 import urlsafe_b64decode
+
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 from django.test import TestCase
@@ -34,3 +36,4 @@ class TestAppleJWE(TestCase):
         self.assertEqual(payload, b'{"foo": "bar"}')
         self.assertEqual(parsed.jose_header["apv"], apv)
         self.assertEqual(parsed.jose_header["typ"], "platformsso-login-response+jwt")
+        self.assertIn(b"APPLE", urlsafe_b64decode(parsed.jose_header["apu"]))


### PR DESCRIPTION
Without this change, with FIPS enabled, we'd get this error

```
Unknown OpenSSL error. This error is commonly encountered
                    when another library is not cleaning up the OpenSSL error
                    stack. If you are using cryptography with another library
                    that uses OpenSSL try disabling it before reporting a bug.
                    Otherwise please file an issue at
                    https://github.com/pyca/cryptography/issues with
                    information on how to reproduce this. (error:030000BE:digital envelope routines:EVP_CIPHER_CTX_copy:not able to copy ctx:../crypto/evp/evp_enc.c:1787:)
```

This can apparently be caused by OpenSSL version mismatches, which checks out since we run OpenSSL 3.5 with OpenSSL FIPS 3.1.2 

this accomplishes the same but doesn't fail...?