### PR TITLE
sources/telegram: implement connecting existing user to a Telegram account

### DIFF
--- a/authentik/sources/telegram/api/source.py
+++ b/authentik/sources/telegram/api/source.py
@@ -65,13 +65,6 @@ class TelegramSourceViewSet(UsedByMixin, ModelViewSet):
             201: UserTelegramSourceConnectionSerializer,
             403: OpenApiResponse(description="Access denied"),
         },
-        # parameters=[
-        #     OpenApiParameter(
-        #         name="slug",
-        #         location=OpenApiParameter.PATH,
-        #         type=OpenApiTypes.STR,
-        #     )
-        # ],
     )
     @action(
         methods=["POST"],

--- a/authentik/sources/telegram/api/source.py
+++ b/authentik/sources/telegram/api/source.py
@@ -1,8 +1,17 @@
+from django.utils.translation import gettext_lazy as _
+from drf_spectacular.utils import OpenApiResponse, extend_schema
+from rest_framework.decorators import action
+from rest_framework.generics import get_object_or_404
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
 from authentik.core.api.sources import SourceSerializer
 from authentik.core.api.used_by import UsedByMixin
-from authentik.sources.telegram.models import TelegramSource
+from authentik.sources.telegram.api.source_connection import UserTelegramSourceConnectionSerializer
+from authentik.sources.telegram.models import TelegramSource, UserTelegramSourceConnection
+from authentik.sources.telegram.telegram import TelegramAuth
 
 
 class TelegramSourceSerializer(SourceSerializer):
@@ -17,6 +26,16 @@ class TelegramSourceSerializer(SourceSerializer):
         extra_kwargs = {
             "bot_token": {"write_only": True},
         }
+
+
+class TelegramAuthSerializer(TelegramAuth):
+
+    def __init__(self, *args, **kwargs):
+        self._bot_token = kwargs.pop("bot_token", None)
+        super().__init__(*args, **kwargs)
+
+    def get_bot_token(self):
+        return self._bot_token
 
 
 class TelegramSourceViewSet(UsedByMixin, ModelViewSet):
@@ -39,3 +58,45 @@ class TelegramSourceViewSet(UsedByMixin, ModelViewSet):
     ]
     search_fields = ["name", "slug"]
     ordering = ["name"]
+
+    @extend_schema(
+        request=TelegramAuthSerializer,
+        responses={
+            201: UserTelegramSourceConnectionSerializer,
+            403: OpenApiResponse(description="Access denied"),
+        },
+        # parameters=[
+        #     OpenApiParameter(
+        #         name="slug",
+        #         location=OpenApiParameter.PATH,
+        #         type=OpenApiTypes.STR,
+        #     )
+        # ],
+    )
+    @action(
+        methods=["POST"],
+        url_path="connect_user",
+        detail=True,
+        pagination_class=None,
+        filter_backends=[],
+        permission_classes=[IsAuthenticated],
+    )
+    def connect_user(self, request: Request, slug: str) -> Response:
+
+        source: TelegramSource = get_object_or_404(TelegramSource, slug=slug)
+        serializer = TelegramAuthSerializer(bot_token=source.bot_token, data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        connection, created = UserTelegramSourceConnection.objects.get_or_create(
+            source=source,
+            identifier=serializer.validated_data["id"],
+            defaults={"user": request.user},
+        )
+        if not created and connection.user != request.user:
+            return Response(
+                data={"detail": _("This Telegram account is already connected to another user.")},
+                status=403,
+            )
+        return Response(
+            data=UserTelegramSourceConnectionSerializer(instance=connection).data, status=201
+        )

--- a/authentik/sources/telegram/models.py
+++ b/authentik/sources/telegram/models.py
@@ -1,6 +1,7 @@
 """Telegram source"""
 
 from typing import Any
+from urllib.parse import urlencode
 
 from django.db import models
 from django.http import HttpRequest
@@ -75,6 +76,12 @@ class TelegramSource(Source):
                 "title": self.name,
                 "component": "ak-user-settings-source-telegram",
                 "icon_url": self.icon_url,
+                "configure_url": urlencode(
+                    {
+                        "bot_username": self.bot_username,
+                        "request_message_access": str(self.request_message_access),
+                    }
+                ),
             }
         )
 

--- a/authentik/sources/telegram/stage.py
+++ b/authentik/sources/telegram/stage.py
@@ -1,12 +1,8 @@
-import hashlib
-import hmac
-from datetime import datetime, timedelta
-
 from django.utils.translation import gettext_lazy as _
-from rest_framework.fields import BooleanField, CharField, IntegerField, URLField
-from rest_framework.serializers import ValidationError
+from rest_framework.fields import BooleanField, CharField
 
 from authentik.flows.challenge import Challenge, ChallengeResponse
+from authentik.sources.telegram.telegram import TelegramAuth
 from authentik.stages.identification.stage import LoginChallengeMixin
 
 
@@ -16,33 +12,15 @@ class TelegramLoginChallenge(LoginChallengeMixin, Challenge):
     request_message_access = BooleanField()
 
 
-class TelegramChallengeResponse(ChallengeResponse):
+class TelegramChallengeResponse(TelegramAuth, ChallengeResponse):
     component = CharField(default="ak-source-telegram")
 
-    id = IntegerField()
-    first_name = CharField(max_length=255, required=False)
-    last_name = CharField(max_length=255, required=False)
-    username = CharField(max_length=255, required=False)
-    photo_url = URLField(required=False)
-    auth_date = IntegerField(required=True)
-    hash = CharField(max_length=64, required=True)
-
-    def validate_auth_date(self, auth_date: int) -> int:
-        if datetime.fromtimestamp(auth_date) < datetime.now() - timedelta(minutes=5):
-            raise ValidationError(_("Authentication date is too old"))
-        return auth_date
+    def get_bot_token(self) -> str:
+        return self.stage.source.bot_token
 
     def validate(self, attrs: dict) -> dict:
-        # Check the response as defined in https://core.telegram.org/widgets/login
         attrs_to_check = attrs.copy()
-        attrs_to_check.pop("component")
-        attrs_to_check.pop("hash")
-        check_str = "\n".join([f"{key}={value}" for key, value in sorted(attrs_to_check.items())])
-        digest = hmac.new(
-            hashlib.sha256(self.stage.source.bot_token.encode("utf-8")).digest(),
-            check_str.encode("utf-8"),
-            "sha256",
-        ).hexdigest()
-        if not hmac.compare_digest(digest, attrs["hash"]):
-            raise ValidationError(_("Invalid hash"))
-        return attrs
+        component = attrs_to_check.pop("component")
+        validated = super().validate(attrs_to_check)
+        validated["component"] = component
+        return validated

--- a/authentik/sources/telegram/telegram.py
+++ b/authentik/sources/telegram/telegram.py
@@ -1,0 +1,36 @@
+import hashlib
+import hmac
+from datetime import datetime, timedelta
+
+from django.utils.translation import gettext_lazy as _
+from rest_framework.fields import CharField, IntegerField, URLField
+from rest_framework.serializers import Serializer, ValidationError
+
+
+class TelegramAuth(Serializer):
+    id = IntegerField()
+    first_name = CharField(max_length=255, required=False)
+    last_name = CharField(max_length=255, required=False)
+    username = CharField(max_length=255, required=False)
+    photo_url = URLField(required=False)
+    auth_date = IntegerField(required=True)
+    hash = CharField(max_length=64, required=True)
+
+    def validate_auth_date(self, auth_date: int) -> int:
+        if datetime.fromtimestamp(auth_date) < datetime.now() - timedelta(minutes=5):
+            raise ValidationError(_("Authentication date is too old"))
+        return auth_date
+
+    def validate(self, attrs: dict) -> dict:
+        # Check the response as defined in https://core.telegram.org/widgets/login
+        check_str = "\n".join(
+            [f"{key}={value}" for key, value in sorted(attrs.items()) if key != "hash"]
+        )
+        digest = hmac.new(
+            hashlib.sha256(self.get_bot_token().encode("utf-8")).digest(),
+            check_str.encode("utf-8"),
+            "sha256",
+        ).hexdigest()
+        if not hmac.compare_digest(digest, attrs["hash"]):
+            raise ValidationError(_("Invalid hash"))
+        return attrs

--- a/schema.yml
+++ b/schema.yml
@@ -24488,6 +24488,39 @@ paths:
           $ref: '#/components/responses/ValidationErrorResponse'
         '403':
           $ref: '#/components/responses/GenericErrorResponse'
+  /sources/telegram/{slug}/connect_user/:
+    post:
+      operationId: sources_telegram_connect_user_create
+      description: Mixin to add a used_by endpoint to return a list of all objects
+        using this object
+      parameters:
+      - in: path
+        name: slug
+        schema:
+          type: string
+          description: Internal source name, used in URLs.
+        required: true
+      tags:
+      - sources
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TelegramAuthRequest'
+        required: true
+      security:
+      - authentik: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserTelegramSourceConnection'
+          description: ''
+        '403':
+          description: Access denied
+        '400':
+          $ref: '#/components/responses/ValidationErrorResponse'
   /sources/telegram/{slug}/used_by/:
     get:
       operationId: sources_telegram_used_by_list
@@ -53508,14 +53541,9 @@ components:
       - warning
       - error
       type: string
-    TelegramChallengeResponseRequest:
+    TelegramAuthRequest:
       type: object
-      description: Base class for all challenge responses
       properties:
-        component:
-          type: string
-          minLength: 1
-          default: ak-source-telegram
         id:
           type: integer
         first_name:
@@ -53540,6 +53568,42 @@ components:
           type: string
           minLength: 1
           maxLength: 64
+      required:
+      - auth_date
+      - hash
+      - id
+    TelegramChallengeResponseRequest:
+      type: object
+      description: Base class for all challenge responses
+      properties:
+        id:
+          type: integer
+        first_name:
+          type: string
+          minLength: 1
+          maxLength: 255
+        last_name:
+          type: string
+          minLength: 1
+          maxLength: 255
+        username:
+          type: string
+          minLength: 1
+          maxLength: 255
+        photo_url:
+          type: string
+          format: uri
+          minLength: 1
+        auth_date:
+          type: integer
+        hash:
+          type: string
+          minLength: 1
+          maxLength: 64
+        component:
+          type: string
+          minLength: 1
+          default: ak-source-telegram
       required:
       - auth_date
       - hash

--- a/web/src/elements/user/sources/SourceSettingsTelegram.ts
+++ b/web/src/elements/user/sources/SourceSettingsTelegram.ts
@@ -1,20 +1,27 @@
 import "#elements/Spinner";
 
+import { loadTelegramWidget, TelegramUserResponse } from "../../../flow/sources/telegram/utils";
+
 import { DEFAULT_CONFIG } from "#common/api/config";
 import { EVENT_REFRESH } from "#common/constants";
 import { parseAPIResponseError, pluckErrorDetail } from "#common/errors/network";
 import { MessageLevel } from "#common/messages";
 
 import { showMessage } from "#elements/messages/MessageContainer";
+import { SlottedTemplateResult } from "#elements/types";
 import { BaseUserSettings } from "#elements/user/sources/BaseUserSettings";
 
-import { SourcesApi } from "@goauthentik/api";
+import { SourcesApi, UserTelegramSourceConnection } from "@goauthentik/api";
 
 import { msg, str } from "@lit/localize";
+import { html } from "lit";
 import { customElement } from "lit/decorators.js";
+import { createRef, ref } from "lit/directives/ref.js";
 
 @customElement("ak-user-settings-source-telegram")
 export class SourceSettingsTelegram extends BaseUserSettings {
+    connectBtnRef = createRef();
+
     protected disconnectSource(): Promise<void> {
         return new SourcesApi(DEFAULT_CONFIG)
             .sourcesUserConnectionsTelegramDestroy({
@@ -43,6 +50,61 @@ export class SourceSettingsTelegram extends BaseUserSettings {
                     }),
                 );
             });
+    }
+
+    protected renderConnectButton(): SlottedTemplateResult {
+        if (!this.configureURL) {
+            return null;
+        }
+
+        return html` <div ${ref(this.connectBtnRef)}>
+            <button @click=${this.connectTelegram} class="pf-c-button pf-m-primary">
+                ${msg("Connect")}
+            </button>
+        </div>`;
+    }
+
+    protected async connectTelegram(): Promise<void> {
+        const params = new URLSearchParams(this.configureURL || "");
+        const botUsername: string = params.get("bot_username") || "";
+        const requestMessageAccess = params.get("request_message_access") === "True";
+        if (this.connectBtnRef.value) this.connectBtnRef.value.textContent = "";
+        loadTelegramWidget(
+            this.connectBtnRef.value,
+            botUsername,
+            requestMessageAccess,
+            (user: TelegramUserResponse) => {
+                new SourcesApi(DEFAULT_CONFIG)
+                    .sourcesTelegramConnectUserCreate({
+                        slug: this.objectId,
+                        telegramAuthRequest: {
+                            id: user.id,
+                            authDate: user.auth_date,
+                            hash: user.hash,
+                            firstName: user.first_name,
+                            lastName: user.last_name,
+                            username: user.username,
+                            photoUrl: user.photo_url,
+                        },
+                    })
+                    .then((connection: UserTelegramSourceConnection) => {
+                        this.connectionPk = connection.pk;
+                        showMessage({
+                            level: MessageLevel.info,
+                            message: msg("Successfully connected source"),
+                        });
+                    })
+                    .catch(async (error: unknown) => {
+                        const parsedError = await parseAPIResponseError(error);
+                        showMessage({
+                            level: MessageLevel.error,
+                            message: msg(
+                                str`Failed to connect source: ${pluckErrorDetail(parsedError)}`,
+                            ),
+                        });
+                    });
+            },
+        );
     }
 }
 

--- a/web/src/flow/sources/telegram/TelegramLogin.ts
+++ b/web/src/flow/sources/telegram/TelegramLogin.ts
@@ -1,3 +1,5 @@
+import { loadTelegramWidget, TelegramUserResponse } from "./utils";
+
 import { BaseStage } from "#flow/stages/base";
 
 import { TelegramChallengeResponseRequest, TelegramLoginChallenge } from "@goauthentik/api";
@@ -15,16 +17,6 @@ import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
 import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
-type TelegramUserResponse = {
-    id: number;
-    first_name?: string;
-    last_name?: string;
-    username?: string;
-    photo_url?: string;
-    auth_date: number;
-    hash: string;
-};
-
 @customElement("ak-flow-source-telegram")
 export class TelegramLogin extends BaseStage<
     TelegramLoginChallenge,
@@ -37,17 +29,10 @@ export class TelegramLogin extends BaseStage<
     }
 
     firstUpdated(): void {
-        const widgetScript = document.createElement("script");
-        widgetScript.src = "https://telegram.org/js/telegram-widget.js?22";
-        widgetScript.type = "text/javascript";
-        widgetScript.setAttribute("data-radius", "0");
-        widgetScript.setAttribute("data-telegram-login", this.challenge.botUsername);
-        if (this.challenge.requestMessageAccess) {
-            widgetScript.setAttribute("data-request-access", "write");
-        }
-        const callbackName =
-            "__ak_telegram_login_callback_" + (Math.random() + 1).toString(36).substring(7);
-        (window as unknown as Record<string, (user: TelegramUserResponse) => void>)[callbackName] =
+        loadTelegramWidget(
+            this.btnRef.value,
+            this.challenge.botUsername,
+            this.challenge.requestMessageAccess,
             (user: TelegramUserResponse) => {
                 this.host.submit({
                     id: user.id,
@@ -58,15 +43,8 @@ export class TelegramLogin extends BaseStage<
                     username: user.username,
                     photoUrl: user.photo_url,
                 });
-            };
-        widgetScript.setAttribute("data-onauth", callbackName + "(user)");
-        this.btnRef.value?.appendChild(widgetScript);
-        widgetScript.onload = () => {
-            if (widgetScript.previousSibling) {
-                this.btnRef.value?.appendChild(widgetScript.previousSibling);
-            }
-        };
-        document.body.append(widgetScript);
+            },
+        );
     }
 
     render(): TemplateResult {

--- a/web/src/flow/sources/telegram/utils.ts
+++ b/web/src/flow/sources/telegram/utils.ts
@@ -1,0 +1,37 @@
+export type TelegramUserResponse = {
+    id: number;
+    first_name?: string;
+    last_name?: string;
+    username?: string;
+    photo_url?: string;
+    auth_date: number;
+    hash: string;
+};
+
+export function loadTelegramWidget(
+    targetElement: Element | undefined,
+    botUsername: string,
+    requestMessageAccess: boolean,
+    callback: (user: TelegramUserResponse) => void,
+) {
+    const widgetScript = document.createElement("script");
+    widgetScript.src = "https://telegram.org/js/telegram-widget.js?22";
+    widgetScript.type = "text/javascript";
+    widgetScript.setAttribute("data-radius", "0");
+    widgetScript.setAttribute("data-telegram-login", botUsername);
+    if (requestMessageAccess) {
+        widgetScript.setAttribute("data-request-access", "write");
+    }
+    const callbackName =
+        "__ak_telegram_login_callback_" + (Math.random() + 1).toString(36).substring(7);
+    (window as unknown as Record<string, (user: TelegramUserResponse) => void>)[callbackName] =
+        callback;
+    widgetScript.setAttribute("data-onauth", callbackName + "(user)");
+    targetElement?.appendChild(widgetScript);
+    widgetScript.onload = () => {
+        if (widgetScript.previousSibling) {
+            targetElement?.appendChild(widgetScript.previousSibling);
+        }
+    };
+    document.body.append(widgetScript);
+}


### PR DESCRIPTION

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
This PR implements missing "connect account" functionality for the Telegram source. When a Telegram source is configured, existing users should be able connect their Telegram account by going to Settings -> Connected services. Currently this functionality is missing and this PR addresses that. 

A respective view is added in sources/telegram/api/source.py  and renderConnectButton is implemented in SourceSettingsTelegram.ts.

This closes #18467

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [x] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)

If applicable

-   [n/a] The documentation has been updated
-   [n/a] The documentation has been formatted (`make docs`)
