### PR TITLE
web/admin: fix brands default switch label

### DIFF
--- a/web/src/admin/brands/BrandForm.ts
+++ b/web/src/admin/brands/BrandForm.ts
@@ -75,7 +75,7 @@ export class BrandForm extends ModelForm<Brand, string> {
 
             <ak-switch-input
                 name="_default"
-                label=${msg("Sign assertions")}
+                label=${msg("Default")}
                 ?checked=${this.instance?._default ?? false}
                 help=${msg("Use this brand for each domain that doesn't have a dedicated brand.")}
             >


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
Hello! After migrating from 2025.2 to 2025.10 we noticed that the "default" checkbox for brands now has a weird label. I assume this is a mistake, it seems to be introduced here: https://github.com/goauthentik/authentik/commit/1eb78ac9ae71a6a0c8f42f4062bf5e62d49dfc29

---

## Checklist

Sorry, I am using Windows and was not able to set up a local dev env in reasonable time. If this PR is not appropriate let me know if I should make an issue instead.

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
