### PR TITLE
web: Locale selector

### DIFF
--- a/web/src/common/api/config.ts
+++ b/web/src/common/api/config.ts
@@ -7,26 +7,20 @@ import {
 import { globalAK } from "#common/global";
 import { SentryMiddleware } from "#common/sentry/middleware";
 
-import { Config, Configuration, CurrentBrand, RootApi } from "@goauthentik/api";
+import { Configuration, CurrentBrand } from "@goauthentik/api";
+
+const { locale, api, brand } = globalAK();
 
 export const DEFAULT_CONFIG = new Configuration({
-    basePath: `${globalAK().api.base}api/v3`,
+    basePath: `${api.base}api/v3`,
     middleware: [
         new CSRFMiddleware(),
         new EventMiddleware(),
-        new LoggingMiddleware(globalAK().brand),
+        new LoggingMiddleware(brand),
         new SentryMiddleware(),
-        new LocaleMiddleware(),
+        new LocaleMiddleware(locale),
     ],
 });
-
-let globalConfigPromise: Promise<Config> | undefined = Promise.resolve(globalAK().config);
-export function config(): Promise<Config> {
-    if (!globalConfigPromise) {
-        globalConfigPromise = new RootApi(DEFAULT_CONFIG).rootConfigRetrieve();
-    }
-    return globalConfigPromise;
-}
 
 export function brandSetFavicon(brand: CurrentBrand) {
     /**

--- a/web/src/elements/controllers/LocaleContextController.ts
+++ b/web/src/elements/controllers/LocaleContextController.ts
@@ -124,7 +124,7 @@ export class LocaleContextController implements ReactiveController {
      * @param host The host element.
      * @param localeHint The initial locale code to set.
      */
-    constructor(host: ReactiveElementHost<LocaleMixin>, localeHint?: string) {
+    constructor(host: ReactiveElementHost<LocaleMixin>, localeHint?: TargetLocale) {
         this.#host = host;
 
         const contextValue = configureLocalization({
@@ -140,7 +140,7 @@ export class LocaleContextController implements ReactiveController {
 
         this.#host[kAKLocale] = contextValue;
 
-        const nextLocale = autoDetectLanguage(localeHint);
+        const nextLocale = localeHint || autoDetectLanguage();
 
         if (nextLocale !== sourceLocale) {
             this.#applyLocale(nextLocale);

--- a/web/src/elements/controllers/SessionContextController.ts
+++ b/web/src/elements/controllers/SessionContextController.ts
@@ -66,43 +66,6 @@ export class SessionContextController implements ReactiveController {
             .finally(() => {
                 this.#abortController = null;
             });
-
-        // return me()
-        //     .then((session) => {
-        //         const localeHint: string | undefined = session.user.settings.locale;
-
-        //         if (localeHint) {
-        //             const locale = autoDetectLanguage(localeHint);
-        //             this.#log(`Activating user's configured locale '${locale}'`);
-        //             this.#host[kAKLocale]?.setLocale(locale);
-        //         }
-
-        //         const config = this.#host[kAKConfig];
-
-        //         if (config?.errorReporting.sendPii) {
-        //             console.debug("authentik/config: Sentry with PII enabled.");
-
-        //             setUser({ email: session.user.email });
-        //         }
-
-        //         console.debug("authentik/controller/session: Fetched session", session);
-        //         this.#context.setValue(session);
-        //         this.#host.session = session;
-        //     })
-        //     .catch(async (error: unknown) => {
-        //         if (isCausedByAbortError(error)) {
-        //             this.#log("Aborted fetching session");
-        //             return;
-        //         }
-
-        //         const parsedError = parseAPIResponseError(error);
-        //         console.error("authentik/controller/session: Failed to fetch session", parsedError);
-
-        //         throw error;
-        //     })
-        //     .finally(() => {
-        //         this.#abortController = null;
-        //     });
     };
 
     public hostConnected() {

--- a/web/src/flow/FlowExecutor.css
+++ b/web/src/flow/FlowExecutor.css
@@ -29,7 +29,7 @@
     border-color: transparent;
     border-width: thin;
 
-    &:hover {
+    &:has(select:hover) {
         cursor: pointer;
         border-color: var(--pf-global--Color--100);
     }

--- a/web/src/flow/FlowExecutor.css
+++ b/web/src/flow/FlowExecutor.css
@@ -12,3 +12,42 @@
     right: 1rem;
     z-index: 100;
 }
+
+.locale-selector {
+    position: absolute;
+    inset-block-start: 1rem;
+    inset-inline-start: 1rem;
+    z-index: 100;
+    display: flex;
+    flex-flow: row;
+    align-items: center;
+    gap: var(--pf-global--spacer--sm);
+    padding-inline-start: var(--pf-global--spacer--sm);
+    padding-block: var(--pf-global--spacer--xs);
+    border-radius: var(--pf-global--BorderRadius--sm);
+    border-style: solid;
+    border-color: transparent;
+    border-width: thin;
+
+    &:hover {
+        cursor: pointer;
+        border-color: var(--pf-global--Color--100);
+    }
+
+    select {
+        background-color: transparent;
+        color: var(--pf-global--Color--100);
+
+        border: none;
+
+        &:focus {
+            outline: none;
+        }
+
+        appearance: base-select;
+
+        &::picker-icon {
+            color: transparent;
+        }
+    }
+}

--- a/web/src/flow/FlowExecutor.ts
+++ b/web/src/flow/FlowExecutor.ts
@@ -21,6 +21,7 @@ import { globalAK } from "#common/global";
 import { configureSentry } from "#common/sentry/index";
 import { applyBackgroundImageProperty } from "#common/theme";
 import { formatLocaleOptions, PseudoLocale, TargetLocale } from "#common/ui/locale/definitions";
+import { setSessionLocale } from "#common/ui/locale/utils";
 import { WebsocketClient, WSMessage } from "#common/ws";
 
 import { Interface } from "#elements/Interface";
@@ -49,6 +50,7 @@ import { spread } from "@open-wc/lit-helpers";
 import { msg } from "@lit/localize";
 import { CSSResult, html, nothing, PropertyValues, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
+import { repeat } from "lit/directives/repeat.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { until } from "lit/directives/until.js";
 
@@ -486,7 +488,10 @@ export class FlowExecutor
     #localeChangeListener = (event: Event) => {
         const select = event.target as HTMLSelectElement;
         const locale = select.value as TargetLocale;
+
         this.locale = locale;
+
+        setSessionLocale(locale);
     };
 
     protected renderLocaleSelector() {
@@ -497,7 +502,9 @@ export class FlowExecutor
             localeOptions = localeOptions.filter(([, code]) => code !== PseudoLocale);
         }
 
-        const options = localeOptions.map(
+        const options = repeat(
+            localeOptions,
+            ([_locale, code]) => code,
             ([label, code]) =>
                 html`<option value=${code} ?selected=${code === locale}>${label}</option>`,
         );

--- a/web/src/flow/FlowExecutor.ts
+++ b/web/src/flow/FlowExecutor.ts
@@ -503,15 +503,20 @@ export class FlowExecutor
         );
 
         return html`<div class="locale-selector">
-            <i class="fa fa-globe" aria-hidden="true"></i>
-            <select
-                @change=${this.#localeChangeListener}
-                class="pf-c-form-control"
-                name="locale"
+            <label
+                for="locale-selector"
                 aria-label=${msg("Select language", {
                     id: "language-selector-label",
                     desc: "Label for the language selection dropdown",
                 })}
+            >
+                <i class="fa fa-globe" aria-hidden="true"></i>
+            </label>
+            <select
+                id="locale-selector"
+                @change=${this.#localeChangeListener}
+                class="pf-c-form-control"
+                name="locale"
             >
                 ${options}
             </select>

--- a/web/src/styles/authentik/base/colors.css
+++ b/web/src/styles/authentik/base/colors.css
@@ -215,6 +215,7 @@
     --pf-global--primary-color--200: oklab(0.3763 -0.0324 -0.1182);
     --pf-global--primary-color--light-100: oklab(0.7706 -0.0485 -0.1012);
     --pf-global--primary-color--dark-100: oklab(0.522 -0.0434 -0.1717);
+    --pf-global--primary-color--300: oklab(0.522 -0.0434 -0.1717);
 }
 
 /* #endregion */


### PR DESCRIPTION
## Details

This PR adds a locale selector to the flow executor.

### Changes

- API middleware now synchronizes with the current locale
- Selecting a locale persists the preference for the browser session. After authentication, user attributes take priority over the session preference (if any user attributes exist)
- Removed commented-out context controller code

## Screenshots

<img width="1470" height="888" alt="Screenshot 2025-12-03 at 07 33 49" src="https://github.com/user-attachments/assets/15481a49-5707-4495-aebd-6cc5302ae18c" />

<img width="546" height="500" alt="Screenshot 2025-12-03 at 07 34 04" src="https://github.com/user-attachments/assets/72091cfc-41da-48a4-825b-a7ee7332ea87" />

<img width="500" height="922" alt="Screenshot 2025-12-03 at 07 34 13" src="https://github.com/user-attachments/assets/e43333fb-38a1-4b9f-b787-2defb1478824" />
