### PR TITLE
website/docs: add missing API sidebar entry

### DIFF
--- a/website/api/sidebar.mjs
+++ b/website/api/sidebar.mjs
@@ -46,6 +46,12 @@ const sidebar = {
         },
 
         {
+            type: "doc",
+            label: "Websockets",
+            id: "websocket",
+        },
+
+        {
             type: "category",
             label: "API Clients",
             collapsed: false,


### PR DESCRIPTION
## Details

Found this missing sidebar entry while trying to troubleshoot search issues.

Makes this doc actually show up in the sidebar: https://api.goauthentik.io/websocket/

Might no longer be required. In which case we can remove the doc and the sidebar entry
