### PR TITLE
web: Remove Patternfly 4 base CSS stub

### DIFF
--- a/web/bundler/style-loader-plugin/node.js
+++ b/web/bundler/style-loader-plugin/node.js
@@ -76,13 +76,6 @@ export function styleLoaderPlugin({
                 }
             });
 
-            build.onLoad({ filter: /patternfly-base.css/ }, () => {
-                return {
-                    contents: "",
-                    loader: "text",
-                };
-            });
-
             build.onResolve(...fontResolverArgs);
 
             /**

--- a/web/src/admin/AdminInterface/index.entrypoint.ts
+++ b/web/src/admin/AdminInterface/index.entrypoint.ts
@@ -41,7 +41,6 @@ import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFDrawer from "@patternfly/patternfly/components/Drawer/drawer.css";
 import PFNav from "@patternfly/patternfly/components/Nav/nav.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 if (process.env.NODE_ENV === "development") {
     await import("@goauthentik/esbuild-plugin-live-reload/client");
@@ -78,7 +77,7 @@ export class AdminInterface extends WithCapabilitiesConfig(WithSession(Authentic
 
     static styles: CSSResult[] = [
         // ---
-        PFBase,
+
         PFPage,
         PFButton,
         PFDrawer,

--- a/web/src/admin/DebugPage.ts
+++ b/web/src/admin/DebugPage.ts
@@ -18,11 +18,10 @@ import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFCard from "@patternfly/patternfly/components/Card/card.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-admin-debug-page")
 export class DebugPage extends AKElement {
-    static styles: CSSResult[] = [PFBase, PFCard, PFPage, PFGrid, PFButton];
+    static styles: CSSResult[] = [PFCard, PFPage, PFGrid, PFButton];
 
     render(): TemplateResult {
         return html`

--- a/web/src/admin/admin-overview/AdminOverviewPage.ts
+++ b/web/src/admin/admin-overview/AdminOverviewPage.ts
@@ -30,14 +30,12 @@ import PFContent from "@patternfly/patternfly/components/Content/content.css";
 import PFDivider from "@patternfly/patternfly/components/Divider/divider.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 const AdminOverviewBase = WithLicenseSummary(WithSession(AKElement));
 
 @customElement("ak-admin-overview")
 export class AdminOverviewPage extends AdminOverviewBase {
     static styles: CSSResult[] = [
-        PFBase,
         PFGrid,
         PFPage,
         PFContent,

--- a/web/src/admin/admin-settings/AdminSettingsFooterLinks.ts
+++ b/web/src/admin/admin-settings/AdminSettingsFooterLinks.ts
@@ -12,7 +12,6 @@ import { customElement, property, queryAll } from "lit/decorators.js";
 
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFInputGroup from "@patternfly/patternfly/components/InputGroup/input-group.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 export interface IFooterLinkInput {
     footerLink: FooterLink;
@@ -25,7 +24,6 @@ const hasLegalScheme = (url: string) =>
 @customElement("ak-admin-settings-footer-link")
 export class FooterLinkInput extends AkControlElement<FooterLink> {
     static styles = [
-        PFBase,
         PFInputGroup,
         PFFormControl,
         css`

--- a/web/src/admin/admin-settings/AdminSettingsPage.ts
+++ b/web/src/admin/admin-settings/AdminSettingsPage.ts
@@ -30,12 +30,10 @@ import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-admin-settings")
 export class AdminSettingsPage extends AKElement {
     static styles = [
-        PFBase,
         PFButton,
         PFPage,
         PFGrid,

--- a/web/src/admin/applications/ApplicationViewPage.ts
+++ b/web/src/admin/applications/ApplicationViewPage.ts
@@ -37,12 +37,10 @@ import PFList from "@patternfly/patternfly/components/List/list.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFFlex from "@patternfly/patternfly/layouts/Flex/flex.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-application-view")
 export class ApplicationViewPage extends AKElement {
     static styles: CSSResult[] = [
-        PFBase,
         PFList,
         PFBanner,
         PFPage,

--- a/web/src/admin/applications/ApplicationWizardHint.ts
+++ b/web/src/admin/applications/ApplicationWizardHint.ts
@@ -17,7 +17,6 @@ import { styleMap } from "lit/directives/style-map.js";
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFLabel from "@patternfly/patternfly/components/Label/label.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 const closeButtonIcon = html`<svg
     fill="currentColor"
@@ -36,7 +35,6 @@ const closeButtonIcon = html`<svg
 @customElement("ak-application-wizard-hint")
 export class AkApplicationWizardHint extends AKElement implements ShowHintControllerHost {
     static styles = [
-        PFBase,
         PFButton,
         PFPage,
         PFLabel,

--- a/web/src/admin/applications/wizard/ApplicationWizardFormStepStyles.styles.ts
+++ b/web/src/admin/applications/wizard/ApplicationWizardFormStepStyles.styles.ts
@@ -9,10 +9,8 @@ import PFInputGroup from "@patternfly/patternfly/components/InputGroup/input-gro
 import PFRadio from "@patternfly/patternfly/components/Radio/radio.css";
 import PFSwitch from "@patternfly/patternfly/components/Switch/switch.css";
 import PFWizard from "@patternfly/patternfly/components/Wizard/wizard.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 export const styles = [
-    PFBase,
     PFCard,
     PFButton,
     PFForm,

--- a/web/src/admin/applications/wizard/steps/bindings/ak-application-wizard-bindings-toolbar.ts
+++ b/web/src/admin/applications/wizard/steps/bindings/ak-application-wizard-bindings-toolbar.ts
@@ -6,11 +6,10 @@ import { customElement, property } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFToolbar from "@patternfly/patternfly/components/Toolbar/toolbar.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-application-wizard-bindings-toolbar")
 export class ApplicationWizardBindingsToolbar extends AKElement {
-    static styles = [PFBase, PFButton, PFToolbar];
+    static styles = [PFButton, PFToolbar];
 
     @property({ type: Boolean, attribute: "can-delete", reflect: true })
     canDelete = false;

--- a/web/src/admin/endpoints/connectors/ConnectorWizard.ts
+++ b/web/src/admin/endpoints/connectors/ConnectorWizard.ts
@@ -18,11 +18,10 @@ import { CSSResult, html, TemplateResult } from "lit";
 import { property, query } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-endpoint-connector-wizard")
 export class EndpointConnectorWizard extends AKElement {
-    static styles: CSSResult[] = [PFBase, PFButton];
+    static styles: CSSResult[] = [PFButton];
 
     @property()
     createText = msg("Create");

--- a/web/src/admin/endpoints/connectors/agent/AgentConnectorSetup.ts
+++ b/web/src/admin/endpoints/connectors/agent/AgentConnectorSetup.ts
@@ -24,7 +24,6 @@ import { createRef, ref } from "lit/directives/ref.js";
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFList from "@patternfly/patternfly/components/List/list.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-endpoints-connector-agent-setup")
 export class AgentConnectorSetup extends AKElement {
@@ -37,7 +36,6 @@ export class AgentConnectorSetup extends AKElement {
     #tokenSelectRef = createRef<SearchSelect<EnrollmentToken>>();
 
     static styles: CSSResult[] = [
-        PFBase,
         PFGrid,
         PFButton,
         PFList,

--- a/web/src/admin/endpoints/connectors/agent/AgentConnectorViewPage.ts
+++ b/web/src/admin/endpoints/connectors/agent/AgentConnectorViewPage.ts
@@ -26,7 +26,6 @@ import PFCard from "@patternfly/patternfly/components/Card/card.css";
 import PFDescriptionList from "@patternfly/patternfly/components/DescriptionList/description-list.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-endpoints-connector-agent-view")
 export class AgentConnectorViewPage extends AKElement {
@@ -39,7 +38,7 @@ export class AgentConnectorViewPage extends AKElement {
     @state()
     protected error?: APIError;
 
-    static styles: CSSResult[] = [PFBase, PFCard, PFPage, PFGrid, PFButton, PFDescriptionList];
+    static styles: CSSResult[] = [PFCard, PFPage, PFGrid, PFButton, PFDescriptionList];
 
     protected fetchDevice(id: string) {
         new EndpointsApi(DEFAULT_CONFIG)

--- a/web/src/admin/endpoints/devices/DeviceViewPage.ts
+++ b/web/src/admin/endpoints/devices/DeviceViewPage.ts
@@ -29,7 +29,6 @@ import PFCard from "@patternfly/patternfly/components/Card/card.css";
 import PFDescriptionList from "@patternfly/patternfly/components/DescriptionList/description-list.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-endpoints-device-view")
 export class DeviceViewPage extends AKElement {
@@ -42,7 +41,7 @@ export class DeviceViewPage extends AKElement {
     @state()
     protected error?: APIError;
 
-    static styles: CSSResult[] = [PFBase, PFCard, PFPage, PFGrid, PFButton, PFDescriptionList];
+    static styles: CSSResult[] = [PFCard, PFPage, PFGrid, PFButton, PFDescriptionList];
 
     protected fetchDevice(id: string) {
         new EndpointsApi(DEFAULT_CONFIG)

--- a/web/src/admin/enterprise/EnterpriseStatusCard.ts
+++ b/web/src/admin/enterprise/EnterpriseStatusCard.ts
@@ -11,7 +11,6 @@ import PFCard from "@patternfly/patternfly/components/Card/card.css";
 import PFDescriptionList from "@patternfly/patternfly/components/DescriptionList/description-list.css";
 import PFProgress from "@patternfly/patternfly/components/Progress/progress.css";
 import PFSplit from "@patternfly/patternfly/layouts/Split/split.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-enterprise-status-card")
 export class EnterpriseStatusCard extends AKElement {
@@ -21,7 +20,7 @@ export class EnterpriseStatusCard extends AKElement {
     @state()
     summary?: LicenseSummary;
 
-    static styles: CSSResult[] = [PFBase, PFDescriptionList, PFCard, PFSplit, PFProgress];
+    static styles: CSSResult[] = [PFDescriptionList, PFCard, PFSplit, PFProgress];
 
     renderSummaryBadge() {
         switch (this.summary?.status) {

--- a/web/src/admin/events/EventMap.ts
+++ b/web/src/admin/events/EventMap.ts
@@ -23,7 +23,6 @@ import { css, CSSResult, html, PropertyValues, TemplateResult } from "lit";
 import { customElement, property, query } from "lit/decorators.js";
 
 import PFCard from "@patternfly/patternfly/components/Card/card.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 import OL from "ol/ol.css";
 
 @customElement("ak-map")
@@ -69,7 +68,6 @@ export class EventMap extends AKElement {
     zoomPaddingPx = 100;
 
     static styles: CSSResult[] = [
-        PFBase,
         PFCard,
         css`
             .pf-c-card,

--- a/web/src/admin/events/EventViewPage.ts
+++ b/web/src/admin/events/EventViewPage.ts
@@ -22,7 +22,6 @@ import PFContent from "@patternfly/patternfly/components/Content/content.css";
 import PFDescriptionList from "@patternfly/patternfly/components/DescriptionList/description-list.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-event-view")
 export class EventViewPage extends AKElement {
@@ -32,7 +31,7 @@ export class EventViewPage extends AKElement {
     @state()
     event!: EventWithContext;
 
-    static styles: CSSResult[] = [PFBase, PFGrid, PFDescriptionList, PFPage, PFContent, PFCard];
+    static styles: CSSResult[] = [PFGrid, PFDescriptionList, PFPage, PFContent, PFCard];
 
     fetchEvent(eventUuid: string) {
         new EventsApi(DEFAULT_CONFIG).eventsEventsRetrieve({ eventUuid }).then((ev) => {

--- a/web/src/admin/flows/FlowViewPage.ts
+++ b/web/src/admin/flows/FlowViewPage.ts
@@ -29,7 +29,6 @@ import PFContent from "@patternfly/patternfly/components/Content/content.css";
 import PFDescriptionList from "@patternfly/patternfly/components/DescriptionList/description-list.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-flow-view")
 export class FlowViewPage extends AKElement {
@@ -40,7 +39,6 @@ export class FlowViewPage extends AKElement {
     flow!: Flow;
 
     static styles: CSSResult[] = [
-        PFBase,
         PFPage,
         PFDescriptionList,
         PFButton,

--- a/web/src/admin/groups/GroupViewPage.ts
+++ b/web/src/admin/groups/GroupViewPage.ts
@@ -31,7 +31,6 @@ import PFDescriptionList from "@patternfly/patternfly/components/DescriptionList
 import PFList from "@patternfly/patternfly/components/List/list.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 import PFDisplay from "@patternfly/patternfly/utilities/Display/display.css";
 import PFSizing from "@patternfly/patternfly/utilities/Sizing/sizing.css";
 
@@ -53,7 +52,6 @@ export class GroupViewPage extends AKElement {
     group?: Group;
 
     static styles: CSSResult[] = [
-        PFBase,
         PFPage,
         PFButton,
         PFDisplay,

--- a/web/src/admin/outposts/OutpostHealth.ts
+++ b/web/src/admin/outposts/OutpostHealth.ts
@@ -12,7 +12,6 @@ import { css, CSSResult, html, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import PFDescriptionList from "@patternfly/patternfly/components/DescriptionList/description-list.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-outpost-health")
 export class OutpostHealthElement extends AKElement {
@@ -20,7 +19,6 @@ export class OutpostHealthElement extends AKElement {
     outpostHealth?: OutpostHealth;
 
     static styles: CSSResult[] = [
-        PFBase,
         PFDescriptionList,
         css`
             li {

--- a/web/src/admin/outposts/OutpostHealthSimple.ts
+++ b/web/src/admin/outposts/OutpostHealthSimple.ts
@@ -10,10 +10,8 @@ import { PFColor } from "#elements/Label";
 import { OutpostHealth, OutpostsApi } from "@goauthentik/api";
 
 import { msg, str } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { html, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-outpost-health-simple")
 export class OutpostHealthSimpleElement extends AKElement {
@@ -28,8 +26,6 @@ export class OutpostHealthSimpleElement extends AKElement {
 
     @property({ attribute: false })
     showVersion = true;
-
-    static styles: CSSResult[] = [PFBase];
 
     constructor() {
         super();

--- a/web/src/admin/outposts/ServiceConnectionWizard.ts
+++ b/web/src/admin/outposts/ServiceConnectionWizard.ts
@@ -18,11 +18,10 @@ import { CSSResult, html, TemplateResult } from "lit";
 import { property, query } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-service-connection-wizard")
 export class ServiceConnectionWizard extends AKElement {
-    static styles: CSSResult[] = [PFBase, PFButton];
+    static styles: CSSResult[] = [PFButton];
 
     @property()
     createText = msg("Create");

--- a/web/src/admin/policies/PolicyWizard.ts
+++ b/web/src/admin/policies/PolicyWizard.ts
@@ -27,11 +27,10 @@ import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { property, query } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-policy-wizard")
 export class PolicyWizard extends AKElement {
-    static styles: CSSResult[] = [PFBase, PFButton];
+    static styles: CSSResult[] = [PFButton];
 
     @property()
     createText = msg("Create");

--- a/web/src/admin/property-mappings/PropertyMappingWizard.ts
+++ b/web/src/admin/property-mappings/PropertyMappingWizard.ts
@@ -32,11 +32,10 @@ import { html, TemplateResult } from "lit";
 import { property, query } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-property-mapping-wizard")
 export class PropertyMappingWizard extends AKElement {
-    static styles = [PFBase, PFButton];
+    static styles = [PFButton];
 
     @property({ attribute: false })
     mappingTypes: TypeCreate[] = [];

--- a/web/src/admin/providers/ProviderWizard.ts
+++ b/web/src/admin/providers/ProviderWizard.ts
@@ -23,11 +23,10 @@ import { CSSResult, html, TemplateResult } from "lit";
 import { property, query } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-provider-wizard")
 export class ProviderWizard extends AKElement {
-    static styles: CSSResult[] = [PFBase, PFButton];
+    static styles: CSSResult[] = [PFButton];
 
     @property()
     createText = msg("Create");

--- a/web/src/admin/providers/RelatedApplicationButton.ts
+++ b/web/src/admin/providers/RelatedApplicationButton.ts
@@ -11,11 +11,10 @@ import { CSSResult, html, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-provider-related-application")
 export class RelatedApplicationButton extends AKElement {
-    static styles: CSSResult[] = [PFBase, PFButton];
+    static styles: CSSResult[] = [PFButton];
 
     @property({ attribute: false })
     provider?: Provider;

--- a/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderViewPage.ts
+++ b/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderViewPage.ts
@@ -38,7 +38,6 @@ import PFList from "@patternfly/patternfly/components/List/list.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
 import PFStack from "@patternfly/patternfly/layouts/Stack/stack.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-provider-google-workspace-view")
 export class GoogleWorkspaceProviderViewPage extends AKElement {
@@ -49,7 +48,6 @@ export class GoogleWorkspaceProviderViewPage extends AKElement {
     provider?: GoogleWorkspaceProvider;
 
     static styles: CSSResult[] = [
-        PFBase,
         PFButton,
         PFForm,
         PFFormControl,

--- a/web/src/admin/providers/ldap/LDAPProviderViewPage.ts
+++ b/web/src/admin/providers/ldap/LDAPProviderViewPage.ts
@@ -35,7 +35,6 @@ import PFFormControl from "@patternfly/patternfly/components/FormControl/form-co
 import PFList from "@patternfly/patternfly/components/List/list.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-provider-ldap-view")
 export class LDAPProviderViewPage extends WithSession(AKElement) {
@@ -46,7 +45,6 @@ export class LDAPProviderViewPage extends WithSession(AKElement) {
     provider?: LDAPProvider;
 
     static styles: CSSResult[] = [
-        PFBase,
         PFButton,
         PFBanner,
         PFForm,

--- a/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderViewPage.ts
+++ b/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderViewPage.ts
@@ -38,7 +38,6 @@ import PFList from "@patternfly/patternfly/components/List/list.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
 import PFStack from "@patternfly/patternfly/layouts/Stack/stack.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-provider-microsoft-entra-view")
 export class MicrosoftEntraProviderViewPage extends AKElement {
@@ -49,7 +48,6 @@ export class MicrosoftEntraProviderViewPage extends AKElement {
     provider?: MicrosoftEntraProvider;
 
     static styles: CSSResult[] = [
-        PFBase,
         PFButton,
         PFForm,
         PFFormControl,

--- a/web/src/admin/providers/oauth2/OAuth2ProviderRedirectURI.ts
+++ b/web/src/admin/providers/oauth2/OAuth2ProviderRedirectURI.ts
@@ -13,7 +13,6 @@ import { ifDefined } from "lit/directives/if-defined.js";
 
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFInputGroup from "@patternfly/patternfly/components/InputGroup/input-group.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 export type RedirectURIProperties = LitPropertyRecord<{
     redirectURI: RedirectURI;
@@ -25,7 +24,6 @@ export type RedirectURIProperties = LitPropertyRecord<{
 @customElement("ak-provider-oauth2-redirect-uri")
 export class OAuth2ProviderRedirectURI extends AkControlElement<RedirectURI> {
     static styles = [
-        PFBase,
         PFInputGroup,
         PFFormControl,
         css`

--- a/web/src/admin/providers/oauth2/OAuth2ProviderViewPage.ts
+++ b/web/src/admin/providers/oauth2/OAuth2ProviderViewPage.ts
@@ -49,7 +49,6 @@ import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 export function TypeToLabel(type?: ClientTypeEnum): string {
     if (!type) return "";
@@ -89,7 +88,6 @@ export class OAuth2ProviderViewPage extends AKElement {
     previewUser?: User;
 
     static styles: CSSResult[] = [
-        PFBase,
         PFButton,
         PFPage,
         PFGrid,

--- a/web/src/admin/providers/proxy/ProxyProviderViewPage.ts
+++ b/web/src/admin/providers/proxy/ProxyProviderViewPage.ts
@@ -48,7 +48,6 @@ import PFFormControl from "@patternfly/patternfly/components/FormControl/form-co
 import PFList from "@patternfly/patternfly/components/List/list.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 export function ModeToLabel(action?: ProxyMode): string {
     if (!action) return "";
@@ -85,7 +84,6 @@ export class ProxyProviderViewPage extends AKElement {
     provider?: ProxyProvider;
 
     static styles: CSSResult[] = [
-        PFBase,
         PFButton,
         PFPage,
         PFGrid,

--- a/web/src/admin/providers/rac/RACProviderViewPage.ts
+++ b/web/src/admin/providers/rac/RACProviderViewPage.ts
@@ -37,7 +37,6 @@ import PFFormControl from "@patternfly/patternfly/components/FormControl/form-co
 import PFList from "@patternfly/patternfly/components/List/list.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-provider-rac-view")
 export class RACProviderViewPage extends AKElement {
@@ -48,7 +47,6 @@ export class RACProviderViewPage extends AKElement {
     provider?: RACProvider;
 
     static styles: CSSResult[] = [
-        PFBase,
         PFButton,
         PFPage,
         PFGrid,

--- a/web/src/admin/providers/radius/RadiusProviderViewPage.ts
+++ b/web/src/admin/providers/radius/RadiusProviderViewPage.ts
@@ -29,7 +29,6 @@ import PFContent from "@patternfly/patternfly/components/Content/content.css";
 import PFDescriptionList from "@patternfly/patternfly/components/DescriptionList/description-list.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFGallery from "@patternfly/patternfly/layouts/Gallery/gallery.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 import PFDisplay from "@patternfly/patternfly/utilities/Display/display.css";
 import PFSizing from "@patternfly/patternfly/utilities/Sizing/sizing.css";
 
@@ -42,7 +41,6 @@ export class RadiusProviderViewPage extends AKElement {
     provider?: RadiusProvider;
 
     static styles: CSSResult[] = [
-        PFBase,
         PFButton,
         PFPage,
         PFDisplay,

--- a/web/src/admin/providers/saml/SAMLProviderViewPage.ts
+++ b/web/src/admin/providers/saml/SAMLProviderViewPage.ts
@@ -46,7 +46,6 @@ import PFFormControl from "@patternfly/patternfly/components/FormControl/form-co
 import PFList from "@patternfly/patternfly/components/List/list.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 interface SAMLPreviewAttribute {
     attributes: {
@@ -80,7 +79,6 @@ export class SAMLProviderViewPage extends AKElement {
     previewUser?: User;
 
     static styles: CSSResult[] = [
-        PFBase,
         PFButton,
         PFPage,
         PFGrid,

--- a/web/src/admin/providers/scim/SCIMProviderViewPage.ts
+++ b/web/src/admin/providers/scim/SCIMProviderViewPage.ts
@@ -43,7 +43,6 @@ import PFList from "@patternfly/patternfly/components/List/list.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
 import PFStack from "@patternfly/patternfly/layouts/Stack/stack.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-provider-scim-view")
 export class SCIMProviderViewPage extends AKElement {
@@ -54,7 +53,6 @@ export class SCIMProviderViewPage extends AKElement {
     provider?: SCIMProvider;
 
     static styles: CSSResult[] = [
-        PFBase,
         PFButton,
         PFBanner,
         PFForm,

--- a/web/src/admin/providers/ssf/SSFProviderViewPage.ts
+++ b/web/src/admin/providers/ssf/SSFProviderViewPage.ts
@@ -36,7 +36,6 @@ import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-provider-ssf-view")
 export class SSFProviderViewPage extends AKElement {
@@ -55,7 +54,6 @@ export class SSFProviderViewPage extends AKElement {
     provider?: SSFProvider;
 
     static styles: CSSResult[] = [
-        PFBase,
         PFButton,
         PFPage,
         PFGrid,

--- a/web/src/admin/rbac/ObjectPermissionModal.ts
+++ b/web/src/admin/rbac/ObjectPermissionModal.ts
@@ -11,7 +11,6 @@ import { css, CSSResult, html, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 /**
  * This is a bit of a hack to get the viewport checking from ModelForm,
@@ -47,7 +46,6 @@ export class ObjectPermissionsPageForm extends ModelForm<unknown, string> {
 @customElement("ak-rbac-object-permission-modal")
 export class ObjectPermissionModal extends AKElement {
     static styles: CSSResult[] = [
-        PFBase,
         PFButton,
         css`
             button {

--- a/web/src/admin/rbac/ObjectPermissionsPage.ts
+++ b/web/src/admin/rbac/ObjectPermissionsPage.ts
@@ -14,7 +14,6 @@ import { customElement, property } from "lit/decorators.js";
 import PFCard from "@patternfly/patternfly/components/Card/card.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-rbac-object-permission-page")
 export class ObjectPermissionPage extends AKElement {
@@ -27,7 +26,7 @@ export class ObjectPermissionPage extends AKElement {
     @property({ type: Boolean })
     embedded = false;
 
-    static styles = [PFBase, PFGrid, PFPage, PFCard];
+    static styles = [PFGrid, PFPage, PFCard];
 
     render() {
         return this.model === RbacPermissionsAssignedByRolesListModelEnum.AuthentikRbacRole

--- a/web/src/admin/roles/RoleViewPage.ts
+++ b/web/src/admin/roles/RoleViewPage.ts
@@ -27,7 +27,6 @@ import PFContent from "@patternfly/patternfly/components/Content/content.css";
 import PFDescriptionList from "@patternfly/patternfly/components/DescriptionList/description-list.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 import PFDisplay from "@patternfly/patternfly/utilities/Display/display.css";
 
 @customElement("ak-role-view")
@@ -47,7 +46,6 @@ export class RoleViewPage extends AKElement {
     targetRole?: Role;
 
     static styles = [
-        PFBase,
         PFPage,
         PFButton,
         PFDisplay,

--- a/web/src/admin/sources/SourceWizard.ts
+++ b/web/src/admin/sources/SourceWizard.ts
@@ -23,11 +23,10 @@ import { CSSResult, html, TemplateResult } from "lit";
 import { property, query } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-source-wizard")
 export class SourceWizard extends AKElement {
-    static styles: CSSResult[] = [PFBase, PFButton];
+    static styles: CSSResult[] = [PFButton];
 
     @property({ attribute: false })
     sourceTypes: TypeCreate[] = [];

--- a/web/src/admin/sources/kerberos/KerberosSourceConnectivity.ts
+++ b/web/src/admin/sources/kerberos/KerberosSourceConnectivity.ts
@@ -7,7 +7,6 @@ import { CSSResult, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import PFList from "@patternfly/patternfly/components/List/list.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-source-kerberos-connectivity")
 export class KerberosSourceConnectivity extends AKElement {
@@ -18,7 +17,7 @@ export class KerberosSourceConnectivity extends AKElement {
         };
     };
 
-    static styles: CSSResult[] = [PFBase, PFList];
+    static styles: CSSResult[] = [PFList];
 
     render(): SlottedTemplateResult {
         if (!this.connectivity) {

--- a/web/src/admin/sources/kerberos/KerberosSourceViewPage.ts
+++ b/web/src/admin/sources/kerberos/KerberosSourceViewPage.ts
@@ -37,7 +37,6 @@ import PFDescriptionList from "@patternfly/patternfly/components/DescriptionList
 import PFList from "@patternfly/patternfly/components/List/list.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-source-kerberos-view")
 export class KerberosSourceViewPage extends AKElement {
@@ -56,7 +55,6 @@ export class KerberosSourceViewPage extends AKElement {
     source!: KerberosSource;
 
     static styles: CSSResult[] = [
-        PFBase,
         PFPage,
         PFButton,
         PFGrid,

--- a/web/src/admin/sources/ldap/LDAPSourceConnectivity.ts
+++ b/web/src/admin/sources/ldap/LDAPSourceConnectivity.ts
@@ -8,7 +8,6 @@ import { CSSResult, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import PFList from "@patternfly/patternfly/components/List/list.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-source-ldap-connectivity")
 export class LDAPSourceConnectivity extends AKElement {
@@ -19,7 +18,7 @@ export class LDAPSourceConnectivity extends AKElement {
         };
     };
 
-    static styles: CSSResult[] = [PFBase, PFList];
+    static styles: CSSResult[] = [PFList];
 
     render(): SlottedTemplateResult {
         if (!this.connectivity) {

--- a/web/src/admin/sources/ldap/LDAPSourceViewPage.ts
+++ b/web/src/admin/sources/ldap/LDAPSourceViewPage.ts
@@ -34,7 +34,6 @@ import PFDescriptionList from "@patternfly/patternfly/components/DescriptionList
 import PFList from "@patternfly/patternfly/components/List/list.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-source-ldap-view")
 export class LDAPSourceViewPage extends AKElement {
@@ -53,7 +52,6 @@ export class LDAPSourceViewPage extends AKElement {
     source!: LDAPSource;
 
     static styles: CSSResult[] = [
-        PFBase,
         PFPage,
         PFButton,
         PFGrid,

--- a/web/src/admin/sources/oauth/OAuthSourceViewPage.ts
+++ b/web/src/admin/sources/oauth/OAuthSourceViewPage.ts
@@ -33,7 +33,6 @@ import PFContent from "@patternfly/patternfly/components/Content/content.css";
 import PFDescriptionList from "@patternfly/patternfly/components/DescriptionList/description-list.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 export function ProviderToLabel(provider?: ProviderTypeEnum): string {
     switch (provider) {
@@ -92,15 +91,7 @@ export class OAuthSourceViewPage extends AKElement {
     @property({ attribute: false })
     source?: OAuthSource;
 
-    static styles: CSSResult[] = [
-        PFBase,
-        PFPage,
-        PFButton,
-        PFGrid,
-        PFContent,
-        PFCard,
-        PFDescriptionList,
-    ];
+    static styles: CSSResult[] = [PFPage, PFButton, PFGrid, PFContent, PFCard, PFDescriptionList];
 
     constructor() {
         super();

--- a/web/src/admin/sources/plex/PlexSourceViewPage.ts
+++ b/web/src/admin/sources/plex/PlexSourceViewPage.ts
@@ -31,7 +31,6 @@ import PFContent from "@patternfly/patternfly/components/Content/content.css";
 import PFDescriptionList from "@patternfly/patternfly/components/DescriptionList/description-list.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-source-plex-view")
 export class PlexSourceViewPage extends AKElement {
@@ -49,15 +48,7 @@ export class PlexSourceViewPage extends AKElement {
     @property({ attribute: false })
     source?: PlexSource;
 
-    static styles: CSSResult[] = [
-        PFBase,
-        PFPage,
-        PFButton,
-        PFGrid,
-        PFContent,
-        PFCard,
-        PFDescriptionList,
-    ];
+    static styles: CSSResult[] = [PFPage, PFButton, PFGrid, PFContent, PFCard, PFDescriptionList];
 
     constructor() {
         super();

--- a/web/src/admin/sources/saml/SAMLSourceViewPage.ts
+++ b/web/src/admin/sources/saml/SAMLSourceViewPage.ts
@@ -33,7 +33,6 @@ import PFContent from "@patternfly/patternfly/components/Content/content.css";
 import PFDescriptionList from "@patternfly/patternfly/components/DescriptionList/description-list.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-source-saml-view")
 export class SAMLSourceViewPage extends AKElement {
@@ -54,15 +53,7 @@ export class SAMLSourceViewPage extends AKElement {
     @state()
     metadata?: SAMLMetadata;
 
-    static styles: CSSResult[] = [
-        PFBase,
-        PFPage,
-        PFGrid,
-        PFButton,
-        PFContent,
-        PFCard,
-        PFDescriptionList,
-    ];
+    static styles: CSSResult[] = [PFPage, PFGrid, PFButton, PFContent, PFCard, PFDescriptionList];
 
     constructor() {
         super();

--- a/web/src/admin/sources/scim/SCIMSourceViewPage.ts
+++ b/web/src/admin/sources/scim/SCIMSourceViewPage.ts
@@ -33,7 +33,6 @@ import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-source-scim-view")
 export class SCIMSourceViewPage extends AKElement {
@@ -52,7 +51,6 @@ export class SCIMSourceViewPage extends AKElement {
     source?: SCIMSource;
 
     static styles: CSSResult[] = [
-        PFBase,
         PFPage,
         PFButton,
         PFForm,

--- a/web/src/admin/stages/StageWizard.ts
+++ b/web/src/admin/stages/StageWizard.ts
@@ -44,11 +44,10 @@ import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { property, query } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-stage-wizard")
 export class StageWizard extends AKElement {
-    static styles: CSSResult[] = [PFBase, PFButton];
+    static styles: CSSResult[] = [PFButton];
 
     @property()
     createText = msg("Create");

--- a/web/src/admin/stages/invitation/InvitationListLink.ts
+++ b/web/src/admin/stages/invitation/InvitationListLink.ts
@@ -12,7 +12,6 @@ import { until } from "lit/directives/until.js";
 import PFDescriptionList from "@patternfly/patternfly/components/DescriptionList/description-list.css";
 import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-stage-invitation-list-link")
 export class InvitationListLink extends AKElement {
@@ -22,7 +21,7 @@ export class InvitationListLink extends AKElement {
     @property()
     selectedFlow?: string;
 
-    static styles: CSSResult[] = [PFBase, PFForm, PFFormControl, PFDescriptionList];
+    static styles: CSSResult[] = [PFForm, PFFormControl, PFDescriptionList];
 
     renderLink(): string {
         if (this.invitation?.flowObj) {

--- a/web/src/admin/users/UserViewPage.ts
+++ b/web/src/admin/users/UserViewPage.ts
@@ -59,7 +59,6 @@ import PFContent from "@patternfly/patternfly/components/Content/content.css";
 import PFDescriptionList from "@patternfly/patternfly/components/DescriptionList/description-list.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 import PFDisplay from "@patternfly/patternfly/utilities/Display/display.css";
 import PFSizing from "@patternfly/patternfly/utilities/Sizing/sizing.css";
 
@@ -80,7 +79,6 @@ export class UserViewPage extends WithCapabilitiesConfig(WithSession(AKElement))
     protected user: User | null = null;
 
     static styles = [
-        PFBase,
         PFPage,
         PFButton,
         PFDisplay,

--- a/web/src/components/ak-event-info.ts
+++ b/web/src/components/ak-event-info.ts
@@ -23,7 +23,6 @@ import PFList from "@patternfly/patternfly/components/List/list.css";
 import PFTable from "@patternfly/patternfly/components/Table/table.css";
 import PFFlex from "@patternfly/patternfly/layouts/Flex/flex.css";
 import PFSplit from "@patternfly/patternfly/layouts/Split/split.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 // TODO: Settle these types. It's too hard to make sense of what we're expecting here.
 type EventSlotValueType =
@@ -85,7 +84,6 @@ export class EventInfo extends AKElement {
     event!: EventWithContext;
 
     static styles: CSSResult[] = [
-        PFBase,
         PFButton,
         PFFlex,
         PFCard,

--- a/web/src/components/ak-multi-select.ts
+++ b/web/src/components/ak-multi-select.ts
@@ -10,7 +10,6 @@ import { createRef, ref, Ref } from "lit/directives/ref.js";
 
 import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 type Pair = [string, string];
 
@@ -27,7 +26,7 @@ const selectStyles = css`
  */
 @customElement("ak-multi-select")
 export class AkMultiSelect extends AkControlElement {
-    static styles = [PFBase, PFForm, PFFormControl, selectStyles];
+    static styles = [PFForm, PFFormControl, selectStyles];
 
     /**
      * The [name] attribute, which is also distributed to the layout manager and the input control.

--- a/web/src/components/ak-nav-buttons.ts
+++ b/web/src/components/ak-nav-buttons.ts
@@ -24,7 +24,6 @@ import PFDrawer from "@patternfly/patternfly/components/Drawer/drawer.css";
 import PFDropdown from "@patternfly/patternfly/components/Dropdown/dropdown.css";
 import PFNotificationBadge from "@patternfly/patternfly/components/NotificationBadge/notification-badge.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 import PFDisplay from "@patternfly/patternfly/utilities/Display/display.css";
 
 @customElement("ak-nav-buttons")
@@ -39,7 +38,6 @@ export class NavigationButtons extends WithSession(AKElement) {
     notificationsCount = 0;
 
     static styles = [
-        PFBase,
         PFDisplay,
         PFBrand,
         PFPage,

--- a/web/src/components/ak-page-navbar.ts
+++ b/web/src/components/ak-page-navbar.ts
@@ -22,7 +22,6 @@ import PFDrawer from "@patternfly/patternfly/components/Drawer/drawer.css";
 import PFDropdown from "@patternfly/patternfly/components/Dropdown/dropdown.css";
 import PFNotificationBadge from "@patternfly/patternfly/components/NotificationBadge/notification-badge.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 export class PageDetailsUpdate extends Event {
     static readonly eventName = "ak-page-details-update";
@@ -69,7 +68,6 @@ export class AKPageNavbar
     //#region Static Properties
 
     static styles: CSSResult[] = [
-        PFBase,
         PFButton,
         PFPage,
         PFDrawer,

--- a/web/src/components/ak-search-ql/index.ts
+++ b/web/src/components/ak-search-ql/index.ts
@@ -19,7 +19,6 @@ import { createRef, ref, Ref } from "lit/directives/ref.js";
 
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFSearchInput from "@patternfly/patternfly/components/SearchInput/search-input.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 export class QL extends DjangoQL {
     createCompletionElement() {
@@ -57,7 +56,7 @@ export class QLSearch extends FormAssociatedElement<string> implements FormAssoc
 
     public static styles: CSSResult[] = [
         // ---
-        PFBase,
+
         PFFormControl,
         PFSearchInput,
         Styles,

--- a/web/src/components/ak-status-label.ts
+++ b/web/src/components/ak-status-label.ts
@@ -10,7 +10,6 @@ import { customElement, property } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 
 import PFLabel from "@patternfly/patternfly/components/Label/label.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 const statusToDetails = new Map<P4Disposition, [string, string]>([
     [P4Disposition.Error, ["pf-m-red", "fa-times"]],
@@ -41,7 +40,7 @@ const statusToDetails = new Map<P4Disposition, [string, string]>([
 
 @customElement("ak-status-label")
 export class AkStatusLabel extends AKElement {
-    static styles = [PFBase, PFLabel, Styles];
+    static styles = [PFLabel, Styles];
 
     @property({ type: Boolean })
     good = false;

--- a/web/src/components/ak-visibility-toggle.ts
+++ b/web/src/components/ak-visibility-toggle.ts
@@ -5,7 +5,6 @@ import { html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 export interface VisibilityToggleProps {
     open: boolean;
@@ -27,7 +26,7 @@ export interface VisibilityToggleProps {
  */
 @customElement("ak-visibility-toggle")
 export class VisibilityToggle extends AKElement implements VisibilityToggleProps {
-    static styles = [PFBase, PFButton];
+    static styles = [PFButton];
 
     /**
      * @property

--- a/web/src/elements/Alert.ts
+++ b/web/src/elements/Alert.ts
@@ -8,7 +8,6 @@ import { customElement, property } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 
 import PFAlert from "@patternfly/patternfly/components/Alert/alert.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 export enum Level {
     Warning = "pf-m-warning",
@@ -65,7 +64,6 @@ export class AKAlert extends AKElement implements IAlert {
     public icon = "fa-exclamation-circle";
 
     static styles = [
-        PFBase,
         PFAlert,
         css`
             p {

--- a/web/src/elements/Divider.ts
+++ b/web/src/elements/Divider.ts
@@ -4,12 +4,9 @@ import { type SlottedTemplateResult } from "#elements/types";
 import { css, html, nothing } from "lit";
 import { customElement } from "lit/decorators.js";
 
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
-
 @customElement("ak-divider")
 export class Divider extends AKElement {
     static styles = [
-        PFBase,
         css`
             .separator {
                 display: flex;

--- a/web/src/elements/EmptyState.ts
+++ b/web/src/elements/EmptyState.ts
@@ -14,7 +14,6 @@ import { classMap } from "lit/directives/class-map.js";
 
 import PFEmptyState from "@patternfly/patternfly/components/EmptyState/empty-state.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 /**
  * Props for the EmptyState component
@@ -67,7 +66,6 @@ export class EmptyState extends AKElement implements IEmptyState {
     public role = "status";
 
     static styles = [
-        PFBase,
         PFEmptyState,
         PFTitle,
         css`

--- a/web/src/elements/a11y/ak-skip-to-content.ts
+++ b/web/src/elements/a11y/ak-skip-to-content.ts
@@ -5,8 +5,6 @@ import { css, html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ref, RefOrCallback } from "lit/directives/ref.js";
 
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
-
 /**
  * Finds the main content element within a given context.
  *
@@ -49,7 +47,6 @@ export function findMainContent(context: HTMLElement): HTMLElement | null {
 export class AKSkipToContent extends AKElement {
     static shadowRootOptions = { ...LitElement.shadowRootOptions, delegatesFocus: true };
     static styles = [
-        PFBase,
         css`
             [part="show-on-focus"] {
                 position: absolute !important;

--- a/web/src/elements/ak-array-input.ts
+++ b/web/src/elements/ak-array-input.ts
@@ -13,7 +13,6 @@ import { repeat } from "lit/directives/repeat.js";
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFInputGroup from "@patternfly/patternfly/components/InputGroup/input-group.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 export type InputCell<T> = (el: T, idx: number) => TemplateResult | typeof nothing;
 
@@ -30,7 +29,6 @@ type Keyed<T> = { key: string; item: T };
 @customElement("ak-array-input")
 export class ArrayInput<T> extends AkControlElement<T[]> implements IArrayInput<T> {
     static styles = [
-        PFBase,
         PFButton,
         PFInputGroup,
         PFFormControl,

--- a/web/src/elements/ak-checkbox-group/ak-checkbox-group.ts
+++ b/web/src/elements/ak-checkbox-group/ak-checkbox-group.ts
@@ -9,7 +9,6 @@ import { map } from "lit/directives/map.js";
 
 import PFCheck from "@patternfly/patternfly/components/Check/check.css";
 import PFForm from "@patternfly/patternfly/components/Form/form.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 type CheckboxKv = { name: string; label: string | TemplateResult };
 type CheckboxPr = [string, string | TemplateResult];
@@ -80,7 +79,6 @@ const AkElementWithCustomEvents = CustomEmitterElement(AkControlElement);
 @customElement("ak-checkbox-group")
 export class CheckboxGroup extends AkElementWithCustomEvents {
     static styles = [
-        PFBase,
         PFForm,
         PFCheck,
         css`

--- a/web/src/elements/ak-dual-select/ak-dual-select.ts
+++ b/web/src/elements/ak-dual-select/ak-dual-select.ts
@@ -28,7 +28,6 @@ import { createRef, ref } from "lit/directives/ref.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 function localeComparator(a: DualSelectPair, b: DualSelectPair) {
     const aSortBy = String(a[2] || a[0]);
@@ -62,7 +61,7 @@ const DelegatedEvents = [
  */
 @customElement("ak-dual-select")
 export class AkDualSelect extends CustomEmitterElement(CustomListenerElement(AKElement)) {
-    static styles = [PFBase, PFButton, globalVariables, mainStyles];
+    static styles = [PFButton, globalVariables, mainStyles];
 
     //#region Properties
 

--- a/web/src/elements/ak-dual-select/components/ak-dual-select-available-pane.ts
+++ b/web/src/elements/ak-dual-select/components/ak-dual-select-available-pane.ts
@@ -12,7 +12,6 @@ import { createRef, ref } from "lit/directives/ref.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFDualListSelector from "@patternfly/patternfly/components/DualListSelector/dual-list-selector.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 const hostAttributes = [
     ["aria-labelledby", "dual-list-selector-available-pane-status"],
@@ -40,7 +39,7 @@ const hostAttributes = [
 export class AkDualSelectAvailablePane extends CustomEmitterElement<DualSelectEventType>(
     AKElement,
 ) {
-    static styles = [PFBase, PFButton, PFDualListSelector, listStyles, availablePaneStyles];
+    static styles = [PFButton, PFDualListSelector, listStyles, availablePaneStyles];
 
     //#region Properties
 

--- a/web/src/elements/ak-dual-select/components/ak-dual-select-controls.ts
+++ b/web/src/elements/ak-dual-select/components/ak-dual-select-controls.ts
@@ -8,7 +8,6 @@ import { css, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 /**
  * @element ak-dual-select-controls
@@ -20,7 +19,6 @@ import PFBase from "@patternfly/patternfly/patternfly-base.css";
 @customElement("ak-dual-select-controls")
 export class AkDualSelectControls extends CustomEmitterElement<DualSelectEventType>(AKElement) {
     static styles = [
-        PFBase,
         PFButton,
         css`
             :host {

--- a/web/src/elements/ak-dual-select/components/ak-dual-select-selected-pane.ts
+++ b/web/src/elements/ak-dual-select/components/ak-dual-select-selected-pane.ts
@@ -11,7 +11,6 @@ import { map } from "lit/directives/map.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFDualListSelector from "@patternfly/patternfly/components/DualListSelector/dual-list-selector.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 const hostAttributes = [
     ["aria-labelledby", "dual-list-selector-selected-pane-status"],
@@ -36,7 +35,7 @@ const hostAttributes = [
  */
 @customElement("ak-dual-select-selected-pane")
 export class AkDualSelectSelectedPane extends CustomEmitterElement<DualSelectEventType>(AKElement) {
-    static styles = [PFBase, PFButton, PFDualListSelector, listStyles, selectedPaneStyles];
+    static styles = [PFButton, PFDualListSelector, listStyles, selectedPaneStyles];
 
     //#region Properties
 

--- a/web/src/elements/ak-dual-select/components/ak-pagination.ts
+++ b/web/src/elements/ak-dual-select/components/ak-pagination.ts
@@ -9,12 +9,10 @@ import { customElement, property } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFPagination from "@patternfly/patternfly/components/Pagination/pagination.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-pagination")
 export class AkPagination extends CustomEmitterElement<DualSelectEventType>(AKElement) {
     static styles = [
-        PFBase,
         PFButton,
         PFPagination,
         css`

--- a/web/src/elements/ak-dual-select/components/ak-search-bar.ts
+++ b/web/src/elements/ak-dual-select/components/ak-search-bar.ts
@@ -9,11 +9,9 @@ import { html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { createRef, ref } from "lit/directives/ref.js";
 
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
-
 @customElement("ak-search-bar")
 export class AkSearchbar extends CustomEmitterElement(AKElement) {
-    static styles = [PFBase, globalVariables, searchStyles];
+    static styles = [globalVariables, searchStyles];
 
     @property({ type: String, reflect: true })
     public value = "";

--- a/web/src/elements/ak-list-select/ak-list-select.ts
+++ b/web/src/elements/ak-list-select/ak-list-select.ts
@@ -11,7 +11,6 @@ import { customElement, property, query, state } from "lit/decorators.js";
 
 import PFDropdown from "@patternfly/patternfly/components/Dropdown/dropdown.css";
 import PFSelect from "@patternfly/patternfly/components/Select/select.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 export interface IListSelect {
     options: SelectOptions;
@@ -46,7 +45,6 @@ export interface IListSelect {
 @customElement("ak-list-select")
 export class ListSelect extends AKElement implements IListSelect {
     static styles = [
-        PFBase,
         PFDropdown,
         PFSelect,
         css`

--- a/web/src/elements/ak-mdx/ak-mdx.tsx
+++ b/web/src/elements/ak-mdx/ak-mdx.tsx
@@ -39,7 +39,6 @@ import { customElement, property } from "lit/decorators.js";
 import PFContent from "@patternfly/patternfly/components/Content/content.css";
 import PFList from "@patternfly/patternfly/components/List/list.css";
 import PFTable from "@patternfly/patternfly/components/Table/table.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 const highlightThemeOptions: HighlightOptions = {
     languages: {
@@ -73,7 +72,7 @@ export class AKMDX extends AKElement {
 
     static styles = [
         // ---
-        PFBase,
+
         PFList,
         PFTable,
         PFContent,

--- a/web/src/elements/ak-table/ak-simple-table.ts
+++ b/web/src/elements/ak-table/ak-simple-table.ts
@@ -12,7 +12,6 @@ import { map } from "lit/directives/map.js";
 import { repeat } from "lit/directives/repeat.js";
 
 import PFTable from "@patternfly/patternfly/components/Table/table.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 export type RawContent = string | number | TemplateResult;
 export type ContentType = RawContent[][] | TableRow[] | TableGrouped;
@@ -75,7 +74,6 @@ export interface ISimpleTable {
 @customElement("ak-simple-table")
 export class SimpleTable extends AKElement implements ISimpleTable {
     static styles = [
-        PFBase,
         PFTable,
         css`
             .pf-c-table thead .pf-c-table__check {

--- a/web/src/elements/buttons/ModalButton.ts
+++ b/web/src/elements/buttons/ModalButton.ts
@@ -20,7 +20,6 @@ import PFModalBox from "@patternfly/patternfly/components/ModalBox/modal-box.css
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
 import PFBullseye from "@patternfly/patternfly/layouts/Bullseye/bullseye.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 export const MODAL_BUTTON_STYLES = css`
     :host {
@@ -52,7 +51,6 @@ export abstract class ModalButton extends AKElement {
     public locked = false;
 
     static styles: CSSResult[] = [
-        PFBase,
         PFButton,
         PFModalBox,
         PFForm,

--- a/web/src/elements/buttons/SpinnerButton/BaseTaskButton.ts
+++ b/web/src/elements/buttons/SpinnerButton/BaseTaskButton.ts
@@ -11,12 +11,10 @@ import { property } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFSpinner from "@patternfly/patternfly/components/Spinner/spinner.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 // `pointer-events: none` makes the button inaccessible during the processing phase.
 
 const buttonStyles = [
-    PFBase,
     PFButton,
     PFSpinner,
     css`

--- a/web/src/elements/cards/AggregateCard.ts
+++ b/web/src/elements/cards/AggregateCard.ts
@@ -7,7 +7,6 @@ import { customElement, property } from "lit/decorators.js";
 
 import PFCard from "@patternfly/patternfly/components/Card/card.css";
 import PFFlex from "@patternfly/patternfly/layouts/Flex/flex.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 export interface IAggregateCard {
     icon?: string | null;
@@ -59,7 +58,7 @@ export class AggregateCard extends AKElement implements IAggregateCard {
     @property({ type: String })
     public subtext: string | null = null;
 
-    public static styles: CSSResult[] = [PFBase, PFCard, PFFlex, Styles];
+    public static styles: CSSResult[] = [PFCard, PFFlex, Styles];
 
     renderInner(): SlottedTemplateResult {
         if (this.role === "status") {

--- a/web/src/elements/cards/QuickActionsCard.ts
+++ b/web/src/elements/cards/QuickActionsCard.ts
@@ -9,7 +9,6 @@ import { ifDefined } from "lit/directives/if-defined.js";
 import { map } from "lit/directives/map.js";
 
 import PFList from "@patternfly/patternfly/components/List/list.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 export type QuickAction = [label: string, url: string, isExternal?: boolean];
 
@@ -39,7 +38,7 @@ function renderItem([label, url, external]: QuickAction) {
  */
 @customElement("ak-quick-actions-card")
 export class QuickActionsCard extends AKElement implements IQuickActionsCard {
-    static styles = [PFBase, PFList];
+    static styles = [PFList];
 
     /**
      * Card title

--- a/web/src/elements/chips/Chip.ts
+++ b/web/src/elements/chips/Chip.ts
@@ -8,7 +8,6 @@ import { customElement, property } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFChip from "@patternfly/patternfly/components/Chip/chip.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-chip")
 export class Chip extends AKElement {
@@ -18,7 +17,7 @@ export class Chip extends AKElement {
     @property({ type: Boolean })
     removable = false;
 
-    static styles: CSSResult[] = [PFBase, PFButton, PFChip];
+    static styles: CSSResult[] = [PFButton, PFChip];
 
     render(): TemplateResult {
         return html`<li class="pf-c-chip-group__list-item">

--- a/web/src/elements/chips/ChipGroup.ts
+++ b/web/src/elements/chips/ChipGroup.ts
@@ -7,12 +7,10 @@ import { customElement, property } from "lit/decorators.js";
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFChip from "@patternfly/patternfly/components/Chip/chip.css";
 import PFChipGroup from "@patternfly/patternfly/components/ChipGroup/chip-group.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-chip-group")
 export class ChipGroup extends AKElement {
     static styles: CSSResult[] = [
-        PFBase,
         PFChip,
         PFChipGroup,
         PFButton,

--- a/web/src/elements/forms/Form.ts
+++ b/web/src/elements/forms/Form.ts
@@ -36,7 +36,6 @@ import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFInputGroup from "@patternfly/patternfly/components/InputGroup/input-group.css";
 import PFSwitch from "@patternfly/patternfly/components/Switch/switch.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 function isIgnored<T extends Element>(element: T) {
     if (!(element instanceof HTMLElement)) return false;
@@ -237,7 +236,6 @@ export abstract class Form<T = Record<string, unknown>> extends AKElement {
     nonFieldErrors?: string[];
 
     static styles: CSSResult[] = [
-        PFBase,
         PFCard,
         PFButton,
         PFForm,

--- a/web/src/elements/forms/FormGroup.ts
+++ b/web/src/elements/forms/FormGroup.ts
@@ -9,7 +9,6 @@ import { createRef, ref } from "lit/directives/ref.js";
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 /**
  * Form Group
@@ -21,7 +20,7 @@ import PFBase from "@patternfly/patternfly/patternfly-base.css";
  */
 @customElement("ak-form-group")
 export class AKFormGroup extends AKElement {
-    static styles: CSSResult[] = [PFBase, PFForm, PFButton, PFFormControl, Styles];
+    static styles: CSSResult[] = [PFForm, PFButton, PFFormControl, Styles];
 
     //region Properties
 

--- a/web/src/elements/forms/HorizontalFormElement.ts
+++ b/web/src/elements/forms/HorizontalFormElement.ts
@@ -10,7 +10,6 @@ import { customElement, property } from "lit/decorators.js";
 
 import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 /**
  * Horizontal Form Element Container.
@@ -29,7 +28,6 @@ import PFBase from "@patternfly/patternfly/patternfly-base.css";
 @customElement("ak-form-element-horizontal")
 export class HorizontalFormElement extends AKElement {
     static styles: CSSResult[] = [
-        PFBase,
         PFForm,
         PFFormControl,
         css`

--- a/web/src/elements/forms/Radio.ts
+++ b/web/src/elements/forms/Radio.ts
@@ -10,7 +10,6 @@ import { map } from "lit/directives/map.js";
 
 import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFRadio from "@patternfly/patternfly/components/Radio/radio.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 export interface RadioOption<T> {
     label: string;
@@ -36,7 +35,7 @@ export class Radio<T> extends CustomEmitterElement(AKElement) {
 
     static styles: CSSResult[] = [
         // ---
-        PFBase,
+
         PFRadio,
         PFForm,
         Styles,

--- a/web/src/elements/forms/SearchSelect/SearchSelect.ts
+++ b/web/src/elements/forms/SearchSelect/SearchSelect.ts
@@ -17,8 +17,6 @@ import { msg } from "@lit/localize";
 import { html, PropertyValues, TemplateResult } from "lit";
 import { property, state } from "lit/decorators.js";
 
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
-
 type Group<T> = [string, T[]];
 
 export interface ISearchSelectBase<T> {
@@ -35,8 +33,6 @@ export abstract class SearchSelectBase<T>
     extends AkControlElement<string>
     implements ISearchSelectBase<T>
 {
-    static styles = [PFBase];
-
     //#region Properties
 
     /**

--- a/web/src/elements/forms/SearchSelect/ak-search-select-ez.ts
+++ b/web/src/elements/forms/SearchSelect/ak-search-select-ez.ts
@@ -45,8 +45,6 @@ export interface ISearchSelectEz<T> extends ISearchSelectBase<T> {
 
 @customElement("ak-search-select-ez")
 export class SearchSelectEz<T> extends SearchSelectBase<T> implements ISearchSelectEz<T> {
-    static styles = [...SearchSelectBase.styles];
-
     public fetchObjects!: (query?: string) => Promise<T[]>;
     public renderElement!: (element: T) => string;
     public renderDescription?: ((element: T) => string | TemplateResult) | undefined;

--- a/web/src/elements/forms/SearchSelect/ak-search-select-loading-indicator.ts
+++ b/web/src/elements/forms/SearchSelect/ak-search-select-loading-indicator.ts
@@ -7,7 +7,6 @@ import { customElement } from "lit/decorators.js";
 
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFSelect from "@patternfly/patternfly/components/Select/select.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 /**
  * @class SearchSelectLoadingIndicator
@@ -25,7 +24,7 @@ import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-search-select-loading-indicator")
 export class SearchSelectLoadingIndicator extends AKElement {
-    static styles = [PFBase, PFFormControl, PFSelect];
+    static styles = [PFFormControl, PFSelect];
 
     connectedCallback() {
         super.connectedCallback();

--- a/web/src/elements/forms/SearchSelect/ak-search-select-view.ts
+++ b/web/src/elements/forms/SearchSelect/ak-search-select-view.ts
@@ -17,7 +17,6 @@ import { createRef, ref, Ref } from "lit/directives/ref.js";
 import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFSelect from "@patternfly/patternfly/components/Select/select.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 export interface ISearchSelectView {
     options: SelectOptions;
@@ -70,7 +69,6 @@ export interface ISearchSelectView {
 @customElement("ak-search-select-view")
 export class SearchSelectView extends AKElement implements ISearchSelectView {
     static styles: CSSResult[] = [
-        PFBase,
         PFForm,
         PFFormControl,
         PFSelect,

--- a/web/src/elements/forms/SearchSelect/ak-search-select.ts
+++ b/web/src/elements/forms/SearchSelect/ak-search-select.ts
@@ -46,8 +46,6 @@ export interface ISearchSelect<T> extends ISearchSelectBase<T> {
  */
 @customElement("ak-search-select")
 export class SearchSelect<T> extends SearchSelectBase<T> implements ISearchSelect<T> {
-    static styles = [...SearchSelectBase.styles];
-
     @property({ attribute: false })
     public fetchObjects!: (query?: string) => Promise<T[]>;
 

--- a/web/src/elements/messages/Message.ts
+++ b/web/src/elements/messages/Message.ts
@@ -11,7 +11,6 @@ import { ifDefined } from "lit/directives/if-defined.js";
 import PFAlert from "@patternfly/patternfly/components/Alert/alert.css";
 import PFAlertGroup from "@patternfly/patternfly/components/AlertGroup/alert-group.css";
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 /**
  * An error message returned from an API endpoint.
@@ -43,7 +42,7 @@ const LevelARIALiveMap = {
 
 @customElement("ak-message")
 export class Message extends AKElement {
-    static styles: CSSResult[] = [PFBase, PFButton, PFAlert, PFAlertGroup];
+    static styles: CSSResult[] = [PFButton, PFAlert, PFAlertGroup];
 
     //#region Properties
 

--- a/web/src/elements/messages/MessageContainer.ts
+++ b/web/src/elements/messages/MessageContainer.ts
@@ -17,7 +17,6 @@ import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
 import PFAlertGroup from "@patternfly/patternfly/components/AlertGroup/alert-group.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 /**
  * Adds a message to the message container, displaying it to the user.
@@ -93,7 +92,6 @@ export class MessageContainer extends AKElement {
     alignment: "top" | "bottom" = "top";
 
     static styles: CSSResult[] = [
-        PFBase,
         PFAlertGroup,
         css`
             /* Fix spacing between messages */

--- a/web/src/elements/notifications/APIDrawer.ts
+++ b/web/src/elements/notifications/APIDrawer.ts
@@ -14,7 +14,6 @@ import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFContent from "@patternfly/patternfly/components/Content/content.css";
 import PFDropdown from "@patternfly/patternfly/components/Dropdown/dropdown.css";
 import PFNotificationDrawer from "@patternfly/patternfly/components/NotificationDrawer/notification-drawer.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 function renderItem(item: RequestInfo, idx: number): TemplateResult {
     const subheading = `${item.method}: ${item.status}`;
@@ -48,7 +47,6 @@ export class APIDrawer extends AKElement {
     requests: RequestInfo[] = [];
 
     static styles: CSSResult[] = [
-        PFBase,
         PFNotificationDrawer,
         PFButton,
         PFContent,

--- a/web/src/elements/notifications/NotificationDrawer.ts
+++ b/web/src/elements/notifications/NotificationDrawer.ts
@@ -25,7 +25,6 @@ import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFContent from "@patternfly/patternfly/components/Content/content.css";
 import PFDropdown from "@patternfly/patternfly/components/Dropdown/dropdown.css";
 import PFNotificationDrawer from "@patternfly/patternfly/components/NotificationDrawer/notification-drawer.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-notification-drawer")
 export class NotificationDrawer extends WithSession(AKElement) {
@@ -36,7 +35,6 @@ export class NotificationDrawer extends WithSession(AKElement) {
     unread = 0;
 
     static styles: CSSResult[] = [
-        PFBase,
         PFButton,
         PFNotificationDrawer,
         PFContent,

--- a/web/src/elements/router/Router404.ts
+++ b/web/src/elements/router/Router404.ts
@@ -6,14 +6,13 @@ import { customElement, property } from "lit/decorators.js";
 
 import PFEmptyState from "@patternfly/patternfly/components/EmptyState/empty-state.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-router-404")
 export class Router404 extends AKElement {
     @property()
     url = "";
 
-    static styles: CSSResult[] = [PFBase, PFEmptyState, PFTitle];
+    static styles: CSSResult[] = [PFEmptyState, PFTitle];
 
     render(): TemplateResult {
         return html`<div class="pf-c-empty-state pf-m-full-height">

--- a/web/src/elements/sidebar/SidebarVersion.ts
+++ b/web/src/elements/sidebar/SidebarVersion.ts
@@ -17,12 +17,10 @@ import { customElement } from "lit/decorators.js";
 import PFAvatar from "@patternfly/patternfly/components/Avatar/avatar.css";
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFNav from "@patternfly/patternfly/components/Nav/nav.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-sidebar-version")
 export class SidebarVersion extends WithLicenseSummary(WithVersion(AKElement)) {
     static styles: CSSResult[] = [
-        PFBase,
         PFNav,
         PFAvatar,
         PFButton,

--- a/web/src/elements/table/Table.ts
+++ b/web/src/elements/table/Table.ts
@@ -42,7 +42,6 @@ import PFSwitch from "@patternfly/patternfly/components/Switch/switch.css";
 import PFTable from "@patternfly/patternfly/components/Table/table.css";
 import PFToolbar from "@patternfly/patternfly/components/Toolbar/toolbar.css";
 import PFBullseye from "@patternfly/patternfly/layouts/Bullseye/bullseye.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 export * from "./shared.js";
 export * from "./TableColumn.js";
@@ -75,7 +74,6 @@ export abstract class Table<T extends object>
     implements TableLike
 {
     static styles: CSSResult[] = [
-        PFBase,
         PFTable,
         PFBullseye,
         PFButton,

--- a/web/src/elements/table/TablePagination.ts
+++ b/web/src/elements/table/TablePagination.ts
@@ -8,7 +8,6 @@ import { customElement, property } from "lit/decorators.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFPagination from "@patternfly/patternfly/components/Pagination/pagination.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 export type TablePageChangeListener = (page: number) => void;
 
@@ -27,7 +26,6 @@ export class TablePagination extends AKElement {
     public onPageChange?: TablePageChangeListener;
 
     static styles: CSSResult[] = [
-        PFBase,
         PFButton,
         PFPagination,
         css`

--- a/web/src/elements/table/TableSearch.ts
+++ b/web/src/elements/table/TableSearch.ts
@@ -14,7 +14,6 @@ import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFInputGroup from "@patternfly/patternfly/components/InputGroup/input-group.css";
 import PFToolbar from "@patternfly/patternfly/components/Toolbar/toolbar.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-table-search")
 export class TableSearchForm extends WithLicenseSummary(AKElement) {
@@ -37,7 +36,6 @@ export class TableSearchForm extends WithLicenseSummary(AKElement) {
     public onSearch?: (value: string) => void;
 
     static styles: CSSResult[] = [
-        PFBase,
         PFButton,
         PFToolbar,
         PFInputGroup,

--- a/web/src/elements/tasks/TaskStatusSummary.ts
+++ b/web/src/elements/tasks/TaskStatusSummary.ts
@@ -11,12 +11,10 @@ import { customElement, property } from "lit/decorators.js";
 
 import PFCard from "@patternfly/patternfly/components/Card/card.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-task-status-summary")
 export class TaskStatusSummary extends AKElement {
     static styles: CSSResult[] = [
-        PFBase,
         PFGrid,
         PFCard,
         css`

--- a/web/src/elements/utils/TimeDeltaHelp.ts
+++ b/web/src/elements/utils/TimeDeltaHelp.ts
@@ -8,14 +8,13 @@ import { customElement, property } from "lit/decorators.js";
 
 import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFList from "@patternfly/patternfly/components/List/list.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-utils-time-delta-help")
 export class TimeDeltaHelp extends AKElement {
     @property({ type: Boolean })
     negative = false;
 
-    static styles: CSSResult[] = [PFBase, PFForm, PFList];
+    static styles: CSSResult[] = [PFForm, PFList];
 
     render(): TemplateResult {
         return html`<div class="pf-c-form__helper-text">

--- a/web/src/elements/wizard/ActionWizardPage.ts
+++ b/web/src/elements/wizard/ActionWizardPage.ts
@@ -13,7 +13,6 @@ import PFEmptyState from "@patternfly/patternfly/components/EmptyState/empty-sta
 import PFProgressStepper from "@patternfly/patternfly/components/ProgressStepper/progress-stepper.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
 import PFBullseye from "@patternfly/patternfly/layouts/Bullseye/bullseye.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 export enum ActionState {
     pending = "pending",
@@ -30,7 +29,7 @@ export interface ActionStateBundle {
 
 @customElement("ak-wizard-page-action")
 export class ActionWizardPage extends WizardPage {
-    static styles: CSSResult[] = [PFBase, PFBullseye, PFEmptyState, PFTitle, PFProgressStepper];
+    static styles: CSSResult[] = [PFBullseye, PFEmptyState, PFTitle, PFProgressStepper];
 
     @property({ attribute: false })
     states: ActionStateBundle[] = [];

--- a/web/src/elements/wizard/TypeCreateWizardPage.ts
+++ b/web/src/elements/wizard/TypeCreateWizardPage.ts
@@ -17,7 +17,6 @@ import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFRadio from "@patternfly/patternfly/components/Radio/radio.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 export enum TypeCreateWizardPageLayouts {
     list = "list",
@@ -40,7 +39,6 @@ export class TypeCreateWizardPage extends WithLicenseSummary(WizardPage) {
     //#endregion
 
     static styles: CSSResult[] = [
-        PFBase,
         PFForm,
         PFGrid,
         PFRadio,

--- a/web/src/elements/wizard/WizardFormPage.ts
+++ b/web/src/elements/wizard/WizardFormPage.ts
@@ -11,7 +11,6 @@ import PFCard from "@patternfly/patternfly/components/Card/card.css";
 import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFInputGroup from "@patternfly/patternfly/components/InputGroup/input-group.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 export abstract class WizardForm extends Form {
     viewportCheck = false;
@@ -37,15 +36,7 @@ export abstract class WizardForm extends Form {
 }
 
 export class WizardFormPage extends WizardPage {
-    static styles: CSSResult[] = [
-        PFBase,
-        PFCard,
-        PFButton,
-        PFForm,
-        PFAlert,
-        PFInputGroup,
-        PFFormControl,
-    ];
+    static styles: CSSResult[] = [PFCard, PFButton, PFForm, PFAlert, PFInputGroup, PFFormControl];
 
     inputCallback(): void {
         const form = this.shadowRoot?.querySelector<HTMLFormElement>("form");

--- a/web/src/elements/wizard/WizardPage.ts
+++ b/web/src/elements/wizard/WizardPage.ts
@@ -1,10 +1,8 @@
 import { AKElement } from "#elements/Base";
 import { Wizard } from "#elements/wizard/Wizard";
 
-import { CSSResult, html, LitElement, PropertyDeclaration, TemplateResult } from "lit";
+import { html, LitElement, PropertyDeclaration, TemplateResult } from "lit";
 import { property } from "lit/decorators.js";
-
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 /**
  * Callback for when the page is brought into view.
@@ -19,8 +17,6 @@ export type WizardPageActiveCallback = () => void | Promise<void>;
 export type WizardPageNextCallback = () => boolean | Promise<boolean>;
 
 export abstract class WizardPage extends AKElement {
-    static styles: CSSResult[] = [PFBase];
-
     /**
      * The label to display in the sidebar for this page.
      *

--- a/web/src/flow/FlowInspector.ts
+++ b/web/src/flow/FlowInspector.ts
@@ -21,7 +21,6 @@ import PFDescriptionList from "@patternfly/patternfly/components/DescriptionList
 import PFNotificationDrawer from "@patternfly/patternfly/components/NotificationDrawer/notification-drawer.css";
 import PFProgressStepper from "@patternfly/patternfly/components/ProgressStepper/progress-stepper.css";
 import PFStack from "@patternfly/patternfly/layouts/Stack/stack.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 function stringify(obj: unknown): string {
     return JSON.stringify(obj, null, 4);
@@ -39,7 +38,6 @@ export class FlowInspector extends AKElement {
     error?: APIError;
 
     static styles: CSSResult[] = [
-        PFBase,
         PFButton,
         PFStack,
         PFCard,

--- a/web/src/flow/components/ak-brand-footer.ts
+++ b/web/src/flow/components/ak-brand-footer.ts
@@ -11,7 +11,6 @@ import { customElement, property } from "lit/decorators.js";
 import { map } from "lit/directives/map.js";
 
 import PFList from "@patternfly/patternfly/components/List/list.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 const styles = css`
     .pf-c-list a {
@@ -27,7 +26,7 @@ const styles = css`
 
 @customElement("ak-brand-links")
 export class BrandLinks extends AKElement {
-    static styles = [PFBase, PFList, styles];
+    static styles = [PFList, styles];
 
     @property({ type: Array, attribute: false })
     public links: FooterLink[] = globalAK().brand.uiFooterLinks || [];

--- a/web/src/flow/components/ak-flow-card.ts
+++ b/web/src/flow/components/ak-flow-card.ts
@@ -12,7 +12,6 @@ import { customElement, property } from "lit/decorators.js";
 
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 /**
  * @element ak-flow-card
@@ -33,7 +32,7 @@ export class FlowCard extends AKElement {
     @property({ type: Boolean })
     loading = false;
 
-    static styles: CSSResult[] = [PFBase, PFLogin, PFTitle, Styles];
+    static styles: CSSResult[] = [PFLogin, PFTitle, Styles];
 
     render() {
         let inner = html`<slot></slot>`;

--- a/web/src/flow/components/ak-flow-password-input.ts
+++ b/web/src/flow/components/ak-flow-password-input.ts
@@ -15,7 +15,6 @@ import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFInputGroup from "@patternfly/patternfly/components/InputGroup/input-group.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 /**
  * A configuration object for the visibility states of the password input.
@@ -41,7 +40,7 @@ const Visibility = {
 
 @customElement("ak-flow-input-password")
 export class InputPassword extends AKElement {
-    static styles = [PFBase, PFForm, PFInputGroup, PFFormControl, PFButton];
+    static styles = [PFForm, PFInputGroup, PFFormControl, PFButton];
 
     //#region Properties
 

--- a/web/src/flow/providers/IFrameLogoutStage.ts
+++ b/web/src/flow/providers/IFrameLogoutStage.ts
@@ -18,7 +18,6 @@ import PFFormControl from "@patternfly/patternfly/components/FormControl/form-co
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFProgress from "@patternfly/patternfly/components/Progress/progress.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 interface LogoutStatus {
     providerName: string;
@@ -67,7 +66,6 @@ export class IFrameLogoutStage extends BaseStage<
     }
 
     public static styles: CSSResult[] = [
-        PFBase,
         PFLogin,
         PFForm,
         PFButton,

--- a/web/src/flow/providers/SessionEnd.ts
+++ b/web/src/flow/providers/SessionEnd.ts
@@ -17,11 +17,10 @@ import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-stage-session-end")
 export class SessionEnd extends BaseStage<SessionEndChallenge, unknown> {
-    static styles: CSSResult[] = [PFBase, PFLogin, PFForm, PFFormControl, PFTitle, PFButton];
+    static styles: CSSResult[] = [PFLogin, PFForm, PFFormControl, PFTitle, PFButton];
 
     render(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>

--- a/web/src/flow/providers/oauth2/DeviceCode.ts
+++ b/web/src/flow/providers/oauth2/DeviceCode.ts
@@ -21,7 +21,6 @@ import PFFormControl from "@patternfly/patternfly/components/FormControl/form-co
 import PFInputGroup from "@patternfly/patternfly/components/InputGroup/input-group.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-flow-provider-oauth2-code")
 export class OAuth2DeviceCode extends BaseStage<
@@ -30,15 +29,7 @@ export class OAuth2DeviceCode extends BaseStage<
 > {
     static shadowRootOptions = { ...LitElement.shadowRootOptions, delegatesFocus: true };
 
-    static styles: CSSResult[] = [
-        PFBase,
-        PFLogin,
-        PFForm,
-        PFFormControl,
-        PFTitle,
-        PFButton,
-        PFInputGroup,
-    ];
+    static styles: CSSResult[] = [PFLogin, PFForm, PFFormControl, PFTitle, PFButton, PFInputGroup];
 
     render(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>

--- a/web/src/flow/providers/saml/NativeLogoutStage.ts
+++ b/web/src/flow/providers/saml/NativeLogoutStage.ts
@@ -19,7 +19,6 @@ import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-provider-saml-native-logout")
 export class NativeLogoutStage extends BaseStage<
@@ -28,7 +27,7 @@ export class NativeLogoutStage extends BaseStage<
 > {
     #formRef: Ref<HTMLFormElement> = createRef();
 
-    public static styles: CSSResult[] = [PFBase, PFLogin, PFForm, PFButton, PFFormControl, PFTitle];
+    public static styles: CSSResult[] = [PFLogin, PFForm, PFButton, PFFormControl, PFTitle];
 
     public override firstUpdated(changedProperties: PropertyValues): void {
         super.firstUpdated(changedProperties);

--- a/web/src/flow/sources/apple/AppleLoginInit.ts
+++ b/web/src/flow/sources/apple/AppleLoginInit.ts
@@ -13,14 +13,13 @@ import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-flow-source-oauth-apple")
 export class AppleLoginInit extends BaseStage<AppleLoginChallenge, AppleChallengeResponseRequest> {
     @property({ type: Boolean })
     isModalShown = false;
 
-    static styles: CSSResult[] = [PFBase, PFLogin, PFForm, PFFormControl, PFButton, PFTitle];
+    static styles: CSSResult[] = [PFLogin, PFForm, PFFormControl, PFButton, PFTitle];
 
     firstUpdated(): void {
         const appleAuth = document.createElement("script");

--- a/web/src/flow/sources/plex/PlexLoginInit.ts
+++ b/web/src/flow/sources/plex/PlexLoginInit.ts
@@ -25,7 +25,6 @@ import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-flow-source-plex")
 export class PlexLoginInit extends BaseStage<
@@ -35,15 +34,7 @@ export class PlexLoginInit extends BaseStage<
     @state()
     authUrl?: string;
 
-    static styles: CSSResult[] = [
-        PFBase,
-        PFLogin,
-        PFForm,
-        PFFormControl,
-        PFButton,
-        PFTitle,
-        PFDivider,
-    ];
+    static styles: CSSResult[] = [PFLogin, PFForm, PFFormControl, PFButton, PFTitle, PFDivider];
 
     async firstUpdated(): Promise<void> {
         const authInfo = await PlexAPIClient.getPin(this.challenge?.clientId || "");

--- a/web/src/flow/stages/FlowErrorStage.ts
+++ b/web/src/flow/stages/FlowErrorStage.ts
@@ -14,12 +14,10 @@ import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-stage-flow-error")
 export class FlowErrorStage extends BaseStage<FlowErrorChallenge, FlowChallengeResponseRequest> {
     static styles: CSSResult[] = [
-        PFBase,
         PFLogin,
         PFForm,
         PFFormControl,

--- a/web/src/flow/stages/FlowFrameStage.ts
+++ b/web/src/flow/stages/FlowFrameStage.ts
@@ -13,11 +13,10 @@ import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("xak-flow-frame")
 export class FlowFrameStage extends BaseStage<FrameChallenge, FrameChallengeResponseRequest> {
-    static styles: CSSResult[] = [PFBase, PFLogin, PFForm, PFFormControl, PFTitle, css``];
+    static styles: CSSResult[] = [PFLogin, PFForm, PFFormControl, PFTitle, css``];
 
     render(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>

--- a/web/src/flow/stages/RedirectStage.ts
+++ b/web/src/flow/stages/RedirectStage.ts
@@ -13,7 +13,6 @@ import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-stage-redirect")
 export class RedirectStage extends BaseStage<RedirectChallenge, FlowChallengeResponseRequest> {
@@ -24,7 +23,6 @@ export class RedirectStage extends BaseStage<RedirectChallenge, FlowChallengeRes
     startedRedirect = false;
 
     static styles: CSSResult[] = [
-        PFBase,
         PFLogin,
         PFForm,
         PFButton,

--- a/web/src/flow/stages/access_denied/AccessDeniedStage.ts
+++ b/web/src/flow/stages/access_denied/AccessDeniedStage.ts
@@ -14,14 +14,13 @@ import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-stage-access-denied")
 export class AccessDeniedStage extends BaseStage<
     AccessDeniedChallenge,
     FlowChallengeResponseRequest
 > {
-    static styles: CSSResult[] = [PFBase, PFLogin, PFForm, PFTitle, PFFormControl];
+    static styles: CSSResult[] = [PFLogin, PFForm, PFTitle, PFFormControl];
 
     render(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>

--- a/web/src/flow/stages/authenticator_duo/AuthenticatorDuoStage.ts
+++ b/web/src/flow/stages/authenticator_duo/AuthenticatorDuoStage.ts
@@ -22,14 +22,13 @@ import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-stage-authenticator-duo")
 export class AuthenticatorDuoStage extends BaseStage<
     AuthenticatorDuoChallenge,
     AuthenticatorDuoChallengeResponseRequest
 > {
-    static styles: CSSResult[] = [PFBase, PFLogin, PFForm, PFFormControl, PFTitle, PFButton];
+    static styles: CSSResult[] = [PFLogin, PFForm, PFFormControl, PFTitle, PFButton];
 
     updated(changedProperties: PropertyValues<this>) {
         super.updated(changedProperties);

--- a/web/src/flow/stages/authenticator_email/AuthenticatorEmailStage.ts
+++ b/web/src/flow/stages/authenticator_email/AuthenticatorEmailStage.ts
@@ -23,7 +23,6 @@ import PFFormControl from "@patternfly/patternfly/components/FormControl/form-co
 import PFInputGroup from "@patternfly/patternfly/components/InputGroup/input-group.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-stage-authenticator-email")
 export class AuthenticatorEmailStage extends BaseStage<
@@ -31,7 +30,6 @@ export class AuthenticatorEmailStage extends BaseStage<
     AuthenticatorEmailChallengeResponseRequest
 > {
     static styles: CSSResult[] = [
-        PFBase,
         PFAlert,
         PFLogin,
         PFForm,

--- a/web/src/flow/stages/authenticator_sms/AuthenticatorSMSStage.ts
+++ b/web/src/flow/stages/authenticator_sms/AuthenticatorSMSStage.ts
@@ -23,7 +23,6 @@ import PFFormControl from "@patternfly/patternfly/components/FormControl/form-co
 import PFInputGroup from "@patternfly/patternfly/components/InputGroup/input-group.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-stage-authenticator-sms")
 export class AuthenticatorSMSStage extends BaseStage<
@@ -31,7 +30,6 @@ export class AuthenticatorSMSStage extends BaseStage<
     AuthenticatorSMSChallengeResponseRequest
 > {
     static styles: CSSResult[] = [
-        PFBase,
         PFAlert,
         PFLogin,
         PFForm,

--- a/web/src/flow/stages/authenticator_static/AuthenticatorStaticStage.ts
+++ b/web/src/flow/stages/authenticator_static/AuthenticatorStaticStage.ts
@@ -19,7 +19,6 @@ import PFFormControl from "@patternfly/patternfly/components/FormControl/form-co
 import PFInputGroup from "@patternfly/patternfly/components/InputGroup/input-group.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-stage-authenticator-static")
 export class AuthenticatorStaticStage extends BaseStage<
@@ -27,7 +26,6 @@ export class AuthenticatorStaticStage extends BaseStage<
     AuthenticatorStaticChallengeResponseRequest
 > {
     static styles: CSSResult[] = [
-        PFBase,
         PFLogin,
         PFForm,
         PFFormControl,

--- a/web/src/flow/stages/authenticator_totp/AuthenticatorTOTPStage.ts
+++ b/web/src/flow/stages/authenticator_totp/AuthenticatorTOTPStage.ts
@@ -27,7 +27,6 @@ import PFFormControl from "@patternfly/patternfly/components/FormControl/form-co
 import PFInputGroup from "@patternfly/patternfly/components/InputGroup/input-group.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-stage-authenticator-totp")
 export class AuthenticatorTOTPStage extends BaseStage<
@@ -35,7 +34,6 @@ export class AuthenticatorTOTPStage extends BaseStage<
     AuthenticatorTOTPChallengeResponseRequest
 > {
     static styles: CSSResult[] = [
-        PFBase,
         PFLogin,
         PFForm,
         PFFormControl,

--- a/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStage.ts
+++ b/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStage.ts
@@ -30,7 +30,6 @@ import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 interface DevicePickerProps {
     icon?: string;
@@ -85,15 +84,7 @@ export class AuthenticatorValidateStage
     >
     implements StageHost
 {
-    static styles: CSSResult[] = [
-        PFBase,
-        PFLogin,
-        PFForm,
-        PFFormControl,
-        PFTitle,
-        PFButton,
-        Styles,
-    ];
+    static styles: CSSResult[] = [PFLogin, PFForm, PFFormControl, PFTitle, PFButton, Styles];
 
     flowSlug = "";
 

--- a/web/src/flow/stages/authenticator_validate/base.ts
+++ b/web/src/flow/stages/authenticator_validate/base.ts
@@ -12,7 +12,6 @@ import PFFormControl from "@patternfly/patternfly/components/FormControl/form-co
 import PFInputGroup from "@patternfly/patternfly/components/InputGroup/input-group.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 export class BaseDeviceStage<
     Tin extends FlowInfoChallenge & PendingUserChallenge,
@@ -24,15 +23,7 @@ export class BaseDeviceStage<
     @property({ type: Boolean })
     showBackButton = false;
 
-    static styles: CSSResult[] = [
-        PFBase,
-        PFLogin,
-        PFForm,
-        PFFormControl,
-        PFInputGroup,
-        PFTitle,
-        PFButton,
-    ];
+    static styles: CSSResult[] = [PFLogin, PFForm, PFFormControl, PFInputGroup, PFTitle, PFButton];
 
     submit(payload: Tin): Promise<boolean> {
         return this.host?.submit(payload) || Promise.resolve();

--- a/web/src/flow/stages/authenticator_webauthn/WebAuthnAuthenticatorRegisterStage.ts
+++ b/web/src/flow/stages/authenticator_webauthn/WebAuthnAuthenticatorRegisterStage.ts
@@ -25,7 +25,6 @@ import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 export interface WebAuthnAuthenticatorRegisterChallengeResponse {
     response: Assertion;
@@ -44,7 +43,7 @@ export class WebAuthnAuthenticatorRegisterStage extends BaseStage<
 
     publicKeyCredentialCreateOptions?: PublicKeyCredentialCreationOptions;
 
-    static styles: CSSResult[] = [PFBase, PFLogin, PFFormControl, PFForm, PFTitle, PFButton];
+    static styles: CSSResult[] = [PFLogin, PFFormControl, PFForm, PFTitle, PFButton];
 
     async register(): Promise<void> {
         if (!this.challenge) {

--- a/web/src/flow/stages/autosubmit/AutosubmitStage.ts
+++ b/web/src/flow/stages/autosubmit/AutosubmitStage.ts
@@ -13,7 +13,6 @@ import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-stage-autosubmit")
 export class AutosubmitStage extends BaseStage<
@@ -23,7 +22,7 @@ export class AutosubmitStage extends BaseStage<
     @query("form")
     private form?: HTMLFormElement;
 
-    static styles: CSSResult[] = [PFBase, PFLogin, PFForm, PFFormControl, PFButton, PFTitle];
+    static styles: CSSResult[] = [PFLogin, PFForm, PFFormControl, PFButton, PFTitle];
 
     updated(changed: PropertyValues<this>): void {
         super.updated(changed);

--- a/web/src/flow/stages/captcha/CaptchaStage.ts
+++ b/web/src/flow/stages/captcha/CaptchaStage.ts
@@ -25,7 +25,6 @@ import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 export type TokenListener = (token: string) => void;
 
@@ -47,7 +46,6 @@ type IframeMessageEvent = MessageEvent<CaptchaMessage | LoadMessage>;
 @customElement("ak-stage-captcha")
 export class CaptchaStage extends BaseStage<CaptchaChallenge, CaptchaChallengeResponseRequest> {
     static styles: CSSResult[] = [
-        PFBase,
         PFLogin,
         PFForm,
         PFFormControl,

--- a/web/src/flow/stages/consent/ConsentStage.ts
+++ b/web/src/flow/stages/consent/ConsentStage.ts
@@ -20,14 +20,12 @@ import PFFormControl from "@patternfly/patternfly/components/FormControl/form-co
 import PFList from "@patternfly/patternfly/components/List/list.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 import PFSpacing from "@patternfly/patternfly/utilities/Spacing/spacing.css";
 import PFText from "@patternfly/patternfly/utilities/Text/text.css";
 
 @customElement("ak-stage-consent")
 export class ConsentStage extends BaseStage<ConsentChallenge, ConsentChallengeResponseRequest> {
     static styles: CSSResult[] = [
-        PFBase,
         PFLogin,
         PFList,
         PFForm,

--- a/web/src/flow/stages/dummy/DummyStage.ts
+++ b/web/src/flow/stages/dummy/DummyStage.ts
@@ -14,11 +14,10 @@ import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-stage-dummy")
 export class DummyStage extends BaseStage<DummyChallenge, DummyChallengeResponseRequest> {
-    static styles: CSSResult[] = [PFBase, PFLogin, PFForm, PFFormControl, PFTitle, PFButton];
+    static styles: CSSResult[] = [PFLogin, PFForm, PFFormControl, PFTitle, PFButton];
 
     render(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>

--- a/web/src/flow/stages/email/EmailStage.ts
+++ b/web/src/flow/stages/email/EmailStage.ts
@@ -13,11 +13,10 @@ import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-stage-email")
 export class EmailStage extends BaseStage<EmailChallenge, EmailChallengeResponseRequest> {
-    static styles: CSSResult[] = [PFBase, PFLogin, PFForm, PFFormControl, PFButton, PFTitle];
+    static styles: CSSResult[] = [PFLogin, PFForm, PFFormControl, PFButton, PFTitle];
 
     render(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>

--- a/web/src/flow/stages/endpoint/agent/EndpointAgentStage.ts
+++ b/web/src/flow/stages/endpoint/agent/EndpointAgentStage.ts
@@ -14,14 +14,13 @@ import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-stage-endpoint-agent")
 export class EndpointAgentStage extends BaseStage<
     EndpointAgentChallenge,
     EndpointAgentChallengeResponseRequest
 > {
-    static styles: CSSResult[] = [PFBase, PFLogin, PFForm, PFFormControl, PFTitle, css``];
+    static styles: CSSResult[] = [PFLogin, PFForm, PFFormControl, PFTitle, css``];
 
     firstUpdated() {
         window.addEventListener("message", (ev) => {

--- a/web/src/flow/stages/identification/IdentificationStage.ts
+++ b/web/src/flow/stages/identification/IdentificationStage.ts
@@ -36,7 +36,6 @@ import PFFormControl from "@patternfly/patternfly/components/FormControl/form-co
 import PFInputGroup from "@patternfly/patternfly/components/InputGroup/input-group.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 export const PasswordManagerPrefill: {
     password?: string;
@@ -54,7 +53,6 @@ export class IdentificationStage extends BaseStage<
     IdentificationChallengeResponseRequest
 > {
     static styles: CSSResult[] = [
-        PFBase,
         PFAlert,
         PFInputGroup,
         PFLogin,

--- a/web/src/flow/stages/password/PasswordStage.ts
+++ b/web/src/flow/stages/password/PasswordStage.ts
@@ -20,19 +20,10 @@ import PFFormControl from "@patternfly/patternfly/components/FormControl/form-co
 import PFInputGroup from "@patternfly/patternfly/components/InputGroup/input-group.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-stage-password")
 export class PasswordStage extends BaseStage<PasswordChallenge, PasswordChallengeResponseRequest> {
-    static styles: CSSResult[] = [
-        PFBase,
-        PFLogin,
-        PFInputGroup,
-        PFForm,
-        PFFormControl,
-        PFButton,
-        PFTitle,
-    ];
+    static styles: CSSResult[] = [PFLogin, PFInputGroup, PFForm, PFFormControl, PFButton, PFTitle];
 
     #errors(field: string): ErrorProp[] | undefined {
         const errors = this.challenge?.responseErrors?.[field];

--- a/web/src/flow/stages/prompt/PromptStage.ts
+++ b/web/src/flow/stages/prompt/PromptStage.ts
@@ -31,7 +31,6 @@ import PFFormControl from "@patternfly/patternfly/components/FormControl/form-co
 import PFInputGroup from "@patternfly/patternfly/components/InputGroup/input-group.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 // Fixes horizontal rule <hr> warning in select dropdowns.
 /* eslint-disable lit/no-invalid-html */
@@ -41,7 +40,6 @@ export class PromptStage extends WithCapabilitiesConfig(
     BaseStage<PromptChallenge, PromptChallengeResponseRequest>,
 ) {
     static styles: CSSResult[] = [
-        PFBase,
         PFLogin,
         PFAlert,
         PFForm,

--- a/web/src/flow/stages/user_login/UserLoginStage.ts
+++ b/web/src/flow/stages/user_login/UserLoginStage.ts
@@ -15,7 +15,6 @@ import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 import PFSpacing from "@patternfly/patternfly/utilities/Spacing/spacing.css";
 
 @customElement("ak-stage-user-login")
@@ -23,15 +22,7 @@ export class PasswordStage extends BaseStage<
     UserLoginChallenge,
     UserLoginChallengeResponseRequest
 > {
-    static styles: CSSResult[] = [
-        PFBase,
-        PFLogin,
-        PFForm,
-        PFFormControl,
-        PFSpacing,
-        PFButton,
-        PFTitle,
-    ];
+    static styles: CSSResult[] = [PFLogin, PFForm, PFFormControl, PFSpacing, PFButton, PFTitle];
 
     render(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>

--- a/web/src/rac/index.entrypoint.ts
+++ b/web/src/rac/index.entrypoint.ts
@@ -13,7 +13,6 @@ import { customElement, property, state } from "lit/decorators.js";
 
 import PFContent from "@patternfly/patternfly/components/Content/content.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 enum GuacClientState {
     IDLE = 0,
@@ -49,7 +48,7 @@ const RECONNECT_ATTEMPTS = 5;
 export class RacInterface extends WithBrandConfig(Interface) {
     static styles: CSSResult[] = [
         // ---
-        PFBase,
+
         PFPage,
         PFContent,
         Styles,

--- a/web/src/standalone/loading/index.entrypoint.ts
+++ b/web/src/standalone/loading/index.entrypoint.ts
@@ -5,12 +5,10 @@ import { css, html, TemplateResult } from "lit";
 import { customElement } from "lit/decorators.js";
 
 import PFSpinner from "@patternfly/patternfly/components/Spinner/spinner.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-loading")
 export class Loading extends AKElement {
     static styles = [
-        PFBase,
         PFSpinner,
         css`
             :host {

--- a/web/src/user/LibraryPage/ak-library-application-empty-list.ts
+++ b/web/src/user/LibraryPage/ak-library-application-empty-list.ts
@@ -10,7 +10,6 @@ import { customElement, property } from "lit/decorators.js";
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFContent from "@patternfly/patternfly/components/Content/content.css";
 import PFEmptyState from "@patternfly/patternfly/components/EmptyState/empty-state.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 import PFSpacing from "@patternfly/patternfly/utilities/Spacing/spacing.css";
 
 export interface ILibraryPageApplicationEmptyList {
@@ -30,7 +29,6 @@ export class LibraryPageApplicationEmptyList
     implements ILibraryPageApplicationEmptyList
 {
     static styles = [
-        PFBase,
         PFEmptyState,
         PFButton,
         PFContent,

--- a/web/src/user/LibraryPage/ak-library-impl.ts
+++ b/web/src/user/LibraryPage/ak-library-impl.ts
@@ -37,7 +37,6 @@ import PFEmptyState from "@patternfly/patternfly/components/EmptyState/empty-sta
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFPage from "@patternfly/patternfly/components/Page/page.css";
 import PFGrid from "@patternfly/patternfly/layouts/Grid/grid.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 import PFDisplay from "@patternfly/patternfly/utilities/Display/display.css";
 import PFSpacing from "@patternfly/patternfly/utilities/Spacing/spacing.css";
 
@@ -68,7 +67,7 @@ export class LibraryPage extends WithSession(AKElement) {
 
     static styles = [
         // ---
-        PFBase,
+
         PFDisplay,
         PFEmptyState,
         PFPage,

--- a/web/src/user/user-settings/details/UserPassword.ts
+++ b/web/src/user/user-settings/details/UserPassword.ts
@@ -12,14 +12,13 @@ import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFCard from "@patternfly/patternfly/components/Card/card.css";
 import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-user-settings-password")
 export class UserSettingsPassword extends AKElement {
     @property()
     configureUrl?: string;
 
-    static styles: CSSResult[] = [PFBase, PFCard, PFButton, PFForm, PFFormControl];
+    static styles: CSSResult[] = [PFCard, PFButton, PFForm, PFFormControl];
 
     render(): TemplateResult {
         // For this stage we don't need to check for a configureFlow,


### PR DESCRIPTION
## Details

This PR removes references to Patternfly's base css in our elements. Prior to #17444, it was necessary to insert base styles into components. That PR moved much of the styles into global scope, or into our Lit element `AKBase` class.

#17444 avoided a larger(er) file count change by stubbing any references to the `base.css` import with an empty stylesheet. This PR removes the references and the stub logic from our bundler. 