### PR TITLE
web: Improved table selection behavior

### DIFF
--- a/web/src/elements/table/Table.ts
+++ b/web/src/elements/table/Table.ts
@@ -167,7 +167,7 @@ export abstract class Table<T extends object>
     public page = getURLParam(this.#pageParam, 1);
 
     /**
-     * Set if your `selectedElements\` use of the selection box is to enable bulk-delete,
+     * Set if your `selectedElements` use of the selection box is to enable bulk-delete,
      * so that stale data is cleared out when the API returns a new list minus the deleted entries.
      *
      * @prop

--- a/web/src/elements/table/Table.ts
+++ b/web/src/elements/table/Table.ts
@@ -496,9 +496,11 @@ export abstract class Table<T extends object>
             this.expandedElements.delete(itemKey);
         } else {
             this.expandedElements.add(itemKey);
+
             requestAnimationFrame(() => {
                 currentTarget?.scrollIntoView({
                     behavior: "smooth",
+                    block: "center",
                 });
             });
         }


### PR DESCRIPTION
## Details

This PR fixes a caching issue which cause the table row selector to use stale references after refreshing. 

### Included Fixes

- Smooth scrolling on expanded rows now aligns to the center of the row instead of the block-start of the table
- Cherry-picks #18412