### PR TITLE
wed/admin: change s to S in "Stage"

### DIFF
--- a/web/src/admin/flows/BoundStagesList.ts
+++ b/web/src/admin/flows/BoundStagesList.ts
@@ -145,7 +145,7 @@ export class BoundStagesList extends Table<FlowStageBinding> {
                         <ak-stage-binding-form slot="form" targetPk=${ifDefined(this.target)}>
                         </ak-stage-binding-form>
                         <button slot="trigger" class="pf-c-button pf-m-primary">
-                            ${msg("Bind existing stage")}
+                            ${msg("Bind existing Stage")}
                         </button>
                     </ak-forms-modal>
                 </div>
@@ -166,7 +166,7 @@ export class BoundStagesList extends Table<FlowStageBinding> {
                 <ak-stage-binding-form slot="form" targetPk=${ifDefined(this.target)}>
                 </ak-stage-binding-form>
                 <button slot="trigger" class="pf-c-button pf-m-primary">
-                    ${msg("Bind existing stage")}
+                    ${msg("Bind existing Stage")}
                 </button>
             </ak-forms-modal>
             ${super.renderToolbar()}


### PR DESCRIPTION
## Details

Makes the capitalization consistent on the flows page

<img width="517" height="224" alt="image" src="https://github.com/user-attachments/assets/ccd77795-0e7f-424f-aa55-b82a7b575a20" />

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

-   [x] The code has been formatted (`make web`)

