### PR TITLE
stages/password: replace session-based retries with reputation

### DIFF
--- a/authentik/stages/password/stage.py
+++ b/authentik/stages/password/stage.py
@@ -5,6 +5,7 @@ from typing import Any
 from django.contrib.auth import _clean_credentials
 from django.contrib.auth.backends import BaseBackend
 from django.core.exceptions import PermissionDenied
+from django.db.models import Sum
 from django.http import HttpRequest, HttpResponse
 from django.urls import reverse
 from django.utils.translation import gettext as _
@@ -25,13 +26,13 @@ from authentik.flows.models import Flow, Stage
 from authentik.flows.planner import PLAN_CONTEXT_PENDING_USER
 from authentik.flows.stage import ChallengeStageView
 from authentik.lib.utils.reflection import path_to_class
+from authentik.policies.reputation.models import Reputation
 from authentik.stages.password.models import PasswordStage
 
 LOGGER = get_logger()
 PLAN_CONTEXT_AUTHENTICATION_BACKEND = "user_backend"
 PLAN_CONTEXT_METHOD = "auth_method"
 PLAN_CONTEXT_METHOD_ARGS = "auth_method_args"
-SESSION_KEY_INVALID_TRIES = "authentik/stages/password/user_invalid_tries"
 
 
 def authenticate(
@@ -151,16 +152,14 @@ class PasswordStageView(ChallengeStageView):
         return challenge
 
     def challenge_invalid(self, response: PasswordChallengeResponse) -> HttpResponse:
-        if SESSION_KEY_INVALID_TRIES not in self.request.session:
-            self.request.session[SESSION_KEY_INVALID_TRIES] = 0
-        self.request.session[SESSION_KEY_INVALID_TRIES] += 1
         current_stage: PasswordStage = self.executor.current_stage
         if (
-            self.request.session[SESSION_KEY_INVALID_TRIES]
-            >= current_stage.failed_attempts_before_cancel
-        ):
+            Reputation.objects.filter(identifier=self.get_pending_user().username).aggregate(
+                total_score=Sum("score")
+            )["total_score"]
+            or 0
+        ) <= current_stage.failed_attempts_before_cancel:
             self.logger.debug("User has exceeded maximum tries")
-            del self.request.session[SESSION_KEY_INVALID_TRIES]
             return self.executor.stage_invalid(_("Invalid password"))
         return super().challenge_invalid(response)
 

--- a/authentik/stages/password/stage.py
+++ b/authentik/stages/password/stage.py
@@ -164,7 +164,10 @@ class PasswordStageView(ChallengeStageView):
 
     def challenge_invalid(self, response: PasswordChallengeResponse) -> HttpResponse:
         current_stage: PasswordStage = self.executor.current_stage
-        initial_score = self.executor.plan.context.get(PLAN_CONTEXT_INITIAL_SCORE, 0)
+        initial_score = self.executor.plan.context.get(PLAN_CONTEXT_INITIAL_SCORE)
+        if initial_score is None:
+            initial_score = self.get_reputation_score()
+            self.executor.plan.context[PLAN_CONTEXT_INITIAL_SCORE] = initial_score
         new_score = self.get_reputation_score()
         if (initial_score - new_score) >= current_stage.failed_attempts_before_cancel:
             self.logger.debug("User has exceeded maximum tries")

--- a/authentik/stages/password/tests.py
+++ b/authentik/stages/password/tests.py
@@ -135,6 +135,13 @@ class TestPasswordStage(FlowTestCase):
         session[SESSION_KEY_PLAN] = plan
         session.save()
 
+        res = self.client.get(
+            reverse(
+                "authentik_api:flow-executor",
+                kwargs={"flow_slug": self.flow.slug},
+            ),
+        )
+        self.assertEqual(res.status_code, 200)
         for _ in range(self.stage.failed_attempts_before_cancel - 1):
             response = self.client.post(
                 reverse(


### PR DESCRIPTION
needs to be discussed

upsides:
- updates to the session are not atomic so it is possible to squeeze in more requests that should've been rejected
- retries are global and not scoped to user session (upside and downside)

downsides:
- definitely changes the expected behaviour