### PR TITLE
sources/oauth/twitter: update fields, scopes and profile URL to match current X API 

### DIFF
--- a/authentik/sources/oauth/types/twitter.py
+++ b/authentik/sources/oauth/types/twitter.py
@@ -15,7 +15,7 @@ class TwitterOAuthRedirect(OAuthRedirect):
     """Twitter OAuth2 Redirect"""
 
     def get_additional_parameters(self, source):  # pragma: no cover
-        scopes = ["users.read", "tweet.read"]
+        scopes = ["users.read", "tweet.read","users.email"]
         # If admin has defined custom scopes in the provider UI, merge them
         configured = getattr(source, "scope", []) or []
         for s in configured:
@@ -47,17 +47,17 @@ class TwitterType(SourceType):
 
     authorization_url = "https://twitter.com/i/oauth2/authorize"
     access_token_url = "https://api.twitter.com/2/oauth2/token"  # nosec
-    profile_url = "https://api.twitter.com/2/users/me?user.fields=verified,username,name,profile_image_url,confirmed_email"
+    profile_url = (
+    "https://api.twitter.com/2/users/me"
+    "?user.fields=id,name,username,confirmed_email,profile_image_url,verified"
+    )
 
     pkce = PKCEMethod.S256
 
     def get_base_user_properties(self, info: dict[str, Any], **kwargs) -> dict[str, Any]:
         data = info.get("data", {})
-        email = (
-            data.get("confirmed_email")
-            or data.get("email")
-            or None
-        )
+        email = data.get("confirmed_email")
+
         return {
             "username": data.get("username"),
             "email": email,


### PR DESCRIPTION
This updates the Twitter OAuth2 source so it aligns with the current X API requirements. The previous implementation did not request the required user.fields and was missing newer scopes, which caused the Twitter login flow to fail.

This PR updates the profile URL to include the correct fields, adds the required scopes, and expands the user property mapping to match the response returned by X.

closes #18466