### PR TITLE
core: remove superuser check from `Token` list

### DIFF
--- a/authentik/core/api/tokens.py
+++ b/authentik/core/api/tokens.py
@@ -4,7 +4,6 @@ from typing import Any
 
 from django.utils.timezone import now
 from drf_spectacular.utils import OpenApiResponse, extend_schema
-from guardian.shortcuts import get_anonymous_user
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.fields import CharField
@@ -144,12 +143,6 @@ class TokenViewSet(UsedByMixin, ModelViewSet):
     ordering = ["identifier", "expires"]
     owner_field = "user"
     rbac_allow_create_without_perm = True
-
-    def get_queryset(self):
-        user = self.request.user if self.request else get_anonymous_user()
-        if user.is_superuser:
-            return super().get_queryset()
-        return super().get_queryset().filter(user=user.pk)
 
     def perform_create(self, serializer: TokenSerializer):
         if not self.request.user.is_superuser:

--- a/authentik/core/tests/test_token_api.py
+++ b/authentik/core/tests/test_token_api.py
@@ -183,16 +183,16 @@ class TestTokenAPI(APITestCase):
         self.assertEqual(len(body["results"]), 1)
         self.assertEqual(body["results"][0]["identifier"], token_should.identifier)
 
-    def test_list_admin(self):
-        """Test Token List (Test with admin auth)"""
+    def test_list_with_permission(self):
+        """Test Token List (Test with `view_token` permission)"""
         Token.objects.all().delete()
-        self.client.force_login(self.admin)
         token_should: Token = Token.objects.create(
             identifier="test", expiring=False, user=self.user
         )
         token_should_not: Token = Token.objects.create(
             identifier="test-2", expiring=False, user=get_anonymous_user()
         )
+        self.user.assign_perms_to_managed_role("authentik_core.view_token")
         response = self.client.get(reverse("authentik_api:token-list"))
         body = loads(response.content)
         self.assertEqual(len(body["results"]), 2)


### PR DESCRIPTION
With this change, users with global `view_token` permissions will be able to see other users' tokens (but not their keys).