### PR TITLE
web/flow: Fix spurious double submit  on ak-stage-autosubmit

### DIFF
--- a/web/src/flow/stages/RedirectStage.ts
+++ b/web/src/flow/stages/RedirectStage.ts
@@ -41,9 +41,12 @@ export class RedirectStage extends BaseStage<RedirectChallenge, FlowChallengeRes
         return new URL(this.challenge.to, document.baseURI).toString();
     }
 
-    firstUpdated(changed: PropertyValues<this>): void {
-        super.firstUpdated(changed);
+    updated(changed: PropertyValues<this>): void {
+        super.updated(changed);
 
+        if (!changed.has("challenge")) {
+            return;
+        }
         if (this.promptUser) {
             document.addEventListener("keydown", (ev) => {
                 if (ev.key === "Enter") {

--- a/web/src/flow/stages/autosubmit/AutosubmitStage.ts
+++ b/web/src/flow/stages/autosubmit/AutosubmitStage.ts
@@ -25,10 +25,10 @@ export class AutosubmitStage extends BaseStage<
 
     static styles: CSSResult[] = [PFBase, PFLogin, PFForm, PFFormControl, PFButton, PFTitle];
 
-    firstUpdated(changed: PropertyValues<this>): void {
-        super.firstUpdated(changed);
+    updated(changed: PropertyValues<this>): void {
+        super.updated(changed);
 
-        if (this.challenge.url !== undefined) {
+        if (changed.has("challenge") && this.challenge.url !== undefined) {
             console.debug("authentik/flow/stages/autosubmit: submitting");
             this.form?.submit();
         }

--- a/web/src/flow/stages/autosubmit/AutosubmitStage.ts
+++ b/web/src/flow/stages/autosubmit/AutosubmitStage.ts
@@ -25,10 +25,11 @@ export class AutosubmitStage extends BaseStage<
 
     static styles: CSSResult[] = [PFBase, PFLogin, PFForm, PFFormControl, PFButton, PFTitle];
 
-    updated(changed: PropertyValues<this>): void {
-        super.updated(changed);
+    firstUpdated(changed: PropertyValues<this>): void {
+        super.firstUpdated(changed);
 
         if (this.challenge.url !== undefined) {
+            console.debug("authentik/flow/stages/autosubmit: submitting");
             this.form?.submit();
         }
     }


### PR DESCRIPTION

## Details

Use correct lifecycle hook for ak-stage-autosubmit.

Fixes #18655 

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
