### PR TITLE
website/integrations: m365: fix string match

### DIFF
--- a/website/integrations/platforms/microsoft/index.md
+++ b/website/integrations/platforms/microsoft/index.md
@@ -136,8 +136,7 @@ Connect-MgGraph -Scopes "User.ReadWrite.All"
 $users = Get-MgUser -Filter "endsWith(mail,'@domain.company')" -All
 foreach ($user in $users) {
     if ($user.Mail) {
-        $immutableId = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($user.Mail))
-        Update-MgUser -UserId $user.Id -OnPremisesImmutableId $immutableId
+        Update-MgUser -UserId $user.Id -OnPremisesImmutableId $user.Mail
         Write-Host "Set ImmutableId for $($user.Mail)"
     }
 }


### PR DESCRIPTION
This needs to just be a simple string match, and earlier in the docs the custom property mapping is created that simply returns "user.email"

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->

Simple minor doc update. As written the Microsoft365 SAML SSO docs do not work.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [X] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
