### PR TITLE
web/admin: make empty table message configurable

### DIFF
--- a/web/src/elements/table/Table.ts
+++ b/web/src/elements/table/Table.ts
@@ -102,6 +102,11 @@ export abstract class Table<T extends object>
     protected abstract row(item: T): SlottedTemplateResult[];
 
     /**
+     * Customize the "No objects found" message.
+     */
+    protected emptyStateMessage = msg("No objects found.");
+
+    /**
      * The total number of defined and additional columns in the table.
      */
     #columnCount = 0;
@@ -368,7 +373,7 @@ export abstract class Table<T extends object>
                     <div class="pf-l-bullseye">
                         ${inner ??
                         html`<ak-empty-state
-                            ><span>${msg("No objects found.")}</span>
+                            ><span>${this.emptyStateMessage}</span>
                             <div slot="primary">${this.renderObjectCreate()}</div>
                         </ak-empty-state>`}
                     </div>

--- a/web/src/elements/table/TablePage.ts
+++ b/web/src/elements/table/TablePage.ts
@@ -119,7 +119,7 @@ export abstract class TablePage<T extends object> extends Table<T> {
             ${inner
                 ? inner
                 : html`<ak-empty-state icon=${this.pageIcon}
-                      ><span>${msg("No objects found.")}</span>
+                      ><span>${this.emptyStateMessage}</span>
                       <div slot="body">
                           ${this.searchEnabled ? this.renderEmptyClearSearch() : nothing}
                       </div>


### PR DESCRIPTION
admin: make empty table message configurable

# What

This commit provides a new field at the Table level for the empty state message. The field defaults to the original message, “No objects found.”

# Why

The icon has long been configurable, but not the message. It makes sense to customize this message and let people know if they’re looking at files, properties, applications, and other objects.

## Checklist

-   [X] The code has been formatted (`make web`)
