### PR TITLE
website/integrations: wazuh: Change exchange key generation to 64 bytes

### DIFF
--- a/website/integrations/monitoring/wazuh/index.mdx
+++ b/website/integrations/monitoring/wazuh/index.mdx
@@ -87,7 +87,7 @@ The file `wazuh_authentik_meta.xml` serves as a placeholder for your SAML Metada
 1. For the next step, you will need an exchange key. To generate this key, use the following command:
 
     ```bash
-    openssl rand -hex 32
+    openssl rand -hex 64
     ```
 
 2. Copy the downloaded metadata file to the `/etc/wazuh-indexer/opensearch-security/` directory on your Wazuh Indexer server.


### PR DESCRIPTION
Updated the command to generate an exchange key from 32 to 64 bytes. as of wazuh 4.9 the exchange key needs to be 64 characters long

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
