### PR TITLE
website/docs: add jellyseer integration doc

### DIFF
--- a/website/integrations/media/jellyseerr/index.md
+++ b/website/integrations/media/jellyseerr/index.md
@@ -1,0 +1,61 @@
+---
+title: Integrate with Jellyseerr
+sidebar_label: Jellyseerr
+support_level: community
+---
+
+## What is Jellyseerr
+
+> Jellyseerr is a free and open source software application for managing requests for your media library.
+> It integrates with the media server of your choice: Jellyfin, Plex, and Emby.
+> In addition, it integrates with your existing services, such as Sonarr, Radarr.
+>
+> -- https://docs.seerr.dev/
+
+## Preparation
+
+- `jellyseerr.company` is the FQDN of the Jellyseerr installation.
+- `authentik.company` is the FQDN of the authentik installation.
+
+## authentik configuration
+
+The steps to configure authentik include creating an application and provider pair in authentik, obtaining the Client ID, Client Secret, and slug values, setting the redirect URI, and selecting a signing key.
+
+1. Log in to authentik as an administrator and open the authentik Admin interface.
+2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
+
+- **Application**: provide a descriptive name (`Jellyseerr`), a slug (`jellyseerr`), an optional group for the type of application, the policy engine mode, and optional UI settings.
+- **Choose a Provider type**: OAuth2/OpenID
+- **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and any required configurations.
+    - Note the **Client ID**, **Client Secret**, and **slug** values because they will be required later.
+    - Set a `Strict` redirect URI to `https://jellyseerr.company/login?provider=authentik&callback=true`.
+    - Select any available signing key.
+- **Configure Bindings** _(optional):_ you can create a [binding](https://docs.goauthentik.io/docs/add-secure-apps/flows-stages/bindings/) (policy, group, or user) to manage the listing and access to applications on a user’s **My applications** page.
+
+3. Click **Submit** to save the new application and provider.
+
+## Jellyseerr configuration
+
+:::info
+Jellyseer OAuth support is currently in preview, please make sure to use the `preview-OIDC` docker tag.
+:::
+
+1. Log in to Jellyseerr with an administrator account and navigate to the user settings page by clicking **Settings > Users**.
+2. Toggle on **Enable OpenID Connect Sign-In** and click on the cogwheel icon next to it.
+3. Click **Add OpenID Connect Provider** and fill the form:
+    - Provider Name: `authentik`
+    - Logo: `https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/authentik.svg`
+    - Issuer URL: `https://authentik.company/application/o/jellyseerr/`
+    - Client ID: Client ID from provider
+    - Client Secret: Client Secret from provider
+    - Advanced Settings:
+        - Scopes: `openid profile email groups`
+        - Allow New Users: **CHECKED**
+4. Click **Save Changes**.
+
+## Configuration verification
+
+- Open your web browser and go to: `https://jellyseerr.company`.
+- Click **authentik** to log in.
+- You should be redirected to authentik (following the login flow you configured). After logging in, authentik will redirect you back to `https://jellyseerr.company`.
+- If you successfully return to the Jellyseerr WebGUI, the login is working correctly.

--- a/website/integrations/media/jellyseerr/index.md
+++ b/website/integrations/media/jellyseerr/index.md
@@ -44,8 +44,8 @@ Jellyseer OAuth support is currently in preview, please make sure to use the `pr
     - **Provider Name**: `authentik`
     - **Logo**: `https://authentik.company/static/dist/assets/icons/icon.svg`
     - **Issuer URL**: `https://authentik.company/application/o/jellyseerr/`
-    - **Client ID**: Client ID from provider
-    - **Client Secret**: Client Secret from provider
+    - **Client ID**: Client ID from authentik
+    - **Client Secret**: Client Secret from authentik
     - Under **Advanced Settings**:
         - **Scopes**: `openid profile email groups`
         - **Allow New Users**: Enabled

--- a/website/integrations/media/jellyseerr/index.md
+++ b/website/integrations/media/jellyseerr/index.md
@@ -21,7 +21,7 @@ To support the integration of Jellyseerr with authentik, you need to create an a
 
 1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
-    - **Application**: provide a descriptive name (`Jellyseerr`), a slug (`jellyseerr`), an optional group for the type of application, the policy engine mode, and optional UI settings. Take note of the **Slug** value as it will be required later.
+    - **Application**: provide a descriptive name, a slug, an optional group for the type of application, the policy engine mode, and optional UI settings. Take note of the **Slug** value as it will be required later.
     - **Choose a Provider type**: OAuth2/OpenID
     - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and any required configurations.
         - Note the **Client ID** and **Client Secret** values because they will be required later.
@@ -34,7 +34,7 @@ To support the integration of Jellyseerr with authentik, you need to create an a
 ## Jellyseerr configuration
 
 :::info
-Jellyseer OAuth support is currently in preview, please make sure to use the `preview-OIDC` docker tag.
+Jellyseer OAuth support is currently in preview, please make sure to use the `preview-OIDC` Docker tag.
 :::
 
 1. Log in to Jellyseerr with an administrator account.

--- a/website/integrations/media/jellyseerr/index.md
+++ b/website/integrations/media/jellyseerr/index.md
@@ -6,9 +6,7 @@ support_level: community
 
 ## What is Jellyseerr
 
-> Jellyseerr is a free and open source software application for managing requests for your media library.
-> It integrates with the media server of your choice: Jellyfin, Plex, and Emby.
-> In addition, it integrates with your existing services, such as Sonarr, Radarr.
+> Jellyseerr is a free and open source application for managing requests in your media library. It integrates with media servers like Jellyfin, Plex, and Emby, and services such as Sonarr and Radarr.
 >
 > -- https://docs.seerr.dev/
 
@@ -19,18 +17,17 @@ support_level: community
 
 ## authentik configuration
 
-The steps to configure authentik include creating an application and provider pair in authentik, obtaining the Client ID, Client Secret, and slug values, setting the redirect URI, and selecting a signing key.
+To support the integration of Jellyseerr with authentik, you need to create an application/provider pair in authentik.
 
 1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
-
-- **Application**: provide a descriptive name (`Jellyseerr`), a slug (`jellyseerr`), an optional group for the type of application, the policy engine mode, and optional UI settings.
-- **Choose a Provider type**: OAuth2/OpenID
-- **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and any required configurations.
-    - Note the **Client ID**, **Client Secret**, and **slug** values because they will be required later.
-    - Set a `Strict` redirect URI to `https://jellyseerr.company/login?provider=authentik&callback=true`.
-    - Select any available signing key.
-- **Configure Bindings** _(optional):_ you can create a [binding](https://docs.goauthentik.io/docs/add-secure-apps/flows-stages/bindings/) (policy, group, or user) to manage the listing and access to applications on a user’s **My applications** page.
+    - **Application**: provide a descriptive name (`Jellyseerr`), a slug (`jellyseerr`), an optional group for the type of application, the policy engine mode, and optional UI settings. Take note of the **Slug** value as it will be required later.
+    - **Choose a Provider type**: OAuth2/OpenID
+    - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and any required configurations.
+        - Note the **Client ID** and **Client Secret** values because they will be required later.
+        - Set a `Strict` redirect URI to `https://jellyseerr.company/login?provider=authentik&callback=true`.
+        - Select any available signing key.
+    - **Configure Bindings** _(optional):_ you can create a [binding](https://docs.goauthentik.io/docs/add-secure-apps/flows-stages/bindings/) (policy, group, or user) to manage the listing and access to applications on a user’s **My applications** page.
 
 3. Click **Submit** to save the new application and provider.
 
@@ -40,22 +37,20 @@ The steps to configure authentik include creating an application and provider pa
 Jellyseer OAuth support is currently in preview, please make sure to use the `preview-OIDC` docker tag.
 :::
 
-1. Log in to Jellyseerr with an administrator account and navigate to the user settings page by clicking **Settings > Users**.
-2. Toggle on **Enable OpenID Connect Sign-In** and click on the cogwheel icon next to it.
-3. Click **Add OpenID Connect Provider** and fill the form:
-    - Provider Name: `authentik`
-    - Logo: `https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/authentik.svg`
-    - Issuer URL: `https://authentik.company/application/o/jellyseerr/`
-    - Client ID: Client ID from provider
-    - Client Secret: Client Secret from provider
-    - Advanced Settings:
-        - Scopes: `openid profile email groups`
-        - Allow New Users: **CHECKED**
-4. Click **Save Changes**.
+1. Log in to Jellyseerr with an administrator account.
+2. Navigate to **Settings** > **Users**.
+3. Toggle on **Enable OpenID Connect Sign-In** and click on the cogwheel icon next to it.
+4. Click **Add OpenID Connect Provider** and configure the following settings:
+    - **Provider Name**: `authentik`
+    - **Logo**: `https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/authentik.svg`
+    - **Issuer URL**: `https://authentik.company/application/o/jellyseerr/`
+    - **Client ID**: Client ID from provider
+    - **Client Secret**: Client Secret from provider
+    - Under **Advanced Settings**:
+        - **Scopes**: `openid profile email groups`
+        - **Allow New Users**: Enabled
+5. Click **Save Changes**.
 
 ## Configuration verification
 
-- Open your web browser and go to: `https://jellyseerr.company`.
-- Click **authentik** to log in.
-- You should be redirected to authentik (following the login flow you configured). After logging in, authentik will redirect you back to `https://jellyseerr.company`.
-- If you successfully return to the Jellyseerr WebGUI, the login is working correctly.
+To verify that authentik is correctly set up with Jellyseerr, log out of Jellyseerr and try logging back in using the authentik button. You should be redirected to authentik, and once authenticated you will be signed in to Jellyseerr.

--- a/website/integrations/media/jellyseerr/index.md
+++ b/website/integrations/media/jellyseerr/index.md
@@ -42,7 +42,7 @@ Jellyseer OAuth support is currently in preview, please make sure to use the `pr
 3. Toggle on **Enable OpenID Connect Sign-In** and click on the cogwheel icon next to it.
 4. Click **Add OpenID Connect Provider** and configure the following settings:
     - **Provider Name**: `authentik`
-    - **Logo**: `https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/authentik.svg`
+    - **Logo**: `https://authentik.company/static/dist/assets/icons/icon.svg`
     - **Issuer URL**: `https://authentik.company/application/o/jellyseerr/`
     - **Client ID**: Client ID from provider
     - **Client Secret**: Client Secret from provider

--- a/website/integrations/monitoring/beszel/index.mdx
+++ b/website/integrations/monitoring/beszel/index.mdx
@@ -38,7 +38,7 @@ The steps to configure authentik include creating an application and provider pa
     - Note the **Client ID**, **Client Secret**, and **slug** values because they will be required later.
     - Set a `Strict` redirect URI to `https://beszel.company/api/oauth2-redirect`.
     - Select any available signing key.
-- **Configure Bindings** _(optional):_ you can create a [binding](https://docs.goauthentik.io/docs/add-secure-apps/flows-stages/bindings/) (policy, group, or user) to manage the listing and access to applications on a user’s \***\*My applications** \*_page_.\*
+- **Configure Bindings** _(optional):_ you can create a [binding](https://docs.goauthentik.io/docs/add-secure-apps/flows-stages/bindings/) (policy, group, or user) to manage the listing and access to applications on a user’s **My applications** page.
 
 3. Click **Submit** to save the new application and provider.
 


### PR DESCRIPTION
## Details

Add an integration page with Jellyseerr (which has a preview feature with OIDC support).

Follows discussion https://github.com/goauthentik/authentik/discussions/18806

---

## Checklist

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
