### PR TITLE
web: add custom message with links for empty data export list

### DIFF
--- a/web/src/admin/events/DataExportListPage.ts
+++ b/web/src/admin/events/DataExportListPage.ts
@@ -91,6 +91,20 @@ export class DataExportListPage extends TablePage<DataExport> {
             </div>
         </dl>`;
     }
+
+    protected renderEmpty(_inner?: TemplateResult): TemplateResult {
+        return super.renderEmpty(
+            html`<ak-empty-state icon=${this.pageIcon}
+                ><span
+                    >${msg(
+                        html`To create a data export, navigate to
+                            <a href="#/identity/users">Directory > Users</a> or to
+                            <a href="#/events/log">Events > Logs</a>.`,
+                    )}</span
+                >
+            </ak-empty-state>`,
+        );
+    }
 }
 
 declare global {


### PR DESCRIPTION
## Details


This adds the text "To create a data export, navigate to Directory > Users or to Events > Logs." (with hyperlinks to respective pages) to the Data Exports page when there are no data exports instead of the default "No objects found.". 

---

## Checklist

-   [x] The code has been formatted (`make web`)
