### PR TITLE
core: add skip s3_test_server_available to TestResolveFileUrlS3Backend

### DIFF
--- a/authentik/admin/files/tests/test_manager.py
+++ b/authentik/admin/files/tests/test_manager.py
@@ -1,10 +1,16 @@
 """Test file service layer"""
 
+from unittest import skipUnless
+
 from django.http import HttpRequest
 from django.test import TestCase
 
 from authentik.admin.files.manager import FileManager
-from authentik.admin.files.tests.utils import FileTestFileBackendMixin, FileTestS3BackendMixin
+from authentik.admin.files.tests.utils import (
+    FileTestFileBackendMixin,
+    FileTestS3BackendMixin,
+    s3_test_server_available,
+)
 from authentik.admin.files.usage import FileUsage
 from authentik.lib.config import CONFIG
 
@@ -81,6 +87,7 @@ class TestResolveFileUrlFileBackend(FileTestFileBackendMixin, TestCase):
         self.assertEqual(result, "http://example.com/files/media/public/test.png")
 
 
+@skipUnless(s3_test_server_available(), "S3 test server not available")
 class TestResolveFileUrlS3Backend(FileTestS3BackendMixin, TestCase):
     @CONFIG.patch("storage.media.s3.custom_domain", "s3.test:8080/test")
     @CONFIG.patch("storage.media.s3.secure_urls", False)


### PR DESCRIPTION
## Details

add missing skip s3_test_server_available to TestResolveFileUrlS3Backend to fix the release-tag action
commit already in 2025.12 branch, no need to cherry-picked

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
