### PR TITLE
rbac: alter migrated direct permission roles

### DIFF
--- a/authentik/core/migrations/0056_user_roles.py
+++ b/authentik/core/migrations/0056_user_roles.py
@@ -18,10 +18,9 @@ def migrate_object_permissions(apps: Apps, schema_editor: BaseDatabaseSchemaEdit
     RoleModelPermission = apps.get_model("guardian", "RoleModelPermission")
 
     def get_role_for_user_id(user_id: int) -> Role:
-        name = f"ak-managed-role--user-{user_id}"
+        name = f"ak-migrated-role--user-{user_id}"
         role, created = Role.objects.using(db_alias).get_or_create(
             name=name,
-            managed=name,
         )
         if created:
             role.users.add(user_id)
@@ -32,11 +31,10 @@ def migrate_object_permissions(apps: Apps, schema_editor: BaseDatabaseSchemaEdit
         if not role:
             # Every django group should already have a role, so this should never happen.
             # But let's be nice.
-            name = f"ak-managed-role--group-{group_id}"
+            name = f"ak-migrated-role--group-{group_id}"
             role, created = Role.objects.using(db_alias).get_or_create(
                 group_id=group_id,
                 name=name,
-                managed=name,
             )
             if created:
                 role.group_id = group_id


### PR DESCRIPTION
These should not be marked as managed, because many of these permissions were created by admins.