### PR TITLE
web/admin: add UI copy to RBAC modal

### DIFF
--- a/web/src/admin/rbac/RoleObjectPermissionForm.ts
+++ b/web/src/admin/rbac/RoleObjectPermissionForm.ts
@@ -71,40 +71,45 @@ export class RoleObjectPermissionForm extends ModelForm<RoleAssignData, number> 
         if (!this.modelPermissions) {
             return nothing;
         }
-        return html`<form class="pf-c-form pf-m-horizontal">
-            <ak-form-element-horizontal label=${msg("Role")} name="role">
-                <ak-search-select
-                    .fetchObjects=${async (query?: string): Promise<Role[]> => {
-                        const args: RbacRolesListRequest = {
-                            ordering: "name",
-                        };
-                        if (query !== undefined) {
-                            args.search = query;
-                        }
-                        const roles = await new RbacApi(DEFAULT_CONFIG).rbacRolesList(args);
-                        return roles.results;
-                    }}
-                    .renderElement=${(role: Role): string => {
-                        return role.name;
-                    }}
-                    .value=${(role: Role | undefined): string | undefined => {
-                        return role?.pk;
-                    }}
-                >
-                </ak-search-select>
-            </ak-form-element-horizontal>
-            ${this.modelPermissions?.results
-                .filter((perm) => {
-                    const [_app, model] = this.model?.split(".") || "";
-                    return perm.codename !== `add_${model}`;
-                })
-                .map((perm) => {
-                    return html`<ak-switch-input
-                        name="permissions.${perm.codename}"
-                        label=${perm.name}
-                    ></ak-switch-input>`;
-                })}
-        </form>`;
+        return html`<span
+                >${msg(
+                    "Choose the object permissions that you want the selected role to have on this object. These object permissions are in addition to any global permissions already within the role.",
+                )}</span
+            >
+            <form class="pf-c-form pf-m-horizontal">
+                <ak-form-element-horizontal label=${msg("Role")} name="role">
+                    <ak-search-select
+                        .fetchObjects=${async (query?: string): Promise<Role[]> => {
+                            const args: RbacRolesListRequest = {
+                                ordering: "name",
+                            };
+                            if (query !== undefined) {
+                                args.search = query;
+                            }
+                            const roles = await new RbacApi(DEFAULT_CONFIG).rbacRolesList(args);
+                            return roles.results;
+                        }}
+                        .renderElement=${(role: Role): string => {
+                            return role.name;
+                        }}
+                        .value=${(role: Role | undefined): string | undefined => {
+                            return role?.pk;
+                        }}
+                    >
+                    </ak-search-select>
+                </ak-form-element-horizontal>
+                ${this.modelPermissions?.results
+                    .filter((perm) => {
+                        const [_app, model] = this.model?.split(".") || "";
+                        return perm.codename !== `add_${model}`;
+                    })
+                    .map((perm) => {
+                        return html`<ak-switch-input
+                            name="permissions.${perm.codename}"
+                            label=${perm.name}
+                        ></ak-switch-input>`;
+                    })}
+            </form>`;
     }
 }
 

--- a/web/src/admin/rbac/RoleObjectPermissionTable.ts
+++ b/web/src/admin/rbac/RoleObjectPermissionTable.ts
@@ -87,7 +87,7 @@ export class RoleAssignedObjectPermissionTable extends Table<RoleAssignedObjectP
     renderObjectCreate(): TemplateResult {
         return html`<ak-forms-modal>
             <span slot="submit">${msg("Assign")}</span>
-            <span slot="header">${msg("Assign permission to role")}</span>
+            <span slot="header">${msg("Assign object permissions to role")}</span>
             <ak-rbac-role-object-permission-form
                 model=${ifDefined(this.model)}
                 objectPk=${ifDefined(this.objectPk)}


### PR DESCRIPTION
This PR adds two sentences to RoleObjectPermissionForm.ts, explaining why users must select at least one object permission. Also adds the word "object" to the modal title. 


## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
