### PR TITLE
packages/ak-guardian: cast safely

### DIFF
--- a/packages/ak-guardian/guardian/shortcuts.py
+++ b/packages/ak-guardian/guardian/shortcuts.py
@@ -296,7 +296,9 @@ def get_objects_for_user(  # noqa: PLR0912 PLR0915
     # `perms_queryset` is ran. Otherwise, the query planner may decide to cast every `object_pk`,
     # which breaks (for example) if it tries to cast an integer to a UUID. In such a case, the WHERE
     # of `perms_queryset` will remove any integer.
-    perms_subquery_sql, perms_subquery_params = perms_queryset.query.sql_with_params()
+    perms_subquery_sql, perms_subquery_params = perms_queryset.values_list(
+        pk_field, flat=True
+    ).query.sql_with_params()
     subquery = RawSQL(
         f"""
         SELECT ("permission_subquery"."object_pk")::{cast_type} as "object_pk"

--- a/packages/ak-guardian/guardian/shortcuts.py
+++ b/packages/ak-guardian/guardian/shortcuts.py
@@ -310,10 +310,10 @@ def get_objects_for_user(  # noqa: PLR0912 PLR0915
     ).query.sql_with_params()
     subquery = RawSQL(
         f"""
-        SELECT ("permission_subquery"."object_pk")::{cast_type} as "object_pk"
-        FROM ({perms_subquery_sql}) "permission_subquery"
-        OFFSET 0
-    """,
+            SELECT ("permission_subquery"."object_pk")::{cast_type} as "object_pk"
+            FROM ({perms_subquery_sql}) "permission_subquery"
+            OFFSET 0
+        """,  # nosec
         perms_subquery_params,
     )
     return queryset.filter(pk__in=subquery)

--- a/packages/ak-guardian/guardian/shortcuts.py
+++ b/packages/ak-guardian/guardian/shortcuts.py
@@ -298,6 +298,7 @@ def get_objects_for_user(  # noqa: PLR0912 PLR0915
 
     cast_type = _cast_type(pk)
 
+    perms_queryset = perms_queryset.values_list(pk_field, flat=True)
     # The raw subquery is done to ensure that casting only takes place after the WHERE clause of
     # `perms_queryset` is ran. Otherwise, the query planner may decide to cast every `object_pk`,
     # which breaks (for example) if it tries to cast an integer to a UUID. In such a case, the WHERE
@@ -305,12 +306,10 @@ def get_objects_for_user(  # noqa: PLR0912 PLR0915
     # However, the subquery might get optimized out by the query planner, which would cause the same
     # cast issue as before. To prevent the subquery from being collapsed in the query below, we add
     # OFFSET 0.
-    perms_subquery_sql, perms_subquery_params = perms_queryset.values_list(
-        pk_field, flat=True
-    ).query.sql_with_params()
+    perms_subquery_sql, perms_subquery_params = perms_queryset.query.sql_with_params()
     subquery = RawSQL(
         f"""
-            SELECT ("permission_subquery"."object_pk")::{cast_type} as "object_pk"
+            SELECT ("permission_subquery"."{pk_field}")::{cast_type} as "object_pk"
             FROM ({perms_subquery_sql}) "permission_subquery"
             OFFSET 0
         """,  # nosec


### PR DESCRIPTION
`RoleObjectPermission.object_pk` is a `VARCHAR`, which needs to be cast to either `uuid` or an integer type before comparison. The resulting query (if the cast was to `uuid`) used include a subquery like

```
      SELECT 
        (X0."object_pk"):: uuid AS "obj_pk" 
      FROM 
        "guardian_roleobjectpermission" X0 
        INNER JOIN "auth_permission" X2 ON (X0."permission_id" = X2."id") 
      WHERE 
        (
          (... all_roles() query ...)
          AND X2."content_type_id" = 759
          AND X2."codename" IN ('view_certificatekeypair')
        )
```

Sometimes, the query planner would run the `:: uuid` cast before the `WHERE` clause, which would result in an error with "integer-in-varchar-form" `object_pk`s like

> ERROR:  invalid input syntax for type uuid: "30"

---

After this PR, that subquery is broken into two, as such:

```
    SELECT 
      (
        "permission_subquery"."object_pk"
      ):: uuid as "object_pk" 
    FROM 
      (
        SELECT 
          "guardian_roleobjectpermission"."object_pk" AS "object_pk" 
        FROM 
          "guardian_roleobjectpermission" 
          INNER JOIN "auth_permission" ON (
            "guardian_roleobjectpermission"."permission_id" = "auth_permission"."id"
          ) 
        WHERE 
            (... all_roles() query ...)
            AND "auth_permission"."content_type_id" = 58 
            AND "auth_permission"."codename" IN ('view_outpost')
          )
      ) "permission_subquery" OFFSET 0
  ) 
```