### PR TITLE
web/elements: progress-bar and table loading header

### DIFF
--- a/web/src/admin/enterprise/EnterpriseStatusCard.ts
+++ b/web/src/admin/enterprise/EnterpriseStatusCard.ts
@@ -1,3 +1,5 @@
+import "#elements/ak-progress-bar";
+
 import { AKElement } from "#elements/Base";
 import { PFColor } from "#elements/Label";
 
@@ -9,7 +11,6 @@ import { customElement, state } from "lit/decorators.js";
 
 import PFCard from "@patternfly/patternfly/components/Card/card.css";
 import PFDescriptionList from "@patternfly/patternfly/components/DescriptionList/description-list.css";
-import PFProgress from "@patternfly/patternfly/components/Progress/progress.css";
 import PFSplit from "@patternfly/patternfly/layouts/Split/split.css";
 import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
@@ -21,7 +22,7 @@ export class EnterpriseStatusCard extends AKElement {
     @state()
     summary?: LicenseSummary;
 
-    static styles: CSSResult[] = [PFBase, PFDescriptionList, PFCard, PFSplit, PFProgress];
+    static styles: CSSResult[] = [PFBase, PFDescriptionList, PFCard, PFSplit];
 
     renderSummaryBadge() {
         switch (this.summary?.status) {
@@ -81,66 +82,32 @@ export class EnterpriseStatusCard extends AKElement {
                         </div>
                     </dl>
                     <div class="pf-l-split__item pf-m-fill">
-                        <div
-                            class="pf-c-progress ${internalUserPercentage > 100
+                        <ak-progress-bar
+                            class="${internalUserPercentage > 100
                                 ? "pf-m-danger"
                                 : ""} ${internalUserPercentage >= 80 ? "pf-m-warning" : ""}"
-                            id="internalUsers"
+                            value=${internalUserPercentage}
                         >
-                            <div class="pf-c-progress__description">
-                                ${msg("Internal user usage")}
-                            </div>
-                            <div class="pf-c-progress__status" aria-hidden="true">
-                                <span class="pf-c-progress__measure"
-                                    >${msg(
-                                        str`${internalUserPercentage < Infinity ? internalUserPercentage : "∞"}%`,
-                                    )}</span
-                                >
-                            </div>
-                            <div
-                                class="pf-c-progress__bar"
-                                role="progressbar"
-                                aria-valuemin="0"
-                                aria-valuemax="100"
-                                aria-valuenow="${internalUserPercentage}"
-                            >
-                                <div
-                                    class="pf-c-progress__indicator"
-                                    style="width:${Math.min(internalUserPercentage, 100)}%;"
-                                ></div>
-                            </div>
-                        </div>
-                        <div
-                            class="pf-c-progress ${externalUserPercentage > 100
+                            <span slot="description">${msg("Internal user usage")}</span>
+                            <span slot="status">
+                                ${msg(
+                                    str`${internalUserPercentage < Infinity ? internalUserPercentage : "∞"}%`,
+                                )}
+                            </span>
+                        </ak-progress-bar>
+                        <ak-progress-bar
+                            class="${externalUserPercentage > 100
                                 ? "pf-m-danger"
                                 : ""} ${externalUserPercentage >= 80 ? "pf-m-warning" : ""}"
-                            id="externalUsers"
+                            value=${externalUserPercentage}
                         >
-                            <div class="pf-c-progress__description">
-                                ${msg("External user usage")}
-                            </div>
-                            <div class="pf-c-progress__status" aria-hidden="true">
-                                <span class="pf-c-progress__measure"
-                                    >${msg(
-                                        str`${externalUserPercentage < Infinity ? externalUserPercentage : "∞"}%`,
-                                    )}</span
-                                >
-                            </div>
-                            <div
-                                class="pf-c-progress__bar"
-                                role="progressbar"
-                                aria-valuemin="0"
-                                aria-valuemax="100"
-                                aria-valuenow="${externalUserPercentage < Infinity
-                                    ? externalUserPercentage
-                                    : "∞"}"
-                            >
-                                <div
-                                    class="pf-c-progress__indicator"
-                                    style="width:${Math.min(externalUserPercentage, 100)}%;"
-                                ></div>
-                            </div>
-                        </div>
+                            <span slot="description">${msg("External user usage")}</span>
+                            <span slot="status">
+                                ${msg(
+                                    str`${externalUserPercentage < Infinity ? externalUserPercentage : "∞"}%`,
+                                )}
+                            </span>
+                        </ak-progress-bar>
                     </div>
                 </div>
             </div>

--- a/web/src/elements/ak-progress-bar.ts
+++ b/web/src/elements/ak-progress-bar.ts
@@ -19,7 +19,11 @@ export class ProgressBar extends AKElement {
         PFProgress,
         css`
             .pf-c-progress.pf-m-indeterminate {
+                --pf-c-progress__bar--Height: 2px;
                 --pf-c-progress--GridGap: 0;
+                margin-bottom: calc(var(--pf-c-progress__bar--Height) * -1);
+                z-index: 1;
+                position: relative;
             }
             .pf-c-progress.pf-m-indeterminate .pf-c-progress__bar .pf-c-progress__indicator {
                 width: 100%;

--- a/web/src/elements/ak-progress-bar.ts
+++ b/web/src/elements/ak-progress-bar.ts
@@ -18,6 +18,9 @@ export class ProgressBar extends AKElement {
     static styles = [
         PFProgress,
         css`
+            .pf-c-progress.pf-m-indeterminate {
+                --pf-c-progress--GridGap: 0;
+            }
             .pf-c-progress.pf-m-indeterminate .pf-c-progress__bar .pf-c-progress__indicator {
                 width: 100%;
                 height: 100%;

--- a/web/src/elements/ak-progress-bar.ts
+++ b/web/src/elements/ak-progress-bar.ts
@@ -1,0 +1,89 @@
+import { PFSize } from "#common/enums";
+
+import { AKElement } from "#elements/Base";
+
+import { spread } from "@open-wc/lit-helpers";
+
+import { css, html, nothing } from "lit";
+import { customElement, property } from "lit/decorators.js";
+
+import PFProgress from "@patternfly/patternfly/components/Progress/progress.css";
+
+/**
+ * @slot description - Description text above the progress bar, on the left
+ * @slot status - Human-readable status above the progress bar, on the right
+ */
+@customElement("ak-progress-bar")
+export class ProgressBar extends AKElement {
+    static styles = [
+        PFProgress,
+        css`
+            .pf-c-progress.pf-m-indeterminate .pf-c-progress__bar .pf-c-progress__indicator {
+                width: 100%;
+                height: 100%;
+                animation: indeterminateAnimation 1s infinite linear;
+                transform-origin: 0% 50%;
+            }
+            @keyframes indeterminateAnimation {
+                0% {
+                    transform: translateX(0) scaleX(0);
+                }
+                40% {
+                    transform: translateX(0) scaleX(0.4);
+                }
+                100% {
+                    transform: translateX(100%) scaleX(0.5);
+                }
+            }
+        `,
+    ];
+
+    @property({ type: Number })
+    min = 0;
+    @property({ type: Number })
+    max = 100;
+    @property({ type: Number })
+    value = 0;
+
+    @property({ type: Boolean })
+    indeterminate = false;
+
+    @property()
+    size: PFSize = PFSize.Medium;
+
+    render() {
+        const barAttrs: { [key: string]: unknown } = {};
+        const indicatorAttrs: { [key: string]: unknown } = {};
+        if (!this.indeterminate) {
+            barAttrs["aria-valuemin"] = this.min;
+            barAttrs["aria-valuemax"] = this.max;
+            barAttrs["aria-valuenow"] = this.value;
+            indicatorAttrs.style = `"width:${Math.min(this.value, 100)}%;";`;
+        }
+        return html`<div
+            class="pf-c-progress ${this.classList} ${this.indeterminate
+                ? "pf-m-indeterminate"
+                : ""} ${this.size.toString()}"
+        >
+            ${this.hasSlotted("description")
+                ? html`
+                      <div class="pf-c-progress__description">
+                          <slot name="description"></slot>
+                      </div>
+                  `
+                : nothing}
+            ${this.hasSlotted("status")
+                ? html`
+                      <div class="pf-c-progress__status" aria-hidden="true">
+                          <span class="pf-c-progress__measure">
+                              <slot name="status"></slot>
+                          </span>
+                      </div>
+                  `
+                : nothing}
+            <div class="pf-c-progress__bar" role="progressbar" ${spread(barAttrs)}>
+                <div class="pf-c-progress__indicator" ${spread(indicatorAttrs)}></div>
+            </div>
+        </div> `;
+    }
+}

--- a/web/src/elements/ak-progress-bar.ts
+++ b/web/src/elements/ak-progress-bar.ts
@@ -18,6 +18,9 @@ export class ProgressBar extends AKElement {
     static styles = [
         PFProgress,
         css`
+            .pf-c-progress {
+                overflow: hidden;
+            }
             .pf-c-progress.pf-m-indeterminate {
                 --pf-c-progress__bar--Height: 2px;
                 --pf-c-progress--GridGap: 0;

--- a/web/src/elements/table/Table.ts
+++ b/web/src/elements/table/Table.ts
@@ -1,3 +1,4 @@
+import "#elements/ak-progress-bar";
 import "#elements/EmptyState";
 import "#elements/buttons/SpinnerButton/index";
 import "#elements/chips/Chip";
@@ -866,6 +867,11 @@ export abstract class Table<T extends object>
         `;
     }
 
+    protected renderLoadingBar() {
+        if (!this.loading) return nothing;
+        return html`<ak-progress-bar indeterminate></ak-progress-bar>`;
+    }
+
     protected renderTable(): TemplateResult {
         const totalItemCount = this.data?.pagination.count ?? -1;
 
@@ -877,7 +883,9 @@ export abstract class Table<T extends object>
                 ${this.renderTablePagination()}
             </div>`;
 
-        return html`${this.needChipGroup ? this.renderChipGroup() : nothing}
+        return html`${this.renderLoadingBar()}${this.needChipGroup
+                ? this.renderChipGroup()
+                : nothing}
             ${this.renderToolbarContainer()}
             <div part="table-container">
                 <table


### PR DESCRIPTION
Turn PFProgress into an element and add intermediate mode
<img width="774" height="312" alt="image" src="https://github.com/user-attachments/assets/e9e2a087-d57a-4d66-a11c-a1ba5bc815b3" />