### PR TITLE
lib/sync: block on user/group deletion

### DIFF
--- a/authentik/lib/sync/outgoing/signals.py
+++ b/authentik/lib/sync/outgoing/signals.py
@@ -71,7 +71,7 @@ def register_signals(
             class_to_path(instance.__class__),
             instance.pk,
             Direction.remove.value,
-        )
+        ).get_result(block=True)
 
     pre_delete.connect(model_pre_delete, User, dispatch_uid=uid, weak=False)
     pre_delete.connect(model_pre_delete, Group, dispatch_uid=uid, weak=False)


### PR DESCRIPTION
Not a final solution, however with the current non-blocking implementation deletion is not propagated correctly due to the object already being deleted by the time the task runs