### PR TITLE
website/docs: Prioritize "Release Candidate" over "Current Release"

### DIFF
--- a/website/api/docusaurus.config.esm.mjs
+++ b/website/api/docusaurus.config.esm.mjs
@@ -2,7 +2,7 @@
  * @file Docusaurus config.
  *
  * @import { UserThemeConfig, UserThemeConfigExtra } from "@goauthentik/docusaurus-config";
- * @import { AKReleasesPluginOptions } from "@goauthentik/docusaurus-theme/releases/plugin"
+ * @import { AKReleasesPluginOptions } from "@goauthentik/docusaurus-theme/releases/common"
  * @import * as OpenApiPlugin from "docusaurus-plugin-openapi-docs";
  * @import {Options as PresetOptions} from '@docusaurus/preset-classic';
  * @import { Options as RedirectsPluginOptions } from "@docusaurus/plugin-client-redirects";

--- a/website/docusaurus-theme/components/VersionPicker/VersionDropdown.tsx
+++ b/website/docusaurus-theme/components/VersionPicker/VersionDropdown.tsx
@@ -81,14 +81,14 @@ export const VersionDropdown = memo<VersionDropdownProps>((props) => {
                 {visibleReleases.map((releaseName, idx) => {
                     const semVer = normalizeReleaseName(releaseName);
 
-                    let label = semVer;
+                    let label = releaseName;
                     const frontmatter = frontMatterRecord[semVer];
 
                     if (frontmatter?.draft) {
                         return null;
                     }
 
-                    if (idx === 0 && !frontmatter?.beta) {
+                    if (idx === 0 && !frontmatter?.beta && semVer === releaseName) {
                         label += " (Current Release)";
                     }
 


### PR DESCRIPTION
## Details

This PR is a follow up to #18974, _tentatively_ completing the alignment of version picker behaviors for...

- `next.goauthentik.io`
- `main.goauthentik.io`
- `version-2025-12.goauthentik.io`
- `version-2025-10.goauthentik.io` and below.

---

The primary change in this PR is an update to the version picker's labeling of entries, preferring a more recent label retrieved from `next.goauthentik.io` vs the label inferred at build time.