### PR TITLE
website/integrations: Fix path for Cloudflare Access

### DIFF
--- a/website/integrations/security/cloudflare-access/index.md
+++ b/website/integrations/security/cloudflare-access/index.md
@@ -49,7 +49,7 @@ To support the integration of Cloudflare Access with authentik, you need to crea
 
 ## Cloudflare Access configuration
 
-1. Open the [Cloudflare Access dashboard](https://one.dash.cloudflare.com) and navigate to **Intergrations** > **Identity provider**.
+1. Open the [Cloudflare Access dashboard](https://one.dash.cloudflare.com) and navigate to **Integrations** > **Identity provider**.
 2. Click **Add an identity provider**, and then select **OpenID Connect**.
 3. From the authentik provider you created earlier, copy the following details and paste them into the corresponding fields:
     - **Client ID** > App ID

--- a/website/integrations/security/cloudflare-access/index.md
+++ b/website/integrations/security/cloudflare-access/index.md
@@ -49,8 +49,8 @@ To support the integration of Cloudflare Access with authentik, you need to crea
 
 ## Cloudflare Access configuration
 
-1. Open the [Cloudflare Access dashboard](https://one.dash.cloudflare.com) and navigate to **Settings** > **Authentication**.
-2. Click **Login methods**, and then select **Add** > **OpenID Connect**.
+1. Open the [Cloudflare Access dashboard](https://one.dash.cloudflare.com) and navigate to **Intergrations** > **Identity provider**.
+2. Click **Add an identity provider**, and then select **OpenID Connect**.
 3. From the authentik provider you created earlier, copy the following details and paste them into the corresponding fields:
     - **Client ID** > App ID
     - **Client Secret** > Client Secret


### PR DESCRIPTION
## Details
The Cloudflare Access UI has changed: OpenID Connect login methods are now configured under Settings → Authentication → Identity providers instead of Login methods.
The existing documentation still referenced the old navigation path, which can cause confusion during setup.