### PR TITLE
web: fix Open button selecting row instead of navigating

### DIFF
--- a/web/src/elements/utils/pointer.ts
+++ b/web/src/elements/utils/pointer.ts
@@ -22,8 +22,16 @@ export function isEventTargetingListener(event?: Pick<Event, "target" | "current
         return false;
     }
 
-    return !!(
-        triggerElement.matches(InteractiveElementsQuery) ||
-        triggerElement.parentElement?.matches(InteractiveElementsQuery)
-    );
+    // Traverse up the DOM tree to find any interactive ancestor between
+    // the trigger element and the listener target (the table cell).
+    let current: HTMLElement | null = triggerElement;
+
+    while (current && current !== listenerTarget) {
+        if (current.matches(InteractiveElementsQuery)) {
+            return true;
+        }
+        current = current.parentElement;
+    }
+
+    return false;
 }


### PR DESCRIPTION
the `isEventTargetingListener()` function only checked the click target and the immediate parent for interactive elements (like links, buttons and more). when clicking the icon inside the Open button, the DOM structure is:

```
<a href=...>  <--- 2 levels up, never checked
<pf-tooltip>  <--- immediate parent, not interactive 
<i> <---- click target, not interactive
```

Because <i> and <pf-tooltip> did not match the interactive elements query, the function returned false which caused the table rowClickListener to continue with row selection isntead of allowing the click.

The fix is to update the function to to traverse (up) the entire dom tree from the click target to the listener element (the table cell) and check for each ancestor for the interactive elements.

Closes: https://github.com/goauthentik/authentik/issues/18955