### PR TITLE
enterprise/search: add static autocomplete structure

### DIFF
--- a/authentik/core/api/groups.py
+++ b/authentik/core/api/groups.py
@@ -256,7 +256,7 @@ class GroupViewSet(UsedByMixin, ModelViewSet):
         return [
             StrField(Group, "name"),
             BoolField(Group, "is_superuser", nullable=True),
-            JSONSearchField(Group, "attributes", suggest_nested=False),
+            JSONSearchField(Group, "attributes"),
         ]
 
     def get_queryset(self):

--- a/authentik/core/api/users.py
+++ b/authentik/core/api/users.py
@@ -518,7 +518,7 @@ class UserViewSet(
             StrField(User, "path"),
             BoolField(User, "is_active", nullable=True),
             ChoiceSearchField(User, "type"),
-            JSONSearchField(User, "attributes", suggest_nested=False),
+            JSONSearchField(User, "attributes"),
         ]
 
     def get_queryset(self):

--- a/authentik/enterprise/search/fields.py
+++ b/authentik/enterprise/search/fields.py
@@ -7,6 +7,7 @@ from django.db import connection
 from django.db.models import Model, Q
 from djangoql.compat import text_type
 from djangoql.schema import StrField
+from djangoql.serializers import DjangoQLSchemaSerializer
 
 
 class JSONSearchField(StrField):
@@ -14,10 +15,18 @@ class JSONSearchField(StrField):
 
     model: Model
 
-    def __init__(self, model=None, name=None, nullable=None, suggest_nested=True):
+    def __init__(
+        self,
+        model=None,
+        name=None,
+        nullable=None,
+        suggest_nested=True,
+        fixed_structure: OrderedDict | None = None,
+    ):
         # Set this in the constructor to not clobber the type variable
         self.type = "relation"
         self.suggest_nested = suggest_nested
+        self.fixed_structure = fixed_structure
         super().__init__(model, name, nullable)
 
     def get_lookup(self, path, operator, value):
@@ -57,11 +66,20 @@ class JSONSearchField(StrField):
             )
             return (x[0] for x in cursor.fetchall())
 
+    def get_fixed_structure(self) -> OrderedDict:
+        new_dict = OrderedDict()
+        if not self.fixed_structure:
+            return new_dict
+        for key, value in self.fixed_structure.items():
+            new_dict[key] = DjangoQLSchemaSerializer().serialize_field(value)
+        return new_dict
+
     def get_nested_options(self) -> OrderedDict:
         """Get keys of all nested objects to show autocomplete"""
         if not self.suggest_nested:
+            if self.fixed_structure:
+                return OrderedDict(**{self.relation(): self.get_fixed_structure()})
             return OrderedDict()
-        base_model_name = f"{self.model._meta.app_label}.{self.model._meta.model_name}_{self.name}"
 
         def recursive_function(parts: list[str], parent_parts: list[str] | None = None):
             if not parent_parts:
@@ -87,7 +105,7 @@ class JSONSearchField(StrField):
         relation_structure = defaultdict(dict)
 
         for relations in self.json_field_keys():
-            result = recursive_function([base_model_name] + relations)
+            result = recursive_function([self.relation()] + relations)
             for relation_key, value in result.items():
                 for sub_relation_key, sub_value in value.items():
                     if not relation_structure[relation_key].get(sub_relation_key, None):

--- a/authentik/enterprise/search/schema.py
+++ b/authentik/enterprise/search/schema.py
@@ -12,7 +12,7 @@ class AKQLSchemaSerializer(DjangoQLSchemaSerializer):
             for _, field in fields.items():
                 if not isinstance(field, JSONSearchField):
                     continue
-                serialization["models"].update(field.get_nested_options())
+                serialization["models"].update(field.get_nested_options(self))
         return serialization
 
     def serialize_field(self, field):

--- a/authentik/events/api/events.py
+++ b/authentik/events/api/events.py
@@ -1,5 +1,6 @@
 """Events API Views"""
 
+from collections import OrderedDict
 from datetime import timedelta
 
 import django_filters
@@ -136,7 +137,7 @@ class EventViewSet(
     filterset_class = EventsFilter
 
     def get_ql_fields(self):
-        from djangoql.schema import DateTimeField, StrField
+        from djangoql.schema import DateTimeField, IntField, StrField
 
         from authentik.enterprise.search.fields import ChoiceSearchField, JSONSearchField
 
@@ -145,8 +146,27 @@ class EventViewSet(
             StrField(Event, "event_uuid"),
             StrField(Event, "app", suggest_options=True),
             StrField(Event, "client_ip"),
-            JSONSearchField(Event, "user", suggest_nested=False),
-            JSONSearchField(Event, "brand", suggest_nested=False),
+            JSONSearchField(
+                Event,
+                "user",
+                suggest_nested=False,
+                fixed_structure=OrderedDict(
+                    pk=IntField(),
+                    username=StrField(),
+                    email=StrField(),
+                ),
+            ),
+            JSONSearchField(
+                Event,
+                "brand",
+                suggest_nested=False,
+                fixed_structure=OrderedDict(
+                    pk=StrField(),
+                    app=StrField(),
+                    name=StrField(),
+                    model_name=StrField(),
+                ),
+            ),
             JSONSearchField(Event, "context", suggest_nested=False),
             DateTimeField(Event, "created", suggest_options=True),
         ]

--- a/authentik/events/api/events.py
+++ b/authentik/events/api/events.py
@@ -149,7 +149,6 @@ class EventViewSet(
             JSONSearchField(
                 Event,
                 "user",
-                suggest_nested=False,
                 fixed_structure=OrderedDict(
                     pk=IntField(),
                     username=StrField(),
@@ -159,7 +158,6 @@ class EventViewSet(
             JSONSearchField(
                 Event,
                 "brand",
-                suggest_nested=False,
                 fixed_structure=OrderedDict(
                     pk=StrField(),
                     app=StrField(),
@@ -167,7 +165,23 @@ class EventViewSet(
                     model_name=StrField(),
                 ),
             ),
-            JSONSearchField(Event, "context", suggest_nested=False),
+            JSONSearchField(
+                Event,
+                "context",
+                fixed_structure=OrderedDict(
+                    http_request=JSONSearchField(
+                        Event,
+                        "context_http_request",
+                        fixed_structure=OrderedDict(
+                            args=JSONSearchField(Event, "context_http_request_args"),
+                            path=StrField(),
+                            method=StrField(),
+                            request_id=StrField(),
+                            user_agent=StrField(),
+                        ),
+                    ),
+                ),
+            ),
             DateTimeField(Event, "created", suggest_options=True),
         ]
 


### PR DESCRIPTION
related to https://github.com/goauthentik/authentik/pull/15138

since we had to disable autocomplete generation for JSON fields due to database load, this re-adds static autocomplete for certain json fields which have a known structure