### PR TITLE
website/integrations: Add Wallos

### DIFF
--- a/website/integrations/miscellaneous/wallos/index.mdx
+++ b/website/integrations/miscellaneous/wallos/index.mdx
@@ -14,8 +14,8 @@ support_level: community
 
 The following placeholders are used in this guide:
 
--   `https://wallos.company` is the FQDN of the Wallos installation.
--   `https://authentik.company` is the FQDN of the authentik installation.
+- `https://wallos.company` is the FQDN of the Wallos installation.
+- `https://authentik.company` is the FQDN of the authentik installation.
 
 :::info
 This documentation lists only the settings that you need to change from their default values. Be aware that any changes other than those explicitly mentioned in this guide could cause issues accessing your application.
@@ -29,38 +29,32 @@ To support the integration of Wallos with authentik, you need to create an appli
 
 1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair in authentik. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
-
--   **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
--   **Choose a Provider type**: select **OAuth2/OpenID Connect** as the provider type.
--   **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
-    -   Note the **Client ID** and **Client Secret** values because they will be required later.
-    -   Set a `Strict` redirect URI to `https://wallos.company/index.php`.
-    -   Select any available signing key.
--   **Configure Bindings** (optional): you can create a [binding](/docs/add-secure-apps/flows-stages/bindings/) (policy, group, or user) to manage the listing and access to applications on a user's **My applications** page.
+    - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
+    - **Choose a Provider type**: select **OAuth2/OpenID Connect** as the provider type.
+    - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
+        - Note the **Client ID** and **Client Secret** values because they will be required later.
+        - Set a `Strict` redirect URI to `https://wallos.company/index.php`.
+        - Select any available signing key.
+    - **Configure Bindings** (optional): you can create a [binding](/docs/add-secure-apps/flows-stages/bindings/) (policy, group, or user) to manage the listing and access to applications on a user's **My applications** page.
 
 3. Click **Submit** to save the new application and provider.
 
 ## Wallos configuration
 
-This configuration is done in the Wallos Admin Panel.
+To support the integration of authentik with Wallos, you need to enable and configure OIDC authentication in Wallos.
 
 1. Log in to your Wallos installation as an administrator and open the Admin Panel.
 2. Scroll to the **OIDC settings** section and enable OIDC/OAuth.
-3. Fill in the fields below.
-
-### Wallos OIDC fields
-
-Set the following values in Wallos:
-
--   **Provider Name**: `authentik`
--   **Client ID**: Enter the Client ID from authentik
--   **Client Secret**: Enter the Client Secret from authentik
--   **Authorization URL**: `https://authentik.company/application/o/authorize/`
--   **Token URL**: `https://authentik.company/application/o/token/`
--   **User Info URL**: `https://authentik.company/application/o/userinfo/`
--   **Redirect URL**: `https://wallos.company/index.php`
--   **User Identifier Field**: `sub`
--   **Scopes**: `openid email profile`
+3. Configure the following settings:
+    - **Provider Name**: `authentik`
+    - **Client ID**: Enter the Client ID from authentik
+    - **Client Secret**: Enter the Client Secret from authentik
+    - **Authorization URL**: `https://authentik.company/application/o/authorize/`
+    - **Token URL**: `https://authentik.company/application/o/token/`
+    - **User Info URL**: `https://authentik.company/application/o/userinfo/`
+    - **Redirect URL**: `https://wallos.company/index.php`
+    - **User Identifier Field**: `sub`
+    - **Scopes**: `openid email profile`
 
 ## Configuration verification
 
@@ -68,5 +62,5 @@ To confirm authentik is correctly integrated with Wallos, log out and attempt to
 
 ## Resources
 
--   [Wallos website](https://wallosapp.com/)
--   [Wallos GitHub repository](https://github.com/ellite/wallos)
+- [Wallos website](https://wallosapp.com/)
+- [Wallos GitHub repository](https://github.com/ellite/wallos)

--- a/website/integrations/miscellaneous/wallos/index.mdx
+++ b/website/integrations/miscellaneous/wallos/index.mdx
@@ -14,8 +14,8 @@ support_level: community
 
 The following placeholders are used in this guide:
 
-- `https://wallos.company` is the FQDN of the Wallos installation.
-- `https://authentik.company` is the FQDN of the authentik installation.
+-   `https://wallos.company` is the FQDN of the Wallos installation.
+-   `https://authentik.company` is the FQDN of the authentik installation.
 
 :::info
 This documentation lists only the settings that you need to change from their default values. Be aware that any changes other than those explicitly mentioned in this guide could cause issues accessing your application.
@@ -30,13 +30,13 @@ To support the integration of Wallos with authentik, you need to create an appli
 1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair in authentik. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
 
-- **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
-- **Choose a Provider type**: select **OAuth2/OpenID Connect** as the provider type.
-- **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
-  - Note the **Client ID** and **Client Secret** values because they will be required later.
-  - Set a `Strict` redirect URI to `https://wallos.company/index.php`.
-  - Select any available signing key.
-- **Configure Bindings** (optional): you can create a [binding](/docs/add-secure-apps/flows-stages/bindings/) (policy, group, or user) to manage the listing and access to applications on a user's **My applications** page.
+-   **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
+-   **Choose a Provider type**: select **OAuth2/OpenID Connect** as the provider type.
+-   **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
+    -   Note the **Client ID** and **Client Secret** values because they will be required later.
+    -   Set a `Strict` redirect URI to `https://wallos.company/index.php`.
+    -   Select any available signing key.
+-   **Configure Bindings** (optional): you can create a [binding](/docs/add-secure-apps/flows-stages/bindings/) (policy, group, or user) to manage the listing and access to applications on a user's **My applications** page.
 
 3. Click **Submit** to save the new application and provider.
 
@@ -52,15 +52,15 @@ This configuration is done in the Wallos Admin Panel.
 
 Set the following values in Wallos:
 
-- **Provider Name**: `authentik`
-- **Client ID**: Enter the Client ID from authentik
-- **Client Secret**: Enter the Client Secret from authentik
-- **Authorization URL**: `https://authentik.company/application/o/authorize/`
-- **Token URL**: `https://authentik.company/application/o/token/`
-- **User Info URL**: `https://authentik.company/application/o/userinfo/`
-- **Redirect URL**: `https://wallos.company/index.php`
-- **User Identifier Field**: `sub`
-- **Scopes**: `openid email profile`
+-   **Provider Name**: `authentik`
+-   **Client ID**: Enter the Client ID from authentik
+-   **Client Secret**: Enter the Client Secret from authentik
+-   **Authorization URL**: `https://authentik.company/application/o/authorize/`
+-   **Token URL**: `https://authentik.company/application/o/token/`
+-   **User Info URL**: `https://authentik.company/application/o/userinfo/`
+-   **Redirect URL**: `https://wallos.company/index.php`
+-   **User Identifier Field**: `sub`
+-   **Scopes**: `openid email profile`
 
 ## Configuration verification
 
@@ -68,5 +68,5 @@ To confirm authentik is correctly integrated with Wallos, log out and attempt to
 
 ## Resources
 
-- [Wallos website](https://wallosapp.com/)
-- [Wallos GitHub repository](https://github.com/ellite/wallos)
+-   [Wallos website](https://wallosapp.com/)
+-   [Wallos GitHub repository](https://github.com/ellite/wallos)

--- a/website/integrations/miscellaneous/wallos/index.mdx
+++ b/website/integrations/miscellaneous/wallos/index.mdx
@@ -1,0 +1,72 @@
+---
+title: Integrate with Wallos
+sidebar_label: Wallos
+support_level: community
+---
+
+## What is Wallos
+
+> Wallos is a self-hosted subscription and budget planning application.
+>
+> -- https://wallosapp.com/
+
+## Preparation
+
+The following placeholders are used in this guide:
+
+- `https://wallos.company` is the FQDN of the Wallos installation.
+- `https://authentik.company` is the FQDN of the authentik installation.
+
+:::info
+This documentation lists only the settings that you need to change from their default values. Be aware that any changes other than those explicitly mentioned in this guide could cause issues accessing your application.
+:::
+
+## authentik configuration
+
+To support the integration of Wallos with authentik, you need to create an application/provider pair in authentik.
+
+### Create an application and provider in authentik
+
+1. Log in to authentik as an administrator and open the authentik Admin interface.
+2. Navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair in authentik. (Alternatively you can first create a provider separately, then create the application and connect it with the provider.)
+
+- **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
+- **Choose a Provider type**: select **OAuth2/OpenID Connect** as the provider type.
+- **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
+  - Note the **Client ID** and **Client Secret** values because they will be required later.
+  - Set a `Strict` redirect URI to `https://wallos.company/index.php`.
+  - Select any available signing key.
+- **Configure Bindings** (optional): you can create a [binding](/docs/add-secure-apps/flows-stages/bindings/) (policy, group, or user) to manage the listing and access to applications on a user's **My applications** page.
+
+3. Click **Submit** to save the new application and provider.
+
+## Wallos configuration
+
+This configuration is done in the Wallos Admin Panel.
+
+1. Log in to your Wallos installation as an administrator and open the Admin Panel.
+2. Scroll to the **OIDC settings** section and enable OIDC/OAuth.
+3. Fill in the fields below.
+
+### Wallos OIDC fields
+
+Set the following values in Wallos:
+
+- **Provider Name**: `authentik`
+- **Client ID**: Enter the Client ID from authentik
+- **Client Secret**: Enter the Client Secret from authentik
+- **Authorization URL**: `https://authentik.company/application/o/authorize/`
+- **Token URL**: `https://authentik.company/application/o/token/`
+- **User Info URL**: `https://authentik.company/application/o/userinfo/`
+- **Redirect URL**: `https://wallos.company/index.php`
+- **User Identifier Field**: `sub`
+- **Scopes**: `openid email profile`
+
+## Configuration verification
+
+To confirm authentik is correctly integrated with Wallos, log out and attempt to log back in using OIDC/OAuth. You should be redirected to authentik, and after successful authentication, back to Wallos.
+
+## Resources
+
+- [Wallos website](https://wallosapp.com/)
+- [Wallos GitHub repository](https://github.com/ellite/wallos)

--- a/website/integrations/miscellaneous/wallos/index.mdx
+++ b/website/integrations/miscellaneous/wallos/index.mdx
@@ -58,7 +58,7 @@ To support the integration of authentik with Wallos, you need to enable and conf
 
 ## Configuration verification
 
-To confirm authentik is correctly integrated with Wallos, log out and attempt to log back in using OIDC/OAuth. You should be redirected to authentik, and after successful authentication, back to Wallos.
+To confirm that authentik is correctly integrated with Wallos, log out and attempt to log back in using OIDC/OAuth. You should be redirected to authentik, and after successful authentication, back to Wallos.
 
 ## Resources
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

This PR adds a **community-supported** integration guide for **Wallos** (OAuth2/OpenID Connect).

Changes:
- Adds `website/integrations/miscellaneous/wallos/index.mdx`

The guide documents:
- authentik application/provider setup (OAuth2/OpenID Connect)
- required redirect URL for Wallos
- Wallos OIDC field values (Authorization URL, Token URL, User Info URL)

Verification:
- Started the integrations docs locally via `npm start -w integrations` and verified the page loads at `/miscellaneous/wallos`.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
