### PR TITLE
web: Fix Storybook package resolution with `npm link`

### DIFF
--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -20,6 +20,10 @@ export default defineConfig({
             "./assets/pficon": join(patternflyPath, "assets", "pficon"),
         },
     },
+    optimizeDeps: {
+        // Fixes dependency resolution issue associated with `npm link`ed packages.
+        include: ["@goauthentik/api"],
+    },
     plugins: [
         // ---
         inlineCSSPlugin(),


### PR DESCRIPTION
## Details

This PR fixes an runtime error which arises when...

1. `make gen-client-ts` uses `npm link` to symlink `@goauthentik/api`
2. A module within Storybook's setup or a component story imports a TypeScript file
3. That file imports or references `@goauthentik/api`