### PR TITLE
blueprints: fix deadlock and task context error in MetaApplyBlueprint

### DIFF
--- a/authentik/blueprints/v1/meta/apply_blueprint.py
+++ b/authentik/blueprints/v1/meta/apply_blueprint.py
@@ -37,14 +37,20 @@ class ApplyBlueprintMetaSerializer(PassiveSerializer):
         return super().validate(attrs)
 
     def create(self, validated_data: dict) -> MetaResult:
-        from authentik.blueprints.v1.tasks import apply_blueprint
+        from authentik.blueprints.v1.importer import Importer
 
         if not self.blueprint_instance:
             LOGGER.info("Blueprint does not exist, but not required")
             return MetaResult()
         LOGGER.debug("Applying blueprint from meta model", blueprint=self.blueprint_instance)
 
-        apply_blueprint.send(self.blueprint_instance.pk).get_result(block=True)
+        # Apply blueprint directly using Importer to avoid task context requirements
+        # and prevent deadlocks when called from within another blueprint task
+        blueprint_content = self.blueprint_instance.retrieve()
+        importer = Importer.from_string(blueprint_content, self.blueprint_instance.context)
+        valid, logs = importer.validate()
+        if valid:
+            importer.apply()
         return MetaResult()
 
 

--- a/authentik/blueprints/v1/meta/apply_blueprint.py
+++ b/authentik/blueprints/v1/meta/apply_blueprint.py
@@ -49,6 +49,7 @@ class ApplyBlueprintMetaSerializer(PassiveSerializer):
         blueprint_content = self.blueprint_instance.retrieve()
         importer = Importer.from_string(blueprint_content, self.blueprint_instance.context)
         valid, logs = importer.validate()
+        [log.log() for log in logs]
         if valid:
             importer.apply()
         return MetaResult()

--- a/authentik/events/logs.py
+++ b/authentik/events/logs.py
@@ -14,8 +14,6 @@ from structlog.types import EventDict
 from authentik.core.api.utils import PassiveSerializer
 from authentik.events.utils import sanitize_dict
 
-LOGGER = get_logger("").bind()
-
 
 @dataclass()
 class LogEvent:
@@ -39,9 +37,7 @@ class LogEvent:
         )
 
     def log(self):
-        LOGGER.getChild(self.logger).log(
-            NAME_TO_LEVEL[self.log_level], self.event, **self.attributes
-        )
+        get_logger(self.logger).log(NAME_TO_LEVEL[self.log_level], self.event, **self.attributes)
 
 
 class LogEventSerializer(PassiveSerializer):

--- a/authentik/events/logs.py
+++ b/authentik/events/logs.py
@@ -7,12 +7,14 @@ from typing import Any
 from django.utils.timezone import now
 from rest_framework.fields import CharField, ChoiceField, DateTimeField, DictField
 from structlog import configure, get_config
-from structlog.stdlib import NAME_TO_LEVEL, ProcessorFormatter
+from structlog.stdlib import NAME_TO_LEVEL, ProcessorFormatter, get_logger
 from structlog.testing import LogCapture
 from structlog.types import EventDict
 
 from authentik.core.api.utils import PassiveSerializer
 from authentik.events.utils import sanitize_dict
+
+LOGGER = get_logger("").bind()
 
 
 @dataclass()
@@ -34,6 +36,11 @@ class LogEvent:
         item.pop("log_level", None)
         return LogEvent(
             event, log_level, item.pop("logger"), timestamp, attributes=sanitize_dict(item)
+        )
+
+    def log(self):
+        LOGGER.getChild(self.logger).log(
+            NAME_TO_LEVEL[self.log_level], self.event, **self.attributes
         )
 
 


### PR DESCRIPTION
The change in fa65d4730 introduced two issues when applying blueprints that contain MetaApplyBlueprint entries (like default-brand.yaml):

1. Deadlock: Using apply_blueprint.send().get_result(block=True) sends a task to the worker and blocks waiting. Since the worker is already processing the parent blueprint, it cant process the nested task.
2. Task context error: Calling apply_blueprint() directly fails because the dramatiq actor requires CurrentTask context which doesn't exist when running from management commands or nested calls.

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
