### PR TITLE
web: fix file search input not resetting results properly

### DIFF
--- a/web/src/components/ak-file-search-input.ts
+++ b/web/src/components/ak-file-search-input.ts
@@ -95,9 +95,10 @@ export class AKFileSearchInput extends AKElement {
 
                 let results = fileResponse;
 
-                // If we have a current value and it's not in the results (e.g., fa:// or custom URL),
-                // add it as a synthetic item so it shows up as selected
-                if (this.value && !results.find((item) => item.name === this.value)) {
+                // Only add synthetic item on initial load (no query), not during search.
+                // This prevents stale values from appearing in search results.
+                // The synthetic item is needed for fa:// URLs or custom URLs that aren't in the API.
+                if (!query && this.value && !results.find((item) => item.name === this.value)) {
                     results = [
                         {
                             name: this.value,

--- a/web/src/elements/forms/SearchSelect/SearchSelect.ts
+++ b/web/src/elements/forms/SearchSelect/SearchSelect.ts
@@ -269,6 +269,8 @@ export abstract class SearchSelectBase<T>
 
         if (!value) {
             this.selectedObject = null;
+            this.query = undefined;
+            this.updateData();
             return;
         }
 


### PR DESCRIPTION
when searching in ak-file-search-input the current value was  ncorrectly added to search results on every fetch which cause stale items to persist. and, clearing the input kept showing old filtered results instead of all files.

so: only add synthetic item for current value on initial load (no query), not during active searches ++ refetch all results when input is cleared instead of keeping stale filtered results

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
