### PR TITLE
core: fix get_provider returning base Provider instead of subclass

### DIFF
--- a/authentik/core/models.py
+++ b/authentik/core/models.py
@@ -813,11 +813,12 @@ class Application(SerializerModel, PolicyBindingModel):
                     parent = getattr(parent, level)
                 except AttributeError:
                     break
+            # Skip if we didn't find a subclass (parent is still the base Provider)
+            if type(parent) is base_class:
+                continue
             if parent in candidates:
                 continue
-            idx = subclass.count(LOOKUP_SEP)
-            if type(parent) is not base_class:
-                idx += 1
+            idx = subclass.count(LOOKUP_SEP) + 1
             candidates.insert(idx, parent)
         if not candidates:
             return None

--- a/authentik/core/models.py
+++ b/authentik/core/models.py
@@ -17,7 +17,6 @@ from django.contrib.sessions.base_session import AbstractBaseSession
 from django.core.validators import validate_slug
 from django.db import models
 from django.db.models import Q, QuerySet, options
-from django.db.models.constants import LOOKUP_SEP
 from django.http import HttpRequest
 from django.utils.functional import cached_property
 from django.utils.timezone import now
@@ -45,6 +44,7 @@ from authentik.lib.models import (
     DomainlessFormattedURLValidator,
     SerializerModel,
 )
+from authentik.lib.utils.inheritance import get_deepest_child
 from authentik.lib.utils.time import timedelta_from_string
 from authentik.policies.models import PolicyBindingModel
 from authentik.rbac.models import Role
@@ -803,26 +803,7 @@ class Application(SerializerModel, PolicyBindingModel):
         """Get casted provider instance. Needs Application queryset with_provider"""
         if not self.provider:
             return None
-
-        best_candidate = None
-        best_depth = -1
-        base_class = Provider
-        for subclass in base_class.objects.get_queryset()._get_subclasses_recurse(base_class):
-            parent = self.provider
-            for level in subclass.split(LOOKUP_SEP):
-                try:
-                    parent = getattr(parent, level)
-                except AttributeError:
-                    break
-            # Skip if we didn't find a subclass (parent is still the base Provider)
-            if type(parent) is base_class:
-                continue
-            # Track the most specific (deepest) subclass
-            depth = subclass.count(LOOKUP_SEP)
-            if depth > best_depth:
-                best_depth = depth
-                best_candidate = parent
-        return best_candidate
+        return get_deepest_child(self.provider)
 
     def backchannel_provider_for[T: Provider](self, provider_type: type[T], **kwargs) -> T | None:
         """Get Backchannel provider for a specific type"""

--- a/authentik/core/models.py
+++ b/authentik/core/models.py
@@ -804,7 +804,8 @@ class Application(SerializerModel, PolicyBindingModel):
         if not self.provider:
             return None
 
-        candidates = []
+        best_candidate = None
+        best_depth = -1
         base_class = Provider
         for subclass in base_class.objects.get_queryset()._get_subclasses_recurse(base_class):
             parent = self.provider
@@ -816,13 +817,12 @@ class Application(SerializerModel, PolicyBindingModel):
             # Skip if we didn't find a subclass (parent is still the base Provider)
             if type(parent) is base_class:
                 continue
-            if parent in candidates:
-                continue
-            idx = subclass.count(LOOKUP_SEP) + 1
-            candidates.insert(idx, parent)
-        if not candidates:
-            return None
-        return candidates[-1]
+            # Track the most specific (deepest) subclass
+            depth = subclass.count(LOOKUP_SEP)
+            if depth > best_depth:
+                best_depth = depth
+                best_candidate = parent
+        return best_candidate
 
     def backchannel_provider_for[T: Provider](self, provider_type: type[T], **kwargs) -> T | None:
         """Get Backchannel provider for a specific type"""

--- a/authentik/lib/tests/test_utils_inheritance.py
+++ b/authentik/lib/tests/test_utils_inheritance.py
@@ -1,0 +1,86 @@
+"""Tests for inheritance helpers."""
+
+from django.test import TestCase
+
+from authentik.core.models import Provider
+from authentik.core.tests.utils import create_test_flow
+from authentik.lib.generators import generate_id
+from authentik.lib.utils.inheritance import get_deepest_child
+from authentik.providers.ldap.models import LDAPProvider
+from authentik.providers.oauth2.models import OAuth2Provider
+from authentik.providers.proxy.models import ProxyProvider
+
+
+class TestInheritanceUtils(TestCase):
+    """Tests for helper functions in authentik.lib.utils.inheritance."""
+
+    def _get_provider_with_all_subclasses(self, provider_pk):
+        qs = Provider.objects.all()
+        for subclass in Provider.objects.get_queryset()._get_subclasses_recurse(Provider):
+            qs = qs.select_related(subclass)
+        return qs.get(pk=provider_pk)
+
+    def test_get_deepest_child_grandparent_to_parent(self):
+        """Provider -> OAuth2Provider (non-leaf subclass)."""
+        oauth2 = OAuth2Provider.objects.create(
+            name=generate_id(),
+            authorization_flow=create_test_flow(),
+        )
+        provider = Provider.objects.select_related("oauth2provider").get(pk=oauth2.pk)
+
+        resolved = get_deepest_child(provider)
+
+        self.assertIsInstance(resolved, OAuth2Provider)
+        self.assertEqual(resolved.pk, oauth2.pk)
+
+    def test_get_deepest_child_grandparent_to_leaf(self):
+        """Provider -> LDAPProvider (single-level leaf subclass)."""
+        ldap = LDAPProvider.objects.create(name=generate_id())
+        provider = Provider.objects.select_related("ldapprovider").get(pk=ldap.pk)
+
+        resolved = get_deepest_child(provider)
+
+        self.assertIsInstance(resolved, LDAPProvider)
+        self.assertEqual(resolved.pk, ldap.pk)
+
+    def test_get_deepest_child_grandparent_to_grandchild(self):
+        """Provider -> OAuth2Provider -> ProxyProvider."""
+        proxy = ProxyProvider.objects.create(
+            name=generate_id(),
+            authorization_flow=create_test_flow(),
+            external_host=f"https://{generate_id()}.goauthentik.io",
+        )
+        provider = Provider.objects.select_related("oauth2provider__proxyprovider").get(pk=proxy.pk)
+
+        resolved = get_deepest_child(provider)
+
+        self.assertIsInstance(resolved, ProxyProvider)
+        self.assertEqual(resolved.pk, proxy.pk)
+
+    def test_get_deepest_child_parent_to_child(self):
+        """OAuth2Provider -> ProxyProvider (start from non-root)."""
+        proxy = ProxyProvider.objects.create(
+            name=generate_id(),
+            authorization_flow=create_test_flow(),
+            external_host=f"https://{generate_id()}.goauthentik.io",
+        )
+        parent = OAuth2Provider.objects.select_related("proxyprovider").get(pk=proxy.pk)
+
+        resolved = get_deepest_child(parent)
+
+        self.assertIsInstance(resolved, ProxyProvider)
+        self.assertEqual(resolved.pk, proxy.pk)
+
+    def test_get_deepest_child_no_queries_with_preloaded_relations(self):
+        """When all subclass relations are preloaded, no additional queries are needed."""
+        proxy = ProxyProvider.objects.create(
+            name=generate_id(),
+            authorization_flow=create_test_flow(),
+            external_host=f"https://{generate_id()}.goauthentik.io",
+        )
+        provider = self._get_provider_with_all_subclasses(proxy.pk)
+
+        with self.assertNumQueries(0):
+            resolved = get_deepest_child(provider)
+
+        self.assertIsInstance(resolved, ProxyProvider)

--- a/authentik/lib/utils/inheritance.py
+++ b/authentik/lib/utils/inheritance.py
@@ -1,0 +1,41 @@
+from django.db.models import Model, OneToOneField, OneToOneRel
+
+
+def get_deepest_child(parent: Model) -> Model:
+    """
+    In multiple table inheritance, given any ancestor object, get the deepest child object.
+    See https://docs.djangoproject.com/en/dev/topics/db/models/#multi-table-inheritance
+
+    This function does not query the database if `select_related` has been performed on all
+    subclasses of `parent`'s model.
+    """
+
+    # Almost verbatim copy from django-model-utils, see
+    # https://github.com/jazzband/django-model-utils/blob/5.0.0/model_utils/managers.py#L132
+    one_to_one_rels = [
+        field for field in parent._meta.get_fields() if isinstance(field, OneToOneRel)
+    ]
+
+    submodel_fields = [
+        rel
+        for rel in one_to_one_rels
+        if isinstance(rel.field, OneToOneField)
+        and issubclass(rel.field.model, parent._meta.model)
+        and parent._meta.model is not rel.field.model
+        and rel.parent_link
+    ]
+
+    submodel_accessors = [submodel_field.get_accessor_name() for submodel_field in submodel_fields]
+    # End Copy
+
+    child = None
+    for submodel in submodel_accessors:
+        try:
+            child = getattr(parent, submodel)
+            break
+        except AttributeError:
+            continue
+
+    if not child:
+        return parent
+    return get_deepest_child(child)


### PR DESCRIPTION
Ref: https://discord.com/channels/809154715984199690/809154716507963434/1454160532641808689

On a GET to https://authentik/api/v3/core/applications/?ordering=name&page=1&page_size=20&search=&superuser_full_list=true

Notice `verbose_name` and `verbose_name_plural` for an ldap provider:
```
    "provider_obj": {
                "pk": 5,
                "name": "Provider for ldap2",
                "authentication_flow": null,
                "authorization_flow": "fbfce655-f381-4303-a4a4-d55dad102727",
                "invalidation_flow": "d88f01fc-9f87-41f3-8621-a3c2065a0da0",
                "property_mappings": [],
                "component": "",
                "assigned_application_slug": "ldap2",
                "assigned_application_name": "ldap2",
                "assigned_backchannel_application_slug": null,
                "assigned_backchannel_application_name": null,
                "verbose_name": "provider",
                "verbose_name_plural": "providers",
                "meta_model_name": "authentik_core.provider"
            },
```

vs an oauth2 one:

```
                "verbose_name": "OAuth2/OpenID Provider",
                "verbose_name_plural": "OAuth2/OpenID Providers",
```