### PR TITLE
core: handle deserialization errors from FileField migration

### DIFF
--- a/authentik/core/sessions.py
+++ b/authentik/core/sessions.py
@@ -66,9 +66,12 @@ class SessionStore(SessionBase):
     def decode(self, session_data):
         try:
             return pickle.loads(session_data)  # nosec
-        except pickle.PickleError:
-            # ValueError, unpickling exceptions. If any of these happen, just return an empty
-            # dictionary (an empty session)
+        except (pickle.PickleError, AttributeError, TypeError):
+            # PickleError, ValueError - unpickling exceptions
+            # AttributeError - can happen when Django model fields (e.g., FileField) are unpickled
+            #                  and their descriptors fail to initialize (e.g., missing storage)
+            # TypeError - can happen with incompatible pickled objects
+            # If any of these happen, just return an empty dictionary (an empty session)
             pass
         return {}
 


### PR DESCRIPTION
after migration 0054 changed icon fields from Django FileField to a TextField based custom FileField, old sessions which had serialized Source/Application model instances fail to deserialize.

The old FieldFile descriptors try to access field.storage which no longer exists.

We can't edit that migration since it has already been ran by many/

So, you  add AttributeError and TypeError to exception handling in SessionStore.decode() to return an empty session instead of crashing with 500.

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
