### PR TITLE
website/docs: endpoints: mention connector key required for stage to work

### DIFF
--- a/website/docs/endpoint-devices/device-compliance/connectors.md
+++ b/website/docs/endpoint-devices/device-compliance/connectors.md
@@ -19,6 +19,19 @@ The following connectors are currently supported:
 - Unlike other connectors, the agent connector is used by the agent directly compared to other connectors talking to separate systems and APIs to integrate with other agents. Hence the functionality of the agent connector behaves differently than other connectors.
 - the agent connector mainly holds configuration for the agent itself, as well as implementing certain platform specific protocols like Apple's Platform SSO.
 
+#### Challenge Key
+
+The Agent Connector requires a **Challenge Key** (Certificate Keypair) to be configured when using the [Endpoint Stage](../../add-secure-apps/flows-stages/stages/endpoint/index.md). This keypair is used to sign challenges sent to the [browser extension](./browser-extension.mdx) for device verification.
+
+Without a Challenge Key configured, the Endpoint Stage will silently skip device verification.
+
+To configure a Challenge Key:
+
+1. Navigate to **System** > **Certificates** and create a new certificate keypair, or select an existing one.
+2. Navigate to **Endpoint Devices** > **Connectors** and edit your Agent Connector.
+3. Set the **Challenge Key** field to your certificate keypair.
+4. Click **Update**.
+
 ## Adding a connector
 
 1. Log in to authentik as an administrator and open the authentik Admin interface.


### PR DESCRIPTION


keypair = CertificateKeyPair.objects.filter(pk=stage.connector.challenge_key_id).first()
  if not keypair:
      return self.executor.stage_ok()  # < --- skips the stage

took me a bit of time to find this and yea

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
