### PR TITLE
core: make trailing slash optional for flow URLs

### DIFF
--- a/authentik/core/urls.py
+++ b/authentik/core/urls.py
@@ -2,7 +2,7 @@
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.urls import path
+from django.urls import path, re_path
 
 from authentik.core.api.application_entitlements import ApplicationEntitlementViewSet
 from authentik.core.api.applications import ApplicationViewSet
@@ -55,8 +55,8 @@ urlpatterns = [
         BrandDefaultRedirectView.as_view(template_name="if/user.html"),
         name="if-user",
     ),
-    path(
-        "if/flow/<slug:flow_slug>/",
+    re_path(
+        r"^if/flow/(?P<flow_slug>[-\w]+)/?$",
         # FIXME: move this url to the flows app...also will cause all
         # of the reverse calls to be adjusted
         FlowInterfaceView.as_view(),


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
The required trailing slash is likely inconsequential in the majority of cases, however specifically when bootstrapping the project and using `/if/flow/initialsetup/` it seems there are many people including myself (see [this comment](https://github.com/goauthentik/authentik/issues/9584#issuecomment-2122152762)) that have mistakenly not included the trailing slash and are not used to the URLs `/if/flow/initialsetup` and `/if/flow/initialsetup/` being handled differently.

This change is made by swapping path() to re_path() to regex the pattern with and without the trailing slash.

It is worth mentioning that this is essentially the default behavior with APPEND_SLASH=True but this was previously disabled for other reasons (#6928).

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)