### PR TITLE
website/docs: endpoint devices: add path to macos setup

### DIFF
--- a/website/docs/endpoint-devices/authentik-agent/agent-deployment/macos.md
+++ b/website/docs/endpoint-devices/authentik-agent/agent-deployment/macos.md
@@ -59,7 +59,7 @@ To enable [device compliance features](../../device-compliance/index.mdx), you m
 1. Open a Terminal session and run the following command:
 
 ```sh
-"/Applications/authentik Agent.app/Contents/MacOS/ak-sysd" domains join <deployment_name> --authentik-url https://authentik.company
+sudo "/Applications/authentik Agent.app/Contents/MacOS/ak-sysd" domains join <deployment_name> --authentik-url https://authentik.company
 ```
 
 - `deployment_name` is the name that will be used to identify the authentik deployment on the device.

--- a/website/docs/endpoint-devices/authentik-agent/agent-deployment/macos.md
+++ b/website/docs/endpoint-devices/authentik-agent/agent-deployment/macos.md
@@ -59,7 +59,7 @@ To enable [device compliance features](../../device-compliance/index.mdx), you m
 1. Open a Terminal session and run the following command:
 
 ```sh
-ak-sysd domains join <deployment_name> --authentik-url https://authentik.company
+"/Applications/authentik Agent.app/Contents/MacOS/ak-sysd" domains join <deployment_name> --authentik-url https://authentik.company
 ```
 
 - `deployment_name` is the name that will be used to identify the authentik deployment on the device.


### PR DESCRIPTION
## Details

Fixes the command in the macos setup

---

## Checklist

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
