### PR TITLE
Update Vaultwarden documentation by removing warning

### DIFF
--- a/website/integrations/security/vaultwarden/index.md
+++ b/website/integrations/security/vaultwarden/index.md
@@ -21,10 +21,6 @@ The following placeholders are used in this guide:
 This documentation lists only the settings that you need to change from their default values. Be aware that any changes other than those explicitly mentioned in this guide could cause issues accessing your application.
 :::
 
-:::warning
-Please note that this feature is currently only available on `:testing` images. More information can be found in [Vaultwarden's "Enabling SSO support using OpenID Connect"](https://github.com/dani-garcia/vaultwarden/wiki/Enabling-SSO-support-using-OpenId-Connect) documentation.
-:::
-
 ## authentik configuration
 
 To support the integration of Vaultwarden with authentik, you need to create an application/provider pair in authentik.


### PR DESCRIPTION
Removed warning about SSO feature availability on testing images.

## Details

This PR updates the Vaultwarden integration documentation at https://integrations.goauthentik.io/security/vaultwarden/ to remove the warning message that this feature is only available on `:testing` images.

As of Vaultwarden v1.35.0, released on December 27th, 2025, SSO is fully supported in the main release, therefore the warning is no longer required.

Reference: https://github.com/dani-garcia/vaultwarden/releases/tag/1.35.0 

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [X] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
