### PR TITLE
web: Fix Impersonation, Lit Reactive Controller Contexts

### DIFF
--- a/web/src/elements/controllers/LicenseContextController.ts
+++ b/web/src/elements/controllers/LicenseContextController.ts
@@ -1,8 +1,8 @@
 import { DEFAULT_CONFIG } from "#common/api/config";
 import { EVENT_REFRESH_ENTERPRISE } from "#common/constants";
-import { isCausedByAbortError } from "#common/errors/network";
 import { isGuest } from "#common/users";
 
+import { ReactiveContextController } from "#elements/controllers/ReactiveContextController";
 import { LicenseContext, LicenseMixin } from "#elements/mixins/license";
 import { SessionMixin } from "#elements/mixins/session";
 import type { ReactiveElementHost } from "#elements/types";
@@ -10,16 +10,17 @@ import type { ReactiveElementHost } from "#elements/types";
 import { EnterpriseApi, LicenseSummary } from "@goauthentik/api";
 
 import { ContextProvider } from "@lit/context";
-import type { ReactiveController } from "lit";
 
-export class LicenseContextController implements ReactiveController {
-    #log = console.debug.bind(console, `authentik/controller/license`);
-    #abortController: null | AbortController = null;
+export class LicenseContextController extends ReactiveContextController<LicenseSummary> {
+    protected static refreshEvent = EVENT_REFRESH_ENTERPRISE;
+    protected static logPrefix = "license";
 
     #host: ReactiveElementHost<SessionMixin & LicenseMixin>;
     #context: ContextProvider<LicenseContext>;
 
     constructor(host: ReactiveElementHost<LicenseMixin>, initialValue?: LicenseSummary) {
+        super();
+
         this.#host = host;
         this.#context = new ContextProvider(this.#host, {
             context: LicenseContext,
@@ -27,60 +28,26 @@ export class LicenseContextController implements ReactiveController {
         });
     }
 
-    #fetch = () => {
-        this.#log("Fetching license summary...");
-
-        this.#abortController = new AbortController();
-
-        return new EnterpriseApi(DEFAULT_CONFIG)
-            .enterpriseLicenseSummaryRetrieve(
-                {},
-                {
-                    signal: this.#abortController.signal,
-                },
-            )
-            .then((enterprise) => {
-                this.#context.setValue(enterprise);
-                this.#host.licenseSummary = enterprise;
-            })
-
-            .catch((error: unknown) => {
-                if (isCausedByAbortError(error)) {
-                    this.#log("Aborted fetching license summary");
-                    return;
-                }
-
-                throw error;
-            })
-            .finally(() => {
-                this.#abortController = null;
-            });
-    };
-
-    #refreshListener = (event: Event) => {
-        this.#abortController?.abort(event.type);
-        this.#fetch();
-    };
-
-    public hostConnected() {
-        window.addEventListener(EVENT_REFRESH_ENTERPRISE, this.#refreshListener);
+    protected apiEndpoint(requestInit?: RequestInit) {
+        return new EnterpriseApi(DEFAULT_CONFIG).enterpriseLicenseSummaryRetrieve({}, requestInit);
     }
 
-    public hostDisconnected() {
-        window.removeEventListener(EVENT_REFRESH_ENTERPRISE, this.#refreshListener);
+    protected doRefresh(licenseSummary: LicenseSummary) {
+        this.#context.setValue(licenseSummary);
+        this.#host.licenseSummary = licenseSummary;
     }
 
     public hostUpdate() {
         const { currentUser } = this.#host;
 
-        if (currentUser && !isGuest(currentUser) && !this.#abortController) {
-            this.#fetch();
+        if (currentUser && !isGuest(currentUser) && !this.abortController) {
+            this.refresh();
 
             return;
         }
 
-        if (!currentUser && this.#abortController) {
-            this.#abortController.abort("session-invalidated");
+        if (!currentUser && this.abortController) {
+            this.abort("Session Invalidated");
         }
     }
 }

--- a/web/src/elements/controllers/ReactiveContextController.ts
+++ b/web/src/elements/controllers/ReactiveContextController.ts
@@ -1,0 +1,180 @@
+import { EVENT_REFRESH } from "#common/constants";
+import { isCausedByAbortError, parseAPIResponseError } from "#common/errors/network";
+
+import type { ReactiveController } from "lit";
+
+/**
+ * A base Lit controller for API-backed context providers.
+ *
+ * Subclasses must implement {@linkcode apiEndpoint} and {@linkcode doRefresh}
+ * to fetch data and update the context value, respectively.
+ */
+export abstract class ReactiveContextController<T extends object> implements ReactiveController {
+    /**
+     * A prefix for log messages from this controller.
+     */
+    protected static logPrefix = "controller";
+    /**
+     * An event name that triggers a refresh when dispatched on the global context.
+     */
+    protected static refreshEvent = EVENT_REFRESH;
+
+    /**
+     * Log a debug message with the controller's prefix.
+     *
+     * @todo Port `ConsoleLogger` here for better logging.
+     */
+    protected debug: (...args: unknown[]) => void;
+
+    /**
+     * An {@linkcode AbortController} that can be used to cancel ongoing refreshes.
+     *
+     * Generally this is handled automatically by {@linkcode refresh},
+     * but may be useful for subclasses with unique behavior.
+     */
+    protected abortController: null | AbortController = null;
+
+    /**
+     * An {@linkcode AbortController} that can be used to cancel ongoing operations
+     * when the host disconnects.
+     */
+    protected hostAbortController: AbortController | null = null;
+
+    public constructor() {
+        const Constructor = this.constructor as typeof ReactiveContextController;
+        const logPrefix = Constructor.logPrefix;
+
+        this.debug = console.debug.bind(console, `authentik/context/${logPrefix}`);
+    }
+
+    /**
+     * Updates the context value with the provided data.
+     *
+     * @param data The data to set in the context.
+     *
+     * @see {@linkcode refresh} for fetching new data.
+     */
+    protected abstract doRefresh(data: T): void | Promise<void>;
+
+    /**
+     * Fetches data from the API endpoint.
+     *
+     * @param requestInit Optional request initialization parameters.
+     * @returns A promise that resolves to the fetched data.
+     */
+    protected abstract apiEndpoint(requestInit?: RequestInit): Promise<T>;
+
+    /**
+     * Refreshes the context by calling the API endpoint and updating the context value.
+     *
+     * @see {@linkcode apiEndpoint} for the API call.
+     * @see {@linkcode doRefresh} for updating the context value.
+     */
+    protected refresh = (): Promise<void> => {
+        this.abort("Refresh aborted by new refresh call");
+
+        this.debug("Refreshing...");
+
+        this.abortController?.abort();
+
+        this.abortController = new AbortController();
+
+        return this.apiEndpoint({
+            signal: this.abortController.signal,
+        })
+            .then((data) => this.doRefresh(data))
+            .catch(this.suppressAbortError)
+            .catch(this.reportSessionError);
+    };
+
+    /**
+     * A helper function to gracefully handle aborted requests.
+     *
+     * @see {@linkcode isCausedByAbortError} for the underlying implementation.
+     */
+    protected suppressAbortError = (error: unknown) => {
+        if (isCausedByAbortError(error)) {
+            this.debug("Aborted:", error.message);
+
+            return;
+        }
+
+        throw error;
+    };
+
+    /**
+     * Reports an error that occurred during session refresh.
+     *
+     * @param error The error to report.
+     */
+    protected reportSessionError = async (error: unknown) => {
+        const parsedError = await parseAPIResponseError(error);
+
+        this.debug(parsedError);
+    };
+
+    /**
+     * Abort the ongoing request, if any.
+     *
+     * @param message An optional message for the abort reason.
+     */
+    protected abort(message?: string): void {
+        // Do we have a controller to abort?
+        if (!this.abortController) return;
+
+        const Constructor = this.constructor as typeof ReactiveContextController;
+        const logPrefix = Constructor.logPrefix;
+
+        const reason = new DOMException(`${logPrefix}: ${message ?? "Aborted"}`, "AbortError");
+
+        this.abortController.abort(reason);
+        this.abortController = null;
+    }
+
+    /**
+     * Registers the refresh event on the window.
+     *
+     * This is called automatically when the host connects.
+     *
+     * @see {@linkcode hostConnected} for more details.
+     */
+    protected registerRefreshEvent() {
+        this.hostAbortController = new AbortController();
+
+        const Constructor = this.constructor as typeof ReactiveContextController;
+
+        window.addEventListener(Constructor.refreshEvent, this.refresh, {
+            signal: this.hostAbortController.signal,
+        });
+    }
+
+    /**
+     * Called when the host is connected.
+     *
+     * This method may be overridden without calling `super.hostConnected()`.
+     *
+     * @see {@linkcode registerRefreshEvent} to manually register the refresh event.
+     */
+    public hostConnected() {
+        this.registerRefreshEvent();
+    }
+
+    /**
+     * Called when the host is disconnected.
+     *
+     * If this method is overridden, be sure to call `super.hostDisconnected()`
+     * to abort ongoing network requests.
+     */
+    public hostDisconnected() {
+        const Constructor = this.constructor as typeof ReactiveContextController;
+        const logPrefix = Constructor.logPrefix;
+
+        const reason = new DOMException(`${logPrefix}: Host disconnected`, "AbortError");
+
+        this.hostAbortController?.abort(reason);
+        this.abortController?.abort(reason);
+
+        this.hostAbortController = null;
+        this.abortController = null;
+    }
+}

--- a/web/src/elements/mixins/session.ts
+++ b/web/src/elements/mixins/session.ts
@@ -124,12 +124,17 @@ export const WithSession = createMixin<SessionMixin>(
                 subscribe,
             })
             public set session(nextResult: APIResult<SessionUser>) {
+                const previousValue = this.#data;
+
                 this.#data = nextResult;
+
                 if (isAPIResultReady(nextResult)) {
                     const { settings = {} } = nextResult.user || {};
 
                     this.#uiConfig = createUIConfig(settings);
                 }
+
+                this.requestUpdate("session", previousValue);
             }
 
             public get session(): APIResult<Readonly<SessionUser>> {


### PR DESCRIPTION
## Details

This fixes several lifecycle issues within our Lit Controller Contexts that prevented consistent refresh behaviors:

- Ported the near duplicate lifecycle code from session, license, version, and config contexts into `ReactiveContextController`, fixing some logical disparities as each controller has matured
- Fixed race condition where rapid refresh events can trigger an abort controller with a string error, rather than an `Error` instance 
- Fixed race condition where references to abort controllers can become stale 
- Fixed issue where session mixin does not `requestUpdate` after impersonation
- Added abort controllers on `hostDisconnected` callbacks, fixing momentary errors logged during page reloads while impersonating.