### PR TITLE
web: Capitalize language display names, code owner fix

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -38,7 +38,7 @@ packages/tsconfig                       @goauthentik/frontend
 # Web
 web/                                    @goauthentik/frontend
 # Locale
-locale/                                 @goauthentik/backend @goauthentik/frontend
+/locale/                                @goauthentik/backend @goauthentik/frontend
 web/xliff/                              @goauthentik/backend @goauthentik/frontend
 # Docs
 website/                                @goauthentik/docs

--- a/web/src/elements/locale/ak-locale-select.ts
+++ b/web/src/elements/locale/ak-locale-select.ts
@@ -156,7 +156,7 @@ export class AKLocaleSelect extends WithLocale(WithCapabilitiesConfig(AKElement)
                     part="select"
                     id="locale-selector"
                     @change=${this.#localeChangeListener}
-                    class="pf-c-form-control"
+                    class="pf-c-form-control ak-m-capitalize"
                     name="locale"
                 >
                     ${renderLocaleDisplayNames(entries, activeLocaleTag)}

--- a/web/src/flow/stages/prompt/PromptStage.ts
+++ b/web/src/flow/stages/prompt/PromptStage.ts
@@ -226,7 +226,7 @@ ${prompt.initialValue}</textarea
                     : null;
 
                 return html`<select
-                    class="pf-c-form-control"
+                    class="pf-c-form-control ak-m-capitalize"
                     id=${fieldId}
                     name="${prompt.fieldKey}"
                     aria-label=${msg("Select language", {

--- a/web/src/styles/authentik/base/common.css
+++ b/web/src/styles/authentik/base/common.css
@@ -57,6 +57,10 @@
     }
 }
 
+.ak-m-capitalize {
+    text-transform: capitalize;
+}
+
 ::placeholder {
     font-style: italic;
 }


### PR DESCRIPTION
## Details

Small fix to language display names.

<img width="510" height="481" alt="Screenshot 2025-12-30 at 18 17 49" src="https://github.com/user-attachments/assets/d5bc4ce5-7a65-4451-beff-840f13e58bf6" />

Additionally, updates to `CODEOWNERS` to only require backend approval on the repo root `locale` directory, rather than on sub-directories named `locale`.