### PR TITLE
web: Token Form Fixes

### DIFF
--- a/web/src/admin/endpoints/connectors/agent/AgentConnectorForm.ts
+++ b/web/src/admin/endpoints/connectors/agent/AgentConnectorForm.ts
@@ -61,9 +61,11 @@ export class AgentConnectorForm extends WithBrandConfig(ModelForm<AgentConnector
     renderForm() {
         return html`<ak-text-input
                 name="name"
-                placeholder=${msg("Connector name...")}
+                placeholder=${msg("Type a connector name...")}
                 label=${msg("Connector name")}
                 value=${ifDefined(this.instance?.name)}
+                input-hint="code"
+                autofocus
                 required
             ></ak-text-input>
             <ak-text-input

--- a/web/src/admin/endpoints/connectors/agent/EnrollmentTokenForm.ts
+++ b/web/src/admin/endpoints/connectors/agent/EnrollmentTokenForm.ts
@@ -24,10 +24,10 @@ const EXPIRATION_DURATION = 30 * 60 * 1000; // 30 minutes
 
 @customElement("ak-endpoints-agent-enrollment-token-form")
 export class EnrollmentTokenForm extends WithBrandConfig(ModelForm<EnrollmentToken, string>) {
-    protected expirationMinimumDate: string = dateTimeLocal();
+    protected expirationMinimumDate = new Date();
 
     @state()
-    protected expiresAt: string | null = dateTimeLocal(Date.now() + EXPIRATION_DURATION);
+    protected expiresAt: Date | null = new Date(Date.now() + EXPIRATION_DURATION);
 
     @property({ type: String, attribute: "connector-id" })
     public connectorID?: string;
@@ -40,7 +40,7 @@ export class EnrollmentTokenForm extends WithBrandConfig(ModelForm<EnrollmentTok
         });
 
         this.expiresAt = token.expiring
-            ? dateTimeLocal(token.expires || Date.now() + EXPIRATION_DURATION)
+            ? new Date(token.expires || Date.now() + EXPIRATION_DURATION)
             : null;
 
         return token;
@@ -80,11 +80,11 @@ export class EnrollmentTokenForm extends WithBrandConfig(ModelForm<EnrollmentTok
         }
 
         if (this.instance?.expiring && this.instance.expires) {
-            this.expiresAt = dateTimeLocal(this.instance.expires);
+            this.expiresAt = new Date(this.instance.expires);
             return;
         }
 
-        this.expiresAt = dateTimeLocal(Date.now() + EXPIRATION_DURATION);
+        this.expiresAt = new Date(Date.now() + EXPIRATION_DURATION);
     };
 
     //#endregion
@@ -132,8 +132,8 @@ export class EnrollmentTokenForm extends WithBrandConfig(ModelForm<EnrollmentTok
                 <input
                     id="expiration-date-input"
                     type="datetime-local"
-                    value=${this.expiresAt ?? ""}
-                    min=${this.expirationMinimumDate}
+                    value=${this.expiresAt ? dateTimeLocal(this.expiresAt) : ""}
+                    min=${dateTimeLocal(this.expirationMinimumDate)}
                     ?disabled=${!this.expiresAt}
                     class="pf-c-form-control"
                 />

--- a/web/src/admin/endpoints/connectors/agent/EnrollmentTokenForm.ts
+++ b/web/src/admin/endpoints/connectors/agent/EnrollmentTokenForm.ts
@@ -20,16 +20,14 @@ import { html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
-const createExpirationValue = (value?: Date | null) => {
-    return dateTimeLocal(value || new Date(Date.now() + 30 * 60 * 1000));
-};
+const EXPIRATION_DURATION = 30 * 60 * 1000; // 30 minutes
 
 @customElement("ak-endpoints-agent-enrollment-token-form")
 export class EnrollmentTokenForm extends WithBrandConfig(ModelForm<EnrollmentToken, string>) {
-    protected expirationMinimumDate: string = dateTimeLocal(new Date());
+    protected expirationMinimumDate: string = dateTimeLocal();
 
     @state()
-    protected expiresAt: string | null = createExpirationValue();
+    protected expiresAt: string | null = dateTimeLocal(Date.now() + EXPIRATION_DURATION);
 
     @property({ type: String, attribute: "connector-id" })
     public connectorID?: string;
@@ -41,7 +39,9 @@ export class EnrollmentTokenForm extends WithBrandConfig(ModelForm<EnrollmentTok
             tokenUuid: pk,
         });
 
-        this.expiresAt = token.expiring ? createExpirationValue(token.expires) : null;
+        this.expiresAt = token.expiring
+            ? dateTimeLocal(token.expires || Date.now() + EXPIRATION_DURATION)
+            : null;
 
         return token;
     }
@@ -84,7 +84,7 @@ export class EnrollmentTokenForm extends WithBrandConfig(ModelForm<EnrollmentTok
             return;
         }
 
-        this.expiresAt = createExpirationValue();
+        this.expiresAt = dateTimeLocal(Date.now() + EXPIRATION_DURATION);
     };
 
     //#endregion

--- a/web/src/admin/endpoints/connectors/agent/EnrollmentTokenForm.ts
+++ b/web/src/admin/endpoints/connectors/agent/EnrollmentTokenForm.ts
@@ -1,7 +1,8 @@
-import "#components/ak-text-input";
-import "#components/ak-number-input";
 import "#elements/forms/HorizontalFormElement";
 import "#elements/forms/FormGroup";
+import "#components/ak-text-input";
+import "#components/ak-number-input";
+import "#components/ak-switch-input";
 import "#admin/endpoints/ak-endpoints-device-group-search";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
@@ -10,20 +11,28 @@ import { dateTimeLocal } from "#common/temporal";
 import { ModelForm } from "#elements/forms/ModelForm";
 import { WithBrandConfig } from "#elements/mixins/branding";
 
+import { AKLabel } from "#components/ak-label";
+
 import { EndpointsApi, EnrollmentToken, EnrollmentTokenRequest } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { html, nothing } from "lit";
+import { html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
+const createExpirationValue = (value?: Date | null) => {
+    return dateTimeLocal(value || new Date(Date.now() + 30 * 60 * 1000));
+};
+
 @customElement("ak-endpoints-agent-enrollment-token-form")
 export class EnrollmentTokenForm extends WithBrandConfig(ModelForm<EnrollmentToken, string>) {
-    @property()
-    connectorID?: string;
+    protected expirationMinimumDate: string = dateTimeLocal(new Date());
 
     @state()
-    protected showExpiry = false;
+    protected expiresAt: string | null = createExpirationValue();
+
+    @property({ type: String, attribute: "connector-id" })
+    public connectorID?: string;
 
     async loadInstance(pk: string): Promise<EnrollmentToken> {
         const token = await new EndpointsApi(
@@ -31,7 +40,9 @@ export class EnrollmentTokenForm extends WithBrandConfig(ModelForm<EnrollmentTok
         ).endpointsAgentsEnrollmentTokensRetrieve({
             tokenUuid: pk,
         });
-        this.showExpiry = token.expiring ?? false;
+
+        this.expiresAt = token.expiring ? createExpirationValue(token.expires) : null;
+
         return token;
     }
 
@@ -58,24 +69,36 @@ export class EnrollmentTokenForm extends WithBrandConfig(ModelForm<EnrollmentTok
         });
     }
 
-    renderExpiry() {
-        return html`<ak-form-element-horizontal label=${msg("Expires on")} name="expires">
-            <input
-                type="datetime-local"
-                data-type="datetime-local"
-                value="${dateTimeLocal(this.instance?.expires ?? new Date())}"
-                class="pf-c-form-control"
-            />
-        </ak-form-element-horizontal>`;
-    }
+    //#region Event Listeners
+
+    #expiringChangeListener = (event: Event) => {
+        const expiringElement = event.target as HTMLInputElement;
+
+        if (!expiringElement.checked) {
+            this.expiresAt = null;
+            return;
+        }
+
+        if (this.instance?.expiring && this.instance.expires) {
+            this.expiresAt = dateTimeLocal(this.instance.expires);
+            return;
+        }
+
+        this.expiresAt = createExpirationValue();
+    };
+
+    //#endregion
+
+    //#region Rendering
 
     renderForm() {
         return html`<ak-text-input
                 name="name"
-                placeholder=${msg("Token name...")}
+                placeholder=${msg("Type a name for the token...")}
                 label=${msg("Token name")}
                 value=${ifDefined(this.instance?.name)}
                 required
+                ?autofocus=${!this.instance}
             ></ak-text-input>
             <ak-form-element-horizontal label=${msg("Device Access Group")} name="deviceGroup">
                 <ak-endpoints-device-group-search
@@ -85,32 +108,39 @@ export class EnrollmentTokenForm extends WithBrandConfig(ModelForm<EnrollmentTok
                     ${msg("Select a device access group to be added to upon enrollment.")}
                 </p>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal name="expiring">
-                <label class="pf-c-switch">
-                    <input
-                        class="pf-c-switch__input"
-                        type="checkbox"
-                        ?checked=${this.instance?.expiring ?? false}
-                        @change=${(ev: Event) => {
-                            const el = ev.target as HTMLInputElement;
-                            this.showExpiry = el.checked;
-                        }}
-                    />
-                    <span class="pf-c-switch__toggle">
-                        <span class="pf-c-switch__toggle-icon">
-                            <i class="fas fa-check" aria-hidden="true"></i>
-                        </span>
-                    </span>
-                    <span class="pf-c-switch__label">${msg("Expiring")}</span>
-                </label>
-                <p class="pf-c-form__helper-text">
-                    ${msg(
-                        "If this is selected, the token will expire. Upon expiration, the token will be rotated.",
-                    )}
-                </p>
-            </ak-form-element-horizontal>
-            ${this.showExpiry ? this.renderExpiry() : nothing}`;
+
+            <ak-switch-input
+                name="expiring"
+                label=${msg("Expiring")}
+                help=${msg(
+                    "Whether the token will expire. Upon expiration, the token will be rotated.",
+                )}
+                @change=${this.#expiringChangeListener}
+                ?checked=${this.expiresAt}
+            ></ak-switch-input>
+
+            <ak-form-element-horizontal name="expires">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "expiration-date-input",
+                    },
+                    msg("Expires on"),
+                )}
+
+                <input
+                    id="expiration-date-input"
+                    type="datetime-local"
+                    value=${this.expiresAt ?? ""}
+                    min=${this.expirationMinimumDate}
+                    ?disabled=${!this.expiresAt}
+                    class="pf-c-form-control"
+                />
+            </ak-form-element-horizontal> `;
     }
+
+    //#endregion
 }
 
 declare global {

--- a/web/src/admin/endpoints/connectors/agent/EnrollmentTokenListPage.ts
+++ b/web/src/admin/endpoints/connectors/agent/EnrollmentTokenListPage.ts
@@ -88,7 +88,7 @@ export class EnrollmentTokenListPage extends Table<EnrollmentToken> {
             html`<div>
                 <ak-forms-modal>
                     <span slot="submit">${msg("Update")}</span>
-                    <span slot="header">${msg("Update Enrollment token")}</span>
+                    <span slot="header">${msg("Update Enrollment Token")}</span>
                     <ak-endpoints-agent-enrollment-token-form
                         slot="form"
                         .instancePk=${item.tokenUuid}

--- a/web/src/admin/tokens/TokenForm.ts
+++ b/web/src/admin/tokens/TokenForm.ts
@@ -18,23 +18,23 @@ import { msg } from "@lit/localize";
 import { html, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 
-const createExpirationValue = (value?: Date | null) => {
-    return dateTimeLocal(value || new Date(Date.now() + 30 * 60 * 1000));
-};
+const EXPIRATION_DURATION = 30 * 60 * 1000; // 30 minutes
 
 @customElement("ak-token-form")
 export class TokenForm extends ModelForm<Token, string> {
-    protected expirationMinimumDate: string = dateTimeLocal(new Date());
+    protected expirationMinimumDate: string = dateTimeLocal();
 
     @state()
-    protected expiresAt: string | null = createExpirationValue();
+    protected expiresAt: string | null = dateTimeLocal(Date.now() + EXPIRATION_DURATION);
 
     async loadInstance(pk: string): Promise<Token> {
         const token = await new CoreApi(DEFAULT_CONFIG).coreTokensRetrieve({
             identifier: pk,
         });
 
-        this.expiresAt = token.expiring ? createExpirationValue(token.expires) : null;
+        this.expiresAt = token.expiring
+            ? dateTimeLocal(token.expires || Date.now() + EXPIRATION_DURATION)
+            : null;
 
         return token;
     }
@@ -72,7 +72,7 @@ export class TokenForm extends ModelForm<Token, string> {
             return;
         }
 
-        this.expiresAt = createExpirationValue();
+        this.expiresAt = dateTimeLocal(Date.now() + EXPIRATION_DURATION);
     };
 
     //#endregion

--- a/web/src/admin/tokens/TokenForm.ts
+++ b/web/src/admin/tokens/TokenForm.ts
@@ -2,28 +2,40 @@ import "#elements/forms/FormGroup";
 import "#elements/forms/HorizontalFormElement";
 import "#elements/forms/Radio";
 import "#elements/forms/SearchSelect/index";
+import "#components/ak-text-input";
+import "#components/ak-switch-input";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
 import { dateTimeLocal } from "#common/temporal";
 
 import { ModelForm } from "#elements/forms/ModelForm";
 
+import { AKLabel } from "#components/ak-label";
+
 import { CoreApi, CoreUsersListRequest, IntentEnum, Token, User } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { html, nothing, TemplateResult } from "lit";
+import { html, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
+
+const createExpirationValue = (value?: Date | null) => {
+    return dateTimeLocal(value || new Date(Date.now() + 30 * 60 * 1000));
+};
 
 @customElement("ak-token-form")
 export class TokenForm extends ModelForm<Token, string> {
+    protected expirationMinimumDate: string = dateTimeLocal(new Date());
+
     @state()
-    showExpiry = true;
+    protected expiresAt: string | null = createExpirationValue();
 
     async loadInstance(pk: string): Promise<Token> {
         const token = await new CoreApi(DEFAULT_CONFIG).coreTokensRetrieve({
             identifier: pk,
         });
-        this.showExpiry = token.expiring ?? true;
+
+        this.expiresAt = token.expiring ? createExpirationValue(token.expires) : null;
+
         return token;
     }
 
@@ -45,46 +57,64 @@ export class TokenForm extends ModelForm<Token, string> {
         });
     }
 
-    renderExpiry(): TemplateResult {
-        return html`<ak-form-element-horizontal label=${msg("Expires on")} name="expires">
-            <input
-                type="datetime-local"
-                data-type="datetime-local"
-                value="${dateTimeLocal(this.instance?.expires ?? new Date())}"
-                class="pf-c-form-control"
-            />
-        </ak-form-element-horizontal>`;
-    }
+    //#region Event Listeners
+
+    #expiringChangeListener = (event: Event) => {
+        const expiringElement = event.target as HTMLInputElement;
+
+        if (!expiringElement.checked) {
+            this.expiresAt = null;
+            return;
+        }
+
+        if (this.instance?.expiring && this.instance.expires) {
+            this.expiresAt = dateTimeLocal(this.instance.expires);
+            return;
+        }
+
+        this.expiresAt = createExpirationValue();
+    };
+
+    //#endregion
+
+    //#region Renders
 
     renderForm(): TemplateResult {
-        return html` <ak-form-element-horizontal
-                label=${msg("Identifier")}
+        return html`<ak-text-input
                 name="identifier"
+                value="${this.instance?.identifier ?? ""}"
+                label=${msg("Identifier")}
+                placeholder=${msg("Type a unique identifier...")}
+                spellcheck="false"
+                input-hint="code"
                 required
-            >
-                <input
-                    type="text"
-                    value="${this.instance?.identifier ?? ""}"
-                    class="pf-c-form-control pf-m-monospace"
-                    autocomplete="off"
-                    spellcheck="false"
-                    required
-                />
-                <p class="pf-c-form__helper-text">
-                    ${msg("Unique identifier the token is referenced by.")}
-                </p>
-            </ak-form-element-horizontal>
+                ?autofocus=${!this.instance}
+                help=${msg("Unique identifier the token is referenced by.")}
+            ></ak-text-input>
+
             <ak-form-element-horizontal label=${msg("User")} required name="user">
                 <ak-search-select
                     .fetchObjects=${async (query?: string): Promise<User[]> => {
                         const args: CoreUsersListRequest = {
                             ordering: "username",
                         };
-                        if (query !== undefined) {
+
+                        if (typeof query !== "undefined") {
                             args.search = query;
                         }
+
                         const users = await new CoreApi(DEFAULT_CONFIG).coreUsersList(args);
-                        return users.results;
+                        const instanceUser = this.instance?.userObj;
+
+                        if (!instanceUser) {
+                            return users.results;
+                        }
+
+                        if (users.results.find((user) => user.pk === instanceUser.pk)) {
+                            return users.results;
+                        }
+
+                        return [instanceUser, ...users.results];
                     }}
                     .renderElement=${(user: User): string => {
                         return user.username;
@@ -120,39 +150,46 @@ export class TokenForm extends ModelForm<Token, string> {
                 >
                 </ak-radio>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal label=${msg("Description")} name="description">
+
+            <ak-text-input
+                name="description"
+                value="${this.instance?.description ?? ""}"
+                label=${msg("Description")}
+                placeholder=${msg("Type a token description...")}
+            ></ak-text-input>
+
+            <ak-switch-input
+                name="expiring"
+                label=${msg("Expiring")}
+                help=${msg(
+                    "Whether the token will expire. Upon expiration, the token will be rotated.",
+                )}
+                @change=${this.#expiringChangeListener}
+                ?checked=${this.expiresAt}
+            ></ak-switch-input>
+
+            <ak-form-element-horizontal name="expires">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "expiration-date-input",
+                    },
+                    msg("Expires on"),
+                )}
+
                 <input
-                    type="text"
-                    value="${this.instance?.description ?? ""}"
+                    id="expiration-date-input"
+                    type="datetime-local"
+                    value=${this.expiresAt ?? ""}
+                    min=${this.expirationMinimumDate}
+                    ?disabled=${!this.expiresAt}
                     class="pf-c-form-control"
                 />
-            </ak-form-element-horizontal>
-            <ak-form-element-horizontal name="expiring">
-                <label class="pf-c-switch">
-                    <input
-                        class="pf-c-switch__input"
-                        type="checkbox"
-                        ?checked=${this.instance?.expiring ?? true}
-                        @change=${(ev: Event) => {
-                            const el = ev.target as HTMLInputElement;
-                            this.showExpiry = el.checked;
-                        }}
-                    />
-                    <span class="pf-c-switch__toggle">
-                        <span class="pf-c-switch__toggle-icon">
-                            <i class="fas fa-check" aria-hidden="true"></i>
-                        </span>
-                    </span>
-                    <span class="pf-c-switch__label">${msg("Expiring")}</span>
-                </label>
-                <p class="pf-c-form__helper-text">
-                    ${msg(
-                        "If this is selected, the token will expire. Upon expiration, the token will be rotated.",
-                    )}
-                </p>
-            </ak-form-element-horizontal>
-            ${this.showExpiry ? this.renderExpiry() : nothing}`;
+            </ak-form-element-horizontal>`;
     }
+
+    //#endregion
 }
 
 declare global {

--- a/web/src/admin/tokens/TokenForm.ts
+++ b/web/src/admin/tokens/TokenForm.ts
@@ -22,10 +22,10 @@ const EXPIRATION_DURATION = 30 * 60 * 1000; // 30 minutes
 
 @customElement("ak-token-form")
 export class TokenForm extends ModelForm<Token, string> {
-    protected expirationMinimumDate: string = dateTimeLocal();
+    protected expirationMinimumDate = new Date();
 
     @state()
-    protected expiresAt: string | null = dateTimeLocal(Date.now() + EXPIRATION_DURATION);
+    protected expiresAt: Date | null = new Date(Date.now() + EXPIRATION_DURATION);
 
     async loadInstance(pk: string): Promise<Token> {
         const token = await new CoreApi(DEFAULT_CONFIG).coreTokensRetrieve({
@@ -33,7 +33,7 @@ export class TokenForm extends ModelForm<Token, string> {
         });
 
         this.expiresAt = token.expiring
-            ? dateTimeLocal(token.expires || Date.now() + EXPIRATION_DURATION)
+            ? new Date(token.expires || Date.now() + EXPIRATION_DURATION)
             : null;
 
         return token;
@@ -68,11 +68,11 @@ export class TokenForm extends ModelForm<Token, string> {
         }
 
         if (this.instance?.expiring && this.instance.expires) {
-            this.expiresAt = dateTimeLocal(this.instance.expires);
+            this.expiresAt = new Date(this.instance.expires);
             return;
         }
 
-        this.expiresAt = dateTimeLocal(Date.now() + EXPIRATION_DURATION);
+        this.expiresAt = new Date(Date.now() + EXPIRATION_DURATION);
     };
 
     //#endregion
@@ -181,8 +181,8 @@ export class TokenForm extends ModelForm<Token, string> {
                 <input
                     id="expiration-date-input"
                     type="datetime-local"
-                    value=${this.expiresAt ?? ""}
-                    min=${this.expirationMinimumDate}
+                    value=${this.expiresAt ? dateTimeLocal(this.expiresAt) : ""}
+                    min=${dateTimeLocal(this.expirationMinimumDate)}
                     ?disabled=${!this.expiresAt}
                     class="pf-c-form-control"
                 />

--- a/web/src/admin/users/ServiceAccountForm.ts
+++ b/web/src/admin/users/ServiceAccountForm.ts
@@ -10,6 +10,8 @@ import { dateTimeLocal } from "#common/temporal";
 import { Form } from "#elements/forms/Form";
 import { ModalForm } from "#elements/forms/ModalForm";
 
+import { AKLabel } from "#components/ak-label";
+
 import {
     CoreApi,
     Group,
@@ -21,20 +23,17 @@ import {
 
 import { msg, str } from "@lit/localize";
 import { html, TemplateResult } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
-import { createRef, ref } from "lit/directives/ref.js";
+
+const createExpirationValue = () => {
+    return dateTimeLocal(new Date(Date.now() + 1000 * 60 ** 2 * 24 * 360));
+};
 
 @customElement("ak-user-service-account-form")
 export class ServiceAccountForm extends Form<UserServiceAccountRequest> {
-    #initialExpirationValue = dateTimeLocal(new Date(Date.now() + 1000 * 60 ** 2 * 24 * 360));
-
-    //#region Refs
-
-    #expiringInputRef = createRef<HTMLInputElement>();
-    #expirationDateInputRef = createRef<HTMLInputElement>();
-
-    //#endregion
+    @state()
+    protected expiresAt: string | null = createExpirationValue();
 
     //#region Properties
 
@@ -87,12 +86,23 @@ export class ServiceAccountForm extends Form<UserServiceAccountRequest> {
         (this.parentElement as ModalForm).showSubmitButton = true;
     }
 
+    //#region Event Listeners
+
+    #expiringChangeListener = (event: Event) => {
+        const expiringElement = event.target as HTMLInputElement;
+
+        this.expiresAt = expiringElement.checked ? createExpirationValue() : null;
+    };
+
+    //#endregion
+
+    //#region Rendering
+
     renderForm(): TemplateResult {
         return html`<ak-text-input
                 name="name"
                 label=${msg("Username")}
                 placeholder=${msg("Type a username for the user...")}
-                autocomplete="off"
                 value=""
                 input-hint="code"
                 required
@@ -110,35 +120,32 @@ export class ServiceAccountForm extends Form<UserServiceAccountRequest> {
             >
             </ak-switch-input>
 
-            <ak-form-element-horizontal name="expiring">
-                <label class="pf-c-switch">
-                    <input
-                        ${ref(this.#expiringInputRef)}
-                        class="pf-c-switch__input"
-                        type="checkbox"
-                        checked
-                        @change=${this.expiringChangeListener}
-                    />
-                    <span class="pf-c-switch__toggle">
-                        <span class="pf-c-switch__toggle-icon">
-                            <i class="fas fa-check" aria-hidden="true"></i>
-                        </span>
-                    </span>
-                    <span class="pf-c-switch__label">${msg("Expiring")}</span>
-                </label>
-                <p class="pf-c-form__helper-text">
-                    ${msg(
-                        "Whether the token will expire. Upon expiration, the token will be rotated.",
-                    )}
-                </p>
-            </ak-form-element-horizontal>
+            <ak-switch-input
+                name="expiring"
+                label=${msg("Expiring")}
+                help=${msg(
+                    "Whether the token will expire. Upon expiration, the token will be rotated.",
+                )}
+                @change=${this.#expiringChangeListener}
+                ?checked=${this.expiresAt}
+            ></ak-switch-input>
 
-            <ak-form-element-horizontal label=${msg("Expires on")} name="expires">
+            <ak-form-element-horizontal name="expires">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "expiration-date-input",
+                    },
+                    msg("Expires on"),
+                )}
+
                 <input
-                    ${ref(this.#expirationDateInputRef)}
+                    id="expiration-date-input"
                     type="datetime-local"
                     data-type="datetime-local"
-                    value="${this.#initialExpirationValue}"
+                    value=${this.expiresAt ?? ""}
+                    ?disabled=${!this.expiresAt}
                     class="pf-c-form-control"
                 />
             </ak-form-element-horizontal>`;
@@ -173,21 +180,14 @@ export class ServiceAccountForm extends Form<UserServiceAccountRequest> {
             </form>`;
     }
 
-    expiringChangeListener = () => {
-        const expiringElement = this.#expiringInputRef.value;
-        const expirationDateElement = this.#expirationDateInputRef.value;
-
-        if (!expiringElement || !expirationDateElement) return;
-
-        expirationDateElement.disabled = !expiringElement.checked;
-    };
-
     renderFormWrapper(): TemplateResult {
         if (this.result) {
             return this.renderResponseForm();
         }
         return super.renderFormWrapper();
     }
+
+    //#endregion
 }
 
 declare global {

--- a/web/src/admin/users/ServiceAccountForm.ts
+++ b/web/src/admin/users/ServiceAccountForm.ts
@@ -26,14 +26,12 @@ import { html, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
-const createExpirationValue = () => {
-    return dateTimeLocal(new Date(Date.now() + 1000 * 60 ** 2 * 24 * 360));
-};
+const EXPIRATION_DURATION = 1000 * 60 ** 2 * 24 * 360; // 360 days
 
 @customElement("ak-user-service-account-form")
 export class ServiceAccountForm extends Form<UserServiceAccountRequest> {
     @state()
-    protected expiresAt: string | null = createExpirationValue();
+    protected expiresAt: string | null = dateTimeLocal(Date.now() + EXPIRATION_DURATION);
 
     //#region Properties
 
@@ -91,7 +89,9 @@ export class ServiceAccountForm extends Form<UserServiceAccountRequest> {
     #expiringChangeListener = (event: Event) => {
         const expiringElement = event.target as HTMLInputElement;
 
-        this.expiresAt = expiringElement.checked ? createExpirationValue() : null;
+        this.expiresAt = expiringElement.checked
+            ? dateTimeLocal(Date.now() + EXPIRATION_DURATION)
+            : null;
     };
 
     //#endregion

--- a/web/src/admin/users/ServiceAccountForm.ts
+++ b/web/src/admin/users/ServiceAccountForm.ts
@@ -97,6 +97,7 @@ export class ServiceAccountForm extends Form<UserServiceAccountRequest> {
                 input-hint="code"
                 required
                 maxlength=${150}
+                autofocus
                 help=${msg(
                     "The user's primary identifier used for authentication. 150 characters or fewer.",
                 )}

--- a/web/src/admin/users/ServiceAccountForm.ts
+++ b/web/src/admin/users/ServiceAccountForm.ts
@@ -31,7 +31,7 @@ const EXPIRATION_DURATION = 1000 * 60 ** 2 * 24 * 360; // 360 days
 @customElement("ak-user-service-account-form")
 export class ServiceAccountForm extends Form<UserServiceAccountRequest> {
     @state()
-    protected expiresAt: string | null = dateTimeLocal(Date.now() + EXPIRATION_DURATION);
+    protected expiresAt: Date | null = new Date(Date.now() + EXPIRATION_DURATION);
 
     //#region Properties
 
@@ -90,7 +90,7 @@ export class ServiceAccountForm extends Form<UserServiceAccountRequest> {
         const expiringElement = event.target as HTMLInputElement;
 
         this.expiresAt = expiringElement.checked
-            ? dateTimeLocal(Date.now() + EXPIRATION_DURATION)
+            ? new Date(Date.now() + EXPIRATION_DURATION)
             : null;
     };
 
@@ -144,7 +144,7 @@ export class ServiceAccountForm extends Form<UserServiceAccountRequest> {
                     id="expiration-date-input"
                     type="datetime-local"
                     data-type="datetime-local"
-                    value=${this.expiresAt ?? ""}
+                    value=${this.expiresAt ? dateTimeLocal(this.expiresAt) : ""}
                     ?disabled=${!this.expiresAt}
                     class="pf-c-form-control"
                 />

--- a/web/src/common/temporal.ts
+++ b/web/src/common/temporal.ts
@@ -98,7 +98,9 @@ export function formatElapsedTime(d1: Date, d2: Date = new Date()): string {
  * Additionally, `toISOString` always returns the date without timezone,
  * which we would like to include for better usability
  */
-export function dateTimeLocal(input: Date): string {
+export function dateTimeLocal(input: Date | number = new Date()): string {
+    input = typeof input === "number" ? new Date(input) : input;
+
     const tzOffset = new Date().getTimezoneOffset() * 60_000; //offset in milliseconds
     const localISOTime = new Date(input.getTime() - tzOffset).toISOString().slice(0, -1);
 

--- a/web/src/components/ak-text-input.ts
+++ b/web/src/components/ak-text-input.ts
@@ -40,7 +40,7 @@ export class AkTextInput extends HorizontalLightComponent<string> {
     public override renderControl() {
         const code = this.inputHint === "code";
 
-        return html` <input
+        return html`<input
             type=${this.type}
             id=${ifDefined(this.fieldID)}
             @input=${this.#inputListener}
@@ -57,6 +57,8 @@ export class AkTextInput extends HorizontalLightComponent<string> {
             placeholder=${ifPresent(this.placeholder)}
             inputmode=${this.inputMode}
             ?required=${this.required}
+            ?autofocus=${this.autofocus}
+            ${this.autofocusTarget.toRef()}
         />`;
     }
 }

--- a/web/src/flow/stages/authenticator_email/AuthenticatorEmailStage.ts
+++ b/web/src/flow/stages/authenticator_email/AuthenticatorEmailStage.ts
@@ -65,7 +65,7 @@ export class AuthenticatorEmailStage extends BaseStage<
                         type="email"
                         name="email"
                         placeholder="${msg("Please enter your email address.")}"
-                        autofocus=""
+                        autofocus
                         autocomplete="email"
                         class="pf-c-form-control"
                         required
@@ -112,7 +112,7 @@ export class AuthenticatorEmailStage extends BaseStage<
                         inputmode="numeric"
                         pattern="[0-9]*"
                         placeholder="${msg("Please enter the code you received via email")}"
-                        autofocus=""
+                        autofocus
                         autocomplete="one-time-code"
                         class="pf-c-form-control pf-m-monospace"
                         required

--- a/web/src/flow/stages/authenticator_sms/AuthenticatorSMSStage.ts
+++ b/web/src/flow/stages/authenticator_sms/AuthenticatorSMSStage.ts
@@ -65,7 +65,7 @@ export class AuthenticatorSMSStage extends BaseStage<
                         type="tel"
                         name="phoneNumber"
                         placeholder="${msg("Please enter your Phone number.")}"
-                        autofocus=""
+                        autofocus
                         autocomplete="tel"
                         class="pf-c-form-control"
                         required
@@ -110,7 +110,7 @@ export class AuthenticatorSMSStage extends BaseStage<
                         inputmode="numeric"
                         pattern="[0-9]*"
                         placeholder="${msg("Please enter the code you received via SMS")}"
-                        autofocus=""
+                        autofocus
                         autocomplete="one-time-code"
                         class="pf-c-form-control pf-m-monospace"
                         required

--- a/web/src/flow/stages/identification/IdentificationStage.ts
+++ b/web/src/flow/stages/identification/IdentificationStage.ts
@@ -435,7 +435,7 @@ export class IdentificationStage extends BaseStage<
                     type=${type}
                     name="uidField"
                     placeholder=${label}
-                    autofocus=""
+                    autofocus
                     autocomplete=${autocomplete}
                     spellcheck="false"
                     class="pf-c-form-control"


### PR DESCRIPTION
## Details

This PR fixes a few issues discovered while testing the creation of authentication tokens for users, device enrollment, and similar interactions on forms with expiration fields.

- Fixed issue where autofocus is not consistently applied when creating a token or service user
- Fixed an issue where labels are misaligned with their sibling fields
- Fixed expiration date time fields not consistently disabling when expiration is toggled
- Fixed issue where editing a token may not show itself in a search select element if the paginated response does not include it
- Fixed field/label association for screen readers