### PR TITLE
web: disable user settings fields when changes are not allowed

### DIFF
--- a/web/src/flow/stages/prompt/PromptStage.ts
+++ b/web/src/flow/stages/prompt/PromptStage.ts
@@ -59,7 +59,7 @@ export class PromptStage extends WithCapabilitiesConfig(
         `,
     ];
 
-    renderPromptInner(prompt: StagePrompt): TemplateResult {
+    renderPromptInner(prompt: StagePrompt, disabled = false): TemplateResult {
         const fieldId = `field-${prompt.fieldKey}`;
 
         switch (prompt.type) {
@@ -71,6 +71,7 @@ export class PromptStage extends WithCapabilitiesConfig(
                     placeholder="${prompt.placeholder}"
                     autocomplete="off"
                     class="pf-c-form-control"
+                    ?disabled=${disabled}
                     ?required=${prompt.required}
                     value="${prompt.initialValue}"
                 />`;
@@ -81,6 +82,7 @@ export class PromptStage extends WithCapabilitiesConfig(
                     placeholder="${prompt.placeholder}"
                     autocomplete="off"
                     class="pf-c-form-control"
+                    ?disabled=${disabled}
                     ?required=${prompt.required}
                 >
 ${prompt.initialValue}</textarea
@@ -114,6 +116,7 @@ ${prompt.initialValue}</textarea
                     autocomplete="username"
                     spellcheck="false"
                     class="pf-c-form-control"
+                    ?disabled=${disabled}
                     ?required=${prompt.required}
                     value="${prompt.initialValue}"
                 />`;
@@ -125,6 +128,7 @@ ${prompt.initialValue}</textarea
                     name="${prompt.fieldKey}"
                     placeholder="${prompt.placeholder}"
                     class="pf-c-form-control"
+                    ?disabled=${disabled}
                     ?required=${prompt.required}
                     value="${prompt.initialValue}"
                 />`;
@@ -136,6 +140,7 @@ ${prompt.initialValue}</textarea
                     placeholder="${prompt.placeholder}"
                     autocomplete="new-password"
                     class="pf-c-form-control"
+                    ?disabled=${disabled}
                     ?required=${prompt.required}
                 />`;
             case PromptTypeEnum.Number:
@@ -145,6 +150,7 @@ ${prompt.initialValue}</textarea
                     name="${prompt.fieldKey}"
                     placeholder="${prompt.placeholder}"
                     class="pf-c-form-control"
+                    ?disabled=${disabled}
                     ?required=${prompt.required}
                     value="${prompt.initialValue}"
                 />`;
@@ -155,6 +161,7 @@ ${prompt.initialValue}</textarea
                     name="${prompt.fieldKey}"
                     placeholder="${prompt.placeholder}"
                     class="pf-c-form-control"
+                    ?disabled=${disabled}
                     ?required=${prompt.required}
                     value="${prompt.initialValue}"
                 />`;
@@ -165,6 +172,7 @@ ${prompt.initialValue}</textarea
                     name="${prompt.fieldKey}"
                     placeholder="${prompt.placeholder}"
                     class="pf-c-form-control"
+                    ?disabled=${disabled}
                     ?required=${prompt.required}
                     value="${prompt.initialValue}"
                 />`;
@@ -175,6 +183,7 @@ ${prompt.initialValue}</textarea
                     name="${prompt.fieldKey}"
                     placeholder="${prompt.placeholder}"
                     class="pf-c-form-control"
+                    ?disabled=${disabled}
                     ?required=${prompt.required}
                     value="${prompt.initialValue}"
                 />`;
@@ -192,7 +201,11 @@ ${prompt.initialValue}</textarea
             case PromptTypeEnum.Static:
                 return html`<p>${unsafeHTML(prompt.initialValue)}</p>`;
             case PromptTypeEnum.Dropdown:
-                return html`<select class="pf-c-form-control" name="${prompt.fieldKey}">
+                return html`<select
+                    class="pf-c-form-control"
+                    name="${prompt.fieldKey}"
+                    ?disabled=${disabled}
+                >
                     ${prompt.choices?.map((choice) => {
                         return html`<option
                             value="${choice.value}"
@@ -212,6 +225,7 @@ ${prompt.initialValue}</textarea
                             name="${prompt.fieldKey}"
                             id="${id}"
                             ?checked="${prompt.initialValue === choice.value}"
+                            ?disabled=${disabled}
                             ?required="${prompt.required}"
                             value="${choice.value}"
                         />
@@ -229,6 +243,7 @@ ${prompt.initialValue}</textarea
                     class="pf-c-form-control ak-m-capitalize"
                     id=${fieldId}
                     name="${prompt.fieldKey}"
+                    ?disabled=${disabled}
                     aria-label=${msg("Select language", {
                         id: "language-selector-label",
                         desc: "Label for the language selection dropdown",

--- a/web/src/user/user-settings/details/stages/prompt/PromptStage.ts
+++ b/web/src/user/user-settings/details/stages/prompt/PromptStage.ts
@@ -59,8 +59,6 @@ export class UserSettingsPromptStage extends PromptStage {
     }
 
     renderPromptInner(prompt: StagePrompt): TemplateResult {
-        const fieldId = `field-${prompt.fieldKey}`;
-
         if (prompt.type === PromptTypeEnum.Checkbox) {
             return html`<input
                 type="checkbox"
@@ -72,60 +70,8 @@ export class UserSettingsPromptStage extends PromptStage {
             />`;
         }
 
-        // Check if email field should be read-only
-        if (
-            prompt.type === PromptTypeEnum.Email &&
-            this.settings?.defaultUserChangeEmail === false
-        ) {
-            return html`<input
-                type="email"
-                id=${fieldId}
-                autocomplete="email"
-                name="${prompt.fieldKey}"
-                placeholder="${prompt.placeholder}"
-                class="pf-c-form-control"
-                disabled
-                value="${prompt.initialValue}"
-            />`;
-        }
-
-        // Check if username field should be read-only
-        if (
-            prompt.type === PromptTypeEnum.Username &&
-            this.settings?.defaultUserChangeUsername === false
-        ) {
-            return html`<input
-                type="text"
-                id=${fieldId}
-                name="${prompt.fieldKey}"
-                placeholder="${prompt.placeholder}"
-                autocomplete="username"
-                spellcheck="false"
-                class="pf-c-form-control"
-                disabled
-                value="${prompt.initialValue}"
-            />`;
-        }
-
-        // Check if name field should be read-only (text field with fieldKey "name")
-        if (
-            prompt.type === PromptTypeEnum.Text &&
-            prompt.fieldKey === "name" &&
-            this.settings?.defaultUserChangeName === false
-        ) {
-            return html`<input
-                type="text"
-                id=${fieldId}
-                name="${prompt.fieldKey}"
-                placeholder="${prompt.placeholder}"
-                autocomplete="off"
-                class="pf-c-form-control"
-                disabled
-                value="${prompt.initialValue}"
-            />`;
-        }
-
-        return super.renderPromptInner(prompt);
+        const disabled = this.isFieldReadOnly(prompt);
+        return super.renderPromptInner(prompt, disabled);
     }
 
     renderField(prompt: StagePrompt): TemplateResult {


### PR DESCRIPTION
Previously, when admins disabled the ability to change email, username, or name in System Settings, users would only see an error after attempting to submit the form.

Now, the field is marked as disabled.

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
