### PR TITLE
website/integrations: vaultwarden: add custom email scope

### DIFF
--- a/website/integrations/security/vaultwarden/index.md
+++ b/website/integrations/security/vaultwarden/index.md
@@ -27,12 +27,9 @@ To support the integration of Vaultwarden with authentik, you need to create an 
 
 ### Create custom scope mapping
 
-Vaultwarden either requires the email scope to return a true value for whether the email address is verified, or no
-value at all. As of [authentik
-2025.10](https://docs.goauthentik.io/releases/2025.10/#default-oauth-scope-mappings) the default behavior is to return `email_verified: False`, so a custom scope
-mapping is required for Vaultwarden to allow authentication.
+Vaultwarden either requires the email scope to return a true value for whether the email address is verified, or no value at all. As of [authentik 2025.10](https://docs.goauthentik.io/releases/2025.10/#default-oauth-scope-mappings) the default behavior is to return `email_verified: False`, so a custom scope mapping is required for Vaultwarden to allow authentication.
 
-1. Log into authentik as admin and open the authentik Admin interface
+1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Customization** > **Property Mappings** and click **Create**.
     - **Select type**: select **Scope Mapping**.
     - **Configure the Scope Mapping**: Provide a descriptive name (e.g. `Vaultwarden Email Scope`), and an optional description.
@@ -70,7 +67,7 @@ mapping is required for Vaultwarden to allow authentication.
 
 To configure authentik with Vaultwarden, you must add the following environment variables to your Vaultwarden deployment:
 
-```yamlhospital
+```yaml
 SSO_ENABLED=true
 SSO_AUTHORITY=https://authentik.company/application/o/<application_slug>/
 SSO_CLIENT_ID=<client_id>


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
As of a default behavior change in authentik 2025.10, Vaultwarden now needs a custom scope mapping to return a functional value for `email_verified` in the email scope request. See https://github.com/dani-garcia/vaultwarden/issues/6642 for details.

I apologize for not completing the linting and build testing checklist below, my system seems to really hate your build packages, but I was able to run `make integrations-watch` and the site looks good, most of my changes are based on the formatting from the Bitwarden integration so hopefully nothing is too out of sorts.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
