### PR TITLE
web: Defer table refresh, visibility checks.

### DIFF
--- a/web/src/elements/ak-progress-bar.ts
+++ b/web/src/elements/ak-progress-bar.ts
@@ -64,19 +64,19 @@ export class ProgressBar extends AKElement {
         `,
     ];
 
-    @property({ type: Number })
+    @property({ type: Number, reflect: true, useDefault: true })
     public min = 0;
 
-    @property({ type: Number })
+    @property({ type: Number, reflect: true, useDefault: true })
     public max = 100;
 
-    @property({ type: Number })
+    @property({ type: Number, reflect: true, useDefault: true })
     public value = 0;
 
-    @property({ type: Boolean })
+    @property({ type: Boolean, reflect: true, useDefault: true })
     public indeterminate = false;
 
-    @property({ type: String })
+    @property({ type: String, reflect: true, useDefault: true })
     public size: PFSize = PFSize.Medium;
 
     @property({ type: String })
@@ -105,7 +105,7 @@ export class ProgressBar extends AKElement {
                   `
                 : nothing}
             <div
-                class="pf-c-progress__bar"
+                class="pf-c-progress__bar ak-fade-in"
                 role="progressbar"
                 aria-valuemin=${this.min}
                 aria-valuemax=${this.max}

--- a/web/src/elements/forms/DeleteBulkForm.ts
+++ b/web/src/elements/forms/DeleteBulkForm.ts
@@ -12,7 +12,7 @@ import { SlottedTemplateResult } from "#elements/types";
 import { UsedBy, UsedByActionEnum } from "@goauthentik/api";
 
 import { msg, str } from "@lit/localize";
-import { CSSResult, html, nothing, TemplateResult } from "lit";
+import { CSSResult, html, nothing, PropertyValues, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { until } from "lit/directives/until.js";
 
@@ -79,9 +79,9 @@ export class DeleteObjectsTable<T extends object> extends Table<T> {
         return nothing;
     }
 
-    firstUpdated(): void {
+    firstUpdated(changedProperties: PropertyValues<this>): void {
         this.expandable = this.usedBy !== undefined;
-        super.firstUpdated();
+        super.firstUpdated(changedProperties);
     }
 
     renderExpanded(item: T): TemplateResult {

--- a/web/src/elements/table/Table.css
+++ b/web/src/elements/table/Table.css
@@ -146,6 +146,7 @@ time {
 }
 
 :host {
+    display: block;
     container-type: inline-size;
 }
 

--- a/web/src/styles/authentik/base/common.css
+++ b/web/src/styles/authentik/base/common.css
@@ -67,6 +67,29 @@
 
 /* #endregion */
 
+/* #region Animations */
+
+@keyframes ak-fade-in {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
+.ak-fade-in {
+    opacity: 0;
+    animation-fill-mode: forwards;
+    animation-name: ak-fade-in;
+    animation-duration: 150ms;
+    animation-iteration-count: 1;
+    animation-timing-function: linear;
+    animation-delay: 500ms;
+}
+
+/* #endregion */
+
 /* #region Dark Theme */
 
 /**


### PR DESCRIPTION
## Details

This PR defers table `fetch` calls after the element becomes visible, fixing excessive API requests on tabbed layouts.