### PR TITLE
website/docs: rewrite section about users and perms

### DIFF
--- a/website/docs/users-sources/user/user_basic_operations.md
+++ b/website/docs/users-sources/user/user_basic_operations.md
@@ -79,9 +79,11 @@ After the creation of the user, you can edit any parameter defined during the cr
 
 To modify a user object, go to **Directory** > **Users**, and click the edit icon beside the name. You can also go into [user details](#view-user-details), and click **Edit**.
 
-## Assign, modify, or remove permissions for a user
+## Manage user permissions
 
-You can grant a user specific global or object-level permissions. Alternatively, you can add a user to a group that has the appropriate permissions, and the user inherits all of the group's permissions.
+You cannot grant a user any permissions. Instead, either assign the user to a role with the appropriate permissions, or add a user to a group that has the appropriate permissions (via the group's role).
+
+You can however grant _object_ permissions on a user, meaning you can define what permissions any specific role has on that user object (what can be done TO that user object, not by that user).
 
 For more information, review ["Permissions"](../access-control/permissions.md).
 

--- a/website/docs/users-sources/user/user_basic_operations.md
+++ b/website/docs/users-sources/user/user_basic_operations.md
@@ -81,11 +81,9 @@ To modify a user object, go to **Directory** > **Users**, and click the edit ico
 
 ## Manage user permissions
 
-You cannot grant a user any permissions. Instead, either assign the user to a role with the appropriate permissions, or add a user to a group that has the appropriate permissions (via the group's role).
+You cannot directly grant a user any permissions. Instead, either assign the user to a role with the appropriate permissions, or add a user to a group that has the appropriate permissions (via the group's role/roles).
 
-You can however grant _object_ permissions on a user, meaning you can define what permissions any specific role has on that user object (what can be done TO that user object, not by that user).
-
-For more information, review ["Permissions"](../access-control/permissions.md).
+On the flipside, to grant permissions on a user object to a role, review ["Manage permissions"](../access-control/manage_permissions.md#assign-or-remove-permissions-for-a-specific-role).
 
 ## Add a user to a group
 


### PR DESCRIPTION
This PR fixes a section in the docs about user perms; rewrote to make it clear that you cannot assign perms to a user, only a role. Also changed header/title...

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
