### PR TITLE
Update OpenID redirect URI for Guacamole

### DIFF
--- a/website/integrations/infrastructure/apache-guacamole/index.mdx
+++ b/website/integrations/infrastructure/apache-guacamole/index.mdx
@@ -66,7 +66,7 @@ Docker containers are typically configured using environment variables. To ensur
     OPENID_CLIENT_ID=<Client ID from authentik>
     OPENID_ISSUER=https://authentik.company/application/o/<application_slug>/
     OPENID_JWKS_ENDPOINT=https://authentik.company/application/o/<application_slug>/jwks/
-    OPENID_REDIRECT_URI=https://guacamole.company/
+    OPENID_REDIRECT_URI=https://guacamole.company/guacamole
     OPENID_USERNAME_CLAIM_TYPE=preferred_username
     OPENID_ENABLED=true
     ```


### PR DESCRIPTION
I believe the bare redirect URI is incorrect, and needs to end with /guacamole.  At least, that's what was needed in my bare-bones setup, and I presume for all.

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
