### PR TITLE
revert: web: disable user settings fields when changes are not allowed

### DIFF
--- a/web/src/flow/stages/prompt/PromptStage.ts
+++ b/web/src/flow/stages/prompt/PromptStage.ts
@@ -59,7 +59,7 @@ export class PromptStage extends WithCapabilitiesConfig(
         `,
     ];
 
-    renderPromptInner(prompt: StagePrompt, disabled = false): TemplateResult {
+    renderPromptInner(prompt: StagePrompt): TemplateResult {
         const fieldId = `field-${prompt.fieldKey}`;
 
         switch (prompt.type) {
@@ -71,7 +71,6 @@ export class PromptStage extends WithCapabilitiesConfig(
                     placeholder="${prompt.placeholder}"
                     autocomplete="off"
                     class="pf-c-form-control"
-                    ?disabled=${disabled}
                     ?required=${prompt.required}
                     value="${prompt.initialValue}"
                 />`;
@@ -82,7 +81,6 @@ export class PromptStage extends WithCapabilitiesConfig(
                     placeholder="${prompt.placeholder}"
                     autocomplete="off"
                     class="pf-c-form-control"
-                    ?disabled=${disabled}
                     ?required=${prompt.required}
                 >
 ${prompt.initialValue}</textarea
@@ -116,7 +114,6 @@ ${prompt.initialValue}</textarea
                     autocomplete="username"
                     spellcheck="false"
                     class="pf-c-form-control"
-                    ?disabled=${disabled}
                     ?required=${prompt.required}
                     value="${prompt.initialValue}"
                 />`;
@@ -128,7 +125,6 @@ ${prompt.initialValue}</textarea
                     name="${prompt.fieldKey}"
                     placeholder="${prompt.placeholder}"
                     class="pf-c-form-control"
-                    ?disabled=${disabled}
                     ?required=${prompt.required}
                     value="${prompt.initialValue}"
                 />`;
@@ -140,7 +136,6 @@ ${prompt.initialValue}</textarea
                     placeholder="${prompt.placeholder}"
                     autocomplete="new-password"
                     class="pf-c-form-control"
-                    ?disabled=${disabled}
                     ?required=${prompt.required}
                 />`;
             case PromptTypeEnum.Number:
@@ -150,7 +145,6 @@ ${prompt.initialValue}</textarea
                     name="${prompt.fieldKey}"
                     placeholder="${prompt.placeholder}"
                     class="pf-c-form-control"
-                    ?disabled=${disabled}
                     ?required=${prompt.required}
                     value="${prompt.initialValue}"
                 />`;
@@ -161,7 +155,6 @@ ${prompt.initialValue}</textarea
                     name="${prompt.fieldKey}"
                     placeholder="${prompt.placeholder}"
                     class="pf-c-form-control"
-                    ?disabled=${disabled}
                     ?required=${prompt.required}
                     value="${prompt.initialValue}"
                 />`;
@@ -172,7 +165,6 @@ ${prompt.initialValue}</textarea
                     name="${prompt.fieldKey}"
                     placeholder="${prompt.placeholder}"
                     class="pf-c-form-control"
-                    ?disabled=${disabled}
                     ?required=${prompt.required}
                     value="${prompt.initialValue}"
                 />`;
@@ -183,7 +175,6 @@ ${prompt.initialValue}</textarea
                     name="${prompt.fieldKey}"
                     placeholder="${prompt.placeholder}"
                     class="pf-c-form-control"
-                    ?disabled=${disabled}
                     ?required=${prompt.required}
                     value="${prompt.initialValue}"
                 />`;
@@ -201,11 +192,7 @@ ${prompt.initialValue}</textarea
             case PromptTypeEnum.Static:
                 return html`<p>${unsafeHTML(prompt.initialValue)}</p>`;
             case PromptTypeEnum.Dropdown:
-                return html`<select
-                    class="pf-c-form-control"
-                    name="${prompt.fieldKey}"
-                    ?disabled=${disabled}
-                >
+                return html`<select class="pf-c-form-control" name="${prompt.fieldKey}">
                     ${prompt.choices?.map((choice) => {
                         return html`<option
                             value="${choice.value}"
@@ -225,7 +212,6 @@ ${prompt.initialValue}</textarea
                             name="${prompt.fieldKey}"
                             id="${id}"
                             ?checked="${prompt.initialValue === choice.value}"
-                            ?disabled=${disabled}
                             ?required="${prompt.required}"
                             value="${choice.value}"
                         />
@@ -243,7 +229,6 @@ ${prompt.initialValue}</textarea
                     class="pf-c-form-control ak-m-capitalize"
                     id=${fieldId}
                     name="${prompt.fieldKey}"
-                    ?disabled=${disabled}
                     aria-label=${msg("Select language", {
                         id: "language-selector-label",
                         desc: "Label for the language selection dropdown",

--- a/web/src/user/user-settings/details/stages/prompt/PromptStage.ts
+++ b/web/src/user/user-settings/details/stages/prompt/PromptStage.ts
@@ -1,63 +1,20 @@
 import "#elements/forms/HorizontalFormElement";
 import "#flow/components/ak-flow-card";
 
-import { DEFAULT_CONFIG } from "#common/api/config";
 import { globalAK } from "#common/global";
 
 import { AKLabel } from "#components/ak-label";
 
 import { PromptStage } from "#flow/stages/prompt/PromptStage";
 
-import { AdminApi, PromptTypeEnum, Settings, StagePrompt } from "@goauthentik/api";
+import { PromptTypeEnum, StagePrompt } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
 import { html, nothing, TemplateResult } from "lit";
-import { customElement, state } from "lit/decorators.js";
+import { customElement } from "lit/decorators.js";
 
 @customElement("ak-user-stage-prompt")
 export class UserSettingsPromptStage extends PromptStage {
-    @state()
-    private settings?: Settings;
-
-    constructor() {
-        super();
-        new AdminApi(DEFAULT_CONFIG).adminSettingsRetrieve().then((settings) => {
-            this.settings = settings;
-        });
-    }
-
-    isFieldReadOnly(prompt: StagePrompt): boolean {
-        if (
-            prompt.type === PromptTypeEnum.Email &&
-            this.settings?.defaultUserChangeEmail === false
-        ) {
-            return true;
-        }
-        if (
-            prompt.type === PromptTypeEnum.Username &&
-            this.settings?.defaultUserChangeUsername === false
-        ) {
-            return true;
-        }
-        if (
-            prompt.type === PromptTypeEnum.Text &&
-            prompt.fieldKey === "name" &&
-            this.settings?.defaultUserChangeName === false
-        ) {
-            return true;
-        }
-        return false;
-    }
-
-    renderPromptHelpText(prompt: StagePrompt) {
-        if (this.isFieldReadOnly(prompt)) {
-            return html`<p class="pf-c-form__helper-text">
-                ${msg("Not allowed to change this field. Please contact your administrator.")}
-            </p>`;
-        }
-        return super.renderPromptHelpText(prompt);
-    }
-
     renderPromptInner(prompt: StagePrompt): TemplateResult {
         if (prompt.type === PromptTypeEnum.Checkbox) {
             return html`<input
@@ -70,8 +27,7 @@ export class UserSettingsPromptStage extends PromptStage {
             />`;
         }
 
-        const disabled = this.isFieldReadOnly(prompt);
-        return super.renderPromptInner(prompt, disabled);
+        return super.renderPromptInner(prompt);
     }
 
     renderField(prompt: StagePrompt): TemplateResult {


### PR DESCRIPTION
Reverts goauthentik/authentik#19132

cc @dominic-r 

regular users won't have permission to access this API, and also this setting can be configured on a per-user level with attributes which this doesn't check