### PR TITLE
web: Flow info, localization, back button.

### DIFF
--- a/web/src/flow/FormStatic.ts
+++ b/web/src/flow/FormStatic.ts
@@ -1,22 +1,38 @@
 import { AKElement } from "#elements/Base";
+import { LitFC } from "#elements/types";
 import { isDefaultAvatar } from "#elements/utils/images";
+
+import {
+    AccessDeniedChallenge,
+    AuthenticatorDuoChallenge,
+    AuthenticatorEmailChallenge,
+    AuthenticatorStaticChallenge,
+    AuthenticatorTOTPChallenge,
+    AuthenticatorWebAuthnChallenge,
+    CaptchaChallenge,
+    ConsentChallenge,
+    PasswordChallenge,
+    SessionEndChallenge,
+    UserLoginChallenge,
+} from "@goauthentik/api";
 
 import { msg, str } from "@lit/localize";
 import { css, CSSResult, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
+import { guard } from "lit/directives/guard.js";
 
 import PFAvatar from "@patternfly/patternfly/components/Avatar/avatar.css";
 
 @customElement("ak-form-static")
-export class FormStatic extends AKElement {
+export class AKFormStatic extends AKElement {
     public override role = "banner";
     public override ariaLabel = msg("User information");
 
-    @property()
-    userAvatar?: string;
+    @property({ type: String })
+    public avatar: string = "";
 
-    @property()
-    user?: string;
+    @property({ type: String })
+    public username: string = "";
 
     static styles: CSSResult[] = [
         PFAvatar,
@@ -64,21 +80,27 @@ export class FormStatic extends AKElement {
         `,
     ];
 
-    render() {
-        if (!this.user) {
+    protected override render() {
+        if (!this.username) {
             return nothing;
         }
 
         return html`
             <div class="primary-content">
-                ${this.userAvatar && !isDefaultAvatar(this.userAvatar)
+                ${this.avatar && !isDefaultAvatar(this.avatar)
                     ? html`<img
                           class="pf-c-avatar"
-                          src=${this.userAvatar}
-                          alt=${this.user ? msg(str`Avatar for ${this.user}`) : msg("User avatar")}
+                          src=${this.avatar}
+                          alt=${this.username
+                              ? msg(str`Avatar for ${this.username}`, {
+                                    id: "avatar.alt-text-for-user",
+                                })
+                              : msg("User avatar", {
+                                    id: "avatar.alt-text",
+                                })}
                       />`
                     : nothing}
-                <div class="username" aria-description=${msg("Username")}>${this.user}</div>
+                <div class="username" aria-description=${msg("Username")}>${this.username}</div>
             </div>
             <div class="links">
                 <slot name="link"></slot>
@@ -87,8 +109,51 @@ export class FormStatic extends AKElement {
     }
 }
 
+/**
+ * @internal
+ */
+export type FormStaticChallenge =
+    | SessionEndChallenge
+    | AccessDeniedChallenge
+    | AuthenticatorDuoChallenge
+    | AuthenticatorEmailChallenge
+    | AuthenticatorStaticChallenge
+    | AuthenticatorTOTPChallenge
+    | AuthenticatorWebAuthnChallenge
+    | CaptchaChallenge
+    | ConsentChallenge
+    | PasswordChallenge
+    | UserLoginChallenge;
+
+export interface FlowUserDetailsProps {
+    challenge?: Partial<
+        Pick<FormStaticChallenge, "pendingUserAvatar" | "pendingUser" | "flowInfo">
+    >;
+}
+
+export const FlowUserDetails: LitFC<FlowUserDetailsProps> = ({ challenge }) => {
+    const { pendingUserAvatar, pendingUser, flowInfo } = challenge || {};
+    return guard(
+        [pendingUserAvatar, pendingUser, flowInfo],
+        () =>
+            html`<ak-form-static
+                class="pf-c-form__group"
+                avatar=${pendingUserAvatar}
+                username=${pendingUser}
+            >
+                ${flowInfo?.cancelUrl
+                    ? html`
+                          <div slot="link">
+                              <a href=${flowInfo.cancelUrl}>${msg("Not you?")}</a>
+                          </div>
+                      `
+                    : nothing}
+            </ak-form-static>`,
+    );
+};
+
 declare global {
     interface HTMLElementTagNameMap {
-        "ak-form-static": FormStatic;
+        "ak-form-static": AKFormStatic;
     }
 }

--- a/web/src/flow/FormStatic.ts
+++ b/web/src/flow/FormStatic.ts
@@ -1,5 +1,6 @@
 import { AKElement } from "#elements/Base";
 import { LitFC } from "#elements/types";
+import { ifPresent } from "#elements/utils/attributes";
 import { isDefaultAvatar } from "#elements/utils/images";
 
 import {
@@ -138,8 +139,8 @@ export const FlowUserDetails: LitFC<FlowUserDetailsProps> = ({ challenge }) => {
         () =>
             html`<ak-form-static
                 class="pf-c-form__group"
-                avatar=${pendingUserAvatar}
-                username=${pendingUser}
+                avatar=${ifPresent(pendingUserAvatar)}
+                username=${ifPresent(pendingUser)}
             >
                 ${flowInfo?.cancelUrl
                     ? html`

--- a/web/src/flow/providers/SessionEnd.ts
+++ b/web/src/flow/providers/SessionEnd.ts
@@ -3,6 +3,7 @@ import "#flow/components/ak-flow-card";
 
 import { globalAK } from "#common/global";
 
+import { FlowUserDetails } from "#flow/FormStatic";
 import { BaseStage } from "#flow/stages/base";
 
 import { SessionEndChallenge } from "@goauthentik/api";
@@ -10,7 +11,6 @@ import { SessionEndChallenge } from "@goauthentik/api";
 import { msg, str } from "@lit/localize";
 import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement } from "lit/decorators.js";
-import { ifDefined } from "lit/directives/if-defined.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFForm from "@patternfly/patternfly/components/Form/form.css";
@@ -26,17 +26,8 @@ export class SessionEnd extends BaseStage<SessionEndChallenge, unknown> {
     render(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>
             <form class="pf-c-form">
-                <ak-form-static
-                    class="pf-c-form__group"
-                    userAvatar="${this.challenge.pendingUserAvatar}"
-                    user=${this.challenge.pendingUser}
-                >
-                    <div slot="link">
-                        <a href="${ifDefined(this.challenge.flowInfo?.cancelUrl)}"
-                            >${msg("Not you?")}</a
-                        >
-                    </div>
-                </ak-form-static>
+                ${FlowUserDetails({ challenge: this.challenge })}
+
                 <p>
                     ${msg(
                         str`You've logged out of ${this.challenge.applicationName}. You can go back to the overview to launch another application, or log out of your authentik account.`,

--- a/web/src/flow/stages/access_denied/AccessDeniedStage.ts
+++ b/web/src/flow/stages/access_denied/AccessDeniedStage.ts
@@ -10,18 +10,25 @@ import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
+import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-stage-access-denied")
 export class AccessDeniedStage extends BaseStage<
     AccessDeniedChallenge,
     FlowChallengeResponseRequest
 > {
-    static styles: CSSResult[] = [PFBase, PFLogin, PFForm, PFTitle, PFFormControl];
+    static styles: CSSResult[] = [
+        // ---
+        PFLogin,
+        PFForm,
+        PFTitle,
+        PFFormControl,
+        PFButton,
+    ];
 
     render(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>
@@ -47,6 +54,17 @@ export class AccessDeniedStage extends BaseStage<
                           `
                         : nothing}
                 </ak-empty-state>
+                <fieldset class="pf-c-form__group pf-m-action">
+                    <legend class="sr-only">${msg("Form actions")}</legend>
+                    <a
+                        class="pf-c-button pf-m-primary pf-m-block"
+                        href=${this.challenge.flowInfo?.cancelUrl}
+                    >
+                        ${msg("Go back", {
+                            id: "flow.navigation.go-back",
+                        })}
+                    </a>
+                </fieldset>
             </form>
         </ak-flow-card>`;
     }

--- a/web/src/flow/stages/access_denied/AccessDeniedStage.ts
+++ b/web/src/flow/stages/access_denied/AccessDeniedStage.ts
@@ -44,17 +44,20 @@ export class AccessDeniedStage extends BaseStage<
                           `
                         : nothing}
                 </ak-empty-state>
-                <fieldset class="pf-c-form__group pf-m-action">
-                    <legend class="sr-only">${msg("Form actions")}</legend>
-                    <a
-                        class="pf-c-button pf-m-primary pf-m-block"
-                        href=${this.challenge.flowInfo?.cancelUrl}
-                    >
-                        ${msg("Go back", {
-                            id: "flow.navigation.go-back",
-                        })}
-                    </a>
-                </fieldset>
+                ${this.challenge.flowInfo?.cancelUrl
+                    ? html`<fieldset class="pf-c-form__group pf-m-action">
+                          <legend class="sr-only">${msg("Form actions")}</legend>
+                          <a
+                              class="pf-c-button pf-m-primary pf-m-block"
+                              href=${this.challenge.flowInfo?.cancelUrl}
+                          >
+                              ${msg("Go back", {
+                                  id: "flow.navigation.go-back",
+                              })}
+                          </a>
+                      </fieldset>`
+                    : nothing}
+                }
             </form>
         </ak-flow-card>`;
     }

--- a/web/src/flow/stages/access_denied/AccessDeniedStage.ts
+++ b/web/src/flow/stages/access_denied/AccessDeniedStage.ts
@@ -1,6 +1,7 @@
 import "#flow/FormStatic";
 import "#flow/components/ak-flow-card";
 
+import { FlowUserDetails } from "#flow/FormStatic";
 import { BaseStage } from "#flow/stages/base";
 
 import { AccessDeniedChallenge, FlowChallengeResponseRequest } from "@goauthentik/api";
@@ -8,7 +9,6 @@ import { AccessDeniedChallenge, FlowChallengeResponseRequest } from "@goauthenti
 import { msg } from "@lit/localize";
 import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement } from "lit/decorators.js";
-import { ifDefined } from "lit/directives/if-defined.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFForm from "@patternfly/patternfly/components/Form/form.css";
@@ -33,17 +33,7 @@ export class AccessDeniedStage extends BaseStage<
     render(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>
             <form class="pf-c-form">
-                <ak-form-static
-                    class="pf-c-form__group"
-                    userAvatar="${this.challenge?.pendingUserAvatar}"
-                    user=${this.challenge?.pendingUser}
-                >
-                    <div slot="link">
-                        <a href="${ifDefined(this.challenge.flowInfo?.cancelUrl)}"
-                            >${msg("Not you?")}</a
-                        >
-                    </div>
-                </ak-form-static>
+                ${FlowUserDetails({ challenge: this.challenge })}
                 <ak-empty-state icon="fa-times"
                     ><span>${msg("Request has been denied.")}</span>
                     ${this.challenge.errorMessage

--- a/web/src/flow/stages/authenticator_duo/AuthenticatorDuoStage.ts
+++ b/web/src/flow/stages/authenticator_duo/AuthenticatorDuoStage.ts
@@ -3,6 +3,7 @@ import "#flow/components/ak-flow-card";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
 
+import { FlowUserDetails } from "#flow/FormStatic";
 import { BaseStage } from "#flow/stages/base";
 
 import {
@@ -15,7 +16,6 @@ import {
 import { msg } from "@lit/localize";
 import { CSSResult, html, PropertyValues, TemplateResult } from "lit";
 import { customElement } from "lit/decorators.js";
-import { ifDefined } from "lit/directives/if-defined.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFForm from "@patternfly/patternfly/components/Form/form.css";
@@ -67,17 +67,8 @@ export class AuthenticatorDuoStage extends BaseStage<
     render(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>
             <form class="pf-c-form" @submit=${this.submitForm}>
-                <ak-form-static
-                    class="pf-c-form__group"
-                    userAvatar="${this.challenge.pendingUserAvatar}"
-                    user=${this.challenge.pendingUser}
-                >
-                    <div slot="link">
-                        <a href="${ifDefined(this.challenge.flowInfo?.cancelUrl)}"
-                            >${msg("Not you?")}</a
-                        >
-                    </div>
-                </ak-form-static>
+                ${FlowUserDetails({ challenge: this.challenge })}
+
                 <img src=${this.challenge.activationBarcode} alt=${msg("Duo activation QR code")} />
                 <p>
                     ${msg(

--- a/web/src/flow/stages/authenticator_email/AuthenticatorEmailStage.ts
+++ b/web/src/flow/stages/authenticator_email/AuthenticatorEmailStage.ts
@@ -4,6 +4,7 @@ import "#flow/components/ak-flow-card";
 import { AKFormErrors } from "#components/ak-field-errors";
 import { AKLabel } from "#components/ak-label";
 
+import { FlowUserDetails } from "#flow/FormStatic";
 import { BaseStage } from "#flow/stages/base";
 
 import {
@@ -14,7 +15,6 @@ import {
 import { msg, str } from "@lit/localize";
 import { CSSResult, html, TemplateResult } from "lit";
 import { customElement } from "lit/decorators.js";
-import { ifDefined } from "lit/directives/if-defined.js";
 
 import PFAlert from "@patternfly/patternfly/components/Alert/alert.css";
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
@@ -44,17 +44,8 @@ export class AuthenticatorEmailStage extends BaseStage<
     renderEmailInput(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>
             <form class="pf-c-form" @submit=${this.submitForm}>
-                <ak-form-static
-                    class="pf-c-form__group"
-                    userAvatar="${this.challenge.pendingUserAvatar}"
-                    user=${this.challenge.pendingUser}
-                >
-                    <div slot="link">
-                        <a href="${ifDefined(this.challenge.flowInfo?.cancelUrl)}"
-                            >${msg("Not you?")}</a
-                        >
-                    </div>
-                </ak-form-static>
+                ${FlowUserDetails({ challenge: this.challenge })}
+
                 <div class="pf-c-form__group">
                     ${AKLabel(
                         { required: true, htmlFor: "email-input" },
@@ -91,19 +82,8 @@ export class AuthenticatorEmailStage extends BaseStage<
         const { email } = this.challenge;
 
         return html`<ak-flow-card .challenge=${this.challenge}>
-            <ak-form-static
-                class="pf-c-form__group"
-                userAvatar="${this.challenge.pendingUserAvatar}"
-                user=${this.challenge.pendingUser}
-            >
-                <div slot="link">
-                    <a href="${ifDefined(this.challenge.flowInfo?.cancelUrl)}"
-                        >${msg("Not you?")}</a
-                    >
-                </div>
-            </ak-form-static>
-            A verification token has been sent to your configured email address
-            ${ifDefined(this.challenge.email)}
+            ${FlowUserDetails({ challenge: this.challenge })}
+
             <p>
                 ${email
                     ? msg(

--- a/web/src/flow/stages/authenticator_email/AuthenticatorEmailStage.ts
+++ b/web/src/flow/stages/authenticator_email/AuthenticatorEmailStage.ts
@@ -11,7 +11,7 @@ import {
     AuthenticatorEmailChallengeResponseRequest,
 } from "@goauthentik/api";
 
-import { msg } from "@lit/localize";
+import { msg, str } from "@lit/localize";
 import { CSSResult, html, TemplateResult } from "lit";
 import { customElement } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -88,6 +88,8 @@ export class AuthenticatorEmailStage extends BaseStage<
     }
 
     renderEmailOTPInput(): TemplateResult {
+        const { email } = this.challenge;
+
         return html`<ak-flow-card .challenge=${this.challenge}>
             <ak-form-static
                 class="pf-c-form__group"
@@ -102,6 +104,20 @@ export class AuthenticatorEmailStage extends BaseStage<
             </ak-form-static>
             A verification token has been sent to your configured email address
             ${ifDefined(this.challenge.email)}
+            <p>
+                ${email
+                    ? msg(
+                          str`A verification token has been sent to your configured email address: ${email}`,
+                          {
+                              id: "stage.authenticator.email.sent-to-address",
+                              desc: "Displayed when a verification token has been sent to the user's configured email address.",
+                          },
+                      )
+                    : msg("A verification token has been sent to your email address.", {
+                          id: "stage.authenticator.email.sent",
+                          desc: "Displayed when a verification token has been sent to the user's email address.",
+                      })}
+            </p>
             <form class="pf-c-form" @submit=${this.submitForm}>
                 <div class="pf-c-form__group">
                     ${AKLabel({ required: true, htmlFor: "code-input" }, msg("Code"))}

--- a/web/src/flow/stages/authenticator_sms/AuthenticatorSMSStage.ts
+++ b/web/src/flow/stages/authenticator_sms/AuthenticatorSMSStage.ts
@@ -4,6 +4,7 @@ import "#flow/components/ak-flow-card";
 import { AKFormErrors } from "#components/ak-field-errors";
 import { AKLabel } from "#components/ak-label";
 
+import { FlowUserDetails } from "#flow/FormStatic";
 import { BaseStage } from "#flow/stages/base";
 
 import {
@@ -14,7 +15,6 @@ import {
 import { msg } from "@lit/localize";
 import { CSSResult, html, TemplateResult } from "lit";
 import { customElement } from "lit/decorators.js";
-import { ifDefined } from "lit/directives/if-defined.js";
 
 import PFAlert from "@patternfly/patternfly/components/Alert/alert.css";
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
@@ -44,17 +44,8 @@ export class AuthenticatorSMSStage extends BaseStage<
     renderPhoneNumber(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>
             <form class="pf-c-form" @submit=${this.submitForm}>
-                <ak-form-static
-                    class="pf-c-form__group"
-                    userAvatar=${this.challenge.pendingUserAvatar}
-                    user=${this.challenge.pendingUser}
-                >
-                    <div slot="link">
-                        <a href="${ifDefined(this.challenge.flowInfo?.cancelUrl)}"
-                            >${msg("Not you?")}</a
-                        >
-                    </div>
-                </ak-form-static>
+                ${FlowUserDetails({ challenge: this.challenge })}
+
                 <div class="pf-c-form__group">
                     ${AKLabel(
                         { required: true, htmlFor: "phone-number-input" },
@@ -90,17 +81,7 @@ export class AuthenticatorSMSStage extends BaseStage<
     renderCode(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>
             <form class="pf-c-form" @submit=${this.submitForm}>
-                <ak-form-static
-                    class="pf-c-form__group"
-                    userAvatar="${this.challenge.pendingUserAvatar}"
-                    user=${this.challenge.pendingUser}
-                >
-                    <div slot="link">
-                        <a href="${ifDefined(this.challenge.flowInfo?.cancelUrl)}"
-                            >${msg("Not you?")}</a
-                        >
-                    </div>
-                </ak-form-static>
+                ${FlowUserDetails({ challenge: this.challenge })}
                 <div class="pf-c-form__group">
                     ${AKLabel({ required: true, htmlFor: "sms-code-input" }, msg("Code"))}
                     <input

--- a/web/src/flow/stages/authenticator_static/AuthenticatorStaticStage.ts
+++ b/web/src/flow/stages/authenticator_static/AuthenticatorStaticStage.ts
@@ -1,6 +1,7 @@
 import "#flow/FormStatic";
 import "#flow/components/ak-flow-card";
 
+import { FlowUserDetails } from "#flow/FormStatic";
 import { BaseStage } from "#flow/stages/base";
 
 import {
@@ -11,7 +12,6 @@ import {
 import { msg } from "@lit/localize";
 import { css, CSSResult, html, TemplateResult } from "lit";
 import { customElement } from "lit/decorators.js";
-import { ifDefined } from "lit/directives/if-defined.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFForm from "@patternfly/patternfly/components/Form/form.css";
@@ -53,17 +53,8 @@ export class AuthenticatorStaticStage extends BaseStage<
     render(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>
             <form class="pf-c-form" @submit=${this.submitForm}>
-                <ak-form-static
-                    class="pf-c-form__group"
-                    userAvatar="${this.challenge.pendingUserAvatar}"
-                    user=${this.challenge.pendingUser}
-                >
-                    <div slot="link">
-                        <a href="${ifDefined(this.challenge.flowInfo?.cancelUrl)}"
-                            >${msg("Not you?")}</a
-                        >
-                    </div>
-                </ak-form-static>
+                ${FlowUserDetails({ challenge: this.challenge })}
+
                 <ul class="pf-c-form__group token-list">
                     ${this.challenge.codes.map((token) => {
                         return html`<li>${token}</li>`;

--- a/web/src/flow/stages/authenticator_totp/AuthenticatorTOTPStage.ts
+++ b/web/src/flow/stages/authenticator_totp/AuthenticatorTOTPStage.ts
@@ -9,6 +9,7 @@ import { showMessage } from "#elements/messages/MessageContainer";
 import { AKFormErrors } from "#components/ak-field-errors";
 import { AKLabel } from "#components/ak-label";
 
+import { FlowUserDetails } from "#flow/FormStatic";
 import { BaseStage } from "#flow/stages/base";
 
 import {
@@ -19,7 +20,6 @@ import {
 import { msg } from "@lit/localize";
 import { css, CSSResult, html, TemplateResult } from "lit";
 import { customElement } from "lit/decorators.js";
-import { ifDefined } from "lit/directives/if-defined.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFForm from "@patternfly/patternfly/components/Form/form.css";
@@ -54,17 +54,8 @@ export class AuthenticatorTOTPStage extends BaseStage<
     render(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>
             <form class="pf-c-form" @submit=${this.submitForm}>
-                <ak-form-static
-                    class="pf-c-form__group"
-                    userAvatar="${this.challenge.pendingUserAvatar}"
-                    user=${this.challenge.pendingUser}
-                >
-                    <div slot="link">
-                        <a href="${ifDefined(this.challenge.flowInfo?.cancelUrl)}"
-                            >${msg("Not you?")}</a
-                        >
-                    </div>
-                </ak-form-static>
+                ${FlowUserDetails({ challenge: this.challenge })}
+
                 <input type="hidden" name="otp_uri" value=${this.challenge.configUrl} />
 
                 <div class="pf-c-form__group">

--- a/web/src/flow/stages/authenticator_webauthn/WebAuthnAuthenticatorRegisterStage.ts
+++ b/web/src/flow/stages/authenticator_webauthn/WebAuthnAuthenticatorRegisterStage.ts
@@ -9,6 +9,7 @@ import {
     transformNewAssertionForServer,
 } from "#common/helpers/webauthn";
 
+import { FlowUserDetails } from "#flow/FormStatic";
 import { BaseStage } from "#flow/stages/base";
 
 import {
@@ -19,7 +20,6 @@ import {
 import { msg, str } from "@lit/localize";
 import { CSSResult, html, nothing, PropertyValues, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
-import { ifDefined } from "lit/directives/if-defined.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFForm from "@patternfly/patternfly/components/Form/form.css";
@@ -116,17 +116,8 @@ export class WebAuthnAuthenticatorRegisterStage extends BaseStage<
     render(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>
             <form class="pf-c-form">
-                <ak-form-static
-                    class="pf-c-form__group"
-                    userAvatar="${this.challenge.pendingUserAvatar}"
-                    user=${this.challenge.pendingUser}
-                >
-                    <div slot="link">
-                        <a href="${ifDefined(this.challenge.flowInfo?.cancelUrl)}"
-                            >${msg("Not you?")}</a
-                        >
-                    </div>
-                </ak-form-static>
+                ${FlowUserDetails({ challenge: this.challenge })}
+
                 <ak-empty-state ?loading="${this.registerRunning}" icon="fa-times">
                     <span
                         >${this.registerRunning

--- a/web/src/flow/stages/base.ts
+++ b/web/src/flow/stages/base.ts
@@ -7,12 +7,12 @@ import { intersectionObserver } from "#elements/decorators/intersection-observer
 import { WithLocale } from "#elements/mixins/locale";
 import { FocusTarget } from "#elements/utils/focus";
 
+import { FlowUserDetails } from "#flow/FormStatic";
+
 import { ContextualFlowInfo, CurrentBrand, ErrorDetail } from "@goauthentik/api";
 
-import { msg } from "@lit/localize";
 import { html, LitElement, nothing, PropertyValues } from "lit";
 import { property } from "lit/decorators.js";
-import { ifDefined } from "lit/directives/if-defined.js";
 
 export interface SubmitOptions {
     invisible: boolean;
@@ -178,17 +178,7 @@ export abstract class BaseStage<
             return nothing;
         }
         return html`
-            <ak-form-static
-                class="pf-c-form__group"
-                userAvatar="${this.challenge.pendingUserAvatar}"
-                user=${this.challenge.pendingUser}
-            >
-                <div slot="link">
-                    <a href="${ifDefined(this.challenge.flowInfo?.cancelUrl)}"
-                        >${msg("Not you?")}</a
-                    >
-                </div>
-            </ak-form-static>
+            ${FlowUserDetails({ challenge: this.challenge })}
             <input
                 name="username"
                 autocomplete="username"

--- a/web/src/flow/stages/captcha/CaptchaStage.ts
+++ b/web/src/flow/stages/captcha/CaptchaStage.ts
@@ -8,6 +8,7 @@ import { ifPresent } from "#elements/utils/attributes";
 import { ListenerController } from "#elements/utils/listenerController";
 import { randomId } from "#elements/utils/randomId";
 
+import { FlowUserDetails } from "#flow/FormStatic";
 import { BaseStage } from "#flow/stages/base";
 import { CaptchaHandler, CaptchaProvider, iframeTemplate } from "#flow/stages/captcha/shared";
 
@@ -20,7 +21,6 @@ import { match } from "ts-pattern";
 import { LOCALE_STATUS_EVENT, LocaleStatusEventDetail, msg } from "@lit/localize";
 import { css, CSSResult, html, nothing, PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import { ifDefined } from "lit/directives/if-defined.js";
 import { createRef, ref } from "lit/directives/ref.js";
 
 import PFForm from "@patternfly/patternfly/components/Form/form.css";
@@ -351,18 +351,7 @@ export class CaptchaStage extends BaseStage<CaptchaChallenge, CaptchaChallengeRe
     renderMain() {
         return html`<ak-flow-card .challenge=${this.challenge}>
             <form class="pf-c-form">
-                <ak-form-static
-                    class="pf-c-form__group"
-                    userAvatar="${this.challenge.pendingUserAvatar}"
-                    user=${this.challenge.pendingUser}
-                >
-                    <div slot="link">
-                        <a href="${ifDefined(this.challenge.flowInfo?.cancelUrl)}"
-                            >${msg("Not you?")}</a
-                        >
-                    </div>
-                </ak-form-static>
-                ${this.renderBody()}
+                ${FlowUserDetails({ challenge: this.challenge })} ${this.renderBody()}
             </form>
         </ak-flow-card>`;
     }

--- a/web/src/flow/stages/consent/ConsentStage.ts
+++ b/web/src/flow/stages/consent/ConsentStage.ts
@@ -1,6 +1,7 @@
 import "#flow/FormStatic";
 import "#flow/components/ak-flow-card";
 
+import { FlowUserDetails } from "#flow/FormStatic";
 import { BaseStage } from "#flow/stages/base";
 
 import {
@@ -12,7 +13,6 @@ import {
 import { msg } from "@lit/localize";
 import { CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement } from "lit/decorators.js";
-import { ifDefined } from "lit/directives/if-defined.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFForm from "@patternfly/patternfly/components/Form/form.css";
@@ -113,17 +113,7 @@ export class ConsentStage extends BaseStage<ConsentChallenge, ConsentChallengeRe
                     });
                 }}
             >
-                <ak-form-static
-                    class="pf-c-form__group"
-                    userAvatar="${this.challenge.pendingUserAvatar}"
-                    user=${this.challenge.pendingUser}
-                >
-                    <div slot="link">
-                        <a href="${ifDefined(this.challenge.flowInfo?.cancelUrl)}"
-                            >${msg("Not you?")}</a
-                        >
-                    </div>
-                </ak-form-static>
+                ${FlowUserDetails({ challenge: this.challenge })}
                 ${this.challenge.additionalPermissions.length > 0
                     ? this.renderAdditional()
                     : this.renderNoPrevious()}

--- a/web/src/flow/stages/password/PasswordStage.ts
+++ b/web/src/flow/stages/password/PasswordStage.ts
@@ -4,6 +4,7 @@ import "#flow/components/ak-flow-password-input";
 
 import { ErrorProp } from "#components/ak-field-errors";
 
+import { FlowUserDetails } from "#flow/FormStatic";
 import { BaseStage } from "#flow/stages/base";
 import { PasswordManagerPrefill } from "#flow/stages/identification/IdentificationStage";
 
@@ -12,7 +13,6 @@ import { PasswordChallenge, PasswordChallengeResponseRequest } from "@goauthenti
 import { msg } from "@lit/localize";
 import { CSSResult, html, TemplateResult } from "lit";
 import { customElement } from "lit/decorators.js";
-import { ifDefined } from "lit/directives/if-defined.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFForm from "@patternfly/patternfly/components/Form/form.css";
@@ -43,17 +43,8 @@ export class PasswordStage extends BaseStage<PasswordChallenge, PasswordChalleng
     render(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>
             <form class="pf-c-form" @submit=${this.submitForm}>
-                <ak-form-static
-                    class="pf-c-form__group"
-                    userAvatar="${this.challenge.pendingUserAvatar}"
-                    user=${this.challenge.pendingUser}
-                >
-                    <div slot="link">
-                        <a href="${ifDefined(this.challenge.flowInfo?.cancelUrl)}"
-                            >${msg("Not you?")}</a
-                        >
-                    </div>
-                </ak-form-static>
+                ${FlowUserDetails({ challenge: this.challenge })}
+
                 <input
                     name="username"
                     type="text"

--- a/web/src/flow/stages/user_login/UserLoginStage.ts
+++ b/web/src/flow/stages/user_login/UserLoginStage.ts
@@ -1,6 +1,7 @@
 import "#flow/FormStatic";
 import "#flow/components/ak-flow-card";
 
+import { FlowUserDetails } from "#flow/FormStatic";
 import { BaseStage } from "#flow/stages/base";
 
 import { UserLoginChallenge, UserLoginChallengeResponseRequest } from "@goauthentik/api";
@@ -8,7 +9,6 @@ import { UserLoginChallenge, UserLoginChallengeResponseRequest } from "@goauthen
 import { msg } from "@lit/localize";
 import { CSSResult, html, TemplateResult } from "lit";
 import { customElement } from "lit/decorators.js";
-import { ifDefined } from "lit/directives/if-defined.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFForm from "@patternfly/patternfly/components/Form/form.css";
@@ -48,17 +48,8 @@ export class PasswordStage extends BaseStage<
                     });
                 }}
             >
-                <ak-form-static
-                    class="pf-c-form__group"
-                    userAvatar="${this.challenge.pendingUserAvatar}"
-                    user=${this.challenge.pendingUser}
-                >
-                    <div slot="link">
-                        <a href="${ifDefined(this.challenge.flowInfo?.cancelUrl)}"
-                            >${msg("Not you?")}</a
-                        >
-                    </div>
-                </ak-form-static>
+                ${FlowUserDetails({ challenge: this.challenge })}
+
                 <div class="pf-c-form__group">
                     <h3 data-test-id="stage-heading" class="pf-c-title pf-m-xl pf-u-mb-xl">
                         ${msg("Stay signed in?")}


### PR DESCRIPTION
## Details

This PR addresses some feedback on 2025.12 RC2:


- Deduplicated `<ak-form-static>` usage in stages
- Added back button to denied stage, letting the user get out of partially setup flows, such as enrollment stages.
- Localized the email sent message in the identification stage.

## Related Merge Branch

- #19229