### PR TITLE
sources/oauth: add fallback for id_token when profile URL is not available

### DIFF
--- a/authentik/sources/oauth/clients/oauth2.py
+++ b/authentik/sources/oauth/clients/oauth2.py
@@ -189,6 +189,8 @@ class UserprofileHeaderAuthClient(OAuth2Client):
         profile_url = self.source.source_type.profile_url or ""
         if self.source.source_type.urls_customizable and self.source.profile_url:
             profile_url = self.source.profile_url
+        if profile_url == "":
+            return None
         response = self.session.request(
             "get",
             profile_url,
@@ -198,7 +200,7 @@ class UserprofileHeaderAuthClient(OAuth2Client):
             response.raise_for_status()
         except RequestException as exc:
             LOGGER.warning(
-                "Unable to fetch user profile",
+                "Unable to fetch user profile from profile_url",
                 exc=exc,
                 response=exc.response.text if exc.response else str(exc),
             )

--- a/authentik/sources/oauth/types/oidc.py
+++ b/authentik/sources/oauth/types/oidc.py
@@ -50,7 +50,7 @@ class OpenIDConnectClient(UserprofileHeaderAuthClient):
             jwk = PyJWKSet.from_dict(self.source.oidc_jwks)
             key = [key for key in jwk.keys if key.key_id == raw["kid"]][0]
             return decode(id_token, key=key, algorithms=raw["alg"])
-        except (PyJWTError, IndexError, ValueError):
+        except PyJWTError, IndexError, ValueError:
             return None
 
 

--- a/authentik/sources/oauth/types/oidc.py
+++ b/authentik/sources/oauth/types/oidc.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from jwt import PyJWKSet, PyJWTError, decode, get_unverified_header
 from requests.auth import AuthBase, HTTPBasicAuth
 
 from authentik.sources.oauth.clients.oauth2 import UserprofileHeaderAuthClient
@@ -35,6 +36,22 @@ class OpenIDConnectClient(UserprofileHeaderAuthClient):
         if self.source.authorization_code_auth_method == AuthorizationCodeAuthMethod.BASIC_AUTH:
             return HTTPBasicAuth(self.get_client_id(), self.get_client_secret())
         return None
+
+    def get_profile_info(self, token: dict[str, str]) -> dict[str, Any] | None:
+        profile = super().get_profile_info(token)
+        if profile:
+            return profile
+        if "id_token" not in token:
+            self.logger.warning("no id_token given")
+            return None
+        id_token = token["id_token"]
+        try:
+            raw = get_unverified_header(id_token)
+            jwk = PyJWKSet.from_dict(self.source.oidc_jwks)
+            key = [key for key in jwk.keys if key.key_id == raw["kid"]][0]
+            return decode(id_token, key=key, algorithms=raw["alg"])
+        except (PyJWTError, IndexError, ValueError):
+            return None
 
 
 class OpenIDConnectOAuth2Callback(OAuthCallback):


### PR DESCRIPTION
For OpenID sources specifically, when a profile URL is not available, fallback to the id_token (if possible); if no id_token is available the same error is returned

https://github.com/goauthentik/internal-customer-ref/issues/2