### PR TITLE
web: Add support for pinned tabs

### DIFF
--- a/web/src/admin/AdminInterface/AdminSidebarPinned.ts
+++ b/web/src/admin/AdminInterface/AdminSidebarPinned.ts
@@ -91,7 +91,6 @@ export async function handlePinToggle(
 export function renderSidebarEntry(
     entry: SidebarEntry,
     pinnedPaths: string[],
-    _excludePinned = false,
 ): TemplateResult | typeof nothing {
     const [path, label, attributes, children] = entry;
 
@@ -136,7 +135,7 @@ export function renderPinnedSection(
     if (pinnedEntries.length === 0) return nothing;
 
     return html`<ak-sidebar-item label=${msg("Pinned")} ?expanded=${true}>
-        ${pinnedEntries.map((entry) => renderSidebarEntry(entry, pinnedPaths, false))}
+        ${pinnedEntries.map((entry) => renderSidebarEntry(entry, pinnedPaths))}
     </ak-sidebar-item>`;
 }
 
@@ -148,6 +147,6 @@ export function renderSidebarEntries(
     pinnedPaths: string[],
 ): TemplateResult[] {
     return entries
-        .map((entry) => renderSidebarEntry(entry, pinnedPaths, true))
+        .map((entry) => renderSidebarEntry(entry, pinnedPaths))
         .filter((t): t is TemplateResult => t !== nothing);
 }

--- a/web/src/admin/AdminInterface/AdminSidebarPinned.ts
+++ b/web/src/admin/AdminInterface/AdminSidebarPinned.ts
@@ -1,0 +1,173 @@
+import { DEFAULT_CONFIG } from "#common/api/config";
+
+import { SidebarEntry } from "#admin/AdminInterface/AdminSidebar";
+
+import { CoreApi, UserSelf } from "@goauthentik/api";
+
+import { msg } from "@lit/localize";
+import { html, nothing, TemplateResult } from "lit";
+
+/**
+ * Get the list of pinned tab paths from user settings.
+ */
+export function getPinnedPaths(user: UserSelf | null | undefined): string[] {
+    const settings = user?.settings as Record<string, unknown> | undefined;
+    const adminSettings = settings?.admin as Record<string, unknown> | undefined;
+    return (adminSettings?.pinnedTabs as string[]) ?? [];
+}
+
+/**
+ * Find sidebar entries by their paths from a nested entry structure.
+ */
+export function findEntriesByPaths(
+    entries: readonly SidebarEntry[],
+    paths: string[],
+): SidebarEntry[] {
+    const result: SidebarEntry[] = [];
+
+    for (const entry of entries) {
+        const [path, , , children] = entry;
+        if (path && paths.includes(path)) {
+            result.push(entry);
+        }
+        if (children) {
+            result.push(...findEntriesByPaths(children, paths));
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Handle pin toggle event by updating user settings.
+ */
+export async function handlePinToggle(
+    user: UserSelf,
+    pinnedPaths: string[],
+    path: string,
+    pinned: boolean,
+    onSuccess: () => Promise<void>,
+): Promise<void> {
+    const currentPinned = [...pinnedPaths];
+
+    if (pinned && !currentPinned.includes(path)) {
+        currentPinned.push(path);
+    } else if (!pinned) {
+        const index = currentPinned.indexOf(path);
+        if (index > -1) currentPinned.splice(index, 1);
+    }
+
+    try {
+        const fullUser = await new CoreApi(DEFAULT_CONFIG).coreUsersRetrieve({
+            id: user.pk,
+        });
+
+        await new CoreApi(DEFAULT_CONFIG).coreUsersPartialUpdate({
+            id: user.pk,
+            patchedUserRequest: {
+                attributes: {
+                    ...(fullUser.attributes ?? {}),
+                    settings: {
+                        ...((fullUser.attributes?.settings as Record<string, unknown>) ?? {}),
+                        admin: {
+                            ...((fullUser.attributes?.settings as Record<string, unknown>)?.admin ??
+                                {}),
+                            pinnedTabs: currentPinned,
+                        },
+                    },
+                },
+            },
+        });
+
+        await onSuccess();
+    } catch (error) {
+        console.error("Failed to update pinned tabs:", error);
+    }
+}
+
+/**
+ * Render a sidebar entry with pinnable/pinned state.
+ */
+export function renderSidebarEntry(
+    entry: SidebarEntry,
+    pinnedPaths: string[],
+    excludePinned = false,
+): TemplateResult | typeof nothing {
+    const [path, label, attributes, children] = entry;
+
+    // Exclude pinned entries from their original location
+    if (excludePinned && path && pinnedPaths.includes(path)) {
+        return nothing;
+    }
+
+    const properties: Record<string, unknown> = Array.isArray(attributes)
+        ? { ".activeWhen": attributes }
+        : { ...(attributes ?? {}) };
+
+    if (path) {
+        properties.path = path;
+        // Leaf items (no children) are pinnable
+        if (!children) {
+            properties.pinnable = true;
+            properties.pinned = pinnedPaths.includes(path);
+        }
+    }
+
+    // Filter out pinned children
+    const visibleChildren = children
+        ? children.filter((child) => {
+              const [childPath] = child;
+              return !excludePinned || !childPath || !pinnedPaths.includes(childPath);
+          })
+        : undefined;
+
+    // Hide parent if all children are pinned (and excluded)
+    if (children && excludePinned && (!visibleChildren || visibleChildren.length === 0)) {
+        return nothing;
+    }
+
+    return html`<ak-sidebar-item
+        exportparts="list-item, link"
+        label=${label}
+        .path=${path}
+        .pinnable=${properties.pinnable ?? false}
+        .pinned=${properties.pinned ?? false}
+        ?expanded=${properties["?expanded"]}
+        ?enterprise=${properties.enterprise}
+        .activeWhen=${properties[".activeWhen"] ?? []}
+    >
+        ${visibleChildren
+            ? visibleChildren.map((child) => renderSidebarEntry(child, pinnedPaths, excludePinned))
+            : nothing}
+    </ak-sidebar-item>`;
+}
+
+/**
+ * Render the pinned section at the top of the sidebar.
+ */
+export function renderPinnedSection(
+    allEntries: readonly SidebarEntry[],
+    pinnedPaths: string[],
+): TemplateResult | typeof nothing {
+    if (pinnedPaths.length === 0) return nothing;
+
+    const pinnedEntries = findEntriesByPaths(allEntries, pinnedPaths);
+
+    if (pinnedEntries.length === 0) return nothing;
+
+    return html`<ak-sidebar-item label=${msg("Pinned")} ?expanded=${true}>
+        ${pinnedEntries.map((entry) => renderSidebarEntry(entry, pinnedPaths, false))}
+    </ak-sidebar-item>`;
+}
+
+/**
+ * Render sidebar entries, excluding pinned items from their original location.
+ */
+export function renderSidebarEntries(
+    entries: readonly SidebarEntry[],
+    pinnedPaths: string[],
+): TemplateResult[] {
+    return entries
+        .map((entry) => renderSidebarEntry(entry, pinnedPaths, true))
+        .filter((t): t is TemplateResult => t !== nothing);
+}

--- a/web/src/admin/AdminInterface/AdminSidebarPinned.ts
+++ b/web/src/admin/AdminInterface/AdminSidebarPinned.ts
@@ -91,14 +91,9 @@ export async function handlePinToggle(
 export function renderSidebarEntry(
     entry: SidebarEntry,
     pinnedPaths: string[],
-    excludePinned = false,
+    _excludePinned = false,
 ): TemplateResult | typeof nothing {
     const [path, label, attributes, children] = entry;
-
-    // Exclude pinned entries from their original location
-    if (excludePinned && path && pinnedPaths.includes(path)) {
-        return nothing;
-    }
 
     const properties: Record<string, unknown> = Array.isArray(attributes)
         ? { ".activeWhen": attributes }
@@ -113,19 +108,6 @@ export function renderSidebarEntry(
         }
     }
 
-    // Filter out pinned children
-    const visibleChildren = children
-        ? children.filter((child) => {
-              const [childPath] = child;
-              return !excludePinned || !childPath || !pinnedPaths.includes(childPath);
-          })
-        : undefined;
-
-    // Hide parent if all children are pinned (and excluded)
-    if (children && excludePinned && (!visibleChildren || visibleChildren.length === 0)) {
-        return nothing;
-    }
-
     return html`<ak-sidebar-item
         exportparts="list-item, link"
         label=${label}
@@ -136,9 +118,7 @@ export function renderSidebarEntry(
         ?enterprise=${properties.enterprise}
         .activeWhen=${properties[".activeWhen"] ?? []}
     >
-        ${visibleChildren
-            ? visibleChildren.map((child) => renderSidebarEntry(child, pinnedPaths, excludePinned))
-            : nothing}
+        ${children ? children.map((child) => renderSidebarEntry(child, pinnedPaths)) : nothing}
     </ak-sidebar-item>`;
 }
 
@@ -161,7 +141,7 @@ export function renderPinnedSection(
 }
 
 /**
- * Render sidebar entries, excluding pinned items from their original location.
+ * Render sidebar entries.
  */
 export function renderSidebarEntries(
     entries: readonly SidebarEntry[],

--- a/web/src/common/ui/config.ts
+++ b/web/src/common/ui/config.ts
@@ -66,6 +66,9 @@ export interface UIConfig {
     defaults: {
         userPath: string;
     };
+    admin: {
+        pinnedTabs: string[];
+    };
 }
 
 export const DefaultUIConfig = {
@@ -93,6 +96,9 @@ export const DefaultUIConfig = {
     locale: "",
     defaults: {
         userPath: "users",
+    },
+    admin: {
+        pinnedTabs: [],
     },
 } as const satisfies UIConfig;
 

--- a/web/src/elements/sidebar/SidebarItem.css
+++ b/web/src/elements/sidebar/SidebarItem.css
@@ -58,3 +58,42 @@ button.pf-c-nav__link {
     padding: 0.1rem 0.5rem;
     border-radius: var(--pf-global--BorderRadius--sm);
 }
+
+/* Pin button styles */
+.pf-c-nav__item {
+    position: relative;
+}
+
+.ak-sidebar-pin-button {
+    position: absolute;
+    right: 0.5rem;
+    top: 50%;
+    transform: translateY(-50%);
+    opacity: 0;
+    transition: opacity 0.15s ease-in-out;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 0.25rem;
+    color: var(--pf-global--Color--200);
+    font-size: var(--pf-global--FontSize--sm);
+}
+
+.pf-c-nav__item:hover .ak-sidebar-pin-button,
+.pf-c-nav__item:focus-within .ak-sidebar-pin-button {
+    opacity: 0.6;
+}
+
+.ak-sidebar-pin-button:hover {
+    opacity: 1 !important;
+    color: var(--pf-global--primary-color--100);
+}
+
+.ak-sidebar-pin-button.pinned {
+    opacity: 1;
+    color: var(--pf-global--primary-color--100);
+}
+
+.ak-sidebar-item--pinned .ak-sidebar-pin-button {
+    opacity: 1;
+}


### PR DESCRIPTION
Overview:

Allows admins to customize their sidebar by pinning frequently accessed pages to the top for quicker navigation

Screenshots:

<img width="291" height="386" alt="image" src="https://github.com/user-attachments/assets/479490de-9442-4131-9413-3cb9d85b7774" />

Testing:

In the Admin interface sidebar, hover over an item and click the pin. Refresh at will, and unpin

Motivation:

Closes: https://github.com/goauthentik/authentik/issues/19232

Depends on:

https://authentiksecurity.slack.com/archives/C08C0SCU2JV/p1772063050087159?thread_ts=1772063004.777489&cid=C08C0SCU2JV

Closes #25323
