### PR TITLE
website/docs: mention dynamic overrides in redirect stage documentation

### DIFF
--- a/website/docs/add-secure-apps/flows-stages/stages/redirect/index.md
+++ b/website/docs/add-secure-apps/flows-stages/stages/redirect/index.md
@@ -5,6 +5,8 @@ authentik_version: "2024.12"
 
 This stage's main purpose is to redirect the user to a new Flow while keeping flow context. For convenience, it can also redirect the user to a static URL.
 
+The redirection target can also be overwritten dynamically in an expression policy by setting the [redirect_stage_target](../../flow/context/#redirect_stage_target-string) key in the flow context.
+
 ## Redirect stage modes
 
 ### Static mode


### PR DESCRIPTION
## Details

This PR updates the documentation of the redirect stage to mention the possibility to override the redirection target programmatically in an expression policy.

---

## Checklist

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
