### PR TITLE
web/admin: Pluralize Certificate-Key Pair deletion confirmation

### DIFF
--- a/web/src/admin/crypto/CertificateKeyPairListPage.ts
+++ b/web/src/admin/crypto/CertificateKeyPairListPage.ts
@@ -59,8 +59,9 @@ export class CertificateKeyPairListPage extends TablePage<CertificateKeyPair> {
 
     renderToolbarSelected(): TemplateResult {
         const disabled = this.selectedElements.length < 1;
+        const count = this.selectedElements.length;
         return html`<ak-forms-delete-bulk
-            objectLabel=${msg("Certificate-Key Pair(s)")}
+            objectLabel=${count === 1 ? msg("Certificate-Key Pair") : msg("Certificate-Key Pairs")}
             .objects=${this.selectedElements}
             .metadata=${(item: CertificateKeyPair) => {
                 return [


### PR DESCRIPTION
What:

Pluralizes the confirmation dialog for Certificate-Key Pair dialog in the Admin interface. Previously, the objectLabel was set to use (s), so this is a little UX fix.

How was this tested:

Created several pairs and attempted to delete them and confirmed the correct messages appear as shown in this screenshot:

<img width="637" height="150" alt="image" src="https://github.com/user-attachments/assets/2cd32ff5-caa1-4fb0-b56a-2271cf919fba" />