### PR TITLE
website/docs: add 2026.2 release notes draft page

### DIFF
--- a/website/docs/releases/2026/v2026.2.md
+++ b/website/docs/releases/2026/v2026.2.md
@@ -1,0 +1,53 @@
+---
+title: Release 2026.2
+slug: "/releases/2026.2"
+draft: true
+---
+
+:::info
+2026.2 has not been released yet! We're publishing these release notes as a preview of what's to come, and for our awesome beta testers trying out release candidates.
+
+To try out the release candidate, replace your Docker image tag with the latest release candidate number, such as 2026.2.0-rc1. You can find the latest one in [the latest releases on GitHub](https://github.com/goauthentik/authentik/releases). If you don't find any, it means we haven't released one yet.
+:::
+
+## Highlights
+
+<!-- ## Breaking changes -->
+
+## New features and improvements
+
+## Upgrading
+
+This release does not introduce any new requirements. You can follow the upgrade instructions below; for more detailed information about upgrading authentik, refer to our [Upgrade documentation](../../install-config/upgrade.mdx).
+
+:::warning
+When you upgrade, be aware that the version of the authentik instance and of any outposts must be the same. We recommended that you always upgrade any outposts at the same time you upgrade your authentik instance.
+:::
+
+### Docker Compose
+
+To upgrade, download the new docker-compose file and update the Docker stack with the new version, using these commands:
+
+```shell
+wget -O docker-compose.yml https://goauthentik.io/version/2026.2/docker-compose.yml
+docker compose up -d
+```
+
+The `-O` flag retains the downloaded file's name, overwriting any existing local file with the same name.
+
+### Kubernetes
+
+Upgrade the Helm Chart to the new version, using the following commands:
+
+```shell
+helm repo update
+helm upgrade authentik authentik/authentik -f values.yaml --version ^2026.2
+```
+
+## Minor changes/fixes
+
+<!-- _Insert the output of `make gen-changelog` here_ -->
+
+## API Changes
+
+<!-- _Insert output of `make gen-diff` here_ -->


### PR DESCRIPTION
This page is marked as `draft: true`, so it's not present in a production build.

From now on, any PR should include a note here if it's relevant enough.