### PR TITLE
ci: fix checkout stable (for 2025.12) (#19448)

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -84,7 +84,7 @@ jobs:
           # Current version family based on
           current_version_family=$(cat internal/constants/VERSION | grep -vE -- 'rc[0-9]+$' || true)
           if [[ -n $current_version_family ]]; then
-              prev_stable=$current_version_family
+              prev_stable="version/${current_version_family}"
           fi
           echo "::notice::Checking out ${prev_stable} as stable version..."
           git checkout ${prev_stable}


### PR DESCRIPTION
* ci: fix checkout stable (again)

Fixes the fix at https://github.com/goauthentik/authentik/pull/18303

This fails on version branches that already have releases, because the version tag is named `version/${numbers}`, not just `${numbers}`.

* lint by human

Thank you <3


manual cherry pick of https://github.com/goauthentik/authentik/pull/19448