### PR TITLE
endpoints/connectors/agent: Skip Endpoint stage on device IA & fix confusing identification subtext

### DIFF
--- a/authentik/endpoints/connectors/agent/stage.py
+++ b/authentik/endpoints/connectors/agent/stage.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from hashlib import sha256
 from hmac import compare_digest
 
 from django.http import HttpResponse
@@ -8,7 +9,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.fields import CharField, IntegerField
 
 from authentik.crypto.models import CertificateKeyPair
-from authentik.endpoints.connectors.agent.models import DeviceToken
+from authentik.endpoints.connectors.agent.models import DeviceAuthenticationToken, DeviceToken
 from authentik.endpoints.models import Device, EndpointStage, StageMode
 from authentik.flows.challenge import (
     Challenge,
@@ -20,6 +21,7 @@ from authentik.lib.generators import generate_id
 from authentik.lib.utils.time import timedelta_from_string
 from authentik.providers.oauth2.models import JWTAlgorithms
 
+PLAN_CONTEXT_DEVICE_AUTH_TOKEN = "goauthentik.io/endpoints/device_auth_token"  # nosec
 PLAN_CONTEXT_AGENT_ENDPOINT_CHALLENGE = "goauthentik.io/endpoints/connectors/agent/challenge"
 QS_CHALLENGE = "challenge"
 QS_CHALLENGE_RESPONSE = "response"
@@ -85,11 +87,31 @@ class AuthenticatorEndpointStageView(ChallengeStageView):
     response_class = EndpointAgentChallengeResponse
 
     def get(self, request, *args, **kwargs):
+        # Check if we're in a device interactive auth flow, in which case we use that
+        # to prove which device is being used
+        if response := self.check_device_ia():
+            return response
         stage: EndpointStage = self.executor.current_stage
         keypair = CertificateKeyPair.objects.filter(pk=stage.connector.challenge_key_id).first()
         if not keypair:
             return self.executor.stage_ok()
         return super().get(request, *args, **kwargs)
+
+    def check_device_ia(self):
+        """Check if we're in a device interactive authentication flow, and if so,
+        there won't be a browser extension to talk to. However we can authenticate
+        on the DTH header"""
+        if PLAN_CONTEXT_DEVICE_AUTH_TOKEN not in self.executor.plan.context:
+            return None
+        auth_token: DeviceAuthenticationToken = self.executor.plan.context.get(PLAN_CONTEXT_DEVICE_AUTH_TOKEN)
+        device_token_hash = self.request.headers.get("X-Authentik-Platform-Auth-DTH")
+        if not device_token_hash:
+            return None
+        if not compare_digest(
+            device_token_hash, sha256(auth_token.device_token.key.encode()).hexdigest()
+        ):
+            return self.executor.stage_invalid("Invalid device token")
+        return self.executor.stage_ok()
 
     def get_challenge(self, *args, **kwargs) -> Challenge:
         stage: EndpointStage = self.executor.current_stage

--- a/authentik/endpoints/connectors/agent/stage.py
+++ b/authentik/endpoints/connectors/agent/stage.py
@@ -103,7 +103,9 @@ class AuthenticatorEndpointStageView(ChallengeStageView):
         on the DTH header"""
         if PLAN_CONTEXT_DEVICE_AUTH_TOKEN not in self.executor.plan.context:
             return None
-        auth_token: DeviceAuthenticationToken = self.executor.plan.context.get(PLAN_CONTEXT_DEVICE_AUTH_TOKEN)
+        auth_token: DeviceAuthenticationToken = self.executor.plan.context.get(
+            PLAN_CONTEXT_DEVICE_AUTH_TOKEN
+        )
         device_token_hash = self.request.headers.get("X-Authentik-Platform-Auth-DTH")
         if not device_token_hash:
             return None

--- a/authentik/enterprise/endpoints/connectors/agent/views/auth_interactive.py
+++ b/authentik/enterprise/endpoints/connectors/agent/views/auth_interactive.py
@@ -8,6 +8,7 @@ from authentik.endpoints.connectors.agent.auth import (
     check_device_policies,
 )
 from authentik.endpoints.connectors.agent.models import AgentConnector, DeviceAuthenticationToken
+from authentik.endpoints.connectors.agent.stage import PLAN_CONTEXT_DEVICE_AUTH_TOKEN
 from authentik.endpoints.models import Device
 from authentik.enterprise.policy import EnterprisePolicyAccessView
 from authentik.flows.exceptions import FlowNonApplicableException
@@ -15,8 +16,6 @@ from authentik.flows.models import in_memory_stage
 from authentik.flows.planner import PLAN_CONTEXT_DEVICE, FlowPlanner
 from authentik.flows.stage import StageView
 from authentik.providers.oauth2.utils import HttpResponseRedirectScheme
-
-PLAN_CONTEXT_DEVICE_AUTH_TOKEN = "goauthentik.io/endpoints/device_auth_token"  # nosec
 
 QS_AGENT_IA_TOKEN = "ak-auth-ia-token"  # nosec
 

--- a/authentik/stages/identification/stage.py
+++ b/authentik/stages/identification/stage.py
@@ -17,6 +17,9 @@ from sentry_sdk import start_span
 from authentik.core.api.utils import JSONDictField, PassiveSerializer
 from authentik.core.models import Application, Source, User
 from authentik.endpoints.models import Device
+from authentik.enterprise.endpoints.connectors.agent.views.auth_interactive import (
+    PLAN_CONTEXT_DEVICE_AUTH_TOKEN,
+)
 from authentik.events.middleware import audit_ignore
 from authentik.events.utils import sanitize_item
 from authentik.flows.challenge import (
@@ -315,7 +318,10 @@ class IdentificationStageView(ChallengeStageView):
             challenge.initial_data["application_pre"] = self.executor.plan.context.get(
                 PLAN_CONTEXT_APPLICATION, Application()
             ).name
-        if PLAN_CONTEXT_DEVICE in self.executor.plan.context:
+        if (
+            PLAN_CONTEXT_DEVICE in self.executor.plan.context
+            and PLAN_CONTEXT_DEVICE_AUTH_TOKEN in self.executor.plan.context
+        ):
             challenge.initial_data["application_pre"] = self.executor.plan.context.get(
                 PLAN_CONTEXT_DEVICE, Device()
             ).name


### PR DESCRIPTION
- when doing device interactive auth, let the endpoint stage continue as we already know the device based on the DTH header
- only show "continuing to device xyz" when using device IA flow, not when using an endpoint stage only