### PR TITLE
website/docs: limiting permissions of AD service account

### DIFF
--- a/website/docs/users-sources/sources/directory-sync/active-directory/index.md
+++ b/website/docs/users-sources/sources/directory-sync/active-directory/index.md
@@ -39,9 +39,9 @@ To support the integration of Active Directory with authentik, you need to creat
     ![](./02_delegate.png)
 
 :::info Limiting service account permissions
-Optionally, if you don't want authentik to be able to view and sync objects within certain OUs, you can limit the servive account's permissions:
+Optionally, if you don't want authentik to be able to view and sync objects within certain Organizational Units, you can limit the service account's permissions:
 
-1. Right click on the OU in question and navigate to **Properties** > **Security**.
+1. Right click the Organizational Unit in question and navigate to **Properties** > **Security**.
 2. Select the authentik service account that you created.
 3. Under the **Deny** column, check **Read**.
 4. Cick **Apply**.

--- a/website/docs/users-sources/sources/directory-sync/active-directory/index.md
+++ b/website/docs/users-sources/sources/directory-sync/active-directory/index.md
@@ -44,7 +44,7 @@ Optionally, if you don't want authentik to be able to view and sync objects with
 1. Right click the Organizational Unit in question and navigate to **Properties** > **Security**.
 2. Select the authentik service account that you created.
 3. Under the **Deny** column, check **Read**.
-4. Cick **Apply**.
+4. Click **Apply**.
 
 You can repeat this process for other OUs and objects within Active Directory.
 :::

--- a/website/docs/users-sources/sources/directory-sync/active-directory/index.md
+++ b/website/docs/users-sources/sources/directory-sync/active-directory/index.md
@@ -38,6 +38,18 @@ To support the integration of Active Directory with authentik, you need to creat
 
     ![](./02_delegate.png)
 
+:::info Limiting service account permissions
+Optionally, if you don't want authentik to be able to view and sync objects within certain OUs, you can limit the servive account's permissions:
+
+1. Right click on the OU in question and navigate to **Properties** > **Security** > **Advanced**.
+2. Select the authentik service account that you created.
+3. Select **Apply to this object and all descendant objects**
+4. Deny the following: **List contents**, **Read all properties**, and **Read permissions**
+5. Cick apply.
+
+You can repeat this process for other OUs and objects within Active Directory.
+:::
+
 ## authentik Setup
 
 To support the integration of authentik with Active Directory, you will need to create a new LDAP Source in authentik.
@@ -72,6 +84,8 @@ To support the integration of authentik with Active Directory, you will need to 
     - **Group membership field**: the user object attribute or the group object attribute that determines the group membership of a user (e.g. `member`). If **Lookup using a user attribute** is set, this should be a user object attribute, otherwise a group object attribute.
     - **User membership attribute**: ensure that this is set to `distinguishedName`.
     - **Object uniqueness field**: a user attribute that contains a unique identifier (e.g. `objectSid`).
+
+    :::info
 
 5. Click **Finish** to save the LDAP Source. An LDAP synchronization will begin in the background. Once completed, you can view the summary by navigating to **Dashboards** > **System Tasks**:
 

--- a/website/docs/users-sources/sources/directory-sync/active-directory/index.md
+++ b/website/docs/users-sources/sources/directory-sync/active-directory/index.md
@@ -41,11 +41,10 @@ To support the integration of Active Directory with authentik, you need to creat
 :::info Limiting service account permissions
 Optionally, if you don't want authentik to be able to view and sync objects within certain OUs, you can limit the servive account's permissions:
 
-1. Right click on the OU in question and navigate to **Properties** > **Security** > **Advanced**.
+1. Right click on the OU in question and navigate to **Properties** > **Security**.
 2. Select the authentik service account that you created.
-3. Select **Apply to this object and all descendant objects**
-4. Deny the following: **List contents**, **Read all properties**, and **Read permissions**
-5. Cick apply.
+3. Under the **Deny** column, check **Read**.
+4. Cick **Apply**.
 
 You can repeat this process for other OUs and objects within Active Directory.
 :::


### PR DESCRIPTION
## Details

Adds info box about limiting AD sync service account permissions.

---

## Checklist

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
