### PR TITLE
endpoints/connectors/agent: add tests for IA endpoint stage

### DIFF
--- a/authentik/endpoints/connectors/agent/stage.py
+++ b/authentik/endpoints/connectors/agent/stage.py
@@ -113,6 +113,8 @@ class AuthenticatorEndpointStageView(ChallengeStageView):
             device_token_hash, sha256(auth_token.device_token.key.encode()).hexdigest()
         ):
             return self.executor.stage_invalid("Invalid device token")
+        self.logger.debug("Setting device based on DTH header")
+        self.executor.plan.context[PLAN_CONTEXT_DEVICE] = auth_token.device
         return self.executor.stage_ok()
 
     def get_challenge(self, *args, **kwargs) -> Challenge:

--- a/authentik/flows/tests/__init__.py
+++ b/authentik/flows/tests/__init__.py
@@ -51,6 +51,11 @@ class FlowTestCase(APITestCase):
     def get_flow_plan(self) -> FlowPlan | None:
         return self.client.session.get(SESSION_KEY_PLAN)
 
+    def set_flow_plan(self, plan: FlowPlan):
+        session = self.client.session
+        session[SESSION_KEY_PLAN] = plan
+        session.save()
+
     def assertStageRedirects(self, response: HttpResponse, to: str) -> dict[str, Any]:
         """Wrapper around assertStageResponse that checks for a redirect"""
         return self.assertStageResponse(response, component="xak-flow-redirect", to=to)


### PR DESCRIPTION
followup to https://github.com/goauthentik/authentik/pull/19482

adds some tests and actually adds the device to the flow plan