### PR TITLE
web: Reduce Sentry Development Errors

### DIFF
--- a/web/src/elements/router/RouterOutlet.ts
+++ b/web/src/elements/router/RouterOutlet.ts
@@ -91,7 +91,7 @@ export class RouterOutlet extends AKElement {
 
         window.addEventListener("hashchange", this.navigate);
 
-        if (this.#sentryClient) {
+        if (process.env.NODE_ENV !== "production" && this.#sentryClient) {
             this.#pageLoadSpan =
                 startBrowserTracingPageLoadSpan(this.#sentryClient, {
                     name: window.location.pathname,


### PR DESCRIPTION
## Details

This PR address two sources of Sentry errors on page load when debugging is enabled:

1. When Sentry initializes a session
2. When the client-side router changes pages

<img width="1304" height="234" alt="Screenshot 2026-01-16 at 04 07 24" src="https://github.com/user-attachments/assets/148182b1-c44a-451d-a0e4-a440eb889160" />
 