### PR TITLE
website: Omit Drafts From Version Picker

### DIFF
--- a/website/docusaurus-theme/releases/node.mjs
+++ b/website/docusaurus-theme/releases/node.mjs
@@ -13,6 +13,46 @@ import FastGlob from "fast-glob";
 import { coerce } from "semver";
 
 /**
+ * Number of supported releases to show in the sidebar.
+ */
+export const SUPPORTED_RELEASE_COUNT = 3;
+
+/**
+ * @typedef {FastGlob.Entry & AKReleaseFile} AKReleaseFileEntry
+ */
+
+/**
+ * Reads and parses the front matter of recent release files.
+ *
+ * @param {string} releasesParentDirectory
+ * @param {AKReleaseFileEntry} release
+ * @param {number} index
+ */
+function parseRelease(releasesParentDirectory, release, index) {
+    if (index > SUPPORTED_RELEASE_COUNT - 1) {
+        return release;
+    }
+
+    const extension = extname(release.dirent.name);
+
+    const fileContent = readFileSync(
+        join(releasesParentDirectory, `${release.path}${extension}`),
+        "utf-8",
+    );
+
+    const { frontMatter } = parseFileContentFrontMatter(fileContent);
+
+    if (frontMatter.beta) {
+        release.name += " (Release Candidate)";
+    }
+
+    return {
+        ...release,
+        frontMatter,
+    };
+}
+
+/**
  * Collect all Markdown files from the releases directory.
  *
  * @param {string} releasesParentDirectory
@@ -20,7 +60,7 @@ import { coerce } from "semver";
  */
 export function collectReleaseFiles(releasesParentDirectory) {
     /**
-     * @type {Array<FastGlob.Entry & AKReleaseFile>}
+     * @type {AKReleaseFileEntry[]}
      */
     const releaseFiles = FastGlob.sync("releases/**/v*.{md,mdx}", {
         cwd: releasesParentDirectory,
@@ -45,29 +85,12 @@ export function collectReleaseFiles(releasesParentDirectory) {
             return b.name.localeCompare(a.name);
         });
 
-    const [latestRelease] = releaseFiles;
+    const parsedReleaseFiles = releaseFiles.map((release, index) =>
+        parseRelease(releasesParentDirectory, release, index),
+    );
 
-    if (latestRelease) {
-        const extension = extname(latestRelease.dirent.name);
-
-        const fileContent = readFileSync(
-            join(releasesParentDirectory, `${latestRelease.path}${extension}`),
-            "utf-8",
-        );
-
-        const { frontMatter } = parseFileContentFrontMatter(fileContent);
-
-        latestRelease.frontMatter = frontMatter;
-
-        if (latestRelease.frontMatter.beta) {
-            latestRelease.name += " (Release Candidate)";
-        }
-    }
-
-    return releaseFiles;
+    return parsedReleaseFiles;
 }
-
-export const SUPPORTED_RELEASE_COUNT = 3;
 
 /**
  *

--- a/website/docusaurus-theme/releases/plugin.mjs
+++ b/website/docusaurus-theme/releases/plugin.mjs
@@ -32,7 +32,9 @@ async function akReleasesPlugin(loadContext, options) {
             };
 
             const releases = collectReleaseFiles(options.docsDirectory);
-            const releaseNames = releases.map((release) => release.name);
+            const releaseNames = releases
+                .filter((release) => !release.frontMatter?.draft)
+                .map((release) => release.name);
 
             const outputPath = path.join(loadContext.siteDir, "static", RELEASES_FILENAME);
 


### PR DESCRIPTION
## Details

This PR adds support for state previously not included in docs version picker:

1. A version of authentik has release notes
2. The release notes has `draft: true` in the front-matter
3. The version does not yet have a release candidate

### Previous behavior

The version picker incorrectly displays the non-existent version in the select dropdown:  

<img width="651" height="332" alt="Screenshot 2026-01-16 at 04 48 39" src="https://github.com/user-attachments/assets/84f66d3c-3024-4c74-92a2-aef45b5a9bd7" />


### New behavior

The version picker correctly omits the draft release notes from the emitted `releases.json`, preventing the version picker from showing the non-existent version.
