### PR TITLE
admin/files: fix manageable check blocking file creation on fresh installs

### DIFF
--- a/authentik/admin/files/backends/file.py
+++ b/authentik/admin/files/backends/file.py
@@ -45,8 +45,13 @@ class FileBackend(ManageableBackend):
 
     @property
     def manageable(self) -> bool:
+        # Check _base_dir (the mount point, e.g. /data) rather than base_path
+        # (which includes usage/schema subdirs, e.g. /data/media/public).
+        # The subdirectories are created on first file write via mkdir(parents=True)
+        # in save_file(), so requiring them to exist beforehand would prevent
+        # file creation on fresh installs.
         return (
-            self.base_path.exists()
+            self._base_dir.exists()
             and (self._base_dir.is_mount() or (self._base_dir / self.usage.value).is_mount())
             or (settings.DEBUG or settings.TEST)
         )


### PR DESCRIPTION
Overview:

The manageable property in `FileBackend` checked `base_path.exists()` which includes the usage and schema subdirectories (e.g. `/data/media/public`).

On fresh installs these directories don't exist yet, which causes the check to return False and blocking file uploads under Customization > Files (and the corresponding API routes).

Changed to check `_base_dir.exists()` (e.g. `/data`) instead, since that's the actual mount point. The subdirectories are created automatically by `save_file()` via `mkdir(parents=True)` when the first file is uploaded.

An explanation has also been added above the changed line.

Testing:

Spun up a Docker installation using the docs. Then, made the fix and built an image locally. Ran `docker compose down -v` and deleted volume directories, then ran the compose file again to ensure a fresh set up, and confirmed files can be created.

Motivation:

Closes: https://github.com/goauthentik/authentik/issues/19546