### PR TITLE
providers/oauth2: add `logout+jwt` token type for oidc logout token.

### DIFF
--- a/authentik/providers/oauth2/models.py
+++ b/authentik/providers/oauth2/models.py
@@ -386,11 +386,18 @@ class OAuth2Provider(WebfingerProvider, Provider):
     def __str__(self):
         return f"OAuth2 Provider {self.name}"
 
-    def encode(self, payload: dict[str, Any]) -> str:
-        """Represent the ID Token as a JSON Web Token (JWT)."""
+    def encode(self, payload: dict[str, Any], jwt_type: str | None = None) -> str:
+        """Represent the ID Token as a JSON Web Token (JWT).
+
+        :param payload The payload to encode into the JWT
+        :param jwt_type The type of the JWT. This will be put in the JWT header using the `typ`
+            parameter. See RFC7515 Section 4.1.9. If not set fallback to the default of `JWT`.
+        """
         headers = {}
         if self.signing_key:
             headers["kid"] = self.signing_key.kid
+        if jwt_type is not None:
+            headers["typ"] = jwt_type
         key, alg = self.jwt_key
         encoded = encode(payload, key, algorithm=alg, headers=headers)
         if self.encryption_key:

--- a/authentik/providers/oauth2/utils.py
+++ b/authentik/providers/oauth2/utils.py
@@ -259,4 +259,4 @@ def create_logout_token(
     if session_key:
         payload["sid"] = hash_session_key(session_key)
     # Encode the token
-    return provider.encode(payload, "logout+jwt")
+    return provider.encode(payload, jwt_type="logout+jwt")

--- a/authentik/providers/oauth2/utils.py
+++ b/authentik/providers/oauth2/utils.py
@@ -259,4 +259,4 @@ def create_logout_token(
     if session_key:
         payload["sid"] = hash_session_key(session_key)
     # Encode the token
-    return provider.encode(payload)
+    return provider.encode(payload, "logout+jwt")


### PR DESCRIPTION


<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

The oidc back-channel logout spec recommends using explicitly typed JWTs using the `typ` parameter in the JWT's header.

[spec](https://openid.net/specs/openid-connect-backchannel-1_0.html#CrossJWT)

This may be a breaking change for some implementations if they were already checking the type of the token to be `JWT` (the default value).

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->

---

## Checklist

-   [X] Local tests pass (`ak test authentik/`)
-   [X] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
