### PR TITLE
web/admin: fix captcha stage provider selector not showing saved value

### DIFF
--- a/web/src/admin/stages/captcha/CaptchaStageForm.ts
+++ b/web/src/admin/stages/captcha/CaptchaStageForm.ts
@@ -109,9 +109,9 @@ const CAPTCHA_PROVIDERS: Record<string, CaptchaProviderPreset> = {
 @customElement("ak-stage-captcha-form")
 export class CaptchaStageForm extends BaseStageForm<CaptchaStage> {
     @state()
-    protected selectedProvider = "custom";
+    protected selectedProvider = "recaptcha_v2";
 
-    currentPreset: CaptchaProviderPreset = CAPTCHA_PROVIDERS.custom;
+    currentPreset: CaptchaProviderPreset = CAPTCHA_PROVIDERS.recaptcha_v2;
 
     public override reset(): void {
         super.reset();

--- a/web/src/admin/stages/captcha/CaptchaStageForm.ts
+++ b/web/src/admin/stages/captcha/CaptchaStageForm.ts
@@ -227,13 +227,12 @@ export class CaptchaStageForm extends BaseStageForm<CaptchaStage> {
 
     renderProviderSelector(): TemplateResult {
         return html`<ak-form-element-horizontal label=${msg("Provider Type")} name="providerType">
-            <select
-                class="pf-c-form-control"
-                @change=${this.handleProviderChange}
-                .value=${this.selectedProvider}
-            >
+            <select class="pf-c-form-control" @change=${this.handleProviderChange}>
                 ${Object.entries(CAPTCHA_PROVIDERS).map(
-                    ([key, preset]) => html`<option value=${key}>${preset.label}</option>`,
+                    ([key, preset]) =>
+                        html`<option value=${key} ?selected=${key === this.selectedProvider}>
+                            ${preset.label}
+                        </option>`,
                 )}
             </select>
             <p class="pf-c-form__helper-text">


### PR DESCRIPTION
Overview:

When editing an existing captcha stage, the Provider Type dropdown always showed "Google reCAPTCHA v2" (the first option) instead of the actual configured provider (e.g. Cloudflare Turnstile).

The root cause was using `.value=${this.selectedProvider}` on the `<select>` element, which doesn't work reliably in Lit templates. the browser selects the first `<option>` by default before the property binding takes effect.

Fixed by adding the `selected` attribute directly to each `<option>` element.

Testing:

1. Create a new captcha stage with Cloudflare Turnstile
2. Save and close the form
3. Edit the stage again
4. Verify the Provider Type dropdown shows "Cloudflare Turnstile" instead of "Google reCAPTCHA v2"

Motivation:

Closes https://github.com/goauthentik/authentik/issues/19550