### PR TITLE
web/forms: fix invalid date error for empty datetime-local inputs

### DIFF
--- a/web/src/elements/forms/Form.ts
+++ b/web/src/elements/forms/Form.ts
@@ -114,9 +114,10 @@ export function serializeForm<T = Record<string, unknown>>(elements: Iterable<AK
             }
 
             if (inputElement.type === "datetime-local") {
+                const valueAsNumber = inputElement.valueAsNumber;
                 return assignValue(
                     inputElement,
-                    dateToUTC(new Date(inputElement.valueAsNumber)),
+                    isNaN(valueAsNumber) ? null : dateToUTC(new Date(valueAsNumber)),
                     json,
                 );
             }
@@ -124,7 +125,8 @@ export function serializeForm<T = Record<string, unknown>>(elements: Iterable<AK
             if ("type" in inputElement.dataset && inputElement.dataset.type === "datetime-local") {
                 // Workaround for Firefox <93, since 92 and older don't support
                 // datetime-local fields
-                return assignValue(inputElement, dateToUTC(new Date(inputElement.value)), json);
+                const date = new Date(inputElement.value);
+                return assignValue(inputElement, isNaN(date.getTime()) ? null : dateToUTC(date), json);
             }
 
             if (inputElement.type === "checkbox") {

--- a/web/src/elements/forms/Form.ts
+++ b/web/src/elements/forms/Form.ts
@@ -126,7 +126,11 @@ export function serializeForm<T = Record<string, unknown>>(elements: Iterable<AK
                 // Workaround for Firefox <93, since 92 and older don't support
                 // datetime-local fields
                 const date = new Date(inputElement.value);
-                return assignValue(inputElement, isNaN(date.getTime()) ? null : dateToUTC(date), json);
+                return assignValue(
+                    inputElement,
+                    isNaN(date.getTime()) ? null : dateToUTC(date),
+                    json,
+                );
             }
 
             if (inputElement.type === "checkbox") {


### PR DESCRIPTION
Overview:

When a datetime-local input is empty, `valueAsNumber` returns `NaN` and `new Date("")` creates an Invalid Date. Previously, form serialization passed these invalid dates to the API, which caused  "RangeError: Invalid time value" when `toISOString()` was called. Now empty datetime inputs correctly serialize to `null`.

Testing:

1. Go to Directory > Tokens and App passwords
2. Create or edit a token
3. Uncheck the "Expiring" checkbox
4. Save the token
5. Verify no error occurs and token is saved without expiry

Motivation:

Closes: https://github.com/goauthentik/authentik/issues/19558