### PR TITLE
web/forms: fix forms not resetting state when modal closes

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -72,6 +72,7 @@
         "#tests/*": "./tests/*.js",
         "#e2e": "./e2e/index.ts",
         "#e2e/*": "./e2e/*.ts",
+        "#types/*": "./types/*/index.d.ts",
         "#*/browser": {
             "types": "./out/*/browser.d.ts",
             "import": "./*/browser.js"

--- a/web/src/admin/AdminInterface/index.entrypoint.ts
+++ b/web/src/admin/AdminInterface/index.entrypoint.ts
@@ -165,7 +165,7 @@ export class AdminInterface extends WithCapabilitiesConfig(
         };
 
         return html`<div class="pf-c-page">
-            <ak-page-navbar ?open=${this.sidebarOpen}>
+            <ak-page-navbar>
                 <button
                     slot="toggle"
                     aria-controls="global-nav"

--- a/web/src/admin/applications/ApplicationCheckAccessForm.ts
+++ b/web/src/admin/applications/ApplicationCheckAccessForm.ts
@@ -24,13 +24,13 @@ import PFDescriptionList from "@patternfly/patternfly/components/DescriptionList
 @customElement("ak-application-check-access-form")
 export class ApplicationCheckAccessForm extends Form<{ forUser: number }> {
     @property({ attribute: false })
-    application!: Application;
+    public application!: Application;
 
     @property({ attribute: false })
-    result: PolicyTestResult | null = null;
+    public result: PolicyTestResult | null = null;
 
     @property({ attribute: false })
-    request?: number;
+    public request?: number;
 
     getSuccessMessage(): string {
         return msg("Successfully sent test-request.");
@@ -45,7 +45,7 @@ export class ApplicationCheckAccessForm extends Form<{ forUser: number }> {
         return (this.result = result);
     }
 
-    reset(): void {
+    public override reset(): void {
         super.reset();
         this.result = null;
     }

--- a/web/src/admin/applications/ApplicationForm.ts
+++ b/web/src/admin/applications/ApplicationForm.ts
@@ -52,6 +52,11 @@ export class ApplicationForm extends WithCapabilitiesConfig(ModelForm<Applicatio
     @state()
     protected backchannelProviders: Provider[] = [];
 
+    reset(): void {
+        super.reset();
+        this.backchannelProviders = [];
+    }
+
     public override getSuccessMessage(): string {
         return this.instance
             ? msg("Successfully updated application.")

--- a/web/src/admin/applications/ApplicationForm.ts
+++ b/web/src/admin/applications/ApplicationForm.ts
@@ -57,7 +57,7 @@ export class ApplicationForm extends WithCapabilitiesConfig(ModelForm<Applicatio
     @state()
     protected backchannelProviders: Provider[] = [];
 
-    reset(): void {
+    public override reset(): void {
         super.reset();
         this.backchannelProviders = [];
     }

--- a/web/src/admin/applications/ApplicationForm.ts
+++ b/web/src/admin/applications/ApplicationForm.ts
@@ -32,6 +32,11 @@ import { html, nothing, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
+/**
+ * Application Form
+ *
+ * @prop {string} instancePk - The primary key of the instance to load.
+ */
 @customElement("ak-application-form")
 export class ApplicationForm extends WithCapabilitiesConfig(ModelForm<Application, string>) {
     #api = new CoreApi(DEFAULT_CONFIG);

--- a/web/src/admin/applications/ProviderSelectModal.ts
+++ b/web/src/admin/applications/ProviderSelectModal.ts
@@ -14,18 +14,18 @@ import { customElement, property } from "lit/decorators.js";
 
 @customElement("ak-provider-select-table")
 export class ProviderSelectModal extends TableModal<Provider> {
-    checkbox = true;
-    checkboxChip = true;
+    public override checkbox = true;
+    public override checkboxChip = true;
 
     protected override searchEnabled = true;
 
     @property({ type: Boolean })
-    backchannel = false;
+    public backchannel = false;
 
-    @property()
-    confirm!: (selectedItems: Provider[]) => Promise<unknown>;
+    @property({ attribute: false })
+    public confirm!: (selectedItems: Provider[]) => Promise<unknown>;
 
-    order = "name";
+    public override order = "name";
 
     async apiEndpoint(): Promise<PaginatedResponse<Provider>> {
         return new ProvidersApi(DEFAULT_CONFIG).providersAllList({

--- a/web/src/admin/applications/components/ak-backchannel-input.ts
+++ b/web/src/admin/applications/components/ak-backchannel-input.ts
@@ -3,10 +3,11 @@ import "#elements/chips/Chip";
 import "#elements/chips/ChipGroup";
 
 import { AKElement } from "#elements/Base";
+import { SlottedTemplateResult } from "#elements/types";
 
 import { Provider } from "@goauthentik/api";
 
-import { html, nothing, TemplateResult } from "lit";
+import { html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { map } from "lit/directives/map.js";
@@ -29,31 +30,31 @@ export class AkBackchannelProvidersInput extends AKElement {
     }
 
     @property({ type: String })
-    name!: string;
+    public name!: string;
 
     @property({ type: String })
-    label = "";
+    public label = "";
 
     @property({ type: Array })
-    providers: Provider[] = [];
-
-    @property({ type: Object })
-    tooltip?: TemplateResult;
+    public providers: Provider[] = [];
 
     @property({ attribute: false, type: Object })
-    confirm!: ({ items }: { items: Provider[] }) => Promise<void>;
+    public tooltip?: SlottedTemplateResult;
 
     @property({ attribute: false, type: Object })
-    remover!: (provider: Provider) => () => void;
+    public confirm!: (items: Provider[]) => Promise<void>;
+
+    @property({ attribute: false, type: Object })
+    public remover!: (provider: Provider) => () => void;
 
     @property({ type: String })
-    value = "";
+    public value = "";
 
     @property({ type: Boolean })
-    required = false;
+    public required = false;
 
     @property({ type: String })
-    help = "";
+    public help = "";
 
     render() {
         const renderOneChip = (provider: Provider) =>

--- a/web/src/admin/applications/components/ak-provider-search-input.ts
+++ b/web/src/admin/applications/components/ak-provider-search-input.ts
@@ -17,7 +17,7 @@ import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
 const renderElement = (item: Provider) => item.name;
-const renderValue = (item: Provider | undefined) => item?.pk;
+const renderValue = (item: Provider | null) => item?.pk ?? "";
 const doGroupBy = (items: Provider[]) => groupBy(items, (item) => item.verboseName);
 
 @customElement("ak-provider-search-input")

--- a/web/src/admin/applications/entitlements/ApplicationEntitlementPage.ts
+++ b/web/src/admin/applications/entitlements/ApplicationEntitlementPage.ts
@@ -105,7 +105,7 @@ export class ApplicationEntitlementsPage extends Table<ApplicationEntitlement> {
             <p>${msg("These bindings control which users have access to this entitlement.")}</p>
             <ak-bound-policies-list
                 .target=${item.pbmUuid}
-                .allowedTypes=${[PolicyBindingCheckTarget.group, PolicyBindingCheckTarget.user]}
+                .allowedTypes=${[PolicyBindingCheckTarget.Group, PolicyBindingCheckTarget.User]}
             >
             </ak-bound-policies-list>
         </div>`;

--- a/web/src/admin/applications/wizard/steps/ak-application-wizard-edit-binding-step.ts
+++ b/web/src/admin/applications/wizard/steps/ak-application-wizard-edit-binding-step.ts
@@ -12,11 +12,17 @@ import "#elements/forms/SearchSelect/index";
 import { DEFAULT_CONFIG } from "#common/api/config";
 import { groupBy } from "#common/utils";
 
+import { ISearchSelectConfig } from "#elements/forms/SearchSelect/ak-search-select-ez";
 import { type SearchSelectBase } from "#elements/forms/SearchSelect/SearchSelect";
 
 import { type NavigableButton, type WizardButton } from "#components/ak-wizard/types";
 
 import { ApplicationWizardStep } from "#admin/applications/wizard/ApplicationWizardStep";
+import {
+    createPassFailOptions,
+    PolicyBindingCheckTarget,
+    PolicyObjectKeys,
+} from "#admin/policies/utils";
 
 import { CoreApi, Group, PoliciesApi, Policy, PolicyBinding, User } from "@goauthentik/api";
 
@@ -25,23 +31,6 @@ import { html, nothing } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
 
 const withQuery = <T>(search: string | undefined, args: T) => (search ? { ...args, search } : args);
-
-enum target {
-    policy = "policy",
-    group = "group",
-    user = "user",
-}
-
-const policyObjectKeys: Record<target, keyof PolicyBinding> = {
-    [target.policy]: "policyObj",
-    [target.group]: "groupObj",
-    [target.user]: "userObj",
-};
-
-const PASS_FAIL = [
-    [msg("Pass"), true, false],
-    [msg("Don't Pass"), false, true],
-].map(([label, value, d]) => ({ label, value, default: d }));
 
 @customElement("ak-application-wizard-edit-binding-step")
 export class ApplicationWizardEditBindingStep extends ApplicationWizardStep {
@@ -57,7 +46,7 @@ export class ApplicationWizardEditBindingStep extends ApplicationWizardStep {
     searchSelect!: SearchSelectBase<Policy> | SearchSelectBase<Group> | SearchSelectBase<User>;
 
     @state()
-    policyGroupUser: target = target.policy;
+    policyGroupUser: PolicyBindingCheckTarget = PolicyBindingCheckTarget.Policy;
 
     instanceId = -1;
 
@@ -76,8 +65,9 @@ export class ApplicationWizardEditBindingStep extends ApplicationWizardStep {
             if (!this.form?.checkValidity()) {
                 return;
             }
+
             const policyObject = this.searchSelect.selectedObject;
-            const policyKey = policyObjectKeys[this.policyGroupUser];
+            const policyKey = PolicyObjectKeys[this.policyGroupUser];
             const newBinding: PolicyBinding = {
                 ...(this.formValues as unknown as PolicyBinding),
                 [policyKey]: policyObject,
@@ -93,67 +83,75 @@ export class ApplicationWizardEditBindingStep extends ApplicationWizardStep {
 
             this.instanceId = -1;
             this.handleUpdate({ bindings }, "bindings");
+
             return;
         }
+
         super.handleButton(button);
     }
 
     // The search select configurations for the three different types of fetches that we care about,
     // policy, user, and group, all using the SearchSelectEZ protocol.
-    searchSelectConfigs(kind: target) {
+    searchSelectConfigs(
+        kind: PolicyBindingCheckTarget,
+    ): ISearchSelectConfig<Policy> | ISearchSelectConfig<Group> | ISearchSelectConfig<User> {
         switch (kind) {
-            case target.policy:
+            case PolicyBindingCheckTarget.Policy:
                 return {
-                    fetchObjects: async (query?: string): Promise<Policy[]> => {
+                    fetchObjects: async (query) => {
                         const policies = await new PoliciesApi(DEFAULT_CONFIG).policiesAllList(
                             withQuery(query, {
                                 ordering: "name",
                             }),
                         );
+
                         return policies.results;
                     },
-                    groupBy: (items: Policy[]) =>
-                        groupBy(items, (policy) => policy.verboseNamePlural),
-                    renderElement: (policy: Policy): string => policy.name,
-                    value: (policy: Policy | undefined): string | undefined => policy?.pk,
-                    selected: (policy: Policy): boolean => policy.pk === this.instance?.policy,
-                };
-            case target.group:
+                    groupBy: (items) => groupBy(items, (policy) => policy.verboseNamePlural),
+                    renderElement: (policy): string => policy.name,
+                    value: (policy) => policy?.pk ?? "",
+                    selected: (policy) => policy.pk === this.instance?.policy,
+                } satisfies ISearchSelectConfig<Policy>;
+
+            case PolicyBindingCheckTarget.Group:
                 return {
-                    fetchObjects: async (query?: string): Promise<Group[]> => {
+                    fetchObjects: async (query) => {
                         const groups = await new CoreApi(DEFAULT_CONFIG).coreGroupsList(
                             withQuery(query, {
                                 ordering: "name",
                                 includeUsers: false,
                             }),
                         );
+
                         return groups.results;
                     },
-                    renderElement: (group: Group): string => group.name,
-                    value: (group: Group | undefined): string | undefined => group?.pk,
-                    selected: (group: Group): boolean => group.pk === this.instance?.group,
-                };
-            case target.user:
+                    renderElement: (group) => group.name,
+                    value: (group) => group?.pk ?? "",
+                    selected: (group) => group.pk === this.instance?.group,
+                } satisfies ISearchSelectConfig<Group>;
+            case PolicyBindingCheckTarget.User:
                 return {
-                    fetchObjects: async (query?: string): Promise<User[]> => {
+                    fetchObjects: async (query) => {
                         const users = await new CoreApi(DEFAULT_CONFIG).coreUsersList(
                             withQuery(query, {
                                 ordering: "username",
                             }),
                         );
+
                         return users.results;
                     },
-                    renderElement: (user: User): string => user.username,
-                    renderDescription: (user: User) => html`${user.name}`,
-                    value: (user: User | undefined): number | undefined => user?.pk,
-                    selected: (user: User): boolean => user.pk === this.instance?.user,
-                };
+                    renderElement: (user): string => user.username,
+                    renderDescription: (user) => html`${user.name}`,
+                    value: (user) => String(user?.pk ?? ""),
+                    selected: (user) => user.pk === this.instance?.user,
+                } satisfies ISearchSelectConfig<User>;
+
             default:
                 throw new Error(`Unrecognized policy binding target ${kind}`);
         }
     }
 
-    renderSearch(title: string, policyKind: target) {
+    renderSearch(title: string, policyKind: PolicyBindingCheckTarget) {
         if (policyKind !== this.policyGroupUser) {
             return nothing;
         }
@@ -174,19 +172,21 @@ export class ApplicationWizardEditBindingStep extends ApplicationWizardStep {
                     <div class="pf-c-card__body">
                         <ak-toggle-group
                             value=${this.policyGroupUser}
-                            @ak-toggle=${(ev: CustomEvent<{ value: target }>) => {
+                            @ak-toggle=${(ev: CustomEvent<{ value: PolicyBindingCheckTarget }>) => {
                                 this.policyGroupUser = ev.detail.value;
                             }}
                         >
-                            <option value=${target.policy}>${msg("Policy")}</option>
-                            <option value=${target.group}>${msg("Group")}</option>
-                            <option value=${target.user}>${msg("User")}</option>
+                            <option value=${PolicyBindingCheckTarget.Policy}>
+                                ${msg("Policy")}
+                            </option>
+                            <option value=${PolicyBindingCheckTarget.Group}>${msg("Group")}</option>
+                            <option value=${PolicyBindingCheckTarget.User}>${msg("User")}</option>
                         </ak-toggle-group>
                     </div>
                     <div class="pf-c-card__footer">
-                        ${this.renderSearch(msg("Policy"), target.policy)}
-                        ${this.renderSearch(msg("Group"), target.group)}
-                        ${this.renderSearch(msg("User"), target.user)}
+                        ${this.renderSearch(msg("Policy"), PolicyBindingCheckTarget.Policy)}
+                        ${this.renderSearch(msg("Group"), PolicyBindingCheckTarget.Group)}
+                        ${this.renderSearch(msg("User"), PolicyBindingCheckTarget.User)}
                     </div>
                 </div>
                 <ak-switch-input
@@ -215,7 +215,7 @@ export class ApplicationWizardEditBindingStep extends ApplicationWizardStep {
                 <ak-radio-input
                     name="failureResult"
                     label=${msg("Failure result")}
-                    .options=${PASS_FAIL}
+                    .options=${createPassFailOptions}
                 ></ak-radio-input>
             </form>`;
     }

--- a/web/src/admin/blueprints/BlueprintForm.ts
+++ b/web/src/admin/blueprints/BlueprintForm.ts
@@ -121,9 +121,7 @@ export class BlueprintForm extends ModelForm<BlueprintInstance, string> {
                                       }
                                       return name;
                                   }}
-                                  .value=${(
-                                      item: BlueprintFile | undefined,
-                                  ): string | undefined => {
+                                  .value=${(item: BlueprintFile | null) => {
                                       return item?.path;
                                   }}
                                   .selected=${(item: BlueprintFile): boolean => {

--- a/web/src/admin/blueprints/BlueprintForm.ts
+++ b/web/src/admin/blueprints/BlueprintForm.ts
@@ -33,6 +33,11 @@ export class BlueprintForm extends ModelForm<BlueprintInstance, string> {
     @state()
     source: blueprintSource = blueprintSource.file;
 
+    reset(): void {
+        super.reset();
+        this.source = blueprintSource.file;
+    }
+
     async loadInstance(pk: string): Promise<BlueprintInstance> {
         const inst = await new ManagedApi(DEFAULT_CONFIG).managedBlueprintsRetrieve({
             instanceUuid: pk,

--- a/web/src/admin/blueprints/BlueprintForm.ts
+++ b/web/src/admin/blueprints/BlueprintForm.ts
@@ -22,20 +22,21 @@ import { ifDefined } from "lit/directives/if-defined.js";
 
 import PFContent from "@patternfly/patternfly/components/Content/content.css";
 
-enum blueprintSource {
-    file = "file",
-    oci = "oci",
-    internal = "internal",
+enum BlueprintSource {
+    File = "file",
+    OCI = "oci",
+    Internal = "internal",
 }
 
 @customElement("ak-blueprint-form")
 export class BlueprintForm extends ModelForm<BlueprintInstance, string> {
     @state()
-    source: blueprintSource = blueprintSource.file;
+    protected source: BlueprintSource = BlueprintSource.File;
 
-    reset(): void {
+    public override reset(): void {
         super.reset();
-        this.source = blueprintSource.file;
+
+        this.source = BlueprintSource.File;
     }
 
     async loadInstance(pk: string): Promise<BlueprintInstance> {
@@ -43,10 +44,10 @@ export class BlueprintForm extends ModelForm<BlueprintInstance, string> {
             instanceUuid: pk,
         });
         if (inst.path?.startsWith("oci://")) {
-            this.source = blueprintSource.oci;
+            this.source = BlueprintSource.OCI;
         }
         if (inst.content !== "") {
-            this.source = blueprintSource.internal;
+            this.source = BlueprintSource.Internal;
         }
         return inst;
     }
@@ -91,17 +92,17 @@ export class BlueprintForm extends ModelForm<BlueprintInstance, string> {
                 <div class="pf-c-card__body">
                     <ak-toggle-group
                         value=${this.source}
-                        @ak-toggle=${(ev: CustomEvent<{ value: blueprintSource }>) => {
+                        @ak-toggle=${(ev: CustomEvent<{ value: BlueprintSource }>) => {
                             this.source = ev.detail.value;
                         }}
                     >
-                        <option value=${blueprintSource.file}>${msg("Local path")}</option>
-                        <option value=${blueprintSource.oci}>${msg("OCI Registry")}</option>
-                        <option value=${blueprintSource.internal}>${msg("Internal")}</option>
+                        <option value=${BlueprintSource.File}>${msg("Local path")}</option>
+                        <option value=${BlueprintSource.OCI}>${msg("OCI Registry")}</option>
+                        <option value=${BlueprintSource.Internal}>${msg("Internal")}</option>
                     </ak-toggle-group>
                 </div>
                 <div class="pf-c-card__footer">
-                    ${this.source === blueprintSource.file
+                    ${this.source === BlueprintSource.File
                         ? html`<ak-form-element-horizontal label=${msg("Path")} name="path">
                               <ak-search-select
                                   .fetchObjects=${async (
@@ -132,7 +133,7 @@ export class BlueprintForm extends ModelForm<BlueprintInstance, string> {
                               </ak-search-select>
                           </ak-form-element-horizontal>`
                         : nothing}
-                    ${this.source === blueprintSource.oci
+                    ${this.source === BlueprintSource.OCI
                         ? html` <ak-text-input
                               name="path"
                               label=${msg("OCI URL")}
@@ -164,7 +165,7 @@ export class BlueprintForm extends ModelForm<BlueprintInstance, string> {
                           >
                           </ak-text-input>`
                         : nothing}
-                    ${this.source === blueprintSource.internal
+                    ${this.source === BlueprintSource.Internal
                         ? html`<ak-form-element-horizontal label=${msg("Blueprint")} name="content">
                               <ak-codemirror
                                   mode="yaml"

--- a/web/src/admin/brands/BrandForm.ts
+++ b/web/src/admin/brands/BrandForm.ts
@@ -169,16 +169,13 @@ export class BrandForm extends ModelForm<Brand, string> {
                                 const users = await new CoreApi(
                                     DEFAULT_CONFIG,
                                 ).coreApplicationsList(args);
+
                                 return users.results;
                             }}
-                            .renderElement=${(item: Application): string => {
-                                return item.name;
-                            }}
-                            .renderDescription=${(item: Application): TemplateResult => {
-                                return html`${item.slug}`;
-                            }}
-                            .value=${(item: Application | undefined): string | undefined => {
-                                return item?.pk;
+                            .renderElement=${(item: Application) => item.name}
+                            .renderDescription=${(item: Application) => html`${item.slug}`}
+                            .value=${(item: Application | null) => {
+                                return String(item?.pk);
                             }}
                             .selected=${(item: Application): boolean => {
                                 return item.pk === this.instance?.defaultApplication;

--- a/web/src/admin/brands/Certificates.ts
+++ b/web/src/admin/brands/Certificates.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_CONFIG } from "#common/api/config";
 
 import {
+    DataProvider,
     DataProvision,
     DualSelectPair,
     DualSelectPairSource,
@@ -12,7 +13,10 @@ const certToSelect = (cert: CertificateKeyPair): DualSelectPair<CertificateKeyPa
     return [cert.pk, cert.name, cert.name, cert];
 };
 
-export async function certificateProvider(page = 1, search = ""): Promise<DataProvision> {
+export const certificateProvider: DataProvider = async (
+    page = 1,
+    search = "",
+): Promise<DataProvision> => {
     return new CryptoApi(DEFAULT_CONFIG)
         .cryptoCertificatekeypairsList({
             ordering: "name",
@@ -27,7 +31,7 @@ export async function certificateProvider(page = 1, search = ""): Promise<DataPr
                 options: results.map(certToSelect),
             };
         });
-}
+};
 
 export function certificateSelector(
     instanceMappings?: string[],

--- a/web/src/admin/common/ak-core-group-search.ts
+++ b/web/src/admin/common/ak-core-group-search.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { AKElement } from "#elements/Base";
-import { SearchSelect } from "#elements/forms/SearchSelect/index";
+import { ISearchSelect } from "#elements/forms/SearchSelect/ak-search-select";
 import { CustomListenerElement } from "#elements/utils/eventEmitter";
 
 import { CoreApi, CoreGroupsListRequest, Group } from "@goauthentik/api";
@@ -23,7 +23,7 @@ async function fetchObjects(query?: string): Promise<Group[]> {
 
 const renderElement = (group: Group): string => group.name;
 
-const renderValue = (group: Group | undefined): string | undefined => group?.pk;
+const renderValue = (group: Group | null) => group?.pk;
 
 /**
  * Core Group Search
@@ -47,7 +47,7 @@ export class CoreGroupSearch extends CustomListenerElement(AKElement) {
     group?: string;
 
     @query("ak-search-select")
-    search!: SearchSelect<Group>;
+    search!: ISearchSelect<Group>;
 
     @property({ type: String })
     public name?: string | null;

--- a/web/src/admin/common/ak-crypto-certificate-search.ts
+++ b/web/src/admin/common/ak-crypto-certificate-search.ts
@@ -3,7 +3,7 @@ import "#elements/forms/SearchSelect/index";
 import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { AKElement } from "#elements/Base";
-import { SearchSelect } from "#elements/forms/SearchSelect/index";
+import { ISearchSelect } from "#elements/forms/SearchSelect/ak-search-select";
 import { ifPresent } from "#elements/utils/attributes";
 import { CustomListenerElement } from "#elements/utils/eventEmitter";
 
@@ -20,7 +20,7 @@ import { customElement, property, query } from "lit/decorators.js";
 
 const renderElement = (item: CertificateKeyPair): string => item.name;
 
-const renderValue = (item: CertificateKeyPair | undefined): string | undefined => item?.pk;
+const renderValue = (item: CertificateKeyPair | null) => item?.pk;
 
 /**
  * Cryptographic Certificate Search
@@ -36,10 +36,10 @@ const renderValue = (item: CertificateKeyPair | undefined): string | undefined =
 @customElement("ak-crypto-certificate-search")
 export class AkCryptoCertificateSearch extends CustomListenerElement(AKElement) {
     @property({ type: String, reflect: true })
-    certificate?: string;
+    certificate?: string | null;
 
     @query("ak-search-select")
-    search!: SearchSelect<CertificateKeyPair>;
+    search!: ISearchSelect<CertificateKeyPair>;
 
     @property({ type: String })
     public name?: string | null;

--- a/web/src/admin/common/ak-flow-search/FlowSearch.ts
+++ b/web/src/admin/common/ak-flow-search/FlowSearch.ts
@@ -6,6 +6,8 @@ import { AKElement } from "#elements/Base";
 import type { HorizontalFormElement } from "#elements/forms/HorizontalFormElement";
 import { CustomListenerElement } from "#elements/utils/eventEmitter";
 
+import { AKFormErrors, ErrorProp } from "#components/ak-field-errors";
+
 import { RenderFlowOption } from "#admin/flows/utils";
 
 import type { Flow, FlowsInstancesListRequest } from "@goauthentik/api";
@@ -24,8 +26,8 @@ export function renderDescription(flow: Flow) {
     return html`${flow.slug}`;
 }
 
-export function getFlowValue(flow: Flow | undefined): string | undefined {
-    return flow?.pk;
+export function getFlowValue(flow: Flow | null): string {
+    return String(flow?.pk ?? "");
 }
 
 /**
@@ -52,7 +54,13 @@ export abstract class FlowSearch<T extends Flow> extends CustomListenerElement(A
      * @attr
      */
     @property({ type: String })
-    public currentFlow?: string;
+    public currentFlow?: string | null;
+
+    /**
+     * @property
+     */
+    @property({ attribute: false })
+    public errorMessages?: ErrorProp[];
 
     /**
      * If true, it is not valid to leave the flow blank.
@@ -191,6 +199,7 @@ export abstract class FlowSearch<T extends Flow> extends CustomListenerElement(A
                 ?blankable=${!this.required}
             >
             </ak-search-select>
+            ${AKFormErrors({ errors: this.errorMessages })}
         `;
     }
 

--- a/web/src/admin/endpoints/DeviceAccessGroupForm.ts
+++ b/web/src/admin/endpoints/DeviceAccessGroupForm.ts
@@ -13,6 +13,11 @@ import { html } from "lit";
 import { customElement } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
+/**
+ * Device Access Group Form
+ *
+ * @prop {string} instancePk - The primary key of the instance to load.
+ */
 @customElement("ak-endpoints-device-access-groups-form")
 export class DeviceAccessGroupForm extends WithBrandConfig(ModelForm<DeviceAccessGroup, string>) {
     loadInstance(pk: string): Promise<DeviceAccessGroup> {

--- a/web/src/admin/endpoints/ak-endpoints-device-group-search.ts
+++ b/web/src/admin/endpoints/ak-endpoints-device-group-search.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { AKElement } from "#elements/Base";
-import { SearchSelect } from "#elements/forms/SearchSelect/index";
+import { ISearchSelect } from "#elements/forms/SearchSelect/ak-search-select";
 import { CustomListenerElement } from "#elements/utils/eventEmitter";
 
 import {
@@ -26,7 +26,7 @@ async function fetchObjects(query?: string): Promise<DeviceAccessGroup[]> {
 
 const renderElement = (group: DeviceAccessGroup): string => group.name;
 
-const renderValue = (group: DeviceAccessGroup | undefined): string | undefined => group?.pbmUuid;
+const renderValue = (group: DeviceAccessGroup | null) => group?.pbmUuid;
 
 /**
  * @element ak-endpoints-device-group-search
@@ -43,7 +43,7 @@ export class EndpointsDeviceAccessGroupSearch extends CustomListenerElement(AKEl
     group?: string;
 
     @query("ak-search-select")
-    search!: SearchSelect<DeviceAccessGroup>;
+    search!: ISearchSelect<DeviceAccessGroup>;
 
     @property({ type: String })
     public name?: string | null;

--- a/web/src/admin/endpoints/connectors/agent/AgentConnectorSetup.ts
+++ b/web/src/admin/endpoints/connectors/agent/AgentConnectorSetup.ts
@@ -135,7 +135,7 @@ export class AgentConnectorSetup extends AKElement {
                         .renderDescription=${(token: EnrollmentToken) => {
                             return html`${token.name}`;
                         }}
-                        .value=${(token: EnrollmentToken | undefined): string | undefined => {
+                        .value=${(token: EnrollmentToken | null) => {
                             return token?.tokenUuid;
                         }}
                         @ak-change=${(ev: CustomEvent) => {
@@ -149,7 +149,6 @@ export class AgentConnectorSetup extends AKElement {
                         <li>
                             <ak-endpoints-agent-connector-config
                                 class="pf-m-secondary"
-                                label=${msg("Windows")}
                                 .request=${{
                                     connectorUuid: this.connector?.connectorUuid || "",
                                     mDMConfigRequest: {
@@ -170,7 +169,6 @@ export class AgentConnectorSetup extends AKElement {
                         <li>
                             <ak-endpoints-agent-connector-config
                                 class="pf-m-link"
-                                label=${msg("macOS")}
                                 .request=${{
                                     connectorUuid: this.connector?.connectorUuid || "",
                                     mDMConfigRequest: {

--- a/web/src/admin/endpoints/connectors/agent/ConfigModal.ts
+++ b/web/src/admin/endpoints/connectors/agent/ConfigModal.ts
@@ -16,7 +16,7 @@ import {
     MDMConfigResponse,
 } from "@goauthentik/api";
 
-import { msg } from "@lit/localize";
+import { msg, str } from "@lit/localize";
 import { html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -28,6 +28,25 @@ export class ConfigModal extends ModalButton {
 
     @state()
     config?: MDMConfigResponse;
+
+    #downloadConnectorConfig = async () => {
+        if (!this.config) {
+            return;
+        }
+
+        downloadFile({
+            content: this.config.config,
+            filename: this.config.filename,
+            type: this.config.mimeType,
+        });
+
+        showMessage({
+            level: MessageLevel.info,
+            message: msg(str`Successfully downloaded ${this.config.filename}!`),
+        });
+
+        this.close();
+    };
 
     connectedCallback(): void {
         super.connectedCallback();
@@ -68,20 +87,7 @@ export class ConfigModal extends ModalButton {
                 </ak-expand>
             </div>
             <footer class="pf-c-modal-box__footer pf-m-align-left">
-                <ak-action-button
-                    class="pf-m-primary"
-                    .apiRequest=${() => {
-                        if (!this.config) {
-                            return;
-                        }
-                        downloadFile(
-                            this.config.config,
-                            this.config.filename,
-                            this.config.mimeType,
-                        );
-                        this.close();
-                    }}
-                >
+                <ak-action-button class="pf-m-primary" .apiRequest=${this.#downloadConnectorConfig}>
                     ${msg("Download")}
                 </ak-action-button>
                 &nbsp;

--- a/web/src/admin/endpoints/connectors/agent/EnrollmentTokenForm.ts
+++ b/web/src/admin/endpoints/connectors/agent/EnrollmentTokenForm.ts
@@ -32,6 +32,11 @@ export class EnrollmentTokenForm extends WithBrandConfig(ModelForm<EnrollmentTok
     @property({ type: String, attribute: "connector-id" })
     public connectorID?: string;
 
+    reset(): void {
+        super.reset();
+        this.expiresAt = new Date(Date.now() + EXPIRATION_DURATION);
+    }
+
     async loadInstance(pk: string): Promise<EnrollmentToken> {
         const token = await new EndpointsApi(
             DEFAULT_CONFIG,

--- a/web/src/admin/endpoints/connectors/agent/EnrollmentTokenForm.ts
+++ b/web/src/admin/endpoints/connectors/agent/EnrollmentTokenForm.ts
@@ -22,6 +22,11 @@ import { ifDefined } from "lit/directives/if-defined.js";
 
 const EXPIRATION_DURATION = 30 * 60 * 1000; // 30 minutes
 
+/**
+ * Enrollment Token Form
+ *
+ * @prop {string} instancePk - The primary key of the instance to load.
+ */
 @customElement("ak-endpoints-agent-enrollment-token-form")
 export class EnrollmentTokenForm extends WithBrandConfig(ModelForm<EnrollmentToken, string>) {
     protected expirationMinimumDate = new Date();

--- a/web/src/admin/endpoints/connectors/agent/EnrollmentTokenForm.ts
+++ b/web/src/admin/endpoints/connectors/agent/EnrollmentTokenForm.ts
@@ -37,8 +37,9 @@ export class EnrollmentTokenForm extends WithBrandConfig(ModelForm<EnrollmentTok
     @property({ type: String, attribute: "connector-id" })
     public connectorID?: string;
 
-    reset(): void {
+    public override reset(): void {
         super.reset();
+
         this.expiresAt = new Date(Date.now() + EXPIRATION_DURATION);
     }
 

--- a/web/src/admin/endpoints/devices/BoundDeviceUsersList.ts
+++ b/web/src/admin/endpoints/devices/BoundDeviceUsersList.ts
@@ -37,7 +37,7 @@ export class BoundDeviceUsersList extends BoundPoliciesList<DeviceUserBinding> {
 
     protected columns: TableColumn[] = [
         [
-            [PolicyBindingCheckTarget.user, PolicyBindingCheckTarget.group]
+            [PolicyBindingCheckTarget.User, PolicyBindingCheckTarget.Group]
                 .map((ct) => PolicyBindingCheckTargetToLabel(ct))
                 .join(" / "),
         ],

--- a/web/src/admin/endpoints/devices/DeviceUserBindingForm.ts
+++ b/web/src/admin/endpoints/devices/DeviceUserBindingForm.ts
@@ -18,13 +18,13 @@ export class DeviceUserBindingForm extends PolicyBindingForm<DeviceUserBinding> 
             policyBindingUuid: pk,
         });
         if (binding?.policyObj) {
-            this.policyGroupUser = PolicyBindingCheckTarget.policy;
+            this.policyGroupUser = PolicyBindingCheckTarget.Policy;
         }
         if (binding?.groupObj) {
-            this.policyGroupUser = PolicyBindingCheckTarget.group;
+            this.policyGroupUser = PolicyBindingCheckTarget.Group;
         }
         if (binding?.userObj) {
-            this.policyGroupUser = PolicyBindingCheckTarget.user;
+            this.policyGroupUser = PolicyBindingCheckTarget.User;
         }
         this.defaultOrder = await this.getOrder();
         return binding;
@@ -35,15 +35,15 @@ export class DeviceUserBindingForm extends PolicyBindingForm<DeviceUserBinding> 
             data.target = this.targetPk;
         }
         switch (this.policyGroupUser) {
-            case PolicyBindingCheckTarget.policy:
+            case PolicyBindingCheckTarget.Policy:
                 data.user = null;
                 data.group = null;
                 break;
-            case PolicyBindingCheckTarget.group:
+            case PolicyBindingCheckTarget.Group:
                 data.policy = null;
                 data.user = null;
                 break;
-            case PolicyBindingCheckTarget.user:
+            case PolicyBindingCheckTarget.User:
                 data.policy = null;
                 data.group = null;
                 break;

--- a/web/src/admin/enterprise/EnterpriseLicenseForm.ts
+++ b/web/src/admin/enterprise/EnterpriseLicenseForm.ts
@@ -19,6 +19,11 @@ export class EnterpriseLicenseForm extends ModelForm<License, string> {
     @state()
     installID?: string;
 
+    reset(): void {
+        super.reset();
+        this.installID = undefined;
+    }
+
     loadInstance(pk: string): Promise<License> {
         return new EnterpriseApi(DEFAULT_CONFIG).enterpriseLicenseRetrieve({
             licenseUuid: pk,

--- a/web/src/admin/enterprise/EnterpriseLicenseForm.ts
+++ b/web/src/admin/enterprise/EnterpriseLicenseForm.ts
@@ -6,22 +6,23 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { EVENT_REFRESH_ENTERPRISE } from "#common/constants";
 
 import { ModelForm } from "#elements/forms/ModelForm";
+import { ifPresent } from "#elements/utils/attributes";
 
 import { EnterpriseApi, License } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
 import { html, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
-import { ifDefined } from "lit/directives/if-defined.js";
 
 @customElement("ak-enterprise-license-form")
 export class EnterpriseLicenseForm extends ModelForm<License, string> {
     @state()
-    installID?: string;
+    protected installID: string | null = null;
 
-    reset(): void {
+    public override reset(): void {
         super.reset();
-        this.installID = undefined;
+
+        this.installID = null;
     }
 
     loadInstance(pk: string): Promise<License> {
@@ -66,7 +67,7 @@ export class EnterpriseLicenseForm extends ModelForm<License, string> {
                     spellcheck="false"
                     readonly
                     type="text"
-                    value="${ifDefined(this.installID)}"
+                    value="${ifPresent(this.installID)}"
                 />
             </ak-form-element-horizontal>
             <ak-secret-textarea-input

--- a/web/src/admin/events/EventMap.ts
+++ b/web/src/admin/events/EventMap.ts
@@ -1,6 +1,7 @@
 import "@openlayers-elements/core/ol-layer-vector";
 import "@openlayers-elements/maps/ol-layer-openstreetmap";
 import "@openlayers-elements/maps/ol-select";
+import "./OpenLayer.d.ts";
 
 import { EventWithContext } from "#common/events";
 import { globalAK } from "#common/global";

--- a/web/src/admin/events/RuleForm.ts
+++ b/web/src/admin/events/RuleForm.ts
@@ -10,6 +10,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { severityToLabel } from "#common/labels";
 
 import { ModelForm } from "#elements/forms/ModelForm";
+import { RadioOption } from "#elements/forms/Radio";
 
 import {
     CoreApi,
@@ -76,18 +77,17 @@ export class RuleForm extends ModelForm<NotificationRule, string> {
                             ordering: "name",
                             includeUsers: false,
                         };
+
                         if (query !== undefined) {
                             args.search = query;
                         }
+
                         const groups = await new CoreApi(DEFAULT_CONFIG).coreGroupsList(args);
+
                         return groups.results;
                     }}
-                    .renderElement=${(group: Group): string => {
-                        return group.name;
-                    }}
-                    .value=${(group: Group | undefined): string | undefined => {
-                        return group?.pk;
-                    }}
+                    .renderElement=${(group: Group) => group.name}
+                    .value=${(group: Group | null) => group?.pk}
                     .selected=${(group: Group): boolean => {
                         return group.pk === this.instance?.destinationGroup;
                     }}
@@ -141,7 +141,7 @@ export class RuleForm extends ModelForm<NotificationRule, string> {
                             label: severityToLabel(SeverityEnum.Notice),
                             value: SeverityEnum.Notice,
                         },
-                    ]}
+                    ] satisfies RadioOption<SeverityEnum>[]}
                     .value=${this.instance?.severity}
                 >
                 </ak-radio>

--- a/web/src/admin/events/RuleFormHelpers.ts
+++ b/web/src/admin/events/RuleFormHelpers.ts
@@ -1,12 +1,17 @@
 import { DEFAULT_CONFIG } from "#common/api/config";
 
-import { DualSelectPair } from "#elements/ak-dual-select/types";
+import { DataProvider, DualSelectPair, DualSelectPairSource } from "#elements/ak-dual-select/types";
 
 import { EventsApi, NotificationTransport } from "@goauthentik/api";
 
-const transportToSelect = (transport: NotificationTransport) => [transport.pk, transport.name];
+export type TransportSelect = [pk: string, name: string];
 
-export async function eventTransportsProvider(page = 1, search = "") {
+const transportToSelect = (transport: NotificationTransport): TransportSelect => [
+    transport.pk,
+    transport.name,
+];
+
+export const eventTransportsProvider: DataProvider = async (page = 1, search = "") => {
     const eventTransports = await new EventsApi(DEFAULT_CONFIG).eventsTransportsList({
         ordering: "name",
         pageSize: 20,
@@ -18,26 +23,29 @@ export async function eventTransportsProvider(page = 1, search = "") {
         pagination: eventTransports.pagination,
         options: eventTransports.results.map(transportToSelect),
     };
-}
+};
 
-export function eventTransportsSelector(instanceTransports: string[] | undefined) {
+export function eventTransportsSelector(
+    instanceTransports: string[] | undefined,
+): DualSelectPairSource<NotificationTransport> {
     if (!instanceTransports) {
-        return async (transports: DualSelectPair<NotificationTransport>[]) =>
+        return (async (transports) =>
             transports.filter(
                 ([_0, _1, _2, stage]: DualSelectPair<NotificationTransport>) => stage !== undefined,
-            );
+            )) satisfies DualSelectPairSource<NotificationTransport>;
     }
 
-    return async () => {
+    return (async () => {
         const transportsApi = new EventsApi(DEFAULT_CONFIG);
         const transports = await Promise.allSettled(
             instanceTransports.map((instanceId) =>
                 transportsApi.eventsTransportsRetrieve({ uuid: instanceId }),
             ),
         );
+
         return transports
             .filter((s) => s.status === "fulfilled")
             .map((s) => s.value)
             .map(transportToSelect);
-    };
+    }) satisfies DualSelectPairSource<NotificationTransport>;
 }

--- a/web/src/admin/events/TransportForm.ts
+++ b/web/src/admin/events/TransportForm.ts
@@ -162,12 +162,8 @@ export class TransportForm extends ModelForm<NotificationTransport, string> {
                         ).propertymappingsNotificationList(args);
                         return items.results;
                     }}
-                    .renderElement=${(item: NotificationWebhookMapping): string => {
-                        return item.name;
-                    }}
-                    .value=${(item: NotificationWebhookMapping | undefined): string | undefined => {
-                        return item?.pk;
-                    }}
+                    .renderElement=${(item: NotificationWebhookMapping) => item.name}
+                    .value=${(item: NotificationWebhookMapping | null) => item?.pk}
                     .selected=${(item: NotificationWebhookMapping): boolean => {
                         return this.instance?.webhookMappingBody === item.pk;
                     }}
@@ -198,9 +194,7 @@ export class TransportForm extends ModelForm<NotificationTransport, string> {
                     .renderElement=${(item: NotificationWebhookMapping): string => {
                         return item.name;
                     }}
-                    .value=${(item: NotificationWebhookMapping | undefined): string | undefined => {
-                        return item?.pk;
-                    }}
+                    .value=${(item: NotificationWebhookMapping | null) => item?.pk}
                     .selected=${(item: NotificationWebhookMapping): boolean => {
                         return this.instance?.webhookMappingHeaders === item.pk;
                     }}

--- a/web/src/admin/files/FileUploadForm.ts
+++ b/web/src/admin/files/FileUploadForm.ts
@@ -61,8 +61,9 @@ export class FileUploadForm extends Form<Record<string, unknown>> {
 
     #formRef = createRef<HTMLFormElement>();
 
-    reset(): void {
+    public override reset(): void {
         super.reset();
+
         this.selectedFile = null;
     }
 

--- a/web/src/admin/files/FileUploadForm.ts
+++ b/web/src/admin/files/FileUploadForm.ts
@@ -61,6 +61,11 @@ export class FileUploadForm extends Form<Record<string, unknown>> {
 
     #formRef = createRef<HTMLFormElement>();
 
+    reset(): void {
+        super.reset();
+        this.selectedFile = null;
+    }
+
     #fileChangeListener = (e: Event) => {
         const input = e.target as HTMLInputElement;
         if (input.files?.length) {

--- a/web/src/admin/flows/FlowForm.ts
+++ b/web/src/admin/flows/FlowForm.ts
@@ -28,6 +28,11 @@ import { html, TemplateResult } from "lit";
 import { customElement } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
+/**
+ * Flow Form
+ *
+ * @prop {string} instancePk - The primary key of the instance to load.
+ */
 @customElement("ak-flow-form")
 export class FlowForm extends WithCapabilitiesConfig(ModelForm<Flow, string>) {
     async loadInstance(pk: string): Promise<Flow> {

--- a/web/src/admin/flows/FlowImportForm.ts
+++ b/web/src/admin/flows/FlowImportForm.ts
@@ -20,19 +20,20 @@ import PFDescriptionList from "@patternfly/patternfly/components/DescriptionList
 
 @customElement("ak-flow-import-form")
 export class FlowImportForm extends Form<Flow> {
-    @state()
-    result?: FlowImportResult;
+    static styles: CSSResult[] = [...super.styles, PFDescriptionList];
 
-    reset(): void {
+    @state()
+    protected result: FlowImportResult | null = null;
+
+    public override reset(): void {
         super.reset();
-        this.result = undefined;
+
+        this.result = null;
     }
 
     getSuccessMessage(): string {
         return msg("Successfully imported flow.");
     }
-
-    static styles: CSSResult[] = [...super.styles, PFDescriptionList];
 
     async send(): Promise<FlowImportResult> {
         const file = this.files().get("flow");

--- a/web/src/admin/flows/FlowImportForm.ts
+++ b/web/src/admin/flows/FlowImportForm.ts
@@ -23,6 +23,11 @@ export class FlowImportForm extends Form<Flow> {
     @state()
     result?: FlowImportResult;
 
+    reset(): void {
+        super.reset();
+        this.result = undefined;
+    }
+
     getSuccessMessage(): string {
         return msg("Successfully imported flow.");
     }

--- a/web/src/admin/flows/StageBindingForm.ts
+++ b/web/src/admin/flows/StageBindingForm.ts
@@ -42,6 +42,11 @@ export class StageBindingForm extends ModelForm<FlowStageBinding, string> {
     @state()
     defaultOrder = 0;
 
+    reset(): void {
+        super.reset();
+        this.defaultOrder = 0;
+    }
+
     getSuccessMessage(): string {
         if (this.instance?.pk) {
             return msg("Successfully updated binding.");

--- a/web/src/admin/flows/StageBindingForm.ts
+++ b/web/src/admin/flows/StageBindingForm.ts
@@ -61,13 +61,14 @@ export class StageBindingForm extends ModelForm<FlowStageBinding, string> {
     }
 
     @property()
-    targetPk?: string;
+    public targetPk?: string;
 
     @state()
-    defaultOrder = 0;
+    protected defaultOrder = 0;
 
-    reset(): void {
+    public override reset(): void {
         super.reset();
+
         this.defaultOrder = 0;
     }
 

--- a/web/src/admin/flows/StageBindingForm.ts
+++ b/web/src/admin/flows/StageBindingForm.ts
@@ -8,6 +8,7 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { groupBy } from "#common/utils";
 
 import { ModelForm } from "#elements/forms/ModelForm";
+import { RadioOption } from "#elements/forms/Radio";
 import { SlottedTemplateResult } from "#elements/types";
 
 import { policyEngineModes } from "#admin/policies/PolicyEngineModes";
@@ -25,6 +26,29 @@ import {
 import { msg } from "@lit/localize";
 import { html, nothing, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
+
+function createInvalidResponseOptions(): RadioOption<InvalidResponseActionEnum>[] {
+    return [
+        {
+            label: "RETRY",
+            value: InvalidResponseActionEnum.Retry,
+            default: true,
+            description: msg("Returns the error message and a similar challenge to the executor"),
+        },
+        {
+            label: "RESTART",
+            value: InvalidResponseActionEnum.Restart,
+            description: msg("Restarts the flow from the beginning"),
+        },
+        {
+            label: "RESTART_WITH_CONTEXT",
+            value: InvalidResponseActionEnum.RestartWithContext,
+            description: msg(
+                "Restarts the flow from the beginning, while keeping the flow context",
+            ),
+        },
+    ];
+}
 
 @customElement("ak-stage-binding-form")
 export class StageBindingForm extends ModelForm<FlowStageBinding, string> {
@@ -116,9 +140,7 @@ export class StageBindingForm extends ModelForm<FlowStageBinding, string> {
                     .renderElement=${(stage: Stage): string => {
                         return stage.name;
                     }}
-                    .value=${(stage: Stage | undefined): string | undefined => {
-                        return stage?.pk;
-                    }}
+                    .value=${(stage: Stage | null) => stage?.pk}
                     .selected=${(stage: Stage): boolean => {
                         return stage.pk === this.instance?.stage;
                     }}
@@ -153,28 +175,7 @@ export class StageBindingForm extends ModelForm<FlowStageBinding, string> {
                 name="invalidResponseAction"
             >
                 <ak-radio
-                    .options=${[
-                        {
-                            label: "RETRY",
-                            value: InvalidResponseActionEnum.Retry,
-                            default: true,
-                            description: html`${msg(
-                                "Returns the error message and a similar challenge to the executor",
-                            )}`,
-                        },
-                        {
-                            label: "RESTART",
-                            value: InvalidResponseActionEnum.Restart,
-                            description: html`${msg("Restarts the flow from the beginning")}`,
-                        },
-                        {
-                            label: "RESTART_WITH_CONTEXT",
-                            value: InvalidResponseActionEnum.RestartWithContext,
-                            description: html`${msg(
-                                "Restarts the flow from the beginning, while keeping the flow context",
-                            )}`,
-                        },
-                    ]}
+                    .options=${createInvalidResponseOptions()}
                     .value=${this.instance?.invalidResponseAction}
                 >
                 </ak-radio>

--- a/web/src/admin/outposts/OutpostForm.ts
+++ b/web/src/admin/outposts/OutpostForm.ts
@@ -106,6 +106,12 @@ export class OutpostForm extends ModelForm<Outpost, string> {
 
     defaultConfig?: OutpostDefaultConfig;
 
+    reset(): void {
+        super.reset();
+        this.type = OutpostTypeEnum.Proxy;
+        this.providers = providerProvider(this.type);
+    }
+
     async loadInstance(pk: string): Promise<Outpost> {
         const o = await new OutpostsApi(DEFAULT_CONFIG).outpostsInstancesRetrieve({
             uuid: pk,

--- a/web/src/admin/outposts/OutpostForm.ts
+++ b/web/src/admin/outposts/OutpostForm.ts
@@ -106,8 +106,9 @@ export class OutpostForm extends ModelForm<Outpost, string> {
 
     defaultConfig?: OutpostDefaultConfig;
 
-    reset(): void {
+    public override reset(): void {
         super.reset();
+
         this.type = OutpostTypeEnum.Proxy;
         this.providers = providerProvider(this.type);
     }

--- a/web/src/admin/outposts/OutpostForm.ts
+++ b/web/src/admin/outposts/OutpostForm.ts
@@ -214,9 +214,7 @@ export class OutpostForm extends ModelForm<Outpost, string> {
                     .renderElement=${(item: ServiceConnection): string => {
                         return item.name;
                     }}
-                    .value=${(item: ServiceConnection | undefined): string | undefined => {
-                        return item?.pk;
-                    }}
+                    .value=${(item: ServiceConnection | null) => item?.pk}
                     .groupBy=${(items: ServiceConnection[]) => {
                         return groupBy(items, (item) => item.verboseName);
                     }}

--- a/web/src/admin/policies/BoundPoliciesList.ts
+++ b/web/src/admin/policies/BoundPoliciesList.ts
@@ -42,9 +42,9 @@ export class BoundPoliciesList<T extends PolicyBinding = PolicyBinding> extends 
 
     @property({ type: Array })
     allowedTypes: PolicyBindingCheckTarget[] = [
-        PolicyBindingCheckTarget.policy,
-        PolicyBindingCheckTarget.group,
-        PolicyBindingCheckTarget.user,
+        PolicyBindingCheckTarget.Policy,
+        PolicyBindingCheckTarget.Group,
+        PolicyBindingCheckTarget.User,
     ];
 
     @property({ type: Array })
@@ -244,7 +244,7 @@ export class BoundPoliciesList<T extends PolicyBinding = PolicyBinding> extends 
     }
 
     renderToolbar(): TemplateResult {
-        return html`${this.allowedTypes.includes(PolicyBindingCheckTarget.policy)
+        return html`${this.allowedTypes.includes(PolicyBindingCheckTarget.Policy)
                 ? html`<ak-policy-wizard
                       createText=${msg("Create and bind Policy")}
                       showBindingPage

--- a/web/src/admin/policies/PolicyBindingForm.ts
+++ b/web/src/admin/policies/PolicyBindingForm.ts
@@ -72,6 +72,12 @@ export class PolicyBindingForm<T extends PolicyBinding = PolicyBinding> extends 
     @state()
     defaultOrder = 0;
 
+    reset(): void {
+        super.reset();
+        this.policyGroupUser = PolicyBindingCheckTarget.policy;
+        this.defaultOrder = 0;
+    }
+
     getSuccessMessage(): string {
         if (this.instance?.pk) {
             return msg("Successfully updated binding.");

--- a/web/src/admin/policies/PolicyBindingForm.ts
+++ b/web/src/admin/policies/PolicyBindingForm.ts
@@ -40,6 +40,8 @@ export class PolicyBindingForm<T extends PolicyBinding = PolicyBinding> extends 
     T,
     string
 > {
+    static styles: CSSResult[] = [...super.styles, PFContent];
+
     async loadInstance(pk: string): Promise<T> {
         const binding = await new PoliciesApi(DEFAULT_CONFIG).policiesBindingsRetrieve({
             policyBindingUuid: pk,
@@ -58,26 +60,27 @@ export class PolicyBindingForm<T extends PolicyBinding = PolicyBinding> extends 
     }
 
     @property()
-    targetPk?: string;
+    public targetPk?: string;
 
     @state()
-    policyGroupUser: PolicyBindingCheckTarget = PolicyBindingCheckTarget.Policy;
+    protected policyGroupUser: PolicyBindingCheckTarget = PolicyBindingCheckTarget.Policy;
 
     @property({ type: Array })
-    allowedTypes: PolicyBindingCheckTarget[] = [
+    public allowedTypes: PolicyBindingCheckTarget[] = [
         PolicyBindingCheckTarget.Policy,
         PolicyBindingCheckTarget.Group,
         PolicyBindingCheckTarget.User,
     ];
 
     @property({ type: Array })
-    typeNotices: PolicyBindingNotice[] = [];
+    public typeNotices: PolicyBindingNotice[] = [];
 
     @state()
-    defaultOrder = 0;
+    protected defaultOrder = 0;
 
-    reset(): void {
+    public override reset(): void {
         super.reset();
+
         this.policyGroupUser = PolicyBindingCheckTarget.Policy;
         this.defaultOrder = 0;
     }
@@ -88,8 +91,6 @@ export class PolicyBindingForm<T extends PolicyBinding = PolicyBinding> extends 
         }
         return msg("Successfully created binding.");
     }
-
-    static styles: CSSResult[] = [...super.styles, PFContent];
 
     async load(): Promise<void> {
         // Overwrite the default for policyGroupUser with the first allowed type,

--- a/web/src/admin/policies/PolicyTestForm.ts
+++ b/web/src/admin/policies/PolicyTestForm.ts
@@ -37,6 +37,11 @@ export class PolicyTestForm extends Form<PolicyTestRequest> {
     @property({ attribute: false })
     request?: PolicyTestRequest;
 
+    reset(): void {
+        super.reset();
+        this.result = undefined;
+    }
+
     getSuccessMessage(): string {
         return msg("Successfully sent test-request.");
     }

--- a/web/src/admin/policies/PolicyTestForm.ts
+++ b/web/src/admin/policies/PolicyTestForm.ts
@@ -29,17 +29,18 @@ import PFDescriptionList from "@patternfly/patternfly/components/DescriptionList
 @customElement("ak-policy-test-form")
 export class PolicyTestForm extends Form<PolicyTestRequest> {
     @property({ attribute: false })
-    policy?: Policy;
+    public policy?: Policy;
 
     @state()
-    result?: PolicyTestResult;
+    protected result: PolicyTestResult | null = null;
 
     @property({ attribute: false })
-    request?: PolicyTestRequest;
+    public request?: PolicyTestRequest;
 
-    reset(): void {
+    public override reset(): void {
         super.reset();
-        this.result = undefined;
+
+        this.result = null;
     }
 
     getSuccessMessage(): string {

--- a/web/src/admin/policies/password/PasswordPolicyForm.ts
+++ b/web/src/admin/policies/password/PasswordPolicyForm.ts
@@ -16,16 +16,17 @@ import { ifDefined } from "lit/directives/if-defined.js";
 @customElement("ak-policy-password-form")
 export class PasswordPolicyForm extends BasePolicyForm<PasswordPolicy> {
     @state()
-    showStatic = true;
+    protected showStatic = true;
 
     @state()
-    showHIBP = false;
+    protected showHIBP = false;
 
     @state()
-    showZxcvbn = false;
+    protected showZxcvbn = false;
 
-    reset(): void {
+    public override reset(): void {
         super.reset();
+
         this.showStatic = true;
         this.showHIBP = false;
         this.showZxcvbn = false;

--- a/web/src/admin/policies/password/PasswordPolicyForm.ts
+++ b/web/src/admin/policies/password/PasswordPolicyForm.ts
@@ -24,6 +24,13 @@ export class PasswordPolicyForm extends BasePolicyForm<PasswordPolicy> {
     @state()
     showZxcvbn = false;
 
+    reset(): void {
+        super.reset();
+        this.showStatic = true;
+        this.showHIBP = false;
+        this.showZxcvbn = false;
+    }
+
     async loadInstance(pk: string): Promise<PasswordPolicy> {
         const policy = await new PoliciesApi(DEFAULT_CONFIG).policiesPasswordRetrieve({
             policyUuid: pk,

--- a/web/src/admin/policies/utils.ts
+++ b/web/src/admin/policies/utils.ts
@@ -1,18 +1,42 @@
+import { RadioOption } from "#elements/forms/Radio";
+
+import { PolicyBinding } from "@goauthentik/api";
+
 import { msg } from "@lit/localize";
 
 export enum PolicyBindingCheckTarget {
-    policy = "policy",
-    group = "group",
-    user = "user",
+    Policy = "policy",
+    Group = "group",
+    User = "user",
 }
 
 export function PolicyBindingCheckTargetToLabel(ct: PolicyBindingCheckTarget): string {
     switch (ct) {
-        case PolicyBindingCheckTarget.group:
+        case PolicyBindingCheckTarget.Group:
             return msg("Group");
-        case PolicyBindingCheckTarget.user:
+        case PolicyBindingCheckTarget.User:
             return msg("User");
-        case PolicyBindingCheckTarget.policy:
+        case PolicyBindingCheckTarget.Policy:
             return msg("Policy");
     }
+}
+
+export const PolicyObjectKeys = {
+    [PolicyBindingCheckTarget.Policy]: "policyObj",
+    [PolicyBindingCheckTarget.Group]: "groupObj",
+    [PolicyBindingCheckTarget.User]: "userObj",
+} as const satisfies Record<PolicyBindingCheckTarget, keyof PolicyBinding>;
+
+export function createPassFailOptions(): RadioOption<boolean>[] {
+    return [
+        {
+            label: msg("Pass"),
+            value: true,
+        },
+        {
+            label: msg("Don't Pass"),
+            value: false,
+            default: true,
+        },
+    ];
 }

--- a/web/src/admin/providers/BaseProviderForm.ts
+++ b/web/src/admin/providers/BaseProviderForm.ts
@@ -5,6 +5,11 @@ import { ModelForm } from "#elements/forms/ModelForm";
 
 import { msg } from "@lit/localize";
 
+/**
+ * Base form for all provider forms.
+ *
+ * @prop {number} instancePk - The primary key of the instance to load.
+ */
 export abstract class BaseProviderForm<T> extends ModelForm<T, number> {
     public override getSuccessMessage(): string {
         return this.instance

--- a/web/src/admin/providers/ldap/LDAPProviderForm.ts
+++ b/web/src/admin/providers/ldap/LDAPProviderForm.ts
@@ -13,6 +13,11 @@ import { LDAPProvider, ProvidersApi } from "@goauthentik/api";
 
 import { customElement } from "lit/decorators.js";
 
+/**
+ * LDAP Provider Form
+ *
+ * @prop {number} instancePk - The primary key of the instance to load.
+ */
 @customElement("ak-provider-ldap-form")
 export class LDAPProviderFormPage extends WithBrandConfig(BaseProviderForm<LDAPProvider>) {
     async loadInstance(pk: number): Promise<LDAPProvider> {

--- a/web/src/admin/providers/oauth2/OAuth2ProviderForm.ts
+++ b/web/src/admin/providers/oauth2/OAuth2ProviderForm.ts
@@ -65,6 +65,12 @@ export class OAuth2ProviderFormPage extends BaseProviderForm<OAuth2Provider> {
     @state()
     showLogoutMethod = false;
 
+    reset(): void {
+        super.reset();
+        this.showClientSecret = true;
+        this.showLogoutMethod = false;
+    }
+
     static styles = [
         ...super.styles,
         css`

--- a/web/src/admin/providers/oauth2/OAuth2ProviderForm.ts
+++ b/web/src/admin/providers/oauth2/OAuth2ProviderForm.ts
@@ -60,13 +60,14 @@ export function oauth2ProviderSelector(instanceProviders: number[] | undefined) 
 @customElement("ak-provider-oauth2-form")
 export class OAuth2ProviderFormPage extends BaseProviderForm<OAuth2Provider> {
     @state()
-    showClientSecret = true;
+    protected showClientSecret = true;
 
     @state()
-    showLogoutMethod = false;
+    protected showLogoutMethod = false;
 
-    reset(): void {
+    public override reset(): void {
         super.reset();
+
         this.showClientSecret = true;
         this.showLogoutMethod = false;
     }

--- a/web/src/admin/providers/proxy/ProxyProviderForm.ts
+++ b/web/src/admin/providers/proxy/ProxyProviderForm.ts
@@ -35,6 +35,12 @@ export class ProxyProviderFormPage extends BaseProviderForm<ProxyProvider> {
     @state()
     mode: ProxyMode = ProxyMode.Proxy;
 
+    reset(): void {
+        super.reset();
+        this.showHttpBasic = true;
+        this.mode = ProxyMode.Proxy;
+    }
+
     async send(data: ProxyProvider): Promise<ProxyProvider> {
         data.mode = this.mode;
         if (this.mode !== ProxyMode.ForwardDomain) {

--- a/web/src/admin/providers/proxy/ProxyProviderForm.ts
+++ b/web/src/admin/providers/proxy/ProxyProviderForm.ts
@@ -30,13 +30,14 @@ export class ProxyProviderFormPage extends BaseProviderForm<ProxyProvider> {
     }
 
     @state()
-    showHttpBasic = true;
+    protected showHttpBasic = true;
 
     @state()
-    mode: ProxyMode = ProxyMode.Proxy;
+    protected mode: ProxyMode = ProxyMode.Proxy;
 
-    reset(): void {
+    public override reset(): void {
         super.reset();
+
         this.showHttpBasic = true;
         this.mode = ProxyMode.Proxy;
     }

--- a/web/src/admin/providers/radius/RadiusProviderForm.ts
+++ b/web/src/admin/providers/radius/RadiusProviderForm.ts
@@ -10,6 +10,11 @@ import { ProvidersApi, RadiusProvider } from "@goauthentik/api";
 
 import { customElement } from "lit/decorators.js";
 
+/**
+ * Radius Provider Form
+ *
+ * @prop {number} instancePk - The primary key of the instance to load.
+ */
 @customElement("ak-provider-radius-form")
 export class RadiusProviderFormPage extends WithBrandConfig(BaseProviderForm<RadiusProvider>) {
     loadInstance(pk: number): Promise<RadiusProvider> {

--- a/web/src/admin/providers/saml/SAMLProviderForm.ts
+++ b/web/src/admin/providers/saml/SAMLProviderForm.ts
@@ -26,10 +26,12 @@ export class SAMLProviderFormPage extends BaseProviderForm<SAMLProvider> {
     protected hasPostBinding = false;
 
     @state()
-    protected logoutMethod: string = SAMLProviderLogoutMethodEnum.FrontchannelIframe;
+    protected logoutMethod: SAMLProviderLogoutMethodEnum =
+        SAMLProviderLogoutMethodEnum.FrontchannelIframe;
 
-    reset(): void {
+    public override reset(): void {
         super.reset();
+
         this.hasSigningKp = false;
         this.hasSlsUrl = false;
         this.hasPostBinding = false;
@@ -98,7 +100,7 @@ export class SAMLProviderFormPage extends BaseProviderForm<SAMLProvider> {
 
         const setLogoutMethod = (ev: Event) => {
             const target = ev.target as HTMLInputElement;
-            this.logoutMethod = target.value;
+            this.logoutMethod = target.value as SAMLProviderLogoutMethodEnum;
         };
 
         return renderForm({

--- a/web/src/admin/providers/saml/SAMLProviderForm.ts
+++ b/web/src/admin/providers/saml/SAMLProviderForm.ts
@@ -28,6 +28,14 @@ export class SAMLProviderFormPage extends BaseProviderForm<SAMLProvider> {
     @state()
     protected logoutMethod: string = SAMLProviderLogoutMethodEnum.FrontchannelIframe;
 
+    reset(): void {
+        super.reset();
+        this.hasSigningKp = false;
+        this.hasSlsUrl = false;
+        this.hasPostBinding = false;
+        this.logoutMethod = SAMLProviderLogoutMethodEnum.FrontchannelIframe;
+    }
+
     async loadInstance(pk: number): Promise<SAMLProvider> {
         const provider = await new ProvidersApi(DEFAULT_CONFIG).providersSamlRetrieve({
             id: pk,

--- a/web/src/admin/rbac/RoleObjectPermissionForm.ts
+++ b/web/src/admin/rbac/RoleObjectPermissionForm.ts
@@ -31,17 +31,18 @@ interface RoleAssignData {
 @customElement("ak-rbac-role-object-permission-form")
 export class RoleObjectPermissionForm extends ModelForm<RoleAssignData, number> {
     @property()
-    model?: ModelEnum;
+    public model?: ModelEnum;
 
     @property()
-    objectPk?: string;
+    public objectPk?: string;
 
     @state()
-    modelPermissions?: PaginatedPermissionList;
+    protected modelPermissions: PaginatedPermissionList | null = null;
 
-    reset(): void {
+    public override reset(): void {
         super.reset();
-        this.modelPermissions = undefined;
+
+        this.modelPermissions = null;
     }
 
     async load(): Promise<void> {

--- a/web/src/admin/rbac/RoleObjectPermissionForm.ts
+++ b/web/src/admin/rbac/RoleObjectPermissionForm.ts
@@ -39,6 +39,11 @@ export class RoleObjectPermissionForm extends ModelForm<RoleAssignData, number> 
     @state()
     modelPermissions?: PaginatedPermissionList;
 
+    reset(): void {
+        super.reset();
+        this.modelPermissions = undefined;
+    }
+
     async load(): Promise<void> {
         const [appLabel, modelName] = (this.model || "").split(".");
         this.modelPermissions = await new RbacApi(DEFAULT_CONFIG).rbacPermissionsList({

--- a/web/src/admin/roles/RolePermissionForm.ts
+++ b/web/src/admin/roles/RolePermissionForm.ts
@@ -28,6 +28,11 @@ export class RolePermissionForm extends ModelForm<RolePermissionAssign, number> 
     @property({ type: String })
     public roleUuid: string | null = null;
 
+    reset(): void {
+        super.reset();
+        this.permissionsToAdd = [];
+    }
+
     loadInstance(): Promise<RolePermissionAssign> {
         throw new Error("Method not implemented.");
     }

--- a/web/src/admin/roles/RolePermissionForm.ts
+++ b/web/src/admin/roles/RolePermissionForm.ts
@@ -23,13 +23,14 @@ interface RolePermissionAssign {
 @customElement("ak-role-permission-form")
 export class RolePermissionForm extends ModelForm<RolePermissionAssign, number> {
     @state()
-    permissionsToAdd: Permission[] = [];
+    protected permissionsToAdd: Permission[] = [];
 
     @property({ type: String })
     public roleUuid: string | null = null;
 
-    reset(): void {
+    public override reset(): void {
         super.reset();
+
         this.permissionsToAdd = [];
     }
 

--- a/web/src/admin/sources/saml/SAMLSourceForm.ts
+++ b/web/src/admin/sources/saml/SAMLSourceForm.ts
@@ -40,10 +40,11 @@ import { ifDefined } from "lit/directives/if-defined.js";
 @customElement("ak-source-saml-form")
 export class SAMLSourceForm extends BaseSourceForm<SAMLSource> {
     @state()
-    hasSigningCert = false;
+    protected hasSigningCert = false;
 
-    reset(): void {
+    public override reset(): void {
         super.reset();
+
         this.hasSigningCert = false;
     }
 

--- a/web/src/admin/sources/saml/SAMLSourceForm.ts
+++ b/web/src/admin/sources/saml/SAMLSourceForm.ts
@@ -42,6 +42,11 @@ export class SAMLSourceForm extends BaseSourceForm<SAMLSource> {
     @state()
     hasSigningCert = false;
 
+    reset(): void {
+        super.reset();
+        this.hasSigningCert = false;
+    }
+
     setHasSigningCert(ev: InputEvent): void {
         const target = ev.target as AkCryptoCertificateSearch;
         if (!target) return;

--- a/web/src/admin/sources/utils.ts
+++ b/web/src/admin/sources/utils.ts
@@ -23,13 +23,13 @@ export function renderSourceIcon(name: string, iconUrl: string | undefined | nul
 export function sourceBindingTypeNotices() {
     return [
         {
-            type: PolicyBindingCheckTarget.group,
+            type: PolicyBindingCheckTarget.Group,
             notice: msg(
                 "Group mappings can only be checked if a user is already logged in when trying to access this source.",
             ),
         },
         {
-            type: PolicyBindingCheckTarget.user,
+            type: PolicyBindingCheckTarget.User,
             notice: msg(
                 "User mappings can only be checked if a user is already logged in when trying to access this source.",
             ),

--- a/web/src/admin/stages/captcha/CaptchaStageForm.ts
+++ b/web/src/admin/stages/captcha/CaptchaStageForm.ts
@@ -113,6 +113,12 @@ export class CaptchaStageForm extends BaseStageForm<CaptchaStage> {
 
     currentPreset: CaptchaProviderPreset = CAPTCHA_PROVIDERS.custom;
 
+    reset(): void {
+        super.reset();
+        this.selectedProvider = "custom";
+        this.currentPreset = CAPTCHA_PROVIDERS.custom;
+    }
+
     loadInstance(pk: string): Promise<CaptchaStage> {
         return new StagesApi(DEFAULT_CONFIG).stagesCaptchaRetrieve({
             stageUuid: pk,

--- a/web/src/admin/stages/captcha/CaptchaStageForm.ts
+++ b/web/src/admin/stages/captcha/CaptchaStageForm.ts
@@ -109,12 +109,13 @@ const CAPTCHA_PROVIDERS: Record<string, CaptchaProviderPreset> = {
 @customElement("ak-stage-captcha-form")
 export class CaptchaStageForm extends BaseStageForm<CaptchaStage> {
     @state()
-    selectedProvider = "custom";
+    protected selectedProvider = "custom";
 
     currentPreset: CaptchaProviderPreset = CAPTCHA_PROVIDERS.custom;
 
-    reset(): void {
+    public override reset(): void {
         super.reset();
+
         this.selectedProvider = "custom";
         this.currentPreset = CAPTCHA_PROVIDERS.custom;
     }

--- a/web/src/admin/stages/prompt/PromptForm.ts
+++ b/web/src/admin/stages/prompt/PromptForm.ts
@@ -52,6 +52,13 @@ export class PromptForm extends ModelForm<Prompt, string> {
     @state()
     previewResult: unknown;
 
+    reset(): void {
+        super.reset();
+        this.preview = undefined;
+        this.previewError = undefined;
+        this.previewResult = undefined;
+    }
+
     send(data: Prompt): Promise<unknown> {
         if (this.instance) {
             return new StagesApi(DEFAULT_CONFIG).stagesPromptPromptsUpdate({

--- a/web/src/admin/stages/prompt/PromptForm.ts
+++ b/web/src/admin/stages/prompt/PromptForm.ts
@@ -4,24 +4,20 @@ import "#flow/stages/prompt/PromptStage";
 import "#components/ak-switch-input";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
-import { parseAPIResponseError, pluckErrorDetail } from "#common/errors/network";
+import { parseAPIResponseError } from "#common/errors/network";
 
 import { ModelForm } from "#elements/forms/ModelForm";
 import { SlottedTemplateResult } from "#elements/types";
 
+import { AKFormErrors, ErrorProp } from "#components/ak-field-errors";
+
 import { StageHost } from "#flow/stages/base";
 
-import {
-    instanceOfValidationError,
-    Prompt,
-    PromptChallenge,
-    PromptTypeEnum,
-    StagesApi,
-} from "@goauthentik/api";
+import { Prompt, PromptChallenge, PromptTypeEnum, StagesApi } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
 import { CSSResult, html, nothing, TemplateResult } from "lit";
-import { customElement, state } from "lit/decorators.js";
+import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { map } from "lit/directives/map.js";
 
@@ -44,19 +40,20 @@ class PreviewStageHost implements StageHost {
 @customElement("ak-prompt-form")
 export class PromptForm extends ModelForm<Prompt, string> {
     @state()
-    preview?: PromptChallenge;
+    protected preview: PromptChallenge | null = null;
 
     @state()
-    previewError?: string[];
+    protected previewError: ErrorProp | null = null;
 
-    @state()
-    previewResult: unknown;
+    @property({ attribute: false })
+    public previewResult: unknown;
 
-    reset(): void {
+    public override reset(): void {
         super.reset();
-        this.preview = undefined;
-        this.previewError = undefined;
-        this.previewResult = undefined;
+
+        this.preview = null;
+        this.previewError = null;
+        this.previewResult = null;
     }
 
     send(data: Prompt): Promise<unknown> {
@@ -93,14 +90,10 @@ export class PromptForm extends ModelForm<Prompt, string> {
             })
             .then((nextPreview) => {
                 this.preview = nextPreview;
-                this.previewError = undefined;
+                this.previewError = null;
             })
             .catch(async (error: unknown) => {
-                const parsedError = await parseAPIResponseError(error);
-
-                this.previewError = instanceOfValidationError(parsedError)
-                    ? parsedError.nonFieldErrors
-                    : [pluckErrorDetail(parsedError, msg("Failed to preview prompt"))];
+                this.previewError = await parseAPIResponseError(error);
             });
     }
 
@@ -192,7 +185,7 @@ export class PromptForm extends ModelForm<Prompt, string> {
                           <div class="pf-c-card pf-l-grid__item pf-m-12-col">
                               <div class="pf-c-card__body">${msg("Preview errors")}</div>
                               <div class="pf-c-card__body">
-                                  ${this.previewError.map((err) => html`<pre>${err}</pre>`)}
+                                  ${AKFormErrors({ errors: [this.previewError] })}
                               </div>
                           </div>
                       `

--- a/web/src/admin/tokens/TokenForm.ts
+++ b/web/src/admin/tokens/TokenForm.ts
@@ -27,8 +27,9 @@ export class TokenForm extends ModelForm<Token, string> {
     @state()
     protected expiresAt: Date | null = new Date(Date.now() + EXPIRATION_DURATION);
 
-    reset(): void {
+    public override reset(): void {
         super.reset();
+
         this.expiresAt = new Date(Date.now() + EXPIRATION_DURATION);
     }
 

--- a/web/src/admin/tokens/TokenForm.ts
+++ b/web/src/admin/tokens/TokenForm.ts
@@ -27,6 +27,11 @@ export class TokenForm extends ModelForm<Token, string> {
     @state()
     protected expiresAt: Date | null = new Date(Date.now() + EXPIRATION_DURATION);
 
+    reset(): void {
+        super.reset();
+        this.expiresAt = new Date(Date.now() + EXPIRATION_DURATION);
+    }
+
     async loadInstance(pk: string): Promise<Token> {
         const token = await new CoreApi(DEFAULT_CONFIG).coreTokensRetrieve({
             identifier: pk,

--- a/web/src/admin/users/ServiceAccountForm.ts
+++ b/web/src/admin/users/ServiceAccountForm.ts
@@ -78,9 +78,10 @@ export class ServiceAccountForm extends Form<UserServiceAccountRequest> {
         return result;
     }
 
-    reset(): void {
+    public override reset(): void {
         super.reset();
         this.result = null;
+
         this.expiresAt = new Date(Date.now() + EXPIRATION_DURATION);
         (this.parentElement as ModalForm).showSubmitButton = true;
     }

--- a/web/src/admin/users/ServiceAccountForm.ts
+++ b/web/src/admin/users/ServiceAccountForm.ts
@@ -81,6 +81,7 @@ export class ServiceAccountForm extends Form<UserServiceAccountRequest> {
     reset(): void {
         super.reset();
         this.result = null;
+        this.expiresAt = new Date(Date.now() + EXPIRATION_DURATION);
         (this.parentElement as ModalForm).showSubmitButton = true;
     }
 

--- a/web/src/admin/users/UserPasswordForm.ts
+++ b/web/src/admin/users/UserPasswordForm.ts
@@ -39,7 +39,7 @@ export class UserPasswordForm extends Form<UserPasswordSetRequest> {
      *
      * Still, we can at least hint at our preferred behavior...
      */
-    public override autocomplete: AutoFill = "off";
+    public override autocomplete: Exclude<AutoFillBase, ""> = "off";
 
     //#endregion
 

--- a/web/src/common/download.ts
+++ b/web/src/common/download.ts
@@ -1,23 +1,32 @@
-import { MessageLevel } from "#common/messages";
+/**
+ * @file Download utility functions.
+ */
 
-import { showMessage } from "#elements/messages/MessageContainer";
+export interface DownloadInit extends BlobPropertyBag {
+    content: BlobPart | BlobPart[];
+    filename: string;
+}
 
-import { msg, str } from "@lit/localize";
+/**
+ * Download a file directly from the frontend.
+ *
+ * @remarks
+ * This function must be called from a user-interaction event handler
+ * as it uses an `<a>` element behind the scenes.
+ */
+export function downloadFile({ content, filename, ...options }: DownloadInit): void {
+    const blob = new Blob(Array.isArray(content) ? content : [content], options);
 
-// Download a file directly from the frontend. Must be called from a user-interaction event handler
-// as this uses an <a> element behind the scenes.
-export function downloadFile(content: string, filename: string, mime: string) {
-    const blob = new Blob([content], { type: mime });
-    const url = window.URL.createObjectURL(blob);
+    const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
+
     a.style.display = "none";
     a.href = url;
     a.download = filename;
     document.body.appendChild(a);
+
     a.click();
-    window.URL.revokeObjectURL(url);
-    showMessage({
-        level: MessageLevel.info,
-        message: msg(str`Successfully downloaded ${filename}!`),
-    });
+
+    URL.revokeObjectURL(url);
+    document.body.removeChild(a);
 }

--- a/web/src/components/HorizontalLightComponent.ts
+++ b/web/src/components/HorizontalLightComponent.ts
@@ -10,7 +10,7 @@ import { AKLabel } from "#components/ak-label";
 
 import { IDGenerator } from "@goauthentik/core/id";
 
-import { html, nothing, PropertyValues, TemplateResult } from "lit";
+import { html, nothing, PropertyValues } from "lit";
 import { property } from "lit/decorators.js";
 
 export interface HorizontalLightComponentProps<T> extends AKElementProps {
@@ -99,7 +99,7 @@ export abstract class HorizontalLightComponent<T>
      * @property
      */
     @property({ type: Object })
-    bighelp?: TemplateResult | TemplateResult[];
+    bighelp?: SlottedTemplateResult | SlottedTemplateResult[];
 
     /**
      * @property

--- a/web/src/components/stories/ak-page-navbar.stories.ts
+++ b/web/src/components/stories/ak-page-navbar.stories.ts
@@ -40,13 +40,9 @@ declare global {
 }
 
 export const SimplePageNavbar = () => {
-    return html`
-        <story-ak-page-navbar open @ak-page-nav-menu-toggle=${() => {}}> </story-ak-page-navbar>
-    `;
+    return html`<story-ak-page-navbar></story-ak-page-navbar>`;
 };
 
 export const PageNavbarWithIcon = () => {
-    return html`
-        <story-ak-page-navbar open @ak-page-nav-menu-toggle=${() => {}}> </story-ak-page-navbar>
-    `;
+    return html`<story-ak-page-navbar></story-ak-page-navbar>`;
 };

--- a/web/src/elements/ak-dual-select/components/ak-dual-select-available-pane.ts
+++ b/web/src/elements/ak-dual-select/components/ak-dual-select-available-pane.ts
@@ -12,7 +12,6 @@ import { createRef, ref } from "lit/directives/ref.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFDualListSelector from "@patternfly/patternfly/components/DualListSelector/dual-list-selector.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 const hostAttributes = [
     ["aria-labelledby", "dual-list-selector-available-pane-status"],
@@ -33,6 +32,10 @@ const hostAttributes = [
  *
  * @fires ak-dual-select-add-one - Double-click with the element clicked on.
  *
+ * @prop {DualSelectPair[]} options - The full list of key/value pairs that are currently available to be selected.
+ *
+ * @prop {Set<string|number>} selected - A set of keys that are currently selected, so they can be marked as such.
+ *
  * It is not expected that the `ak-dual-select-available-move-changed` event will be used; instead,
  * the attribute will be read by the parent when a control is clicked.
  */
@@ -40,7 +43,7 @@ const hostAttributes = [
 export class AkDualSelectAvailablePane extends CustomEmitterElement<DualSelectEventType>(
     AKElement,
 ) {
-    static styles = [PFBase, PFButton, PFDualListSelector, listStyles, availablePaneStyles];
+    static styles = [PFButton, PFDualListSelector, listStyles, availablePaneStyles];
 
     //#region Properties
 

--- a/web/src/elements/ak-dual-select/components/ak-dual-select-selected-pane.ts
+++ b/web/src/elements/ak-dual-select/components/ak-dual-select-selected-pane.ts
@@ -11,7 +11,6 @@ import { map } from "lit/directives/map.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFDualListSelector from "@patternfly/patternfly/components/DualListSelector/dual-list-selector.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 const hostAttributes = [
     ["aria-labelledby", "dual-list-selector-selected-pane-status"],
@@ -33,10 +32,11 @@ const hostAttributes = [
  * It is not expected that the `ak-dual-select-selected-move-changed` will be used; instead, the
  * attribute will be read by the parent when a control is clicked.
  *
+ * @prop {DualSelectPair[]} selected - The full list of key/value pairs that are currently
  */
 @customElement("ak-dual-select-selected-pane")
 export class AkDualSelectSelectedPane extends CustomEmitterElement<DualSelectEventType>(AKElement) {
-    static styles = [PFBase, PFButton, PFDualListSelector, listStyles, selectedPaneStyles];
+    static styles = [PFButton, PFDualListSelector, listStyles, selectedPaneStyles];
 
     //#region Properties
 

--- a/web/src/elements/ak-dual-select/stories/ak-dual-select-available-pane.stories.ts
+++ b/web/src/elements/ak-dual-select/stories/ak-dual-select-available-pane.stories.ts
@@ -4,6 +4,8 @@ import "./sb-host-provider.js";
 
 import { AkDualSelectAvailablePane } from "../components/ak-dual-select-available-pane.js";
 
+import { DualSelectPair } from "#elements/ak-dual-select/types";
+
 import { Meta, StoryObj } from "@storybook/web-components";
 import { kebabCase } from "change-case";
 
@@ -88,7 +90,7 @@ const goodForYou = [
     "Cauliflower",
 ];
 
-const goodForYouPairs = goodForYou.map((key) => [kebabCase(key), key]);
+const goodForYouPairs = goodForYou.map((key): DualSelectPair => [kebabCase(key), key]);
 
 export const Default: Story = {
     render: () =>

--- a/web/src/elements/ak-dual-select/stories/ak-dual-select-selected-pane.stories.ts
+++ b/web/src/elements/ak-dual-select/stories/ak-dual-select-selected-pane.stories.ts
@@ -4,6 +4,8 @@ import "./sb-host-provider.js";
 
 import { AkDualSelectSelectedPane } from "../components/ak-dual-select-selected-pane.js";
 
+import { DualSelectPair } from "#elements/ak-dual-select/types";
+
 import { Meta, StoryObj } from "@storybook/web-components";
 import { kebabCase } from "change-case";
 
@@ -87,7 +89,7 @@ const goodForYou = [
     "Cauliflower",
 ];
 
-const goodForYouPairs = goodForYou.map((key) => [kebabCase(key), key]);
+const goodForYouPairs = goodForYou.map((key): DualSelectPair => [kebabCase(key), key]);
 
 export const Default: Story = {
     render: () =>

--- a/web/src/elements/cards/stories/AggregatePromiseCard.stories.ts
+++ b/web/src/elements/cards/stories/AggregatePromiseCard.stories.ts
@@ -63,7 +63,7 @@ export const DefaultStory: StoryObj = {
         headerLink: undefined,
         subtext: `Demo has a ${EXAMPLE_TIMEOUT / MILLIS_PER_SECOND} second delay until resolution`,
     },
-    render: ({ icon, label: header, headerLink, subtext }: IAggregatePromiseCard) => {
+    render: ({ icon, label, headerLink, subtext }: IAggregatePromiseCard) => {
         const runThis = (timeout: number, value: string) =>
             new Promise((resolve) => setTimeout(resolve, timeout, value));
 
@@ -76,7 +76,7 @@ export const DefaultStory: StoryObj = {
                 }
             </style>
             <ak-aggregate-card-promise
-                header=${ifPresent(header)}
+                label=${ifPresent(label)}
                 headerLink=${ifPresent(headerLink)}
                 subtext=${ifPresent(subtext)}
                 icon=${ifPresent(icon)}
@@ -94,13 +94,7 @@ export const PromiseRejected: StoryObj = {
         subtext: `Demo has a ${EXAMPLE_TIMEOUT / MILLIS_PER_SECOND} second delay until resolution`,
         failureMessage: undefined,
     },
-    render: ({
-        icon,
-        label: header,
-        headerLink,
-        subtext,
-        failureMessage,
-    }: IAggregatePromiseCard) => {
+    render: ({ icon, label, headerLink, subtext, failureMessage }: IAggregatePromiseCard) => {
         const runThis = (timeout: number, value: string) =>
             new Promise((_resolve, reject) => setTimeout(reject, timeout, value));
 
@@ -113,7 +107,7 @@ export const PromiseRejected: StoryObj = {
                 }
             </style>
             <ak-aggregate-card-promise
-                header=${ifPresent(header)}
+                label=${ifPresent(label)}
                 headerLink=${ifPresent(headerLink)}
                 subtext=${ifPresent(subtext)}
                 icon=${ifPresent(icon)}

--- a/web/src/elements/forms/Form.ts
+++ b/web/src/elements/forms/Form.ts
@@ -230,7 +230,7 @@ export abstract class Form<T = Record<string, unknown>> extends AKElement {
     public successMessage?: string;
 
     @property({ type: String })
-    public autocomplete?: AutoFill;
+    public autocomplete?: Exclude<AutoFillBase, "">;
 
     //#endregion
 

--- a/web/src/elements/forms/ModelForm.ts
+++ b/web/src/elements/forms/ModelForm.ts
@@ -83,8 +83,11 @@ export abstract class ModelForm<T, PKT extends string | number> extends Form<T> 
     }
 
     reset(): void {
+        super.reset();
         this.instance = undefined;
         this.#initialLoad = false;
+        this.#initialDataLoad = false;
+        this.requestUpdate();
     }
 
     renderVisible(): TemplateResult {

--- a/web/src/elements/forms/ModelForm.ts
+++ b/web/src/elements/forms/ModelForm.ts
@@ -88,11 +88,13 @@ export abstract class ModelForm<T, PKT extends string | number> extends Form<T> 
         });
     }
 
-    reset(): void {
+    public override reset(): void {
         super.reset();
+
         this.instance = undefined;
         this.#initialLoad = false;
         this.#initialDataLoad = false;
+
         this.requestUpdate();
     }
 

--- a/web/src/elements/forms/ModelForm.ts
+++ b/web/src/elements/forms/ModelForm.ts
@@ -10,7 +10,13 @@ import { property } from "lit/decorators.js";
 
 /**
  * A base form that automatically tracks the server-side object (instance)
- * that we're interested in.  Handles loading and tracking of the instance.
+ * that we're interested in. Handles loading and tracking of the instance.
+ *
+ * @template T The type of the model instance.
+ * @template PKT The type of the primary key of the model instance.
+ *
+ * @prop {T} instance - The current instance being edited or viewed.
+ * @prop {PKT} instancePk - The primary key of the instance to load.
  */
 export abstract class ModelForm<T, PKT extends string | number> extends Form<T> {
     /**

--- a/web/src/elements/forms/Radio.ts
+++ b/web/src/elements/forms/Radio.ts
@@ -1,20 +1,20 @@
 import { AKElement } from "#elements/Base";
 import Styles from "#elements/forms/Radio.css";
+import { SlottedTemplateResult } from "#elements/types";
 import { CustomEmitterElement } from "#elements/utils/eventEmitter";
 
 import { IDGenerator } from "@goauthentik/core/id";
 
-import { CSSResult, html, nothing, TemplateResult } from "lit";
+import { CSSResult, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { map } from "lit/directives/map.js";
 
 import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFRadio from "@patternfly/patternfly/components/Radio/radio.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 export interface RadioOption<T> {
     label: string;
-    description?: TemplateResult;
+    description?: SlottedTemplateResult;
     className?: string;
     default?: boolean;
     value: T;
@@ -22,30 +22,29 @@ export interface RadioOption<T> {
 }
 
 @customElement("ak-radio")
-export class Radio<T> extends CustomEmitterElement(AKElement) {
+export class Radio<T = never> extends CustomEmitterElement(AKElement) {
+    static styles: CSSResult[] = [
+        // ---
+        PFRadio,
+        PFForm,
+        Styles,
+    ];
+
     /**
      * Options to display in the radio group.
      *
      * Can be either an array of RadioOption<T> or a function returning such an array.
      */
     @property({ attribute: false })
-    public options: RadioOption<T>[] | (() => RadioOption<T>[]) = [];
+    public options!: RadioOption<T>[] | (() => RadioOption<T>[]);
 
     @property()
     public name = "";
 
     @property({ attribute: false })
-    public value?: T;
+    public value?: T | unknown;
 
     #fieldID: string = this.name || IDGenerator.randomID();
-
-    static styles: CSSResult[] = [
-        // ---
-        PFBase,
-        PFRadio,
-        PFForm,
-        Styles,
-    ];
 
     #optionsArray(): RadioOption<T>[] {
         return typeof this.options === "function" ? this.options() : this.options;
@@ -99,7 +98,7 @@ export class Radio<T> extends CustomEmitterElement(AKElement) {
                 aria-label=${option.label}
                 id=${id}
                 .checked=${option.value === this.value}
-                .disabled=${option.disabled}
+                .disabled=${!!option.disabled}
             />
             <label class="pf-c-radio__label ${option.className ?? ""}" for=${id}
                 >${option.label}</label
@@ -119,7 +118,7 @@ export class Radio<T> extends CustomEmitterElement(AKElement) {
 
 declare global {
     interface HTMLElementTagNameMap {
-        "ak-radio": Radio<unknown>;
+        "ak-radio": Radio<never>;
     }
 }
 

--- a/web/src/elements/forms/SearchSelect/SearchSelect.ts
+++ b/web/src/elements/forms/SearchSelect/SearchSelect.ts
@@ -9,15 +9,18 @@ import { groupBy } from "#common/utils";
 
 import { AkControlElement } from "#elements/AkControlElement";
 import { PreventFormSubmit } from "#elements/forms/helpers";
-import type { GroupedOptions, SelectGroup, SelectOption } from "#elements/types";
+import type {
+    GroupedOptions,
+    SelectGroup,
+    SelectOption,
+    SlottedTemplateResult,
+} from "#elements/types";
 import { ifPresent } from "#elements/utils/attributes";
 import { randomId } from "#elements/utils/randomId";
 
 import { msg } from "@lit/localize";
-import { html, PropertyValues, TemplateResult } from "lit";
+import { html, PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
-
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 type Group<T> = [string, T[]];
 
@@ -36,8 +39,6 @@ export abstract class SearchSelectBase<T>
     extends AkControlElement<string>
     implements ISearchSelectBase<T>
 {
-    static styles = [PFBase];
-
     //#region Properties
 
     /**
@@ -55,13 +56,13 @@ export abstract class SearchSelectBase<T>
     /**
      * Render a string description representation of items of the collection under search.
      */
-    public abstract renderDescription?: (element: T) => string | TemplateResult;
+    public abstract renderDescription?: (element: T) => SlottedTemplateResult;
 
     /**
      * A function which returns the currently selected object's primary key, used for serialization
      * into forms.
      */
-    public abstract value: (element: T | null) => string;
+    public abstract value: (element: T | null) => string | number | undefined;
 
     /**
      * A function passed to this object that determines an object in the collection under search
@@ -201,7 +202,7 @@ export abstract class SearchSelectBase<T>
             }
         }
 
-        return this.value(this.selectedObject) || "";
+        return String(this.value(this.selectedObject ?? null) ?? "");
     }
 
     public json() {
@@ -309,7 +310,7 @@ export abstract class SearchSelectBase<T>
                 // We fix this by forcing a string cast here.
                 // Remove this after migrating to Lit JSX.
 
-                const serialized = `${this.value(obj)}`;
+                const serialized = String(this.value(obj));
 
                 return serialized && serialized === value;
             }) || null;
@@ -335,7 +336,7 @@ export abstract class SearchSelectBase<T>
             items.map((item) => [
                 `${this.value(item)}`,
                 this.renderElement(item),
-                this.renderDescription ? this.renderDescription(item) : undefined,
+                this.renderDescription ? this.renderDescription(item) : null,
             ]);
 
         const makeSearchGroups = (items: Group<T>[]): SelectGroup[] =>

--- a/web/src/elements/forms/SearchSelect/ak-portal.ts
+++ b/web/src/elements/forms/SearchSelect/ak-portal.ts
@@ -21,7 +21,7 @@ import { customElement, property } from "lit/decorators.js";
  */
 
 export interface IPortal {
-    anchor: HTMLElement;
+    anchor?: HTMLElement;
     open: boolean;
     name?: string;
 }

--- a/web/src/elements/forms/SearchSelect/ak-search-select-ez.ts
+++ b/web/src/elements/forms/SearchSelect/ak-search-select-ez.ts
@@ -3,7 +3,7 @@ import { type ISearchSelectBase, SearchSelectBase } from "./SearchSelect.js";
 import { TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
-export interface ISearchSelectApi<T> {
+export interface ISearchSelectConfig<T = unknown> {
     fetchObjects: (query?: string) => Promise<T[]>;
     renderElement: (element: T) => string;
     renderDescription?: (element: T) => string | TemplateResult;
@@ -12,8 +12,8 @@ export interface ISearchSelectApi<T> {
     groupBy?: (items: T[]) => [string, T[]][];
 }
 
-export interface ISearchSelectEz<T> extends ISearchSelectBase<T> {
-    config: ISearchSelectApi<T>;
+export interface ISearchSelectEz<T = unknown> extends ISearchSelectBase<T> {
+    config: ISearchSelectConfig<T>;
 }
 
 /**
@@ -44,9 +44,7 @@ export interface ISearchSelectEz<T> extends ISearchSelectBase<T> {
  */
 
 @customElement("ak-search-select-ez")
-export class SearchSelectEz<T> extends SearchSelectBase<T> implements ISearchSelectEz<T> {
-    static styles = [...SearchSelectBase.styles];
-
+export class SearchSelectEz<T> extends SearchSelectBase<T> {
     public fetchObjects!: (query?: string) => Promise<T[]>;
     public renderElement!: (element: T) => string;
     public renderDescription?: ((element: T) => string | TemplateResult) | undefined;
@@ -54,7 +52,8 @@ export class SearchSelectEz<T> extends SearchSelectBase<T> implements ISearchSel
     public selected?: ((element: T, elements: T[]) => boolean) | undefined;
 
     @property({ type: Object, attribute: false })
-    public config!: ISearchSelectApi<T>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    public config!: ISearchSelectConfig<T | any>;
 
     public override connectedCallback() {
         this.fetchObjects = this.config.fetchObjects;

--- a/web/src/elements/forms/SearchSelect/ak-search-select.ts
+++ b/web/src/elements/forms/SearchSelect/ak-search-select.ts
@@ -2,14 +2,21 @@ import { type ISearchSelectBase, SearchSelectBase } from "./SearchSelect.js";
 
 import { groupBy } from "#common/utils";
 
-import { TemplateResult } from "lit";
+import { SlottedTemplateResult } from "#elements/types";
+
 import { customElement, property } from "lit/decorators.js";
+
+type AsyncReturnArrayElement<T extends (query?: string) => Promise<never[]>> = T extends (
+    query?: string,
+) => Promise<(infer U)[]>
+    ? U
+    : never;
 
 export interface ISearchSelect<T> extends ISearchSelectBase<T> {
     fetchObjects: (query?: string) => Promise<T[]>;
     renderElement: (element: T) => string;
-    renderDescription?: (element: T) => string | TemplateResult;
-    value: (element: T | null) => string;
+    renderDescription?: (element: T) => SlottedTemplateResult;
+    value: (element: T | null) => string | number;
     selected?: (element: T, elements: T[]) => boolean;
     groupBy: (items: T[]) => [string, T[]][];
 }
@@ -45,20 +52,21 @@ export interface ISearchSelect<T> extends ISearchSelectBase<T> {
  *
  */
 @customElement("ak-search-select")
-export class SearchSelect<T> extends SearchSelectBase<T> implements ISearchSelect<T> {
-    static styles = [...SearchSelectBase.styles];
-
+export class SearchSelect<
+    TFetch extends (query?: string) => Promise<never[]>,
+    T = AsyncReturnArrayElement<TFetch>,
+> extends SearchSelectBase<T> {
     @property({ attribute: false })
-    public fetchObjects!: (query?: string) => Promise<T[]>;
+    public fetchObjects!: TFetch;
 
     @property({ attribute: false })
     public renderElement!: (element: T) => string;
 
     @property({ attribute: false })
-    public renderDescription?: (element: T) => string | TemplateResult;
+    public renderDescription?: (element: T) => SlottedTemplateResult;
 
     @property({ attribute: false })
-    public value!: (element: T | null) => string;
+    public value!: (element: T | null) => string | number | undefined;
 
     @property({ attribute: false })
     public selected?: (element: T, elements: T[]) => boolean;
@@ -73,6 +81,6 @@ export default SearchSelect;
 
 declare global {
     interface HTMLElementTagNameMap {
-        "ak-search-select": SearchSelect<unknown>;
+        "ak-search-select": SearchSelect<(query?: string) => Promise<never[]>>;
     }
 }

--- a/web/src/elements/forms/SearchSelect/stories/ak-search-select-view.stories.ts
+++ b/web/src/elements/forms/SearchSelect/stories/ak-search-select-view.stories.ts
@@ -3,6 +3,7 @@ import "#elements/forms/SearchSelect/ak-search-select-view";
 import { groupedSampleData, sampleData } from "./sampleData.js";
 
 import { SearchSelectView } from "#elements/forms/SearchSelect/ak-search-select-view";
+import { SelectOptions } from "#elements/types";
 
 import { Meta } from "@storybook/web-components";
 import { kebabCase } from "change-case";
@@ -39,9 +40,9 @@ const container = (testItem: TemplateResult) =>
         <ul id="message-pad" style="margin-top: 1em"></ul>
     </div>`;
 
-const longGoodForYouPairs = {
+const longGoodForYouPairs: SelectOptions<string> = {
     grouped: false,
-    options: sampleData.map(({ produce }) => [kebabCase(produce), produce]),
+    options: sampleData.map(({ produce }) => [kebabCase(produce), produce, null]),
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/web/src/elements/forms/SearchSelect/stories/ak-search-select.stories.ts
+++ b/web/src/elements/forms/SearchSelect/stories/ak-search-select.stories.ts
@@ -5,8 +5,8 @@ import { sampleData } from "./sampleData.js";
 
 import { groupBy } from "#common/utils";
 
-import { SearchSelect } from "#elements/forms/SearchSelect/ak-search-select";
-import { type ISearchSelectApi } from "#elements/forms/SearchSelect/ak-search-select-ez";
+import { ISearchSelect } from "#elements/forms/SearchSelect/ak-search-select";
+import { type ISearchSelectConfig } from "#elements/forms/SearchSelect/ak-search-select-ez";
 
 import { Meta } from "@storybook/web-components";
 
@@ -32,7 +32,7 @@ const getSamples = (query = "") => {
     return Promise.resolve(samples.filter((s) => check.test(s.name)));
 };
 
-const metadata: Meta<SearchSelect<Sample>> = {
+const metadata: Meta<ISearchSelect<Sample>> = {
     title: "Elements / Search Select / API Interface",
     component: "ak-search-select",
     parameters: {
@@ -73,7 +73,7 @@ export const Default = () =>
         html`<ak-search-select
             .fetchObjects=${getSamples}
             .renderElement=${(sample: Sample) => sample.name}
-            .value=${(sample: Sample) => sample.pk}
+            .value=${(sample: Sample | null) => sample?.pk}
             @ak-change=${displayChange}
         ></ak-search-select>`,
     );
@@ -83,7 +83,7 @@ export const Grouped = () => {
         html`<ak-search-select
             .fetchObjects=${getSamples}
             .renderElement=${(sample: Sample) => sample.name}
-            .value=${(sample: Sample) => sample.pk}
+            .value=${(sample: Sample | null) => sample?.pk}
             .groupBy=${(samples: Sample[]) =>
                 groupBy(samples, (sample: Sample) => sample.season[0] ?? "")}
             @ak-change=${displayChange}
@@ -92,7 +92,7 @@ export const Grouped = () => {
 };
 
 export const GroupedAndEz = () => {
-    const config: ISearchSelectApi<Sample> = {
+    const config: ISearchSelectConfig<Sample> = {
         fetchObjects: getSamples,
         renderElement: (sample: Sample) => sample.name,
         value: (sample: Sample | null) => sample?.pk ?? "",
@@ -114,7 +114,7 @@ export const SelectedAndBlankable = () => {
             blankable
             .fetchObjects=${getSamples}
             .renderElement=${(sample: Sample) => sample.name}
-            .value=${(sample: Sample) => sample.pk}
+            .value=${(sample: Sample | null) => sample?.pk}
             .selected=${(sample: Sample) => sample.pk === "herbs"}
             @ak-change=${displayChange}
         ></ak-search-select>`,

--- a/web/src/elements/forms/SearchSelect/stories/sampleData.ts
+++ b/web/src/elements/forms/SearchSelect/stories/sampleData.ts
@@ -1,3 +1,5 @@
+import { SelectOptions } from "#elements/types";
+
 import { kebabCase } from "change-case";
 
 import type { TemplateResult } from "lit";
@@ -340,10 +342,14 @@ const reseason = (acc: Seasoned[], { produce, seasons, desc }: ViewSample): Seas
     ...seasons.map((s) => [s, produce, desc] as Seasoned),
 ];
 
-export const groupedSampleData = (() => {
+export const groupedSampleData = ((): SelectOptions<string> => {
     const seasoned: Seasoned[] = sampleData.reduce(reseason, [] as Seasoned[]);
     const grouped = Object.groupBy(seasoned, ([season]) => season);
-    const ungrouped = ([_season, label, desc]: Seasoned) => [kebabCase(label), label, desc];
+    const ungrouped = ([_season, label, desc]: Seasoned): Seasoned => [
+        kebabCase(label),
+        label,
+        desc,
+    ];
 
     if (grouped === undefined) {
         throw new Error("Not possible with existing data.");

--- a/web/src/elements/stories/EmptyState.stories.ts
+++ b/web/src/elements/stories/EmptyState.stories.ts
@@ -94,7 +94,7 @@ const Template: Story = {
         <ak-empty-state
             icon=${ifDefined(args.icon)}
             ?loading=${args.loading}
-            ?default=${args.defaultLabel}
+            ?default-label=${args.defaultLabel}
             ?full-height=${args.fullHeight}
         >
             ${args.headingText ? html`<span>${args.headingText}</span>` : nothing}

--- a/web/src/elements/stories/Expand.stories.ts
+++ b/web/src/elements/stories/Expand.stories.ts
@@ -72,8 +72,8 @@ export const DefaultStory: StoryObj = {
         container(
             html` <ak-expand
                 ?expanded=${expanded}
-                textOpen=${ifDefined(textOpen)}
-                textClosed=${ifDefined(textClosed)}
+                text-open=${ifDefined(textOpen)}
+                text-closed=${ifDefined(textClosed)}
                 ><div>
                     <p>Μήτ᾽ ἔμοι μέλι μήτε μέλισσα</p>
                     <p>"Neither the bee nor the honey for me." - Sappho, 600 BC</p>

--- a/web/src/elements/types.ts
+++ b/web/src/elements/types.ts
@@ -223,7 +223,7 @@ export type SelectOption<T = never> = [
     /**
      * A string or TemplateResult used to describe the option.
      */
-    desc?: string | TemplateResult,
+    desc: SlottedTemplateResult,
     /**
      * The object the key represents; used by some specific apps. API layers may use
      *   this as a way to find the referenced object, rather than the string and keeping a local map.

--- a/web/src/flow/FlowExecutor.ts
+++ b/web/src/flow/FlowExecutor.ts
@@ -58,6 +58,8 @@ import PFList from "@patternfly/patternfly/components/List/list.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
 
+/// <reference types="../../types/lit.d.ts" />
+
 @customElement("ak-flow-executor")
 export class FlowExecutor
     extends WithCapabilitiesConfig(WithBrandConfig(Interface))

--- a/web/src/flow/components/ak-flow-card.ts
+++ b/web/src/flow/components/ak-flow-card.ts
@@ -14,6 +14,8 @@ import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
 import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
+type ExcludeComponent<T> = T extends { component: string } ? Omit<T, "component"> : T;
+
 /**
  * @element ak-flow-card
  * @class FlowCard
@@ -28,7 +30,7 @@ export class FlowCard extends AKElement {
     role = "presentation";
 
     @property({ type: Object })
-    challenge?: ChallengeTypes;
+    challenge?: ExcludeComponent<ChallengeTypes>;
 
     @property({ type: Boolean })
     loading = false;

--- a/web/src/flow/components/ak-flow-password-input.ts
+++ b/web/src/flow/components/ak-flow-password-input.ts
@@ -69,6 +69,9 @@ export class InputPassword extends AKElement {
     @property({ type: String })
     label = msg("Password");
 
+    @property({ type: Boolean })
+    public required = false;
+
     /**
      * The placeholder text for the input field.
      *
@@ -308,7 +311,7 @@ export class InputPassword extends AKElement {
     }
 
     render() {
-        return html` ${AKLabel({ required: true, htmlFor: this.inputID }, this.label)}
+        return html` ${AKLabel({ required: this.required, htmlFor: this.inputID }, this.label)}
             <div class="pf-c-form__group">
                 <div class="pf-c-form__group-control">
                     <div class="pf-c-input-group">
@@ -323,7 +326,7 @@ export class InputPassword extends AKElement {
                                 "pf-m-icon": true,
                                 "pf-m-caps-lock": this.capsLock,
                             })}"
-                            required
+                            ?required=${this.required}
                             aria-invalid=${this.errors?.length ? "true" : "false"}
                             value=${this.initialValue}
                             ${ref(this.inputRef)}

--- a/web/src/flow/stages/authenticator_totp/AuthenticatorTOTPStage.ts
+++ b/web/src/flow/stages/authenticator_totp/AuthenticatorTOTPStage.ts
@@ -1,6 +1,7 @@
 import "#flow/FormStatic";
 import "#flow/components/ak-flow-card";
 import "webcomponent-qr-code";
+import "#types/qr-code";
 
 import { MessageLevel } from "#common/messages";
 
@@ -27,7 +28,6 @@ import PFFormControl from "@patternfly/patternfly/components/FormControl/form-co
 import PFInputGroup from "@patternfly/patternfly/components/InputGroup/input-group.css";
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
-import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
 @customElement("ak-stage-authenticator-totp")
 export class AuthenticatorTOTPStage extends BaseStage<
@@ -35,7 +35,6 @@ export class AuthenticatorTOTPStage extends BaseStage<
     AuthenticatorTOTPChallengeResponseRequest
 > {
     static styles: CSSResult[] = [
-        PFBase,
         PFLogin,
         PFForm,
         PFFormControl,

--- a/web/src/flow/stages/authenticator_totp/QrCode.d.ts
+++ b/web/src/flow/stages/authenticator_totp/QrCode.d.ts
@@ -1,7 +1,0 @@
-import { type QRCode } from "webcomponent-qr-code";
-
-declare global {
-    interface HTMLElementTagNameMap {
-        "qr-code": QRCode;
-    }
-}

--- a/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStage.ts
+++ b/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStage.ts
@@ -112,10 +112,10 @@ export class AuthenticatorValidateStage
     @state()
     _firstInitialized: boolean = false;
 
-    #selectedDeviceChallenge?: DeviceChallenge;
+    #selectedDeviceChallenge: DeviceChallenge | null = null;
 
     @state()
-    protected set selectedDeviceChallenge(value: DeviceChallenge | undefined) {
+    protected set selectedDeviceChallenge(value: DeviceChallenge | null) {
         const previousChallenge = this.#selectedDeviceChallenge;
         this.#selectedDeviceChallenge = value;
 
@@ -142,7 +142,7 @@ export class AuthenticatorValidateStage
         });
     }
 
-    protected get selectedDeviceChallenge(): DeviceChallenge | undefined {
+    protected get selectedDeviceChallenge(): DeviceChallenge | null {
         return this.#selectedDeviceChallenge;
     }
 
@@ -154,7 +154,7 @@ export class AuthenticatorValidateStage
     }
 
     public reset(): void {
-        this.selectedDeviceChallenge = undefined;
+        this.selectedDeviceChallenge = null;
     }
 
     willUpdate(_changed: PropertyValues<this>) {

--- a/web/src/flow/stages/base.ts
+++ b/web/src/flow/stages/base.ts
@@ -58,6 +58,13 @@ export interface ResponseErrorsChallenge {
     };
 }
 
+/**
+ * Base class for all flow stages.
+ *
+ * @template Tin The type of the challenge this stage accepts.
+ * @prop {StageHost} host The host managing this stage.
+ * @prop {Tin} challenge The challenge provided to this stage.
+ */
 export abstract class BaseStage<
     Tin extends FlowInfoChallenge & PendingUserChallenge & ResponseErrorsChallenge,
     Tout,

--- a/web/src/flow/stages/identification/IdentificationStage.ts
+++ b/web/src/flow/stages/identification/IdentificationStage.ts
@@ -417,7 +417,7 @@ export class IdentificationStage extends BaseStage<
             }
         )?.passkeyChallenge;
         // When passkey is enabled, add "webauthn" to autocomplete to enable passkey autofill
-        const autocomplete = passkeyChallenge ? "username webauthn" : "username";
+        const autocomplete: AutoFill = passkeyChallenge ? "username webauthn" : "username";
 
         return html`${this.challenge.flowDesignation === FlowDesignationEnum.Recovery
                 ? html`

--- a/web/src/flow/stages/prompt/PromptStage.ts
+++ b/web/src/flow/stages/prompt/PromptStage.ts
@@ -33,6 +33,10 @@ import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
 import PFBase from "@patternfly/patternfly/patternfly-base.css";
 
+/**
+ * @prop {PromptChallenge} challenge - The challenge provided to this stage.
+ * @prop {StageHost} host - The host managing this stage.
+ */
 @customElement("ak-stage-prompt")
 export class PromptStage extends WithCapabilitiesConfig(
     BaseStage<PromptChallenge, PromptChallengeResponseRequest>,

--- a/web/src/standalone/api-browser/index.entrypoint.ts
+++ b/web/src/standalone/api-browser/index.entrypoint.ts
@@ -1,5 +1,5 @@
-// sort-imports-ignore
 import "rapidoc";
+import "#types/rapi-doc";
 
 import styles from "./index.entrypoint.css";
 

--- a/web/src/user/user-settings/UserSettingsPage.ts
+++ b/web/src/user/user-settings/UserSettingsPage.ts
@@ -165,7 +165,7 @@ export class UserSettingsPage extends WithSession(AKElement) {
                             </div>
                             <ak-user-settings-source
                                 allow-configuration
-                                userId=${ifPresent(currentUser?.pk)}
+                                user-id=${ifPresent(currentUser?.pk)}
                             ></ak-user-settings-source>
                         </div>
                     </div>

--- a/web/src/user/user-settings/details/stages/prompt/PromptStage.ts
+++ b/web/src/user/user-settings/details/stages/prompt/PromptStage.ts
@@ -16,6 +16,10 @@ import { msg } from "@lit/localize";
 import { html, nothing } from "lit";
 import { customElement } from "lit/decorators.js";
 
+/**
+ * @prop {StageHost} host - The host managing this stage.
+ *
+ */
 @customElement("ak-user-stage-prompt")
 export class UserSettingsPromptStage extends PromptStage {
     protected override renderPromptInner(prompt: StagePrompt): SlottedTemplateResult {

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -18,16 +18,36 @@
         // TODO: We should enable this when when we're ready to enforce it.
         "noUncheckedIndexedAccess": false,
         "plugins": [
+            // #region Lit
             {
                 "name": "ts-lit-plugin",
                 "strict": true,
                 "rules": {
-                    "no-unknown-tag-name": "off",
-                    "no-missing-import": "off",
-                    "no-incompatible-type-binding": "off",
-                    "no-unknown-property": "off",
-                    "no-unknown-attribute": "off"
-                }
+                    "no-incompatible-type-binding": "off"
+                },
+
+                "globalAttributes": [
+                    //#region Testing
+
+                    "name",
+
+                    //#endregion
+
+                    //#region ARIA
+
+                    "aria-description",
+                    "inert",
+
+                    //#endregion
+
+                    //#region Popover
+
+                    "popover",
+                    "popovertarget",
+                    "popovertargetaction"
+
+                    //#endregion
+                ]
             },
             {
                 "name": "@genesiscommunitysuccess/custom-elements-lsp",

--- a/web/types/lit.d.ts
+++ b/web/types/lit.d.ts
@@ -18,4 +18,8 @@ declare global {
          */
         litNonce?: string;
     }
+
+    interface HTMLElementTagNameMap {
+        "qr-code": import("webcomponent-qr-code").default;
+    }
 }

--- a/web/types/qr-code/index.d.ts
+++ b/web/types/qr-code/index.d.ts
@@ -1,0 +1,19 @@
+/**
+ * @file QR code web component type definitions.
+ */
+
+declare module "webcomponent-qr-code" {
+    /**
+     * QR Code Web Component
+     *
+     * @element qr-code
+     *
+     * @attr {"svg" | "png" | "html"} format - The type of QR code to generate.
+     * @attr {string} data - The data to encode in the QR code.
+     *
+     * @see {@link https://www.webcomponents.org/element/webcomponent-qr-code}
+     */
+    class QRCode extends HTMLElement {}
+
+    export default QRCode;
+}

--- a/web/types/rapi-doc/index.d.ts
+++ b/web/types/rapi-doc/index.d.ts
@@ -1,0 +1,115 @@
+declare module "rapidoc" {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type Booleanish = "true" | "false";
+
+    /**
+     * Web Component based Swagger & OpenAPI Spec Viewer
+     *
+     * @element rapi-doc
+     *
+     * @attr {string} spec-url - URL of the OpenAPI spec to view.
+     * @attr {Booleanish} update-route - Setting true will update the browser URL when a new section is visited. Default: true.
+     * @attr {string} route-prefix - Custom prefix for generated routes to support third-party routing. Default: "#".
+     * @attr {Booleanish} sort-tags - List tags in alphabetical order instead of spec order. Default: false.
+     * @attr {Booleanish} sort-schemas - List schemas in alphabetical order (only in focused render-style with show-components). Default: false.
+     * @attr {"path" | "method" | "summary" | "none"} sort-endpoints-by - Sort endpoints within each tag. Default: "path".
+     * @attr {string} heading-text - Heading text displayed on the top-left corner.
+     * @attr {string} goto-path - Initial location after spec loads, in format {method}-{path} (e.g., "get-/user/login").
+     * @attr {Booleanish} fill-request-fields-with-example - Fill request fields with example values from spec. Default: true.
+     * @attr {Booleanish} persist-auth - Persist authentication to localStorage. Default: false.
+     * @attr {"light" | "dark"} theme - Base theme for calculating UI colors. Default: "dark".
+     * @attr {string} bg-color - Hex color code for main background (dark: #333, light: #fff).
+     * @attr {string} text-color - Hex color code for text (dark: #bbb, light: #444).
+     * @attr {string} header-color - Hex color code for header background. Default: "#444444".
+     * @attr {string} primary-color - Hex color code for buttons, tabs, and controls. Default: "#FF791A".
+     * @attr {Booleanish} load-fonts - Load fonts from CDN. Default: true.
+     * @attr {string} regular-font - Font name(s) for regular text. Default: '"Open Sans", Avenir, "Segoe UI", Arial, sans-serif'.
+     * @attr {string} mono-font - Font name(s) for mono-spaced text. Default: "Monaco, 'Andale Mono', 'Roboto Mono', 'Consolas' monospace".
+     * @attr {"default" | "large" | "largest"} font-size - Relative font size for the entire document. Default: "default".
+     * @attr {string} css-file - Name of external CSS file to inject custom styles.
+     * @attr {string} css-classes - Space-separated CSS class names to apply to RapiDoc element.
+     * @attr {"false" | "as-plain-text" | "as-colored-text" | "as-colored-block"} show-method-in-nav-bar - Show API method names in navigation bar. Default: "false".
+     * @attr {Booleanish} use-path-in-nav-bar - Show API paths instead of summary/description in nav bar. Default: false.
+     * @attr {string} nav-bg-color - Navigation bar background color.
+     * @attr {string} nav-text-color - Navigation bar text color.
+     * @attr {string} nav-hover-bg-color - Navigation item background color on hover.
+     * @attr {string} nav-hover-text-color - Navigation item text color on hover.
+     * @attr {string} nav-accent-color - Accent color for navigation bar (e.g., active item background).
+     * @attr {string} nav-accent-text-color - Text color for selected navigation items.
+     * @attr {"left-bar" | "colored-block"} nav-active-item-marker - Navigation active item indicator style. Default: "left-bar".
+     * @attr {"default" | "compact" | "relaxed"} nav-item-spacing - Navigation item spacing. Default: "default".
+     * @attr {"expand-collapse" | "show-description"} on-nav-tag-click - Behavior when clicking a tag in focused mode. Default: "expand-collapse".
+     * @attr {"row" | "column"} layout - Placement of request/response sections (side-by-side or stacked). Default: "row".
+     * @attr {"read" | "view" | "focused"} render-style - Display mode for API docs. Default: "read".
+     * @attr {string} response-area-height - Height of response textarea (e.g., "400px", "50%", "60vh"). Default: "300px".
+     * @attr {Booleanish} show-info - Show/hide the document info section (title, description, version, etc.). Default: true.
+     * @attr {Booleanish} info-description-headings-in-navbar - Include h1/h2 headers from info description in navigation (read mode). Default: false.
+     * @attr {string} match-paths - Filter to show only APIs matching this path (substring or regex based on match-type).
+     * @attr {"includes" | "regex"} match-type - How match-paths filtering is applied. Default: "includes".
+     * @attr {string} remove-endpoints-with-badge-label-as - Comma-separated badge labels to remove from spec.
+     * @attr {Booleanish} show-components - Show components section (schemas, responses, etc.) in focused render-style. Default: false.
+     * @attr {Booleanish} show-header - Show/hide the header. Default: true.
+     * @attr {Booleanish} allow-authentication - Show/hide authentication section. Default: true.
+     * @attr {Booleanish} allow-spec-url-load - Allow loading spec URL from UI. Default: true.
+     * @attr {Booleanish} allow-spec-file-load - Allow loading spec file from local drive (devices > 768px). Default: true.
+     * @attr {Booleanish} allow-spec-file-download - Show buttons to download spec or open in new tab. Default: false.
+     * @attr {Booleanish} allow-search - Enable quick filtering of APIs. Default: true.
+     * @attr {Booleanish} allow-advanced-search - Enable searching through paths, descriptions, parameters, and responses. Default: true.
+     * @attr {Booleanish} allow-try - Enable the TRY feature for making REST calls. Default: true.
+     * @attr {Booleanish} show-curl-before-try - Display cURL snippet between request and response without clicking TRY. Default: false.
+     * @attr {Booleanish} allow-server-selection - Allow user to see/select API server. Default: true.
+     * @attr {Booleanish} allow-schema-description-expand-toggle - Allow expanding/collapsing field descriptions in schema. Default: true.
+     * @attr {"tree" | "table"} schema-style - Display style for object-schemas. Default: "tree".
+     * @attr {number} schema-expand-level - Number of levels to expand in schema. Default: 999.
+     * @attr {Booleanish} schema-description-expanded - Fully expand constraint/description info. Default: false.
+     * @attr {"default" | "never"} schema-hide-read-only - Hide read-only schema attributes in requests. Default: "default".
+     * @attr {"default" | "never"} schema-hide-write-only - Hide write-only schema attributes in responses. Default: "default".
+     * @attr {"schema" | "example" | "model"} default-schema-tab - Default active tab for schema display. Default: "model".
+     * @attr {string} server-url - Custom API server URL not listed in spec.
+     * @attr {string} default-api-server - Default API server from spec for API calls.
+     * @attr {string} api-key-name - Name of the API key for TRY requests.
+     * @attr {"header" | "query"} api-key-location - How to send the API key.
+     * @attr {string} api-key-value - Value of the API key (can be overwritten from UI).
+     * @attr {"omit" | "same-origin" | "include"} fetch-credentials - Credentials mode for cross-domain calls.
+     */
+    class RapiDoc extends HTMLElement {
+        /**
+         * Programmatically load a spec.
+         * @param spec - URL string or JSON object representing a valid OpenAPI spec.
+         */
+        loadSpec(spec: string | object): void;
+
+        /**
+         * Programmatically scroll to a section identified by method and path.
+         * @param path - Path in format {method}-{path} (e.g., "get-/user/login").
+         */
+        scrollToPath(path: string): void;
+
+        /**
+         * Programmatically provide HTTP Basic username and password.
+         * @param securitySchemeId - A valid securityScheme ID defined in the spec.
+         * @param username - The username.
+         * @param password - The password.
+         */
+        setHttpUserNameAndPassword(
+            securitySchemeId: string,
+            username: string,
+            password: string,
+        ): void;
+
+        /**
+         * Programmatically provide an API key.
+         * @param securitySchemeId - A valid securityScheme ID defined in the spec.
+         * @param token - The API key token.
+         */
+        setApiKey(securitySchemeId: string, token: string): void;
+
+        /**
+         * Programmatically set the API server.
+         * @param apiServerUrl - A valid server URL defined in the spec.
+         */
+        setApiServer(apiServerUrl: string): void;
+    }
+
+    export default RapiDoc;
+}


### PR DESCRIPTION
Overview:

Forms were not properly resetting their state when closing modals, which caused stale values to persist when reopening forms. This affected all forms with `@state()` decorated properties.

Testing:

1. Create any item (user, token, application, etc.), close modal
2. Click Create again, form should show default/empty values
3. Edit an item, cancel, click Create - form should be empty
4. Edit an item, cancel, edit same item - should show correct data

Motivation:

Form inputs retained values from previous create/edit operations.