### PR TITLE
providers/saml: fix structure of encrypted saml assertion

### DIFF
--- a/authentik/providers/saml/processors/assertion.py
+++ b/authentik/providers/saml/processors/assertion.py
@@ -320,14 +320,6 @@ class AssertionProcessor:
                 ns=xmlsec.constants.DSigNs,
             )
             assertion.append(signature)
-        if self.provider.encryption_kp:
-            encryption = xmlsec.template.encrypted_data_create(
-                assertion,
-                xmlsec.constants.TransformAes128Cbc,
-                self._assertion_id,
-                ns=xmlsec.constants.DSigNs,
-            )
-            assertion.append(encryption)
 
         assertion.append(self.get_assertion_subject())
         assertion.append(self.get_assertion_conditions())
@@ -403,6 +395,13 @@ class AssertionProcessor:
 
     def _encrypt(self, element: Element, parent: Element):
         """Encrypt SAMLResponse EncryptedAssertion Element"""
+        # Create a standalone copy so namespace declarations are included in the encrypted content
+        element_xml = etree.tostring(element)
+        standalone_element = etree.fromstring(element_xml)
+
+        # Remove the original element from the tree since we're replacing it with encrypted version
+        parent.remove(element)
+
         manager = xmlsec.KeysManager()
         key = xmlsec.Key.from_memory(
             self.provider.encryption_kp.key_data,
@@ -429,11 +428,10 @@ class AssertionProcessor:
         xmlsec.template.encrypted_data_ensure_cipher_value(enc_key)
 
         try:
-            enc_data = encryption_context.encrypt_xml(enc_data, element)
+            enc_data = encryption_context.encrypt_xml(enc_data, standalone_element)
         except xmlsec.Error as exc:
             raise InvalidEncryption() from exc
 
-        parent.remove(enc_data)
         container.append(enc_data)
 
     def build_response(self) -> str:


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
A couple errors caused encrypted assertions to miss attributes or accidentally have an extra encrypteddata tag inside them after decryption. This pr fixes both of those errors

Closes #19585 
Closes #19586 

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
