### PR TITLE
sources/saml: Fix signature verification order to accommodate encrypted assertions

### DIFF
--- a/authentik/sources/saml/processors/response.py
+++ b/authentik/sources/saml/processors/response.py
@@ -2,7 +2,7 @@
 
 from base64 import b64decode
 from time import mktime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import xmlsec
 from defusedxml.lxml import fromstring
@@ -11,6 +11,7 @@ from django.core.exceptions import SuspiciousOperation
 from django.http import HttpRequest
 from django.utils.timezone import now
 from lxml import etree  # nosec
+from lxml.etree import _Element  # nosec
 from structlog.stdlib import get_logger
 
 from authentik.core.models import (
@@ -58,7 +59,7 @@ class ResponseProcessor:
 
     _source: SAMLSource
 
-    _root: Any
+    _root: _Element
     _root_xml: bytes
 
     _http_request: HttpRequest
@@ -120,7 +121,7 @@ class ResponseProcessor:
             decrypted_assertion,
         )
 
-    def _verify_signature(self, signature_node):
+    def _verify_signature(self, signature_node: _Element):
         """Verify a single signature node"""
         xmlsec.tree.add_ids(self._root, ["ID"])
 

--- a/authentik/sources/saml/processors/response.py
+++ b/authentik/sources/saml/processors/response.py
@@ -77,11 +77,17 @@ class ResponseProcessor:
         self._root_xml = b64decode(raw_response.encode())
         self._root = fromstring(self._root_xml)
 
+        # Verify response signature BEFORE decryption (signature covers encrypted content)
+        if self._source.verification_kp and self._source.signed_response:
+            self._verify_response_signature()
+
         if self._source.encryption_kp:
             self._decrypt_response()
 
-        if self._source.verification_kp:
-            self._verify_signed()
+        # Verify assertion signature AFTER decryption (signature is inside encrypted content)
+        if self._source.verification_kp and self._source.signed_assertion:
+            self._verify_assertion_signature()
+
         self._verify_request_id()
         self._verify_status()
 
@@ -114,45 +120,45 @@ class ResponseProcessor:
             decrypted_assertion,
         )
 
-    def _verify_signed(self):
-        """Verify SAML Response's Signature"""
-        signatures = []
+    def _verify_signature(self, signature_node):
+        """Verify a single signature node"""
+        xmlsec.tree.add_ids(self._root, ["ID"])
 
-        if self._source.signed_response:
-            signature_nodes = self._root.xpath("/samlp:Response/ds:Signature", namespaces=NS_MAP)
+        ctx = xmlsec.SignatureContext()
+        key = xmlsec.Key.from_memory(
+            self._source.verification_kp.certificate_data,
+            xmlsec.constants.KeyDataFormatCertPem,
+        )
+        ctx.key = key
 
-            if len(signature_nodes) != 1:
-                raise InvalidSignature("No Signature exists in the Response element.")
-            signatures.extend(signature_nodes)
+        ctx.set_enabled_key_data([xmlsec.constants.KeyDataX509])
+        try:
+            ctx.verify(signature_node)
+        except xmlsec.Error as exc:
+            raise InvalidSignature(
+                "The signature of the SAML object is either missing or invalid."
+            ) from exc
+        LOGGER.debug("Successfully verified signature")
 
-        if self._source.signed_assertion:
-            signature_nodes = self._root.xpath(
-                "/samlp:Response/saml:Assertion/ds:Signature", namespaces=NS_MAP
-            )
+    def _verify_response_signature(self):
+        """Verify SAML Response's Signature (before decryption)"""
+        signature_nodes = self._root.xpath("/samlp:Response/ds:Signature", namespaces=NS_MAP)
 
-            if len(signature_nodes) != 1:
-                raise InvalidSignature("No Signature exists in the Assertion element.")
-            signatures.extend(signature_nodes)
+        if len(signature_nodes) != 1:
+            raise InvalidSignature("No Signature exists in the Response element.")
 
-        if len(signatures) == 0:
-            raise InvalidSignature()
+        self._verify_signature(signature_nodes[0])
 
-        for signature_node in signatures:
-            xmlsec.tree.add_ids(self._root, ["ID"])
+    def _verify_assertion_signature(self):
+        """Verify SAML Assertion's Signature (after decryption)"""
+        signature_nodes = self._root.xpath(
+            "/samlp:Response/saml:Assertion/ds:Signature", namespaces=NS_MAP
+        )
 
-            ctx = xmlsec.SignatureContext()
-            key = xmlsec.Key.from_memory(
-                self._source.verification_kp.certificate_data,
-                xmlsec.constants.KeyDataFormatCertPem,
-            )
-            ctx.key = key
+        if len(signature_nodes) != 1:
+            raise InvalidSignature("No Signature exists in the Assertion element.")
 
-            ctx.set_enabled_key_data([xmlsec.constants.KeyDataX509])
-            try:
-                ctx.verify(signature_node)
-            except xmlsec.Error as exc:
-                raise InvalidSignature() from exc
-            LOGGER.debug("Successfully verified signature")
+        self._verify_signature(signature_nodes[0])
 
     def _verify_request_id(self):
         if self._source.allow_idp_initiated:


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
Since decrypting saml changes its structure, verifying the signature of the response must happen before decryption

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
