### PR TITLE
website/docs: endpoints devices: typo fix

### DIFF
--- a/website/docs/endpoint-devices/device-authentication/ssh-authentication.mdx
+++ b/website/docs/endpoint-devices/device-authentication/ssh-authentication.mdx
@@ -4,7 +4,7 @@ sidebar_label: SSH authentication
 tags: [ssh, authentik Agent]
 ---
 
-You can use the [authentik Agent](../authentik-agent/index.mdx) to authenticate SSH connections ubetween endpoint devices using authentik credentials.
+You can use the [authentik Agent](../authentik-agent/index.mdx) to authenticate SSH connections between endpoint devices using authentik credentials.
 
 Currently, only [Linux](../authentik-agent/agent-deployment/linux.mdx) devices can serve as SSH endpoints. See [Configure SSH authentication on an endpoint device](#configure-ssh-authentication-on-an-endpoint-device) section for more details.
 


### PR DESCRIPTION
~u~between