### PR TITLE
web/elements: reduce spacing between collapsible form groups

### DIFF
--- a/web/src/elements/forms/FormGroup.css
+++ b/web/src/elements/forms/FormGroup.css
@@ -18,14 +18,15 @@ details {
     &::details-content {
         padding-inline-start: var(--pf-c-form__field-group--GridTemplateColumns--toggle);
         padding-inline-end: var(--pf-global--spacer--md);
-        padding-block-end: var(--pf-global--spacer--md);
+        padding-block-end: var(--pf-global--spacer--sm);
     }
 
     & > summary {
         list-style-position: outside;
         margin-inline-start: 2em;
         padding-inline-start: calc(var(--pf-global--spacer--md) + 0.25rem);
-        padding: var(--pf-global--spacer--md);
+        padding-block: var(--pf-global--spacer--sm);
+        padding-inline: var(--pf-global--spacer--md);
         list-style-type: "\f105";
         cursor: pointer;
         user-select: none;
@@ -44,9 +45,12 @@ details {
         }
 
         &:hover::marker {
-            outline: 1px dashed red;
             color: var(--marker-color-hover, var(--pf-global--Color--100));
         }
+    }
+
+    &:not([open]) summary {
+        padding-block: var(--pf-global--spacer--xs);
     }
 
     &[open] summary {


### PR DESCRIPTION
Overview:

Reduce vertical padding on ak-form-group sections to create tighter spacing between collapsible form sections.

- Reduce summary padding-block from 1rem to 0.5rem when open
- Reduce summary padding-block to 0.25rem when closed
- Reduce content bottom padding from 1rem to 0.5rem
- Remove debug red outline on marker hover

Testing:

Visiting the UI

Screenshots:

Before:

<img width="275" height="375" alt="image" src="https://github.com/user-attachments/assets/cdc4a586-703a-4abf-8894-08f482161bfb" />

After:

<img width="286" height="288" alt="image" src="https://github.com/user-attachments/assets/0d02b74f-52bd-49a9-aa03-33d4cf514fee" />

Motivation:

Tooooo muchhhh spaceeeeee wasssstedddd