### PR TITLE
web/a11y: Locale selector select styles, contrast.

### DIFF
--- a/web/src/elements/locale/ak-locale-select.css
+++ b/web/src/elements/locale/ak-locale-select.css
@@ -24,10 +24,12 @@
     cursor: pointer;
     user-select: none;
     opacity: var(--ak-c-locale-select--Opacity, 1);
+    will-change: opacity, text-decoration-color, background-color, color;
+    isolation: isolate;
 
     /* Compatibility mode */
     background-color: var(--ak-c-locale-select--BackgroundColor, transparent) !important;
-    color: inherit !important;
+    color: var(--ak-c-locale-select--Color, inherit) !important;
     text-decoration: underline;
     text-decoration-color: var(--ak-c-locale-select--TextDecorationColor, transparent);
 
@@ -40,6 +42,16 @@
         outline: 1px solid var(--ak-c-locale--select--OutlineColor, transparent);
 
         outline-offset: initial;
+    }
+
+    &:open {
+        /**
+         * Edge is more restrictive with selects state styling.
+         * Using the browser's preferred system colors here strikes
+         * a good balance between visibility and design consistency.
+         */
+        --ak-c-locale-select--BackgroundColor: Field;
+        --ak-c-locale-select--Color: FieldText;
     }
 
     padding-inline-start: var(
@@ -97,7 +109,7 @@
 }
 
 [part="select"] {
-    transition-property: opacity, text-decoration-color;
+    transition-property: opacity;
     transition-duration: 0.2s;
     transition-timing-function: ease-in-out;
 }

--- a/web/src/elements/locale/ak-locale-select.ts
+++ b/web/src/elements/locale/ak-locale-select.ts
@@ -90,8 +90,6 @@ export class AKLocaleSelect extends WithLocale(WithCapabilitiesConfig(AKElement)
     public override connectedCallback(): void {
         super.connectedCallback();
 
-        this.addEventListener("click", this.show);
-
         window.addEventListener(LOCALE_STATUS_EVENT, this.#localeStatusListener, {
             once: true,
             passive: true,

--- a/web/src/flow/FlowExecutor.css
+++ b/web/src/flow/FlowExecutor.css
@@ -14,8 +14,9 @@
 }
 
 [part="locale-select"] {
+    --pf-global--Color--100: var(--pf-global--Color--light-100) !important;
     --ak-c-flow-executor__locale-select--Padding: var(--pf-global--spacer--md);
-    --ak-c-flow-executor__locale-select--Color: var(--pf-global--Color--light-100);
+    --ak-c-flow-executor__locale-select--Color: var(--pf-global--Color--100);
     --ak-c-locale-select--label--Color: var(--ak-c-flow-executor__locale-select--Color);
 
     /* Compatibility mode */
@@ -41,21 +42,11 @@
         --ak-c-locale-select--TextDecorationColor: var(--ak-c-locale-select--label--Color);
         --ak-c-locale-select__after--Opacity: 1;
 
-        color: var(--ak-c-flow-executor__locale-select--Color--hover);
+        --ak-c-locale-select--Color: var(--ak-c-flow-executor__locale-select--Color--hover);
 
         @media (prefers-contrast: more) {
-            --ak-c-flow-executor__locale-select--Color--hover: var(
-                --pf-global--primary-color--dark-100
-            );
-
-            --ak-c-locale--select--OutlineColor: var(
-                --ak-c-flow-executor__locale-select--Color--hover
-            );
+            --ak-c-locale--select--OutlineColor: var(--pf-global--primary-color--dark-100);
         }
-    }
-
-    &::part(select) {
-        color: var(--ak-c-flow-executor__locale-select--Color);
     }
 
     filter: var(--ak-global--background-contrast-Filter);
@@ -79,14 +70,19 @@
         }
     }
 
-    @media (width >= 61.25rem) and (prefers-contrast: more) {
-        --ak-c-flow-executor__locale-select--BackgroundColor--hover: var(
-            --pf-global--BackgroundColor--150
-        );
-    }
-
     /* Card is fully masked to mobile background. */
     @media (width <= 35rem) {
         grid-row: header;
+    }
+}
+
+@media (min-width: 70rem) and (min-height: 17.5rem) {
+    :host([data-layout^="sidebar"]),
+    [data-layout^="sidebar"] /* Compatibility mode */ {
+        --ak-global--background-contrast-Filter: none !important;
+
+        [part="locale-select"] {
+            --ak-c-flow-executor__locale-select--Color: inherit !important;
+        }
     }
 }

--- a/web/src/flow/FlowExecutor.ts
+++ b/web/src/flow/FlowExecutor.ts
@@ -493,6 +493,7 @@ export class FlowExecutor
         return html`<ak-locale-select
                 part="locale-select"
                 exportparts="label:locale-select-label,select:locale-select-select"
+                class="pf-m-dark"
             ></ak-locale-select>
 
             <header class="pf-c-login__header">${this.renderInspectorButton()}</header>

--- a/web/src/styles/authentik/components/Form/form.css
+++ b/web/src/styles/authentik/components/Form/form.css
@@ -158,15 +158,6 @@ fieldset {
 :host([theme="dark"]) {
     /* #region Inputs */
 
-    optgroup,
-    option {
-        color: var(--ak-dark-foreground);
-    }
-    select[multiple] optgroup:checked,
-    select[multiple] option:checked {
-        color: var(--ak-dark-background);
-    }
-
     .pf-c-input-group:not(:has(.pf-c-switch)) {
         --pf-c-input-group--BackgroundColor: transparent;
 


### PR DESCRIPTION
## Details

This PR fixes a few scenarios where the locale selector does not have a consistent visual design, especially in Edge.

- The locale selector now prefers the user agent background and text color when open.
- The locale selector makes better use of the `prefers-contrast: more` query on light mode.
- The contrasting drop-shadow filter is disabled on sidebar layouts, avoiding awkward visuals.
- Edge no longer re-opens the locale selector after selecting a language.

Closes #19509 