### PR TITLE
web/admin: fix brand form sending "undefined" string for blank default application

### DIFF
--- a/web/src/admin/brands/BrandForm.ts
+++ b/web/src/admin/brands/BrandForm.ts
@@ -174,9 +174,7 @@ export class BrandForm extends ModelForm<Brand, string> {
                             }}
                             .renderElement=${(item: Application) => item.name}
                             .renderDescription=${(item: Application) => html`${item.slug}`}
-                            .value=${(item: Application | null) => {
-                                return String(item?.pk);
-                            }}
+                            .value=${(item: Application | null) => item?.pk}
                             .selected=${(item: Application): boolean => {
                                 return item.pk === this.instance?.defaultApplication;
                             }}


### PR DESCRIPTION


Overview:

When the default application field was left blank, the form was sending the string "undefined" instead of null, and that caused a UUID validation error on the backend.

The `.value` callback was using optional chaining which returns `undefined` when the item is null, and this was being converted to the string "undefined" during form serialization. Changed to return `null` explicitly when no application is selected.

Testing:

On main, attempt to set no default application. Then, try again on the PR branch.

Motitation:

Fixes bug