### PR TITLE
web/a11y: CAPTCHA Stage Form

### DIFF
--- a/web/src/admin/enterprise/EnterpriseLicenseForm.ts
+++ b/web/src/admin/enterprise/EnterpriseLicenseForm.ts
@@ -73,6 +73,7 @@ export class EnterpriseLicenseForm extends ModelForm<License, string> {
             <ak-secret-textarea-input
                 name="key"
                 ?revealed=${!this.instance}
+                placeholder=${msg("Paste your license key...")}
                 label=${msg("License key")}
                 input-hint="code"
             >

--- a/web/src/admin/stages/captcha/CaptchaStageForm.ts
+++ b/web/src/admin/stages/captcha/CaptchaStageForm.ts
@@ -1,286 +1,182 @@
+import "#components/ak-text-input";
 import "#components/ak-number-input";
 import "#components/ak-secret-text-input";
 import "#components/ak-switch-input";
 import "#elements/forms/FormGroup";
 import "#elements/forms/HorizontalFormElement";
+import "#elements/Alert";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
 
-import { BaseStageForm } from "#admin/stages/BaseStageForm";
+import { Level } from "#elements/Alert";
+import { SlottedTemplateResult } from "#elements/types";
 
-import { CaptchaStage, CaptchaStageRequest, StagesApi } from "@goauthentik/api";
+import { BaseStageForm } from "#admin/stages/BaseStageForm";
+import {
+    CAPTCHA_PROVIDERS,
+    CaptchaProviderKey,
+    CaptchaProviderKeys,
+    CaptchaProviderPreset,
+    detectProviderFromInstance,
+    pluckFormValues,
+} from "#admin/stages/captcha/shared";
+import Styles from "#admin/stages/captcha/styles.css";
+
+import {
+    CaptchaStage,
+    CaptchaStageRequest,
+    PatchedCaptchaStageRequest,
+    StagesApi,
+} from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { html, PropertyValues, TemplateResult } from "lit";
+import { html, PropertyValues } from "lit";
 import { customElement, state } from "lit/decorators.js";
+import { guard } from "lit/directives/guard.js";
 import { ifDefined } from "lit/directives/if-defined.js";
-
-interface CaptchaProviderPreset {
-    label: string;
-    jsUrl: string;
-    apiUrl: string;
-    interactive: boolean;
-    supportsScore: boolean;
-    score?: { min: number; max: number };
-    help: {
-        keyLinkText: string;
-        keyLinkUrl: string;
-    };
-}
-
-/**
- * Provider presets for common CAPTCHA services.
- * Each preset contains default URLs, settings, and help text with links to provider dashboards.
- * When a provider is selected, these values auto-fill the form but remain editable.
- */
-const CAPTCHA_PROVIDERS: Record<string, CaptchaProviderPreset> = {
-    recaptcha_v2: {
-        label: "Google reCAPTCHA v2",
-        jsUrl: "https://www.recaptcha.net/recaptcha/api.js",
-        apiUrl: "https://www.recaptcha.net/recaptcha/api/siteverify",
-        interactive: true,
-        supportsScore: false,
-        help: {
-            keyLinkText: msg("the reCAPTCHA admin console"),
-            keyLinkUrl: "https://www.google.com/recaptcha/admin",
-        },
-    },
-    recaptcha_v3: {
-        label: "Google reCAPTCHA v3",
-        jsUrl: "https://www.recaptcha.net/recaptcha/api.js",
-        apiUrl: "https://www.recaptcha.net/recaptcha/api/siteverify",
-        interactive: false,
-        supportsScore: true,
-        score: { min: 0.5, max: 1.0 },
-        help: {
-            keyLinkText: msg("the reCAPTCHA admin console"),
-            keyLinkUrl: "https://www.google.com/recaptcha/admin",
-        },
-    },
-    recaptcha_enterprise: {
-        label: "Google reCAPTCHA Enterprise",
-        jsUrl: "https://www.recaptcha.net/recaptcha/enterprise.js",
-        apiUrl: "https://www.recaptcha.net/recaptcha/api/siteverify",
-        interactive: false,
-        supportsScore: true,
-        score: { min: 0.5, max: 1.0 },
-        help: {
-            keyLinkText: msg("Google Cloud reCAPTCHA Enterprise"),
-            keyLinkUrl: "https://cloud.google.com/recaptcha-enterprise",
-        },
-    },
-    hcaptcha: {
-        label: "hCaptcha",
-        jsUrl: "https://js.hcaptcha.com/1/api.js",
-        apiUrl: "https://api.hcaptcha.com/siteverify",
-        interactive: true,
-        supportsScore: true,
-        score: { min: 0.0, max: 0.5 },
-        help: {
-            keyLinkText: msg("the hCaptcha dashboard"),
-            keyLinkUrl: "https://dashboard.hcaptcha.com",
-        },
-    },
-    turnstile: {
-        label: "Cloudflare Turnstile",
-        jsUrl: "https://challenges.cloudflare.com/turnstile/v0/api.js",
-        apiUrl: "https://challenges.cloudflare.com/turnstile/v0/siteverify",
-        interactive: true,
-        supportsScore: false,
-        help: {
-            keyLinkText: msg("the Cloudflare dashboard"),
-            keyLinkUrl: "https://dash.cloudflare.com",
-        },
-    },
-    custom: {
-        label: "Custom",
-        jsUrl: "https://www.recaptcha.net/recaptcha/api.js",
-        apiUrl: "https://www.recaptcha.net/recaptcha/api/siteverify",
-        interactive: false,
-        supportsScore: true,
-        score: { min: 0.5, max: 1.0 },
-        help: {
-            keyLinkText: "",
-            keyLinkUrl: "",
-        },
-    },
-};
 
 @customElement("ak-stage-captcha-form")
 export class CaptchaStageForm extends BaseStageForm<CaptchaStage> {
-    @state()
-    protected selectedProvider = "recaptcha_v2";
+    public static override readonly styles = [...super.styles, Styles];
 
-    currentPreset: CaptchaProviderPreset = CAPTCHA_PROVIDERS.recaptcha_v2;
+    #api = new StagesApi(DEFAULT_CONFIG);
+
+    //#region Lifecycle
+
+    @state()
+    protected selectedProvider: CaptchaProviderKey = "recaptcha_v2";
+
+    #currentPreset: CaptchaProviderPreset = CAPTCHA_PROVIDERS.recaptcha_v2;
 
     public override reset(): void {
         super.reset();
 
         this.selectedProvider = "custom";
-        this.currentPreset = CAPTCHA_PROVIDERS.custom;
+        this.#currentPreset = CAPTCHA_PROVIDERS.custom;
     }
 
-    loadInstance(pk: string): Promise<CaptchaStage> {
-        return new StagesApi(DEFAULT_CONFIG).stagesCaptchaRetrieve({
+    protected loadInstance(pk: string): Promise<CaptchaStage> {
+        return this.#api.stagesCaptchaRetrieve({
             stageUuid: pk,
         });
     }
 
-    /**
-     * Detect which provider preset matches the current instance by comparing URLs.
-     * This allows the form to show the correct provider in the dropdown when editing
-     * an existing CAPTCHA stage. Falls back to "custom" if no match is found.
-     */
-    detectProviderFromInstance(): string {
-        if (!this.instance) return "custom";
-
-        for (const [key, preset] of Object.entries(CAPTCHA_PROVIDERS)) {
-            if (this.instance.jsUrl === preset.jsUrl && this.instance.apiUrl === preset.apiUrl) {
-                return key;
-            }
-        }
-        return "custom";
-    }
-
-    willUpdate(changed: PropertyValues<this>): void {
+    protected override willUpdate(changed: PropertyValues<this>): void {
         super.willUpdate(changed);
+
         if (changed.has("instance")) {
-            this.selectedProvider = this.detectProviderFromInstance();
-            this.currentPreset = CAPTCHA_PROVIDERS[this.selectedProvider];
+            this.selectedProvider = detectProviderFromInstance(this.instance);
+            this.#currentPreset = CAPTCHA_PROVIDERS[this.selectedProvider];
         }
-    }
-
-    /**
-     * Get localized help text for public/private key fields.
-     * These methods return msg() calls with string literals instead of
-     * storing translatable strings in the preset objects, which would break i18n.
-     * The Lit localize library requires msg() to be called with string literals at
-     * compile time so it can extract them for translation.
-     */
-    getPublicKeyHelpText(anchor?: TemplateResult): string | TemplateResult {
-        return anchor
-            ? msg(html`Site key from your CAPTCHA provider. Get keys from ${anchor}`)
-            : msg("Site key from your CAPTCHA provider.");
-    }
-
-    getPrivateKeyHelpText(anchor?: TemplateResult): string | TemplateResult {
-        return anchor
-            ? msg(html`Secret key from your CAPTCHA provider. Get keys from ${anchor}`)
-            : msg("Secret key from your CAPTCHA provider.");
-    }
-
-    /**
-     * Renders help text wrapped in the PF helper text element.
-     * Used for form fields that need to display help text with optional anchor links.
-     */
-    renderHelpText(content: string | TemplateResult): TemplateResult {
-        return html`<p class="pf-c-form__helper-text">${content}</p>`;
-    }
-
-    /**
-     * Get the form values to display, with clear precedence:
-     * 1. If editing an existing instance, use instance values
-     * 2. Otherwise, use the current preset defaults
-     */
-    getFormValues() {
-        if (this.instance) {
-            return {
-                jsUrl: this.instance.jsUrl,
-                apiUrl: this.instance.apiUrl,
-                interactive: this.instance.interactive,
-                scoreMinThreshold: this.instance.scoreMinThreshold,
-                scoreMaxThreshold: this.instance.scoreMaxThreshold,
-                errorOnInvalidScore: this.instance.errorOnInvalidScore ?? true,
-            };
-        }
-        return {
-            jsUrl: this.currentPreset.jsUrl,
-            apiUrl: this.currentPreset.apiUrl,
-            interactive: this.currentPreset.interactive,
-            scoreMinThreshold: this.currentPreset.score?.min ?? 0.5,
-            scoreMaxThreshold: this.currentPreset.score?.max ?? 1.0,
-            errorOnInvalidScore: true,
-        };
     }
 
     /**
      * Handle provider dropdown selection change.
      * Updates the preset, which triggers a re-render with new default values.
      */
-    handleProviderChange(e: Event): void {
+    #providerChangeListener(e: Event): void {
         const select = e.target as HTMLSelectElement;
-        this.selectedProvider = select.value;
-        this.currentPreset = CAPTCHA_PROVIDERS[this.selectedProvider];
+        this.selectedProvider = select.value as CaptchaProviderKey;
+        this.#currentPreset = CAPTCHA_PROVIDERS[this.selectedProvider];
     }
 
-    async send(data: CaptchaStage): Promise<CaptchaStage> {
+    public async send(
+        data: CaptchaStageRequest | PatchedCaptchaStageRequest,
+    ): Promise<CaptchaStage> {
         if (this.instance) {
-            return new StagesApi(DEFAULT_CONFIG).stagesCaptchaPartialUpdate({
+            return this.#api.stagesCaptchaPartialUpdate({
                 stageUuid: this.instance.pk || "",
                 patchedCaptchaStageRequest: data,
             });
         }
-        return new StagesApi(DEFAULT_CONFIG).stagesCaptchaCreate({
-            captchaStageRequest: data as unknown as CaptchaStageRequest,
+
+        return this.#api.stagesCaptchaCreate({
+            captchaStageRequest: data as CaptchaStageRequest,
         });
     }
 
-    renderProviderSelector(): TemplateResult {
+    //#endregion
+
+    //#region Rendering
+
+    protected renderProviderSelector(): SlottedTemplateResult {
         return html`<ak-form-element-horizontal label=${msg("Provider Type")} name="providerType">
-            <select class="pf-c-form-control" @change=${this.handleProviderChange}>
-                ${Object.entries(CAPTCHA_PROVIDERS).map(
-                    ([key, preset]) =>
-                        html`<option value=${key} ?selected=${key === this.selectedProvider}>
-                            ${preset.label}
-                        </option>`,
-                )}
+            <select class="pf-c-form-control" @change=${this.#providerChangeListener}>
+                ${Array.from(CaptchaProviderKeys, (key) => {
+                    const preset = CAPTCHA_PROVIDERS[key];
+
+                    return html`<option value=${key} ?selected=${key === this.selectedProvider}>
+                        ${preset.formatDisplayName()}
+                    </option>`;
+                })}
             </select>
             <p class="pf-c-form__helper-text">
                 ${msg(
-                    "Select a CAPTCHA provider. URLs and settings will be automatically configured, but can be customized below.",
+                    "You can select from popular providers with preset configurations or choose a custom setup to specify your own endpoints and keys.",
                 )}
             </p>
+
+            ${guard([this.#currentPreset], () => {
+                const { formatAPISource, keyURL } = this.#currentPreset;
+
+                if (!formatAPISource || !keyURL) {
+                    return null;
+                }
+
+                return html`<ak-alert level=${Level.Info} icon="fa-key">
+                    ${msg(
+                        html`API keys can be obtained from the
+                        ${html`<a target="_blank" rel="noopener noreferrer" href=${keyURL}
+                                >${formatAPISource()}</a
+                            >.`}`,
+                        {
+                            id: "captcha.provider-link",
+                            desc: "Supplementary help text with link to provider dashboard.",
+                        },
+                    )}
+                </ak-alert>`;
+            })}
         </ak-form-element-horizontal>`;
     }
 
-    renderKeyFields(): TemplateResult {
-        const keyLink =
-            this.currentPreset.help.keyLinkUrl && this.currentPreset.help.keyLinkText
-                ? html`<a
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          href=${this.currentPreset.help.keyLinkUrl}
-                      >
-                          ${this.currentPreset.help.keyLinkText} </a
-                      >.`
-                : undefined;
-
+    protected renderKeyFields(): SlottedTemplateResult {
         return html`
-            <ak-form-element-horizontal label=${msg("Public Key")} required name="publicKey">
-                <input
-                    type="text"
-                    value="${ifDefined(this.instance?.publicKey || "")}"
-                    class="pf-c-form-control pf-m-monospace"
-                    autocomplete="off"
-                    spellcheck="false"
-                    required
-                />
-                ${this.renderHelpText(this.getPublicKeyHelpText(keyLink))}
-            </ak-form-element-horizontal>
+            <ak-text-input
+                label=${msg("Public Key")}
+                required
+                name="publicKey"
+                type="text"
+                value="${ifDefined(this.instance?.publicKey || "")}"
+                autocomplete="off"
+                input-hint="code"
+                placeholder=${msg("Paste your CAPTCHA public key...")}
+                help=${msg("The public key is used by authentik to render the CAPTCHA widget.", {
+                    id: "captcha.public-key.description",
+                    desc: "Description for CAPTCHA public key field.",
+                })}
+            >
+            </ak-text-input>
 
             <ak-secret-text-input
                 name="privateKey"
-                label=${msg("Private Key")}
+                label=${msg("Secret Key")}
                 input-hint="code"
                 ?required=${!this.instance}
                 ?revealed=${!this.instance}
-                .bighelp=${this.renderHelpText(this.getPrivateKeyHelpText(keyLink))}
+                placeholder=${msg("Paste your CAPTCHA secret key...")}
+                help=${msg(
+                    "The secret key allows communication between authentik and the CAPTCHA provider to validate user responses.",
+                    {
+                        id: "captcha.secret-key.description",
+                        desc: "Description for CAPTCHA secret key field.",
+                    },
+                )}
             ></ak-secret-text-input>
         `;
     }
 
-    renderScoreConfiguration(): TemplateResult {
-        if (!this.currentPreset.supportsScore) {
+    protected renderScoreConfiguration(): SlottedTemplateResult {
+        if (!this.#currentPreset.supportsScore) {
             return html`<ak-form-group open label="${msg("Score Configuration")}">
                 <div class="pf-c-form">
                     <p class="pf-c-form__helper-text">
@@ -295,7 +191,8 @@ export class CaptchaStageForm extends BaseStageForm<CaptchaStage> {
             </ak-form-group>`;
         }
 
-        const formValues = this.getFormValues();
+        const formValues = pluckFormValues(this.instance, this.#currentPreset);
+
         return html`<ak-form-group open label="${msg("Score Configuration")}">
             <div class="pf-c-form">
                 <ak-number-input
@@ -328,64 +225,53 @@ export class CaptchaStageForm extends BaseStageForm<CaptchaStage> {
         </ak-form-group>`;
     }
 
-    renderAdvancedSettings(): TemplateResult {
-        const formValues = this.getFormValues();
+    protected renderAdvancedSettings(): SlottedTemplateResult {
+        const formValues = pluckFormValues(this.instance, this.#currentPreset);
+
         return html`<ak-form-group label="${msg("Advanced Settings")}">
             <div class="pf-c-form">
-                <ak-form-element-horizontal label=${msg("JavaScript URL")} required name="jsUrl">
-                    <input
-                        type="url"
-                        value="${ifDefined(formValues.jsUrl)}"
-                        class="pf-c-form-control pf-m-monospace"
-                        autocomplete="off"
-                        spellcheck="false"
-                        required
-                    />
-                    <p class="pf-c-form__helper-text">
-                        ${msg(
-                            "URL to fetch the CAPTCHA JavaScript library from. Automatically set based on provider selection but can be customized.",
-                        )}
-                    </p>
-                </ak-form-element-horizontal>
-                <ak-form-element-horizontal
-                    label=${msg("API Verification URL")}
+                <ak-text-input
+                    label=${msg("JavaScript URL")}
+                    name="jsUrl"
+                    type="url"
+                    value="${ifDefined(formValues.jsUrl)}"
                     required
+                    help=${msg(
+                        "URL to fetch the CAPTCHA JavaScript library from. Automatically set based on provider selection but can be customized.",
+                    )}
+                ></ak-text-input>
+                <ak-text-input
+                    label=${msg("API Verification URL")}
                     name="apiUrl"
-                >
-                    <input
-                        type="url"
-                        value="${ifDefined(formValues.apiUrl)}"
-                        class="pf-c-form-control pf-m-monospace"
-                        autocomplete="off"
-                        spellcheck="false"
-                        required
-                    />
-                    <p class="pf-c-form__helper-text">
-                        ${msg(
-                            "URL used to validate CAPTCHA response on the backend. Automatically set based on provider selection but can be customized.",
-                        )}
-                    </p>
-                </ak-form-element-horizontal>
+                    type="url"
+                    value="${ifDefined(formValues.apiUrl)}"
+                    required
+                    help=${msg(
+                        "URL used to validate CAPTCHA response on the backend. Automatically set based on provider selection but can be customized.",
+                    )}
+                ></ak-text-input>
             </div>
         </ak-form-group>`;
     }
 
-    protected override renderForm(): TemplateResult {
-        const formValues = this.getFormValues();
+    protected override renderForm(): SlottedTemplateResult {
+        const formValues = pluckFormValues(this.instance, this.#currentPreset);
+
         return html`
-            <span>
+            <header>
                 ${msg(
                     "This stage checks the user's current session against a CAPTCHA service to prevent automated abuse.",
                 )}
-            </span>
-            <ak-form-element-horizontal label=${msg("Name")} required name="name">
-                <input
-                    type="text"
-                    value="${ifDefined(this.instance?.name || "")}"
-                    class="pf-c-form-control"
-                    required
-                />
-            </ak-form-element-horizontal>
+            </header>
+            <ak-text-input
+                label=${msg("Stage Name")}
+                required
+                name="name"
+                value="${this.instance?.name || "my-captcha-stage"}"
+                placeholder=${msg("Type a stage name...")}
+                autocomplete="off"
+                help=${msg("The unique name used internally to identify the stage.")}
+            ></ak-text-input>
 
             <ak-form-group open label="${msg("CAPTCHA Provider")}">
                 <div class="pf-c-form">
@@ -393,7 +279,7 @@ export class CaptchaStageForm extends BaseStageForm<CaptchaStage> {
                     <ak-switch-input
                         name="interactive"
                         label=${msg("Interactive")}
-                        ?checked="${formValues.interactive}"
+                        ?checked=${formValues.interactive}
                         help=${msg(
                             "Enable this if the CAPTCHA requires user interaction (clicking checkbox, solving puzzles, etc.). Required for reCAPTCHA v2, hCaptcha interactive mode, and Cloudflare Turnstile.",
                         )}
@@ -404,6 +290,8 @@ export class CaptchaStageForm extends BaseStageForm<CaptchaStage> {
             ${this.renderScoreConfiguration()} ${this.renderAdvancedSettings()}
         `;
     }
+
+    //#endregion
 }
 
 declare global {

--- a/web/src/admin/stages/captcha/shared.ts
+++ b/web/src/admin/stages/captcha/shared.ts
@@ -1,0 +1,171 @@
+import { CaptchaStage, CaptchaStageRequest } from "@goauthentik/api";
+
+import { msg } from "@lit/localize";
+
+export const CaptchaProviderKeys = [
+    "recaptcha_v2",
+    "recaptcha_v3",
+    "recaptcha_enterprise",
+    "hcaptcha",
+    "turnstile",
+    "custom",
+] as const satisfies string[];
+
+export type CaptchaProviderKey = (typeof CaptchaProviderKeys)[number];
+
+export interface CaptchaProviderPreset {
+    formatDisplayName: () => string;
+    jsUrl: string;
+    apiUrl: string;
+    interactive: boolean;
+    supportsScore: boolean;
+    score?: { min: number; max: number };
+    formatAPISource?: () => string;
+    keyURL?: string;
+}
+
+/**
+ * Provider presets for common CAPTCHA services.
+ * Each preset contains default URLs, settings, and help text with links to provider dashboards.
+ * When a provider is selected, these values auto-fill the form but remain editable.
+ */
+export const CAPTCHA_PROVIDERS = {
+    recaptcha_v2: {
+        formatDisplayName: () =>
+            msg("Google reCAPTCHA v2", {
+                id: "captcha.providers.recaptcha-v2",
+            }),
+        jsUrl: "https://www.recaptcha.net/recaptcha/api.js",
+        apiUrl: "https://www.recaptcha.net/recaptcha/api/siteverify",
+        interactive: true,
+        supportsScore: false,
+        formatAPISource: () =>
+            msg("reCAPTCHA admin console", {
+                id: "captcha.providers.recaptcha.admin-console",
+            }),
+        keyURL: "https://www.google.com/recaptcha/admin",
+    },
+    recaptcha_v3: {
+        formatDisplayName: () =>
+            msg("Google reCAPTCHA v3", {
+                id: "captcha.providers.recaptcha-v3",
+            }),
+        jsUrl: "https://www.recaptcha.net/recaptcha/api.js",
+        apiUrl: "https://www.recaptcha.net/recaptcha/api/siteverify",
+        interactive: false,
+        supportsScore: true,
+        score: { min: 0.5, max: 1.0 },
+        formatAPISource: () =>
+            msg("reCAPTCHA admin console", {
+                id: "captcha.providers.recaptcha.api-key-source",
+            }),
+        keyURL: "https://www.google.com/recaptcha/admin",
+    },
+    recaptcha_enterprise: {
+        formatDisplayName: () =>
+            msg("Google reCAPTCHA Enterprise", {
+                id: "captcha.providers.recaptcha-enterprise",
+            }),
+        jsUrl: "https://www.recaptcha.net/recaptcha/enterprise.js",
+        apiUrl: "https://www.recaptcha.net/recaptcha/api/siteverify",
+        interactive: false,
+        supportsScore: true,
+        score: { min: 0.5, max: 1.0 },
+        formatAPISource: () =>
+            msg("Google Cloud Console", {
+                id: "captcha.providers.recaptcha-enterprise.api-key-source",
+            }),
+        keyURL: "https://cloud.google.com/recaptcha-enterprise",
+    },
+    hcaptcha: {
+        formatDisplayName: () =>
+            msg("hCaptcha", {
+                id: "captcha.providers.hcaptcha",
+            }),
+        jsUrl: "https://js.hcaptcha.com/1/api.js",
+        apiUrl: "https://api.hcaptcha.com/siteverify",
+        interactive: true,
+        supportsScore: true,
+        score: { min: 0.0, max: 0.5 },
+        formatAPISource: () =>
+            msg("hCaptcha dashboard", {
+                id: "captcha.providers.hcaptcha.api-key-source",
+            }),
+        keyURL: "https://dashboard.hcaptcha.com",
+    },
+    turnstile: {
+        formatDisplayName: () =>
+            msg("Cloudflare Turnstile", {
+                id: "captcha.providers.turnstile",
+            }),
+        jsUrl: "https://challenges.cloudflare.com/turnstile/v0/api.js",
+        apiUrl: "https://challenges.cloudflare.com/turnstile/v0/siteverify",
+        interactive: true,
+        supportsScore: false,
+        formatAPISource: () =>
+            msg("Cloudflare dashboard", {
+                id: "captcha.providers.turnstile.api-key-source",
+            }),
+        keyURL: "https://dash.cloudflare.com",
+    },
+    custom: {
+        formatDisplayName: () =>
+            msg("Custom", {
+                id: "captcha.providers.custom",
+            }),
+        jsUrl: "https://www.recaptcha.net/recaptcha/api.js",
+        apiUrl: "https://www.recaptcha.net/recaptcha/api/siteverify",
+        interactive: false,
+        supportsScore: true,
+        score: { min: 0.5, max: 1.0 },
+    },
+} as const satisfies Record<CaptchaProviderKey, CaptchaProviderPreset>;
+
+/**
+ * Detect which provider preset matches the given {@linkcode CaptchaStage} instance.
+ * This allows the form to show the correct provider in the dropdown when editing
+ * an existing CAPTCHA stage. Falls back to "custom" if no match is found.
+ */
+export function detectProviderFromInstance(stage?: CaptchaStage | null): CaptchaProviderKey {
+    if (!stage) return "custom";
+
+    for (const key of CaptchaProviderKeys) {
+        const preset = CAPTCHA_PROVIDERS[key];
+
+        if (stage.jsUrl === preset.jsUrl && stage.apiUrl === preset.apiUrl) {
+            return key;
+        }
+    }
+
+    return "custom";
+}
+
+/**
+ * Get the form values to display, with clear precedence:
+ * 1. If editing an existing instance, use instance values
+ * 2. Otherwise, use the current preset defaults
+ */
+export function pluckFormValues(
+    instance?: CaptchaStage | null,
+    preset: CaptchaProviderPreset = CAPTCHA_PROVIDERS.custom,
+): Omit<CaptchaStageRequest, "name" | "publicKey" | "privateKey"> {
+    if (instance) {
+        return {
+            jsUrl: instance.jsUrl,
+            apiUrl: instance.apiUrl,
+            interactive: instance.interactive,
+            scoreMinThreshold: instance.scoreMinThreshold,
+            scoreMaxThreshold: instance.scoreMaxThreshold,
+            errorOnInvalidScore: instance.errorOnInvalidScore ?? true,
+        };
+    }
+
+    return {
+        jsUrl: preset.jsUrl,
+        apiUrl: preset.apiUrl,
+        interactive: preset.interactive,
+        scoreMinThreshold: preset.score?.min ?? 0.5,
+        scoreMaxThreshold: preset.score?.max ?? 1.0,
+        errorOnInvalidScore: true,
+    };
+}

--- a/web/src/admin/stages/captcha/styles.css
+++ b/web/src/admin/stages/captcha/styles.css
@@ -1,0 +1,8 @@
+ak-alert {
+    display: block;
+    margin-block-start: var(--pf-global--spacer--md);
+
+    &::part(container) {
+        --pf-c-alert--BoxShadow: var(--pf-global--BoxShadow--sm-bottom);
+    }
+}

--- a/web/src/components/ak-number-input.ts
+++ b/web/src/components/ak-number-input.ts
@@ -21,6 +21,8 @@ export class AkNumberInput extends HorizontalLightComponent<number> {
         };
 
         return html`<input
+            id=${this.fieldID}
+            aria-describedby=${this.helpID}
             type="number"
             @input=${setValue}
             aria-label=${ifPresent(this.label)}

--- a/web/src/components/ak-text-input.ts
+++ b/web/src/components/ak-text-input.ts
@@ -2,6 +2,7 @@ import { HorizontalLightComponent } from "./HorizontalLightComponent.js";
 
 import { ifPresent } from "#elements/utils/attributes";
 
+import { msg } from "@lit/localize";
 import { html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
@@ -31,14 +32,30 @@ export class AkTextInput extends HorizontalLightComponent<string> {
     inputMode: string = "text";
 
     @property({ type: String })
-    public type: "text" | "email" = "text";
+    public type: "text" | "email" | "url" = "text";
 
     #inputListener(ev: InputEvent) {
         this.value = (ev.target as HTMLInputElement).value;
     }
 
+    #formatPlaceholder(): string | null {
+        if (this.placeholder) {
+            return this.placeholder;
+        }
+
+        if (this.inputMode === "url" || this.type === "url") {
+            return "https://...";
+        }
+
+        if (this.inputMode === "email" || this.type === "email") {
+            return msg("Type an email address...");
+        }
+
+        return null;
+    }
+
     public override renderControl() {
-        const code = this.inputHint === "code";
+        const code = this.inputHint === "code" || this.type === "url";
 
         return html`<input
             type=${this.type}
@@ -54,7 +71,7 @@ export class AkTextInput extends HorizontalLightComponent<string> {
             autocomplete=${ifPresent(code ? "off" : this.autocomplete)}
             spellcheck=${ifPresent(code ? "false" : this.spellcheck)}
             aria-describedby=${this.helpID}
-            placeholder=${ifPresent(this.placeholder)}
+            placeholder=${ifPresent(this.#formatPlaceholder())}
             inputmode=${this.inputMode}
             ?required=${this.required}
             ?autofocus=${this.autofocus}

--- a/web/src/elements/Alert.ts
+++ b/web/src/elements/Alert.ts
@@ -86,11 +86,11 @@ export class AKAlert extends AKElement implements IAlert {
     }
 
     render() {
-        return html`<div class="${classMap(this.classmap)}">
+        return html`<div class="${classMap(this.classmap)}" part="container">
             <div class="pf-c-alert__icon">
                 <i aria-hidden="true" class="fas ${this.icon}"></i>
             </div>
-            <h4 role="presentation" class="pf-c-alert__title"><slot></slot></h4>
+            <div class="pf-c-alert__title"><slot></slot></div>
         </div>`;
     }
 }


### PR DESCRIPTION
## Details

This PR is a follow up on #19555:

- Added ARIA labels and placeholders to form inputs
- Fixed missing ARIA attributes in numeric and secret input components
- Rephrased order of field instructions for a more screen-reader friendly flow.