### PR TITLE
web/common: add dev middleware to show warnings for consecutive identical requests

### DIFF
--- a/web/src/common/api/config.ts
+++ b/web/src/common/api/config.ts
@@ -1,5 +1,6 @@
 import {
     CSRFMiddleware,
+    DevMiddleware,
     EventMiddleware,
     LocaleMiddleware,
     LoggingMiddleware,
@@ -19,6 +20,7 @@ export const DEFAULT_CONFIG = new Configuration({
         new LoggingMiddleware(brand),
         new SentryMiddleware(),
         new LocaleMiddleware(locale),
+        new DevMiddleware(),
     ],
 });
 

--- a/web/src/common/api/config.ts
+++ b/web/src/common/api/config.ts
@@ -1,6 +1,6 @@
 import {
     CSRFMiddleware,
-    DevMiddleware,
+    DevRepeatedRequestsMiddleware,
     EventMiddleware,
     LocaleMiddleware,
     LoggingMiddleware,
@@ -20,7 +20,7 @@ export const DEFAULT_CONFIG = new Configuration({
         new LoggingMiddleware(brand),
         new SentryMiddleware(),
         new LocaleMiddleware(locale),
-        new DevMiddleware(),
+        new DevRepeatedRequestsMiddleware(),
     ],
 });
 

--- a/web/src/common/api/config.ts
+++ b/web/src/common/api/config.ts
@@ -8,9 +8,9 @@ import {
 import { globalAK } from "#common/global";
 import { SentryMiddleware } from "#common/sentry/middleware";
 
-import { Configuration, CurrentBrand } from "@goauthentik/api";
+import { CapabilitiesEnum, Configuration, CurrentBrand } from "@goauthentik/api";
 
-const { locale, api, brand } = globalAK();
+const { locale, api, brand, config } = globalAK();
 
 export const DEFAULT_CONFIG = new Configuration({
     basePath: `${api.base}api/v3`,
@@ -20,7 +20,9 @@ export const DEFAULT_CONFIG = new Configuration({
         new LoggingMiddleware(brand),
         new SentryMiddleware(),
         new LocaleMiddleware(locale),
-        new DevRepeatedRequestsMiddleware(),
+        ...(config.capabilities.includes(CapabilitiesEnum.CanDebug)
+            ? [new DevRepeatedRequestsMiddleware()]
+            : []),
     ],
 });
 

--- a/web/src/common/api/middleware.ts
+++ b/web/src/common/api/middleware.ts
@@ -103,10 +103,23 @@ export class LocaleMiddleware implements Middleware, Disposable {
     }
 }
 
-export class DevMiddleware implements Middleware {
+export class DevRepeatedRequestsMiddleware implements Middleware, Disposable {
     MAX_REQUESTS = 10;
 
     requests: string[] = [];
+
+    #navigationHandler = () => {
+        this.requests = [];
+    };
+
+    constructor() {
+        this.#navigationHandler = this.#navigationHandler.bind(this);
+        window.addEventListener("hashchange", this.#navigationHandler);
+    }
+
+    [Symbol.dispose]() {
+        window.removeEventListener("hashchange", this.#navigationHandler);
+    }
 
     requestToSignature(req: RequestContext): string | undefined {
         const sigParts: string[] = [];


### PR DESCRIPTION
Its fairly easy to add code in the frontend that will call the same endpoint many times. This middleware is only enabled in dev mode and will show a warning when this happens.

For example 
<img width="648" height="174" alt="image" src="https://github.com/user-attachments/assets/7237e798-7fb0-43e9-ae4e-8f0595bc0150" />

indirect ref https://github.com/goauthentik/internal-customer-ref/issues/2
