### PR TITLE
web/admin: fix impersonation form requesting data without being opened

### DIFF
--- a/web/src/admin/users/UserImpersonateForm.ts
+++ b/web/src/admin/users/UserImpersonateForm.ts
@@ -19,7 +19,7 @@ export class UserImpersonateForm extends Form<ImpersonationRequest> {
     @state()
     private requireReason = false;
 
-    async firstUpdated(): Promise<void> {
+    #onOpen = async () => {
         try {
             const settings = await new AdminApi(DEFAULT_CONFIG).adminSettingsRetrieve();
             this.requireReason = settings.impersonationRequireReason ?? false;
@@ -28,6 +28,21 @@ export class UserImpersonateForm extends Form<ImpersonationRequest> {
             // fallback to reason not required as the backend will still validate it
             this.requireReason = false;
         }
+    };
+
+    constructor() {
+        super();
+        this.#onOpen = this.#onOpen.bind(this);
+    }
+
+    connectedCallback(): void {
+        super.connectedCallback();
+        this.addEventListener("ak-modal-show", this.#onOpen);
+    }
+
+    public disconnectedCallback(): void {
+        super.disconnectedCallback();
+        this.removeEventListener("ak-modal-show", this.#onOpen);
     }
 
     protected override formatAPISuccessMessage(): APIMessage | null {

--- a/web/src/admin/users/UserListPage.ts
+++ b/web/src/admin/users/UserListPage.ts
@@ -244,7 +244,7 @@ export class UserListPage extends WithBrandConfig(
     row(item: User): SlottedTemplateResult[] {
         const { currentUser } = this;
 
-        const impersionationVisible =
+        const impersonationVisible =
             this.can(CapabilitiesEnum.CanImpersonate) && currentUser && item.pk !== currentUser.pk;
 
         return [
@@ -266,7 +266,7 @@ export class UserListPage extends WithBrandConfig(
                         </pf-tooltip>
                     </button>
                 </ak-forms-modal>
-                ${impersionationVisible
+                ${impersonationVisible
                     ? html`
                           <ak-forms-modal size=${PFSize.Medium} id="impersonate-request">
                               <span slot="submit">${msg("Impersonate")}</span>

--- a/web/src/elements/buttons/ModalButton.ts
+++ b/web/src/elements/buttons/ModalButton.ts
@@ -93,15 +93,21 @@ export abstract class ModalButton extends AKElement {
         event?.preventDefault();
         this.open = true;
 
-        this.dispatchEvent(new ModalShowEvent(this));
+        const evt = new ModalShowEvent(this);
+        this.dispatchEvent(evt);
 
         this.querySelectorAll<AKElement>("*").forEach((child) => {
+            child.dispatchEvent(evt);
             child.requestUpdate?.();
         });
     };
 
     #closeListener = () => {
-        this.dispatchEvent(new ModalHideEvent(this));
+        const evt = new ModalHideEvent(this);
+        this.dispatchEvent(evt);
+        this.querySelectorAll<AKElement>("*").forEach((child) => {
+            child.dispatchEvent(evt);
+        });
     };
 
     #backdropListener = (event: PointerEvent) => {


### PR DESCRIPTION
inspired #19671

currently when opening a list of 20 users, the impersonation form will make 20 identical requests to the system settings endpoint to know if the reason is required.

this PR fixes the behaviour to only fetch that data when the modal is opened.

@goauthentik/frontend will probably hate me for the change of reverse-bubbling the events down to the modal children, but I can't think of a better way to handle this

ref https://github.com/goauthentik/internal-customer-ref/issues/2