### PR TITLE
core: return bad request when user is authenticated and not active

### DIFF
--- a/authentik/core/middleware.py
+++ b/authentik/core/middleware.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 from django.contrib.auth import logout
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ImproperlyConfigured
-from django.http import HttpRequest, HttpResponse
+from django.http import HttpRequest, HttpResponse, HttpResponseBadRequest
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.functional import SimpleLazyObject
 from django.utils.translation import override
@@ -47,7 +47,7 @@ async def aget_user(request):
 
 
 class AuthenticationMiddleware(MiddlewareMixin):
-    def process_request(self, request):
+    def process_request(self, request: HttpRequest) -> HttpResponseBadRequest | None:
         if not hasattr(request, "session"):
             raise ImproperlyConfigured(
                 "The Django authentication middleware requires session "
@@ -62,7 +62,8 @@ class AuthenticationMiddleware(MiddlewareMixin):
         user = request.user
         if user and user.is_authenticated and not user.is_active:
             logout(request)
-            raise AssertionError()
+            return HttpResponseBadRequest()
+        return None
 
 
 class ImpersonateMiddleware:


### PR DESCRIPTION
Added with https://github.com/goauthentik/authentik/pull/15719

We added an assertionerror because we assumed no one should be able to get into this state, however when a logged in user is deactivated while logged in this happens.