### PR TITLE
root: make logged HTTP headers configurable

### DIFF
--- a/authentik/lib/default.yml
+++ b/authentik/lib/default.yml
@@ -63,6 +63,9 @@ debug: false
 debugger: false
 
 log_level: info
+log:
+  http_headers:
+    - User-Agent
 
 sessions:
   unauthenticated_age: days=1

--- a/internal/config/struct.go
+++ b/internal/config/struct.go
@@ -15,6 +15,7 @@ type Config struct {
 	Debug  bool         `yaml:"debug" env:"AUTHENTIK_DEBUG, overwrite"`
 	Listen ListenConfig `yaml:"listen" env:", prefix=AUTHENTIK_LISTEN__"`
 	Web    WebConfig    `yaml:"web" env:", prefix=AUTHENTIK_WEB__"`
+	Log    LogConfig    `yaml:"log" env:", prefix=AUTHENTIK_LOG__"`
 
 	// Outpost specific config
 	// These are only relevant for proxy/ldap outposts, and cannot be set via YAML
@@ -104,4 +105,8 @@ type OutpostConfig struct {
 
 type WebConfig struct {
 	Path string `yaml:"path" env:"PATH, overwrite"`
+}
+
+type LogConfig struct {
+	HttpHeaders []string `yaml:"http_headers" env:"HTTP_HEADERS, overwrite"`
 }


### PR DESCRIPTION
currently we always log the user agent, this makes that configurable to allow any kind of loadbalancer/waf headers to be logged.

ref https://github.com/goauthentik/internal-customer-ref/issues/2