### PR TITLE
web: display custom attributes on admin view pages

### DIFF
--- a/schema.yml
+++ b/schema.yml
@@ -40110,6 +40110,9 @@ components:
           items:
             type: string
           nullable: true
+        pending_user_identifier:
+          type: string
+          nullable: true
         password_fields:
           type: boolean
         allow_show_password:
@@ -40143,9 +40146,6 @@ components:
         passkey_challenge:
           type: object
           additionalProperties: {}
-          nullable: true
-        pending_user_identifier:
-          type: string
           nullable: true
       required:
       - flow_designation
@@ -57057,18 +57057,22 @@ components:
           type: string
           description: Internal application name, used in URLs.
           readOnly: true
+          nullable: true
         assigned_application_name:
           type: string
           description: Application's display Name.
           readOnly: true
+          nullable: true
         assigned_backchannel_application_slug:
           type: string
           description: Internal application name, used in URLs.
           readOnly: true
+          nullable: true
         assigned_backchannel_application_name:
           type: string
           description: Application's display Name.
           readOnly: true
+          nullable: true
         verbose_name:
           type: string
           description: Return object's verbose_name

--- a/web/src/admin/endpoints/devices/DeviceViewPage.ts
+++ b/web/src/admin/endpoints/devices/DeviceViewPage.ts
@@ -1,3 +1,4 @@
+import "#components/ak-object-attributes-card";
 import "#components/ak-status-label";
 import "#admin/endpoints/devices/BoundDeviceUsersList";
 import "#admin/endpoints/devices/facts/DeviceProcessTable";
@@ -215,6 +216,12 @@ export class DeviceViewPage extends AKElement {
                         .target=${this.device.pbmUuid}
                     ></ak-bound-device-users-list>
                 </div>
+            </div>
+            <div class="pf-c-card pf-l-grid__item pf-m-12-col">
+                <ak-object-attributes-card
+                    .objectAttributes=${this.device.attributes}
+                    .excludeNotes=${false}
+                ></ak-object-attributes-card>
             </div>
         </div>`;
     }

--- a/web/src/admin/groups/GroupViewPage.ts
+++ b/web/src/admin/groups/GroupViewPage.ts
@@ -2,6 +2,7 @@ import "#admin/groups/GroupForm";
 import "#admin/groups/RelatedUserList";
 import "#admin/rbac/ObjectPermissionsPage";
 import "#admin/roles/RelatedRoleList";
+import "#components/ak-object-attributes-card";
 import "#components/ak-status-label";
 import "#components/events/ObjectChangelog";
 import "#elements/CodeMirror";
@@ -213,6 +214,11 @@ export class GroupViewPage extends AKElement {
                                 >
                                 </ak-object-changelog>
                             </div>
+                        </div>
+                        <div class="pf-c-card pf-l-grid__item pf-m-12-col">
+                            <ak-object-attributes-card
+                                .objectAttributes=${this.group.attributes}
+                            ></ak-object-attributes-card>
                         </div>
                     </div>
                 </section>

--- a/web/src/admin/users/UserViewPage.ts
+++ b/web/src/admin/users/UserViewPage.ts
@@ -9,6 +9,7 @@ import "#admin/users/UserForm";
 import "#admin/users/UserImpersonateForm";
 import "#admin/users/UserPasswordForm";
 import "#components/DescriptionList";
+import "#components/ak-object-attributes-card";
 import "#components/ak-status-label";
 import "#components/events/ObjectChangelog";
 import "#components/events/UserEvents";
@@ -462,6 +463,11 @@ export class UserViewPage extends WithCapabilitiesConfig(WithSession(AKElement))
                                 >
                                 </ak-object-changelog>
                             </div>
+                        </div>
+                        <div class="pf-c-card pf-l-grid__item pf-m-12-col">
+                            <ak-object-attributes-card
+                                .objectAttributes=${this.user.attributes}
+                            ></ak-object-attributes-card>
                         </div>
                     </div>
                 </div>

--- a/web/src/components/ak-object-attributes-card.ts
+++ b/web/src/components/ak-object-attributes-card.ts
@@ -1,0 +1,112 @@
+import "#components/ak-status-label";
+
+import { AKElement } from "#elements/Base";
+
+import { type DescriptionPair, renderDescriptionList } from "#components/DescriptionList";
+
+import { msg } from "@lit/localize";
+import { CSSResult, html, TemplateResult } from "lit";
+import { customElement, property } from "lit/decorators.js";
+
+import PFCard from "@patternfly/patternfly/components/Card/card.css";
+import PFDescriptionList from "@patternfly/patternfly/components/DescriptionList/description-list.css";
+
+/**
+ * A reusable card component to display custom attributes for objects like User, Group, or Device.
+ *
+ * This component filters out system attributes (keys starting with `goauthentik.io/`)
+ * and optionally excludes the `notes` attribute (since it's typically displayed separately).
+ *
+ * Value types are rendered appropriately:
+ * - string/number: Plain text
+ * - boolean: ak-status-label component
+ * - simple arrays: Comma-separated list
+ * - objects/complex arrays: Formatted JSON in code block
+ */
+@customElement("ak-object-attributes-card")
+export class ObjectAttributesCard extends AKElement {
+    static styles: CSSResult[] = [PFCard, PFDescriptionList];
+
+    @property({ attribute: false })
+    objectAttributes: Record<string, unknown> = {};
+
+    @property({ type: Boolean, attribute: "exclude-notes" })
+    excludeNotes = true;
+
+    /**
+     * Filters the attributes to only include custom (non-system) attributes.
+     * Excludes keys starting with "goauthentik.io/" and optionally the "notes" key.
+     */
+    private get customAttributes(): Array<[string, unknown]> {
+        return Object.entries(this.objectAttributes || {}).filter(([key]) => {
+            if (key.startsWith("goauthentik.io/")) return false;
+            if (this.excludeNotes && key === "notes") return false;
+            return true;
+        });
+    }
+
+    /**
+     * Formats a value for display based on its type.
+     */
+    private formatValue(value: unknown): TemplateResult | string {
+        if (value === null || value === undefined) {
+            return "-";
+        }
+
+        if (typeof value === "boolean") {
+            return html`<ak-status-label ?good=${value}></ak-status-label>`;
+        }
+
+        if (typeof value === "string" || typeof value === "number") {
+            return String(value);
+        }
+
+        if (Array.isArray(value)) {
+            // Simple arrays of primitives: render as comma-separated list
+            if (value.every((item) => typeof item === "string" || typeof item === "number")) {
+                return value.join(", ");
+            }
+            // Complex arrays: render as JSON
+            return html`<code>
+                <pre style="margin: 0; white-space: pre-wrap;">
+${JSON.stringify(value, null, 2)}</pre
+                >
+            </code>`;
+        }
+
+        if (typeof value === "object") {
+            return html`<code>
+                <pre style="margin: 0; white-space: pre-wrap;">
+${JSON.stringify(value, null, 2)}</pre
+                >
+            </code>`;
+        }
+
+        return String(value);
+    }
+
+    render() {
+        const attrs = this.customAttributes;
+
+        return html`
+            <div class="pf-c-card__title">${msg("Custom Attributes")}</div>
+            <div class="pf-c-card__body">
+                ${attrs.length > 0
+                    ? renderDescriptionList(
+                          attrs.map(([key, value]) => [
+                              key,
+                              this.formatValue(value),
+                          ]) as DescriptionPair[],
+                          { horizontal: true },
+                      )
+                    : html`<p>${msg("No custom attributes defined.")}</p>`}
+            </div>
+        `;
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "ak-object-attributes-card": ObjectAttributesCard;
+    }
+}


### PR DESCRIPTION
Overview:

Add a reusable ak-object-attributes-card component that displays custom attributes on User, Group, and Device admin view pages.

This allows admins to see custom attributes directly on the overview tab without needing to open the edit form.

The component:
- Filters out system attributes (goauthentik.io/* prefixed keys)
- Optionally excludes the notes attribute
- Renders values based on type: booleans as status labels, arrays as comma-separated lists, objects as formatted JSON

Testing:

1. Navigate to Admin > Identity > Users > [any user]
2. Verify "Custom Attributes" card appears below Changelog
3. Add custom attributes via Edit form:
```
{
  "department": "Engineering",
  "employee_id": 12345,
  "is_contractor": false,
  "is_manager": true,
  "skills": ["Python", "TypeScript", "Go"],
  "office_location": {
    "building": "HQ",
    "floor": 3,
    "desk": "A-42"
  },
  "notes": "This should NOT appear in Custom Attributes card",
  "goauthentik.io/user/sources": ["should-be-filtered"]
}
```
4. Confirm they appear in the card, system attributes are hidden
5. Repeat for Groups and Devices

Screenshot:

<img width="447" height="492" alt="image" src="https://github.com/user-attachments/assets/aea0b99e-f077-42f1-8f12-19934c4caa29" />

<img width="286" height="154" alt="image" src="https://github.com/user-attachments/assets/9987704a-5a65-41ef-9c92-e59cf6830c04" />

Motivation:

Admins frequently need to view custom attributes on users, groups, and devices. Currently this requires clicking Edit and scrolling to the attributes field.

Closes: https://github.com/goauthentik/authentik/issues/18625