### PR TITLE
web/elements: stabilize dual-select status height

### DIFF
--- a/web/src/elements/ak-dual-select/ak-dual-select.ts
+++ b/web/src/elements/ak-dual-select/ak-dual-select.ts
@@ -292,14 +292,25 @@ export class AkDualSelect extends CustomEmitterElement(CustomListenerElement(AKE
         const selectedTotal = selected.length;
 
         const availableStatus =
-            availableCount > 0 ? msg(str`${availableCount} item(s) marked to add.`) : "&nbsp;";
+            availableCount > 0
+                ? availableCount === 1
+                    ? msg(str`${availableCount} item marked to add.`)
+                    : msg(str`${availableCount} items marked to add.`)
+                : "&nbsp;";
 
-        const selectedTotalStatus = msg(str`${selectedTotal} item(s) selected.`);
+        const selectedTotalStatus =
+            selectedTotal === 1
+                ? msg(str`${selectedTotal} item selected.`)
+                : msg(str`${selectedTotal} items selected.`);
 
         const selectedCountStatus =
-            selectedCount > 0 ? "  " + msg(str`${selectedCount} item(s) marked to remove.`) : "";
-
-        const selectedStatus = `${selectedTotalStatus} ${selectedCountStatus}`;
+            selectedCount === 1
+                ? msg(str`${selectedCount} item marked to remove.`)
+                : msg(str`${selectedCount} items marked to remove.`);
+        const selectedStatus =
+            selectedCount > 0
+                ? `${selectedTotalStatus} ${selectedCountStatus}`
+                : selectedTotalStatus;
 
         return html`
             <div class="ak-dual-list-selector">
@@ -352,12 +363,10 @@ export class AkDualSelect extends CustomEmitterElement(CustomListenerElement(AKE
                         placeholder=${msg(str`Search ${this.selectedLabel}...`)}
                         name="ak-dual-list-selected-search"
                     ></ak-search-bar>
-                    <div class="pf-c-dual-list-selector__status">
-                        <span
-                            class="pf-c-dual-list-selector__status-text"
-                            id="basic-available-status-text"
-                            >${unsafeHTML(selectedStatus)}</span
-                        >
+                    <div
+                        class="pf-c-dual-list-selector__status ak-dual-list-selector__status--selected"
+                    >
+                        <span class="pf-c-dual-list-selector__status-text">${selectedStatus}</span>
                     </div>
 
                     <ak-dual-select-selected-pane

--- a/web/src/elements/ak-dual-select/components/styles.ts
+++ b/web/src/elements/ak-dual-select/components/styles.ts
@@ -133,7 +133,7 @@ export const mainStyles = css`
     .ak-dual-list-selector__status--selected {
         font-size: var(--pf-c-dual-list-selector__status-text--FontSize);
         line-height: 1.25;
-        min-height: calc(1.25em + 1.25em);
+        min-height: calc(1.25em + 1.25em); /* reserve space for 2 lines */
     }
 
     .ak-dual-list-selector {

--- a/web/src/elements/ak-dual-select/components/styles.ts
+++ b/web/src/elements/ak-dual-select/components/styles.ts
@@ -130,6 +130,12 @@ export const mainStyles = css`
         color: var(--pf-c-dual-list-selector__status-text--Color);
     }
 
+    .ak-dual-list-selector__status--selected {
+        font-size: var(--pf-c-dual-list-selector__status-text--FontSize);
+        line-height: 1.25;
+        min-height: calc(1.25em + 1.25em);
+    }
+
     .ak-dual-list-selector {
         display: grid;
         grid-template-columns: minmax(0, 1fr) min-content minmax(0, 1fr);


### PR DESCRIPTION
Overview:

Reserve a stable two-line height for the selected-status row to minimize layout shifts on small screens, and use proper singular/plural wording for status messages.

Testing:

Behavior shown in linked issue

Motivation:

Avoid accidental removals caused by status text reflow/jumping on narrow viewports.

Closes: https://github.com/goauthentik/authentik/issues/19732