### PR TITLE
web/table: align row action icons and tooltip color

### DIFF
--- a/web/src/elements/table/Table.css
+++ b/web/src/elements/table/Table.css
@@ -37,8 +37,7 @@ td:has(ak-rbac-object-permission-modal) {
     }
 
     button[slot="trigger"]:has(i) {
-        padding-inline-start: 0 !important;
-        padding-inline-end: 0.25em !important;
+        padding-inline: 0.5em !important;
     }
 
     *::part(spinner-button) {
@@ -47,6 +46,10 @@ td:has(ak-rbac-object-permission-modal) {
 
     button.pf-m-tertiary {
         margin-inline-start: 0.25em;
+    }
+
+    pf-tooltip {
+        color: inherit;
     }
 
     & > * {


### PR DESCRIPTION
Overview:

Normalize row-action icon padding and inherit icon color through tooltips to avoid misalignment and false "active" styling on the Tokens page.

Testing:

Replicate linked issue

Motivation:

Fix minor visual inconsistencies in action icons.

Closes https://github.com/goauthentik/authentik/issues/19315