### PR TITLE
core, tasks: harden outpost init and dev healthcheck ports

### DIFF
--- a/authentik/tasks/forks.py
+++ b/authentik/tasks/forks.py
@@ -17,6 +17,11 @@ def worker_healthcheck():
         port = int(port)
     except ValueError:
         LOGGER.error(f"Invalid port entered: {port}")
+        return
+
+    if CONFIG.get_bool("debug"):
+        port += 1
+        LOGGER.debug("Debug mode: offsetting worker healthcheck port", port=port)
 
     WorkerHealthcheckMiddleware.run(host, port)
     pause()


### PR DESCRIPTION
Overview:

Prevent embedded outpost initialization from panicking when the API is not ready yet and add a debug-only port offset for the worker healthcheck server.

This keeps the router on :9000 available while the backend is still bootstrapping and allows starting the worker before the server without a crash or port conflict.

Testing:

Replicate behavior in Slack thread.

Motivation:

Local dev currently breaks when the worker is started first: the worker binds listen.http and the server's router cannot bind :9000, while the embedded outpost can panic when the API isn’t ready.

Closes: https://authentiksecurity.slack.com/archives/C04UGCE7BNV/p1768430758468499?thread_ts=1768411882.588189&cid=C04UGCE7BNV