### PR TITLE
web: Remember me controller clean up.

### DIFF
--- a/web/src/flow/stages/identification/IdentificationStage.ts
+++ b/web/src/flow/stages/identification/IdentificationStage.ts
@@ -437,7 +437,7 @@ export class IdentificationStage extends BaseStage<
                     autocomplete=${autocomplete}
                     spellcheck="false"
                     class="pf-c-form-control"
-                    value=${this.#rememberMe?.username ?? ""}
+                    value=${this.#rememberMe.initialUsername}
                     required
                 />
                 ${this.#rememberMe.render()}


### PR DESCRIPTION
## Details

This PR was split from #19768 and revises the remember me controller in a similar structure to our locale controller:

- Methods which consume global state are moved into exportable functions for use outside of the controller.
- Cached values within the controller are replaced with direct calls to the local storage values, using Lit's `guard` to reduce the amount of reads rather than synchronizing local properties.