### PR TITLE
web: Session UI Config Lifecycle

### DIFF
--- a/web/src/common/theme.ts
+++ b/web/src/common/theme.ts
@@ -134,7 +134,7 @@ export function resolveUITheme(
 /**
  * Effect listener invoked when the color scheme changes.
  */
-export type UIThemeListener = (currentUITheme: ResolvedUITheme) => void;
+export type UIThemeListener = (currentUITheme: ResolvedUITheme, doc?: Document) => void;
 
 /**
  * Effect destructor invoked when cleanup is required.
@@ -257,28 +257,39 @@ declare global {
  * Applies the given theme to the document, i.e. the `<html>` element.
  *
  * @param hint The color scheme hint to use.
+ * @param doc The document to apply the theme to.
  */
-export const applyDocumentTheme = ((currentUITheme = resolveUITheme()): void => {
+export const applyDocumentTheme = ((currentUITheme = resolveUITheme(), doc = document): void => {
     console.debug(`authentik/theme (document): want to switch to ${currentUITheme} theme`);
 
-    const { themeChoice } = document.documentElement.dataset;
+    const { themeChoice } = doc.documentElement.dataset;
 
     if (themeChoice && themeChoice !== "auto") {
         console.debug(
             `authentik/theme (document): skipping theme application due to explicit choice (${themeChoice})`,
         );
 
-        document.dispatchEvent(new ThemeChangeEvent(themeChoice));
+        doc.dispatchEvent(new ThemeChangeEvent(themeChoice));
 
         return;
     }
 
-    document.documentElement.dataset.theme = currentUITheme;
+    doc.documentElement.dataset.theme = currentUITheme;
 
     console.debug(`authentik/theme (document): switching to ${currentUITheme} theme`);
 
-    document.dispatchEvent(new ThemeChangeEvent(currentUITheme));
+    doc.dispatchEvent(new ThemeChangeEvent(currentUITheme));
 }) satisfies UIThemeListener;
+
+/**
+ * Applies the given theme choice to the document element.
+ *
+ * @param hint The theme choice hint to apply.
+ * @param documentElement The document element to apply the theme choice to.
+ */
+export function applyThemeChoice(hint?: string, doc: Document = document): void {
+    doc.documentElement.dataset.themeChoice = hint ? resolveUITheme(hint) : "auto";
+}
 
 /**
  * A CSS variable representing the global background image.

--- a/web/src/elements/Base.ts
+++ b/web/src/elements/Base.ts
@@ -61,7 +61,7 @@ export class AKElement extends LitElement implements AKElementProps {
         const { brand } = globalAK();
 
         const preferredColorScheme = resolveUITheme(
-            document.documentElement.dataset.theme || globalAK().brand.uiTheme,
+            this.ownerDocument.documentElement.dataset.theme || globalAK().brand.uiTheme,
         );
         this.activeTheme = preferredColorScheme;
 

--- a/web/src/user/index.entrypoint.ts
+++ b/web/src/user/index.entrypoint.ts
@@ -35,7 +35,7 @@ import { ConsoleLogger } from "#logger/browser";
 
 import { msg } from "@lit/localize";
 import { html, nothing } from "lit";
-import { customElement, state } from "lit/decorators.js";
+import { customElement, property } from "lit/decorators.js";
 import { guard } from "lit/directives/guard.js";
 
 import PFAvatar from "@patternfly/patternfly/components/Avatar/avatar.css";
@@ -67,8 +67,8 @@ class UserInterface extends WithBrandConfig(WithSession(AuthenticatedInterface))
 
     #logger = ConsoleLogger.prefix("user-interface");
 
-    @state()
-    protected drawer: DrawerState = readDrawerParams();
+    @property({ attribute: false, useDefault: true })
+    public drawer: DrawerState = readDrawerParams();
 
     @listen(AKDrawerChangeEvent)
     protected drawerListener = (event: AKDrawerChangeEvent) => {


### PR DESCRIPTION
## Details

This PR fixes an issue which prevented the UI config from synchronizing after the session context is refreshed: 

- Added a generic `applyThemeChoice` function to validate and assign values to `document.dataset.themeChoice`. This can also be used in a future UI element to toggle the preferred scheme