### PR TITLE
providers/scim: fix email validation mismatch

### DIFF
--- a/authentik/providers/scim/clients/schema.py
+++ b/authentik/providers/scim/clients/schema.py
@@ -1,8 +1,11 @@
 """Custom SCIM schemas"""
 
 from enum import Enum
+from typing import Self
 
-from pydantic import AnyUrl, BaseModel, ConfigDict, Field
+from django.core.exceptions import ValidationError
+from django.core.validators import validate_email
+from pydantic import AnyUrl, BaseModel, ConfigDict, Field, model_validator
 from pydanticscim.group import Group as BaseGroup
 from pydanticscim.responses import PatchOperation as BasePatchOperation
 from pydanticscim.responses import PatchRequest as BasePatchRequest
@@ -12,7 +15,7 @@ from pydanticscim.service_provider import ChangePassword, Filter, Patch, Sort
 from pydanticscim.service_provider import (
     ServiceProviderConfiguration as BaseServiceProviderConfiguration,
 )
-from pydanticscim.user import AddressKind
+from pydanticscim.user import AddressKind, EmailKind
 from pydanticscim.user import User as BaseUser
 
 SCIM_USER_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:User"
@@ -80,6 +83,43 @@ class EnterpriseUser(BaseModel):
     )
 
 
+class Email(BaseModel):
+    value: str | None = Field(
+        None,
+        description=(
+            "Email addresses for the user.  The value SHOULD be canonicalized by the "
+            "service provider, e.g., 'bjensen@example.com' instead of 'bjensen@EXAMPLE.COM'. "
+            "Canonical type values of 'work', 'home', and 'other'."
+        ),
+    )
+    display: str | None = Field(
+        None,
+        description="A human-readable name, primarily used for display purposes.  READ-ONLY.",
+    )
+    type: EmailKind | None = Field(
+        None,
+        description="A label indicating the attribute's function, e.g., 'work' or 'home'.",
+    )
+    primary: bool | None = Field(
+        None,
+        description=(
+            "A Boolean value indicating the 'primary' or preferred attribute value for "
+            "this attribute, e.g., the preferred mailing address or primary email address. "
+            "The primary attribute value 'true' MUST appear no more than once."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def validate_email_django(self) -> Self:
+        """Check that the given email address validates according to django's validation rules.
+        If we used pydantic's built in EmailStr, the rules would be slightly different."""
+        try:
+            validate_email(self.value)
+        except ValidationError as exc:
+            raise ValueError(exc) from exc
+        return self
+
+
 class User(BaseUser):
     """Modified User schema with added externalId field"""
 
@@ -101,6 +141,14 @@ class User(BaseUser):
         alias="urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
         serialization_alias="urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
     )
+    emails: list[Email] | None = Field(
+        None,
+        description=(
+            "Email addresses for the user.  The value SHOULD be canonicalized by the "
+            "service provider, e.g., 'bjensen@example.com' instead of 'bjensen@EXAMPLE.COM'. "
+            "Canonical type values of 'work', 'home', and 'other'."
+        ),
+    )
 
 
 class Group(BaseGroup):
@@ -115,7 +163,6 @@ class Group(BaseGroup):
 
 
 class Bulk(BaseBulk):
-
     maxOperations: int = Field()
 
 
@@ -146,7 +193,6 @@ class ServiceProviderConfiguration(BaseServiceProviderConfiguration):
 
 
 class PatchOp(str, Enum):
-
     replace = "replace"
     remove = "remove"
     add = "add"

--- a/authentik/providers/scim/tests/test_schema.py
+++ b/authentik/providers/scim/tests/test_schema.py
@@ -1,0 +1,13 @@
+from django.test import TestCase
+from pydantic import ValidationError
+
+from authentik.providers.scim.clients.schema import Email
+
+
+class TestSCIMSchema(TestCase):
+    def test_email(self):
+        """Ensure that email addresses that validate in django validate in SCIM"""
+        Email.model_validate({"value": "foo@bar.com"})
+        Email.model_validate({"value": "username@testipa.local"})
+        with self.assertRaises(ValidationError):
+            Email.model_validate({"value": "username"})

--- a/authentik/sources/scim/views/v2/users.py
+++ b/authentik/sources/scim/views/v2/users.py
@@ -6,13 +6,13 @@ from django.db.models import Q
 from django.db.transaction import atomic
 from django.http import QueryDict
 from django.urls import reverse
-from pydanticscim.user import Email, EmailKind, Name
+from pydanticscim.user import EmailKind, Name
 from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from authentik.core.models import User
-from authentik.providers.scim.clients.schema import SCIM_USER_SCHEMA
+from authentik.providers.scim.clients.schema import SCIM_USER_SCHEMA, Email
 from authentik.providers.scim.clients.schema import User as SCIMUserModel
 from authentik.sources.scim.models import SCIMSourceUser
 from authentik.sources.scim.patch.processor import SCIMPatchProcessor


### PR DESCRIPTION
closes #19794

previously we implicitly used pydantic's EmailStr for email address validation, which has different rules than Django does, and as such you could have a broken SCIM sync if a user had an email that django considered valid but pydantic didn't.