### PR TITLE
root: assign cherry-pick PRs to original author

### DIFF
--- a/.github/actions/cherry-pick/action.yml
+++ b/.github/actions/cherry-pick/action.yml
@@ -215,6 +215,9 @@ runs:
                 --head "$CHERRY_PICK_BRANCH" \
                 --label "cherry-pick")
 
+              # Assign the PR to the original author
+              gh pr edit "$NEW_PR" --assignee "$PR_AUTHOR"
+
               echo "✅ Created cherry-pick PR $NEW_PR for $TARGET_BRANCH"
 
               # Comment on original PR
@@ -253,6 +256,9 @@ runs:
                 --base "$TARGET_BRANCH" \
                 --head "$CHERRY_PICK_BRANCH" \
                 --label "cherry-pick")
+
+              # Assign the PR to the original author
+              gh pr edit "$NEW_PR" --assignee "$PR_AUTHOR"
 
               echo "⚠️ Created conflict resolution PR $NEW_PR for $TARGET_BRANCH"
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

Add `gh pr edit --assignee` command to automatically assign cherry-pick PRs to the original PR author for both successful and conflict resolution PRs.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
