### PR TITLE
website/docs: add tip for recovering from accidental main branch work

### DIFF
--- a/website/docs/developer-docs/contributing.md
+++ b/website/docs/developer-docs/contributing.md
@@ -155,6 +155,21 @@ git push -u origin feature/my-awesome-feature
 
 Then open your PR from the feature branch.
 
+:::tip Accidentally made changes on main?
+If you already started working on `main` (even if you've already made commits), you can still recover by creating a branch from your current state, then resetting `main`:
+
+```bash
+# Create a new branch with your current changes/commits
+git checkout -b feature/my-awesome-feature
+
+# Switch back to main and reset it to match origin
+git checkout main
+git reset --hard origin/main
+```
+
+Your changes are now safely on the feature branch, and `main` is back in sync with the remote.
+:::
+
 Please follow these steps to have your contribution considered by the maintainers:
 
 1. Follow the [style guides](#style-guides)


### PR DESCRIPTION
Overview:

Add a tip to the contributing guide explaining how to recover if you accidentally started making changes on `main` instead of a feature branch.

Testing:

n/a

Motivation:

Closes: https://github.com/goauthentik/authentik/issues/18740