### PR TITLE
lib: Add ssh/sftp schemas in to DomainlessFormattedURLValidator

### DIFF
--- a/authentik/lib/models.py
+++ b/authentik/lib/models.py
@@ -110,4 +110,4 @@ class DomainlessFormattedURLValidator(DomainlessURLValidator):
             r"\Z",
             re.IGNORECASE,
         )
-        self.schemes = ["http", "https", "blank"] + list(self.schemes)
+        self.schemes = ["http", "https", "blank", "ssh", "sftp"] + list(self.schemes)


### PR DESCRIPTION
## Details

This PR adds schemas for adding applications with ssh and sftp schemas. This will allow clickable cards to be placed in the user's application library on ssh/sftp servers.

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [x] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
