### PR TITLE
website/docs: Remove stale 2024 version directives

### DIFF
--- a/website/docs/add-secure-apps/flows-stages/flow/context/index.mdx
+++ b/website/docs/add-secure-apps/flows-stages/flow/context/index.mdx
@@ -65,7 +65,7 @@ When an unauthenticated user attempts to access a secured resource, they are red
 
 When a user authenticates/enrolls via an external source, this will be set to the source they are using.
 
-#### `outpost` (dictionary):ak-version[2024.10]
+#### `outpost` (dictionary)
 
 When a flow is executed by an Outpost (for example the [LDAP](../../../providers/ldap/index.md) or [RADIUS](../../../providers/radius/index.mdx)), this will be set to a dictionary containing the Outpost instance under the key `"instance"`.
 
@@ -79,7 +79,7 @@ This key is set to `True` when the flow is executed from an "SSO" context. For e
 
 This key is set when a flow execution is continued from a token. This happens for example when an [Email stage](../../stages/email/index.mdx) is used and the user clicks on the link within the email. The token object contains the key that was used to restore the flow execution. This field is also used by the [Source stage](../../stages/source/index.md) when returning back to the initial flow the Source stage was run on.
 
-#### `is_redirected` (Flow object):ak-version[2024.12]
+#### `is_redirected` (Flow object)
 
 This key is set when the current flow was reached through a [Redirect stage](../../stages/redirect/index.md) in Flow mode.
 
@@ -101,7 +101,7 @@ URL that the form will be submitted to.
 
 Key-value pairs of the data that is included in the form and will be submitted to `url`.
 
-#### Captcha stage:ak-version[2024.6]
+#### Captcha stage:ak-version
 
 ##### `captcha` (dictionary)
 
@@ -227,7 +227,7 @@ This value can be set either via [Prompt data](#prompt_data-dictionary) or via p
 
 #### Redirect stage
 
-##### `redirect_stage_target` (string):ak-version[2024.12]
+##### `redirect_stage_target` (string)
 
 [Set this key](../../../../customize/policies/expression/managing_flow_context_keys.md) in an Expression Policy to override [Redirect stage](../../stages/redirect/index.md) to force it to redirect to a certain URL or flow. This is useful when a flow requires that the redirection target be decided dynamically.
 

--- a/website/docs/add-secure-apps/flows-stages/stages/authenticator_validate/index.mdx
+++ b/website/docs/add-secure-apps/flows-stages/stages/authenticator_validate/index.mdx
@@ -71,7 +71,7 @@ Logins which used Passwordless authentication have the _auth_method_ context var
 }
 ```
 
-#### WebAuthn Device type restrictions:ak-version[2024.4]
+#### WebAuthn Device type restrictions
 
 Optionally restrict which WebAuthn device types can be used to authenticate.
 

--- a/website/docs/add-secure-apps/flows-stages/stages/authenticator_webauthn/index.mdx
+++ b/website/docs/add-secure-apps/flows-stages/stages/authenticator_webauthn/index.mdx
@@ -22,7 +22,7 @@ Configure if the created authenticator is stored in the encrypted memory on the 
 
 Configure if authentik will require either a removable device (like a YubiKey, Google Titan, etc) or a non-removable device (like Windows Hello, TouchID or password managers), or not send a requirement.
 
-#### Device type restrictions:ak-version[2024.4]
+#### Device type restrictions
 
 Optionally restrict the types of devices allowed to be enrolled. This option can be used to ensure users are only able to enroll FIPS-compliant devices for example.
 

--- a/website/docs/add-secure-apps/flows-stages/stages/identification/index.mdx
+++ b/website/docs/add-secure-apps/flows-stages/stages/identification/index.mdx
@@ -70,7 +70,7 @@ authentik will automatically fall back to the normal identification flow when pa
 
 These fields specify if and which flows are linked on the form. The enrollment flow is linked as `Need an account? Sign up.`, and the recovery flow is linked as `Forgot username or password?`.
 
-## Pretend user exists:ak-version[2024.2]
+## Pretend user exists
 
 When enabled, any user identifier will be accepted as valid (as long as they match the correct format, i.e. when [User fields](#user-fields) is set to only allow Emails, then the identifier still needs to be an Email). The stage will succeed and the flow will continue to the next stage. Stages like the [Password stage](../password/index.md) and [Email stage](../email/index.mdx) are aware of this "pretend" user and will behave the same as if the user would exist.
 

--- a/website/docs/add-secure-apps/providers/oauth2/index.mdx
+++ b/website/docs/add-secure-apps/providers/oauth2/index.mdx
@@ -191,6 +191,6 @@ When a _Signing Key_ is selected in the provider, the JWT will be signed asymmet
 
 When no _Signing Key_ is selected, the JWT will be signed symmetrically with the _Client secret_ of the provider, which can be seen in the provider settings.
 
-### Encryption:ak-version[2024.10]
+### Encryption:ak-version
 
 authentik can also encrypt JWTs (turning them into JWEs) it issues by selecting an _Encryption Key_ in the provider. When selected, all JWTs will be encrypted symmetrically using the selected certificate. authentik uses the `RSA-OAEP-256` algorithm with the `A256CBC-HS512` encryption method.

--- a/website/docs/add-secure-apps/providers/oauth2/machine_to_machine.mdx
+++ b/website/docs/add-secure-apps/providers/oauth2/machine_to_machine.mdx
@@ -117,7 +117,7 @@ Other information that's available in the policy expression context:
 
 If you're authorizing with a JWT, then `request.context["oauth_jwt"]` is available which is the parsed JWT as a dictionary.
 
-### authentik-issued JWTs:ak-version[2024.12]
+### authentik-issued JWTs
 
 To allow federation between providers, modify the provider settings of the application (whose token will be used for authentication) to select the provider of the application to which you want to federate.
 

--- a/website/docs/customize/blueprints/v1/models.mdx
+++ b/website/docs/customize/blueprints/v1/models.mdx
@@ -45,7 +45,7 @@ For example:
       password: this-should-be-a-long-value
 ```
 
-### `permissions`:ak-version[2024.8]
+### `permissions`
 
 The `permissions` field can be used to set global permissions for a user. A full list of possible permissions is included in the JSON schema for blueprints.
 
@@ -119,7 +119,7 @@ For example:
 
 ## `authentik_rbac.role`
 
-### `permissions`:ak-version[2024.8]
+### `permissions`
 
 The `permissions` field can be used to set global permissions for a role. A full list of possible permissions is included in the JSON schema for blueprints.
 

--- a/website/docs/customize/blueprints/v1/tags.mdx
+++ b/website/docs/customize/blueprints/v1/tags.mdx
@@ -79,7 +79,7 @@ configure_flow:
 Looks up any model and resolves to the matches' primary key.
 First argument is the model to be queried, remaining arguments are expected to be pairs of key=value pairs to query for.
 
-#### `!FindObject` <span class="badge badge--version">authentik 2025.8+</span>
+#### `!FindObject`:ak-version[2025.8]
 
 Examples:
 
@@ -349,7 +349,7 @@ The above example will resolve to something like this:
     - "bar: (index: 2, letter: r)"
 ```
 
-#### `!AtIndex`:ak-version[2024.12]
+#### `!AtIndex`
 
 Minimal example:
 

--- a/website/docs/enterprise/manage-enterprise.mdx
+++ b/website/docs/enterprise/manage-enterprise.mdx
@@ -106,7 +106,7 @@ The following events occur when a license expires or the internal/external user 
 
     - Users can authenticate and authorize applications
     - Licenses can be modified
-    - Users can be modified/deleted:ak-version[2024.10.5]
+    - Users can be modified/deleted
 
     After the violation is corrected (either the user count returns to be within the limits of the license or the license is renewed), authentik will return to the standard read-write mode and the notification will disappear.
 

--- a/website/docs/install-config/configuration/configuration.mdx
+++ b/website/docs/install-config/configuration/configuration.mdx
@@ -115,7 +115,7 @@ These settings control connection persistence and behavior, which is particularl
 
 ### Advanced Settings
 
-- `AUTHENTIK_POSTGRESQL__DEFAULT_SCHEMA` :ak-version[2024.12]
+- `AUTHENTIK_POSTGRESQL__DEFAULT_SCHEMA`
 
     The name of the database schema for authentik to use. Defaults to `public`.
 
@@ -601,7 +601,7 @@ Configure how long reputation scores should be saved for in seconds.
 
 Defaults to `86400`.
 
-### `AUTHENTIK_SESSION_STORAGE`:ak-version[2024.4]
+### `AUTHENTIK_SESSION_STORAGE`
 
 :::info Deprecated
 This setting is removed as of version 2025.4. Sessions are now exclusively stored in the database. See our [2025.4 release notes](../../releases/2025.4#sessions-are-now-stored-in-the-database) for more information.
@@ -629,15 +629,11 @@ Defaults to 4.
 
 ### `AUTHENTIK_WEB__PATH`
 
-:::info
-Requires authentik 2024.8
-:::
-
 Configure the path under which authentik is served. For example to access authentik under `https://my.domain/authentik/`, set this to `/authentik/`. Value _must_ contain both a leading and trailing slash.
 
 Defaults to `/`.
 
-## System settings:ak-version[2024.2]
+## System settings
 
 Additional settings are configurable using the Admin interface, under **System** > **Settings** or using the API.
 

--- a/website/docs/users-sources/groups/manage_groups.mdx
+++ b/website/docs/users-sources/groups/manage_groups.mdx
@@ -51,7 +51,7 @@ You can assign a role to a group, and then all users in the group inherit the pe
 Roles are inherited through group hierarchy. If a parent group has a role assigned, all child groups (and their users) automatically inherit that role's permissions. You can view both directly assigned and inherited roles on a group's detail page under the **Roles** tab.
 :::
 
-## Delegating group member management:ak-version[2024.4]
+## Delegating group member management
 
 To give a specific role or user the ability to manage group members, the following permissions need to be granted on the matching group object:
 

--- a/website/docs/users-sources/sources/social-logins/entra-id/oauth/index.mdx
+++ b/website/docs/users-sources/sources/social-logins/entra-id/oauth/index.mdx
@@ -91,7 +91,7 @@ For instructions on how to display the new source on the authentik login page, r
 For instructions on embedding the new source within a flow, such as an authorization flow, refer to the [Source Stage documentation](../../../../../../add-secure-apps/flows-stages/stages/source).
 :::
 
-### Machine-to-machine authentication :ak-version[2024.12]
+### Machine-to-machine authentication
 
 If using [Machine-to-Machine](../../../../../add-secure-apps/providers/oauth2/machine_to_machine.mdx#jwt-authentication) authentication, some specific steps need to be considered.
 


### PR DESCRIPTION
## Details

This PR removes instances of `:ak-version[2024.*]`, fixing our documentation build task.