### PR TITLE
website/docs: Add `NODE_ENV: production` to workflow.

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    env:
+      NODE_ENV: production
     strategy:
       fail-fast: false
       matrix:
@@ -30,7 +32,8 @@ jobs:
         run: npm run ${{ matrix.command }}
   build-docs:
     runs-on: ubuntu-latest
-
+    env:
+      NODE_ENV: production
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v5
@@ -46,7 +49,8 @@ jobs:
         run: npm run build
   build-integrations:
     runs-on: ubuntu-latest
-
+    env:
+      NODE_ENV: production
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v5


### PR DESCRIPTION
## Details

This PR applies `NODE_ENV: production` to the docs workflow, matching our Netlify build and allowing production-specific behaviors (warnings vs errors) to apply.