### PR TITLE
web: fix Brand CSS not applied to nested Shadow DOM components

### DIFF
--- a/web/src/elements/Base.ts
+++ b/web/src/elements/Base.ts
@@ -178,9 +178,6 @@ export class AKElement extends LitElement implements AKElementProps {
             },
         );
 
-        // Immediately apply Brand CSS to the style root.
-        // This ensures nested Shadow DOM components created after the initial
-        // ThemeChangeEvent still receive the custom brand styles.
         if (this.#customCSSStyleSheet) {
             applyUITheme(nextStyleRoot, this.#customCSSStyleSheet);
         }

--- a/web/src/elements/Base.ts
+++ b/web/src/elements/Base.ts
@@ -145,6 +145,13 @@ export class AKElement extends LitElement implements AKElementProps {
 
     /**
      * A custom CSS style sheet to apply to the element.
+     *
+     * @deprecated Use CSS parts and custom properties instead.
+     *
+     * @remarks
+     * The use of injected style sheets may result in brittle styles that are hard to
+     * maintain across authentik versions.
+     *
      */
     readonly #customCSSStyleSheet: CSSStyleSheet | null;
 
@@ -156,6 +163,13 @@ export class AKElement extends LitElement implements AKElementProps {
      * The style root to which the theme is applied.
      */
     #styleRoot?: StyleRoot;
+
+    /**
+     * The style root to which the theme is applied.
+     */
+    protected get styleRoot(): StyleRoot | undefined {
+        return this.#styleRoot;
+    }
 
     protected set styleRoot(nextStyleRoot: StyleRoot | undefined) {
         this.#themeAbortController?.abort();
@@ -181,10 +195,6 @@ export class AKElement extends LitElement implements AKElementProps {
         if (this.#customCSSStyleSheet) {
             applyUITheme(nextStyleRoot, this.#customCSSStyleSheet);
         }
-    }
-
-    protected get styleRoot(): StyleRoot | undefined {
-        return this.#styleRoot;
     }
 
     protected hasSlotted(name: string | null) {

--- a/web/src/elements/Base.ts
+++ b/web/src/elements/Base.ts
@@ -177,6 +177,13 @@ export class AKElement extends LitElement implements AKElementProps {
                 signal: this.#themeAbortController.signal,
             },
         );
+
+        // Immediately apply Brand CSS to the style root.
+        // This ensures nested Shadow DOM components created after the initial
+        // ThemeChangeEvent still receive the custom brand styles.
+        if (this.#customCSSStyleSheet) {
+            applyUITheme(nextStyleRoot, this.#customCSSStyleSheet);
+        }
     }
 
     protected get styleRoot(): StyleRoot | undefined {


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->

After PR #17444, Brand CSS was only applied when ThemeChangeEvent fired. Components created after the initial event never received the custom styles.

This fix immediately applies Brand CSS when a style root is set, ensuring all nested Shadow DOM components (like flow stages) receive brand styling regardless of when they are created.

Made and tested with a test image based on the `version/2025.12.2` tag: `mmx233/authentik:2025.12.2-fix-brand-css`

Fixes #19556

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
