### PR TITLE
ci: always generate API clients

### DIFF
--- a/.github/workflows/_reusable-docker-build-single.yml
+++ b/.github/workflows/_reusable-docker-build-single.yml
@@ -67,19 +67,16 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: make empty clients
-        if: ${{ inputs.release }}
-        run: |
-          mkdir -p ./gen-ts-api
-          mkdir -p ./gen-go-api
       - name: Setup node
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v5
         with:
           node-version-file: web/package.json
           cache: "npm"
           cache-dependency-path: web/package-lock.json
-      - name: generate ts client
-        run: make gen-client-ts
+      - name: Generate API Clients
+        run: |
+          make gen-client-ts
+          make gen-client-go
       - name: Build Docker Image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
         id: push

--- a/.github/workflows/_reusable-docker-build-single.yml
+++ b/.github/workflows/_reusable-docker-build-single.yml
@@ -67,12 +67,14 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup node
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v5
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v5
         with:
           node-version-file: web/package.json
           cache: "npm"
           cache-dependency-path: web/package-lock.json
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
+        with:
+          go-version-file: "go.mod"
       - name: Generate API Clients
         run: |
           make gen-client-ts

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -87,6 +87,11 @@ jobs:
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
         with:
           go-version-file: "go.mod"
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v5
+        with:
+          node-version-file: web/package.json
+          cache: "npm"
+          cache-dependency-path: web/package-lock.json
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - name: Set up Docker Buildx

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -98,10 +98,10 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_CORP_USERNAME }}
         with:
           image-name: ghcr.io/goauthentik/${{ matrix.type }},authentik/${{ matrix.type }}
-      - name: make empty clients
+      - name: Generate API Clients
         run: |
-          mkdir -p ./gen-ts-api
-          mkdir -p ./gen-go-api
+          make gen-client-ts
+          make gen-client-go
       - name: Docker Login Registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:

--- a/authentik/endpoints/tests/test_facts.py
+++ b/authentik/endpoints/tests/test_facts.py
@@ -60,20 +60,18 @@ class TestEndpointFacts(APITestCase):
                 ]
             }
         )
-        self.assertEqual(
-            device.cached_facts.data,
-            {
-                "software": [
-                    {
-                        "name": "software-a",
-                        "version": "1.2.3.4",
-                        "source": "package",
-                    },
-                    {
-                        "name": "software-b",
-                        "version": "5.6.7.8",
-                        "source": "package",
-                    },
-                ]
-            },
+        self.assertCountEqual(
+            device.cached_facts.data["software"],
+            [
+                {
+                    "name": "software-a",
+                    "version": "1.2.3.4",
+                    "source": "package",
+                },
+                {
+                    "name": "software-b",
+                    "version": "5.6.7.8",
+                    "source": "package",
+                },
+            ],
         )

--- a/lifecycle/container/Dockerfile
+++ b/lifecycle/container/Dockerfile
@@ -44,6 +44,7 @@ RUN --mount=type=cache,id=apt-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/v
 
 RUN --mount=type=bind,target=/go/src/goauthentik.io/go.mod,src=./go.mod \
     --mount=type=bind,target=/go/src/goauthentik.io/go.sum,src=./go.sum \
+    --mount=type=bind,target=/go/src/goauthentik.io/gen-go-api,src=./gen-go-api \
     --mount=type=cache,target=/go/pkg/mod \
     go mod download
 

--- a/lifecycle/container/Dockerfile
+++ b/lifecycle/container/Dockerfile
@@ -58,6 +58,7 @@ COPY ./go.mod /go/src/goauthentik.io/go.mod
 COPY ./go.sum /go/src/goauthentik.io/go.sum
 
 RUN --mount=type=cache,sharing=locked,target=/go/pkg/mod \
+    --mount=type=bind,target=/go/src/goauthentik.io/gen-go-api,src=./gen-go-api \
     --mount=type=cache,id=go-build-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/root/.cache/go-build \
     if [ "$TARGETARCH" = "arm64" ]; then export CC=aarch64-linux-gnu-gcc && export CC_FOR_TARGET=gcc-aarch64-linux-gnu; fi && \
     CGO_ENABLED=1 GOFIPS140=latest GOARM="${TARGETVARIANT#v}" \


### PR DESCRIPTION
sigh

yep https://github.com/goauthentik/authentik/issues/19878

because we generate clients for outposts used in CI (dev-proxy:gh-main, etc) but not for the actual release build, this wasn't caught in CI