### PR TITLE
core: fix non-expiring service accounts and app passwords

### DIFF
--- a/authentik/core/api/tokens.py
+++ b/authentik/core/api/tokens.py
@@ -75,7 +75,8 @@ class TokenSerializer(ManagedSerializer, ModelSerializer):
                 except ValueError:
                     pass
 
-            if "expires" in attrs and attrs.get("expires") > max_token_lifetime_dt:
+            expires = attrs.get("expires")
+            if expires is not None and expires > max_token_lifetime_dt:
                 raise ValidationError(
                     {
                         "expires": (

--- a/web/src/elements/forms/Form.ts
+++ b/web/src/elements/forms/Form.ts
@@ -118,7 +118,7 @@ export function serializeForm<T = Record<string, unknown>>(elements: Iterable<AK
                 const valueAsNumber = inputElement.valueAsNumber;
                 return assignValue(
                     inputElement,
-                    isNaN(valueAsNumber) ? null : dateToUTC(new Date(valueAsNumber)),
+                    isNaN(valueAsNumber) ? undefined : dateToUTC(new Date(valueAsNumber)),
                     json,
                 );
             }
@@ -129,7 +129,7 @@ export function serializeForm<T = Record<string, unknown>>(elements: Iterable<AK
                 const date = new Date(inputElement.value);
                 return assignValue(
                     inputElement,
-                    isNaN(date.getTime()) ? null : dateToUTC(date),
+                    isNaN(date.getTime()) ? undefined : dateToUTC(date),
                     json,
                 );
             }


### PR DESCRIPTION
    We aim to fix
    https://github.com/goauthentik/authentik/issues/19911 in the next patch
    release, so this commit shouldn't include an API change, which is why we
    do it a bit awkwardly. Additionally, `serializeForm` has no typechecking
    for its return value (`return json as unknown as T`), and should be
    refactored for type safety if at all possible.
    
    There are at least two bugs we're solving in this commit:
    
    1. Type checking fails on `serializeForm`, which results in
    `expires: null` POSTed in a `UserServiceAccountRequest`, where it is not
    allowed. The backend "correctly" returns a 400. For now we address this
    by returning `undefined` from `serializeForm` on a `datetime-local`
    input element when it is unset.
    
    2. The schema allows for `expires: null` in `TokenModel`, but fails with
    a 500 when that is actually sent. For now we address this with a `None`
    check. (Note: this bug will not be encountered by the frontend after the
    change from `null` to `undefined`, but it's still nice to fix.)
    
    Both of these issues should eventually be solved by the backend handling
    `ExpiringModel` in an `ExpiringModelSerializer` instead of the current
    ad hoc way.
    
    Introduced by https://github.com/goauthentik/authentik/pull/19561 for the frontend part

Closes: https://github.com/goauthentik/authentik/issues/19911
