### PR TITLE
stages/authenticator_webauthn: fix double JSON encoding of webauthn options

### DIFF
--- a/authentik/stages/authenticator_validate/challenge.py
+++ b/authentik/stages/authenticator_validate/challenge.py
@@ -1,6 +1,5 @@
 """Validation stage challenge checking"""
 
-from json import loads
 from typing import TYPE_CHECKING
 from urllib.parse import urlencode
 
@@ -12,12 +11,12 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework.fields import CharField, ChoiceField, DateTimeField
 from rest_framework.serializers import ValidationError
 from structlog.stdlib import get_logger
-from webauthn import options_to_json
 from webauthn.authentication.generate_authentication_options import generate_authentication_options
 from webauthn.authentication.verify_authentication_response import verify_authentication_response
 from webauthn.helpers import parse_authentication_credential_json
 from webauthn.helpers.base64url_to_bytes import base64url_to_bytes
 from webauthn.helpers.exceptions import InvalidAuthenticationResponse, InvalidJSONStructure
+from webauthn.helpers.options_to_json_dict import options_to_json_dict
 from webauthn.helpers.structs import PublicKeyCredentialType, UserVerificationRequirement
 
 from authentik.core.api.utils import JSONDictField, PassiveSerializer
@@ -81,7 +80,7 @@ def get_webauthn_challenge_without_user(
         authentication_options.challenge
     )
 
-    return loads(options_to_json(authentication_options))
+    return options_to_json_dict(authentication_options)
 
 
 def get_webauthn_challenge(
@@ -110,7 +109,7 @@ def get_webauthn_challenge(
         authentication_options.challenge
     )
 
-    return loads(options_to_json(authentication_options))
+    return options_to_json_dict(authentication_options)
 
 
 def select_challenge(request: HttpRequest, device: Device):

--- a/authentik/stages/authenticator_webauthn/stage.py
+++ b/authentik/stages/authenticator_webauthn/stage.py
@@ -1,6 +1,5 @@
 """WebAuthn stage"""
 
-from json import loads
 from uuid import UUID
 
 from django.http import HttpRequest, HttpResponse
@@ -9,9 +8,9 @@ from django.utils.translation import gettext as __
 from django.utils.translation import gettext_lazy as _
 from rest_framework.fields import CharField
 from rest_framework.serializers import ValidationError
-from webauthn import options_to_json
 from webauthn.helpers.bytes_to_base64url import bytes_to_base64url
 from webauthn.helpers.exceptions import WebAuthnException
+from webauthn.helpers.options_to_json_dict import options_to_json_dict
 from webauthn.helpers.structs import (
     AttestationConveyancePreference,
     AuthenticatorAttachment,
@@ -145,7 +144,7 @@ class AuthenticatorWebAuthnStageView(ChallengeStageView):
         self.executor.plan.context[PLAN_CONTEXT_WEBAUTHN_CHALLENGE] = registration_options.challenge
         return AuthenticatorWebAuthnChallenge(
             data={
-                "registration": loads(options_to_json(registration_options)),
+                "registration": options_to_json_dict(registration_options),
             }
         )
 


### PR DESCRIPTION
some housekeeping

there used to not be an option exposed for just putting this data in a format that is JSON-serializable so our next closest thing was to just serialize it to json then load it again to include it in our API