### PR TITLE
recovery: consume token in transaction

### DIFF
--- a/authentik/recovery/views.py
+++ b/authentik/recovery/views.py
@@ -2,6 +2,7 @@
 
 from django.contrib import messages
 from django.contrib.auth import login
+from django.db import transaction
 from django.http import Http404, HttpRequest, HttpResponse
 from django.shortcuts import redirect
 from django.utils.translation import gettext as _
@@ -16,11 +17,16 @@ class UseTokenView(View):
 
     def get(self, request: HttpRequest, key: str) -> HttpResponse:
         """Check if token exists, log user in and delete token."""
-        tokens = Token.filter_not_expired(key=key, intent=TokenIntents.INTENT_RECOVERY)
-        if not tokens.exists():
-            raise Http404
-        token = tokens.first()
-        login(request, token.user, backend=BACKEND_INBUILT)
-        token.delete()
+        with transaction.atomic():
+            tokens = (
+                Token.filter_not_expired(key=key, intent=TokenIntents.INTENT_RECOVERY)
+                .select_for_update()
+                .select_related("user")
+            )
+            token = tokens.first()
+            if token is None:
+                raise Http404
+            login(request, token.user, backend=BACKEND_INBUILT)
+            token.delete()
         messages.warning(request, _("Used recovery-link to authenticate."))
         return redirect("authentik_core:if-user")


### PR DESCRIPTION
*Vulnerability identified and fix provided by **[Kolega.dev](https://kolega.dev/)***

## Summary
Fixed a race condition vulnerability in the recovery token view that allowed token reuse via concurrent requests.

## Vulnerability
The `UseTokenView.get()` method performed token existence check, retrieval, user login, and token deletion as separate non-atomic operations. An attacker with a valid recovery token could exploit the race window to authenticate multiple times using the same token before it was deleted.

## Fix
Wrapped the entire token validation and consumption flow in `transaction.atomic()` with `select_for_update()` to ensure exclusive database row locking. This prevents concurrent requests from accessing the same token simultaneously, eliminating the race condition.