### PR TITLE
security: use constant-time comparison for client secrets

### DIFF
--- a/authentik/providers/oauth2/utils.py
+++ b/authentik/providers/oauth2/utils.py
@@ -4,6 +4,7 @@ import re
 import uuid
 from base64 import b64decode, urlsafe_b64encode
 from binascii import Error
+from hmac import compare_digest
 from hashlib import sha256
 from typing import Any
 from urllib.parse import urlparse
@@ -206,7 +207,7 @@ def authenticate_provider(request: HttpRequest) -> OAuth2Provider | None:
     provider, client_id, client_secret = provider_from_request(request)
     if not provider:
         return None
-    if client_id != provider.client_id or client_secret != provider.client_secret:
+    if client_id != provider.client_id or not compare_digest(client_secret, provider.client_secret):
         LOGGER.debug("(basic) Provider for basic auth does not exist")
         return None
     CTX_AUTH_VIA.set("oauth_client_secret")

--- a/authentik/providers/oauth2/views/token.py
+++ b/authentik/providers/oauth2/views/token.py
@@ -3,6 +3,7 @@
 from base64 import b64decode
 from binascii import Error
 from dataclasses import InitVar, dataclass
+from hmac import compare_digest
 from datetime import datetime
 from re import error as RegexError
 from re import fullmatch
@@ -163,7 +164,7 @@ class TokenParams:
         if self.grant_type in [GRANT_TYPE_AUTHORIZATION_CODE, GRANT_TYPE_REFRESH_TOKEN]:
             if (
                 self.provider.client_type == ClientTypes.CONFIDENTIAL
-                and self.provider.client_secret != self.client_secret
+                and not compare_digest(self.provider.client_secret, self.client_secret)
             ):
                 LOGGER.warning(
                     "Invalid client secret",
@@ -322,7 +323,7 @@ class TokenParams:
                 request, request.POST.get("username"), request.POST.get("password")
             )
         # Standard method which creates an automatic user
-        if self.client_secret == self.provider.client_secret:
+        if compare_digest(self.client_secret, self.provider.client_secret):
             return self.__post_init_client_credentials_generated(request)
         # Standard workaround method which stores username:password
         # as client_secret


### PR DESCRIPTION
## Summary
Fixed timing attack vulnerability in OAuth2 client secret comparisons across the token endpoint and provider authentication.

## Vulnerability
Client secrets were compared using standard inequality operators (!=, ==) which perform short-circuiting comparisons. This could theoretically allow an attacker to guess the secret character-by-character through precise timing analysis, as the comparison returns early on the first mismatching byte.

## Fix
Replaced all client secret comparisons with `hmac.compare_digest()`, which performs constant-time string comparisons that don't leak timing information. This matches the existing secure patterns already used elsewhere in the codebase (e.g., `authentik/api/authentication.py`).

Files modified:
- `authentik/providers/oauth2/views/token.py`: Fixed comparisons in TokenParams (lines 166, 326)
- `authentik/providers/oauth2/utils.py`: Fixed comparison in authenticate_provider() (line 209)