### PR TITLE
security: use timezone-aware datetime for JWT expiration check

### DIFF
--- a/authentik/providers/oauth2/views/token.py
+++ b/authentik/providers/oauth2/views/token.py
@@ -3,7 +3,7 @@
 from base64 import b64decode
 from binascii import Error
 from dataclasses import InitVar, dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from re import error as RegexError
 from re import fullmatch
 from typing import Any
@@ -462,9 +462,8 @@ class TokenParams:
             raise TokenError("invalid_grant")
 
         if "exp" in token:
-            exp = datetime.fromtimestamp(token["exp"])
-            # Non-timezone aware check since we assume `exp` is in UTC
-            if datetime.now() >= exp:
+            exp = datetime.fromtimestamp(token["exp"], tz=timezone.utc)
+            if datetime.now(timezone.utc) >= exp:
                 LOGGER.info("JWT token expired")
                 raise TokenError("invalid_grant")
 


### PR DESCRIPTION
## Summary
Fix JWT token expiration check to use timezone-aware datetime objects to prevent expired tokens from being accepted on servers with non-UTC timezones.

## Vulnerability
The JWT token expiration check used datetime.now() which returns local time, but compared against exp which is always in UTC. On servers configured with non-UTC timezones, this could allow expired tokens to be accepted (e.g., up to 5 hours past expiration on a UTC+5 server).

## Fix
Changed to use datetime.now(timezone.utc) and datetime.fromtimestamp(token['exp'], tz=timezone.utc) for proper timezone-aware comparison.