### PR TITLE
Recovery Token Reuse via Race Condition

### DIFF
--- a/authentik/recovery/views.py
+++ b/authentik/recovery/views.py
@@ -2,6 +2,7 @@
 
 from django.contrib import messages
 from django.contrib.auth import login
+from django.db import transaction
 from django.http import Http404, HttpRequest, HttpResponse
 from django.shortcuts import redirect
 from django.utils.translation import gettext as _
@@ -16,11 +17,14 @@ class UseTokenView(View):
 
     def get(self, request: HttpRequest, key: str) -> HttpResponse:
         """Check if token exists, log user in and delete token."""
-        tokens = Token.filter_not_expired(key=key, intent=TokenIntents.INTENT_RECOVERY)
-        if not tokens.exists():
-            raise Http404
-        token = tokens.first()
-        login(request, token.user, backend=BACKEND_INBUILT)
-        token.delete()
+        with transaction.atomic():
+            tokens = Token.filter_not_expired(
+                key=key, intent=TokenIntents.INTENT_RECOVERY
+            ).select_for_update()
+            token = tokens.first()
+            if not token:
+                raise Http404
+            login(request, token.user, backend=BACKEND_INBUILT)
+            token.delete()
         messages.warning(request, _("Used recovery-link to authenticate."))
         return redirect("authentik_core:if-user")


### PR DESCRIPTION
## Location
`authentik/recovery/views.py:19`

## Vulnerability
This is a valid TOCTOU vulnerability. The code performs: (1) check if token exists, (2) get token, (3) login user, (4) delete token - without atomic transaction protection. Multiple concurrent requests could pass the existence check before any deletes the token, allowing token reuse. However, practical exploitability is low because: (1) an attacker would need to intercept a valid recovery token, (2) the race window is very small (milliseconds), (3) the attacker would need to send multiple precisely-timed requests. The fix is straightforward: wrap the operation in transaction.atomic() with select_for_update(). This is a real vulnerability that should be fixed, but the attack scenario requires an attacker to already have obtained a valid token AND execute a timing attack, making real-world exploitation unlikely but not impossible.

## Fix
Wrapped the token validation, retrieval, and deletion in a transaction.atomic() block with select_for_update() to lock the token row. This ensures that only one concurrent request can access the token at a time, preventing race conditions where multiple requests could reuse the same recovery token.