### PR TITLE
brands: fix Domain Matching in Brand Resolution

### DIFF
--- a/authentik/brands/utils.py
+++ b/authentik/brands/utils.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from django.db.models import Case, F, IntegerField, Q, Value, When
-from django.db.models.functions import Length
+from django.db.models.functions import Concat, Length
 from django.http.request import HttpRequest
 from django.utils.html import _json_script_escapes
 from django.utils.safestring import mark_safe
@@ -26,7 +26,8 @@ def get_brand_for_request(request: HttpRequest) -> Brand:
             domain_length=Length("domain"),
             match_priority=Case(
                 When(
-                    condition=Q(host_domain__iendswith=F("domain")),
+                    condition=Q(host_domain__iexact=F("domain"))
+                    | Q(host_domain__iendswith=Concat(Value("."), F("domain"))),
                     then=F("domain_length"),
                 ),
                 default=Value(-1),


### PR DESCRIPTION
*Vulnerability identified and fix provided by **[Kolega.dev](https://kolega.dev/)***

## Location
`authentik/brands/utils.py:30`

## Vulnerability
The domain matching uses iendswith without boundary checking. As demonstrated: 'fake-example.com'.endswith('example.com') returns True. This means if a brand is configured for 'example.com', a request to 'fake-example.com' would match that brand. The matching prioritizes longer domain matches (domain_length), so 'foo.example.com' would correctly match 'foo.example.com' over 'example.com'. However, the vulnerability exists when an attacker controls a domain like 'evil-example.com' - they could potentially receive the branding/flows configured for 'example.com'. The impact depends on what's exposed through branding: custom CSS, authentication flows, recovery flows, etc. The fix should add a dot-boundary check: either prepend a dot to the domain before comparison, or verify the character before the match is a dot or start of string. The model help text even acknowledges this behavior: 'Can be a superset, i.e. `a.b` for `aa.b` and `ba.b`' - suggesting this may be intentional, hence Needs Human Review.

## Fix
Changed the domain matching condition to require a proper boundary: either an exact match (`host_domain__iexact=F("domain")`) or a subdomain match with a dot prefix (`host_domain__iendswith=Concat(Value("."), F("domain"))`). This prevents partial string matches like 'fake-example.com' matching 'example.com' while still correctly matching valid subdomains like 'foo.example.com' to 'example.com'.