### PR TITLE
outposts: fix docker_tls created files permission

### DIFF
--- a/authentik/outposts/docker_ssh.py
+++ b/authentik/outposts/docker_ssh.py
@@ -12,9 +12,9 @@ HEADER = "### Managed by authentik"
 FOOTER = "### End Managed by authentik"
 
 
-def opener(path, flags):
-    """File opener to create files as 700 perms"""
-    return os.open(path, flags, 0o700)
+def opener(path: Path | str, flags: int):
+    """File opener to create files as 600 perms"""
+    return os.open(path, flags, 0o600)
 
 
 class SSHManagedExternallyException(DockerException):

--- a/authentik/outposts/docker_tls.py
+++ b/authentik/outposts/docker_tls.py
@@ -7,11 +7,7 @@ from tempfile import gettempdir
 from docker.tls import TLSConfig
 
 from authentik.crypto.models import CertificateKeyPair
-
-
-def opener(path, flags):
-    """File opener to create files as 600 perms"""
-    return os.open(path, flags, 0o600)
+from authentik.outposts.docker_ssh import opener
 
 
 class DockerInlineTLS:

--- a/authentik/outposts/docker_tls.py
+++ b/authentik/outposts/docker_tls.py
@@ -1,6 +1,6 @@
 """Create Docker TLSConfig from CertificateKeyPair"""
 
-import os
+from os import unlink
 from pathlib import Path
 from tempfile import gettempdir
 
@@ -38,7 +38,7 @@ class DockerInlineTLS:
     def cleanup(self):
         """Clean up certificates when we're done"""
         for path in self._paths:
-            os.unlink(path)
+            unlink(path)
 
     def write(self) -> TLSConfig:
         """Create TLSConfig with Certificate Key pairs"""


### PR DESCRIPTION
*Vulnerability identified and fix provided by **[Kolega.dev](https://kolega.dev/)***

## Location
`authentik/outposts/docker_tls.py:29`

## Vulnerability
Unlike docker_ssh.py which uses a custom opener with 0o700 permissions, docker_tls.py's write_file() method uses plain open() without specifying file permissions. This means files are created with the default umask (typically 0o644), making private keys readable by other users. While the container environment provides significant mitigation (runs as UID 1000, isolated tmpfs at /dev/shm/), this is still a code defect that should be fixed. The fix is simple: add an opener parameter similar to docker_ssh.py or use os.open() with explicit mode 0o600. The practical exploitability is low due to container isolation, but this represents a genuine coding error where sensitive cryptographic material is written with overly permissive file permissions.

## Fix
Added an opener function that creates files with 0o600 permissions, matching the security pattern used in docker_ssh.py. This ensures TLS certificate keys are only readable by the file owner.