### PR TITLE
providers/oauth2: use compare_digest for client_secret comparison

### DIFF
--- a/authentik/providers/oauth2/utils.py
+++ b/authentik/providers/oauth2/utils.py
@@ -3,9 +3,9 @@
 import re
 import uuid
 from base64 import b64decode, urlsafe_b64encode
-from hmac import compare_digest
 from binascii import Error
 from hashlib import sha256
+from hmac import compare_digest
 from typing import Any
 from urllib.parse import urlparse
 
@@ -207,7 +207,9 @@ def authenticate_provider(request: HttpRequest) -> OAuth2Provider | None:
     provider, client_id, client_secret = provider_from_request(request)
     if not provider:
         return None
-    if not compare_digest(client_id, provider.client_id) or not compare_digest(client_secret, provider.client_secret):
+    if not compare_digest(client_id, provider.client_id) or not compare_digest(
+        client_secret, provider.client_secret
+    ):
         LOGGER.debug("(basic) Provider for basic auth does not exist")
         return None
     CTX_AUTH_VIA.set("oauth_client_secret")

--- a/authentik/providers/oauth2/utils.py
+++ b/authentik/providers/oauth2/utils.py
@@ -3,6 +3,7 @@
 import re
 import uuid
 from base64 import b64decode, urlsafe_b64encode
+from hmac import compare_digest
 from binascii import Error
 from hashlib import sha256
 from typing import Any
@@ -206,7 +207,7 @@ def authenticate_provider(request: HttpRequest) -> OAuth2Provider | None:
     provider, client_id, client_secret = provider_from_request(request)
     if not provider:
         return None
-    if client_id != provider.client_id or client_secret != provider.client_secret:
+    if not compare_digest(client_id, provider.client_id) or not compare_digest(client_secret, provider.client_secret):
         LOGGER.debug("(basic) Provider for basic auth does not exist")
         return None
     CTX_AUTH_VIA.set("oauth_client_secret")

--- a/authentik/providers/oauth2/views/token.py
+++ b/authentik/providers/oauth2/views/token.py
@@ -1,6 +1,7 @@
 """authentik OAuth2 Token views"""
 
 from base64 import b64decode
+from hmac import compare_digest
 from binascii import Error
 from dataclasses import InitVar, dataclass
 from datetime import datetime
@@ -163,7 +164,7 @@ class TokenParams:
         if self.grant_type in [GRANT_TYPE_AUTHORIZATION_CODE, GRANT_TYPE_REFRESH_TOKEN]:
             if (
                 self.provider.client_type == ClientTypes.CONFIDENTIAL
-                and self.provider.client_secret != self.client_secret
+                and not compare_digest(self.provider.client_secret, self.client_secret)
             ):
                 LOGGER.warning(
                     "Invalid client secret",

--- a/authentik/providers/oauth2/views/token.py
+++ b/authentik/providers/oauth2/views/token.py
@@ -1,10 +1,10 @@
 """authentik OAuth2 Token views"""
 
 from base64 import b64decode
-from hmac import compare_digest
 from binascii import Error
 from dataclasses import InitVar, dataclass
 from datetime import datetime
+from hmac import compare_digest
 from re import error as RegexError
 from re import fullmatch
 from typing import Any
@@ -162,9 +162,8 @@ class TokenParams:
 
     def __post_init__(self, raw_code: str, raw_token: str, request: HttpRequest):
         if self.grant_type in [GRANT_TYPE_AUTHORIZATION_CODE, GRANT_TYPE_REFRESH_TOKEN]:
-            if (
-                self.provider.client_type == ClientTypes.CONFIDENTIAL
-                and not compare_digest(self.provider.client_secret, self.client_secret)
+            if self.provider.client_type == ClientTypes.CONFIDENTIAL and not compare_digest(
+                self.provider.client_secret, self.client_secret
             ):
                 LOGGER.warning(
                     "Invalid client secret",


### PR DESCRIPTION
*Vulnerability identified and fix provided by **[Kolega.dev](https://kolega.dev/)***

## Location
`authentik/providers/oauth2/views/token.py:166`

## Vulnerability
Line 166 uses '!=' for client secret comparison: 'self.provider.client_secret != self.client_secret'. This is a timing-unsafe comparison that could theoretically leak information about the secret through timing analysis. The codebase correctly uses hmac.compare_digest() elsewhere (authentication.py lines 37, 141, 150) for similar sensitive comparisons, demonstrating awareness of this issue. Additionally, utils.py line 209 has the same problem in authenticate_provider(). While practical exploitation requires many requests and precise timing measurements (making it difficult over network), this is a confirmed vulnerability that violates security best practices. The fix is trivial: import compare_digest from hmac and use 'not compare_digest(self.provider.client_secret, self.client_secret)'. Client secrets are 128-character random strings, making timing attacks harder but not impossible.

## Fix
Replaced insecure '!=' comparisons with hmac.compare_digest() in both token.py and utils.py to prevent timing attacks on client secret validation. This matches the existing secure pattern already used in authentication.py throughout the codebase.