### PR TITLE
web/i18n: Fix Japanese and Korean font overrides.

### DIFF
--- a/web/src/styles/locales/ja/globals.css
+++ b/web/src/styles/locales/ja/globals.css
@@ -2,7 +2,8 @@
  * @file Japanese locale global style overrides.
  */
 
-html[lang="ja"] {
+html[lang="ja"],
+html[lang^="ja-"] {
     --ak-font-family-sans-serif:
         "M PLUS 2", "Noto Sans JP", "Hiragino Kaku Gothic Pro", "ヒラギノ角ゴ Pro W3", メイリオ,
         Meiryo, "ＭＳ Ｐゴシック", var(--ak-generic-sans-serif);

--- a/web/src/styles/locales/ko/globals.css
+++ b/web/src/styles/locales/ko/globals.css
@@ -2,7 +2,8 @@
  * @file Korean locale global style overrides.
  */
 
-html[lang="ko"] {
+html[lang="ko"],
+html[lang^="ko-"] {
     --ak-font-family-sans-serif:
         "Noto Sans KR", "Apple SD Gothic Neo", "Malgun Gothic", "맑은 고딕", sans-serif,
         var(--ak-generic-sans-serif);


### PR DESCRIPTION
## Details

Small fix to better select language codes in the `html[lang]` attribute.