### PR TITLE
enterprise/providers: WSFed configurable realm, default wreply

### DIFF
--- a/authentik/enterprise/providers/ws_federation/api/providers.py
+++ b/authentik/enterprise/providers/ws_federation/api/providers.py
@@ -2,10 +2,9 @@
 
 from django.http import HttpRequest
 from django.urls import reverse
-from rest_framework.fields import SerializerMethodField, URLField
+from rest_framework.fields import CharField, SerializerMethodField, URLField
 
 from authentik.core.api.providers import ProviderSerializer
-from authentik.core.models import Application
 from authentik.enterprise.api import EnterpriseRequiredMixin
 from authentik.enterprise.providers.ws_federation.models import WSFederationProvider
 from authentik.enterprise.providers.ws_federation.processors.metadata import MetadataProcessor
@@ -16,8 +15,8 @@ class WSFederationProviderSerializer(EnterpriseRequiredMixin, SAMLProviderSerial
     """WSFederationProvider Serializer"""
 
     reply_url = URLField(source="acs_url")
+    wtrealm = CharField(source="issuer")
     url_wsfed = SerializerMethodField()
-    wtrealm = SerializerMethodField()
 
     def get_url_wsfed(self, instance: WSFederationProvider) -> str:
         """Get WS-Fed url"""
@@ -26,16 +25,11 @@ class WSFederationProviderSerializer(EnterpriseRequiredMixin, SAMLProviderSerial
         request: HttpRequest = self._context["request"]._request
         return request.build_absolute_uri(reverse("authentik_providers_ws_federation:wsfed"))
 
-    def get_wtrealm(self, instance: WSFederationProvider) -> str:
-        try:
-            return f"goauthentik.io://app/{instance.application.slug}"
-        except Application.DoesNotExist:
-            return None
-
     class Meta(SAMLProviderSerializer.Meta):
         model = WSFederationProvider
         fields = ProviderSerializer.Meta.fields + [
             "reply_url",
+            "wtrealm",
             "assertion_valid_not_before",
             "assertion_valid_not_on_or_after",
             "session_valid_not_on_or_after",
@@ -51,7 +45,6 @@ class WSFederationProviderSerializer(EnterpriseRequiredMixin, SAMLProviderSerial
             "default_name_id_policy",
             "url_download_metadata",
             "url_wsfed",
-            "wtrealm",
         ]
         extra_kwargs = ProviderSerializer.Meta.extra_kwargs
 

--- a/authentik/enterprise/providers/ws_federation/api/providers.py
+++ b/authentik/enterprise/providers/ws_federation/api/providers.py
@@ -15,7 +15,7 @@ class WSFederationProviderSerializer(EnterpriseRequiredMixin, SAMLProviderSerial
     """WSFederationProvider Serializer"""
 
     reply_url = URLField(source="acs_url")
-    wtrealm = CharField(source="issuer")
+    wtrealm = CharField(source="audience")
     url_wsfed = SerializerMethodField()
 
     def get_url_wsfed(self, instance: WSFederationProvider) -> str:

--- a/authentik/enterprise/providers/ws_federation/models.py
+++ b/authentik/enterprise/providers/ws_federation/models.py
@@ -8,6 +8,10 @@ from authentik.providers.saml.models import SAMLProvider
 class WSFederationProvider(SAMLProvider):
     """WS-Federation for applications which support WS-Fed."""
 
+    # Alias'd fields:
+    # - acs_url -> reply_url
+    # - issuer -> realm / wtrealm
+
     @property
     def serializer(self) -> type[Serializer]:
         from authentik.enterprise.providers.ws_federation.api.providers import (

--- a/authentik/enterprise/providers/ws_federation/models.py
+++ b/authentik/enterprise/providers/ws_federation/models.py
@@ -10,7 +10,7 @@ class WSFederationProvider(SAMLProvider):
 
     # Alias'd fields:
     # - acs_url -> reply_url
-    # - issuer -> realm / wtrealm
+    # - audience -> realm / wtrealm
 
     @property
     def serializer(self) -> type[Serializer]:

--- a/authentik/enterprise/providers/ws_federation/processors/sign_in.py
+++ b/authentik/enterprise/providers/ws_federation/processors/sign_in.py
@@ -61,7 +61,7 @@ class SignInRequest:
 
     def get_app_provider(self):
         provider: WSFederationProvider = get_object_or_404(
-            WSFederationProvider, issuer=self.wtrealm
+            WSFederationProvider, audience=self.wtrealm
         )
         application = get_object_or_404(Application, provider=provider)
         return application, provider

--- a/authentik/enterprise/providers/ws_federation/processors/sign_in.py
+++ b/authentik/enterprise/providers/ws_federation/processors/sign_in.py
@@ -53,6 +53,8 @@ class SignInRequest:
         )
 
         _, provider = req.get_app_provider()
+        if not req.wreply:
+            req.wreply = provider.acs_url
         if not req.wreply.startswith(provider.acs_url):
             raise ValueError("Invalid wreply")
         return req

--- a/authentik/enterprise/providers/ws_federation/processors/sign_out.py
+++ b/authentik/enterprise/providers/ws_federation/processors/sign_out.py
@@ -38,7 +38,7 @@ class SignOutRequest:
 
     def get_app_provider(self):
         provider: WSFederationProvider = get_object_or_404(
-            WSFederationProvider, issuer=self.wtrealm
+            WSFederationProvider, audience=self.wtrealm
         )
         application = get_object_or_404(Application, provider=provider)
         return application, provider

--- a/authentik/enterprise/providers/ws_federation/processors/sign_out.py
+++ b/authentik/enterprise/providers/ws_federation/processors/sign_out.py
@@ -30,6 +30,8 @@ class SignOutRequest:
         )
 
         _, provider = req.get_app_provider()
+        if not req.wreply:
+            req.wreply = provider.acs_url
         if not req.wreply.startswith(provider.acs_url):
             raise ValueError("Invalid wreply")
         return req

--- a/authentik/enterprise/providers/ws_federation/tests/test_sign_in.py
+++ b/authentik/enterprise/providers/ws_federation/tests/test_sign_in.py
@@ -43,7 +43,6 @@ class TestWSFedSignIn(TestCase):
                 wtrealm="",
                 wreply="",
                 wctx=None,
-                app_slug="",
             ),
         )
         token = proc.response()[WS_FED_POST_KEY_RESULT]
@@ -65,7 +64,6 @@ class TestWSFedSignIn(TestCase):
                 wtrealm="",
                 wreply="",
                 wctx=None,
-                app_slug="",
             ),
         )
         token = proc.response()[WS_FED_POST_KEY_RESULT]

--- a/blueprints/schema.json
+++ b/blueprints/schema.json
@@ -7165,6 +7165,11 @@
                     "minLength": 1,
                     "title": "Reply url"
                 },
+                "wtrealm": {
+                    "type": "string",
+                    "minLength": 1,
+                    "title": "Wtrealm"
+                },
                 "assertion_valid_not_before": {
                     "type": "string",
                     "minLength": 1,

--- a/schema.yml
+++ b/schema.yml
@@ -50214,6 +50214,9 @@ components:
           type: string
           format: uri
           minLength: 1
+        wtrealm:
+          type: string
+          minLength: 1
         assertion_valid_not_before:
           type: string
           minLength: 1
@@ -57123,6 +57126,8 @@ components:
         reply_url:
           type: string
           format: uri
+        wtrealm:
+          type: string
         assertion_valid_not_before:
           type: string
           description: 'Assertion valid not before current time + this value (Format:
@@ -57183,9 +57188,6 @@ components:
           type: string
           description: Get WS-Fed url
           readOnly: true
-        wtrealm:
-          type: string
-          readOnly: true
       required:
       - assigned_application_name
       - assigned_application_slug
@@ -57232,6 +57234,9 @@ components:
         reply_url:
           type: string
           format: uri
+          minLength: 1
+        wtrealm:
+          type: string
           minLength: 1
         assertion_valid_not_before:
           type: string
@@ -57293,6 +57298,7 @@ components:
       - invalidation_flow
       - name
       - reply_url
+      - wtrealm
     WebAuthnDevice:
       type: object
       description: Serializer for WebAuthn authenticator devices

--- a/tests/e2e/test_provider_ws_fed.py
+++ b/tests/e2e/test_provider_ws_fed.py
@@ -18,6 +18,10 @@ from tests.e2e.utils import SeleniumTestCase, retry
 class TestProviderWSFed(SeleniumTestCase):
     """test WS Federation flow"""
 
+    def setUp(self):
+        self.realm = generate_id()
+        super().setUp()
+
     def setup_client(self, provider: WSFederationProvider, app: Application, **kwargs):
         metadata_url = (
             self.url(
@@ -32,7 +36,7 @@ class TestProviderWSFed(SeleniumTestCase):
                 "8080": "8080",
             },
             environment={
-                "WSFED_TEST_SP_WTREALM": f"goauthentik.io://app/{app.slug}",
+                "WSFED_TEST_SP_WTREALM": self.realm,
                 "WSFED_TEST_SP_METADATA": metadata_url,
                 **kwargs,
             },
@@ -61,6 +65,7 @@ class TestProviderWSFed(SeleniumTestCase):
         provider = WSFederationProvider.objects.create(
             name=generate_id(),
             acs_url="http://localhost:8080",
+            issuer=self.realm,
             authorization_flow=authorization_flow,
             invalidation_flow=invalidation_flow,
             signing_kp=create_test_cert(),
@@ -147,6 +152,7 @@ class TestProviderWSFed(SeleniumTestCase):
         provider = WSFederationProvider.objects.create(
             name=generate_id(),
             acs_url="http://localhost:8080",
+            issuer=self.realm,
             authorization_flow=authorization_flow,
             signing_kp=create_test_cert(),
         )

--- a/tests/e2e/test_provider_ws_fed.py
+++ b/tests/e2e/test_provider_ws_fed.py
@@ -65,7 +65,7 @@ class TestProviderWSFed(SeleniumTestCase):
         provider = WSFederationProvider.objects.create(
             name=generate_id(),
             acs_url="http://localhost:8080",
-            issuer=self.realm,
+            audience=self.realm,
             authorization_flow=authorization_flow,
             invalidation_flow=invalidation_flow,
             signing_kp=create_test_cert(),
@@ -152,7 +152,7 @@ class TestProviderWSFed(SeleniumTestCase):
         provider = WSFederationProvider.objects.create(
             name=generate_id(),
             acs_url="http://localhost:8080",
-            issuer=self.realm,
+            audience=self.realm,
             authorization_flow=authorization_flow,
             signing_kp=create_test_cert(),
         )

--- a/web/src/admin/providers/wsfed/WSFederationProviderForm.ts
+++ b/web/src/admin/providers/wsfed/WSFederationProviderForm.ts
@@ -107,6 +107,14 @@ export class WSFederationProviderForm extends BaseProviderForm<WSFederationProvi
                         value="${ifDefined(this.instance?.replyUrl)}"
                         required
                     ></ak-text-input>
+                    <ak-text-input
+                        name="wtrealm"
+                        label=${msg("Realm")}
+                        placeholder=${msg("")}
+                        input-hint="code"
+                        value="${ifDefined(this.instance?.wtrealm)}"
+                        required
+                    ></ak-text-input>
                 </div>
             </ak-form-group>
 


### PR DESCRIPTION
- Make realm configurable (certain clients such as MS Entra have a hardcoded realm requirement)
- Fallback to configured wreply value if no wreply URL parameter is given