### PR TITLE
core: bump django from v5.2.8 to 5.2.11 (version-2025.10)

### DIFF
--- a/authentik/root/settings.py
+++ b/authentik/root/settings.py
@@ -474,7 +474,7 @@ STORAGES = {
 # as the maximum for a URL to redirect to, mostly for running on windows.
 # However our URLs can easily exceed that with OAuth/SAML Query parameters or hash values
 # 8192 should cover most cases..
-http_response.MAX_URL_LENGTH = http_response.MAX_URL_LENGTH * 4
+http_response.MAX_URL_REDIRECT_LENGTH = http_response.MAX_URL_REDIRECT_LENGTH * 4
 
 
 # Media files

--- a/authentik/root/settings.py
+++ b/authentik/root/settings.py
@@ -6,7 +6,7 @@ from hashlib import sha512
 from pathlib import Path
 
 import orjson
-from django.http import response as http_response
+from django.utils import http as utils_http
 from sentry_sdk import set_tag
 from xmlsec import enable_debug_trace
 
@@ -474,7 +474,7 @@ STORAGES = {
 # as the maximum for a URL to redirect to, mostly for running on windows.
 # However our URLs can easily exceed that with OAuth/SAML Query parameters or hash values
 # 8192 should cover most cases..
-http_response.MAX_URL_REDIRECT_LENGTH = http_response.MAX_URL_REDIRECT_LENGTH * 4
+utils_http.MAX_URL_LENGTH = utils_http.MAX_URL_LENGTH * 4
 
 
 # Media files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
   "dacite==1.9.2",
   "deepmerge==2.0",
   "defusedxml==0.7.1",
-  "django==5.2.8",
+  "django==5.2.11",
   "django-channels-postgres",
   "django-countries==7.6.1",
   "django-cte==2.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -284,7 +284,7 @@ requires-dist = [
     { name = "dacite", specifier = "==1.9.2" },
     { name = "deepmerge", specifier = "==2.0" },
     { name = "defusedxml", specifier = "==0.7.1" },
-    { name = "django", specifier = "==5.2.8" },
+    { name = "django", specifier = "==5.2.11" },
     { name = "django-channels-postgres", editable = "packages/django-channels-postgres" },
     { name = "django-countries", specifier = "==7.6.1" },
     { name = "django-cte", specifier = "==2.0.0" },
@@ -977,16 +977,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.2.8"
+version = "5.2.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/a2/933dbbb3dd9990494960f6e64aca2af4c0745b63b7113f59a822df92329e/django-5.2.8.tar.gz", hash = "sha256:23254866a5bb9a2cfa6004e8b809ec6246eba4b58a7589bc2772f1bcc8456c7f", size = 10849032, upload-time = "2025-11-05T14:07:32.778Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/f2/3e57ef696b95067e05ae206171e47a8e53b9c84eec56198671ef9eaa51a6/django-5.2.11.tar.gz", hash = "sha256:7f2d292ad8b9ee35e405d965fbbad293758b858c34bbf7f3df551aeeac6f02d3", size = 10885017, upload-time = "2026-02-03T13:52:50.554Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/3d/a035a4ee9b1d4d4beee2ae6e8e12fe6dee5514b21f62504e22efcbd9fb46/django-5.2.8-py3-none-any.whl", hash = "sha256:37e687f7bd73ddf043e2b6b97cfe02fcbb11f2dbb3adccc6a2b18c6daa054d7f", size = 8289692, upload-time = "2025-11-05T14:07:28.761Z" },
+    { url = "https://files.pythonhosted.org/packages/91/a7/2b112ab430575bf3135b8304ac372248500d99c352f777485f53fdb9537e/django-5.2.11-py3-none-any.whl", hash = "sha256:e7130df33ada9ab5e5e929bc19346a20fe383f5454acb2cc004508f242ee92c0", size = 8291375, upload-time = "2026-02-03T13:52:42.47Z" },
 ]
 
 [[package]]


### PR DESCRIPTION


## Details



---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
