### PR TITLE
website/docs: automated install: mention no file:// vars

### DIFF
--- a/website/docs/install-config/automated-install.mdx
+++ b/website/docs/install-config/automated-install.mdx
@@ -5,7 +5,7 @@ title: Automated install
 To install authentik automatically (skipping the Out-of-box experience), you can use the following environment variables on the worker container:
 
 :::info
-These can't be defined using the file-based syntax (`file://`), so you can't pass them in as secrets in a docker-compose install.
+These can't be defined using the file-based syntax (`file://`), so you can't pass them in as secrets in a Docker Compose installation.
 :::
 
 ### `AUTHENTIK_BOOTSTRAP_PASSWORD`

--- a/website/docs/install-config/automated-install.mdx
+++ b/website/docs/install-config/automated-install.mdx
@@ -4,6 +4,10 @@ title: Automated install
 
 To install authentik automatically (skipping the Out-of-box experience), you can use the following environment variables on the worker container:
 
+:::info
+These can't be defined using the file-based syntax (`file://`), so you can't pass them in as secrets in a docker-compose install.
+:::
+
 ### `AUTHENTIK_BOOTSTRAP_PASSWORD`
 
 Configure the default password for the `akadmin` user. Only read on the first startup. Can be used for any flow executor.


### PR DESCRIPTION
Add note about environment variable limitations in automated install guide.

Linked to https://github.com/goauthentik/authentik/issues/11023
