### PR TITLE
website/docs: endpoint devices: fix non debian wording

### DIFF
--- a/website/docs/endpoint-devices/authentik-agent/agent-deployment/linux.mdx
+++ b/website/docs/endpoint-devices/authentik-agent/agent-deployment/linux.mdx
@@ -125,7 +125,7 @@ sudo ak-sysd domains join <deployment_name> --authentik-url https://authentik.co
 2. You will be prompted to enter your [enrollment token](#create-an-enrollment-token).
 3. Once provided, the device will be enrolled with your authentik deployment and should appear on the [Devices page](../../manage-devices.mdx) after a [check-in](../../device-compliance/device-reporting.md) is completed.
 
-### Local device login on Debian-based systems
+### Local device login on non-Debian systems
 
 On non-Debian Linux distributions, you currently need to manually configure NSS and PAM:
 

--- a/website/docs/endpoint-devices/device-authentication/local-device-login/linux.md
+++ b/website/docs/endpoint-devices/device-authentication/local-device-login/linux.md
@@ -29,4 +29,4 @@ When configured correctly, when logging in you should see a prompt for **authent
 ## Known issues
 
 - Only Webauthn MFA is supported.
-- On non-Debian Linux distributions, you currently need to [manually configure NSS and PAM](../../authentik-agent/agent-deployment/linux.mdx#local-device-login-on-debian-based-systems).
+- On non-Debian Linux distributions, you currently need to [manually configure NSS and PAM](../../authentik-agent/agent-deployment/linux.mdx#local-device-login-on-non-debian-systems).


### PR DESCRIPTION
## Details

Fixes header and link wording

---

## Checklist

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
