### PR TITLE
website/docs: remove redundant RC notice

### DIFF
--- a/website/docs/releases/_template.md
+++ b/website/docs/releases/_template.md
@@ -3,12 +3,6 @@ title: Release xxxx.x
 slug: "/releases/xxxx.x"
 ---
 
-:::info
-xxxx.x has not been released yet! We're publishing these release notes as a preview of what's to come, and for our awesome beta testers trying out release candidates.
-
-To try out the release candidate, replace your Docker image tag with the latest release candidate number, such as xxxx.x.0-rc1. You can find the latest one in [the latest releases on GitHub](https://github.com/goauthentik/authentik/releases). If you don't find any, it means we haven't released one yet.
-:::
-
 ## Highlights
 
 <!-- ## Breaking changes -->


### PR DESCRIPTION
This is already done by https://github.com/goauthentik/authentik/blob/95233dd9f8d7af4e72b8f53bc525d6b61b76cf22/website/docusaurus-theme/theme/DocItem/Content/PreReleaseAdmonition.tsx#L37