### PR TITLE
internal: define package variables for paths

### DIFF
--- a/internal/gounicorn/gounicorn.go
+++ b/internal/gounicorn/gounicorn.go
@@ -17,6 +17,13 @@ import (
 	"goauthentik.io/internal/utils"
 )
 
+var (
+	manageCmd    string = "./manage.py"
+	gunicornCmd  string = "gunicorn"
+	gunicornConf string = "./lifecycle/gunicorn.conf.py"
+	pidDir       string = ""
+)
+
 type GoUnicorn struct {
 	Healthcheck      func() bool
 	healthyCallbacks []func()
@@ -58,16 +65,16 @@ func New(healthcheck func() bool) *GoUnicorn {
 }
 
 func (g *GoUnicorn) initCmd() {
-	command := "./manage.py"
+	command := manageCmd
 	args := []string{"dev_server"}
 	if !config.Get().Debug {
-		pidFile, err := os.CreateTemp("", "authentik-gunicorn.*.pid")
+		pidFile, err := os.CreateTemp(pidDir, "authentik-gunicorn.*.pid")
 		if err != nil {
 			panic(fmt.Errorf("failed to create temporary pid file: %v", err))
 		}
 		g.pidFile = pidFile.Name()
-		command = "gunicorn"
-		args = []string{"-c", "./lifecycle/gunicorn.conf.py", "authentik.root.asgi:application"}
+		command = gunicornCmd
+		args = []string{"-c", gunicornConf, "authentik.root.asgi:application"}
 		if g.pidFile != "" {
 			args = append(args, "--pid", g.pidFile)
 		}

--- a/internal/web/static.go
+++ b/internal/web/static.go
@@ -64,7 +64,7 @@ func (ws *WebServer) configureStatic() {
 	staticRouter.Use(ws.staticHeaderMiddleware)
 	staticRouter.Use(web.DisableIndex)
 
-	distFs := http.FileServer(http.Dir("./web/dist"))
+	distFs := http.FileServer(staticWeb.StaticDir)
 
 	pathStripper := func(handler http.Handler, paths ...string) http.Handler {
 		h := handler

--- a/web/static.go
+++ b/web/static.go
@@ -11,6 +11,8 @@ var RobotsTxt []byte
 //go:embed security.txt
 var SecurityTxt []byte
 
-var StaticDir = http.Dir("./web/dist/")
+var staticDir = "./web/dist/"
+
+var StaticDir = http.Dir(staticDir)
 
 var StaticHandler = http.FileServer(StaticDir)


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details
During distribution packaging, files are typically installed in standardized paths (for example, adhering to the FHS). Avoid the need for patching the source code to facilitate this by allowing the paths needed by the server to be overwritten at build time.

The defaults are kept as they are to not affect existing behavior.

Example usage (simplified):
```
$ go build \
  -ldflags '-X "goauthentik.io/internal/gounicorn.manageCmd=/usr/bin/ak-manage" -X "goauthentik.io/internal/gounicorn.gunicornCmd=/usr/bin/gunicorn" -X "goauthentik.io/internal/gounicorn.gunicornConf=/etc/authentik/gunicorn.conf.py" -X "goauthentik.io/internal/gounicorn.pidDir=/run/authentik" -X "goauthentik.io/web.staticDir=/usr/share/authentik/web/dist"' ./cmd/server
```

Ideally, similar functionality would also exist for the various path references in the Python code. However, those require further consideration as there is no equivalent concept of build time options like there is in Go.

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
