### PR TITLE
web: Allow unused spreaded properties to strict unsafe.

### DIFF
--- a/web/src/admin/sources/SourceListPage.ts
+++ b/web/src/admin/sources/SourceListPage.ts
@@ -19,7 +19,7 @@ import { StrictUnsafe } from "#elements/utils/unsafe";
 
 import { Source, SourcesApi } from "@goauthentik/api";
 
-import { msg } from "@lit/localize";
+import { msg, str } from "@lit/localize";
 import { html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
@@ -75,9 +75,10 @@ export class SourceListPage extends TablePage<Source> {
     }
 
     row(item: Source): SlottedTemplateResult[] {
-        if (item.component === "") {
+        if (!item.component) {
             return this.rowInbuilt(item);
         }
+
         return [
             html`<a href="#/core/sources/${item.slug}">
                 <div>${item.name}</div>
@@ -91,6 +92,11 @@ export class SourceListPage extends TablePage<Source> {
             html` <ak-forms-modal>
                 ${StrictUnsafe<CustomFormElementTagName>(item.component, {
                     instancePk: item.slug,
+                    slot: "form",
+                    actionLabel: msg("Update"),
+                    headline: msg(str`Update ${item.verboseName}`, {
+                        id: "form.headline.update",
+                    }),
                 })}
                 <button slot="trigger" class="pf-c-button pf-m-plain">
                     <pf-tooltip position="top" content=${msg("Edit")}>

--- a/web/src/elements/forms/ModelForm.ts
+++ b/web/src/elements/forms/ModelForm.ts
@@ -41,7 +41,7 @@ export abstract class ModelForm<
      * @see {@linkcode loadInstance}
      * @returns A promise that resolves when the data has been loaded.
      */
-    async load(): Promise<void> {
+    protected async load(): Promise<void> {
         return Promise.resolve();
     }
 
@@ -104,7 +104,7 @@ export abstract class ModelForm<
             return;
         }
 
-        this.loadInstance(this.#instancePk).then((instance) => {
+        return this.loadInstance(this.#instancePk).then((instance) => {
             this.instance = instance;
         });
     };

--- a/web/src/elements/utils/unsafe.ts
+++ b/web/src/elements/utils/unsafe.ts
@@ -100,13 +100,7 @@ export function StrictUnsafe<T extends string>(
 
             if (observedAttributes.has(key) || key in ElementConstructor.prototype) {
                 filteredProps[key] = String(value);
-
-                continue;
             }
-
-            throw new TypeError(
-                `Property or attribute \`${key}\` is not defined on custom element ${tagName}`,
-            );
         }
 
         return staticHTML`<${unsafeStatic(tagName)} ${spread(filteredProps)}></${unsafeStatic(tagName)}>`;


### PR DESCRIPTION
## Details

This PR fixes a runtime error that occurs on the sources wizard:

```ts
return html`
    <ak-wizard-page-form
        slot=${`type-${type.component}-${type.modelName}`}
        label=${msg(str`Create ${type.name}`)}
    >
        ${StrictUnsafe<CustomFormElementTagName>(type.component, {
            modelName: type.modelName,
        })}
    </ak-wizard-page-form>
`;
```

The issue stems from `StrictUnsafe` throwing an error on components which do not implement the `modelName` property. This was initially to catch errors, but given our common pattern of spreading attributes and properties over a union of elements, it may be more ergonomic to allow this JSX-like behavior.