### PR TITLE
sources/oauth: Fix InvalidAudienceError in id_token fallback

### DIFF
--- a/authentik/sources/oauth/tests/test_type_openid.py
+++ b/authentik/sources/oauth/tests/test_type_openid.py
@@ -62,9 +62,11 @@ class TestTypeOpenID(TestCase):
 
     @Mocker()
     def test_userinfo_jwt(self, mock: Mocker):
-        """Test userinfo API call"""
+        """Test userinfo API call including audience validation"""
         jwks_cert = create_test_cert()
+        client_id = generate_id()
         self.source.profile_url = ""
+        self.source.consumer_key = client_id
         self.source.oidc_jwks = {"keys": [JWKSView.get_jwk_for_key(jwks_cert, "sig")]}
         self.source.save()
         token = generate_id()
@@ -78,6 +80,7 @@ class TestTypeOpenID(TestCase):
                     "id_token": encode(
                         {
                             "foo": "bar",
+                            "aud": client_id,
                         },
                         key=jwks_cert.private_key,
                         algorithm="RS256",
@@ -90,5 +93,6 @@ class TestTypeOpenID(TestCase):
             profile,
             {
                 "foo": "bar",
+                "aud": client_id,
             },
         )

--- a/authentik/sources/oauth/tests/test_type_openid.py
+++ b/authentik/sources/oauth/tests/test_type_openid.py
@@ -1,5 +1,7 @@
 """OpenID Type tests"""
 
+import time
+
 from django.test import RequestFactory, TestCase
 from jwt import encode
 from requests_mock import Mocker
@@ -70,7 +72,7 @@ class TestTypeOpenID(TestCase):
         self.source.oidc_jwks = {"keys": [JWKSView.get_jwk_for_key(jwks_cert, "sig")]}
         self.source.save()
         token = generate_id()
-        now = 12345
+        now = int(time.time())
         id_token_payload = {
             "iss": "https://example.com",
             "sub": OPENID_USER["sub"],

--- a/authentik/sources/oauth/types/oidc.py
+++ b/authentik/sources/oauth/types/oidc.py
@@ -49,8 +49,9 @@ class OpenIDConnectClient(UserprofileHeaderAuthClient):
             raw = get_unverified_header(id_token)
             jwk = PyJWKSet.from_dict(self.source.oidc_jwks)
             key = [key for key in jwk.keys if key.key_id == raw["kid"]][0]
-            return decode(id_token, key=key, algorithms=raw["alg"])
-        except PyJWTError, IndexError, ValueError:
+            return decode(id_token, key=key, algorithms=[raw["alg"]], audience=self.get_client_id())
+        except (PyJWTError, IndexError, ValueError) as exc:
+            self.logger.warning("Failed to decode id_token", exc=exc)
             return None
 
 

--- a/authentik/sources/oauth/types/oidc.py
+++ b/authentik/sources/oauth/types/oidc.py
@@ -49,7 +49,13 @@ class OpenIDConnectClient(UserprofileHeaderAuthClient):
             raw = get_unverified_header(id_token)
             jwk = PyJWKSet.from_dict(self.source.oidc_jwks)
             key = [key for key in jwk.keys if key.key_id == raw["kid"]][0]
-            return decode(id_token, key=key, algorithms=[raw["alg"]], audience=self.get_client_id())
+            return decode(
+                id_token,
+                key=key,
+                algorithms=[raw["alg"]],
+                audience=self.get_client_id(),
+                options={"verify_iss": False},
+            )
         except (PyJWTError, IndexError, ValueError) as exc:
             self.logger.warning("Failed to decode id_token", exc=exc)
             return None


### PR DESCRIPTION

## Details
When using an OIDC source without a profile URL (relying on id_token claims fallback), authentication fails with InvalidAudienceError if the id_token contains an aud claim. The decode() call in OpenIDConnectClient.get_profile_info() doesn't pass an expected audience parameter. PyJWT validates the aud claim by default when present, causing the decode to fail.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
