### PR TITLE
web: Filter users by inactive

### DIFF
--- a/web/src/admin/users/UserListPage.ts
+++ b/web/src/admin/users/UserListPage.ts
@@ -18,10 +18,9 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { PFSize } from "#common/enums";
 import { parseAPIResponseError } from "#common/errors/network";
 import { userTypeToLabel } from "#common/labels";
-import { MessageLevel } from "#common/messages";
 import { DefaultUIConfig } from "#common/ui/config";
 
-import { showAPIErrorMessage, showMessage } from "#elements/messages/MessageContainer";
+import { showAPIErrorMessage } from "#elements/messages/MessageContainer";
 import { WithBrandConfig } from "#elements/mixins/branding";
 import { CapabilitiesEnum, WithCapabilitiesConfig } from "#elements/mixins/capabilities";
 import { WithSession } from "#elements/mixins/session";
@@ -29,7 +28,7 @@ import { getURLParam, getURLParams, updateURLParams } from "#elements/router/Rou
 import { PaginatedResponse, TableColumn, Timestamp } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
 import { SlottedTemplateResult } from "#elements/types";
-import { writeToClipboard } from "#elements/utils/writeToClipboard";
+import { writeToClipboard } from "#common/clipboard";
 
 import { CoreApi, CoreUsersExportCreateRequest, User, UserPath } from "@goauthentik/api";
 
@@ -49,17 +48,7 @@ export const requestRecoveryLink = (user: User) =>
         .coreUsersRecoveryCreate({
             id: user.pk,
         })
-        .then((rec) =>
-            writeToClipboard(rec.link).then((wroteToClipboard) =>
-                showMessage({
-                    level: MessageLevel.success,
-                    message: rec.link,
-                    description: wroteToClipboard
-                        ? msg("A copy of this recovery link has been placed in your clipboard")
-                        : "",
-                }),
-            ),
-        )
+        .then((rec) => writeToClipboard(rec.link, msg("Recovery link")))
         .catch((error: unknown) => parseAPIResponseError(error).then(showAPIErrorMessage));
 
 export const renderRecoveryEmailRequest = (user: User) =>
@@ -172,7 +161,7 @@ export class UserListPage extends WithBrandConfig(
             const legacyHideDeactivated =
                 params.hideDeactivated === true || params.hideDeactivated === "true";
             this.userStatusFilter = legacyHideDeactivated ? "active" : "all";
-            const { hideDeactivated, ...cleanParams } = params;
+            const { hideDeactivated: _hideDeactivated, ...cleanParams } = params;
             updateURLParams({ ...cleanParams, userStatus: this.userStatusFilter }, true);
         } else {
             const urlStatus = getURLParam<string>("userStatus", "all");


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
Retrying https://github.com/goauthentik/authentik/pull/19910
For https://github.com/goauthentik/authentik/issues/20114

Replace the "Show deactivated users" toggle in the admin user list with a three-way filter that allows filtering by:
- All users (default)
- Active only
- Inactive only

In setups where new sign-ups are inactive by default, this helps simplify the searching process significantly. It also simplifies reactivations.

The existing hideDeactivated URL parameter is migrated to the new userStatus parameter for backwards compatibility.
I'm using the existing ak-toggle-group component for consistency.


<img width="1018" height="358" alt="Screenshot 2026-02-09 at 3 58 26 AM" src="https://github.com/user-attachments/assets/bd458651-9a1f-4df5-b6d2-5a4d928359a2" />

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
