### PR TITLE
policies: disable prometheus metrics in policies (2025.10)

### DIFF
--- a/authentik/policies/process.py
+++ b/authentik/policies/process.py
@@ -11,8 +11,6 @@ from structlog.stdlib import get_logger
 from authentik.events.models import Event, EventAction
 from authentik.lib.config import CONFIG
 from authentik.lib.utils.errors import exception_to_dict
-from authentik.lib.utils.reflection import class_to_path
-from authentik.policies.apps import HIST_POLICIES_EXECUTION_TIME
 from authentik.policies.exceptions import PolicyException
 from authentik.policies.models import PolicyBinding
 from authentik.policies.types import CACHE_PREFIX, PolicyRequest, PolicyResult
@@ -123,18 +121,9 @@ class PolicyProcess(PROCESS_CLASS):
 
     def profiling_wrapper(self):
         """Run with profiling enabled"""
-        with (
-            start_span(
-                op="authentik.policy.process.execute",
-            ) as span,
-            HIST_POLICIES_EXECUTION_TIME.labels(
-                binding_order=self.binding.order,
-                binding_target_type=self.binding.target_type,
-                binding_target_name=self.binding.target_name,
-                object_type=class_to_path(self.request.obj.__class__) if self.request.obj else "",
-                mode="execute_process",
-            ).time(),
-        ):
+        with start_span(
+            op="authentik.policy.process.execute",
+        ) as span:
             span: Span
             span.set_data("policy", self.binding.policy)
             span.set_data("request", self.request)


### PR DESCRIPTION
creates a lot of .db files for each policy process