### PR TITLE
website/docs: endpoint/devices: add authentik version tags

### DIFF
--- a/website/docs/endpoint-devices/authentik-agent/agent-deployment/automated.mdx
+++ b/website/docs/endpoint-devices/authentik-agent/agent-deployment/automated.mdx
@@ -2,7 +2,7 @@
 title: Automated authentik Agent deployment
 sidebar_label: Automated
 tags: [authentik Agent, mdm, fleet, deploy]
-authentik_version: "2025.12.0+"
+authentik_version: "2025.12.0"
 ---
 
 authentik Agent can be deployed at scale to multiple devices via Mobile Device Management (MDM) and automation tools.

--- a/website/docs/endpoint-devices/authentik-agent/agent-deployment/automated.mdx
+++ b/website/docs/endpoint-devices/authentik-agent/agent-deployment/automated.mdx
@@ -2,6 +2,7 @@
 title: Automated authentik Agent deployment
 sidebar_label: Automated
 tags: [authentik Agent, mdm, fleet, deploy]
+authentik_version: "2025.12.0+"
 ---
 
 authentik Agent can be deployed at scale to multiple devices via Mobile Device Management (MDM) and automation tools.

--- a/website/docs/endpoint-devices/authentik-agent/agent-deployment/index.mdx
+++ b/website/docs/endpoint-devices/authentik-agent/agent-deployment/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deployment
 sidebar_label: Deployment
-authentik_version: "2025.12.0+"
+authentik_version: "2025.12.0"
 ---
 
 import DocCardList from "@theme/DocCardList";

--- a/website/docs/endpoint-devices/authentik-agent/agent-deployment/index.mdx
+++ b/website/docs/endpoint-devices/authentik-agent/agent-deployment/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Deployment
 sidebar_label: Deployment
+authentik_version: "2025.12.0+"
 ---
 
 import DocCardList from "@theme/DocCardList";

--- a/website/docs/endpoint-devices/authentik-agent/agent-deployment/linux.mdx
+++ b/website/docs/endpoint-devices/authentik-agent/agent-deployment/linux.mdx
@@ -2,7 +2,7 @@
 title: Deploy authentik Agent on Linux
 sidebar_label: Linux
 tags: [authentik Agent, linux, deploy, packages]
-authentik_version: "2025.12.0+"
+authentik_version: "2025.12.0"
 ---
 
 import TabItem from "@theme/TabItem";

--- a/website/docs/endpoint-devices/authentik-agent/agent-deployment/linux.mdx
+++ b/website/docs/endpoint-devices/authentik-agent/agent-deployment/linux.mdx
@@ -2,6 +2,7 @@
 title: Deploy authentik Agent on Linux
 sidebar_label: Linux
 tags: [authentik Agent, linux, deploy, packages]
+authentik_version: "2025.12.0+"
 ---
 
 import TabItem from "@theme/TabItem";

--- a/website/docs/endpoint-devices/authentik-agent/agent-deployment/macos.md
+++ b/website/docs/endpoint-devices/authentik-agent/agent-deployment/macos.md
@@ -2,6 +2,7 @@
 title: Deploy authentik Agent on macOS
 sidebar_label: macOS
 tags: [authentik Agent, mac, macos, deploy]
+authentik_version: "2025.12.0+"
 ---
 
 ## What it can do

--- a/website/docs/endpoint-devices/authentik-agent/agent-deployment/macos.md
+++ b/website/docs/endpoint-devices/authentik-agent/agent-deployment/macos.md
@@ -2,7 +2,7 @@
 title: Deploy authentik Agent on macOS
 sidebar_label: macOS
 tags: [authentik Agent, mac, macos, deploy]
-authentik_version: "2025.12.0+"
+authentik_version: "2025.12.0"
 ---
 
 ## What it can do

--- a/website/docs/endpoint-devices/authentik-agent/agent-deployment/windows.md
+++ b/website/docs/endpoint-devices/authentik-agent/agent-deployment/windows.md
@@ -2,6 +2,7 @@
 title: Deploy authentik Agent on Windows
 sidebar_label: Windows
 tags: [authentik Agent, windows]
+authentik_version: "2025.12.0+"
 ---
 
 ## What it can do

--- a/website/docs/endpoint-devices/authentik-agent/agent-deployment/windows.md
+++ b/website/docs/endpoint-devices/authentik-agent/agent-deployment/windows.md
@@ -2,7 +2,7 @@
 title: Deploy authentik Agent on Windows
 sidebar_label: Windows
 tags: [authentik Agent, windows]
-authentik_version: "2025.12.0+"
+authentik_version: "2025.12.0"
 ---
 
 ## What it can do

--- a/website/docs/endpoint-devices/authentik-agent/configuration.md
+++ b/website/docs/endpoint-devices/authentik-agent/configuration.md
@@ -2,6 +2,7 @@
 title: Configuration
 sidebar_label: Configuration
 tags: [authentik Agent, connector, configure, configuration]
+authentik_version: "2025.12.0+"
 ---
 
 Before deploying the authentik Agent, configure your authentik deployment. This involves:

--- a/website/docs/endpoint-devices/authentik-agent/configuration.md
+++ b/website/docs/endpoint-devices/authentik-agent/configuration.md
@@ -2,7 +2,7 @@
 title: Configuration
 sidebar_label: Configuration
 tags: [authentik Agent, connector, configure, configuration]
-authentik_version: "2025.12.0+"
+authentik_version: "2025.12.0"
 ---
 
 Before deploying the authentik Agent, configure your authentik deployment. This involves:

--- a/website/docs/endpoint-devices/authentik-agent/device-authentication/cli-app-authentication/aws.mdx
+++ b/website/docs/endpoint-devices/authentik-agent/device-authentication/cli-app-authentication/aws.mdx
@@ -2,6 +2,7 @@
 title: AWS CLI authentication
 sidebar_label: AWS
 tags: [authentik Agent, authentik cli, aws, cli]
+authentik_version: "2025.12.0+"
 ---
 
 You can use the authentik Agent to authenticate to the AWS CLI with authentik credentials.

--- a/website/docs/endpoint-devices/authentik-agent/device-authentication/cli-app-authentication/aws.mdx
+++ b/website/docs/endpoint-devices/authentik-agent/device-authentication/cli-app-authentication/aws.mdx
@@ -2,7 +2,7 @@
 title: AWS CLI authentication
 sidebar_label: AWS
 tags: [authentik Agent, authentik cli, aws, cli]
-authentik_version: "2025.12.0+"
+authentik_version: "2025.12.0"
 ---
 
 You can use the authentik Agent to authenticate to the AWS CLI with authentik credentials.

--- a/website/docs/endpoint-devices/authentik-agent/device-authentication/cli-app-authentication/index.mdx
+++ b/website/docs/endpoint-devices/authentik-agent/device-authentication/cli-app-authentication/index.mdx
@@ -2,6 +2,7 @@
 title: CLI application authentication
 sidebar_label: CLI application authentication
 tags: [authentik Agent, authentik cli, kubernetes, k8s, aws, cli]
+authentik_version: "2025.12.0+"
 ---
 
 import DocCardList from "@theme/DocCardList";

--- a/website/docs/endpoint-devices/authentik-agent/device-authentication/cli-app-authentication/index.mdx
+++ b/website/docs/endpoint-devices/authentik-agent/device-authentication/cli-app-authentication/index.mdx
@@ -2,7 +2,7 @@
 title: CLI application authentication
 sidebar_label: CLI application authentication
 tags: [authentik Agent, authentik cli, kubernetes, k8s, aws, cli]
-authentik_version: "2025.12.0+"
+authentik_version: "2025.12.0"
 ---
 
 import DocCardList from "@theme/DocCardList";

--- a/website/docs/endpoint-devices/authentik-agent/device-authentication/cli-app-authentication/k8s.mdx
+++ b/website/docs/endpoint-devices/authentik-agent/device-authentication/cli-app-authentication/k8s.mdx
@@ -2,6 +2,7 @@
 title: Kubernetes CLI authentication
 sidebar_label: Kubernetes
 tags: [authentik Agent, authentik cli, kubernetes, k8s, kubectl, cli]
+authentik_version: "2025.12.0+"
 ---
 
 You can use the authentik Agent to authenticate to `kubectl` with authentik credentials.

--- a/website/docs/endpoint-devices/authentik-agent/device-authentication/cli-app-authentication/k8s.mdx
+++ b/website/docs/endpoint-devices/authentik-agent/device-authentication/cli-app-authentication/k8s.mdx
@@ -2,7 +2,7 @@
 title: Kubernetes CLI authentication
 sidebar_label: Kubernetes
 tags: [authentik Agent, authentik cli, kubernetes, k8s, kubectl, cli]
-authentik_version: "2025.12.0+"
+authentik_version: "2025.12.0"
 ---
 
 You can use the authentik Agent to authenticate to `kubectl` with authentik credentials.

--- a/website/docs/endpoint-devices/authentik-agent/device-authentication/device-access-groups.mdx
+++ b/website/docs/endpoint-devices/authentik-agent/device-authentication/device-access-groups.mdx
@@ -2,6 +2,7 @@
 title: Device access groups
 sidebar_label: Device access groups
 tags: [authentik Agent, device authentication, device login, device groups]
+authentik_version: "2025.12.0+"
 ---
 
 Device access groups control access to endpoint devices. You can organize devices into groups and bind users, user groups, and policies to determine which users can access the device.

--- a/website/docs/endpoint-devices/authentik-agent/device-authentication/device-access-groups.mdx
+++ b/website/docs/endpoint-devices/authentik-agent/device-authentication/device-access-groups.mdx
@@ -2,7 +2,7 @@
 title: Device access groups
 sidebar_label: Device access groups
 tags: [authentik Agent, device authentication, device login, device groups]
-authentik_version: "2025.12.0+"
+authentik_version: "2025.12.0"
 ---
 
 Device access groups control access to endpoint devices. You can organize devices into groups and bind users, user groups, and policies to determine which users can access the device.

--- a/website/docs/endpoint-devices/authentik-agent/device-authentication/index.mdx
+++ b/website/docs/endpoint-devices/authentik-agent/device-authentication/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Device authentication
 sidebar_label: Device authentication
-authentik_version: "2025.12.0+"
+authentik_version: "2025.12.0"
 ---
 
 import DocCardList from "@theme/DocCardList";

--- a/website/docs/endpoint-devices/authentik-agent/device-authentication/index.mdx
+++ b/website/docs/endpoint-devices/authentik-agent/device-authentication/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Device authentication
 sidebar_label: Device authentication
+authentik_version: "2025.12.0+"
 ---
 
 import DocCardList from "@theme/DocCardList";

--- a/website/docs/endpoint-devices/authentik-agent/device-authentication/local-device-login/index.mdx
+++ b/website/docs/endpoint-devices/authentik-agent/device-authentication/local-device-login/index.mdx
@@ -3,7 +3,7 @@ title: Local device login
 sidebar_label: Local device login
 tags: [authentik Agent, device login, device authentication, windows credential provider, wcp]
 authentik_enterprise: true
-authentik_version: "2025.12.0+"
+authentik_version: "2025.12.0"
 ---
 
 import DocCardList from "@theme/DocCardList";

--- a/website/docs/endpoint-devices/authentik-agent/device-authentication/local-device-login/index.mdx
+++ b/website/docs/endpoint-devices/authentik-agent/device-authentication/local-device-login/index.mdx
@@ -3,6 +3,7 @@ title: Local device login
 sidebar_label: Local device login
 tags: [authentik Agent, device login, device authentication, windows credential provider, wcp]
 authentik_enterprise: true
+authentik_version: "2025.12.0+"
 ---
 
 import DocCardList from "@theme/DocCardList";

--- a/website/docs/endpoint-devices/authentik-agent/device-authentication/local-device-login/linux.md
+++ b/website/docs/endpoint-devices/authentik-agent/device-authentication/local-device-login/linux.md
@@ -3,6 +3,7 @@ title: Linux local device login
 sidebar_label: Linux
 tags: [authentik Agent, device login, device authentication, linux]
 authentik_enterprise: true
+authentik_version: "2025.12.0+"
 ---
 
 <!-- TODO @BeryJu add screenshot -->

--- a/website/docs/endpoint-devices/authentik-agent/device-authentication/local-device-login/linux.md
+++ b/website/docs/endpoint-devices/authentik-agent/device-authentication/local-device-login/linux.md
@@ -3,7 +3,7 @@ title: Linux local device login
 sidebar_label: Linux
 tags: [authentik Agent, device login, device authentication, linux]
 authentik_enterprise: true
-authentik_version: "2025.12.0+"
+authentik_version: "2025.12.0"
 ---
 
 <!-- TODO @BeryJu add screenshot -->

--- a/website/docs/endpoint-devices/authentik-agent/device-authentication/local-device-login/windows.md
+++ b/website/docs/endpoint-devices/authentik-agent/device-authentication/local-device-login/windows.md
@@ -3,6 +3,7 @@ title: Windows local device login
 sidebar_label: Windows
 tags: [authentik Agent, device login, device authentication, windows credential provider, wcp]
 authentik_enterprise: true
+authentik_version: "2025.12.0+"
 ---
 
 ## Windows Credential Provider

--- a/website/docs/endpoint-devices/authentik-agent/device-authentication/local-device-login/windows.md
+++ b/website/docs/endpoint-devices/authentik-agent/device-authentication/local-device-login/windows.md
@@ -3,7 +3,7 @@ title: Windows local device login
 sidebar_label: Windows
 tags: [authentik Agent, device login, device authentication, windows credential provider, wcp]
 authentik_enterprise: true
-authentik_version: "2025.12.0+"
+authentik_version: "2025.12.0"
 ---
 
 ## Windows Credential Provider

--- a/website/docs/endpoint-devices/authentik-agent/device-authentication/ssh-authentication.mdx
+++ b/website/docs/endpoint-devices/authentik-agent/device-authentication/ssh-authentication.mdx
@@ -2,6 +2,7 @@
 title: SSH authentication
 sidebar_label: SSH authentication
 tags: [ssh, authentik Agent]
+authentik_version: "2025.12.0+"
 ---
 
 You can use the [authentik Agent](../index.mdx) to authenticate SSH connections between endpoint devices using authentik credentials.

--- a/website/docs/endpoint-devices/authentik-agent/device-authentication/ssh-authentication.mdx
+++ b/website/docs/endpoint-devices/authentik-agent/device-authentication/ssh-authentication.mdx
@@ -2,7 +2,7 @@
 title: SSH authentication
 sidebar_label: SSH authentication
 tags: [ssh, authentik Agent]
-authentik_version: "2025.12.0+"
+authentik_version: "2025.12.0"
 ---
 
 You can use the [authentik Agent](../index.mdx) to authenticate SSH connections between endpoint devices using authentik credentials.

--- a/website/docs/endpoint-devices/device-compliance/configuration.md
+++ b/website/docs/endpoint-devices/device-compliance/configuration.md
@@ -2,7 +2,7 @@
 title: Configuration
 sidebar_label: Configuration
 tags: [device compliance, compliance, configuration]
-authentik_version: "2025.12.0+"
+authentik_version: "2025.12.0"
 ---
 
 ## Prerequisites

--- a/website/docs/endpoint-devices/device-compliance/configuration.md
+++ b/website/docs/endpoint-devices/device-compliance/configuration.md
@@ -2,6 +2,7 @@
 title: Configuration
 sidebar_label: Configuration
 tags: [device compliance, compliance, configuration]
+authentik_version: "2025.12.0+"
 ---
 
 ## Prerequisites

--- a/website/docs/endpoint-devices/device-compliance/connectors/authentik-agent.md
+++ b/website/docs/endpoint-devices/device-compliance/connectors/authentik-agent.md
@@ -2,7 +2,7 @@
 title: authentik Agent connector
 sidebar_label: authentik Agent connector
 tags: [device compliance, compliance, connectors, authentik Agent]
-authentik_version: "2025.12.0+"
+authentik_version: "2025.12.0"
 ---
 
 The authentik Agent connector allows device information to be reported by the [authentik Agent](../../authentik-agent/index.mdx).

--- a/website/docs/endpoint-devices/device-compliance/connectors/authentik-agent.md
+++ b/website/docs/endpoint-devices/device-compliance/connectors/authentik-agent.md
@@ -2,6 +2,7 @@
 title: authentik Agent connector
 sidebar_label: authentik Agent connector
 tags: [device compliance, compliance, connectors, authentik Agent]
+authentik_version: "2025.12.0+"
 ---
 
 The authentik Agent connector allows device information to be reported by the [authentik Agent](../../authentik-agent/index.mdx).

--- a/website/docs/endpoint-devices/device-compliance/connectors/fleetdm.md
+++ b/website/docs/endpoint-devices/device-compliance/connectors/fleetdm.md
@@ -3,7 +3,7 @@ title: Fleet connector
 sidebar_label: Fleet connector
 tags: [device compliance, compliance, connectors, fleet, fleetdm]
 authentik_enterprise: true
-authentik_version: "2026.2.0+"
+authentik_version: "2026.2.0"
 ---
 
 [Fleet](https://fleetdm.com/) is an open-source device management platform designed to monitor, manage, and secure large fleets of devices.

--- a/website/docs/endpoint-devices/device-compliance/connectors/fleetdm.md
+++ b/website/docs/endpoint-devices/device-compliance/connectors/fleetdm.md
@@ -3,6 +3,7 @@ title: Fleet connector
 sidebar_label: Fleet connector
 tags: [device compliance, compliance, connectors, fleet, fleetdm]
 authentik_enterprise: true
+authentik_version: "2026.2.0+"
 ---
 
 [Fleet](https://fleetdm.com/) is an open-source device management platform designed to monitor, manage, and secure large fleets of devices.

--- a/website/docs/endpoint-devices/device-compliance/connectors/index.mdx
+++ b/website/docs/endpoint-devices/device-compliance/connectors/index.mdx
@@ -2,7 +2,7 @@
 title: Connectors
 sidebar_label: Connectors
 tags: [device compliance, compliance, connectors, authentik Agent, fleet, fleetdm]
-authentik_version: "2025.12.0+"
+authentik_version: "2025.12.0"
 ---
 
 Connectors allow device information to be reported to authentik. Connectors for third party services like Fleet can be used standalone or alongside the [authentik Agent](../../authentik-agent/index.mdx) connector.

--- a/website/docs/endpoint-devices/device-compliance/connectors/index.mdx
+++ b/website/docs/endpoint-devices/device-compliance/connectors/index.mdx
@@ -2,6 +2,7 @@
 title: Connectors
 sidebar_label: Connectors
 tags: [device compliance, compliance, connectors, authentik Agent, fleet, fleetdm]
+authentik_version: "2025.12.0+"
 ---
 
 Connectors allow device information to be reported to authentik. Connectors for third party services like Fleet can be used standalone or alongside the [authentik Agent](../../authentik-agent/index.mdx) connector.

--- a/website/docs/endpoint-devices/device-compliance/device-compliance-policy.md
+++ b/website/docs/endpoint-devices/device-compliance/device-compliance-policy.md
@@ -3,7 +3,7 @@ title: Device compliance policy
 sidebar_label: Device compliance policy
 tags: [device compliance, compliance, device access, policy]
 toc_max_heading_level: 4
-authentik_version: "2025.12.0+"
+authentik_version: "2025.12.0"
 ---
 
 Device compliance policies are used to limit access to authentik and applications based on [Device Compliance](./index.mdx) information.

--- a/website/docs/endpoint-devices/device-compliance/device-compliance-policy.md
+++ b/website/docs/endpoint-devices/device-compliance/device-compliance-policy.md
@@ -3,6 +3,7 @@ title: Device compliance policy
 sidebar_label: Device compliance policy
 tags: [device compliance, compliance, device access, policy]
 toc_max_heading_level: 4
+authentik_version: "2025.12.0+"
 ---
 
 Device compliance policies are used to limit access to authentik and applications based on [Device Compliance](./index.mdx) information.

--- a/website/docs/endpoint-devices/device-compliance/device-reporting.md
+++ b/website/docs/endpoint-devices/device-compliance/device-reporting.md
@@ -11,7 +11,7 @@ tags:
         check-in,
         facts,
     ]
-authentik_version: "2025.12.0+"
+authentik_version: "2025.12.0"
 ---
 
 Endpoint Devices registered with authentik via a [connector](./connectors/index.mdx), such as the [authentik Agent](./connectors/authentik-agent.md) connector, regularly [check-in](#device-check-in) with authentik and report their [device facts](#device-facts).

--- a/website/docs/endpoint-devices/device-compliance/device-reporting.md
+++ b/website/docs/endpoint-devices/device-compliance/device-reporting.md
@@ -11,6 +11,7 @@ tags:
         check-in,
         facts,
     ]
+authentik_version: "2025.12.0+"
 ---
 
 Endpoint Devices registered with authentik via a [connector](./connectors/index.mdx), such as the [authentik Agent](./connectors/authentik-agent.md) connector, regularly [check-in](#device-check-in) with authentik and report their [device facts](#device-facts).

--- a/website/docs/endpoint-devices/device-compliance/index.mdx
+++ b/website/docs/endpoint-devices/device-compliance/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Device Compliance
 sidebar_label: Device Compliance
+authentik_version: "2025.12.0+"
 ---
 
 import DocCardList from "@theme/DocCardList";

--- a/website/docs/endpoint-devices/device-compliance/index.mdx
+++ b/website/docs/endpoint-devices/device-compliance/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Device Compliance
 sidebar_label: Device Compliance
-authentik_version: "2025.12.0+"
+authentik_version: "2025.12.0"
 ---
 
 import DocCardList from "@theme/DocCardList";

--- a/website/docs/endpoint-devices/index.mdx
+++ b/website/docs/endpoint-devices/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Endpoint Devices
 sidebar_label: Endpoint Devices
+authentik_version: "2025.12.0+"
 ---
 
 import DocCardList from "@theme/DocCardList";

--- a/website/docs/endpoint-devices/index.mdx
+++ b/website/docs/endpoint-devices/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Endpoint Devices
 sidebar_label: Endpoint Devices
-authentik_version: "2025.12.0+"
+authentik_version: "2025.12.0"
 ---
 
 import DocCardList from "@theme/DocCardList";

--- a/website/docs/endpoint-devices/manage-devices.mdx
+++ b/website/docs/endpoint-devices/manage-devices.mdx
@@ -2,7 +2,7 @@
 title: Manage devices
 sidebar_label: Manage devices
 tags: [devices, device info, device facts, managing devices]
-authentik_version: "2025.12.0+"
+authentik_version: "2025.12.0"
 ---
 
 The Devices page provides a list of all endpoint devices registered with your authentik deployment. Refer to [Device reporting](./device-compliance/device-reporting.md) for more details on how [device facts](./device-compliance/device-reporting.md#device-facts) are reported to authentik.

--- a/website/docs/endpoint-devices/manage-devices.mdx
+++ b/website/docs/endpoint-devices/manage-devices.mdx
@@ -2,6 +2,7 @@
 title: Manage devices
 sidebar_label: Manage devices
 tags: [devices, device info, device facts, managing devices]
+authentik_version: "2025.12.0+"
 ---
 
 The Devices page provides a list of all endpoint devices registered with your authentik deployment. Refer to [Device reporting](./device-compliance/device-reporting.md) for more details on how [device facts](./device-compliance/device-reporting.md#device-facts) are reported to authentik.


### PR DESCRIPTION
## Details

Adds authentik version tags to all endpoint device docs - some users had issues with trying to run this on 2025.10

---

## Checklist

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
