### PR TITLE
enterprise/providers/ws_federation: fix incorrect metadata download URL

### DIFF
--- a/authentik/enterprise/providers/ws_federation/urls.py
+++ b/authentik/enterprise/providers/ws_federation/urls.py
@@ -4,12 +4,19 @@ from django.urls import path
 
 from authentik.enterprise.providers.ws_federation.api.providers import WSFederationProviderViewSet
 from authentik.enterprise.providers.ws_federation.views import WSFedEntryView
+from authentik.providers.saml.views.metadata import MetadataDownload
 
 urlpatterns = [
     path(
         "",
         WSFedEntryView.as_view(),
         name="wsfed",
+    ),
+    # Metadata
+    path(
+        "<slug:application_slug>/metadata/",
+        MetadataDownload.as_view(),
+        name="metadata-download",
     ),
 ]
 


### PR DESCRIPTION
method is currently not overwritten from the SAML metadata