### PR TITLE
core, web: add role-group assignment management

### DIFF
--- a/authentik/core/api/groups.py
+++ b/authentik/core/api/groups.py
@@ -32,6 +32,7 @@ from authentik.core.models import Group, User
 from authentik.endpoints.connectors.agent.auth import AgentAuth
 from authentik.rbac.api.roles import RoleSerializer
 from authentik.rbac.decorators import permission_required
+from authentik.rbac.models import Role
 
 PARTIAL_USER_SERIALIZER_MODEL_FIELDS = [
     "pk",
@@ -222,6 +223,10 @@ class GroupFilter(FilterSet):
         field_name="users",
         queryset=User.objects.all(),
     )
+    roles_by_pk = ModelMultipleChoiceFilter(
+        field_name="roles",
+        queryset=Role.objects.all(),
+    )
 
     def filter_attributes(self, queryset, name, value):
         """Filter attributes by query args"""
@@ -242,7 +247,14 @@ class GroupFilter(FilterSet):
 
     class Meta:
         model = Group
-        fields = ["name", "is_superuser", "members_by_pk", "attributes", "members_by_username"]
+        fields = [
+            "name",
+            "is_superuser",
+            "members_by_pk",
+            "attributes",
+            "members_by_username",
+            "roles_by_pk",
+        ]
 
 
 class GroupViewSet(UsedByMixin, ModelViewSet):

--- a/schema.yml
+++ b/schema.yml
@@ -3454,6 +3454,15 @@ paths:
       - $ref: '#/components/parameters/QueryPaginationOrdering'
       - $ref: '#/components/parameters/QueryPaginationPage'
       - $ref: '#/components/parameters/QueryPaginationPageSize'
+      - in: query
+        name: roles_by_pk
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+        explode: true
+        style: form
       - $ref: '#/components/parameters/QuerySearch'
       tags:
       - core
@@ -21229,6 +21238,37 @@ paths:
           $ref: '#/components/responses/ValidationErrorResponse'
         '403':
           $ref: '#/components/responses/GenericErrorResponse'
+  /rbac/roles/{uuid}/add_group/:
+    post:
+      operationId: rbac_roles_add_group_create
+      description: Add group to role
+      parameters:
+      - in: path
+        name: uuid
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Role.
+        required: true
+      tags:
+      - rbac
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GroupAccountRequest'
+        required: true
+      security:
+      - authentik: []
+      responses:
+        '204':
+          description: Group added
+        '404':
+          description: Group not found
+        '400':
+          $ref: '#/components/responses/ValidationErrorResponse'
+        '403':
+          $ref: '#/components/responses/GenericErrorResponse'
   /rbac/roles/{uuid}/add_user/:
     post:
       operationId: rbac_roles_add_user_create
@@ -21256,6 +21296,37 @@ paths:
           description: User added
         '404':
           description: User not found
+        '400':
+          $ref: '#/components/responses/ValidationErrorResponse'
+        '403':
+          $ref: '#/components/responses/GenericErrorResponse'
+  /rbac/roles/{uuid}/remove_group/:
+    post:
+      operationId: rbac_roles_remove_group_create
+      description: Remove group from role
+      parameters:
+      - in: path
+        name: uuid
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Role.
+        required: true
+      tags:
+      - rbac
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GroupAccountRequest'
+        required: true
+      security:
+      - authentik: []
+      responses:
+        '204':
+          description: Group removed
+        '404':
+          description: Group not found
         '400':
           $ref: '#/components/responses/ValidationErrorResponse'
         '403':
@@ -39967,6 +40038,15 @@ components:
       - pk
       - roles_obj
       - users_obj
+    GroupAccountRequest:
+      type: object
+      description: Group adding/removing operations
+      properties:
+        pk:
+          type: string
+          format: uuid
+      required:
+      - pk
     GroupKerberosSourceConnection:
       type: object
       description: Group Source Connection

--- a/web/src/admin/roles/RoleViewPage.ts
+++ b/web/src/admin/roles/RoleViewPage.ts
@@ -147,6 +147,21 @@ export class RoleViewPage extends WithLicenseSummary(AKElement) {
                         </div>
                     </div>
                 </section>
+                <section
+                    role="tabpanel"
+                    tabindex="0"
+                    slot="page-groups"
+                    id="page-groups"
+                    aria-label="${msg("Groups")}"
+                    class="pf-c-page__main-section pf-m-no-padding-mobile"
+                >
+                    <div class="pf-c-card">
+                        <div class="pf-c-card__body">
+                            <ak-group-related-list .targetRole=${this.targetRole}>
+                            </ak-group-related-list>
+                        </div>
+                    </div>
+                </section>
                 <ak-rbac-object-permission-page
                     class="pf-c-page__main-section pf-m-no-padding-mobile"
                     role="tabpanel"


### PR DESCRIPTION
Add role add/remove group API actions, expose group filtering by role, and wire a Groups tab in role view for managing linked groups.

Closes: https://github.com/goauthentik/authentik/issues/19856

Closes #25327
