### PR TITLE
website/docs: rac: fixes the property mapping formatting

### DIFF
--- a/website/docs/add-secure-apps/providers/rac/rac-public-key.md
+++ b/website/docs/add-secure-apps/providers/rac/rac-public-key.md
@@ -66,8 +66,10 @@ The pipe character (`|`) is required to preserve linebreaks in the YAML text. Se
         - **Expression**:
 
     ```python
-    return {
-    "private-key": "-----BEGIN SSH PRIVATE KEY-----
+    import textwrap
+
+    private_key = textwrap.dedent("""
+    -----BEGIN SSH PRIVATE KEY-----
     SAMPLEgIBAAJBAKj34GkxFhD90vcNLYLInFEX6Ppy1tPf9Cnzj4p4WGeKLs1Pt8Qu
     KUpRKfFLfRYC9AIKjbJTWit+CqvjWYzvQwECAwEAAQJAIJLixBy2qpFoS4DSmoEm
     o3qGy0t6z09AIJtH+5OeRV1be+N4cDYJKffGzDa88vQENZiRm0GRq6a+HPGQMd2k
@@ -75,7 +77,12 @@ The pipe character (`|`) is required to preserve linebreaks in the YAML text. Se
     9mxDXDf6AU0cN/RPBjb9qSHDcWZHGzUCIG2Es59z8ugGrDY+pxLQnwfotadxd+Uy
     v/Ow5T0q5gIJAiEAyS4RaI9YG8EWx/2w0T67ZUVAw8eOMB6BIUg0Xcu+3okCIBOs
     /5OiPgoTdSy7bcF9IGpSE8ZgGKzgYQVZeN97YE00
-    -----END SSH PRIVATE KEY-----",
+    -----END SSH PRIVATE KEY-----
+    """)
+
+    return {
+        "username": "<your_username>",
+        "private-key": private_key
     }
     ```
 


### PR DESCRIPTION
## Details

There was an issue caused by indenation when setting a private key via property mapping. 

Addresses: #15783

---

## Checklist

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
