### PR TITLE
outposts/controllers: fix reconcile for dataclass-based custom objects

### DIFF
--- a/authentik/outposts/controllers/k8s/base.py
+++ b/authentik/outposts/controllers/k8s/base.py
@@ -185,7 +185,11 @@ class KubernetesObjectReconciler[T]:
 
         patch = self.get_patch()
         if patch is not None:
-            current_json = ApiClient().sanitize_for_serialization(current)
+            try:
+                current_json = ApiClient().sanitize_for_serialization(current)
+            # Custom objects will not be known to the clients openapi_types
+            except AttributeError:
+                current_json = asdict(current)
 
             try:
                 if apply_patch(current_json, patch) != current_json:


### PR DESCRIPTION
Add AttributeError handling in reconcile() to support dataclass-based custom objects (e.g., HTTPRoute) that lack openapi_types attribute.

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
The `outpost_controller` task fails when reconciling Gateway API HTTPRoute resources with the error:

```
{
    "exception": [
        {
            "frames": [
                {
                    "name": "process_message",
                    "lineno": 487,
                    "filename": "/ak-root/.venv/lib/python3.13/site-packages/dramatiq/worker.py"
                },
                {
                    "name": "__call__",
                    "lineno": 185,
                    "filename": "/ak-root/.venv/lib/python3.13/site-packages/dramatiq/actor.py"
                },
                {
                    "name": "outpost_controller",
                    "lineno": 126,
                    "filename": "/authentik/outposts/tasks.py"
                },
                {
                    "name": "up_with_logs",
                    "lineno": 118,
                    "filename": "/authentik/outposts/controllers/kubernetes.py"
                },
                {
                    "name": "up",
                    "lineno": 132,
                    "filename": "/authentik/outposts/controllers/k8s/base.py"
                },
                {
                    "name": "reconcile",
                    "lineno": 118,
                    "filename": "/authentik/providers/proxy/controllers/k8s/httproute.py"
                },
                {
                    "name": "reconcile",
                    "lineno": 188,
                    "filename": "/authentik/outposts/controllers/k8s/base.py"
                },
                {
                    "name": "sanitize_for_serialization",
                    "lineno": 238,
                    "filename": "/ak-root/.venv/lib/python3.13/site-packages/kubernetes/client/api_client.py"
                }
            ],
            "exc_type": "AttributeError",
            "is_cause": false,
            "is_group": false,
            "exc_notes": [],
            "exc_value": "'HTTPRoute' object has no attribute 'openapi_types'",
            "exceptions": [],
            "syntax_error": null
        }
    ]
}
```

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
