### PR TITLE
web: fix italic formatting in lifecycle rule help text

### DIFF
--- a/web/src/admin/lifecycle/LifecycleRuleForm.ts
+++ b/web/src/admin/lifecycle/LifecycleRuleForm.ts
@@ -243,9 +243,13 @@ export class LifecycleRuleForm extends ModelForm<LifecycleRule, string> {
                 name="minReviewersIsPerGroup"
                 ?checked=${this.instance?.minReviewersIsPerGroup ?? false}
                 label=${msg("Min reviewers is per-group")}
-                help=${msg(
-                    "If checked, approving a review will require at least that many users from _each_ of the selected groups. When disabled, the value is a total across all groups.",
-                )}
+                .bighelp=${html`<p class="pf-c-form__helper-text">
+                    ${msg(
+                        html`If checked, approving a review will require at least that many users
+                            from <em>each</em> of the selected groups. When disabled, the value is a
+                            total across all groups.`,
+                    )}
+                </p>`}
             >
             </ak-switch-input>
 

--- a/web/src/admin/lifecycle/LifecycleRuleForm.ts
+++ b/web/src/admin/lifecycle/LifecycleRuleForm.ts
@@ -243,13 +243,11 @@ export class LifecycleRuleForm extends ModelForm<LifecycleRule, string> {
                 name="minReviewersIsPerGroup"
                 ?checked=${this.instance?.minReviewersIsPerGroup ?? false}
                 label=${msg("Min reviewers is per-group")}
-                .bighelp=${html`<p class="pf-c-form__helper-text">
-                    ${msg(
-                        html`If checked, approving a review will require at least that many users
-                            from <em>each</em> of the selected groups. When disabled, the value is a
-                            total across all groups.`,
-                    )}
-                </p>`}
+                .help=${msg(
+                    html`If checked, approving a review will require at least that many users from
+                        <em>each</em> of the selected groups. When disabled, the value is a total
+                        across all groups.`,
+                )}
             >
             </ak-switch-input>
 

--- a/web/src/components/ak-switch-input.ts
+++ b/web/src/components/ak-switch-input.ts
@@ -33,7 +33,7 @@ export class AkSwitchInput extends AKElement {
     required = false;
 
     @property({ type: String })
-    help = "";
+    help: string | TemplateResult = "";
 
     /**
      * For more complex help instructions, provide a template result.
@@ -47,11 +47,13 @@ export class AkSwitchInput extends AKElement {
     #fieldID: string = IDGenerator.randomID();
 
     protected renderHelp() {
-        const helpText = this.help.trim();
+        const helpContent = typeof this.help === "string" ? this.help.trim() : this.help;
 
         return [
-            helpText
-                ? html`<p id="${this.#fieldID}-help" class="pf-c-form__helper-text">${helpText}</p>`
+            helpContent
+                ? html`<p id="${this.#fieldID}-help" class="pf-c-form__helper-text">
+                      ${helpContent}
+                  </p>`
                 : nothing,
             this.bighelp ? this.bighelp : nothing,
         ];


### PR DESCRIPTION
Before:

<img width="924" height="115" alt="image" src="https://github.com/user-attachments/assets/7467eecb-ff02-4b41-9dd5-985afa3cce8f" />

After: 

<img width="925" height="111" alt="image" src="https://github.com/user-attachments/assets/c9e32167-82c2-438f-b0db-a0b3ec9aec1d" />
