### PR TITLE
web: add pretty names for lifecycle review events in event logs

### DIFF
--- a/web/src/common/labels.ts
+++ b/web/src/common/labels.ts
@@ -53,6 +53,10 @@ export const eventActionToLabel = new Map<EventActions | undefined, string>([
     [EventActions.EmailSent, msg("Email sent")],
     [EventActions.UpdateAvailable, msg("Update available")],
     [EventActions.ExportReady, msg("Data export ready")],
+    [EventActions.ReviewInitiated, msg("Review initiated")],
+    [EventActions.ReviewOverdue, msg("Review overdue")],
+    [EventActions.ReviewAttested, msg("Review attested")],
+    [EventActions.ReviewCompleted, msg("Review completed")],
 ]);
 
 export const actionToLabel = (action?: EventActions): string =>


### PR DESCRIPTION
Before:

<img width="442" height="591" alt="image" src="https://github.com/user-attachments/assets/845edda3-2e99-4a55-9a72-19792b01400d" />

After:

<img width="417" height="511" alt="image" src="https://github.com/user-attachments/assets/57e22226-9d7e-478c-88de-1933ae93ab47" />
