### PR TITLE
enterprise/lifecycle: fix multiple reviews showing up in "Reviews" when the user is a member of multiple reviewer groups

### DIFF
--- a/authentik/enterprise/lifecycle/api/iterations.py
+++ b/authentik/enterprise/lifecycle/api/iterations.py
@@ -102,7 +102,7 @@ class IterationViewSet(EnterpriseRequiredMixin, CreateModelMixin, GenericViewSet
                 default=Value(False),
                 output_field=ModelBooleanField(),
             )
-        )
+        ).distinct()
 
     @action(
         detail=False,


### PR DESCRIPTION

## Details


This fixes the bug with multiple reviews showing up in "Reviews" when the user is a member of multiple reviewer groups (which is one of the issues mentioned in #20265). That was due to a missing distinct when querying the DB. 

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)
