### PR TITLE
rbac: fix role creation in permissions migration (cherry-pick #20301 to version-2025.12)

### DIFF
--- a/authentik/core/migrations/0056_user_roles.py
+++ b/authentik/core/migrations/0056_user_roles.py
@@ -34,7 +34,7 @@ def migrate_object_permissions(apps: Apps, schema_editor: BaseDatabaseSchemaEdit
             name = f"ak-migrated-role--group-{group_id}"
             role, created = Role.objects.using(db_alias).get_or_create(
                 group_id=group_id,
-                name=name,
+                defaults={"name": name},
             )
             if created:
                 role.group_id = group_id


### PR DESCRIPTION
I'm doing a manual cherry-pick here to immediately create an image.