### PR TITLE
policies: handle lists in messages

### DIFF
--- a/authentik/policies/expression/evaluator.py
+++ b/authentik/policies/expression/evaluator.py
@@ -33,9 +33,12 @@ class PolicyEvaluator(BaseEvaluator):
         self._context["ak_message"] = self.expr_func_message
         self._context["ak_user_has_authenticator"] = self.expr_func_user_has_authenticator
 
-    def expr_func_message(self, message: str):
+    def expr_func_message(self, message: list[str] | str):
         """Wrapper to append to messages list, which is returned with PolicyResult"""
-        self._messages.append(message)
+        if isinstance(message, list):
+            self._messages.extend(message)
+        else:
+            self._messages.append(message)
 
     def set_policy_request(self, request: PolicyRequest):
         """Update context based on policy request (if http request is given, update that too)"""

--- a/authentik/policies/expression/tests.py
+++ b/authentik/policies/expression/tests.py
@@ -45,14 +45,23 @@ class TestEvaluator(TestCase):
         evaluator.set_policy_request(self.request)
         self.assertEqual(evaluator.evaluate(template).passing, True)
 
-    def test_messages(self):
-        """test expression with message return"""
+    def test_message(self):
+        """test expression with single message return"""
         template = 'ak_message("some message");return False'
         evaluator = PolicyEvaluator("test")
         evaluator.set_policy_request(self.request)
         result = evaluator.evaluate(template)
         self.assertEqual(result.passing, False)
         self.assertEqual(result.messages, ("some message",))
+
+    def test_messages(self):
+        """test expression with multi message return"""
+        template = 'ak_message(["some message", "another message"]);return False'
+        evaluator = PolicyEvaluator("test")
+        evaluator.set_policy_request(self.request)
+        result = evaluator.evaluate(template)
+        self.assertEqual(result.passing, False)
+        self.assertEqual(result.messages, ("some message", "another message"))
 
     def test_invalid_syntax(self):
         """test invalid syntax"""

--- a/website/docs/customize/policies/expression.mdx
+++ b/website/docs/customize/policies/expression.mdx
@@ -40,14 +40,21 @@ Expression policies with sample Python that we have documented:
 
 ## Available functions
 
-### `ak_message(message: str)`
+### `ak_message(message: list[str] | str)`
 
 Add a message, visible by the end user. This can be used to show the reason why they were denied.
 
-Example:
+Example for a single message:
 
 ```python
 ak_message("Access denied")
+return False
+```
+
+Example for multiple messages:
+
+```python
+ak_message(["Line 1: Not authorized.", "Line 2: Incorrect length."])
 return False
 ```
 


### PR DESCRIPTION


<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
So far, passing a list to ak_manage() used in a policy in a user settings flow would cause the UI to not only not print any messages, but also to "glitch" (sometimes the form disappears, sometimes the user is redirected to a different flow interface).
It is useful to support returning multiple messages from a policy - for example, with multiline prompts where individual lines yield different validation results, individual alerts are easier to parse for user than a long single line of text.
Hence solve the problem by enhancing the functionality to split list elements across messages, while keeping the existing behavior for strings.

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
