### PR TITLE
website/integrations: add encryption key requirement for Paperless

### DIFF
--- a/website/integrations/documentation/paperless-ngx/index.mdx
+++ b/website/integrations/documentation/paperless-ngx/index.mdx
@@ -40,7 +40,7 @@ To support the integration of Paperless-ngx with authentik, you need to create a
             - `authentik default OAuth Mapping: OpenID 'openid'`
             - `authentik default OAuth Mapping: OpenID 'email'`
             - `authentik default OAuth Mapping: OpenID 'profile'`
-        - **Encryption Key**: Ensure no encyption key is selected.
+        - **Encryption Key**: Ensure that no encryption key is selected.
 
 3. Click **Submit** to save the new application and provider.
 

--- a/website/integrations/documentation/paperless-ngx/index.mdx
+++ b/website/integrations/documentation/paperless-ngx/index.mdx
@@ -40,6 +40,7 @@ To support the integration of Paperless-ngx with authentik, you need to create a
             - `authentik default OAuth Mapping: OpenID 'openid'`
             - `authentik default OAuth Mapping: OpenID 'email'`
             - `authentik default OAuth Mapping: OpenID 'profile'`
+        - **Encryption Key**: Ensure no encyption key is selected.
 
 3. Click **Submit** to save the new application and provider.
 


### PR DESCRIPTION
Added note to ensure no encryption key is selected.

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->

Newer versions of Paperless do not work without turning off the encryption key setting.

I ran into the same issue and found that there are multiple threads on the Paperless repo pertaining to this issue, which recommend this as a fix:
- https://github.com/paperless-ngx/paperless-ngx/discussions/11524#discussioncomment-15140194
- https://github.com/paperless-ngx/paperless-ngx/discussions/11788#discussioncomment-15527701

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
