### PR TITLE
web: unify footer styles

### DIFF
--- a/authentik/core/templates/login/base_full.html
+++ b/authentik/core/templates/login/base_full.html
@@ -45,7 +45,7 @@
                             </div>
                         </main>
                         <footer aria-label="Site footer" class="pf-c-login__footer pf-m-dark">
-                            <ul class="pf-c-list pf-m-inline">
+                            <ul aria-label="Site links" class="pf-c-list pf-m-inline" part="list">
                                 {% for link in footer_links %}
                                 <li>
                                     <a href="{{ link.href }}">{{ link.name }}</a>

--- a/web/src/styles/authentik/components/Login/login.css
+++ b/web/src/styles/authentik/components/Login/login.css
@@ -351,6 +351,16 @@
     @media (min-width: 35rem) and (min-height: 17.5rem) {
         filter: var(--ak-global--background-contrast-Filter);
     }
+
+    &.pf-c-list > a {
+        color: unset;
+    }
+    ul.pf-c-list.pf-m-inline {
+        justify-content: center;
+        padding: 0;
+        column-gap: var(--pf-global--spacer--xl);
+        row-gap: var(--pf-global--spacer--md);
+    }
 }
 
 /* #endregion */


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->

So far, the footer in pages rendered in the server side templates was not formatted the same way as the footer defined in the JS parts. This was mainly noticeable by one footer being aligned centered, while the other was aligned to the left of the page.
Solve this by applying the footer styles in the login component as well.

Note this duplicates the "styles" block from
web/src/flow/components/ak-brand-footer.ts. I could not find where to place the block to have it be included from both places.

Please let me know if there's a good way to deduplicate these.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
