### PR TITLE
web: Center footer links.

### DIFF
--- a/web/src/flow/components/ak-brand-footer.ts
+++ b/web/src/flow/components/ak-brand-footer.ts
@@ -33,21 +33,33 @@ export class BrandLinks extends AKElement {
     public links: FooterLink[] = globalAK().brand.uiFooterLinks || [];
 
     render() {
-        return html`<ul aria-label=${msg("Site links")} class="pf-c-list pf-m-inline" part="list">
-            ${map(this.links, (link) => {
+        const links = [
+            ...this.links,
+            {
+                name: msg("Powered by authentik"),
+                href: null,
+            },
+        ];
+        return html`<ul
+            aria-label=${msg("Site links")}
+            class="pf-c-list pf-m-inline"
+            part="list"
+            data-count=${links.length}
+        >
+            ${map(links, (link, idx) => {
                 const children = sanitizeHTML(BrandedHTMLPolicy, link.name);
 
-                if (link.href) {
-                    return html`<li part="list-item">
-                        <a part="list-item-link" href=${link.href}>${children}</a>
-                    </li>`;
-                }
-
-                return html`<li part="list-item">
-                    <span>${children}</span>
+                return html`<li
+                    part="list-item"
+                    data-index=${idx}
+                    data-kind=${link.href ? "link" : "text"}
+                    data-track-name=${idx === 0 ? "start" : idx === links.length - 1 ? "end" : idx}
+                >
+                    ${link.href
+                        ? html`<a part="list-item-link" href=${link.href}>${children}</a>`
+                        : children}
                 </li>`;
             })}
-            <li part="list-item"><span>${msg("Powered by authentik")}</span></li>
         </ul>`;
     }
 }

--- a/web/src/styles/authentik/components/Login/login.css
+++ b/web/src/styles/authentik/components/Login/login.css
@@ -344,6 +344,10 @@
         (var(--ak-c-login__footer--PaddingBlock) * 2) + (var(--pf-global--LineHeight--md) * 1rem)
     );
 
+    /* Only applicable to the smallest of mobile viewports. */
+    max-width: 100dvw;
+    overflow: hidden;
+
     color: var(--ak-c-login__footer--Color);
 
     @media (max-width: 35rem) {

--- a/web/src/styles/authentik/static.global.css
+++ b/web/src/styles/authentik/static.global.css
@@ -166,6 +166,11 @@
     &::part(list) {
         --pf-c-list--m-inline--li--MarginRight: 0;
 
+        /* 3 entries is a unique scenario where 2 columns is visually balanced. */
+        &[data-count="3"] {
+            --ak-c-login__footer--ColumnCount: 2;
+        }
+
         justify-content: center;
         column-gap: var(--ak-c-login__footer--ColumnGap);
         row-gap: var(--ak-c-login__footer--RowGap);
@@ -174,26 +179,30 @@
         place-items: center;
         display: var(--ak-c-login__footer--Display);
 
-        grid-template-columns: repeat(auto-fit, var(--ak-c-login__footer--TrackWidth));
+        grid-template-columns: repeat(
+            var(--ak-c-login__footer--ColumnCount),
+            var(--ak-c-login__footer--TrackWidth)
+        );
 
         grid-template-rows:
             [header] max-content
             [main] max-content
-            [footer] max-content;
+            [footer];
     }
 
     [part="list-item"],
     &::part(list-item) {
+        /* CSS grid is preferred, but if the custom CSS overrides this, default to something reasonable. */
         flex: 1 1 var(--ak-c-login__footer__list-item--FlexBasis, auto);
         text-align: center;
         max-width: var(--ak-c-login__footer--ItemMaxWidth);
 
         &[data-kind="text"] {
             &[data-track-name="start"] {
-                grid-column: header / 1;
+                grid-column: 1 / -1;
             }
             &[data-track-name="end"] {
-                grid-column: footer / 1;
+                grid-column: 1 / -1;
             }
         }
     }

--- a/web/src/styles/authentik/static.global.css
+++ b/web/src/styles/authentik/static.global.css
@@ -73,14 +73,24 @@
     /* Gracefully degrade to the login max width if CSS size functions are not supported. */
     --ak-c-login__footer--MaxWidth: min(100dvw, var(--ak-c-login--MaxWidth));
 
-    --ak-c-login__footer-ColumnCount: 4;
-    --ak-c-login__footer-ColumnWidth: calc(
-        (var(--ak-c-login__footer--MaxWidth) / var(--ak-c-login__footer-ColumnCount)) -
+    --ak-c-login__footer--TrackMin: max-content;
+    --ak-c-login__footer--TrackWidth: minmax(
+        var(--ak-c-login__footer--TrackMin),
+        var(--ak-c-login__footer--TrackMax)
+    );
+
+    --ak-c-login__footer--ItemMaxWidth: calc(
+        var(--ak-c-login__footer--MaxWidth) - var(--ak-c-login__footer--ColumnGap)
+    );
+
+    --ak-c-login__footer--ColumnCount: 4;
+    --ak-c-login__footer--TrackMax: calc(
+        (var(--ak-c-login__footer--MaxWidth) / var(--ak-c-login__footer--ColumnCount)) -
             var(--ak-c-login__footer--ColumnGap)
     );
 
     @media (width <= 35rem) {
-        --ak-c-login__footer--Display: flex;
+        --ak-c-login__footer--TrackWidth: 1fr;
         --ak-c-login__footer__list-item--FlexBasis: 100%;
     }
 }
@@ -164,16 +174,28 @@
         place-items: center;
         display: var(--ak-c-login__footer--Display);
 
-        grid-template-columns: repeat(
-            auto-fit,
-            minmax(max-content, var(--ak-c-login__footer-ColumnWidth))
-        );
+        grid-template-columns: repeat(auto-fit, var(--ak-c-login__footer--TrackWidth));
+
+        grid-template-rows:
+            [header] max-content
+            [main] max-content
+            [footer] max-content;
     }
 
     [part="list-item"],
     &::part(list-item) {
         flex: 1 1 var(--ak-c-login__footer__list-item--FlexBasis, auto);
         text-align: center;
+        max-width: var(--ak-c-login__footer--ItemMaxWidth);
+
+        &[data-kind="text"] {
+            &[data-track-name="start"] {
+                grid-column: header / 1;
+            }
+            &[data-track-name="end"] {
+                grid-column: footer / 1;
+            }
+        }
     }
 
     [part="list-item-link"],

--- a/web/src/styles/authentik/static.global.css
+++ b/web/src/styles/authentik/static.global.css
@@ -63,6 +63,26 @@
 
     --ak-c-login__footer--PaddingBlock: var(--pf-global--spacer--md);
     --ak-c-login__footer--Color: var(--ak-global--BackgroundColorContrast--100);
+
+    --ak-c-login__footer--ColumnGap: var(--pf-global--spacer--2xl);
+    --ak-c-login__footer--RowGap: var(--pf-global--spacer--md);
+
+    --ak-c-login__footer--Display: grid;
+
+    --ak-c-login__footer--MaxWidth: var(--ak-c-login--MaxWidth);
+    /* Gracefully degrade to the login max width if CSS size functions are not supported. */
+    --ak-c-login__footer--MaxWidth: min(100dvw, var(--ak-c-login--MaxWidth));
+
+    --ak-c-login__footer-ColumnCount: 4;
+    --ak-c-login__footer-ColumnWidth: calc(
+        (var(--ak-c-login__footer--MaxWidth) / var(--ak-c-login__footer-ColumnCount)) -
+            var(--ak-c-login__footer--ColumnGap)
+    );
+
+    @media (width <= 35rem) {
+        --ak-c-login__footer--Display: flex;
+        --ak-c-login__footer__list-item--FlexBasis: 100%;
+    }
 }
 
 [data-theme="dark"] .pf-c-login {
@@ -93,6 +113,9 @@
     --pf-c-login__main-footer-band--BackgroundColor: transparent;
 
     --pf-c-login__footer--c-list--xl--PaddingTop: 0;
+    --pf-c-login__footer--PaddingLeft: var(--pf-global--spacer--lg);
+    --pf-c-login__footer--PaddingRight: var(--pf-global--spacer--lg);
+
     --pf-c-login__container--PaddingLeft: 0 !important;
     --pf-c-login__container--PaddingRight: 0 !important;
 }
@@ -134,8 +157,23 @@
         --pf-c-list--m-inline--li--MarginRight: 0;
 
         justify-content: center;
-        column-gap: var(--pf-global--spacer--2xl);
-        row-gap: var(--pf-global--spacer--md);
+        column-gap: var(--ak-c-login__footer--ColumnGap);
+        row-gap: var(--ak-c-login__footer--RowGap);
+
+        max-width: var(--ak-c-login__footer--MaxWidth);
+        place-items: center;
+        display: var(--ak-c-login__footer--Display);
+
+        grid-template-columns: repeat(
+            auto-fit,
+            minmax(max-content, var(--ak-c-login__footer-ColumnWidth))
+        );
+    }
+
+    [part="list-item"],
+    &::part(list-item) {
+        flex: 1 1 var(--ak-c-login__footer__list-item--FlexBasis, auto);
+        text-align: center;
     }
 
     [part="list-item-link"],

--- a/web/src/styles/authentik/static.global.css
+++ b/web/src/styles/authentik/static.global.css
@@ -64,7 +64,7 @@
     --ak-c-login__footer--PaddingBlock: var(--pf-global--spacer--md);
     --ak-c-login__footer--Color: var(--ak-global--BackgroundColorContrast--100);
 
-    --ak-c-login__footer--ColumnGap: var(--pf-global--spacer--2xl);
+    --ak-c-login__footer--ColumnGap: min(var(--pf-global--spacer--2xl), 2dvw);
     --ak-c-login__footer--RowGap: var(--pf-global--spacer--md);
 
     --ak-c-login__footer--Display: grid;


### PR DESCRIPTION
## Details

This PR centers footer links on the flow executor, along with a few tablet media query improvements for pages which contain many links.

### Notes on the card alignment

We have a strong preference for always keeping the content within the viewport. If the footer is below the fold, the card will forego some space up to a point.

The most strict aspect of the layout is that the card will push all other content out of the viewport if there isn't enough space to render itself. What is calculated as "enough space" is something like "the vertical height needed to render the busiest hypothetical flow" e.g. login and password inputs, captcha, enrollment links, etc. There's also some preference for avoiding vertical repaints during the loading of flows.



## Before

### Desktop

<img width="1728" height="1049" alt="Screenshot 2026-02-17 at 18 27 05" src="https://github.com/user-attachments/assets/318b5cf6-0c05-4333-a012-d01563f44e3e" />

### Mobile

<img width="420" height="858" alt="Screenshot 2026-02-17 at 18 26 52" src="https://github.com/user-attachments/assets/a6e9a7a3-ba62-43b4-bb7e-5d989e482804" />


## After

### Desktop

<img width="1728" height="1007" alt="Screenshot 2026-02-17 at 18 20 13" src="https://github.com/user-attachments/assets/641ff3ac-f00f-4158-acc9-b5542e2b4d36" />


### Mobile

<img width="412" height="853" alt="Screenshot 2026-02-17 at 18 24 24" src="https://github.com/user-attachments/assets/f6dcd0bd-3fec-44dd-8b55-81ecde662a2c" />

