### PR TITLE
ci: fix setup altering package-lock

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -58,7 +58,7 @@ runs:
       run: |
         export PSQL_TAG=${{ inputs.postgresql_version }}
         docker compose -f .github/actions/setup/compose.yml up -d
-        cd web && npm i
+        cd web && npm ci
     - name: Generate config
       if: ${{ contains(inputs.dependencies, 'python') }}
       shell: uv run python {0}


### PR DESCRIPTION
This change was made as a "temporary fix" in #17407 for end-to-end tests. Let's see if we can remove it.

`npm i` here results in changes to `web/package-lock.json` in many workflows, for example when tagging a new release. In [2026.2.0-rc3](https://github.com/goauthentik/authentik/commit/a01c0575db829d701064a6042b2f028d853ac718#diff-3ebf69f247f3231fd796e60555489b4a1ed684e3ad4cb0ace460a2ed07d53a95) it caused a change that broke the lockfile so badly it couldn't be `npm ci`d after in the [release workflow](https://github.com/goauthentik/authentik/actions/runs/22061057802/job/63741127738).