### PR TITLE
web: break preformatted desc list elements

### DIFF
--- a/web/src/styles/authentik/components/Description/description.css
+++ b/web/src/styles/authentik/components/Description/description.css
@@ -3,3 +3,7 @@
     margin-right: 6px;
     margin-bottom: 6px;
 }
+
+pre {
+    white-space: break-spaces;
+}


### PR DESCRIPTION

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->

In the SAML metadata preview, long values were overflowing (into the adjacent column and off the page).

Before:

<img width="1377" height="271" alt="image" src="https://github.com/user-attachments/assets/cc3f3c07-c397-428d-80ec-c0d86bff68e4" />

After:

<img width="1371" height="348" alt="image" src="https://github.com/user-attachments/assets/93a4c458-8f1a-48f2-8351-32dcfdf697b0" />

(Let me know if there's a better way to improve this.)

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
