### PR TITLE
web/admin: maintenance: give dialogs default exports

### DIFF
--- a/web/src/flow/providers/IFrameLogoutStage.ts
+++ b/web/src/flow/providers/IFrameLogoutStage.ts
@@ -105,7 +105,7 @@ export class IFrameLogoutStage extends BaseStage<
         `,
     ];
 
-    public override firstUpdated(changedProperties: PropertyValues): void {
+    public override firstUpdated(changedProperties: PropertyValues<this>): void {
         super.firstUpdated(changedProperties);
 
         // Initialize status tracking
@@ -281,6 +281,8 @@ export class IFrameLogoutStage extends BaseStage<
         </ak-flow-card>`;
     }
 }
+
+export default IFrameLogoutStage;
 
 declare global {
     interface HTMLElementTagNameMap {

--- a/web/src/flow/providers/SessionEnd.ts
+++ b/web/src/flow/providers/SessionEnd.ts
@@ -69,6 +69,8 @@ export class SessionEnd extends BaseStage<SessionEndChallenge, unknown> {
     }
 }
 
+export default SessionEnd;
+
 declare global {
     interface HTMLElementTagNameMap {
         "ak-stage-session-end": SessionEnd;

--- a/web/src/flow/providers/oauth2/DeviceCode.ts
+++ b/web/src/flow/providers/oauth2/DeviceCode.ts
@@ -68,6 +68,8 @@ export class OAuth2DeviceCode extends BaseStage<
     }
 }
 
+export default OAuth2DeviceCode;
+
 declare global {
     interface HTMLElementTagNameMap {
         "ak-flow-provider-oauth2-code": OAuth2DeviceCode;

--- a/web/src/flow/providers/oauth2/DeviceCodeFinish.ts
+++ b/web/src/flow/providers/oauth2/DeviceCodeFinish.ts
@@ -25,6 +25,8 @@ export class DeviceCodeFinish extends BaseStage<
     }
 }
 
+export default DeviceCodeFinish;
+
 declare global {
     interface HTMLElementTagNameMap {
         "ak-flow-provider-oauth2-code-finish": DeviceCodeFinish;

--- a/web/src/flow/providers/saml/NativeLogoutStage.ts
+++ b/web/src/flow/providers/saml/NativeLogoutStage.ts
@@ -31,7 +31,7 @@ export class NativeLogoutStage extends BaseStage<
 
     public static styles: CSSResult[] = [PFLogin, PFForm, PFButton, PFFormControl, PFTitle];
 
-    public override firstUpdated(changedProperties: PropertyValues): void {
+    public override firstUpdated(changedProperties: PropertyValues<this>): void {
         super.firstUpdated(changedProperties);
 
         if (!this.challenge) {
@@ -130,6 +130,8 @@ export class NativeLogoutStage extends BaseStage<
         return html`<ak-flow-card .challenge=${this.challenge} loading></ak-flow-card>`;
     }
 }
+
+export default NativeLogoutStage;
 
 declare global {
     interface HTMLElementTagNameMap {

--- a/web/src/flow/sources/apple/AppleLoginInit.ts
+++ b/web/src/flow/sources/apple/AppleLoginInit.ts
@@ -74,6 +74,8 @@ export class AppleLoginInit extends BaseStage<AppleLoginChallenge, AppleChalleng
     }
 }
 
+export default AppleLoginInit;
+
 declare global {
     interface HTMLElementTagNameMap {
         "ak-flow-source-oauth-apple": AppleLoginInit;

--- a/web/src/flow/sources/plex/PlexLoginInit.ts
+++ b/web/src/flow/sources/plex/PlexLoginInit.ts
@@ -87,6 +87,8 @@ export class PlexLoginInit extends BaseStage<
     }
 }
 
+export default PlexLoginInit;
+
 declare global {
     interface HTMLElementTagNameMap {
         "ak-flow-source-plex": PlexLoginInit;

--- a/web/src/flow/sources/telegram/TelegramLogin.ts
+++ b/web/src/flow/sources/telegram/TelegramLogin.ts
@@ -72,6 +72,8 @@ export class TelegramLogin extends BaseStage<
     }
 }
 
+export default TelegramLogin;
+
 declare global {
     interface HTMLElementTagNameMap {
         "ak-flow-source-telegram": TelegramLogin;

--- a/web/src/flow/stages/FlowErrorStage.ts
+++ b/web/src/flow/stages/FlowErrorStage.ts
@@ -68,6 +68,8 @@ export class FlowErrorStage extends BaseStage<FlowErrorChallenge, FlowChallengeR
     }
 }
 
+export default FlowErrorStage;
+
 declare global {
     interface HTMLElementTagNameMap {
         "ak-stage-flow-error": FlowErrorStage;

--- a/web/src/flow/stages/FlowFrameStage.ts
+++ b/web/src/flow/stages/FlowFrameStage.ts
@@ -41,6 +41,8 @@ export class FlowFrameStage extends BaseStage<FrameChallenge, FrameChallengeResp
     }
 }
 
+export default FlowFrameStage;
+
 declare global {
     interface HTMLElementTagNameMap {
         "xak-flow-frame": FlowFrameStage;

--- a/web/src/flow/stages/RedirectStage.ts
+++ b/web/src/flow/stages/RedirectStage.ts
@@ -118,6 +118,8 @@ export class RedirectStage extends BaseStage<RedirectChallenge, FlowChallengeRes
     }
 }
 
+export default RedirectStage;
+
 declare global {
     interface HTMLElementTagNameMap {
         "ak-stage-redirect": RedirectStage;

--- a/web/src/flow/stages/access_denied/AccessDeniedStage.ts
+++ b/web/src/flow/stages/access_denied/AccessDeniedStage.ts
@@ -55,6 +55,8 @@ export class AccessDeniedStage extends BaseStage<
     }
 }
 
+export default AccessDeniedStage;
+
 declare global {
     interface HTMLElementTagNameMap {
         "ak-stage-access-denied": AccessDeniedStage;

--- a/web/src/flow/stages/authenticator_duo/AuthenticatorDuoStage.ts
+++ b/web/src/flow/stages/authenticator_duo/AuthenticatorDuoStage.ts
@@ -103,6 +103,8 @@ export class AuthenticatorDuoStage extends BaseStage<
     }
 }
 
+export default AuthenticatorDuoStage;
+
 declare global {
     interface HTMLElementTagNameMap {
         "ak-stage-authenticator-duo": AuthenticatorDuoStage;

--- a/web/src/flow/stages/authenticator_email/AuthenticatorEmailStage.ts
+++ b/web/src/flow/stages/authenticator_email/AuthenticatorEmailStage.ts
@@ -142,6 +142,8 @@ export class AuthenticatorEmailStage extends BaseStage<
     }
 }
 
+export default AuthenticatorEmailStage;
+
 declare global {
     interface HTMLElementTagNameMap {
         "ak-stage-authenticator-email": AuthenticatorEmailStage;

--- a/web/src/flow/stages/authenticator_sms/AuthenticatorSMSStage.ts
+++ b/web/src/flow/stages/authenticator_sms/AuthenticatorSMSStage.ts
@@ -129,6 +129,8 @@ export class AuthenticatorSMSStage extends BaseStage<
     }
 }
 
+export default AuthenticatorSMSStage;
+
 declare global {
     interface HTMLElementTagNameMap {
         "ak-stage-authenticator-sms": AuthenticatorSMSStage;

--- a/web/src/flow/stages/authenticator_static/AuthenticatorStaticStage.ts
+++ b/web/src/flow/stages/authenticator_static/AuthenticatorStaticStage.ts
@@ -81,6 +81,8 @@ export class AuthenticatorStaticStage extends BaseStage<
     }
 }
 
+export default AuthenticatorStaticStage;
+
 declare global {
     interface HTMLElementTagNameMap {
         "ak-stage-authenticator-static": AuthenticatorStaticStage;

--- a/web/src/flow/stages/authenticator_totp/AuthenticatorTOTPStage.ts
+++ b/web/src/flow/stages/authenticator_totp/AuthenticatorTOTPStage.ts
@@ -190,6 +190,8 @@ export class AuthenticatorTOTPStage extends BaseStage<
     }
 }
 
+export default AuthenticatorTOTPStage;
+
 declare global {
     interface HTMLElementTagNameMap {
         "ak-stage-authenticator-totp": AuthenticatorTOTPStage;

--- a/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStage.ts
+++ b/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStage.ts
@@ -313,6 +313,8 @@ export class AuthenticatorValidateStage
     }
 }
 
+export default AuthenticatorValidateStage;
+
 declare global {
     interface HTMLElementTagNameMap {
         "ak-stage-authenticator-validate": AuthenticatorValidateStage;

--- a/web/src/flow/stages/autosubmit/AutosubmitStage.ts
+++ b/web/src/flow/stages/autosubmit/AutosubmitStage.ts
@@ -51,6 +51,8 @@ export class AutosubmitStage extends BaseStage<
     }
 }
 
+export default AutosubmitStage;
+
 declare global {
     interface HTMLElementTagNameMap {
         "ak-stage-autosubmit": AutosubmitStage;

--- a/web/src/flow/stages/captcha/CaptchaStage.ts
+++ b/web/src/flow/stages/captcha/CaptchaStage.ts
@@ -559,6 +559,8 @@ export class CaptchaStage
     }
 }
 
+export default CaptchaStage;
+
 declare global {
     interface HTMLElementTagNameMap {
         "ak-stage-captcha": CaptchaStage;

--- a/web/src/flow/stages/consent/ConsentStage.ts
+++ b/web/src/flow/stages/consent/ConsentStage.ts
@@ -141,6 +141,8 @@ export class ConsentStage extends BaseStage<ConsentChallenge, ConsentChallengeRe
     }
 }
 
+export default ConsentStage;
+
 declare global {
     interface HTMLElementTagNameMap {
         "ak-stage-consent": ConsentStage;

--- a/web/src/flow/stages/dummy/DummyStage.ts
+++ b/web/src/flow/stages/dummy/DummyStage.ts
@@ -38,6 +38,8 @@ export class DummyStage extends BaseStage<DummyChallenge, DummyChallengeResponse
     }
 }
 
+export default DummyStage;
+
 declare global {
     interface HTMLElementTagNameMap {
         "ak-stage-dummy": DummyStage;

--- a/web/src/flow/stages/email/EmailStage.ts
+++ b/web/src/flow/stages/email/EmailStage.ts
@@ -40,6 +40,8 @@ export class EmailStage extends BaseStage<EmailChallenge, EmailChallengeResponse
     }
 }
 
+export default EmailStage;
+
 declare global {
     interface HTMLElementTagNameMap {
         "ak-stage-email": EmailStage;

--- a/web/src/flow/stages/endpoint/agent/EndpointAgentStage.ts
+++ b/web/src/flow/stages/endpoint/agent/EndpointAgentStage.ts
@@ -106,6 +106,8 @@ export class EndpointAgentStage extends BaseStage<
     }
 }
 
+export default EndpointAgentStage;
+
 declare global {
     interface HTMLElementTagNameMap {
         "ak-stage-endpoint-agent": EndpointAgentStage;

--- a/web/src/flow/stages/identification/IdentificationStage.ts
+++ b/web/src/flow/stages/identification/IdentificationStage.ts
@@ -548,6 +548,8 @@ export class IdentificationStage extends BaseStage<
     //#endregion
 }
 
+export default IdentificationStage;
+
 declare global {
     interface HTMLElementTagNameMap {
         "ak-stage-identification": IdentificationStage;

--- a/web/src/flow/stages/password/PasswordStage.ts
+++ b/web/src/flow/stages/password/PasswordStage.ts
@@ -82,6 +82,8 @@ export class PasswordStage extends BaseStage<PasswordChallenge, PasswordChalleng
     }
 }
 
+export default PasswordStage;
+
 declare global {
     interface HTMLElementTagNameMap {
         "ak-stage-password": PasswordStage;

--- a/web/src/flow/stages/prompt/PromptStage.ts
+++ b/web/src/flow/stages/prompt/PromptStage.ts
@@ -307,6 +307,8 @@ ${prompt.initialValue}</textarea
     }
 }
 
+export default PromptStage;
+
 declare global {
     interface HTMLElementTagNameMap {
         "ak-stage-prompt": PromptStage;

--- a/web/src/flow/stages/user_login/UserLoginStage.ts
+++ b/web/src/flow/stages/user_login/UserLoginStage.ts
@@ -64,6 +64,8 @@ export class PasswordStage extends BaseStage<
     }
 }
 
+export default PasswordStage;
+
 declare global {
     interface HTMLElementTagNameMap {
         "ak-stage-user-login": PasswordStage;


### PR DESCRIPTION
## What

Provide dynamically imported dialogs and forms a default export.

Some minor cleanup of types: `PropertyValues` -\> `PropertyValues<this>` provides stronger type guarantees.

## Why

We define stages and other dynamic processes on the server side using a token, the server-side component name. Client-side elements are instantiated with a constructor and identified with an element tag name.

Dynamically importing components automatically registered the element tag name with the constructor, enabling custom elements to work. Without the default export, the registration goes to the browser but the identity of the component’s underlying constructor is lost. Browsers provide a reverse lookup: given a component’s constructor it can provide the registration tag. By having default exports, we allow dynamic imports to record the constructor, retrieve the tag, and dynamically construct the templates without having to manually maintain the tag/constructor relationship (which is already complicated enough by that server-side component/client-side element relationship).

## Testing

This is purely internal maintenance; it’s about hardening the build, not changing behavior. If it lints and builds cleanly, the only real test is that nothing is borken afterwards.

-   [X] The code has been formatted (`make web`)
