### PR TITLE
website/integrations: update jellyseerr docs to include enable proxy step

### DIFF
--- a/website/integrations/media/jellyseerr/index.md
+++ b/website/integrations/media/jellyseerr/index.md
@@ -37,6 +37,10 @@ To support the integration of Jellyseerr with authentik, you need to create an a
 Jellyseerr OAuth support is currently in preview, please make sure to use the `preview-OIDC` Docker tag.
 :::
 
+:::warn
+If your access Jellyseerr via a `https://` URL, you need to enable proxy support in **Settings** > **Network**. This allows Jellyseer to trust redirect parameters; otherwise, jellyseerr would forward a `http://` url to Authentik.
+:::
+
 1. Log in to Jellyseerr with an administrator account.
 2. Navigate to **Settings** > **Users**.
 3. Toggle on **Enable OpenID Connect Sign-In** and click on the cogwheel icon next to it.


### PR DESCRIPTION
I ran into this

https://github.com/seerr-team/seerr/pull/1505/changes#r2311308711

will convert to ready to review need to run `make docs` and whatnot