### PR TITLE
Show previously configured NameID and AuthnContextClassRef parameters for SAML

### DIFF
--- a/web/src/admin/providers/saml/SAMLProviderFormForm.ts
+++ b/web/src/admin/providers/saml/SAMLProviderFormForm.ts
@@ -27,6 +27,7 @@ import {
     KeyTypeEnum,
     PropertymappingsApi,
     PropertymappingsProviderSamlListRequest,
+    PropertymappingsProviderSamlRetrieveRequest,
     SAMLBindingsEnum,
     SAMLLogoutMethods,
     SAMLNameIDPolicyEnum,
@@ -333,7 +334,21 @@ export function renderForm({
                             const items = await new PropertymappingsApi(
                                 DEFAULT_CONFIG,
                             ).propertymappingsProviderSamlList(args);
-                            return items.results;
+                            if (!provider.nameIdMapping || query !== undefined) {
+                                return items.results;
+                            }
+
+                            const response = items.results.filter(
+                                (el) => el.pk !== provider.nameIdMapping,
+                            );
+                            const cargs: PropertymappingsProviderSamlRetrieveRequest = {
+                                pmUuid: provider.nameIdMapping,
+                            };
+                            const citem = await new PropertymappingsApi(
+                                DEFAULT_CONFIG,
+                            ).propertymappingsProviderSamlRetrieve(cargs);
+                            response.unshift(citem);
+                            return response;
                         }}
                         .renderElement=${(item: SAMLPropertyMapping): string => {
                             return item.name;
@@ -368,7 +383,21 @@ export function renderForm({
                             const items = await new PropertymappingsApi(
                                 DEFAULT_CONFIG,
                             ).propertymappingsProviderSamlList(args);
-                            return items.results;
+                            if (!provider.authnContextClassRefMapping || query !== undefined) {
+                                return items.results;
+                            }
+
+                            const response = items.results.filter(
+                                (el) => el.pk !== provider.authnContextClassRefMapping,
+                            );
+                            const cargs: PropertymappingsProviderSamlRetrieveRequest = {
+                                pmUuid: provider.authnContextClassRefMapping,
+                            };
+                            const citem = await new PropertymappingsApi(
+                                DEFAULT_CONFIG,
+                            ).propertymappingsProviderSamlRetrieve(cargs);
+                            response.unshift(citem);
+                            return response;
                         }}
                         .renderElement=${(item: SAMLPropertyMapping): string => {
                             return item.name;


### PR DESCRIPTION
## Details

Resolves https://github.com/goauthentik/authentik/issues/20146
Since users filter has been refactored for SCIM provider at the new RC versions, only SAML provider has to be fixed. It's done at the current PR.
It would be better to refactor the whole `ak-search-select` component to accept current value as an argument instead of implementing the logic for every component use. But it would require much broader testing and refactoring. I let Authentik team consider other cases. 

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [+] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
