### PR TITLE
providers/oauth2: device code flow client id via auth header

### DIFF
--- a/authentik/providers/oauth2/views/device_backchannel.py
+++ b/authentik/providers/oauth2/views/device_backchannel.py
@@ -16,7 +16,7 @@ from authentik.lib.config import CONFIG
 from authentik.lib.utils.time import timedelta_from_string
 from authentik.providers.oauth2.errors import DeviceCodeError
 from authentik.providers.oauth2.models import DeviceToken, OAuth2Provider
-from authentik.providers.oauth2.utils import TokenResponse
+from authentik.providers.oauth2.utils import TokenResponse, extract_client_auth
 from authentik.providers.oauth2.views.device_init import QS_KEY_CODE
 
 LOGGER = get_logger()
@@ -32,7 +32,7 @@ class DeviceView(View):
 
     def parse_request(self):
         """Parse incoming request"""
-        client_id = self.request.POST.get("client_id", None)
+        client_id, _ = extract_client_auth(self.request)
         if not client_id:
             raise DeviceCodeError("invalid_client")
         provider = OAuth2Provider.objects.filter(client_id=client_id).first()

--- a/website/docs/add-secure-apps/providers/oauth2/device_code.md
+++ b/website/docs/add-secure-apps/providers/oauth2/device_code.md
@@ -25,6 +25,17 @@ client_id=application_client_id&
 scope=openid email my-other-scope
 ```
 
+Alternatively the client id may be sent via the HTTP Authorization header:
+
+```http
+POST /application/o/device/ HTTP/1.1
+Host: authentik.company
+Content-Type: application/x-www-form-urlencoded
+Authorization: Bearer YXBwbGljYXRpb25fY2xpZW50X2lkOg==
+
+scope=openid email my-other-scope
+```
+
 The response contains the following fields:
 
 - `device_code`: Device code, which is the code kept on the device


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->

Fixes https://github.com/goauthentik/authentik/issues/20454

Adds support for passing the client id for device code flow in via the HTTP Authorization header, as well as the current method of passing it in the POST body.

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [x] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
