### PR TITLE
bug(outpost/ldap): flatten nested attributes into camelCase keys

### DIFF
--- a/internal/outpost/ldap/utils/utils_test.go
+++ b/internal/outpost/ldap/utils/utils_test.go
@@ -70,10 +70,10 @@ func TestAKAttrsToLDAP_String_List(t *testing.T) {
 }
 
 func TestAKAttrsToLDAP_Dict(t *testing.T) {
-	// dict
+	// Nested maps should be flattened to camelCase
 	d := map[string]any{
-		"foo": map[string]string{
-			"foo": "bar",
+		"settings": map[string]any{
+			"locale": "en",
 		},
 	}
 	mapped := AttributesToLDAP(d, func(key string) string {
@@ -82,8 +82,8 @@ func TestAKAttrsToLDAP_Dict(t *testing.T) {
 		return value
 	})
 	assert.Equal(t, 1, len(mapped))
-	assert.Equal(t, "foo", mapped[0].Name)
-	assert.Equal(t, []string{"map[foo:bar]"}, mapped[0].Values)
+	assert.Equal(t, "settingsLocale", mapped[0].Name)
+	assert.Equal(t, []string{"en"}, mapped[0].Values)
 }
 
 func TestAKAttrsToLDAP_Mixed(t *testing.T) {


### PR DESCRIPTION
This PR fixes an issue where nested attribute maps were not properly normalized before being processed for LDAP.

Introduce a flattenAttributes helper to flatten nested maps into camelCase keys recursively

Update AttributesToLDAP to flatten and normalize attributes before further processing

Ensure attribute names remain correctly formatted after dot removal via AttributeKeySanitize

Update test coverage to validate flattened output and camelCase key behavior

Previously, nested attributes could lead to incorrectly formatted LDAP attribute names after sanitization. Flattening them beforehand ensures consistent attribute keys and prevents malformed LDAP entries.

fixes  #16954 