### PR TITLE
providers/proxy: preserve URL-encoded path characters in redirect

### DIFF
--- a/internal/outpost/proxyv2/application/oauth.go
+++ b/internal/outpost/proxyv2/application/oauth.go
@@ -76,7 +76,7 @@ func (a *Application) redirectToStart(rw http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	redirectUrl := urlJoin(a.proxyConfig.ExternalHost, r.URL.Path)
+	redirectUrl := urlJoin(a.proxyConfig.ExternalHost, r.URL.EscapedPath())
 
 	if a.Mode() == api.PROXYMODE_FORWARD_DOMAIN {
 		dom := strings.TrimPrefix(*a.proxyConfig.CookieDomain, ".")

--- a/internal/outpost/proxyv2/application/utils_test.go
+++ b/internal/outpost/proxyv2/application/utils_test.go
@@ -27,6 +27,24 @@ func TestRedirectToStart_Proxy(t *testing.T) {
 	assert.Equal(t, "https://test.goauthentik.io/foo/bar/baz", s.Values[constants.SessionRedirect])
 }
 
+func TestRedirectToStart_Proxy_EncodedSlash(t *testing.T) {
+	a := newTestApplication()
+	a.proxyConfig.Mode = api.PROXYMODE_PROXY.Ptr()
+	a.proxyConfig.ExternalHost = "https://test.goauthentik.io"
+	// %2F is a URL-encoded forward slash, used by apps like RabbitMQ in queue paths
+	req, _ := http.NewRequest("GET", "/api/queues/%2F/MYChannelCreated", nil)
+
+	rr := httptest.NewRecorder()
+	a.redirectToStart(rr, req)
+
+	assert.Equal(t, http.StatusFound, rr.Code)
+	loc, _ := rr.Result().Location()
+	assert.Contains(t, loc.String(), "%252F", "encoded slash %2F must be preserved in redirect URL")
+
+	s, _ := a.sessions.Get(req, a.SessionName())
+	assert.Contains(t, s.Values[constants.SessionRedirect].(string), "%2F", "encoded slash %2F must be preserved in session redirect")
+}
+
 func TestRedirectToStart_Forward(t *testing.T) {
 	a := newTestApplication()
 	a.proxyConfig.Mode = api.PROXYMODE_FORWARD_SINGLE.Ptr()


### PR DESCRIPTION
## Summary

- Use `r.URL.EscapedPath()` instead of `r.URL.Path` in `redirectToStart()` to preserve URL-encoded characters like `%2F`
- `r.URL.Path` returns the decoded path, converting `%2F` to `/`, which `url.JoinPath` then collapses via `path.Clean`, stripping encoded slashes from the redirect URL
- `EscapedPath()` preserves the original encoding while remaining backward compatible for paths without encoded characters

Fixes #12602

## Test plan

- [x] Added `TestRedirectToStart_Proxy_EncodedSlash` test case verifying `%2F` is preserved in both the redirect URL and session redirect value
- [x] All existing `TestRedirectToStart_*` tests continue to pass
- [x] All existing `TestProxy_Redirect*` tests continue to pass
- [x] All existing `TestCheckRedirectParam_*` tests continue to pass
- [x] Full Go test suite passes (excluding pre-existing PostgreSQL-dependent tests that require a database)