### PR TITLE
policies: measure policy process from manager

### DIFF
--- a/authentik/policies/engine.py
+++ b/authentik/policies/engine.py
@@ -185,6 +185,16 @@ class PolicyEngine:
                 # Only call .recv() if no result is saved, otherwise we just deadlock here
                 if not proc_info.result:
                     proc_info.result = proc_info.connection.recv()
+                if proc_info.result and proc_info.result._exec_time:
+                    HIST_POLICIES_EXECUTION_TIME.labels(
+                        binding_order=proc_info.binding.order,
+                        binding_target_type=proc_info.binding.target_type,
+                        binding_target_name=proc_info.binding.target_name,
+                        object_type=(
+                            class_to_path(self.request.obj.__class__) if self.request.obj else ""
+                        ),
+                        mode="execute_process",
+                    ).observe(proc_info.result._exec_time)
             return self
 
     @property

--- a/authentik/policies/types.py
+++ b/authentik/policies/types.py
@@ -86,6 +86,7 @@ class PolicyResult:
         self.source_binding = None
         self.source_results = []
         self.log_messages = []
+        self._exec_time = None
 
     def __repr__(self):
         return self.__str__()

--- a/authentik/policies/types.py
+++ b/authentik/policies/types.py
@@ -77,6 +77,8 @@ class PolicyResult:
 
     log_messages: list[LogEvent] | None
 
+    _exec_time: int | None
+
     def __init__(self, passing: bool, *messages: str):
         self.passing = passing
         self.messages = messages


### PR DESCRIPTION
replaces https://github.com/goauthentik/authentik/pull/20119

currently we do prometheus metrics inside the policy process. However since each policy eval is a new process with a new pid, this can end up with a lot of prometheus multiproc db files, filling up /dev/shm

This moves the metrics up one level, they are measured in the process but reported in the parent process, which has consistent IDs for prometheus multiproc storage