### PR TITLE
web/flow: fix typo in RedirectStage

### DIFF
--- a/web/src/flow/stages/RedirectStage.ts
+++ b/web/src/flow/stages/RedirectStage.ts
@@ -102,7 +102,7 @@ export class RedirectStage extends BaseStage<RedirectChallenge, FlowChallengeRes
             <span slot="title">${msg("Redirect")}</span>
             <form class="pf-c-form">
                 <div class="pf-c-form__group">
-                    <p>${msg("You're about to be redirect to the following URL.")}</p>
+                    <p>${msg("You're about to be redirected to the following URL.")}</p>
                     <code>${this.getURL()}</code>
                 </div>
                 <fieldset class="pf-c-form__group pf-m-action">


### PR DESCRIPTION
Just trying to avoid looking unprofessional:

-   [X] The code has been formatted (`make web`)
