### PR TITLE
website/docs: fix GitHub social-login wording and capitalization

### DIFF
--- a/website/docs/users-sources/sources/social-logins/github/index.mdx
+++ b/website/docs/users-sources/sources/social-logins/github/index.mdx
@@ -1,11 +1,11 @@
 ---
-title: Github
+title: GitHub
 tags:
     - source
     - github
 ---
 
-Allows users to authenticate using their Github credentials by configuring GitHub as a federated identity provider via OAuth2.
+Allows users to authenticate using their GitHub credentials by configuring GitHub as a federated identity provider via OAuth2.
 
 ## Preparation
 
@@ -14,9 +14,9 @@ The following placeholders are used in this guide:
 - `authentik.company` is the FQDN of the authentik installation.
 - `www.my.company` is the Homepage URL for your site
 
-## Github configuration
+## GitHub configuration
 
-To integrate GitHub with authentik you will need to create an OAuth application in GitHub Developer Settings.
+To integrate GitHub with authentik, you need to create an OAuth application in GitHub Developer Settings.
 
 1. Log in to GitHub and open the [Developer Settings](https://github.com/settings/developers) menu.
 2. Create an OAuth app by clicking on the **Register a new application** button and set the following values:
@@ -70,7 +70,7 @@ from authentik.sources.oauth.models import OAuthSource
 # Set this value
 accepted_org = "your_organization"
 
-# Ensure flow is only run during oauth logins via Github
+# Ensure flow is only run during OAuth logins via GitHub
 if not isinstance(context['source'], OAuthSource) or context["source"].provider_type != "github":
     return True
 
@@ -81,7 +81,7 @@ access_token = connection.access_token
 # We also access the user info authentik already retrieved, to get the correct username
 github_username = context["oauth_userinfo"]
 
-# Github does not include Organizations in the userinfo endpoint, so we have to call another URL
+# GitHub does not include organizations in the userinfo endpoint, so we have to call another URL
 orgs_response = requests.get(
     "https://api.github.com/user/orgs",
     auth=(github_username["login"], access_token),


### PR DESCRIPTION
Update the GitHub social-login guide to consistently reference GitHub Developer Settings and correct provider wording.

Standardize GitHub capitalization across the page text and inline policy comments.
