### PR TITLE
providers/oauth2: deactivate locale after testing

### DIFF
--- a/authentik/providers/oauth2/tests/test_authorize.py
+++ b/authentik/providers/oauth2/tests/test_authorize.py
@@ -5,6 +5,7 @@ from urllib.parse import parse_qs, urlparse
 
 from django.test import RequestFactory
 from django.urls import reverse
+from django.utils import translation
 from django.utils.timezone import now
 
 from authentik.blueprints.tests import apply_blueprint
@@ -690,18 +691,21 @@ class TestAuthorize(OAuthTestCase):
         Application.objects.create(name="app", slug="app", provider=provider)
         state = generate_id()
         self.client.logout()
-        response = self.client.get(
-            reverse("authentik_providers_oauth2:authorize"),
-            data={
-                "response_type": "code",
-                "client_id": "test",
-                "state": state,
-                "redirect_uri": "foo://localhost",
-                "ui_locales": "invalid fr",
-            },
-        )
-        parsed = parse_qs(urlparse(response.url).query)
-        self.assertEqual(parsed["locale"], ["fr"])
+        try:
+            response = self.client.get(
+                reverse("authentik_providers_oauth2:authorize"),
+                data={
+                    "response_type": "code",
+                    "client_id": "test",
+                    "state": state,
+                    "redirect_uri": "foo://localhost",
+                    "ui_locales": "invalid fr",
+                },
+            )
+            parsed = parse_qs(urlparse(response.url).query)
+            self.assertEqual(parsed["locale"], ["fr"])
+        finally:
+            translation.deactivate()
 
     @apply_blueprint("default/flow-default-authentication-flow.yaml")
     def test_ui_locales_invalid(self):


### PR DESCRIPTION
fix randomly test flakiness due to the activated locale carrying over into future tests

fixes things like https://github.com/goauthentik/authentik/actions/runs/22321199164/job/64597158678

to test:

```
CI_TEST_SEED=2333807931 CI_RUN_ID=1 CI_TOTAL_RUNS=5 uv run coverage run manage.py test --keepdb --failfast authentik
```