### PR TITLE
fixup(scim): Adjust SCIM client AWS compatibility implementation

### DIFF
--- a/authentik/providers/scim/clients/base.py
+++ b/authentik/providers/scim/clients/base.py
@@ -104,8 +104,6 @@ class SCIMClient[TModel: "Model", TConnection: "Model", TSchema: "BaseModel"](
 
         try:
             config = ServiceProviderConfiguration.model_validate(self._request("GET", path))
-            if self.provider.compatibility_mode == SCIMCompatibilityMode.AWS:
-                config.patch.supported = False
             if self.provider.compatibility_mode == SCIMCompatibilityMode.SLACK:
                 config.filter.supported = True
         except (ValidationError, SCIMRequestException, NotFoundSyncException) as exc:

--- a/authentik/providers/scim/tests/test_membership.py
+++ b/authentik/providers/scim/tests/test_membership.py
@@ -532,6 +532,7 @@ class SCIMMembershipTests(TestCase):
                 "https://localhost/Groups",
                 json={
                     "id": group_scim_id,
+                    "displayName": group.name,
                 },
             )
 
@@ -608,7 +609,10 @@ class SCIMMembershipTests(TestCase):
             )
             mocker.get(
                 f"https://localhost/Groups/{group_scim_id}",
-                json={},
+                json={
+                    "id": group_scim_id,
+                    "displayName": group.name,
+                },
             )
 
             group.name = "newname" + group.name
@@ -639,7 +643,7 @@ class SCIMMembershipTests(TestCase):
                     "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
                     "Operations": [
                         {
-                            "op": "replace",
+                            "op": "add",
                             "path": "externalId",
                             "value": str(group.pk),
                         }


### PR DESCRIPTION
## Details

AWS IAM Identity Center SCIM server does support PATCH operations as it implemented, however the Compatibility Mode was forcing the `patch.supported` flag to false and thus never sending patch requests for user memberships.

When bypassing this by setting `compatibility_mode = "default"`, then memberships could be forwarded but groups couldn't be updated.

This patch aligns the behavior of `compatibility_mode = "aws"` to properly send PATCH requests for group updates as well as user membership updates.

Additionally, dumped the `ServiceProviderConfig` objects with `mode="json"`, it raised JSONSerializationError's without `mode="json"`.

AWS SCIM limitations: https://docs.aws.amazon.com/singlesignon/latest/developerguide/limitations.html

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If applicable (maybe?)

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)

---

Cherry picked from SUSE/authentik#13