### PR TITLE
website/inteegrations: fix redirect URI in Seafile integration

### DIFF
--- a/website/integrations/media/seafile/index.md
+++ b/website/integrations/media/seafile/index.md
@@ -32,7 +32,7 @@ To support the integration of Seafile with authentik, you need to create an appl
     - **Choose a Provider type**: select OAuth2/OpenID Connect as the provider type.
     - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
         - Note the **Client ID** and **Client Secret** values because they will be required later.
-        - Set a `Strict` redirect URI to `https://seafile.company/oauth/callback`.
+        - Set a `Strict` redirect URI to `https://seafile.company/oauth/callback/`.
     - **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/bindings-overview/) (policy, group, or user) to manage the listing and access to applications on a user's **My applications** page.
 
 3. Click **Submit** to save the new application and provider.


### PR DESCRIPTION
If you just follow orders exactly as said here it'll lead you to an error because of the strict policy having a slash at the end but in the seahub_settings.py in the docs tells you to put it without it. This minor change can help people to not encounter this minimal error sometimes difficult to see.
