### PR TITLE
website/docs: fix upgrade link in `2026.2` release notes

### DIFF
--- a/website/docs/releases/2026/v2026.2.md
+++ b/website/docs/releases/2026/v2026.2.md
@@ -83,7 +83,7 @@ When you upgrade, be aware that the version of the authentik instance and of any
 To upgrade, download the new docker-compose file and update the Docker stack with the new version, using these commands:
 
 ```shell
-wget -O docker-compose.yml https://goauthentik.io/version/2026.2/docker-compose.yml
+wget -O docker-compose.yml https://goauthentik.io/version/2026.2/lifecycle/container/compose.yml
 docker compose up -d
 ```
 


### PR DESCRIPTION
Closes #20538 