### PR TITLE
web/flows: Do not show the "log back in" button if the url is blank

### DIFF
--- a/web/src/common/utils.ts
+++ b/web/src/common/utils.ts
@@ -73,3 +73,16 @@ export function assertEveryPresent<T>(
         throw new TypeError(errorMessage);
     }
 }
+
+const isFullUrlRe = new RegExp("://");
+const isHttpRe = new RegExp("http(s?)://");
+const isAuthentikSpecialRe = new RegExp("goauthentik.io://");
+const isNotFullUrl = (url: string) => !isFullUrlRe.test(url);
+const isHttp = (url: string) => isHttpRe.test(url);
+const isAuthentikSpecial = (url: string) => isAuthentikSpecialRe.test(url);
+
+export function isLaunchUrlValid(url: string | null | undefined): url is string {
+    return Boolean(typeof url === "string" &&
+        url &&
+        (isHttp(url) || isNotFullUrl(url) || isAuthentikSpecial(url)));
+}

--- a/web/src/common/utils.ts
+++ b/web/src/common/utils.ts
@@ -82,7 +82,9 @@ const isHttp = (url: string) => isHttpRe.test(url);
 const isAuthentikSpecial = (url: string) => isAuthentikSpecialRe.test(url);
 
 export function isLaunchUrlValid(url: string | null | undefined): url is string {
-    return Boolean(typeof url === "string" &&
+    return Boolean(
+        typeof url === "string" &&
         url &&
-        (isHttp(url) || isNotFullUrl(url) || isAuthentikSpecial(url)));
+        (isHttp(url) || isNotFullUrl(url) || isAuthentikSpecial(url)),
+    );
 }

--- a/web/src/flow/providers/SessionEnd.ts
+++ b/web/src/flow/providers/SessionEnd.ts
@@ -2,6 +2,7 @@ import "#flow/FormStatic";
 import "#flow/components/ak-flow-card";
 
 import { globalAK } from "#common/global";
+import { isLaunchUrlValid } from "#common/utils";
 
 import { SlottedTemplateResult } from "#elements/types";
 
@@ -54,7 +55,7 @@ export class SessionEnd extends BaseStage<SessionEndChallenge, unknown> {
                           </a>
                       `
                     : nothing}
-                ${challenge.applicationLaunchUrl && challenge.applicationName
+                ${isLaunchUrlValid(challenge.applicationLaunchUrl) && challenge.applicationName
                     ? html`
                           <a
                               href="${challenge.applicationLaunchUrl}"

--- a/web/src/user/LibraryPage/LibraryPageImpl.utils.ts
+++ b/web/src/user/LibraryPage/LibraryPageImpl.utils.ts
@@ -1,18 +1,7 @@
 import type { Application } from "@goauthentik/api";
+import { isLaunchUrlValid } from "#common/utils";
 
-const isFullUrlRe = new RegExp("://");
-const isHttpRe = new RegExp("http(s?)://");
-const isAuthentikSpecialRe = new RegExp("goauthentik.io://");
-const isNotFullUrl = (url: string) => !isFullUrlRe.test(url);
-const isHttp = (url: string) => isHttpRe.test(url);
-const isAuthentikSpecial = (url: string) => isAuthentikSpecialRe.test(url);
-
-export const appHasLaunchUrl = (app: Application): boolean => {
+export const appHasLaunchUrl = (app: Application) => {
     const url = app.launchUrl;
-
-    return !!(
-        typeof url === "string" &&
-        url &&
-        (isHttp(url) || isNotFullUrl(url) || isAuthentikSpecial(url))
-    );
+    return isLaunchUrlValid(url)
 };

--- a/web/src/user/LibraryPage/LibraryPageImpl.utils.ts
+++ b/web/src/user/LibraryPage/LibraryPageImpl.utils.ts
@@ -1,7 +1,8 @@
-import type { Application } from "@goauthentik/api";
 import { isLaunchUrlValid } from "#common/utils";
+
+import type { Application } from "@goauthentik/api";
 
 export const appHasLaunchUrl = (app: Application) => {
     const url = app.launchUrl;
-    return isLaunchUrlValid(url)
+    return isLaunchUrlValid(url);
 };


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

Do not show the "Log back into <app>" button if the launch url is set to `blank://blank`
Showing that results in a page reload and then the user just gets stuck.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
