### PR TITLE
web: Use local development prettier config.

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -127,10 +127,41 @@
                 "@esbuild/darwin-arm64": "^0.27.3",
                 "@esbuild/linux-arm64": "^0.27.3",
                 "@esbuild/linux-x64": "^0.27.3",
+                "@goauthentik/prettier-config-dev": "../packages/prettier-config",
                 "@rollup/rollup-darwin-arm64": "^4.57.1",
                 "@rollup/rollup-linux-arm64-gnu": "^4.57.1",
                 "@rollup/rollup-linux-x64-gnu": "^4.57.1",
                 "chromedriver": "^145.0.3"
+            }
+        },
+        "../packages/prettier-config": {
+            "name": "@goauthentik/prettier-config",
+            "version": "3.4.1",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "format-imports": "^4.0.8"
+            },
+            "devDependencies": {
+                "@eslint/js": "^9.39.3",
+                "@goauthentik/eslint-config": "../eslint-config",
+                "@goauthentik/tsconfig": "../tsconfig",
+                "@types/node": "^25.0.0",
+                "@typescript-eslint/eslint-plugin": "^8.49.0",
+                "@typescript-eslint/parser": "^8.49.0",
+                "eslint": "^9.39.3",
+                "prettier": "^3.8.1",
+                "prettier-plugin-packagejson": "^3.0.0",
+                "typescript": "^5.9.3",
+                "typescript-eslint": "^8.56.1"
+            },
+            "engines": {
+                "node": ">=24",
+                "npm": ">=11.10.1"
+            },
+            "peerDependencies": {
+                "prettier": "^3.8.1",
+                "prettier-plugin-packagejson": "^3.0.0"
             }
         },
         "node_modules/@adobe/css-tools": {
@@ -1494,6 +1525,10 @@
                 "prettier": "^3.8.1",
                 "prettier-plugin-packagejson": "^3.0.0"
             }
+        },
+        "node_modules/@goauthentik/prettier-config-dev": {
+            "resolved": "../packages/prettier-config",
+            "link": true
         },
         "node_modules/@goauthentik/tsconfig": {
             "version": "1.0.5",

--- a/web/package.json
+++ b/web/package.json
@@ -198,6 +198,7 @@
         "@esbuild/darwin-arm64": "^0.27.3",
         "@esbuild/linux-arm64": "^0.27.3",
         "@esbuild/linux-x64": "^0.27.3",
+        "@goauthentik/prettier-config-dev": "../packages/prettier-config",
         "@rollup/rollup-darwin-arm64": "^4.57.1",
         "@rollup/rollup-linux-arm64-gnu": "^4.57.1",
         "@rollup/rollup-linux-x64-gnu": "^4.57.1",
@@ -315,7 +316,7 @@
             "onFail": "warn"
         }
     },
-    "prettier": "@goauthentik/prettier-config",
+    "prettier": "./prettier.config.mjs",
     "overrides": {
         "@goauthentik/esbuild-plugin-live-reload": {
             "esbuild": "$esbuild"

--- a/web/prettier.config.mjs
+++ b/web/prettier.config.mjs
@@ -1,0 +1,15 @@
+/**
+ * @file Prettier config resolver.
+ *
+ * This file attempts to import the monorepo's local Prettier config package,
+ * falling back to the published version if the local one cannot be found.
+ */
+
+const config = await import("@goauthentik/prettier-config-dev")
+    .catch(() => {
+        console.debug("Fallback to published @goauthentik/prettier-config");
+        return import("@goauthentik/prettier-config");
+    })
+    .then((module) => module.default);
+
+export default config;


### PR DESCRIPTION
## Details

This PR updates the web package.json to prefer the local prettier config package when available, fixing scenarios where updating the config can result in odd linter behavior.