### PR TITLE
packages/django-dramatiq-postgres: use fork

### DIFF
--- a/packages/django-dramatiq-postgres/django_dramatiq_postgres/management/commands/worker.py
+++ b/packages/django-dramatiq-postgres/django_dramatiq_postgres/management/commands/worker.py
@@ -1,5 +1,6 @@
 import sys
 from argparse import Namespace
+from multiprocessing import set_start_method
 from typing import Any
 
 from django.apps.registry import apps
@@ -69,7 +70,7 @@ class Command(BaseCommand):
             args.pid_file = pid_file
 
         args.verbose = verbosity - 1
-
+        set_start_method("fork")
         connections.close_all()
         sys.exit(main(args))  # type: ignore[no-untyped-call]
 


### PR DESCRIPTION
fixes a big memory issue since upgrading to python 3.14

3.14 switches the default (in our case on linux) to forkserver, which seems to bring with it a much higher memory usage

closes #20537