### PR TITLE
website/integrations: replace Wiki.js hard-coded application slug with placeholder

### DIFF
--- a/website/integrations/documentation/wiki-js/index.md
+++ b/website/integrations/documentation/wiki-js/index.md
@@ -59,8 +59,8 @@ In Wiki.js, configure the authentication strategy with these settings:
 - Authorization Endpoint URL: https://authentik.company/application/o/authorize/
 - Token Endpoint URL: https://authentik.company/application/o/token/
 - User Info Endpoint URL: https://authentik.company/application/o/userinfo/
-- Issuer: https://authentik.company/application/o/wikijs/
-- Logout URL: https://authentik.company/application/o/wikijs/end-session/
+- Issuer: https://authentik.company/application/o/<slug>/
+- Logout URL: https://authentik.company/application/o/<slug>/end-session/
 - Allow self-registration: Enabled
 - Assign to group: The group to which new users logging in from authentik should be assigned.
 

--- a/website/integrations/documentation/wiki-js/index.md
+++ b/website/integrations/documentation/wiki-js/index.md
@@ -59,8 +59,8 @@ In Wiki.js, configure the authentication strategy with these settings:
 - Authorization Endpoint URL: https://authentik.company/application/o/authorize/
 - Token Endpoint URL: https://authentik.company/application/o/token/
 - User Info Endpoint URL: https://authentik.company/application/o/userinfo/
-- Issuer: https://authentik.company/application/o/<slug>/
-- Logout URL: https://authentik.company/application/o/<slug>/end-session/
+- Issuer: `https://authentik.company/application/o/<application_slug>/`
+- Logout URL: `https://authentik.company/application/o/<application_slug>/end-session/`
 - Allow self-registration: Enabled
 - Assign to group: The group to which new users logging in from authentik should be assigned.
 


### PR DESCRIPTION
## Details

Edits a couple of URLs in the Wiki.js instructions, where the application slug was hard-coded.

I named the application `Wiki.js`, and Authentik auto-generated a slug `wiki-js` that doesn't match the one assumed here. Took me a few hours to figure out why it wasn't working.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
