### PR TITLE
crypto: fix kid legacy signal

### DIFF
--- a/authentik/crypto/models.py
+++ b/authentik/crypto/models.py
@@ -78,7 +78,7 @@ def generate_key_id_legacy(key_data: str) -> str:
     """Generate Key ID using MD5 (legacy format for backwards compatibility)."""
     if not key_data:
         return ""
-    return md5(key_data.encode("utf-8")).hexdigest()  # nosec
+    return md5(key_data.encode("utf-8"), usedforsecurity=False).hexdigest()  # nosec
 
 
 class CertificateKeyPair(SerializerModel, ManagedModel, CreatedUpdatedModel):


### PR DESCRIPTION
without this in the container you'd get `UnsupportedDigestmodError [digital envelope routines] unsupported` due to FIPS