### PR TITLE
tasks: fix the occasional DatabaseError for no updated fields

### DIFF
--- a/authentik/tasks/middleware.py
+++ b/authentik/tasks/middleware.py
@@ -295,6 +295,7 @@ class WorkerStatusMiddleware(Middleware):
         lock_id = f"goauthentik.io/worker/status/{status.pk}"
         with pglock.advisory(lock_id, side_effect=pglock.Raise):
             while not event.is_set():
+                status.refresh_from_db()
                 old_last_seen = status.last_seen
                 status.last_seen = now()
                 if old_last_seen != status.last_seen:


### PR DESCRIPTION
seen in https://github.com/goauthentik/authentik/actions/runs/22491570448/job/65154935173

```
    File "/home/runner/work/authentik/authentik/.venv/lib/python3.14/site-packages/sentry_sdk/utils.py", line 1784, in reraise
      raise value
    File "/home/runner/work/authentik/authentik/.venv/lib/python3.14/site-packages/sentry_sdk/integrations/threading.py", line 133, in _run_old_run_func
      return old_run_func(self, *a[1:], **kw)
    File "/opt/hostedtoolcache/Python/3.14.3/x64/lib/python3.14/threading.py", line 1024, in run
      self._target(*self._args, **self._kwargs)
      ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/home/runner/work/authentik/authentik/authentik/tasks/middleware.py", line 285, in run
      WorkerStatusMiddleware.keep(event, status)
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
    File "/home/runner/work/authentik/authentik/authentik/tasks/middleware.py", line 301, in keep
      status.save(update_fields=("last_seen",))
      ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/home/runner/work/authentik/authentik/.venv/lib/python3.14/site-packages/django/db/models/base.py", line 902, in save
      self.save_base(
      ~~~~~~~~~~~~~~^
          using=using,
          ^^^^^^^^^^^^
      ...<2 lines>...
          update_fields=update_fields,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      )
      ^
    File "/home/runner/work/authentik/authentik/.venv/lib/python3.14/site-packages/django/db/models/base.py", line 1008, in save_base
      updated = self._save_table(
          raw,
      ...<4 lines>...
          update_fields,
      )
    File "/home/runner/work/authentik/authentik/.venv/lib/python3.14/site-packages/django/db/models/base.py", line 1144, in _save_table
      raise DatabaseError("Save with update_fields did not affect any rows.")
  django.db.utils.DatabaseError: Save with update_fields did not affect any rows.

```