### PR TITLE
website/docs: fix upgrade link in 2026.5 release notes

### DIFF
--- a/website/docs/releases/2026/v2026.5.md
+++ b/website/docs/releases/2026/v2026.5.md
@@ -12,7 +12,7 @@ draft: true
 
 ## Upgrading
 
-This release does not introduce any new requirements. You can follow the upgrade instructions below; for more detailed information about upgrading authentik, refer to our [Upgrade documentation](../install-config/upgrade.mdx).
+This release does not introduce any new requirements. You can follow the upgrade instructions below; for more detailed information about upgrading authentik, refer to our [Upgrade documentation](../../install-config/upgrade.mdx).
 
 :::warning
 When you upgrade, be aware that the version of the authentik instance and of any outposts must be the same. We recommended that you always upgrade any outposts at the same time you upgrade your authentik instance.


### PR DESCRIPTION
<img width="3070" height="926" alt="image" src="https://github.com/user-attachments/assets/06b5d6af-e8ac-4987-8f99-1e9cf17ff89c" />