### PR TITLE
admin/files: allow configuring S3 signature version

### DIFF
--- a/authentik/admin/files/backends/s3.py
+++ b/authentik/admin/files/backends/s3.py
@@ -100,13 +100,25 @@ class S3Backend(ManageableBackend):
             f"storage.{self.usage.value}.{self.name}.addressing_style",
             CONFIG.get(f"storage.{self.name}.addressing_style", "auto"),
         )
+        signature_version = CONFIG.get(
+            f"storage.{self.usage.value}.{self.name}.signature_version",
+            CONFIG.get(f"storage.{self.name}.signature_version", "s3v4"),
+        )
+        # Keep signature_version pass-through and let boto3/botocore handle it.
+        # In boto3's S3 configuration docs, `s3v4` (default) and deprecated `s3`
+        # are the documented values:
+        # https://github.com/boto/boto3/blob/791a3e8f36d83664a47b4281a0586b3546cef3ec/docs/source/guide/configuration.rst?plain=1#L398-L407
+        # Botocore also supports additional signer names, so we intentionally do
+        # not enforce a restricted allowlist here.
 
         return self.session.client(
             "s3",
             endpoint_url=endpoint_url,
             use_ssl=use_ssl,
             region_name=region_name,
-            config=Config(signature_version="s3v4", s3={"addressing_style": addressing_style}),
+            config=Config(
+                signature_version=signature_version, s3={"addressing_style": addressing_style}
+            ),
         )
 
     @property

--- a/authentik/lib/default.yml
+++ b/authentik/lib/default.yml
@@ -166,6 +166,7 @@ storage:
     # region: "us-east-1"
     # use_ssl: True
     # endpoint: "https://s3.us-east-1.amazonaws.com"
+    # signature_version: "s3v4"
     # access_key: ""
     # secret_key: ""
     # bucket_name: "authentik-data"

--- a/website/docs/install-config/configuration/configuration.mdx
+++ b/website/docs/install-config/configuration/configuration.mdx
@@ -357,6 +357,14 @@ Valid values are `auto` and `path`.
 
 Defaults to `auto`.
 
+#### `AUTHENTIK_STORAGE__S3__SIGNATURE_VERSION`
+
+Configure the signing method used for S3 requests.
+
+Defaults to `s3v4`.
+
+Set to `s3` for legacy S3-compatible providers that do not support signature v4.
+
 #### `AUTHENTIK_STORAGE__S3__SESSION_PROFILE`
 
 Profile to use when using AWS SDK authentication.

--- a/website/docs/sys-mgmt/ops/storage-s3.md
+++ b/website/docs/sys-mgmt/ops/storage-s3.md
@@ -144,6 +144,14 @@ AUTHENTIK_STORAGE__S3__ENDPOINT=https://s3.provider
 AUTHENTIK_STORAGE__S3__CUSTOM_DOMAIN=s3.provider/authentik-media
 ```
 
+If your provider only supports legacy S3 signatures, also set:
+
+```env
+AUTHENTIK_STORAGE__S3__SIGNATURE_VERSION=s3
+```
+
+By default, authentik uses signature version `s3v4`.
+
 The `AUTHENTIK_STORAGE__S3__ENDPOINT` setting controls how authentik communicates with the S3 provider. When set, it overrides region/`USE_SSL`.
 
 The `AUTHENTIK_STORAGE__S3__CUSTOM_DOMAIN` setting controls how media URLs are built for the web interface. It must include the bucket name and must not include a scheme.


### PR DESCRIPTION
Closes: https://github.com/goauthentik/authentik/issues/20564

Allows the configuration of the S3 signature version