### PR TITLE
providers/proxy: move search path to query instead of runtime parameter

### DIFF
--- a/internal/outpost/proxyv2/postgresstore/connpool.go
+++ b/internal/outpost/proxyv2/postgresstore/connpool.go
@@ -25,8 +25,6 @@ type RefreshableConnPool struct {
 	currentDSN string
 	gormConfig *gorm.Config
 
-	SearchPath string
-
 	// Connection pool settings (stored for reapplication after reconnection)
 	maxIdleConns    int
 	maxOpenConns    int
@@ -58,10 +56,6 @@ func NewRefreshableConnPool(initialDSN string, gormConfig *gorm.Config, maxIdleC
 		connMaxLifetime: connMaxLifetime,
 	}
 
-	if err := pool.setSearchPath(context.Background(), db); err != nil {
-		return nil, err
-	}
-
 	return pool, nil
 }
 
@@ -80,17 +74,6 @@ func isAuthError(err error) bool {
 	}
 
 	return false
-}
-
-func (p *RefreshableConnPool) setSearchPath(ctx context.Context, db *sql.DB) error {
-	if p.SearchPath == "" {
-		return nil
-	}
-	if _, err := db.ExecContext(ctx, "SET search_path = %s", p.SearchPath); err != nil {
-		p.log.WithError(err).Error("Failed to set search_path")
-		return err
-	}
-	return nil
 }
 
 // refreshCredentials checks if credentials have changed and reconnects if needed
@@ -137,11 +120,6 @@ func (p *RefreshableConnPool) refreshCredentials(ctx context.Context) error {
 	newDB.SetMaxIdleConns(p.maxIdleConns)
 	newDB.SetMaxOpenConns(p.maxOpenConns)
 	newDB.SetConnMaxLifetime(p.connMaxLifetime)
-
-	if err := p.setSearchPath(ctx, newDB); err != nil {
-		_ = newDB.Close()
-		return err
-	}
 
 	// Verify the connection works BEFORE closing old connection
 	if err := newDB.PingContext(ctx); err != nil {

--- a/internal/outpost/proxyv2/postgresstore/connpool.go
+++ b/internal/outpost/proxyv2/postgresstore/connpool.go
@@ -25,6 +25,8 @@ type RefreshableConnPool struct {
 	currentDSN string
 	gormConfig *gorm.Config
 
+	SearchPath string
+
 	// Connection pool settings (stored for reapplication after reconnection)
 	maxIdleConns    int
 	maxOpenConns    int
@@ -56,6 +58,10 @@ func NewRefreshableConnPool(initialDSN string, gormConfig *gorm.Config, maxIdleC
 		connMaxLifetime: connMaxLifetime,
 	}
 
+	if err := pool.setSearchPath(context.Background(), db); err != nil {
+		return nil, err
+	}
+
 	return pool, nil
 }
 
@@ -74,6 +80,17 @@ func isAuthError(err error) bool {
 	}
 
 	return false
+}
+
+func (p *RefreshableConnPool) setSearchPath(ctx context.Context, db *sql.DB) error {
+	if p.SearchPath == "" {
+		return nil
+	}
+	if _, err := db.ExecContext(ctx, "SET search_path = %s", p.SearchPath); err != nil {
+		p.log.WithError(err).Error("Failed to set search_path")
+		return err
+	}
+	return nil
 }
 
 // refreshCredentials checks if credentials have changed and reconnects if needed
@@ -120,6 +137,11 @@ func (p *RefreshableConnPool) refreshCredentials(ctx context.Context) error {
 	newDB.SetMaxIdleConns(p.maxIdleConns)
 	newDB.SetMaxOpenConns(p.maxOpenConns)
 	newDB.SetConnMaxLifetime(p.connMaxLifetime)
+
+	if err := p.setSearchPath(ctx, newDB); err != nil {
+		_ = newDB.Close()
+		return err
+	}
 
 	// Verify the connection works BEFORE closing old connection
 	if err := newDB.PingContext(ctx); err != nil {

--- a/internal/outpost/proxyv2/postgresstore/postgresstore.go
+++ b/internal/outpost/proxyv2/postgresstore/postgresstore.go
@@ -207,6 +207,15 @@ func BuildConnConfig(cfg config.PostgreSQLConfig) (*pgx.ConnConfig, error) {
 		}
 	}
 
+	// search_path may already be present via pgx/libpq inherited defaults (e.g. service files).
+	// Always remove it from startup RuntimeParams; apply it via AfterConnect instead.
+	if inheritedSearchPath, hasInheritedSearchPath := connConfig.RuntimeParams["search_path"]; hasInheritedSearchPath {
+		if effectiveSearchPath == "" {
+			effectiveSearchPath = inheritedSearchPath
+		}
+		delete(connConfig.RuntimeParams, "search_path")
+	}
+
 	// Set search_path after connection startup to avoid startup-parameter issues with PgBouncer.
 	if effectiveSearchPath != "" {
 		connConfig.AfterConnect = func(ctx context.Context, pgConn *pgconn.PgConn) error {

--- a/internal/outpost/proxyv2/postgresstore/postgresstore.go
+++ b/internal/outpost/proxyv2/postgresstore/postgresstore.go
@@ -187,21 +187,7 @@ func BuildConnConfig(cfg config.PostgreSQLConfig) (*pgx.ConnConfig, error) {
 	if connConfig.RuntimeParams == nil {
 		connConfig.RuntimeParams = make(map[string]string)
 	}
-
-	// Set search_path after connection startup to avoid startup-parameter issues with PgBouncer.
-	if cfg.DefaultSchema != "" {
-		connConfig.AfterConnect = func(ctx context.Context, pgConn *pgconn.PgConn) error {
-			result := pgConn.ExecParams(
-				ctx,
-				"select pg_catalog.set_config('search_path', $1, false)",
-				[][]byte{[]byte(cfg.DefaultSchema)},
-				nil,
-				nil,
-				nil,
-			).Read()
-			return result.Err
-		}
-	}
+	effectiveSearchPath := cfg.DefaultSchema
 
 	// Parse and apply connection options if specified
 	if cfg.ConnOptions != "" {
@@ -209,9 +195,30 @@ func BuildConnConfig(cfg config.PostgreSQLConfig) (*pgx.ConnConfig, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse connection options: %w", err)
 		}
+		// Handle search_path outside of startup RuntimeParams for PgBouncer compatibility.
+		// ConnOptions should still override DefaultSchema when both are set.
+		if connOptionsSearchPath, ok := connOpts["search_path"]; ok {
+			effectiveSearchPath = connOptionsSearchPath
+			delete(connOpts, "search_path")
+		}
 
 		if err := applyConnOptions(connConfig, connOpts); err != nil {
 			return nil, fmt.Errorf("failed to apply connection options: %w", err)
+		}
+	}
+
+	// Set search_path after connection startup to avoid startup-parameter issues with PgBouncer.
+	if effectiveSearchPath != "" {
+		connConfig.AfterConnect = func(ctx context.Context, pgConn *pgconn.PgConn) error {
+			result := pgConn.ExecParams(
+				ctx,
+				"select pg_catalog.set_config('search_path', $1, false)",
+				[][]byte{[]byte(effectiveSearchPath)},
+				nil,
+				nil,
+				nil,
+			).Read()
+			return result.Err
 		}
 	}
 

--- a/internal/outpost/proxyv2/postgresstore/postgresstore.go
+++ b/internal/outpost/proxyv2/postgresstore/postgresstore.go
@@ -188,10 +188,6 @@ func BuildConnConfig(cfg config.PostgreSQLConfig) (*pgx.ConnConfig, error) {
 		connConfig.RuntimeParams = make(map[string]string)
 	}
 
-	if cfg.DefaultSchema != "" {
-		connConfig.RuntimeParams["search_path"] = cfg.DefaultSchema
-	}
-
 	// Parse and apply connection options if specified
 	if cfg.ConnOptions != "" {
 		connOpts, err := parseConnOptions(cfg.ConnOptions)
@@ -335,6 +331,9 @@ func SetupGORMWithRefreshablePool(cfg config.PostgreSQLConfig, gormConfig *gorm.
 	pool, err := NewRefreshableConnPool(dsn, gormConfig, maxIdleConns, maxOpenConns, connMaxLifetime)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create connection pool: %w", err)
+	}
+	if cfg.DefaultSchema != "" {
+		pool.SearchPath = cfg.DefaultSchema
 	}
 
 	// Create GORM DB using the refreshable connection pool

--- a/internal/outpost/proxyv2/postgresstore/postgresstore.go
+++ b/internal/outpost/proxyv2/postgresstore/postgresstore.go
@@ -195,12 +195,9 @@ func BuildConnConfig(cfg config.PostgreSQLConfig) (*pgx.ConnConfig, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse connection options: %w", err)
 		}
-		// Handle search_path outside of startup RuntimeParams for PgBouncer compatibility.
-		// ConnOptions should still override DefaultSchema when both are set.
-		if connOptionsSearchPath, ok := connOpts["search_path"]; ok {
-			effectiveSearchPath = connOptionsSearchPath
-			delete(connOpts, "search_path")
-		}
+		// search_path from ConnOptions is not supported here; Django controls schema selection.
+		// Always remove it so it cannot end up in startup RuntimeParams via applyConnOptions.
+		delete(connOpts, "search_path")
 
 		if err := applyConnOptions(connConfig, connOpts); err != nil {
 			return nil, fmt.Errorf("failed to apply connection options: %w", err)

--- a/internal/outpost/proxyv2/postgresstore/postgresstore.go
+++ b/internal/outpost/proxyv2/postgresstore/postgresstore.go
@@ -188,6 +188,21 @@ func BuildConnConfig(cfg config.PostgreSQLConfig) (*pgx.ConnConfig, error) {
 		connConfig.RuntimeParams = make(map[string]string)
 	}
 
+	// Set search_path after connection startup to avoid startup-parameter issues with PgBouncer.
+	if cfg.DefaultSchema != "" {
+		connConfig.AfterConnect = func(ctx context.Context, pgConn *pgconn.PgConn) error {
+			result := pgConn.ExecParams(
+				ctx,
+				"select pg_catalog.set_config('search_path', $1, false)",
+				[][]byte{[]byte(cfg.DefaultSchema)},
+				nil,
+				nil,
+				nil,
+			).Read()
+			return result.Err
+		}
+	}
+
 	// Parse and apply connection options if specified
 	if cfg.ConnOptions != "" {
 		connOpts, err := parseConnOptions(cfg.ConnOptions)
@@ -331,9 +346,6 @@ func SetupGORMWithRefreshablePool(cfg config.PostgreSQLConfig, gormConfig *gorm.
 	pool, err := NewRefreshableConnPool(dsn, gormConfig, maxIdleConns, maxOpenConns, connMaxLifetime)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create connection pool: %w", err)
-	}
-	if cfg.DefaultSchema != "" {
-		pool.SearchPath = cfg.DefaultSchema
 	}
 
 	// Create GORM DB using the refreshable connection pool

--- a/internal/outpost/proxyv2/postgresstore/postgresstore_test.go
+++ b/internal/outpost/proxyv2/postgresstore/postgresstore_test.go
@@ -700,7 +700,7 @@ func TestBuildConnConfig(t *testing.T) {
 				DefaultSchema: "custom_schema",
 			},
 			validate: func(t *testing.T, cc *pgx.ConnConfig) {
-				assert.Equal(t, "custom_schema", cc.RuntimeParams["search_path"])
+				assert.NotNil(t, cc.AfterConnect)
 			},
 		},
 		{
@@ -756,7 +756,7 @@ func TestBuildConnConfig(t *testing.T) {
 				assert.Equal(t, "admin", cc.User)
 				assert.Equal(t, "my super secret password!@#", cc.Password)
 				assert.Equal(t, "production", cc.Database)
-				assert.Equal(t, "app_schema", cc.RuntimeParams["search_path"])
+				assert.NotNil(t, cc.AfterConnect)
 				assert.Equal(t, "authentik", cc.RuntimeParams["application_name"])
 			},
 		},
@@ -863,7 +863,7 @@ func TestBuildConnConfig_WithSSLCertificates(t *testing.T) {
 				assert.Equal(t, "db.example.com", cc.TLSConfig.ServerName)
 				assert.NotNil(t, cc.TLSConfig.RootCAs)
 				assert.Len(t, cc.TLSConfig.Certificates, 1)
-				assert.Equal(t, "app_schema", cc.RuntimeParams["search_path"])
+				assert.NotNil(t, cc.AfterConnect)
 				assert.Equal(t, "authentik", cc.RuntimeParams["application_name"])
 			},
 		},

--- a/internal/outpost/proxyv2/postgresstore/postgresstore_test.go
+++ b/internal/outpost/proxyv2/postgresstore/postgresstore_test.go
@@ -1357,6 +1357,83 @@ func TestBuildConnConfig_WithBase64EncodedConnOptions(t *testing.T) {
 	}
 }
 
+// Verifies DefaultSchema is applied via AfterConnect and never via startup RuntimeParams.
+func TestBuildConnConfig_SearchPath_DefaultSchema(t *testing.T) {
+	cfg := config.PostgreSQLConfig{
+		Host:          "localhost",
+		Port:          "5432",
+		User:          "authentik",
+		Name:          "authentik",
+		DefaultSchema: "default_schema",
+	}
+
+	connConfig, err := BuildConnConfig(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, connConfig.AfterConnect)
+	_, hasSearchPath := connConfig.RuntimeParams["search_path"]
+	assert.False(t, hasSearchPath, "search_path should not appear in RuntimeParams")
+}
+
+// Verifies ConnOptions search_path is applied via AfterConnect and excluded from startup RuntimeParams.
+func TestBuildConnConfig_SearchPath_ConnOptions(t *testing.T) {
+	cfg := config.PostgreSQLConfig{
+		Host:        "localhost",
+		Port:        "5432",
+		User:        "authentik",
+		Name:        "authentik",
+		ConnOptions: base64.StdEncoding.EncodeToString([]byte(`{"search_path":"connopt_schema"}`)),
+	}
+
+	connConfig, err := BuildConnConfig(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, connConfig.AfterConnect)
+	_, hasSearchPath := connConfig.RuntimeParams["search_path"]
+	assert.False(t, hasSearchPath, "search_path should not appear in RuntimeParams")
+}
+
+// Verifies ConnOptions search_path overrides DefaultSchema while keeping other conn options behavior.
+func TestBuildConnConfig_SearchPath_ConnOptionsOverrideDefault(t *testing.T) {
+	cfg := config.PostgreSQLConfig{
+		Host:          "localhost",
+		Port:          "5432",
+		User:          "authentik",
+		Name:          "authentik",
+		DefaultSchema: "default_schema",
+		ConnOptions:   base64.StdEncoding.EncodeToString([]byte(`{"search_path":"override_schema","application_name":"authentik-proxy"}`)),
+	}
+
+	connConfig, err := BuildConnConfig(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, connConfig.AfterConnect)
+	assert.Equal(t, "authentik-proxy", connConfig.RuntimeParams["application_name"])
+	_, hasSearchPath := connConfig.RuntimeParams["search_path"]
+	assert.False(t, hasSearchPath, "search_path should not appear in RuntimeParams")
+}
+
+// Verifies inherited search_path from pgx/libpq defaults is removed from startup RuntimeParams.
+func TestBuildConnConfig_SearchPath_InheritedServiceSetting(t *testing.T) {
+	serviceFile := filepath.Join(t.TempDir(), "pg_service.conf")
+	err := os.WriteFile(serviceFile, []byte("[authentik-test]\nsearch_path=service_schema\n"), 0o600)
+	require.NoError(t, err)
+
+	t.Setenv("PGSERVICE", "authentik-test")
+	t.Setenv("PGSERVICEFILE", serviceFile)
+
+	cfg := config.PostgreSQLConfig{
+		Host: "localhost",
+		Port: "5432",
+		User: "authentik",
+		Name: "authentik",
+	}
+
+	connConfig, err := BuildConnConfig(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, connConfig.AfterConnect)
+
+	_, hasSearchPath := connConfig.RuntimeParams["search_path"]
+	assert.False(t, hasSearchPath, "search_path should not appear in RuntimeParams")
+}
+
 // TestBuildConnConfig_TargetSessionAttrs demonstrates how target_session_attrs
 // should be properly handled using pgx's ValidateConnect callback
 func TestBuildConnConfig_TargetSessionAttrs(t *testing.T) {

--- a/internal/outpost/proxyv2/postgresstore/postgresstore_test.go
+++ b/internal/outpost/proxyv2/postgresstore/postgresstore_test.go
@@ -1374,7 +1374,7 @@ func TestBuildConnConfig_SearchPath_DefaultSchema(t *testing.T) {
 	assert.False(t, hasSearchPath, "search_path should not appear in RuntimeParams")
 }
 
-// Verifies ConnOptions search_path is applied via AfterConnect and excluded from startup RuntimeParams.
+// Verifies ConnOptions search_path is ignored and excluded from startup RuntimeParams.
 func TestBuildConnConfig_SearchPath_ConnOptions(t *testing.T) {
 	cfg := config.PostgreSQLConfig{
 		Host:        "localhost",
@@ -1386,13 +1386,13 @@ func TestBuildConnConfig_SearchPath_ConnOptions(t *testing.T) {
 
 	connConfig, err := BuildConnConfig(cfg)
 	require.NoError(t, err)
-	require.NotNil(t, connConfig.AfterConnect)
+	assert.Nil(t, connConfig.AfterConnect)
 	_, hasSearchPath := connConfig.RuntimeParams["search_path"]
 	assert.False(t, hasSearchPath, "search_path should not appear in RuntimeParams")
 }
 
-// Verifies ConnOptions search_path overrides DefaultSchema while keeping other conn options behavior.
-func TestBuildConnConfig_SearchPath_ConnOptionsOverrideDefault(t *testing.T) {
+// Verifies ConnOptions search_path does not override DefaultSchema and other conn options still apply.
+func TestBuildConnConfig_SearchPath_ConnOptionsIgnoredWhenDefaultSchemaSet(t *testing.T) {
 	cfg := config.PostgreSQLConfig{
 		Host:          "localhost",
 		Port:          "5432",


### PR DESCRIPTION
runtime parameter is incompatible with pgbouncer

closes #19939