### PR TITLE
web/admin: bad width on policy test results

### DIFF
--- a/web/src/admin/policies/PolicyTestForm.ts
+++ b/web/src/admin/policies/PolicyTestForm.ts
@@ -21,7 +21,7 @@ import {
 import YAML from "yaml";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, nothing, TemplateResult } from "lit";
+import { css, CSSResult, html, nothing, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
 import PFDescriptionList from "@patternfly/patternfly/components/DescriptionList/description-list.css";
@@ -56,7 +56,15 @@ export class PolicyTestForm extends Form<PolicyTestRequest> {
         return (this.result = result);
     }
 
-    static styles: CSSResult[] = [...super.styles, PFDescriptionList];
+    static styles: CSSResult[] = [
+        ...super.styles,
+        PFDescriptionList,
+        css`
+            .ak-policy-test-log-messages {
+                width: 100%;
+            }
+        `,
+    ];
 
     renderResult(): TemplateResult {
         return html`
@@ -89,7 +97,7 @@ export class PolicyTestForm extends Form<PolicyTestRequest> {
 
             <ak-form-element-horizontal label=${msg("Log messages")}>
                 <div class="pf-c-form__group-label">
-                    <div class="c-form__horizontal-group">
+                    <div class="pf-c-form__horizontal-group ak-policy-test-log-messages">
                         <dl class="pf-c-description-list pf-m-horizontal">
                             <ak-log-viewer .logs=${this.result?.logMessages}></ak-log-viewer>
                         </dl>


### PR DESCRIPTION
## What

1.  Set a 100% width on the container for polcy test log messages.

## Why

A classic bug, made more complex by modern sensibilities. The group to be rendered is in a slot, but its parent doesn’t have a set width by default, and so it’s “projected” into a zero-width container. As a result, the `1fr` (“100/100 width”) doesn’t matter here; we need to go old-skool and force its parent to take up the full width of *its* container with a hard `width` setting, which the gives us some room to be 100/100 in.

-   [X] The code has been formatted (`make web`)
