### PR TITLE
web/flow: bug: inspector button not hiding when unavailable

### DIFF
--- a/web/src/flow/inspector/FlowInspectorButton.ts
+++ b/web/src/flow/inspector/FlowInspectorButton.ts
@@ -33,7 +33,7 @@ export class FlowInspectorButton extends WithCapabilitiesConfig(AKElement) {
     public override connectedCallback() {
         super.connectedCallback();
         const inspector = new URLSearchParams(window.location.search).get("inspector");
-        this.available = this.can(CapabilitiesEnum.CanDebug) || !!inspector;
+        this.available = this.can(CapabilitiesEnum.CanDebug) || typeof inspector === "string";
         this.open = inspector === "" || inspector === "open";
     }
 

--- a/web/src/flow/inspector/FlowInspectorButton.ts
+++ b/web/src/flow/inspector/FlowInspectorButton.ts
@@ -33,7 +33,7 @@ export class FlowInspectorButton extends WithCapabilitiesConfig(AKElement) {
     public override connectedCallback() {
         super.connectedCallback();
         const inspector = new URLSearchParams(window.location.search).get("inspector");
-        this.available = this.can(CapabilitiesEnum.CanDebug) || inspector !== undefined;
+        this.available = this.can(CapabilitiesEnum.CanDebug) || !!inspector;
         this.open = inspector === "" || inspector === "open";
     }
 


### PR DESCRIPTION
Bad check on my part; URLSearchParams returns 'null', which is not 'undefined' (according to Javascript).

-   [X] The code has been formatted (`make web`)
