### PR TITLE
core: Block non-super users from managing superuser groups

### DIFF
--- a/authentik/core/api/groups.py
+++ b/authentik/core/api/groups.py
@@ -343,6 +343,12 @@ class GroupViewSet(UsedByMixin, ModelViewSet):
     def add_user(self, request: Request, body: UserAccountSerializer, pk: str) -> Response:
         """Add user to group"""
         group: Group = self.get_object()
+
+        if group.is_superuser and not request.user.is_superuser:
+            raise ValidationError(
+                _("User does not have permission to add users to a superuser group.")
+            )
+
         user: User = (
             get_objects_for_user(request.user, "authentik_core.view_user")
             .filter(
@@ -374,6 +380,12 @@ class GroupViewSet(UsedByMixin, ModelViewSet):
     def remove_user(self, request: Request, body: UserAccountSerializer, pk: str) -> Response:
         """Remove user from group"""
         group: Group = self.get_object()
+
+        if group.is_superuser and not request.user.is_superuser:
+            raise ValidationError(
+                _("User does not have permission to remove users from a superuser group.")
+            )
+
         user: User = (
             get_objects_for_user(request.user, "authentik_core.view_user")
             .filter(

--- a/authentik/core/tests/test_groups_api.py
+++ b/authentik/core/tests/test_groups_api.py
@@ -49,6 +49,37 @@ class TestGroupsAPI(APITestCase):
         group.refresh_from_db()
         self.assertEqual(list(group.users.all()), [self.user])
 
+    def test_add_user_to_superuser_group_no_superuser(self):
+        """Test add_user to a superuser group"""
+        group = Group.objects.create(name=generate_id(), is_superuser=True)
+        self.login_user.assign_perms_to_managed_role("authentik_core.add_user_to_group", group)
+        self.login_user.assign_perms_to_managed_role("authentik_core.view_user")
+        self.client.force_login(self.login_user)
+        res = self.client.post(
+            reverse("authentik_api:group-add-user", kwargs={"pk": group.pk}),
+            data={
+                "pk": self.user.pk,
+            },
+        )
+        self.assertEqual(res.status_code, 400)
+        group.refresh_from_db()
+        self.assertEqual(list(group.users.all()), [])
+
+    def test_add_user_to_superuser_group_with_superuser(self):
+        """Test add_user to a superuser group"""
+        group = Group.objects.create(name=generate_id(), is_superuser=True)
+        self.login_user = create_test_admin_user()
+        self.client.force_login(self.login_user)
+        res = self.client.post(
+            reverse("authentik_api:group-add-user", kwargs={"pk": group.pk}),
+            data={
+                "pk": self.user.pk,
+            },
+        )
+        self.assertEqual(res.status_code, 204)
+        group.refresh_from_db()
+        self.assertEqual(list(group.users.all()), [self.user])
+
     def test_add_user_404(self):
         """Test add_user"""
         group = Group.objects.create(name=generate_id())
@@ -80,6 +111,39 @@ class TestGroupsAPI(APITestCase):
         group.refresh_from_db()
         self.assertEqual(list(group.users.all()), [])
 
+    def test_remove_user_from_superuser_group_no_superuser(self):
+        """Test add_user to a superuser group"""
+        group = Group.objects.create(name=generate_id(), is_superuser=True)
+        group.users.add(self.user)
+        self.login_user.assign_perms_to_managed_role("authentik_core.remove_user_from_group", group)
+        self.login_user.assign_perms_to_managed_role("authentik_core.view_user")
+        self.client.force_login(self.login_user)
+        res = self.client.post(
+            reverse("authentik_api:group-remove-user", kwargs={"pk": group.pk}),
+            data={
+                "pk": self.user.pk,
+            },
+        )
+        self.assertEqual(res.status_code, 400)
+        group.refresh_from_db()
+        self.assertEqual(list(group.users.all()), [self.user])
+
+    def test_remove_user_from_superuser_group_with_superuser(self):
+        """Test add_user to a superuser group"""
+        group = Group.objects.create(name=generate_id(), is_superuser=True)
+        group.users.add(self.user)
+        self.login_user = create_test_admin_user()
+        self.client.force_login(self.login_user)
+        res = self.client.post(
+            reverse("authentik_api:group-remove-user", kwargs={"pk": group.pk}),
+            data={
+                "pk": self.user.pk,
+            },
+        )
+        self.assertEqual(res.status_code, 204)
+        group.refresh_from_db()
+        self.assertEqual(list(group.users.all()), [])
+
     def test_remove_user_404(self):
         """Test remove_user"""
         group = Group.objects.create(name=generate_id())
@@ -95,7 +159,7 @@ class TestGroupsAPI(APITestCase):
         )
         self.assertEqual(res.status_code, 404)
 
-    def test_superuser_no_perm(self):
+    def test_superuser_no_superuser(self):
         """Test creating a superuser group without permission"""
         self.login_user.assign_perms_to_managed_role("authentik_core.add_group")
         self.client.force_login(self.login_user)
@@ -109,7 +173,7 @@ class TestGroupsAPI(APITestCase):
             {"is_superuser": ["User does not have permission to set superuser status to True."]},
         )
 
-    def test_superuser_no_perm_no_superuser(self):
+    def test_superuser_no_superuser_no_superuser(self):
         """Test creating a group without permission and without superuser flag"""
         self.login_user.assign_perms_to_managed_role("authentik_core.add_group")
         self.client.force_login(self.login_user)
@@ -119,7 +183,7 @@ class TestGroupsAPI(APITestCase):
         )
         self.assertEqual(res.status_code, 201)
 
-    def test_superuser_update_no_perm(self):
+    def test_superuser_update_no_superuser(self):
         """Test updating a superuser group without permission"""
         group = Group.objects.create(name=generate_id(), is_superuser=True)
         self.login_user.assign_perms_to_managed_role("authentik_core.view_group", group)


### PR DESCRIPTION
## Details

Any user with a global "add user to group" permission is able to add himself to a super user group and gain undesired permissions.

We spotted this subtle condition when designing directory management roles.

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)
