### PR TITLE
lifecycle: make gunicorn --max-requests configurable

### DIFF
--- a/lifecycle/gunicorn.conf.py
+++ b/lifecycle/gunicorn.conf.py
@@ -42,8 +42,8 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "authentik.root.settings")
 
 preload_app = True
 
-max_requests = 1000
-max_requests_jitter = 50
+max_requests = CONFIG.get_int("web.max_requests", 1000)
+max_requests_jitter = CONFIG.get_int("web.max_requests_jitter", 50)
 
 logconfig_dict = get_logger_config()
 

--- a/website/docs/install-config/configuration/configuration.mdx
+++ b/website/docs/install-config/configuration/configuration.mdx
@@ -635,6 +635,18 @@ Configure how many gunicorn threads a worker processes should have (see https://
 
 Defaults to 4.
 
+### `AUTHENTIK_WEB__MAX_REQUESTS`
+
+The maximum number of requests a worker will process before restarting. If this is set to zero then the automatic worker restarts are disabled (see https://gunicorn.org/reference/settings/#max_requests).
+
+Defaults to 1000.
+
+### `AUTHENTIK_WEB__MAX_REQUESTS_JITTER`
+
+The maximum jitter to add to the `AUTHENTIK_WEB__MAX_REQUESTS` setting (see https://gunicorn.org/reference/settings/#max_requests_jitter).
+
+Defaults to 50.
+
 ### `AUTHENTIK_WEB__PATH`
 
 Configure the path under which authentik is served. For example to access authentik under `https://my.domain/authentik/`, set this to `/authentik/`. Value _must_ contain both a leading and trailing slash.


### PR DESCRIPTION
## Details

Authentik uses _gunicorn_'s `max-request` setting which restarts the server after ~1000 requests. This is currently hardcoded.

I find this behaviour disruptive, i.e. in an environment where only one worker is run (I know it is advised against doing so, but for staging or test environments we still do it) this setting causes periodic downtime, since restarting the server is not instant.

As I understand the setting is only meant as a temporary last line of defense against memory leaks (see also https://github.com/benoitc/gunicorn/discussions/3042); and I hope authentik is actually not leaking memory 😉 

I personally would like to get completely rid of this, but as an intermediate step I think this should be at least configurable. 

This PR makes the setting configurable (by providing a value of `0` it can also be disabled) through environment variables.

Let me know what you think: I'm wondering if I'm missing something and the setting is crucial? I'm also wondering if you think that it should be removed completely?

Also let me know if I should do any changes to the PR; I tried to follow the guidelines and PR template but maybe I missed something.

---

## Checklist

-   [x] The code has been formatted (`make lint-fix`)
-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
