### PR TITLE
web/elements: Add preserve-order, no-search and no-status attributes to ak-dual-select

### DIFF
--- a/web/src/elements/ak-dual-select/ak-dual-select-dynamic-selected-provider.ts
+++ b/web/src/elements/ak-dual-select/ak-dual-select-dynamic-selected-provider.ts
@@ -51,6 +51,9 @@ export class AkDualSelectDynamic extends AkDualSelectProvider {
             .selected=${this.selected}
             available-label=${this.availableLabel}
             selected-label=${this.selectedLabel}
+            ?preserve-order=${this.preserveOrder}
+            ?no-search=${this.noSearch}
+            ?no-status=${this.noStatus}
         ></ak-dual-select>`;
     }
 }

--- a/web/src/elements/ak-dual-select/ak-dual-select-provider.ts
+++ b/web/src/elements/ak-dual-select/ak-dual-select-provider.ts
@@ -61,6 +61,30 @@ export class AkDualSelectProvider extends CustomListenerElement(AkControlElement
     public selectedLabel = msg("Selected options");
 
     /**
+     * When true, the selected pane preserves insertion order instead of sorting alphabetically.
+     *
+     * @attr
+     */
+    @property({ type: Boolean, attribute: "preserve-order" })
+    public preserveOrder = false;
+
+    /**
+     * When true, hides the search bars in both the available and selected panes.
+     *
+     * @attr
+     */
+    @property({ type: Boolean, attribute: "no-search" })
+    public noSearch = false;
+
+    /**
+     * When true, hides the item count status displays in both panes.
+     *
+     * @attr
+     */
+    @property({ type: Boolean, attribute: "no-status" })
+    public noStatus = false;
+
+    /**
      * The debounce for the search as the user is typing in a request
      *
      * @attr
@@ -187,6 +211,9 @@ export class AkDualSelectProvider extends CustomListenerElement(AkControlElement
             .selected=${this.#selected}
             available-label=${this.availableLabel}
             selected-label=${this.selectedLabel}
+            ?preserve-order=${this.preserveOrder}
+            ?no-search=${this.noSearch}
+            ?no-status=${this.noStatus}
         ></ak-dual-select>`;
     }
 }

--- a/web/src/elements/ak-dual-select/ak-dual-select.ts
+++ b/web/src/elements/ak-dual-select/ak-dual-select.ts
@@ -90,6 +90,19 @@ export class AkDualSelect extends CustomEmitterElement(CustomListenerElement(AKE
     @property({ attribute: "selected-label" })
     selectedLabel = msg("Selected options");
 
+    @property({ type: Boolean, attribute: "no-search" })
+    noSearch = false;
+
+    @property({ type: Boolean, attribute: "no-status" })
+    noStatus = false;
+
+    /**
+     * When true, the selected pane preserves insertion order instead of sorting alphabetically.
+     * Use this when the order of selected items is meaningful (e.g. priority-based lists).
+     */
+    @property({ type: Boolean, attribute: "preserve-order" })
+    preserveOrder = false;
+
     //#endregion
 
     //#region State
@@ -322,17 +335,17 @@ export class AkDualSelect extends CustomEmitterElement(CustomListenerElement(AKE
                             </div>
                         </div>
                     </div>
-                    <ak-search-bar
+                    ${this.noSearch ? nothing : html`<ak-search-bar
                         placeholder=${msg(str`Search ${this.availableLabel}...`)}
                         name="ak-dual-list-available-search"
-                    ></ak-search-bar>
-                    <div class="pf-c-dual-list-selector__status">
+                    ></ak-search-bar>`}
+                    ${this.noStatus ? nothing : html`<div class="pf-c-dual-list-selector__status">
                         <span
                             class="pf-c-dual-list-selector__status-text"
                             id="basic-available-status-text"
                             >${unsafeHTML(availableStatus)}</span
                         >
-                    </div>
+                    </div>`}
                     <ak-dual-select-available-pane
                         ${ref(this.availablePane)}
                         .options=${this.options}
@@ -359,19 +372,21 @@ export class AkDualSelect extends CustomEmitterElement(CustomListenerElement(AKE
                             </div>
                         </div>
                     </div>
-                    <ak-search-bar
+                    ${this.noSearch ? nothing : html`<ak-search-bar
                         placeholder=${msg(str`Search ${this.selectedLabel}...`)}
                         name="ak-dual-list-selected-search"
-                    ></ak-search-bar>
-                    <div
+                    ></ak-search-bar>`}
+                    ${this.noStatus ? nothing : html`<div
                         class="pf-c-dual-list-selector__status ak-dual-list-selector__status--selected"
                     >
                         <span class="pf-c-dual-list-selector__status-text">${selectedStatus}</span>
-                    </div>
+                    </div>`}
 
                     <ak-dual-select-selected-pane
                         ${ref(this.selectedPane)}
-                        .selected=${selected.toSorted(localeComparator)}
+                        .selected=${this.preserveOrder
+                            ? selected
+                            : selected.toSorted(localeComparator)}
                     ></ak-dual-select-selected-pane>
                 </div>
             </div>

--- a/web/src/elements/ak-dual-select/ak-dual-select.ts
+++ b/web/src/elements/ak-dual-select/ak-dual-select.ts
@@ -335,17 +335,21 @@ export class AkDualSelect extends CustomEmitterElement(CustomListenerElement(AKE
                             </div>
                         </div>
                     </div>
-                    ${this.noSearch ? nothing : html`<ak-search-bar
-                        placeholder=${msg(str`Search ${this.availableLabel}...`)}
-                        name="ak-dual-list-available-search"
-                    ></ak-search-bar>`}
-                    ${this.noStatus ? nothing : html`<div class="pf-c-dual-list-selector__status">
-                        <span
-                            class="pf-c-dual-list-selector__status-text"
-                            id="basic-available-status-text"
-                            >${unsafeHTML(availableStatus)}</span
-                        >
-                    </div>`}
+                    ${this.noSearch
+                        ? nothing
+                        : html`<ak-search-bar
+                              placeholder=${msg(str`Search ${this.availableLabel}...`)}
+                              name="ak-dual-list-available-search"
+                          ></ak-search-bar>`}
+                    ${this.noStatus
+                        ? nothing
+                        : html`<div class="pf-c-dual-list-selector__status">
+                              <span
+                                  class="pf-c-dual-list-selector__status-text"
+                                  id="basic-available-status-text"
+                                  >${unsafeHTML(availableStatus)}</span
+                              >
+                          </div>`}
                     <ak-dual-select-available-pane
                         ${ref(this.availablePane)}
                         .options=${this.options}
@@ -372,15 +376,21 @@ export class AkDualSelect extends CustomEmitterElement(CustomListenerElement(AKE
                             </div>
                         </div>
                     </div>
-                    ${this.noSearch ? nothing : html`<ak-search-bar
-                        placeholder=${msg(str`Search ${this.selectedLabel}...`)}
-                        name="ak-dual-list-selected-search"
-                    ></ak-search-bar>`}
-                    ${this.noStatus ? nothing : html`<div
-                        class="pf-c-dual-list-selector__status ak-dual-list-selector__status--selected"
-                    >
-                        <span class="pf-c-dual-list-selector__status-text">${selectedStatus}</span>
-                    </div>`}
+                    ${this.noSearch
+                        ? nothing
+                        : html`<ak-search-bar
+                              placeholder=${msg(str`Search ${this.selectedLabel}...`)}
+                              name="ak-dual-list-selected-search"
+                          ></ak-search-bar>`}
+                    ${this.noStatus
+                        ? nothing
+                        : html`<div
+                              class="pf-c-dual-list-selector__status ak-dual-list-selector__status--selected"
+                          >
+                              <span class="pf-c-dual-list-selector__status-text"
+                                  >${selectedStatus}</span
+                              >
+                          </div>`}
 
                     <ak-dual-select-selected-pane
                         ${ref(this.selectedPane)}


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

Add optional boolean attributes to `ak-dual-select`, `ak-dual-select-provider`, and `ak-dual-select-dynamic-selected` for preserving the insertion order instead of alphabetical (`preserve-order`), hiding the search bars (`no-search`), and item count status displays (`no-status`). All default to `false`, preserving existing behavior.

Rationale: When we have just a few items, we want a cleaner interface. Used in the WebAuthn authenticator stage form to simplify the device type hints selector. #20700 

Originally:
<img width="2148" height="772" alt="Screenshot 2026-03-05 at 20-22-38 default-authenticator-webauthn-setup - Admin - authentik" src="https://github.com/user-attachments/assets/07dae408-55a9-4f7b-a797-9f6be563133b" />
After this PR:
<img width="2084" height="660" alt="Screenshot 2026-03-05 at 20-21-57 default-authenticator-webauthn-setup - Admin - authentik" src="https://github.com/user-attachments/assets/503c0083-0a12-4fb4-8c9d-b0734d89be49" />


---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
