### PR TITLE
website: override DocSearch button colors in light mode

### DIFF
--- a/website/docusaurus-theme/config.js
+++ b/website/docusaurus-theme/config.js
@@ -42,7 +42,10 @@ const CommonPresetOptions = {
         anonymizeIP: true,
     },
     theme: {
-        customCss: [require.resolve("@goauthentik/docusaurus-config/css/index.css")],
+        customCss: [
+            require.resolve("@goauthentik/docusaurus-config/css/index.css"),
+            require.resolve("./custom.css"),
+        ],
     },
 
     docs: {

--- a/website/docusaurus-theme/custom.css
+++ b/website/docusaurus-theme/custom.css
@@ -1,0 +1,8 @@
+html[data-theme="light"] .DocSearch-Button {
+    --docsearch-search-button-text-color: var(--ifm-color-primary-darkest);
+    --docsearch-highlight-color: var(--docsearch-search-button-text-color);
+}
+
+html[data-theme="light"] .DocSearch-Button .DocSearch-Button-Placeholder {
+    color: var(--docsearch-search-button-text-color);
+}


### PR DESCRIPTION
After:

<img width="317" height="72" alt="image" src="https://github.com/user-attachments/assets/8c3ada1e-3c2f-435d-b725-c6d0ec21e492" />

<img width="284" height="79" alt="image" src="https://github.com/user-attachments/assets/a489e3ae-6bf3-46dc-90bc-dd3c4d76c697" />



Before:

<img width="292" height="63" alt="image" src="https://github.com/user-attachments/assets/7eaf2fc2-917e-4660-9c18-d6ce9b664d96" />

<img width="312" height="76" alt="image" src="https://github.com/user-attachments/assets/5be3cf38-a9fe-4992-8865-7a1ce728af40" />
