### PR TITLE
core: allow interfaces to specify alternative stylesheets

### DIFF
--- a/authentik/core/templates/base/skeleton.html
+++ b/authentik/core/templates/base/skeleton.html
@@ -21,6 +21,10 @@
         {% block head_before %}
         {% endblock %}
 
+        {% block interface_stylesheet %}
+        <link rel="stylesheet" type="text/css" href="{% versioned_script 'dist/styles/interface-%v.css' %}" />
+        {% endblock %}
+
         {% include "base/theme.html" %}
 
         <style data-id="brand-css">{{ brand_css }}</style>

--- a/authentik/core/templates/base/theme.html
+++ b/authentik/core/templates/base/theme.html
@@ -1,8 +1,6 @@
 {% load static %}
 {% load authentik_core %}
 
-<link rel="stylesheet" type="text/css" href="{% versioned_script 'dist/styles/interface-%v.css' %}" />
-
 {% if ui_theme == "dark" %}
   <meta name="color-scheme" content="dark" />
   <meta name="theme-color" content="#18191a">


### PR DESCRIPTION
Allow interfaces to specify alternative stylesheets

## What

Moves the stylesheet invocation in `theme.html` to `skeleton.html`, give it a block and a block name so that pages using `skeleton.html` can override or extend it as needed.

## Why

The biggest wall we’re hitting right now is the lack of flexibility at the very top of the CSS. We simply use the same CSS file for *too much*, when really we should be thinking in terms of leaner, more targeted top-level CSS for some things, and more rich and expressive CSS when it’s necessary.

The style sheet was being loaded unconditionally in `theme.html`; it’s not in a conditional statement or overridable where it was; `skeleton` just loads it blindly. This change lets `theme.html` be what it is meant to be, an isolated container for the JavaScript logic for discerning the color mode, while enabling CSS developers to elide the stylesheet, provide alternative stylesheets, or (using `{{ block.super}}`) amend or extend the default stylesheet.

-   [X] The code has been formatted (`make web`)
