### PR TITLE
web/rbac: disambiguate duplicate permission names in initial permissions

### DIFF
--- a/web/src/admin/rbac/InitialPermissionsForm.ts
+++ b/web/src/admin/rbac/InitialPermissionsForm.ts
@@ -23,7 +23,15 @@ import { customElement } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
 export function rbacPermissionPair(item: Permission): DualSelectPair {
-    return [item.id.toString(), html`<div class="selection-main">${item.name}</div>`, item.name];
+    const appLabel = item.appLabelVerbose || item.appLabel || "";
+    const modelLabel = item.modelVerbose || item.model || "";
+    const descriptor = `${appLabel} / ${modelLabel} (${item.codename})`;
+    return [
+        item.id.toString(),
+        html`<div class="selection-main">${item.name}</div>
+            <div class="selection-desc">${descriptor}</div>`,
+        `${item.name} ${descriptor}`,
+    ];
 }
 
 @customElement("ak-initial-permissions-form")


### PR DESCRIPTION
## Details

Fixes #19847

The initial permissions dual-select rendered each option using only `Permission.name`, which made entries ambiguous when different models expose the same display name (for example `Device Token`).

This change disambiguates each option by adding a scoped descriptor in the secondary line:
`<app label> / <model label> (<codename>)`.

### Implementation details:
- Updates `rbacPermissionPair` in `web/src/admin/rbac/InitialPermissionsForm.ts` to render both the existing primary label and a deterministic descriptor.
- Extends the searchable text payload for each option to include the descriptor, so duplicate names remain discoverable and distinguishable.

This is a UI-only change. It does not modify permission semantics, API contracts, or stored data.

---

## Checklist

- [ ] Local tests pass (`ak test authentik/`)
- [x] The code has been formatted (`make lint-fix`)

If an API change has been made

- [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

- [x] The code has been formatted (`make web`)

If applicable

- [ ] The documentation has been updated
- [ ] The documentation has been formatted (`make docs`)
