### PR TITLE
web/admin: handle non-string values in formatUUID to prevent Event Log crash

### DIFF
--- a/web/src/admin/events/utils.ts
+++ b/web/src/admin/events/utils.ts
@@ -7,6 +7,9 @@ import { msg, str } from "@lit/localize";
 import { html, nothing, TemplateResult } from "lit";
 
 export function formatUUID(hex: string): string {
+    if (typeof hex !== "string") {
+        return String(hex ?? "");
+    }
     if (hex.length < 32) {
         return hex;
     }


### PR DESCRIPTION
## What

Fixes #20803

When navigating to Events → Log, the page crashes with:
```
TypeError: s.substring is not a function
    at formatUUID (utils.ts:13)
```

## Why

The `formatUUID` function in `web/src/admin/events/utils.ts` assumes its argument is always a string. However, `event.context.device.pk` from the API can be a non-string value (e.g., integer or UUID object), since `EventContext` values are dynamically typed (`EventContextProperty`). When `formatUUID` receives a non-string, calling `.substring()` throws a `TypeError`, crashing the entire Event Log page.

## How

Added a type guard at the top of `formatUUID` that checks `typeof hex !== "string"` and coerces to `String()` if needed, rather than crashing. This is a minimal, defensive fix that keeps the rest of the function logic unchanged.

## Testing

- Verified the fix handles `number`, `undefined`, and `null` inputs without throwing
- Existing string inputs continue to format correctly