### PR TITLE
endpoints: prevent selection of incompatible connector

### DIFF
--- a/authentik/endpoints/api/stages.py
+++ b/authentik/endpoints/api/stages.py
@@ -1,8 +1,11 @@
+from django.utils.translation import gettext_lazy as _
+from rest_framework.exceptions import ValidationError
 from rest_framework.viewsets import ModelViewSet
 
 from authentik.core.api.used_by import UsedByMixin
 from authentik.endpoints.api.connectors import ConnectorSerializer
-from authentik.endpoints.models import EndpointStage
+from authentik.endpoints.controller import Capabilities
+from authentik.endpoints.models import Connector, EndpointStage
 from authentik.flows.api.stages import StageSerializer
 
 
@@ -10,6 +13,13 @@ class EndpointStageSerializer(StageSerializer):
     """EndpointStage Serializer"""
 
     connector_obj = ConnectorSerializer(source="connector", read_only=True)
+
+    def validate_connector(self, connector: Connector) -> Connector:
+        conn: Connector = Connector.objects.get_subclass(pk=connector.pk)
+        controller = conn.controller(conn)
+        if Capabilities.STAGE_ENDPOINTS not in controller.capabilities():
+            raise ValidationError(_("Selected connector is not comaptible with this stage."))
+        return connector
 
     class Meta:
         model = EndpointStage

--- a/authentik/endpoints/connectors/agent/controller.py
+++ b/authentik/endpoints/connectors/agent/controller.py
@@ -8,7 +8,7 @@ from rest_framework.fields import CharField
 
 from authentik.core.api.utils import PassiveSerializer
 from authentik.endpoints.connectors.agent.models import AgentConnector, EnrollmentToken
-from authentik.endpoints.controller import BaseController
+from authentik.endpoints.controller import BaseController, Capabilities
 from authentik.endpoints.facts import OSFamily
 
 
@@ -48,8 +48,8 @@ class AgentConnectorController(BaseController[AgentConnector]):
     def vendor_identifier() -> str:
         return "goauthentik.io/platform"
 
-    def supported_enrollment_methods(self):
-        return []
+    def capabilities(self) -> list[Capabilities]:
+        return [Capabilities.STAGE_ENDPOINTS]
 
     def generate_mdm_config(
         self, target_platform: OSFamily, request: HttpRequest, token: EnrollmentToken

--- a/authentik/endpoints/connectors/agent/stage.py
+++ b/authentik/endpoints/connectors/agent/stage.py
@@ -95,7 +95,9 @@ class AuthenticatorEndpointStageView(ChallengeStageView):
         keypair = CertificateKeyPair.objects.filter(pk=stage.connector.challenge_key_id).first()
         if not keypair:
             return self.executor.stage_ok()
-        return super().get(request, *args, **kwargs)
+        res = super().get(request, *args, **kwargs)
+        res["X-Ak-test"] = self.executor.plan.context.get(PLAN_CONTEXT_AGENT_ENDPOINT_CHALLENGE)
+        return res
 
     def check_device_ia(self):
         """Check if we're in a device interactive authentication flow, and if so,

--- a/authentik/endpoints/controller.py
+++ b/authentik/endpoints/controller.py
@@ -8,13 +8,15 @@ from authentik.lib.sentry import SentryIgnoredException
 MERGED_VENDOR = "goauthentik.io/@merged"
 
 
-class EnrollmentMethods(models.TextChoices):
+class Capabilities(models.TextChoices):
     # Automatically enrolled through user action
-    AUTOMATIC_USER = "automatic_user"
+    ENROLL_AUTOMATIC_USER = "enroll_automatic_user"
     # Automatically enrolled through connector integration
-    AUTOMATIC_API = "automatic_api"
+    ENROLL_AUTOMATIC_API = "enroll_automatic_api"
     # Manually enrolled with user interaction (user scanning a QR code for example)
-    MANUAL_USER = "manual_user"
+    ENROLL_MANUAL_USER = "enroll_manual_user"
+    # Supported for use with Endpoints stage
+    STAGE_ENDPOINTS = "stage_endpoints"
 
 
 class ConnectorSyncException(SentryIgnoredException):
@@ -34,7 +36,7 @@ class BaseController[T: "Connector"]:
     def vendor_identifier() -> str:
         raise NotImplementedError
 
-    def supported_enrollment_methods(self) -> list[EnrollmentMethods]:
+    def capabilities(self) -> list[Capabilities]:
         return []
 
     def stage_view_enrollment(self) -> StageView | None:

--- a/authentik/endpoints/tasks.py
+++ b/authentik/endpoints/tasks.py
@@ -6,7 +6,7 @@ from django.utils.translation import gettext_lazy as _
 from dramatiq.actor import actor
 from structlog.stdlib import get_logger
 
-from authentik.endpoints.controller import EnrollmentMethods
+from authentik.endpoints.controller import Capabilities
 from authentik.endpoints.models import Connector
 
 LOGGER = get_logger()
@@ -21,7 +21,7 @@ def endpoints_sync(connector_pk: Any):
         return
     controller = connector.controller
     ctrl = controller(connector)
-    if EnrollmentMethods.AUTOMATIC_API not in ctrl.supported_enrollment_methods():
+    if Capabilities.AUTOMATIC_API not in ctrl.capabilities():
         return
     LOGGER.info("Syncing connector", connector=connector.name)
     ctrl.sync_endpoints()

--- a/authentik/endpoints/tests/test_api.py
+++ b/authentik/endpoints/tests/test_api.py
@@ -1,0 +1,41 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+from authentik.core.tests.utils import create_test_admin_user
+from authentik.endpoints.connectors.agent.models import AgentConnector
+from authentik.endpoints.models import StageMode
+from authentik.enterprise.endpoints.connectors.fleet.models import FleetConnector
+from authentik.lib.generators import generate_id
+
+
+class TestAPI(APITestCase):
+    def setUp(self):
+        self.user = create_test_admin_user()
+        self.client.force_login(self.user)
+
+    def test_endpoint_stage_agent(self):
+        connector = AgentConnector.objects.create(name=generate_id())
+        res = self.client.post(
+            reverse("authentik_api:stages-endpoint-list"),
+            data={
+                "name": generate_id(),
+                "connector": str(connector.pk),
+                "mode": StageMode.REQUIRED,
+            },
+        )
+        self.assertEqual(res.status_code, 201)
+
+    def test_endpoint_stage_fleet(self):
+        connector = FleetConnector.objects.create(name=generate_id())
+        res = self.client.post(
+            reverse("authentik_api:stages-endpoint-list"),
+            data={
+                "name": generate_id(),
+                "connector": str(connector.pk),
+                "mode": StageMode.REQUIRED,
+            },
+        )
+        self.assertEqual(res.status_code, 400)
+        self.assertJSONEqual(
+            res.content, {"connector": ["Selected connector is not comaptible with this stage."]}
+        )

--- a/authentik/enterprise/endpoints/connectors/fleet/controller.py
+++ b/authentik/enterprise/endpoints/connectors/fleet/controller.py
@@ -6,7 +6,7 @@ from requests import RequestException
 from rest_framework.exceptions import ValidationError
 
 from authentik.core.models import User
-from authentik.endpoints.controller import BaseController, ConnectorSyncException, EnrollmentMethods
+from authentik.endpoints.controller import BaseController, Capabilities, ConnectorSyncException
 from authentik.endpoints.facts import (
     DeviceFacts,
     OSFamily,
@@ -43,8 +43,8 @@ class FleetController(BaseController[DBC]):
     def vendor_identifier() -> str:
         return "fleetdm.com"
 
-    def supported_enrollment_methods(self) -> list[EnrollmentMethods]:
-        return [EnrollmentMethods.AUTOMATIC_API]
+    def capabilities(self) -> list[Capabilities]:
+        return [Capabilities.ENROLL_AUTOMATIC_API]
 
     def _url(self, path: str) -> str:
         return f"{self.connector.url}{path}"

--- a/authentik/enterprise/endpoints/connectors/google_chrome/controller.py
+++ b/authentik/enterprise/endpoints/connectors/google_chrome/controller.py
@@ -4,7 +4,7 @@ from django.http import HttpRequest, HttpResponseRedirect
 from django.urls import reverse
 from googleapiclient.discovery import build
 
-from authentik.endpoints.controller import BaseController, EnrollmentMethods
+from authentik.endpoints.controller import BaseController, Capabilities
 from authentik.endpoints.facts import DeviceFacts, OSFamily
 from authentik.endpoints.models import Device, DeviceConnection
 from authentik.enterprise.endpoints.connectors.google_chrome.google_schema import (
@@ -39,8 +39,8 @@ class GoogleChromeController(BaseController[GoogleChromeConnector]):
     def vendor_identifier() -> str:
         return "chrome.google.com"
 
-    def supported_enrollment_methods(self) -> list[EnrollmentMethods]:
-        return [EnrollmentMethods.AUTOMATIC_USER]
+    def capabilities(self) -> list[Capabilities]:
+        return [Capabilities.STAGE_ENDPOINTS, Capabilities.ENROLL_AUTOMATIC_USER]
 
     def generate_challenge(self, request: HttpRequest) -> HttpResponseRedirect:
         challenge = self.google_client.challenge().generate().execute()


### PR DESCRIPTION
This was made a bit more confusing with the addition of the fleet connector, which by itself cannot be used with the Endpoint stage (it's silently skipped), however the admin UI makes no indication that that is what will happen