### PR TITLE
Fix recovery-token update failures due to intent validation

### DIFF
--- a/authentik/core/api/tokens.py
+++ b/authentik/core/api/tokens.py
@@ -58,8 +58,21 @@ class TokenSerializer(ManagedSerializer, ModelSerializer):
                 raise ValidationError("Missing intent")
         else:
             attrs.setdefault("user", request.user)
-        attrs.setdefault("intent", TokenIntents.INTENT_API)
-        if attrs.get("intent") not in [TokenIntents.INTENT_API, TokenIntents.INTENT_APP_PASSWORD]:
+        allowed_create_intents = [TokenIntents.INTENT_API, TokenIntents.INTENT_APP_PASSWORD]
+        if self.instance:
+            attrs.setdefault("intent", self.instance.intent)
+        else:
+            attrs.setdefault("intent", TokenIntents.INTENT_API)
+
+        # API tokens and app-passwords are user-managed token types.
+        # Other token types (for example recovery/verification) can be updated,
+        # but only with their existing intent.
+        if self.instance and self.instance.intent not in allowed_create_intents:
+            allowed_intents = [self.instance.intent]
+        else:
+            allowed_intents = allowed_create_intents
+
+        if attrs.get("intent") not in allowed_intents:
             raise ValidationError({"intent": f"Invalid intent {attrs.get('intent')}"})
 
         if attrs.get("intent") == TokenIntents.INTENT_APP_PASSWORD:

--- a/authentik/core/tests/test_token_api.py
+++ b/authentik/core/tests/test_token_api.py
@@ -69,6 +69,50 @@ class TestTokenAPI(APITestCase):
         )
         self.assertEqual(response.status_code, 400)
 
+    def test_token_update_recovery_intent(self):
+        """Test updating a recovery token while keeping its recovery intent"""
+        ident = generate_id()
+        token = Token.objects.create(
+            identifier=ident,
+            user=self.user,
+            intent=TokenIntents.INTENT_RECOVERY,
+            expiring=True,
+        )
+        response = self.client.put(
+            reverse("authentik_api:token-detail", kwargs={"identifier": ident}),
+            data={
+                "identifier": ident,
+                "user": self.user.pk,
+                "intent": TokenIntents.INTENT_RECOVERY,
+                "expiring": False,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        token.refresh_from_db()
+        self.assertEqual(token.intent, TokenIntents.INTENT_RECOVERY)
+        self.assertEqual(token.expiring, False)
+
+    def test_token_update_recovery_intent_default(self):
+        """Test updating a recovery token without explicitly sending intent"""
+        ident = generate_id()
+        token = Token.objects.create(
+            identifier=ident,
+            user=self.user,
+            intent=TokenIntents.INTENT_RECOVERY,
+            expiring=True,
+        )
+        response = self.client.put(
+            reverse("authentik_api:token-detail", kwargs={"identifier": ident}),
+            data={
+                "identifier": ident,
+                "expiring": False,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        token.refresh_from_db()
+        self.assertEqual(token.intent, TokenIntents.INTENT_RECOVERY)
+        self.assertEqual(token.expiring, False)
+
     def test_token_create_non_expiring(self):
         """Test token creation endpoint"""
         self.user.attributes[USER_ATTRIBUTE_TOKEN_EXPIRING] = False

--- a/web/src/admin/tokens/TokenForm.ts
+++ b/web/src/admin/tokens/TokenForm.ts
@@ -86,6 +86,41 @@ export class TokenForm extends ModelForm<Token, string> {
     //#region Renders
 
     protected override renderForm(): TemplateResult {
+        const intent = this.instance?.intent;
+        const isFixedIntent =
+            intent !== undefined &&
+            intent !== IntentEnum.Api &&
+            intent !== IntentEnum.AppPassword;
+        const intentOptions = isFixedIntent
+            ? [
+                  {
+                      label:
+                          intent === IntentEnum.Recovery
+                              ? msg("Password recovery token")
+                              : intent === IntentEnum.Verification
+                                ? msg("Verification token")
+                                : msg("System token"),
+                      value: intent,
+                      default: true,
+                      description: html`${msg(
+                          "This intent is managed by authentik and cannot be changed here.",
+                      )}`,
+                  },
+              ]
+            : [
+                  {
+                      label: msg("API Token"),
+                      value: IntentEnum.Api,
+                      default: true,
+                      description: html`${msg("Used to access the API programmatically")}`,
+                  },
+                  {
+                      label: msg("App password."),
+                      value: IntentEnum.AppPassword,
+                      description: html`${msg("Used to login using a flow executor")}`,
+                  },
+              ];
+
         return html`<ak-text-input
                 name="identifier"
                 value="${this.instance?.identifier ?? ""}"
@@ -139,20 +174,8 @@ export class TokenForm extends ModelForm<Token, string> {
             </ak-form-element-horizontal>
             <ak-form-element-horizontal label=${msg("Intent")} required name="intent">
                 <ak-radio
-                    .options=${[
-                        {
-                            label: msg("API Token"),
-                            value: IntentEnum.Api,
-                            default: true,
-                            description: html`${msg("Used to access the API programmatically")}`,
-                        },
-                        {
-                            label: msg("App password."),
-                            value: IntentEnum.AppPassword,
-                            description: html`${msg("Used to login using a flow executor")}`,
-                        },
-                    ]}
-                    .value=${this.instance?.intent}
+                    .options=${intentOptions}
+                    .value=${this.instance?.intent ?? IntentEnum.Api}
                 >
                 </ak-radio>
             </ak-form-element-horizontal>

--- a/web/src/admin/tokens/TokenForm.ts
+++ b/web/src/admin/tokens/TokenForm.ts
@@ -88,9 +88,7 @@ export class TokenForm extends ModelForm<Token, string> {
     protected override renderForm(): TemplateResult {
         const intent = this.instance?.intent;
         const isFixedIntent =
-            intent !== undefined &&
-            intent !== IntentEnum.Api &&
-            intent !== IntentEnum.AppPassword;
+            intent !== undefined && intent !== IntentEnum.Api && intent !== IntentEnum.AppPassword;
         const intentOptions = isFixedIntent
             ? [
                   {


### PR DESCRIPTION
## Details

Fixes #20198

This change scopes token intent validation by operation type:
- Create: still restricted to user-managed intents (`api`, `app_password`).
- Update: non-user-managed tokens (for example `recovery` and `verification`) are now allowed to keep their existing intent, instead of being rejected as invalid.

It also aligns the admin token form so existing system-managed token intents are rendered as fixed, preventing UI/API mismatch during edits.

Added regression coverage for recovery-token updates with and without an explicit `intent` field, while preserving the existing invalid-create check.

---

## Checklist

- [x] Local tests pass (`authentik.core.tests.test_token_api.TestTokenAPI`)
- [x] The code has been formatted/validated for touched Python files (`uv run ruff check ...`)

If changes to the frontend have been made

- [x] Touched frontend file validated (`npm run lint-check -- src/admin/tokens/TokenForm.ts`)

If applicable

- [ ] The documentation has been updated
- [ ] The documentation has been formatted (`make docs`)
