### PR TITLE
outpost/proxyv2: use fallback url if state is missing

### DIFF
--- a/internal/outpost/proxyv2/application/utils.go
+++ b/internal/outpost/proxyv2/application/utils.go
@@ -16,17 +16,13 @@ func urlJoin(originalUrl string, newPath string) string {
 }
 
 func (a *Application) redirect(rw http.ResponseWriter, r *http.Request) {
-	fallbackRedirect := a.proxyConfig.ExternalHost
+	url := a.proxyConfig.ExternalHost
 	state := a.stateFromRequest(rw, r)
-	if state == nil {
-		rw.WriteHeader(http.StatusBadRequest)
-		return
+	if state != nil && state.Redirect != "" {
+		url = state.Redirect
 	}
-	if state.Redirect == "" {
-		state.Redirect = fallbackRedirect
-	}
-	a.log.WithField("redirect", state.Redirect).Trace("final redirect")
-	http.Redirect(rw, r, state.Redirect, http.StatusFound)
+	a.log.WithField("redirect", url).Trace("final redirect")
+	http.Redirect(rw, r, url, http.StatusFound)
 }
 
 // toString Generic to string function, currently supports actual strings and integers


### PR DESCRIPTION
## Details

Occasionally when opening a site protected w/ an outpost and while already logged in, an old cookie (I think?) on the protected hostname causes a session mismatch, even though a valid session is available on the auth host.

```json
{"event":"mismatched session ID","is":"UOQAE7NDSD3I7NIBK7YZLNUHIYS...","level":"warning","logger":"authentik.outpost.proxyv2.application","name":"provider-foo","should":"ZGFF27AG5NQMIJGOHVYK6EU....","timestamp":"2026-03-10T15:04:51Z"}
{"event":"invalid state","level":"warning","logger":"authentik.outpost.proxyv2.application","name":"provider-foo","timestamp":"2026-03-10T15:04:51Z"}
{"event":"mismatched session ID","is":"UOQAE7NDSD3I7NIBK7YZLNUHIYS...","level":"warning","logger":"authentik.outpost.proxyv2.application","name":"provider-foo","should":"ZGFF27AG5NQMIJGOHVYK6EU...","timestamp":"2026-03-10T15:04:51Z"}
{"event":"/outpost.goauthentik.io/callback?X-authentik-auth-callback=true&code=b56...snip...&state=ey...snip...","host":"hub.bixby.io","level":"info","logger":"authentik.outpost.proxyv2.application","method":"GET","name":"provider-foo","remote":"172.18.0.43:55790","runtime":"0.361","scheme":"http","size":0,"status":400,"timestamp":"2026-03-10T15:04:51Z","user":"chetan","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36 Edg/145.0.0.0"}
```

Instead of failing with 400 Bad Request, we should always redirect the user back to the app as a fallback, so that the auth process can start again (the current workaround when you see bad request). 

Closes #10848 

Closes #25317
---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
