### PR TITLE
web/flow/stages: permit the form handler to look in the light or shadowDOM for controls

### DIFF
--- a/web/src/flow/stages/base.ts
+++ b/web/src/flow/stages/base.ts
@@ -104,7 +104,7 @@ export abstract class BaseStage<Tin extends StageChallengeLike, Tout = unknown>
 
         const payload: Record<string, unknown> = defaults || {};
 
-        const form = this.shadowRoot?.querySelector("form");
+        const form = this.shadowRoot?.querySelector("form") ?? this.querySelector("form");
 
         if (form) {
             const data = new FormData(form);


### PR DESCRIPTION
web/flow/stages: permit the form handler to look in the light or shadowDOM for controls

## What

Every stage has its own form handler, inherited from `flows/stages/base.ts`. This change allows stages to place their controls in either the shadowDOM or the lightDOM (but not both), and still have them work correctly.

## Why

This makes Flow more open to the planned changes for compatibility mode while changing no current functionality. No behavioral changes should be observed with this change.

-   [X] The code has been formatted (`make web`)
