### PR TITLE
web/flow: provide labels for the stage import-and-invoke table

### DIFF
--- a/web/src/flow/FlowExecutorStageFactory.ts
+++ b/web/src/flow/FlowExecutorStageFactory.ts
@@ -21,19 +21,7 @@ export type { FlowChallengeComponentName, StageModuleCallback };
 export const propVariants = ["standard", "challenge"] as const;
 export type PropVariant = (typeof propVariants)[number];
 
-// The first type supports "import only."
-type StageEntryMetadata =
-    | []
-    | [tag: string]
-    | [variant: PropVariant]
-    | [tag: string, variant: PropVariant];
-
 const STANDARD = propVariants[0];
-const isImport = (x: unknown): x is StageModuleCallback => typeof x === "function";
-const PVariant = P.when(
-    (x): x is PropVariant => typeof x === "string" && propVariants.includes(x as PropVariant),
-);
-const PTag = P.when((x): x is string => typeof x === "string" && x.includes("-"));
 
 export class StageMappingError extends TypeError {
     constructor(message: string, options?: ErrorOptions) {
@@ -60,11 +48,21 @@ function resolveStageTag(module: ResolvedDefaultESModule<BaseStageConstructor>):
     return tag;
 }
 
+// The first type supports "import only."
+type StageEntryMetadata = {
+    tag: string | undefined;
+    variant: PropVariant | undefined;
+};
+
 interface StageMappingInit {
-    token: FlowChallengeComponentName;
+    stage: FlowChallengeComponentName;
     variant: PropVariant;
     tag?: string;
 }
+
+const PVariant = P.when((x): x is PropVariant => propVariants.includes(x as PropVariant));
+
+const PTag = P.when((x): x is string => typeof x === "string");
 
 /**
  * The metadata needed to load and invoke a stage.
@@ -76,15 +74,15 @@ export class StageMapping {
      * This can be used to determine if a given stage component has a corresponding client-side stage.
      */
     public static readonly registry: ReadonlyMap<FlowChallengeComponentName, StageEntry> = new Map(
-        StageEntries.map((entry) => [entry[0], entry]),
+        StageEntries.map((entry) => [entry.stage, entry]),
     );
 
-    public readonly token: FlowChallengeComponentName;
+    public readonly stage: FlowChallengeComponentName;
     public readonly variant: PropVariant;
     public readonly tag: string;
 
-    protected constructor({ token, variant, tag }: DeepRequired<StageMappingInit>) {
-        this.token = token;
+    protected constructor({ stage, variant, tag }: DeepRequired<StageMappingInit>) {
+        this.stage = stage;
         this.tag = tag;
         this.variant = variant;
     }
@@ -92,19 +90,26 @@ export class StageMapping {
     /**
      * Create a `StageMapping` from a `StageEntry`.
      */
-    public static async from([token, ...rest]: StageEntry): Promise<StageMapping> {
-        const last = rest.at(-1);
-        const callback = isImport(last) ? last : null;
-        const meta = (callback ? rest.slice(0, -1) : rest) as StageEntryMetadata;
+    public static async from(entry: StageEntry): Promise<StageMapping> {
+        const { stage, fetch, variant, tag } = entry;
+        const meta: StageEntryMetadata = { variant, tag };
 
+        // prettier-ignore
         const init = match<StageEntryMetadata, StageMappingInit>(meta)
-            .with([], () => ({ token, variant: STANDARD }))
-            .with([PTag, PVariant], ([tag, variant]) => ({ token, variant, tag }))
-            .with([PVariant], ([variant]) => ({ token, variant }))
-            .with([PTag], ([tag]) => ({ token, variant: STANDARD, tag }))
+            .with({ tag: undefined, variant: undefined },
+                () => ({ stage, variant: STANDARD }))
+            .with({ variant: PVariant, tag: PTag },
+                ({ tag, variant }) => ({ stage, variant, tag, }))
+            .with({ variant: PVariant, tag: undefined },
+                ({ variant }) => ({ stage, variant }))
+            .with({ variant: undefined, tag: PTag },
+                ({ tag }) => ({ stage, variant: STANDARD, tag }))
             .exhaustive();
 
-        const tag = init.tag || (await callback?.().then(resolveStageTag)) || token;
-        return new StageMapping({ ...init, tag });
+        // A StageEntry supplies a tag only when the stage has been imported by default and so the
+        // import event won't happen. Without it, the class constructor won't be available for tag
+        // resolution anyway.
+        const newtag = init.tag || (await fetch?.().then(resolveStageTag)) || stage;
+        return new StageMapping({ ...init, tag: newtag });
     }
 }

--- a/web/src/flow/FlowExecutorStages.ts
+++ b/web/src/flow/FlowExecutorStages.ts
@@ -20,14 +20,14 @@ import type {
 } from "#flow/FlowExecutorStageFactory";
 
 /**
- * A tuple representing the metadata for a stage entry in the stage mapping registry.
+ * An interface representing the metadata for a stage entry in the stage mapping registry.
  */
-// prettier-ignore
-export type StageEntry =
-    | [token: FlowChallengeComponentName, tag: string, variant: PropVariant, import?: StageModuleCallback]
-    | [token: FlowChallengeComponentName, variant: PropVariant, import?: StageModuleCallback]
-    | [token: FlowChallengeComponentName, tag: string, import?: StageModuleCallback]
-    | [token: FlowChallengeComponentName, import?: StageModuleCallback];
+export interface StageEntry {
+    stage: FlowChallengeComponentName;
+    fetch?: StageModuleCallback;
+    variant?: PropVariant;
+    tag?: string;
+}
 
 /**
  * A mapping of server-side stage tokens to client-side custom element tags, along with the variant
@@ -59,40 +59,125 @@ export type StageEntry =
 // |   ||   ||   |    | \ ||---'| | |        ||    ,---||   ||---'`---.    |   ||---'|    |---'
 // `   '`---'`---'    `  `'`---'`-'-'    `---'`---'`---^`---|`---'`---'    `   '`---'`    `---'
 //                                                      `---'
+
 // prettier-ignore
 export const StageEntries: readonly StageEntry[] = [
-    ["ak-provider-iframe-logout", () => import("#flow/providers/IFrameLogoutStage")],
-    ["ak-provider-oauth2-device-code", () => import("#flow/providers/oauth2/DeviceCode")],
-    ["ak-provider-oauth2-device-code-finish", () => import("#flow/providers/oauth2/DeviceCodeFinish")],
-    ["ak-provider-saml-native-logout", () => import("#flow/providers/saml/NativeLogoutStage")],
-
-    ["ak-source-oauth-apple", "ak-flow-source-oauth-apple"],
-    ["ak-source-plex", "ak-flow-source-plex"],
-    ["ak-source-telegram", "ak-flow-source-telegram"],
-
-    ["ak-stage-access-denied", () => import("#flow/stages/access_denied/AccessDeniedStage")],
-    ["ak-stage-authenticator-duo", () => import("#flow/stages/authenticator_duo/AuthenticatorDuoStage")],
-    ["ak-stage-authenticator-email", () => import("#flow/stages/authenticator_email/AuthenticatorEmailStage")],
-    ["ak-stage-authenticator-sms", () => import("#flow/stages/authenticator_sms/AuthenticatorSMSStage")],
-    ["ak-stage-authenticator-static", () => import("#flow/stages/authenticator_static/AuthenticatorStaticStage")],
-    ["ak-stage-authenticator-totp", () => import("#flow/stages/authenticator_totp/AuthenticatorTOTPStage")],
-    ["ak-stage-authenticator-validate", () => import("#flow/stages/authenticator_validate/AuthenticatorValidateStage")],
-    ["ak-stage-authenticator-webauthn"],
-    ["ak-stage-autosubmit", () => import("#flow/stages/autosubmit/AutosubmitStage")],
-    ["ak-stage-captcha", () => import("#flow/stages/captcha/CaptchaStage")],
-    ["ak-stage-consent", () => import("#flow/stages/consent/ConsentStage")],
-    ["ak-stage-dummy", () => import("#flow/stages/dummy/DummyStage")],
-    ["ak-stage-email", () => import("#flow/stages/email/EmailStage")],
-    ["ak-stage-endpoint-agent", "challenge", () => import("#flow/stages/endpoint/agent/EndpointAgentStage")],
-    ["ak-stage-flow-error"],
-    ["ak-stage-identification", () => import("#flow/stages/identification/IdentificationStage")],
-    ["ak-stage-password", () => import("#flow/stages/password/PasswordStage")],
-    ["ak-stage-prompt", () => import("#flow/stages/prompt/PromptStage")],
-    ["ak-stage-session-end", () => import("#flow/providers/SessionEnd")],
-    ["ak-stage-user-login", "challenge", () => import("#flow/stages/user_login/UserLoginStage")],
-
-    ["xak-flow-frame", "challenge"],
-    ["xak-flow-redirect", "ak-stage-redirect"],
-]
+    {
+        stage: "ak-provider-iframe-logout",
+        fetch: () => import("#flow/providers/IFrameLogoutStage"),
+    },
+    {
+        stage: "ak-provider-oauth2-device-code",
+        fetch: () => import("#flow/providers/oauth2/DeviceCode"),
+    },
+    {
+        stage: "ak-provider-oauth2-device-code-finish",
+        fetch: () => import("#flow/providers/oauth2/DeviceCodeFinish"),
+    },
+    {
+        stage: "ak-provider-saml-native-logout",
+        fetch: () => import("#flow/providers/saml/NativeLogoutStage"),
+    },
+    {
+        stage: "ak-source-oauth-apple",
+        tag: "ak-flow-source-oauth-apple",
+    },
+    {
+        stage: "ak-source-plex",
+        tag: "ak-flow-source-plex",
+    },
+    {
+        stage: "ak-source-telegram",
+        tag: "ak-flow-source-telegram",
+    },
+    {
+        stage: "ak-stage-access-denied",
+        fetch: () => import("#flow/stages/access_denied/AccessDeniedStage"),
+    },
+    {
+        stage: "ak-stage-authenticator-duo",
+        fetch: () => import("#flow/stages/authenticator_duo/AuthenticatorDuoStage"),
+    },
+    {
+        stage: "ak-stage-authenticator-email",
+        fetch: () => import("#flow/stages/authenticator_email/AuthenticatorEmailStage"),
+    },
+    {
+        stage: "ak-stage-authenticator-sms",
+        fetch: () => import("#flow/stages/authenticator_sms/AuthenticatorSMSStage"),
+    },
+    {
+        stage: "ak-stage-authenticator-static",
+        fetch: () => import("#flow/stages/authenticator_static/AuthenticatorStaticStage"),
+    },
+    {
+        stage: "ak-stage-authenticator-totp",
+        fetch: () => import("#flow/stages/authenticator_totp/AuthenticatorTOTPStage"),
+    },
+    {
+        stage: "ak-stage-authenticator-validate",
+        fetch: () => import("#flow/stages/authenticator_validate/AuthenticatorValidateStage"),
+    },
+    {
+        stage: "ak-stage-authenticator-webauthn"
+    },
+    {
+        stage: "ak-stage-autosubmit",
+        fetch: () => import("#flow/stages/autosubmit/AutosubmitStage"),
+    },
+    {
+        stage: "ak-stage-captcha",
+        fetch: () => import("#flow/stages/captcha/CaptchaStage"),
+    },
+    {
+        stage: "ak-stage-consent",
+        fetch: () => import("#flow/stages/consent/ConsentStage"),
+    },
+    {
+        stage: "ak-stage-dummy",
+        fetch: () => import("#flow/stages/dummy/DummyStage"),
+    },
+    {
+        stage: "ak-stage-email",
+        fetch: () => import("#flow/stages/email/EmailStage"),
+    },
+    {
+        stage: "ak-stage-endpoint-agent",
+        fetch: () => import("#flow/stages/endpoint/agent/EndpointAgentStage"),
+        variant: "challenge",
+    },
+    {
+        stage: "ak-stage-flow-error"
+    },
+    {
+        stage: "ak-stage-identification",
+        fetch: () => import("#flow/stages/identification/IdentificationStage"),
+    },
+    {
+        stage: "ak-stage-password",
+        fetch: () => import("#flow/stages/password/PasswordStage"),
+    },
+    {
+        stage: "ak-stage-prompt",
+        fetch: () => import("#flow/stages/prompt/PromptStage"),
+    },
+    {
+        stage: "ak-stage-session-end",
+        fetch: () => import("#flow/providers/SessionEnd"),
+    },
+    {
+        stage: "ak-stage-user-login",
+        fetch: () => import("#flow/stages/user_login/UserLoginStage"),
+        variant: "challenge",
+    },
+    {
+        stage: "xak-flow-frame",
+        variant: "challenge"
+    },
+    {
+        stage: "xak-flow-redirect",
+        tag: "ak-stage-redirect",
+    },
+];
 
 export default StageEntries;


### PR DESCRIPTION
## What

Provide labels for the different parts of a stage import-and-invoke record. @BeryJu found the table-oriented set-up hard to read and, having revised the code, I think he was right. This is still more explicit: ‘switch/case/break’ statements are machinery, the *how* and not the *what*; these labels are all the “what” and the “how” is neatly tucked away in the constructor.

-   [X] The code has been formatted (`make web`)
