### PR TITLE
web: upgrade Font Awesome icons from PF4 subset to FA7

### DIFF
--- a/web/bundler/style-loader-plugin/node.js
+++ b/web/bundler/style-loader-plugin/node.js
@@ -37,25 +37,38 @@ export function styleLoaderPlugin({
     logger = ConsoleLogger.child({ name: "style-loader-plugin" }),
 } = {}) {
     const patternflyPath = resolvePackage("@patternfly/patternfly", import.meta);
+    const fontawesomePath = resolvePackage("@fortawesome/fontawesome-free", import.meta);
     const require = createRequire(import.meta.url);
 
     /**
-     * Apply custom resolution for Patternfly font files.
+     * Apply custom resolution for Patternfly and Font Awesome font files.
      *
-     * This is necessary because Patternfly's CSS references fonts via relative paths
+     * This is necessary because these packages reference fonts via relative paths
      * that ESBuild cannot resolve automatically.
      * @type {Parameters<PluginBuild["onResolve"]>}
      */
     const fontResolverArgs = [
         { filter: /\.woff2?$/ },
         async (args) => {
-            if (!args.resolveDir.startsWith(patternflyPath)) {
-                return;
+            // PatternFly references fonts relative to the package root
+            if (
+                args.resolveDir === patternflyPath ||
+                args.resolveDir.startsWith(patternflyPath + "/")
+            ) {
+                return {
+                    path: join(patternflyPath, args.path),
+                };
             }
 
-            return {
-                path: join(patternflyPath, args.path),
-            };
+            // Font Awesome references fonts relative to the CSS file directory
+            if (
+                args.resolveDir === fontawesomePath ||
+                args.resolveDir.startsWith(fontawesomePath + "/")
+            ) {
+                return {
+                    path: join(args.resolveDir, args.path),
+                };
+            }
         },
     ];
 

--- a/web/src/admin/applications/ApplicationForm.ts
+++ b/web/src/admin/applications/ApplicationForm.ts
@@ -199,7 +199,7 @@ export class ApplicationForm extends WithCapabilitiesConfig(ModelForm<Applicatio
                         value=${ifPresent(this.instance?.metaIcon)}
                         .usage=${AdminFileListUsageEnum.Media}
                         help=${msg(
-                            "Select from uploaded files, or type a Font Awesome icon (fa://fa-icon-name) or URL.",
+                            "Select from uploaded files, type a URL, or use a Font Awesome icon like fa://fa-key, fa://fa-shield-halved, or fa://brands/fa-github.",
                         )}
                         blankable
                     ></ak-file-search-input>

--- a/web/src/elements/AppIcon.ts
+++ b/web/src/elements/AppIcon.ts
@@ -2,15 +2,13 @@ import { PFSize } from "#common/enums";
 
 import Styles from "#elements/AppIcon.css";
 import { AKElement } from "#elements/Base";
-import { FontAwesomeProtocol } from "#elements/utils/images";
+import { FontAwesomeProtocol, parseFontAwesomeIcon } from "#elements/utils/images";
 
 import type { ThemedUrls } from "@goauthentik/api";
 
 import { msg, str } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { html, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
-
-import PFFontAwesomeIcons from "@patternfly/patternfly/base/patternfly-fa-icons.css";
 
 export interface IAppIcon {
     name?: string | null;
@@ -23,7 +21,7 @@ export interface IAppIcon {
 export class AppIcon extends AKElement implements IAppIcon {
     public static readonly FontAwesomeProtocol = FontAwesomeProtocol;
 
-    static styles: CSSResult[] = [PFFontAwesomeIcons, Styles];
+    static styles = [Styles];
 
     @property({ type: String })
     public name: string | null = null;
@@ -47,15 +45,15 @@ export class AppIcon extends AKElement implements IAppIcon {
         const applicationName = this.name ?? msg("Application");
         const label = msg(str`${applicationName} Icon`);
 
-        // Check for Font Awesome icons (fa://fa-icon-name)
+        // Check for Font Awesome icons (fa://fa-icon-name or fa://brands/fa-icon-name)
         if (this.icon?.startsWith(AppIcon.FontAwesomeProtocol)) {
-            const iconClass = this.icon.slice(AppIcon.FontAwesomeProtocol.length);
+            const { family, iconClass } = parseFontAwesomeIcon(this.icon);
             return this.#wrap(
                 html`<i
                     part="icon font-awesome"
                     role="img"
                     aria-label=${label}
-                    class="icon fas ${iconClass}"
+                    class="icon ${family} ${iconClass}"
                 ></i>`,
             );
         }

--- a/web/src/elements/utils/images.ts
+++ b/web/src/elements/utils/images.ts
@@ -12,6 +12,46 @@ import { html, nothing } from "lit";
 
 export const FontAwesomeProtocol = "fa://";
 
+const VALID_ICON_CLASS = /^[a-z0-9-]+$/;
+
+const FA_FAMILY_MAP: Record<string, string> = {
+    solid: "fa-solid",
+    regular: "fa-regular",
+    brands: "fa-brands",
+    fas: "fa-solid",
+    far: "fa-regular",
+    fab: "fa-brands",
+};
+
+/**
+ * Parse a fa:// icon string into its family class and icon class.
+ *
+ * Supported formats:
+ *   fa://fa-icon-name          → { family: "fa-solid", iconClass: "fa-icon-name" }
+ *   fa://brands/fa-icon-name   → { family: "fa-brands", iconClass: "fa-icon-name" }
+ *   fa://regular/fa-icon-name  → { family: "fa-regular", iconClass: "fa-icon-name" }
+ *   fa://solid/fa-icon-name    → { family: "fa-solid", iconClass: "fa-icon-name" }
+ */
+export function parseFontAwesomeIcon(icon: string): { family: string; iconClass: string } {
+    const value = icon.slice(FontAwesomeProtocol.length);
+    const slashIndex = value.indexOf("/");
+
+    if (slashIndex !== -1) {
+        const prefix = value.slice(0, slashIndex).toLowerCase();
+        const iconClass = value.slice(slashIndex + 1);
+        const family = FA_FAMILY_MAP[prefix] ?? "fa-solid";
+        return {
+            family,
+            iconClass: VALID_ICON_CLASS.test(iconClass) ? iconClass : "fa-question-circle",
+        };
+    }
+
+    return {
+        family: "fa-solid",
+        iconClass: VALID_ICON_CLASS.test(value) ? value : "fa-question-circle",
+    };
+}
+
 export interface ThemedImageProps extends ImgHTMLAttributes<HTMLImageElement> {
     /**
      * The image path (base URL, may contain %(theme)s for display purposes only)
@@ -38,9 +78,8 @@ export const ThemedImage: LitFC<ThemedImageProps> = ({
 
     // Handle Font Awesome icons
     if (src.startsWith(FontAwesomeProtocol)) {
-        const classes = [className, "font-awesome", "fas", src.slice(FontAwesomeProtocol.length)]
-            .filter(Boolean)
-            .join(" ");
+        const { family, iconClass } = parseFontAwesomeIcon(src);
+        const classes = [className, "font-awesome", family, iconClass].filter(Boolean).join(" ");
 
         return html`<i part="icon font-awesome" role="img" class=${classes} ${spread(props)}></i>`;
     }

--- a/web/src/styles/authentik/flows.global.css
+++ b/web/src/styles/authentik/flows.global.css
@@ -1,7 +1,7 @@
 @import "@patternfly/patternfly/base/patternfly-common.css";
 @import "@patternfly/patternfly/base/patternfly-globals.css";
 @import "@patternfly/patternfly/base/patternfly-themes.css";
-@import "@patternfly/patternfly/base/patternfly-fa-icons.css";
+@import "@fortawesome/fontawesome-free/css/all.css";
 @import "@patternfly/patternfly/base/patternfly-pf-icons.css";
 
 @import "@patternfly/patternfly/components/Spinner/spinner.css";

--- a/web/src/styles/authentik/interface.global.css
+++ b/web/src/styles/authentik/interface.global.css
@@ -1,7 +1,7 @@
 @import "@patternfly/patternfly/base/patternfly-common.css";
 @import "@patternfly/patternfly/base/patternfly-globals.css";
 @import "@patternfly/patternfly/base/patternfly-themes.css";
-@import "@patternfly/patternfly/base/patternfly-fa-icons.css";
+@import "@fortawesome/fontawesome-free/css/all.css";
 @import "@patternfly/patternfly/base/patternfly-pf-icons.css";
 @import "@patternfly/patternfly/components/Spinner/spinner.css";
 @import "#fonts/RedHat/faces.css";

--- a/web/src/styles/patternfly/base.css
+++ b/web/src/styles/patternfly/base.css
@@ -1,6 +1,6 @@
 @import "@patternfly/patternfly/base/patternfly-common.css";
 @import "@patternfly/patternfly/base/patternfly-globals.css";
-@import "@patternfly/patternfly/base/patternfly-fa-icons.css";
+@import "@fortawesome/fontawesome-free/css/all.css";
 @import "@patternfly/patternfly/base/patternfly-pf-icons.css";
 
 a {


### PR DESCRIPTION
## Details

Replace PatternFly 4's bundled Font Awesome 5 icon subset (~1,379 icons) with
Font Awesome 7's `all.css` (2,665 icons) across all three stylesheet entry
points (shadow DOM base, interface global, flows global). This enables:

- **All FA7 solid icons** — previously broken icons like `fa-cow` now render
- **Brand icons** — `fa://brands/fa-github`, `fa://brands/fa-google`, etc.
- **Family prefix syntax** — `fa://brands/`, `fa://regular/`, `fa://solid/`

FA7's `all.css` includes FA5-compatible `@font-face` aliases, so existing
PatternFly 4 light-DOM icon usages (`fas fa-check`, etc.) continue working
unchanged.

Also fixes:
- **CSS class injection** — validates icon class names against `[a-z0-9-]` allowlist
- **Path traversal** — tightens `startsWith` checks in the bundler font resolver

Closes #19517

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)