### PR TITLE
web: add FA Pro family prefixes to fa:// parser

### DIFF
--- a/web/bundler/style-loader-plugin/node.js
+++ b/web/bundler/style-loader-plugin/node.js
@@ -37,25 +37,38 @@ export function styleLoaderPlugin({
     logger = ConsoleLogger.child({ name: "style-loader-plugin" }),
 } = {}) {
     const patternflyPath = resolvePackage("@patternfly/patternfly", import.meta);
+    const fontawesomePath = resolvePackage("@fortawesome/fontawesome-free", import.meta);
     const require = createRequire(import.meta.url);
 
     /**
-     * Apply custom resolution for Patternfly font files.
+     * Apply custom resolution for Patternfly and Font Awesome font files.
      *
-     * This is necessary because Patternfly's CSS references fonts via relative paths
+     * This is necessary because these packages reference fonts via relative paths
      * that ESBuild cannot resolve automatically.
      * @type {Parameters<PluginBuild["onResolve"]>}
      */
     const fontResolverArgs = [
         { filter: /\.woff2?$/ },
         async (args) => {
-            if (!args.resolveDir.startsWith(patternflyPath)) {
-                return;
+            // PatternFly references fonts relative to the package root
+            if (
+                args.resolveDir === patternflyPath ||
+                args.resolveDir.startsWith(patternflyPath + "/")
+            ) {
+                return {
+                    path: join(patternflyPath, args.path),
+                };
             }
 
-            return {
-                path: join(patternflyPath, args.path),
-            };
+            // Font Awesome references fonts relative to the CSS file directory
+            if (
+                args.resolveDir === fontawesomePath ||
+                args.resolveDir.startsWith(fontawesomePath + "/")
+            ) {
+                return {
+                    path: join(args.resolveDir, args.path),
+                };
+            }
         },
     ];
 

--- a/web/src/admin/applications/ApplicationForm.ts
+++ b/web/src/admin/applications/ApplicationForm.ts
@@ -199,7 +199,7 @@ export class ApplicationForm extends WithCapabilitiesConfig(ModelForm<Applicatio
                         value=${ifPresent(this.instance?.metaIcon)}
                         .usage=${AdminFileListUsageEnum.Media}
                         help=${msg(
-                            "Select from uploaded files, type a URL, or use a Font Awesome icon like fa://fa-key, fa://fa-shield-halved, or fa://brands/fa-github.",
+                            "Select from uploaded files, type a URL, or use a Font Awesome icon like fa://fa-key, fa://fa-shield-halved, or fa://brands/fa-github. Pro families (light, thin, duotone, sharp-solid) work if FA Pro CSS is loaded via custom branding.",
                         )}
                         blankable
                     ></ak-file-search-input>

--- a/web/src/admin/applications/ApplicationForm.ts
+++ b/web/src/admin/applications/ApplicationForm.ts
@@ -22,6 +22,7 @@ import { WithCapabilitiesConfig } from "#elements/mixins/capabilities";
 import { navigate } from "#elements/router/RouterOutlet";
 import { ifPresent } from "#elements/utils/attributes";
 
+import { iconHelperText } from "#admin/helperText";
 import { policyEngineModes } from "#admin/policies/PolicyEngineModes";
 
 import { AdminFileListUsageEnum, Application, CoreApi, Provider } from "@goauthentik/api";
@@ -198,9 +199,7 @@ export class ApplicationForm extends WithCapabilitiesConfig(ModelForm<Applicatio
                         label=${msg("Icon")}
                         value=${ifPresent(this.instance?.metaIcon)}
                         .usage=${AdminFileListUsageEnum.Media}
-                        help=${msg(
-                            "Select from uploaded files, type a URL, or use a Font Awesome icon like fa://fa-key, fa://fa-shield-halved, or fa://brands/fa-github. Pro families (light, thin, duotone, sharp-solid) work if FA Pro CSS is loaded via custom branding.",
-                        )}
+                        help=${iconHelperText}
                         blankable
                     ></ak-file-search-input>
                     <ak-text-input

--- a/web/src/admin/applications/ApplicationForm.ts
+++ b/web/src/admin/applications/ApplicationForm.ts
@@ -199,7 +199,7 @@ export class ApplicationForm extends WithCapabilitiesConfig(ModelForm<Applicatio
                         value=${ifPresent(this.instance?.metaIcon)}
                         .usage=${AdminFileListUsageEnum.Media}
                         help=${msg(
-                            "Select from uploaded files, or type a Font Awesome icon (fa://fa-icon-name) or URL.",
+                            "Select from uploaded files, type a URL, or use a Font Awesome icon like fa://fa-key, fa://fa-shield-halved, or fa://brands/fa-github.",
                         )}
                         blankable
                     ></ak-file-search-input>

--- a/web/src/admin/applications/wizard/steps/ak-application-wizard-application-step.ts
+++ b/web/src/admin/applications/wizard/steps/ak-application-wizard-application-step.ts
@@ -15,6 +15,7 @@ import { isSlug } from "#elements/router/utils";
 import { type NavigableButton, type WizardButton } from "#components/ak-wizard/types";
 
 import { ApplicationWizardStep } from "#admin/applications/wizard/ApplicationWizardStep";
+import { iconHelperText } from "#admin/helperText";
 import { policyEngineModes } from "#admin/policies/PolicyEngineModes";
 
 import { AdminFileListUsageEnum, type ApplicationRequest } from "@goauthentik/api";
@@ -188,9 +189,7 @@ export class ApplicationWizardApplicationStep extends ApplicationWizardStep {
                             label=${msg("Icon")}
                             value=${ifDefined(app.metaIcon)}
                             .usage=${AdminFileListUsageEnum.Media}
-                            help=${msg(
-                                "Select from uploaded files, or type a Font Awesome icon (fa://fa-icon-name) or URL.",
-                            )}
+                            help=${iconHelperText}
                             blankable
                         ></ak-file-search-input>
                         <ak-text-input

--- a/web/src/admin/helperText.ts
+++ b/web/src/admin/helperText.ts
@@ -4,7 +4,7 @@ import { msg } from "@lit/localize";
 // multiple locations. They've been extracted to ensure consistency.
 
 export const iconHelperText = msg(
-    "Either input a full URL, a relative path, or use 'fa://fa-test' to use the Font Awesome icon \"fa-test\".",
+    "Select from uploaded files, type a URL, or use a Font Awesome icon like fa://fa-key, fa://fa-shield-halved, or fa://brands/fa-github. Pro families (light, thin, duotone, sharp-solid) work if FA Pro CSS is loaded via custom branding.",
 );
 
 export const placeholderHelperText = msg(

--- a/web/src/admin/sources/utils.ts
+++ b/web/src/admin/sources/utils.ts
@@ -1,3 +1,5 @@
+import { FontAwesomeProtocol, parseFontAwesomeIcon } from "#elements/utils/images";
+
 import { PolicyBindingCheckTarget } from "#admin/policies/utils";
 
 import { msg } from "@lit/localize";
@@ -11,9 +13,14 @@ export function renderSourceIcon(name: string, iconUrl: string | undefined | nul
         title="${name}"
     ></i>`;
     if (iconUrl) {
-        if (iconUrl.startsWith("fa://")) {
-            const url = iconUrl.replaceAll("fa://", "");
-            return html`<i part="source-icon" role="img" class="fas ${url}" title="${name}"></i>`;
+        if (iconUrl.startsWith(FontAwesomeProtocol)) {
+            const { family, iconClass } = parseFontAwesomeIcon(iconUrl);
+            return html`<i
+                part="source-icon"
+                role="img"
+                class="${family} ${iconClass}"
+                title="${name}"
+            ></i>`;
         }
         return html`<img part="source-icon" src="${iconUrl}" alt="${name}" />`;
     }

--- a/web/src/components/ak-page-navbar.ts
+++ b/web/src/components/ak-page-navbar.ts
@@ -7,7 +7,7 @@ import { AKElement } from "#elements/Base";
 import { WithBrandConfig } from "#elements/mixins/branding";
 import { WithSession } from "#elements/mixins/session";
 import { isAdminRoute } from "#elements/router/utils";
-import { ThemedImage } from "#elements/utils/images";
+import { FontAwesomeProtocol, parseFontAwesomeIcon, ThemedImage } from "#elements/utils/images";
 
 import Styles from "#components/ak-page-navbar.css";
 
@@ -149,7 +149,7 @@ export class AKPageNavbar
     protected renderIcon() {
         return guard([this.icon, this.iconImage], () => {
             if (this.icon) {
-                if (this.iconImage && !this.icon.startsWith("fa://")) {
+                if (this.iconImage && !this.icon.startsWith(FontAwesomeProtocol)) {
                     return html`<img
                         aria-hidden="true"
                         class="accent-icon pf-icon"
@@ -158,9 +158,9 @@ export class AKPageNavbar
                     />`;
                 }
 
-                const icon = this.icon.replaceAll("fa://", "fa ");
+                const { family, iconClass } = parseFontAwesomeIcon(this.icon);
 
-                return html`<i class="accent-icon ${icon}" aria-hidden="true"></i>`;
+                return html`<i class="accent-icon ${family} ${iconClass}" aria-hidden="true"></i>`;
             }
 
             return nothing;

--- a/web/src/elements/AppIcon.ts
+++ b/web/src/elements/AppIcon.ts
@@ -2,15 +2,13 @@ import { PFSize } from "#common/enums";
 
 import Styles from "#elements/AppIcon.css";
 import { AKElement } from "#elements/Base";
-import { FontAwesomeProtocol } from "#elements/utils/images";
+import { FontAwesomeProtocol, parseFontAwesomeIcon } from "#elements/utils/images";
 
 import type { ThemedUrls } from "@goauthentik/api";
 
 import { msg, str } from "@lit/localize";
-import { CSSResult, html, TemplateResult } from "lit";
+import { html, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
-
-import PFFontAwesomeIcons from "@patternfly/patternfly/base/patternfly-fa-icons.css";
 
 export interface IAppIcon {
     name?: string | null;
@@ -23,7 +21,7 @@ export interface IAppIcon {
 export class AppIcon extends AKElement implements IAppIcon {
     public static readonly FontAwesomeProtocol = FontAwesomeProtocol;
 
-    static styles: CSSResult[] = [PFFontAwesomeIcons, Styles];
+    static styles = [Styles];
 
     @property({ type: String })
     public name: string | null = null;
@@ -47,15 +45,15 @@ export class AppIcon extends AKElement implements IAppIcon {
         const applicationName = this.name ?? msg("Application");
         const label = msg(str`${applicationName} Icon`);
 
-        // Check for Font Awesome icons (fa://fa-icon-name)
+        // Check for Font Awesome icons (fa://fa-icon-name or fa://brands/fa-icon-name)
         if (this.icon?.startsWith(AppIcon.FontAwesomeProtocol)) {
-            const iconClass = this.icon.slice(AppIcon.FontAwesomeProtocol.length);
+            const { family, iconClass } = parseFontAwesomeIcon(this.icon);
             return this.#wrap(
                 html`<i
                     part="icon font-awesome"
                     role="img"
                     aria-label=${label}
-                    class="icon fas ${iconClass}"
+                    class="icon ${family} ${iconClass}"
                 ></i>`,
             );
         }

--- a/web/src/elements/utils/images.ts
+++ b/web/src/elements/utils/images.ts
@@ -12,6 +12,46 @@ import { html, nothing } from "lit";
 
 export const FontAwesomeProtocol = "fa://";
 
+const VALID_ICON_CLASS = /^[a-z0-9-]+$/;
+
+const FA_FAMILY_MAP: Record<string, string> = {
+    solid: "fa-solid",
+    regular: "fa-regular",
+    brands: "fa-brands",
+    fas: "fa-solid",
+    far: "fa-regular",
+    fab: "fa-brands",
+};
+
+/**
+ * Parse a fa:// icon string into its family class and icon class.
+ *
+ * Supported formats:
+ *   fa://fa-icon-name          → { family: "fa-solid", iconClass: "fa-icon-name" }
+ *   fa://brands/fa-icon-name   → { family: "fa-brands", iconClass: "fa-icon-name" }
+ *   fa://regular/fa-icon-name  → { family: "fa-regular", iconClass: "fa-icon-name" }
+ *   fa://solid/fa-icon-name    → { family: "fa-solid", iconClass: "fa-icon-name" }
+ */
+export function parseFontAwesomeIcon(icon: string): { family: string; iconClass: string } {
+    const value = icon.slice(FontAwesomeProtocol.length);
+    const slashIndex = value.indexOf("/");
+
+    if (slashIndex !== -1) {
+        const prefix = value.slice(0, slashIndex).toLowerCase();
+        const iconClass = value.slice(slashIndex + 1);
+        const family = FA_FAMILY_MAP[prefix] ?? "fa-solid";
+        return {
+            family,
+            iconClass: VALID_ICON_CLASS.test(iconClass) ? iconClass : "fa-question-circle",
+        };
+    }
+
+    return {
+        family: "fa-solid",
+        iconClass: VALID_ICON_CLASS.test(value) ? value : "fa-question-circle",
+    };
+}
+
 export interface ThemedImageProps extends ImgHTMLAttributes<HTMLImageElement> {
     /**
      * The image path (base URL, may contain %(theme)s for display purposes only)
@@ -38,9 +78,8 @@ export const ThemedImage: LitFC<ThemedImageProps> = ({
 
     // Handle Font Awesome icons
     if (src.startsWith(FontAwesomeProtocol)) {
-        const classes = [className, "font-awesome", "fas", src.slice(FontAwesomeProtocol.length)]
-            .filter(Boolean)
-            .join(" ");
+        const { family, iconClass } = parseFontAwesomeIcon(src);
+        const classes = [className, "font-awesome", family, iconClass].filter(Boolean).join(" ");
 
         return html`<i part="icon font-awesome" role="img" class=${classes} ${spread(props)}></i>`;
     }

--- a/web/src/elements/utils/images.ts
+++ b/web/src/elements/utils/images.ts
@@ -15,22 +15,52 @@ export const FontAwesomeProtocol = "fa://";
 const VALID_ICON_CLASS = /^[a-z0-9-]+$/;
 
 const FA_FAMILY_MAP: Record<string, string> = {
-    solid: "fa-solid",
-    regular: "fa-regular",
-    brands: "fa-brands",
-    fas: "fa-solid",
-    far: "fa-regular",
-    fab: "fa-brands",
+    // Free families
+    "solid": "fa-solid",
+    "regular": "fa-regular",
+    "brands": "fa-brands",
+    "fas": "fa-solid",
+    "far": "fa-regular",
+    "fab": "fa-brands",
+    // Pro families (require user-provided FA Pro CSS)
+    "light": "fa-light",
+    "thin": "fa-thin",
+    "duotone": "fa-duotone",
+    "fal": "fa-light",
+    "fat": "fa-thin",
+    "fad": "fa-duotone",
+    // Pro sharp families
+    "sharp-solid": "fa-sharp fa-solid",
+    "sharp-regular": "fa-sharp fa-regular",
+    "sharp-light": "fa-sharp fa-light",
+    "sharp-thin": "fa-sharp fa-thin",
+    "fass": "fa-sharp fa-solid",
+    "fasr": "fa-sharp fa-regular",
+    "fasl": "fa-sharp fa-light",
+    "fast": "fa-sharp fa-thin",
+    // Pro sharp-duotone families
+    "sharp-duotone-solid": "fa-sharp-duotone fa-solid",
+    "sharp-duotone-regular": "fa-sharp-duotone fa-regular",
+    "sharp-duotone-light": "fa-sharp-duotone fa-light",
+    "sharp-duotone-thin": "fa-sharp-duotone fa-thin",
+    "fasds": "fa-sharp-duotone fa-solid",
+    "fasdr": "fa-sharp-duotone fa-regular",
+    "fasdl": "fa-sharp-duotone fa-light",
+    "fasdt": "fa-sharp-duotone fa-thin",
 };
 
 /**
  * Parse a fa:// icon string into its family class and icon class.
  *
  * Supported formats:
- *   fa://fa-icon-name          → { family: "fa-solid", iconClass: "fa-icon-name" }
- *   fa://brands/fa-icon-name   → { family: "fa-brands", iconClass: "fa-icon-name" }
- *   fa://regular/fa-icon-name  → { family: "fa-regular", iconClass: "fa-icon-name" }
- *   fa://solid/fa-icon-name    → { family: "fa-solid", iconClass: "fa-icon-name" }
+ *   fa://fa-icon-name              → { family: "fa-solid", iconClass: "fa-icon-name" }
+ *   fa://brands/fa-icon-name       → { family: "fa-brands", iconClass: "fa-icon-name" }
+ *   fa://regular/fa-icon-name      → { family: "fa-regular", iconClass: "fa-icon-name" }
+ *   fa://solid/fa-icon-name        → { family: "fa-solid", iconClass: "fa-icon-name" }
+ *   fa://light/fa-icon-name        → { family: "fa-light", iconClass: "fa-icon-name" }
+ *   fa://sharp-solid/fa-icon-name  → { family: "fa-sharp fa-solid", iconClass: "fa-icon-name" }
+ *
+ * Pro families (light, thin, duotone, sharp-*) require FA Pro CSS loaded by the user.
  */
 export function parseFontAwesomeIcon(icon: string): { family: string; iconClass: string } {
     const value = icon.slice(FontAwesomeProtocol.length);

--- a/web/src/styles/authentik/flows.global.css
+++ b/web/src/styles/authentik/flows.global.css
@@ -1,7 +1,7 @@
 @import "@patternfly/patternfly/base/patternfly-common.css";
 @import "@patternfly/patternfly/base/patternfly-globals.css";
 @import "@patternfly/patternfly/base/patternfly-themes.css";
-@import "@patternfly/patternfly/base/patternfly-fa-icons.css";
+@import "@fortawesome/fontawesome-free/css/all.css";
 @import "@patternfly/patternfly/base/patternfly-pf-icons.css";
 
 @import "@patternfly/patternfly/components/Spinner/spinner.css";

--- a/web/src/styles/authentik/interface.global.css
+++ b/web/src/styles/authentik/interface.global.css
@@ -1,7 +1,7 @@
 @import "@patternfly/patternfly/base/patternfly-common.css";
 @import "@patternfly/patternfly/base/patternfly-globals.css";
 @import "@patternfly/patternfly/base/patternfly-themes.css";
-@import "@patternfly/patternfly/base/patternfly-fa-icons.css";
+@import "@fortawesome/fontawesome-free/css/all.css";
 @import "@patternfly/patternfly/base/patternfly-pf-icons.css";
 @import "@patternfly/patternfly/components/Spinner/spinner.css";
 @import "#fonts/RedHat/faces.css";

--- a/web/src/styles/patternfly/base.css
+++ b/web/src/styles/patternfly/base.css
@@ -1,6 +1,6 @@
 @import "@patternfly/patternfly/base/patternfly-common.css";
 @import "@patternfly/patternfly/base/patternfly-globals.css";
-@import "@patternfly/patternfly/base/patternfly-fa-icons.css";
+@import "@fortawesome/fontawesome-free/css/all.css";
 @import "@patternfly/patternfly/base/patternfly-pf-icons.css";
 
 a {

--- a/web/test/unit/elements/utils/images.unit.test.ts
+++ b/web/test/unit/elements/utils/images.unit.test.ts
@@ -1,0 +1,114 @@
+import { parseFontAwesomeIcon } from "#elements/utils/images";
+
+import { describe, expect, it } from "vitest";
+
+describe("parseFontAwesomeIcon", () => {
+    it("defaults to fa-solid when no family prefix", () => {
+        const result = parseFontAwesomeIcon("fa://fa-key");
+        expect(result).toEqual({ family: "fa-solid", iconClass: "fa-key" });
+    });
+
+    describe("free families", () => {
+        it.each([
+            ["solid", "fa-solid"],
+            ["regular", "fa-regular"],
+            ["brands", "fa-brands"],
+        ])("parses %s prefix", (prefix, expectedFamily) => {
+            const result = parseFontAwesomeIcon(`fa://${prefix}/fa-github`);
+            expect(result).toEqual({ family: expectedFamily, iconClass: "fa-github" });
+        });
+
+        it.each([
+            ["fas", "fa-solid"],
+            ["far", "fa-regular"],
+            ["fab", "fa-brands"],
+        ])("parses short alias %s", (alias, expectedFamily) => {
+            const result = parseFontAwesomeIcon(`fa://${alias}/fa-github`);
+            expect(result).toEqual({ family: expectedFamily, iconClass: "fa-github" });
+        });
+    });
+
+    describe("pro families", () => {
+        it.each([
+            ["light", "fa-light"],
+            ["thin", "fa-thin"],
+            ["duotone", "fa-duotone"],
+        ])("parses %s prefix", (prefix, expectedFamily) => {
+            const result = parseFontAwesomeIcon(`fa://${prefix}/fa-coffee`);
+            expect(result).toEqual({ family: expectedFamily, iconClass: "fa-coffee" });
+        });
+
+        it.each([
+            ["fal", "fa-light"],
+            ["fat", "fa-thin"],
+            ["fad", "fa-duotone"],
+        ])("parses short alias %s", (alias, expectedFamily) => {
+            const result = parseFontAwesomeIcon(`fa://${alias}/fa-coffee`);
+            expect(result).toEqual({ family: expectedFamily, iconClass: "fa-coffee" });
+        });
+    });
+
+    describe("sharp families", () => {
+        it.each([
+            ["sharp-solid", "fa-sharp fa-solid"],
+            ["sharp-regular", "fa-sharp fa-regular"],
+            ["sharp-light", "fa-sharp fa-light"],
+            ["sharp-thin", "fa-sharp fa-thin"],
+        ])("parses %s prefix into multi-class", (prefix, expectedFamily) => {
+            const result = parseFontAwesomeIcon(`fa://${prefix}/fa-check`);
+            expect(result).toEqual({ family: expectedFamily, iconClass: "fa-check" });
+        });
+
+        it.each([
+            ["fass", "fa-sharp fa-solid"],
+            ["fasr", "fa-sharp fa-regular"],
+            ["fasl", "fa-sharp fa-light"],
+            ["fast", "fa-sharp fa-thin"],
+        ])("parses short alias %s", (alias, expectedFamily) => {
+            const result = parseFontAwesomeIcon(`fa://${alias}/fa-check`);
+            expect(result).toEqual({ family: expectedFamily, iconClass: "fa-check" });
+        });
+    });
+
+    describe("sharp-duotone families", () => {
+        it.each([
+            ["sharp-duotone-solid", "fa-sharp-duotone fa-solid"],
+            ["sharp-duotone-regular", "fa-sharp-duotone fa-regular"],
+            ["sharp-duotone-light", "fa-sharp-duotone fa-light"],
+            ["sharp-duotone-thin", "fa-sharp-duotone fa-thin"],
+        ])("parses %s prefix into multi-class", (prefix, expectedFamily) => {
+            const result = parseFontAwesomeIcon(`fa://${prefix}/fa-star`);
+            expect(result).toEqual({ family: expectedFamily, iconClass: "fa-star" });
+        });
+
+        it.each([
+            ["fasds", "fa-sharp-duotone fa-solid"],
+            ["fasdr", "fa-sharp-duotone fa-regular"],
+            ["fasdl", "fa-sharp-duotone fa-light"],
+            ["fasdt", "fa-sharp-duotone fa-thin"],
+        ])("parses short alias %s", (alias, expectedFamily) => {
+            const result = parseFontAwesomeIcon(`fa://${alias}/fa-star`);
+            expect(result).toEqual({ family: expectedFamily, iconClass: "fa-star" });
+        });
+    });
+
+    it("falls back to fa-solid for unknown prefix", () => {
+        const result = parseFontAwesomeIcon("fa://unknown/fa-widget");
+        expect(result).toEqual({ family: "fa-solid", iconClass: "fa-widget" });
+    });
+
+    it("falls back to fa-question-circle for invalid icon class", () => {
+        const result = parseFontAwesomeIcon("fa://INVALID CHARS!");
+        expect(result).toEqual({ family: "fa-solid", iconClass: "fa-question-circle" });
+    });
+
+    it("falls back to fa-question-circle for invalid icon class with prefix", () => {
+        const result = parseFontAwesomeIcon("fa://brands/INVALID!");
+        expect(result).toEqual({ family: "fa-brands", iconClass: "fa-question-circle" });
+    });
+
+    it("handles prefix case-insensitively", () => {
+        const result = parseFontAwesomeIcon("fa://Brands/fa-github");
+        expect(result).toEqual({ family: "fa-brands", iconClass: "fa-github" });
+    });
+});


### PR DESCRIPTION
## What

Fix two broken `fa://` icon call sites that used naive string replacement
instead of `parseFontAwesomeIcon`, consolidate fragmented icon help text
into the shared `iconHelperText` constant, and add unit test coverage for
the icon parser.

## Why

The string replacement approach (`replaceAll("fa://", "")`) breaks when
`fa://` URLs include a family prefix like `fa://brands/fa-github` — it
produces `brands/fa-github` as a CSS class, which is invalid. This was
already broken by the FA7 upgrade (#20859) and gets worse with Pro family
support. The help text was also duplicated across 3 files with inconsistent
wording.

Depends on #20859.

-   [X] The code has been formatted (`make web`)