### PR TITLE
stages/captcha: fix hcaptcha height

### DIFF
--- a/web/src/flow/stages/captcha/CaptchaStage.ts
+++ b/web/src/flow/stages/captcha/CaptchaStage.ts
@@ -362,9 +362,12 @@ export class CaptchaStage
 
         let synchronizeHeight: () => void;
 
-        if (this.activeController instanceof GReCaptchaController) {
-            // reCAPTCHA's use of nested iframes prevents their internal resize observer from
-            // reporting the correct height back to our iframe, so we have to do it ourselves.
+        if (
+            this.activeController instanceof GReCaptchaController ||
+            this.activeController instanceof HCaptchaController
+        ) {
+            // reCAPTCHA and hCaptcha use nested iframes that prevent their internal resize
+            // observer from reporting the correct height back to our iframe, so we have to do it ourselves.
 
             synchronizeHeight = () => {
                 if (!this.iframeRef) return;
@@ -373,38 +376,38 @@ export class CaptchaStage
 
                 if (!target) return;
 
-                const innerIFrame = contentDocument.querySelector<HTMLIFrameElement>(
-                    'iframe[style~="height:"]',
-                );
+                // Check all iframes. hCaptcha appends the step-2 challenge popup as a
+                // second iframe directly on the body
+                let maxHeight = target.clientHeight;
+                for (const iframe of contentDocument.querySelectorAll("iframe")) {
+                    const styleHeight = parseFloat(iframe.style.height);
+                    const rectBottom = iframe.getBoundingClientRect().bottom;
+                    maxHeight = Math.max(maxHeight, styleHeight || 0, rectBottom);
 
-                const innerBottom = innerIFrame?.getBoundingClientRect().bottom ?? 0;
-
-                const actualHeight = Math.max(innerBottom, target.clientHeight);
-
-                this.iframeHeight = Math.round(actualHeight * 1.1);
-
-                if (innerIFrame?.parentElement) {
-                    innerIFrame.parentElement.style.height = `${actualHeight}px`;
+                    if (iframe.parentElement) {
+                        const height = styleHeight || iframe.getBoundingClientRect().height;
+                        if (height > 0) iframe.parentElement.style.height = `${height}px`;
+                    }
                 }
+
+                this.iframeHeight = Math.round(maxHeight * 1.1);
             };
 
-            // We watch for any newly inserted iframes, as they may alter the height
-            // of the parent iframe...
+            // Watch for new iframes AND style changes on existing iframes.
+            // hCaptcha sometimes resizes its popup by mutating the style attribute
+            // rather than replacing the element entirely.
             this.#mutationObserver = new MutationObserver((mutations) => {
                 for (const mutation of mutations) {
-                    if (mutation.type !== "childList") continue;
-
-                    for (const node of mutation.addedNodes as NodeListOf<HTMLElement>) {
-                        if (node.tagName !== "IFRAME") continue;
-
-                        // And then resize the iframe to match the new size.
-                        //
-                        // This doesn't fix the issue entirely since the challenge frame
-                        // doesn't yet know the correct height, but at least the user can
-                        // try to load the challenge again with the correct height.
-
-                        this.#resizeObserver?.observe(node as HTMLIFrameElement);
-
+                    if (mutation.type === "childList") {
+                        for (const node of mutation.addedNodes as NodeListOf<HTMLElement>) {
+                            if (node.tagName !== "IFRAME") continue;
+                            this.#resizeObserver?.observe(node as HTMLIFrameElement);
+                            requestAnimationFrame(synchronizeHeight);
+                        }
+                    } else if (
+                        mutation.type === "attributes" &&
+                        mutation.target instanceof HTMLIFrameElement
+                    ) {
                         requestAnimationFrame(synchronizeHeight);
                     }
                 }
@@ -413,6 +416,8 @@ export class CaptchaStage
             this.#mutationObserver.observe(contentDocument.body, {
                 childList: true,
                 subtree: true,
+                attributes: true,
+                attributeFilter: ["style"],
             });
         } else {
             synchronizeHeight = () => {


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->

The hCaptcha has a nested iframe that changes height when progressing to the second step. The code change monitors inner iframes to find the correct height whenever the style or children change to correctly update the height.

According to the code, the nested iframes are similar to Google ReCaptcha. This code should be compatible, but I do not have an API key to test with. PLEASE TEST BEFORE MERGING

Example of hCaptcha "Step 1"
<img width="1311" height="920" alt="image" src="https://github.com/user-attachments/assets/a2eca093-f230-4661-91f6-df2dba2c042c" />

Example of hCaptcha "Step 2"
<img width="1209" height="1294" alt="image" src="https://github.com/user-attachments/assets/85057103-6c2d-491c-b883-a5cc19944aac" />


closes #18971 
---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

~~If an API change has been made~~

-   [x] ~~The API schema has been updated (`make gen-build`)~~

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)

~~If applicable~~

-   [x] ~~The documentation has been updated~~
-   [x] ~~The documentation has been formatted (`make docs`)~~
