### PR TITLE
endpoints: fix tasks failing

### DIFF
--- a/authentik/endpoints/controller.py
+++ b/authentik/endpoints/controller.py
@@ -44,3 +44,6 @@ class BaseController[T: "Connector"]:
 
     def stage_view_authentication(self) -> StageView | None:
         return None
+
+    def sync_endpoints(self):
+        raise NotImplementedError

--- a/authentik/endpoints/models.py
+++ b/authentik/endpoints/models.py
@@ -162,8 +162,11 @@ class Connector(ScheduledModel, SerializerModel):
 
     @property
     def schedule_specs(self) -> list[ScheduleSpec]:
+        from authentik.endpoints.controller import Capabilities
         from authentik.endpoints.tasks import endpoints_sync
 
+        if Capabilities.ENROLL_AUTOMATIC_API not in self.controller(self).capabilities():
+            return []
         return [
             ScheduleSpec(
                 actor=endpoints_sync,

--- a/authentik/endpoints/tasks.py
+++ b/authentik/endpoints/tasks.py
@@ -21,7 +21,7 @@ def endpoints_sync(connector_pk: Any):
         return
     controller = connector.controller
     ctrl = controller(connector)
-    if Capabilities.AUTOMATIC_API not in ctrl.capabilities():
+    if Capabilities.ENROLL_AUTOMATIC_API not in ctrl.capabilities():
         return
     LOGGER.info("Syncing connector", connector=connector.name)
     ctrl.sync_endpoints()

--- a/authentik/endpoints/tests/test_tasks.py
+++ b/authentik/endpoints/tests/test_tasks.py
@@ -1,0 +1,32 @@
+from unittest.mock import PropertyMock, patch
+
+from rest_framework.test import APITestCase
+
+from authentik.endpoints.controller import BaseController, Capabilities
+from authentik.endpoints.models import Connector
+from authentik.endpoints.tasks import endpoints_sync
+from authentik.lib.generators import generate_id
+
+
+class TestEndpointTasks(APITestCase):
+    def test_agent_sync(self):
+        class controller(BaseController):
+            def capabilities(self):
+                return [Capabilities.ENROLL_AUTOMATIC_API]
+
+        with patch.object(Connector, "controller", PropertyMock(return_value=controller)):
+            connector = Connector.objects.create(name=generate_id())
+            self.assertEqual(len(connector.schedule_specs), 1)
+
+            endpoints_sync.send(connector.pk).get_result(block=True)
+
+    def test_agent_no_sync(self):
+        class controller(BaseController):
+            def capabilities(self):
+                return []
+
+        with patch.object(Connector, "controller", PropertyMock(return_value=controller)):
+            connector = Connector.objects.create(name=generate_id())
+            self.assertEqual(len(connector.schedule_specs), 0)
+
+            endpoints_sync.send(connector.pk).get_result(block=True)

--- a/authentik/endpoints/tests/test_tasks.py
+++ b/authentik/endpoints/tests/test_tasks.py
@@ -14,6 +14,9 @@ class TestEndpointTasks(APITestCase):
             def capabilities(self):
                 return [Capabilities.ENROLL_AUTOMATIC_API]
 
+            def sync_endpoints(self):
+                pass
+
         with patch.object(Connector, "controller", PropertyMock(return_value=controller)):
             connector = Connector.objects.create(name=generate_id())
             self.assertEqual(len(connector.schedule_specs), 1)

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -58,8 +58,10 @@ def get_local_ip(override=True) -> str:
     if (local_ip := getenv("LOCAL_IP")) and override:
         return local_ip
     hostname = socket.gethostname()
-    ip_addr = socket.gethostbyname(hostname)
-    return ip_addr
+    try:
+        return socket.gethostbyname(hostname)
+    except socket.gaierror:
+        return "0.0.0.0"
 
 
 class SeleniumTestCase(DockerTestCase, StaticLiveServerTestCase):


### PR DESCRIPTION
due to a typo when refactoring and the tasks not being tested, they were failing each schedule run.

this also optimises the task schedule creation to only apply when automatic api enrollment is supported.