### PR TITLE
providers/saml: skip unsupported bindings when importing metadata

### DIFF
--- a/authentik/providers/saml/processors/metadata_extract.py
+++ b/authentik/providers/saml/processors/metadata_extract.py
@@ -1,0 +1,111 @@
+"""SAML metadata XML extractors (no policy): parse, walk, and collect candidates."""
+
+from typing import Any
+
+from lxml import etree  # nosec
+from structlog.stdlib import get_logger
+
+from authentik.common.saml.constants import (
+    NS_MAP,
+    SAML_BINDING_POST,
+    SAML_BINDING_REDIRECT,
+)
+
+LOGGER = get_logger()
+
+
+def extract_sp_descriptor(entity: etree._Element) -> etree._Element:
+    """Return the first SPSSODescriptor element."""
+    sp = entity.xpath("./md:SPSSODescriptor", namespaces=NS_MAP)
+    if not sp:
+        raise ValueError("EntityDescriptor has no SPSSODescriptor")
+    return sp[0]
+
+
+# ============================================================
+# Candidate extraction
+# ============================================================
+
+
+def normalize_binding_uri_to_token(binding_uri: str) -> str:
+    """Convert binding URI to a short token if recognizable; otherwise return input."""
+    # keep this as "normalization", not "policy"
+    if binding_uri == SAML_BINDING_POST:
+        return "post"
+    if "HTTP-Redirect" in SAML_BINDING_REDIRECT:
+        return "redirect"
+    return binding_uri
+
+
+def _extract_all_candidates(desc: etree._Element, element_xpath: str) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for n in desc.xpath(element_xpath, namespaces=NS_MAP):
+        url = (n.attrib.get("Location") or "").strip()
+        binding_uri = (n.attrib.get("Binding") or "").strip()
+        if not url or not binding_uri:
+            continue
+        binding = normalize_binding_uri_to_token(binding_uri)
+        index = int(n.attrib.get("index", 0))
+        results.append({"url": url, "binding": binding, "index": index})
+    results.sort(key=lambda x: x["index"])
+    return results
+
+
+def extract_all_acs(sp_desc: etree._Element) -> list[dict[str, Any]]:
+    """Extract all AssertionConsumerService endpoints (normalized binding token)."""
+    return _extract_all_candidates(sp_desc, "./md:AssertionConsumerService")
+
+
+def extract_all_sls(sp_desc: etree._Element) -> list[dict[str, Any]]:
+    """Extract all SingleLogoutService endpoints (normalized binding token)."""
+    return _extract_all_candidates(sp_desc, "./md:SingleLogoutService")
+
+
+def extract_all_sso(idp_desc: etree._Element) -> list[dict[str, Any]]:
+    """Extract all SingleSignOnService endpoints (normalized binding token)."""
+    return _extract_all_candidates(idp_desc, "./md:SingleSignOnService")
+
+
+def extract_all_slo(idp_desc: etree._Element) -> list[dict[str, Any]]:
+    """Extract all SingleLogoutService endpoints (normalized binding token)."""
+    return _extract_all_candidates(idp_desc, "./md:SingleLogoutService")
+
+
+def extract_nameid_formats(desc: etree._Element) -> list[str]:
+    """Extract NameIDFormat texts (dedup stable)."""
+    vals: list[str] = []
+    for el in desc.xpath("./md:NameIDFormat", namespaces=NS_MAP):
+        if el.text and el.text.strip():
+            vals.append(el.text.strip())
+    seen: set[str] = set()
+    out: list[str] = []
+    for v in vals:
+        if v not in seen:
+            out.append(v)
+            seen.add(v)
+    return out
+
+
+def extract_x509_b64_list(
+    descriptor: etree._Element,
+    *,
+    use: str | None = None,
+) -> list[str]:
+    """Extract X509Certificate values from KeyDescriptor, optionally filtered by @use."""
+    if use == "signing":
+        xp = "./md:KeyDescriptor[@use='signing']//ds:X509Certificate"
+    elif use == "encryption":
+        xp = "./md:KeyDescriptor[@use='encryption']//ds:X509Certificate"
+    elif use is None:
+        xp = "./md:KeyDescriptor[not(@use)]//ds:X509Certificate"
+    else:
+        raise ValueError("Invalid use value")
+
+    out: list[str] = []
+    seen: set[str] = set()
+    for n in descriptor.xpath(xp, namespaces=NS_MAP):
+        txt = (n.text or "").strip()
+        if txt and txt not in seen:
+            out.append(txt)
+            seen.add(txt)
+    return out

--- a/authentik/providers/saml/processors/metadata_parser.py
+++ b/authentik/providers/saml/processors/metadata_parser.py
@@ -1,6 +1,7 @@
-"""SAML ServiceProvider Metadata Parser and dataclass"""
+"""SAML metadata parser (policy + snapshot/runtime + compatibility DTOs)."""
 
 from dataclasses import dataclass
+from typing import Any
 
 import xmlsec
 from cryptography.hazmat.backends import default_backend
@@ -11,16 +12,162 @@ from structlog.stdlib import get_logger
 
 from authentik.common.saml.constants import (
     NS_MAP,
-    NS_SAML_METADATA,
-    SAML_BINDING_POST,
-    SAML_BINDING_REDIRECT,
 )
 from authentik.crypto.models import CertificateKeyPair, format_cert
 from authentik.flows.models import Flow
 from authentik.providers.saml.models import SAMLBindings, SAMLPropertyMapping, SAMLProvider
+from authentik.providers.saml.processors import metadata_extract as mx
 from authentik.sources.saml.models import SAMLNameIDPolicy
 
 LOGGER = get_logger()
+
+"""Allowed binding tokens for SP ACS/SLS selection."""
+_ALLOWED_ACS = {SAMLBindings.POST}  # keep strict for now
+_ALLOWED_SLS = {SAMLBindings.POST, SAMLBindings.REDIRECT}
+
+"""Preferred order for selection."""
+_PREFER_BINDINGS = (SAMLBindings.POST, SAMLBindings.REDIRECT)
+_PREFER_NAME_IDS = {
+    SAMLNameIDPolicy.PERSISTENT,
+    SAMLNameIDPolicy.TRANSIENT,
+    SAMLNameIDPolicy.EMAIL,
+    SAMLNameIDPolicy.UNSPECIFIED,
+}
+
+
+def _norm_str(v: Any) -> str:
+    if v is None:
+        return ""
+    return v.strip() if isinstance(v, str) else str(v).strip()
+
+
+def pick_preferred_service(
+    services: Any,
+    *,
+    allowed_bindings: set[str],
+    prefer_order: tuple[str, ...],
+) -> dict[str, str] | None:
+    """Pick a single endpoint from extracted candidates using allow+prefer policy."""
+    if not isinstance(services, list):
+        return None
+
+    norm: list[dict[str, str]] = []
+    for s in services:
+        if not isinstance(s, dict):
+            continue
+        binding = _norm_str(s.get("binding"))
+        url = _norm_str(s.get("url"))
+        if not url:
+            continue
+        if binding not in allowed_bindings:
+            continue
+        norm.append({"binding": binding, "url": url})
+
+    if not norm:
+        return None
+
+    for b in prefer_order:
+        for s in norm:
+            if s["binding"] == b:
+                return s
+    return norm[0]
+
+
+def pick_preferred_name_id_policy(
+    name_id_formats: Any,
+    *,
+    prefer_order: tuple[str, ...] = (
+        SAMLNameIDPolicy.PERSISTENT,
+        SAMLNameIDPolicy.TRANSIENT,
+        SAMLNameIDPolicy.EMAIL,
+        SAMLNameIDPolicy.UNSPECIFIED,
+    ),
+    default: str = SAMLNameIDPolicy.UNSPECIFIED,
+) -> str:
+    """Pick one NameID policy from a list of NameIDFormat URIs."""
+    if not isinstance(name_id_formats, list) or not name_id_formats:
+        return default
+
+    # normalize + de-dup stable
+    seen: set[str] = set()
+    formats: list[str] = []
+    for v in name_id_formats:
+        s = (v or "").strip()
+        if not s or s in seen:
+            continue
+        formats.append(s)
+        seen.add(s)
+
+    # prefer known values
+    for p in prefer_order:
+        if p in formats:
+            return p
+
+    # fallback: use first advertised format
+    return formats[0] if formats else default
+
+
+def build_sp_snapshot(entity: etree._Element) -> dict[str, Any]:
+    """Build SP snapshot with stable keys."""
+    sp_desc = mx.extract_sp_descriptor(entity)
+
+    acs_list = mx.extract_all_acs(sp_desc)
+    sls_list = mx.extract_all_sls(sp_desc)
+    name_id_list = mx.extract_nameid_formats(sp_desc)
+
+    verification_b64 = mx.extract_x509_b64_list(sp_desc, use="signing") or mx.extract_x509_b64_list(
+        sp_desc, use=None
+    )
+    encryption_b64 = mx.extract_x509_b64_list(sp_desc, use="encryption")
+
+    return {
+        "acs": acs_list,
+        "sls": sls_list,
+        "name_id_formats": name_id_list,
+        "authn_requests_signed": (sp_desc.attrib.get("AuthnRequestsSigned", "").lower() == "true"),
+        "want_assertions_signed": (
+            sp_desc.attrib.get("WantAssertionsSigned", "").lower() == "true"
+        ),
+        "has_verification_cert": bool(verification_b64),
+        "has_encryption_cert": bool(encryption_b64),
+    }
+
+
+def build_sp_runtime_from_snapshot(snapshot: dict[str, Any]) -> dict[str, Any]:
+    """Deterministically derive SP runtime defaults from snapshot using policy."""
+    snap = snapshot or {}
+
+    acs = (
+        pick_preferred_service(
+            snap.get("acs"),
+            allowed_bindings=_ALLOWED_ACS,
+            prefer_order=(SAMLBindings.POST,),
+        )
+        or {}
+    )
+    sls = (
+        pick_preferred_service(
+            snap.get("sls"),
+            allowed_bindings=_ALLOWED_SLS,
+            prefer_order=_PREFER_BINDINGS,
+        )
+        or {}
+    )
+
+    name_id_policy = (
+        pick_preferred_name_id_policy(snap.get("name_id_formats"), prefer_order=_PREFER_NAME_IDS)
+        or {}
+    )
+
+    return {
+        "acs_url": (acs.get("url") or "").strip(),
+        "sp_binding": (acs.get("binding") or "").strip(),
+        "sls_url": (sls.get("url") or "").strip(),
+        "sls_binding": (sls.get("binding") or "").strip(),
+        "authn_requests_signed": bool(snap.get("authn_requests_signed", False)),
+        "want_assertions_signed": bool(snap.get("want_assertions_signed", False)),
+        "name_id_policy": name_id_policy.strip(),
+    }
 
 
 @dataclass(slots=True)
@@ -46,8 +193,7 @@ class ServiceProviderMetadata:
     def to_provider(
         self, name: str, authorization_flow: Flow, invalidation_flow: Flow
     ) -> SAMLProvider:
-        """Create a SAMLProvider instance from the details. `name` is required,
-        as depending on the metadata CertificateKeypairs might have to be created."""
+        """Create a SAMLProvider instance from the details."""
         provider = SAMLProvider.objects.create(
             name=name, authorization_flow=authorization_flow, invalidation_flow=invalidation_flow
         )
@@ -125,7 +271,6 @@ class ServiceProviderMetadataParser:
             return
 
         signature_node = signature_nodes[0]
-
         if signature_node is not None:
             try:
                 ctx = xmlsec.SignatureContext()
@@ -142,54 +287,26 @@ class ServiceProviderMetadataParser:
     def parse(self, raw_xml: str) -> ServiceProviderMetadata:
         """Parse raw XML to ServiceProviderMetadata"""
         root = fromstring(raw_xml.encode())
+        snap = build_sp_snapshot(root)
+        runtime = build_sp_runtime_from_snapshot(snap)
 
         entity_id = root.attrib["entityID"]
-        sp_sso_descriptors = root.findall(f"{{{NS_SAML_METADATA}}}SPSSODescriptor")
-        if len(sp_sso_descriptors) < 1:
-            raise ValueError("no SPSSODescriptor objects found.")
-        # For now we'll only look at the first descriptor.
-        # Even if multiple descriptors exist, we can only configure one
-        descriptor = sp_sso_descriptors[0]
-        auth_n_request_signed = False
-        if "AuthnRequestsSigned" in descriptor.attrib:
-            auth_n_request_signed = descriptor.attrib["AuthnRequestsSigned"].lower() == "true"
-
-        assertion_signed = False
-        if "WantAssertionsSigned" in descriptor.attrib:
-            assertion_signed = descriptor.attrib["WantAssertionsSigned"].lower() == "true"
-
-        acs_services = descriptor.findall(f"{{{NS_SAML_METADATA}}}AssertionConsumerService")
-        if len(acs_services) < 1:
-            raise ValueError("No AssertionConsumerService found.")
-
-        acs_service = acs_services[0]
-        acs_binding = {
-            SAML_BINDING_REDIRECT: SAMLBindings.REDIRECT,
-            SAML_BINDING_POST: SAMLBindings.POST,
-        }[acs_service.attrib["Binding"]]
-        acs_location = acs_service.attrib["Location"]
-
+        auth_n_request_signed = bool(runtime.get("authn_requests_signed", False))
+        assertion_signed = bool(runtime.get("want_assertions_signed", False))
+        acs_binding = runtime.get("sp_binding") or SAMLBindings.POST
+        acs_location = runtime.get("acs_url") or ""
         signing_keypair = self.get_signing_cert(root)
+        """
+            WARNING: Signature verification uses KeyInfo cert from the same XML (trust-on-first-use)
+            do not treat this as an external trust anchor.
+        """
         if signing_keypair:
             self.check_signature(root, signing_keypair)
         encryption_keypair = self.get_encryption_cert(root)
 
-        name_id_format = descriptor.findall(f"{{{NS_SAML_METADATA}}}NameIDFormat")
-        name_id_policy = SAMLNameIDPolicy.UNSPECIFIED
-        if len(name_id_format) > 0:
-            name_id_policy = SAMLNameIDPolicy(name_id_format[0].text)
-
-        # Parse SingleLogoutService (optional)
-        sls_binding = None
-        sls_location = None
-        sls_services = descriptor.findall(f"{{{NS_SAML_METADATA}}}SingleLogoutService")
-        if len(sls_services) > 0:
-            sls_service = sls_services[0]
-            sls_binding = {
-                SAML_BINDING_REDIRECT: SAMLBindings.REDIRECT,
-                SAML_BINDING_POST: SAMLBindings.POST,
-            }.get(sls_service.attrib.get("Binding"))
-            sls_location = sls_service.attrib.get("Location")
+        name_id_policy = runtime.get("name_id_policy") or SAMLNameIDPolicy.UNSPECIFIED
+        sls_binding = runtime.get("sls_binding") or None
+        sls_location = runtime.get("sls_url") or None
 
         return ServiceProviderMetadata(
             entity_id=entity_id,

--- a/authentik/providers/saml/tests/fixtures/multi-bindings.xml
+++ b/authentik/providers/saml/tests/fixtures/multi-bindings.xml
@@ -1,0 +1,108 @@
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" ID="_42425ebd33e1a80275bb8ed6775b69b57b37a450" entityID="https://sp-b.example.org/shibboleth">
+
+  <md:Extensions xmlns:alg="urn:oasis:names:tc:SAML:metadata:algsupport">
+    <alg:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"/>
+    <alg:DigestMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#sha384"/>
+    <alg:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+    <alg:DigestMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#sha224"/>
+    <alg:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+    <alg:SigningMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha512"/>
+    <alg:SigningMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha384"/>
+    <alg:SigningMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256"/>
+    <alg:SigningMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha224"/>
+    <alg:SigningMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha512"/>
+    <alg:SigningMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha384"/>
+    <alg:SigningMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+    <alg:SigningMethod Algorithm="http://www.w3.org/2009/xmldsig11#dsa-sha256"/>
+    <alg:SigningMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha1"/>
+    <alg:SigningMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+    <alg:SigningMethod Algorithm="http://www.w3.org/2000/09/xmldsig#dsa-sha1"/>
+  </md:Extensions>
+
+  <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:Extensions>
+      <init:RequestInitiator xmlns:init="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Binding="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Location="https://sp-b.example.org:10446/Shibboleth.sso/Login"/>
+    </md:Extensions>
+    <md:KeyDescriptor use="signing">
+      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:KeyName>buildkitsandbox</ds:KeyName>
+        <ds:X509Data>
+          <ds:X509SubjectName>CN=buildkitsandbox</ds:X509SubjectName>
+          <ds:X509Certificate>MIID9DCCAlygAwIBAgIJAI4qeDgc0CnnMA0GCSqGSIb3DQEBCwUAMBoxGDAWBgNV
+BAMTD2J1aWxka2l0c2FuZGJveDAeFw0yNjAyMjAxMzMxNDZaFw0zNjAyMTgxMzMx
+NDZaMBoxGDAWBgNVBAMTD2J1aWxka2l0c2FuZGJveDCCAaIwDQYJKoZIhvcNAQEB
+BQADggGPADCCAYoCggGBAOl/ONc2rDQVzW8K9mDGFMYKkZY3ShaJewMjY1dacI1I
+0iicX4qnojBA5lYaxLCx26N8R5Wj0uBIZbFBpD1Bx2rT7wC/3bjB+a59WFH0yln7
+leMZ5/QzztTsKy/TJDUqtLUipuurBI2r6Zut7rwAZm8dADcz0ZiIRBP5WF+rtJOu
+H3m6pgYhU5uCidzCPqeX8kinNq1CcFlh9RabJJsB04GI0iB2tvI1yrARA2WluuSl
+BUw+T9KlCmtci+iF1mny73eyYH8Dl8iNK6gxzs04SYIDvufslObiRZrDkFVNzz2u
+bTJnZbHUQxG+3vtzRA0aGuYy3Q3mOE3jJ2SFg9Ncvf88lwV1mXvNgMcThNuxslKs
+WYjEqxQXgFmrgmFiE9BpNnN21WKaWtu8saKJrqBYJ5aBG/Olv4/wWY44k7gqji0A
+GjbGEcSnCIPCruQTIwThkBV17FyMOugng2PRiXh/pL6TE8QoyiGVEhi5V5uSbkWZ
+TSEcXNmd+oL5alkJel97qQIDAQABoz0wOzAaBgNVHREEEzARgg9idWlsZGtpdHNh
+bmRib3gwHQYDVR0OBBYEFIbZrDyp3oV5lArTnC0Tr0CEQmy7MA0GCSqGSIb3DQEB
+CwUAA4IBgQB/eZ4ru3rLocpjq8VK0sPdown+DIUBT9Wbiilh09bRosXTBlyvCh+K
+b+MVArpukReSWJSBGNr/KHaWC1RXKXsxYbvglOBoMeDf33KJynXZQlHOMg6yNVPp
+bS5lEy1ZMbqnBKZKF+WU1WBDWsM5W2YTPuiz490ENF1wuMNN7UOoy4n1iAYpgKnE
+vs8wOnETu+XYheUYYi8Eeu89DrBpgo9zHKX3Lq9182q1s9cr7F8a+NXIto1txBdk
+zffs5LyUNI/r+1Lx7Pu30xrtzefHdUrqKHcJFczFyPc9j1XA4vqH4zcAASGUzZfl
+iriDa6VNInTjVnyXl2abab22VrojSppvK+XOuwaKpgnl1oOgad5VQSXXeZwWA1kk
+IbZO+l7HluwDIe0N3d0hCltLl8CPOxLOh+uIPWWv+bT4YNUHD1INPQrEKJLjEVHf
+JRb6Z7XwoXz3nb3Rh/uBfbYlCOZVvWySgQxd97Uf/wy9kQmpCtKc6akJS2R9FJzj
+yrz6iUCfc6M=
+</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+    <md:KeyDescriptor use="encryption">
+      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:KeyName>buildkitsandbox</ds:KeyName>
+        <ds:X509Data>
+          <ds:X509SubjectName>CN=buildkitsandbox</ds:X509SubjectName>
+          <ds:X509Certificate>MIID9DCCAlygAwIBAgIJAKbLA8FjpHqmMA0GCSqGSIb3DQEBCwUAMBoxGDAWBgNV
+BAMTD2J1aWxka2l0c2FuZGJveDAeFw0yNjAyMjAxMzMxNDZaFw0zNjAyMTgxMzMx
+NDZaMBoxGDAWBgNVBAMTD2J1aWxka2l0c2FuZGJveDCCAaIwDQYJKoZIhvcNAQEB
+BQADggGPADCCAYoCggGBAJ+tK9SwwNei4A8pMGROlaVAxZMt4+gpAJXGMo8PFIwg
+W4yxSJZJjg4wbgX8/EI32lqjaq/gtmv07vMYX1j1wUxcpTHLJWFCAGPwGxh4gkPw
+lpTPNJLddrrTwEwSRjdDfKRLNNh/uK+1HM2qOdDUp0qWxSjLPr28VZRxW3ipLsLe
+zSqUrsyIiZnOAVGFQrnaCukZ9+eGggA2wxyE9fDU79700v1GiHzHMWe9nQF7p3W1
+PYwEH356cyUr8V0dwAb54UAUCFRXAPK8lUziH4U+agrJDtLH6uDvxqMjnWVENA8Q
+AQfEqE+MMDL/J7Quvmv0pfX6WP1JBV9JkYw/8Ifdpa/beD5qeW4T1C4tv0vsxVAE
+4oZyfF6FjXA6FmR4VcKuki40tzpgyfYSP4gMaugmB9OZVLUf8pH8UsoM1h24INOD
+J2P2CnwlnNAhn0mLkpIr2byDKMqcWNrTAALjp+iEH3wi/M87P6d1yKcRO6d5i2M4
+8J4a5IrTcoAOG/gUIgWKMQIDAQABoz0wOzAaBgNVHREEEzARgg9idWlsZGtpdHNh
+bmRib3gwHQYDVR0OBBYEFC7iiwXwk9Gbc/hz4WmCU9Kpn4ozMA0GCSqGSIb3DQEB
+CwUAA4IBgQCTsV3gBdVCKwhj/mZPgeeERcy3bhlwLlFCgAXW2bnczhjRcMq9OvsC
+/9lbKMaNqoy1TmdUWKC9dvi+G4hGHlXLYTdFPGI1U5voekzZ6Wyapzbrs3cJEVL5
+vps97rC79YClDK5piK0z8w+XN3KBOPM6jzaIVJ7VQCGxCO/Jzf8wd6vSF5JtIxZw
+wDiBZ58SmeamJdyd/Pvn3D6wL+34Ed5Wb3ojj6W9YDhHziApjLPk3thQkVe+ojL3
+mRY+02uG9ZvPNOrYV3ChVHCkz+CzbPOQR6d9Sip10uUkPMDpqtRN0e6QPdvXTKVx
+1ZdTWLOd+cxdbPaQJXVuKfq7I1JQA58cSrmveYUmgyMp8bTikEenJ9zxvhPmEUgK
+Iu+qSdCkCWdho4pjGO4YVCOG5B3aXZgh7KmbauFsj1077qh3wzuuI0+wIg3unu0c
++GJGi9cbfrfSEZrkO5wRONS+M0r/9ZVFU8sd7MjWhu/oFSftKnTtj55xKNDnyKFn
+r4rhCL8zycM=
+</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+      <md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes128-gcm"/>
+      <md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes192-gcm"/>
+      <md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes256-gcm"/>
+      <md:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"/>
+      <md:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes192-cbc"/>
+      <md:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes256-cbc"/>
+      <md:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#tripledes-cbc"/>
+      <md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#rsa-oaep"/>
+      <md:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"/>
+    </md:KeyDescriptor>
+    <md:ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://sp-b.example.org:10446/Shibboleth.sso/Artifact/SOAP" index="1"/>
+    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://sp-b.example.org:10446/Shibboleth.sso/SLO/SOAP"/>
+    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://sp-b.example.org:10446/Shibboleth.sso/SLO/Redirect"/>
+    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://sp-b.example.org:10446/Shibboleth.sso/SLO/POST"/>
+    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://sp-b.example.org:10446/Shibboleth.sso/SLO/Artifact"/>
+    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://sp-b.example.org:10446/Shibboleth.sso/SAML2/POST-SimpleSign" index="1"/>
+    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://sp-b.example.org:10446/Shibboleth.sso/SAML2/POST" index="2"/>
+    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://sp-b.example.org:10446/Shibboleth.sso/SAML2/Artifact" index="3"/>
+    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:PAOS" Location="https://sp-b.example.org:10446/Shibboleth.sso/SAML2/ECP" index="4"/>
+  </md:SPSSODescriptor>
+
+</md:EntityDescriptor>

--- a/authentik/providers/saml/tests/test_metadata.py
+++ b/authentik/providers/saml/tests/test_metadata.py
@@ -168,3 +168,20 @@ class TestServiceProviderMetadataParser(TestCase):
         )
         ctx.key = key
         ctx.verify(signature_node)
+
+    def test_multi_bindings(self):
+        """Test metadata including more than one bindings."""
+        metadata = ServiceProviderMetadataParser().parse(
+            load_fixture("fixtures/multi-bindings.xml")
+        )
+        provider = metadata.to_provider("test", self.flow, self.flow)
+        self.assertEqual(
+            provider.acs_url, "https://sp-b.example.org:10446/Shibboleth.sso/SAML2/POST"
+        )
+        self.assertEqual(provider.audience, "https://sp-b.example.org/shibboleth")
+        self.assertEqual(provider.sp_binding, SAMLBindings.POST)
+        self.assertEqual(provider.default_name_id_policy, SAMLNameIDPolicy.UNSPECIFIED)
+        self.assertEqual(
+            len(provider.property_mappings.all()),
+            len(SAMLPropertyMapping.objects.exclude(managed__isnull=True)),
+        )


### PR DESCRIPTION
## Details

The "SAML Provider from Metadata" flow could select the first ACS/SLS endpoint even when its
Binding is not supported by authentik, resulting in an invalid provider configuration.

Prefer supported bindings (HTTP-POST / HTTP-Redirect) and skip unsupported entries when creating SAML provider from metadata.

This patch will close #21009

Note: Split metadata extraction from endpoint selection policy to keep parsing and decisions separate.

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
