### PR TITLE
fix(core/api): normalize oversized JSON integers in dict fields

### DIFF
--- a/authentik/core/api/utils.py
+++ b/authentik/core/api/utils.py
@@ -29,10 +29,34 @@ def is_dict(value: Any):
     raise ValidationError("Value must be a dictionary, and not have any duplicate keys.")
 
 
+INT_64_MIN = -(2**63)
+INT_64_MAX = 2**63 - 1
+
+
+def normalize_large_integers(value: Any) -> Any:
+    """Normalize integers outside orjson's supported range."""
+    if isinstance(value, dict):
+        return {key: normalize_large_integers(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [normalize_large_integers(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(normalize_large_integers(item) for item in value)
+    if isinstance(value, int) and not isinstance(value, bool):
+        if value < INT_64_MIN or value > INT_64_MAX:
+            return str(value)
+    return value
+
+
 class JSONDictField(JSONField):
     """JSON Field which only allows dictionaries"""
 
     default_validators = [is_dict]
+
+    def to_internal_value(self, data):
+        return normalize_large_integers(super().to_internal_value(data))
+
+    def to_representation(self, value):
+        return normalize_large_integers(super().to_representation(value))
 
 
 class JSONExtension(OpenApiSerializerFieldExtension):

--- a/authentik/core/tests/test_api_utils.py
+++ b/authentik/core/tests/test_api_utils.py
@@ -9,8 +9,14 @@ from rest_framework.serializers import (
 )
 from rest_framework.test import APITestCase
 
+from authentik.core.api.utils import (
+    INT_64_MAX,
+    INT_64_MIN,
+    JSONDictField,
+    is_dict,
+    normalize_large_integers,
+)
 from authentik.core.api.utils import ModelSerializer as CustomModelSerializer
-from authentik.core.api.utils import is_dict
 from authentik.lib.utils.reflection import all_subclasses
 
 
@@ -33,3 +39,34 @@ class TestAPIUtils(APITestCase):
         )
 
         self.assertEqual(expected, actual)
+
+    def test_normalize_large_integers(self):
+        """Test that integers outside int64 are normalized to strings."""
+        lower = INT_64_MIN - 1
+        upper = INT_64_MAX + 1
+        result = normalize_large_integers(
+            {
+                "lower": lower,
+                "upper": upper,
+                "valid_low": INT_64_MIN,
+                "valid_high": INT_64_MAX,
+                "nested": {"numbers": [lower, 0, upper]},
+                "bool": True,
+            }
+        )
+
+        self.assertEqual(result["lower"], str(lower))
+        self.assertEqual(result["upper"], str(upper))
+        self.assertEqual(result["valid_low"], INT_64_MIN)
+        self.assertEqual(result["valid_high"], INT_64_MAX)
+        self.assertEqual(result["nested"]["numbers"], [str(lower), 0, str(upper)])
+        self.assertIs(result["bool"], True)
+
+    def test_json_dict_field_normalizes_large_integers(self):
+        """Test JSONDictField normalization for input and output values."""
+        field = JSONDictField()
+        value = INT_64_MAX + 1
+        validated = field.run_validation({"id": value})
+
+        self.assertEqual(validated["id"], str(value))
+        self.assertEqual(field.to_representation({"id": value})["id"], str(value))

--- a/authentik/core/tests/test_users_api.py
+++ b/authentik/core/tests/test_users_api.py
@@ -82,6 +82,28 @@ class TestUsersAPI(APITestCase):
         response = self.client.get(reverse("authentik_api:user-list"), {"include_groups": "true"})
         self.assertEqual(response.status_code, 200)
 
+    def test_list_with_large_integer_attributes(self):
+        """Test listing users with integer attributes outside int64 range."""
+        large_value = 10**70
+        self.user.attributes = {
+            "external_id": large_value,
+            "nested": {"values": [1, large_value]},
+        }
+        self.user.save(update_fields=["attributes"])
+
+        self.client.force_login(self.admin)
+        response = self.client.get(
+            reverse("authentik_api:user-list"),
+            data={"username": self.user.username},
+        )
+        self.assertEqual(response.status_code, 200)
+
+        body = loads(response.content)
+        result = next((item for item in body["results"] if item["pk"] == self.user.pk), None)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["attributes"]["external_id"], str(large_value))
+        self.assertEqual(result["attributes"]["nested"]["values"], [1, str(large_value)])
+
     def test_recovery_no_flow(self):
         """Test user recovery link (no recovery flow set)"""
         self.client.force_login(self.admin)


### PR DESCRIPTION
Fixes #20868

When user/group attributes contain integers outside the signed 64-bit range, `JSONDictField` accepts them, but API response rendering can fail with `TypeError: Integer exceeds 64-bit range` from `orjson`.

This change normalizes out-of-range integers to strings in `JSONDictField` on both input (`to_internal_value`) and output (`to_representation`). Values inside int64 range remain unchanged, and previously stored oversized values can now be rendered safely.

Also adds unit coverage for large-integer normalization and API coverage for listing users with oversized integer attributes.
