### PR TITLE
events: avoid implicitly setting context from login_failed event

### DIFF
--- a/authentik/core/signals.py
+++ b/authentik/core/signals.py
@@ -24,7 +24,8 @@ from authentik.root.ws.consumer import build_device_group
 
 # Arguments: user: User, password: str
 password_changed = Signal()
-# Arguments: credentials: dict[str, any], request: HttpRequest, stage: Stage
+# Arguments: credentials: dict[str, any], request: HttpRequest,
+#            stage: Stage, context: dict[str, any]
 login_failed = Signal()
 
 LOGGER = get_logger()

--- a/authentik/events/signals.py
+++ b/authentik/events/signals.py
@@ -93,11 +93,13 @@ def on_login_failed(
     credentials: dict[str, str],
     request: HttpRequest,
     stage: Stage | None = None,
+    context: dict[str, Any] | None = None,
     **kwargs,
 ):
     """Failed Login, authentik custom event"""
     user = User.objects.filter(username=credentials.get("username")).first()
-    Event.new(EventAction.LOGIN_FAILED, **credentials, stage=stage, **kwargs).from_http(
+    context = context or {}
+    Event.new(EventAction.LOGIN_FAILED, **credentials, stage=stage, **context).from_http(
         request, user
     )
 

--- a/authentik/stages/authenticator_validate/challenge.py
+++ b/authentik/stages/authenticator_validate/challenge.py
@@ -38,6 +38,7 @@ from authentik.stages.authenticator_validate.models import AuthenticatorValidate
 from authentik.stages.authenticator_webauthn.models import UserVerification, WebAuthnDevice
 from authentik.stages.authenticator_webauthn.stage import PLAN_CONTEXT_WEBAUTHN_CHALLENGE
 from authentik.stages.authenticator_webauthn.utils import get_origin, get_rp_id
+from authentik.stages.password.stage import PLAN_CONTEXT_METHOD_ARGS
 
 LOGGER = get_logger()
 if TYPE_CHECKING:
@@ -149,7 +150,11 @@ def validate_challenge_code(code: str, stage_view: StageView, user: User) -> Dev
             credentials={"username": user.username},
             request=stage_view.request,
             stage=stage_view.executor.current_stage,
-            device_class=DeviceClasses.TOTP.value,
+            context={
+                PLAN_CONTEXT_METHOD_ARGS: {
+                    "device_class": DeviceClasses.TOTP.value,
+                }
+            },
         )
         raise ValidationError(
             _("Invalid Token. Please ensure the time on your device is accurate and try again.")
@@ -221,9 +226,13 @@ def validate_challenge_webauthn(
             credentials={"username": user.username},
             request=stage_view.request,
             stage=stage_view.executor.current_stage,
-            device=device,
-            device_class=DeviceClasses.WEBAUTHN.value,
-            device_type=device.device_type,
+            context={
+                PLAN_CONTEXT_METHOD_ARGS: {
+                    "device": device,
+                    "device_class": DeviceClasses.WEBAUTHN.value,
+                    "device_type": device.device_type,
+                },
+            },
         )
         raise ValidationError("Assertion failed") from exc
 
@@ -273,8 +282,12 @@ def validate_challenge_duo(device_pk: int, stage_view: StageView, user: User) ->
                 credentials={"username": user.username},
                 request=stage_view.request,
                 stage=stage_view.executor.current_stage,
-                device_class=DeviceClasses.DUO.value,
-                duo_response=response,
+                context={
+                    PLAN_CONTEXT_METHOD_ARGS: {
+                        "device_class": DeviceClasses.DUO.value,
+                        "duo_response": response,
+                    }
+                },
             )
             raise ValidationError("Duo denied access", code="denied")
         return device


### PR DESCRIPTION
backend fix related to https://github.com/goauthentik/authentik/pull/20804

previously login_failed events would just dump the device in the flow context, when they should be in auth_method_args