### PR TITLE
fix: guard signal handlers and is_known_device against unsaved user

### DIFF
--- a/authentik/core/signals.py
+++ b/authentik/core/signals.py
@@ -47,6 +47,8 @@ def post_save_application(sender: type[Model], instance, created: bool, **_):
 @receiver(user_logged_in)
 def user_logged_in_session(sender, request: HttpRequest, user: User, **_):
     """Create an AuthenticatedSession from request"""
+    if not user.pk:
+        return
 
     session = AuthenticatedSession.from_request(request, user)
     if session:

--- a/authentik/events/signals.py
+++ b/authentik/events/signals.py
@@ -34,6 +34,8 @@ _session_engine = import_module(settings.SESSION_ENGINE)
 @receiver(user_logged_in)
 def on_user_logged_in(sender, request: HttpRequest, user: User, **_):
     """Log successful login"""
+    if not user.pk:
+        return
     kwargs = {}
     if SESSION_KEY_PLAN in request.session:
         flow_plan: FlowPlan = request.session[SESSION_KEY_PLAN]

--- a/authentik/stages/user_login/stage.py
+++ b/authentik/stages/user_login/stage.py
@@ -122,6 +122,8 @@ class UserLoginStageView(ChallengeStageView):
 
     def is_known_device(self, user: User):
         """Returns `True` if the login happened on a "known" device, by the same user."""
+        if not user.pk:
+            return False
         client_ip = ClientIPMiddleware.get_client_ip(self.request)
         if AuthenticatedSession.objects.filter(session__last_ip=client_ip, user=user).exists():
             return True


### PR DESCRIPTION
## Summary
Fixes #21036.
**Root cause:** The identification stage creates a dummy unsaved User (pk=None) to prevent timing-based user enumeration. When this user propagates to the login stage, `is_known_device()` passes it to `AuthenticatedSession.objects.filter(user=user)`, which raises `ValueError` because Django requires saved model instances in related filters.
**Fix:** Added `if not user.pk: return` guards before DB queries that receive the user object.

## Changes
- `authentik/stages/user_login/stage.py`: return False from `is_known_device()` when user.pk is None
- `authentik/core/signals.py`: skip `user_logged_in_session` when user.pk is None
- `authentik/events/signals.py`: skip `on_user_logged_in` when user.pk is None

## Testing
- Verified all three call sites that receive `user` from the `user_logged_in` signal now guard against unsaved instances