### PR TITLE
providers/proxy: Add a default maxResponseBodySize to Traefik Middleware

### DIFF
--- a/authentik/outposts/controllers/k8s/base.py
+++ b/authentik/outposts/controllers/k8s/base.py
@@ -185,8 +185,10 @@ class KubernetesObjectReconciler[T]:
 
         patch = self.get_patch()
         if patch is not None:
-            current_json = ApiClient().sanitize_for_serialization(current)
-
+            try:
+                current_json = ApiClient().sanitize_for_serialization(current)
+            except AttributeError:
+                current_json = asdict(current)
             try:
                 if apply_patch(current_json, patch) != current_json:
                     raise NeedsUpdate()

--- a/authentik/providers/proxy/controllers/k8s/traefik_3.py
+++ b/authentik/providers/proxy/controllers/k8s/traefik_3.py
@@ -27,6 +27,8 @@ class TraefikMiddlewareSpecForwardAuth:
 
     trustForwardHeader: bool = field(default=True)
 
+    maxResponseBodySize: int = field(default=4194304)
+
 
 @dataclass(slots=True)
 class TraefikMiddlewareSpec:
@@ -140,6 +142,7 @@ class Traefik3MiddlewareReconciler(KubernetesObjectReconciler[TraefikMiddleware]
                     ],
                     authResponseHeadersRegex="",
                     trustForwardHeader=True,
+                    maxResponseBodySize=4194304,
                 )
             ),
         )

--- a/authentik/providers/proxy/controllers/k8s/traefik_3.py
+++ b/authentik/providers/proxy/controllers/k8s/traefik_3.py
@@ -27,7 +27,7 @@ class TraefikMiddlewareSpecForwardAuth:
 
     trustForwardHeader: bool = field(default=True)
 
-    maxResponseBodySize: int = field(default=4194304)
+    maxResponseBodySize: int = field(default=1024 * 1024 * 4)
 
 
 @dataclass(slots=True)
@@ -142,7 +142,7 @@ class Traefik3MiddlewareReconciler(KubernetesObjectReconciler[TraefikMiddleware]
                     ],
                     authResponseHeadersRegex="",
                     trustForwardHeader=True,
-                    maxResponseBodySize=4194304,
+                    maxResponseBodySize=1024 * 1024 * 4,
                 )
             ),
         )


### PR DESCRIPTION
## Details

In response to CVE-2026-26998, Traefik added a `maxResponseBodySize` configuration option and is recommending this be set, otherwise a warning will show in the traefik logs.

https://doc.traefik.io/traefik/reference/routing-configuration/http/middlewares/forwardauth/#maxresponsebodysize

Added a default maxResponseBodySize of 4MB to the `traefik middleware` proxy outpost component. Also fixed an issue where the reconciler would throw an error when trying to run a json patch on a non openapi object.

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
