### PR TITLE
core: uncomment failFast in cspell config file

### DIFF
--- a/cspell.config.jsonc
+++ b/cspell.config.jsonc
@@ -90,10 +90,7 @@
         {
             "name": "ConfSuffix",
             "description": "Variables with `conf` or `config` suffix",
-            "pattern": [
-                "\\w+(conf|config)\\b",
-                "\\b(conf|config)\\w+"
-            ]
+            "pattern": ["\\w+(conf|config)\\b", "\\b(conf|config)\\w+"]
         }
     ],
     "ignoreRegExpList": [
@@ -180,24 +177,16 @@
         },
         {
             "languageId": "python",
-            "dictionaries": [
-                "en-x-authentik-python"
-            ],
-            "includeRegExpList": [
-                "comments"
-            ]
+            "dictionaries": ["en-x-authentik-python"],
+            "includeRegExpList": ["comments"]
         },
         {
             "languageId": "rust",
-            "dictionaries": [
-                "en-x-authentik-rust"
-            ]
+            "dictionaries": ["en-x-authentik-rust"]
         },
         {
             "languageId": "go",
-            "dictionaries": [
-                "en-x-authentik-golang"
-            ]
+            "dictionaries": ["en-x-authentik-golang"]
         },
         {
             "languageId": "makefile,toml,yaml",
@@ -293,6 +282,6 @@
     "useGitignore": true,
     "features": {
         "weighted-suggestions": true
-    }
-    // "failFast": true,
+    },
+    "failFast": true
 }


### PR DESCRIPTION
This PR uncomments the `failFast` option, so that errors in files are shown as soon as they are found. 

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
