### PR TITLE
website/integrations: nextcloud add back-channel logout documentation

### DIFF
--- a/website/integrations/chat-communication-collaboration/nextcloud/index.mdx
+++ b/website/integrations/chat-communication-collaboration/nextcloud/index.mdx
@@ -170,14 +170,14 @@ Depending on your Nextcloud configuration, you may need to use `https://nextclou
 
 ## Enabling OIDC back-channel logout
 
-To automatically log users out of their nextcloud sessions when the log out of authentik, back-channel logout can be enabled.
+To automatically log users out of their Nextcloud sessions when they log out of authentik, enable back-channel logout.
 
-1. In Nextcloud navigate to the **OIDC settings**.
-2. Under **"Registered Providers"** there should now be a provider with the **identifier** used earlier.
-3. Copy the **"back-channel-logout-URL"** listed for that provider. (for example: `https://nextcloud.company/apps/user_oidc/backchannel-logout/<identifier>`)
-4. In authentik navigate to **Applications** > **Providers** and click on the **edit** button for the nextcloud provider.
-5. Under **Protocol Settings** > **Logout URI** paste the url.
-6. For **Protocol Settings** > **Logout Method** choose "Back-channel".
+1. Log in to Nextcloud as an administrator and navigate to **Settings** > **OpenID Connect**.
+2. Under **Registered Providers**, locate the provider with the identifier used earlier.
+3. Copy the `back-channel-logout-URL` value for that provider. For example: `https://nextcloud.company/apps/user_oidc/backchannel-logout/<identifier>`
+4. In authentik, navigate to **Applications** > **Providers** and edit the Nextcloud provider.
+5. Under **Protocol Settings**, set the **Logout URI** to the copied back-channel logout URL.
+6. Set the **Logout Method** to `Back-channel`.
 
 ## Making OIDC the default login method
 

--- a/website/integrations/chat-communication-collaboration/nextcloud/index.mdx
+++ b/website/integrations/chat-communication-collaboration/nextcloud/index.mdx
@@ -168,6 +168,17 @@ Depending on your Nextcloud configuration, you may need to use `https://nextclou
     If you're using the `Nextcloud Profile` property mapping and want administrators to retain their ability to log in, make sure that **Use unique user ID** is disabled. If this setting is enabled, it will remove administrator users from the internal admin group and replace them with a hashed group ID named "admin," which does not have real administrative privileges.
     :::
 
+## Enabling OIDC back-channel logout
+
+To automatically log users out of their nextcloud sessions when the log out of authentik, back-channel logout can be enabled.
+
+1. In Nextcloud navigate to the **OIDC settings**.
+2. Under **"Registered Providers"** there should now be a provider with the **identifier** used earlier.
+3. Copy the **"back-channel-logout-URL"** listed for that provider. (for example: `https://nextcloud.company/apps/user_oidc/backchannel-logout/<identifier>`)
+4. In authentik navigate to **Applications** > **Providers** and click on the **edit** button for the nextcloud provider.
+5. Under **Protocol Settings** > **Logout URI** paste the url.
+6. For **Protocol Settings** > **Logout Method** choose "Back-channel".
+
 ## Making OIDC the default login method
 
 Automatically redirect users to authentik when they access Nextcloud by running the following command on your Nextcloud docker host:


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
This PR adds documentation on how to enable back-channel logout (automatically logging a user out of nextcloud when they log out of authentik using OIDC) for the nextcloud integration. 

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
