### PR TITLE
providers/saml: catch InvalidVersion from cryptography when parsing metadata

### DIFF
--- a/authentik/providers/saml/processors/metadata_parser.py
+++ b/authentik/providers/saml/processors/metadata_parser.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 import xmlsec
 from cryptography.hazmat.backends import default_backend
-from cryptography.x509 import load_pem_x509_certificate
+from cryptography.x509 import InvalidVersion, load_pem_x509_certificate
 from defusedxml.lxml import fromstring
 from lxml import etree  # nosec
 from structlog.stdlib import get_logger
@@ -90,7 +90,10 @@ class ServiceProviderMetadataParser:
             return None
         raw_cert = format_cert(signing_certs[0])
         # sanity check, make sure the certificate is valid.
-        load_pem_x509_certificate(raw_cert.encode("utf-8"), default_backend())
+        try:
+            load_pem_x509_certificate(raw_cert.encode("utf-8"), default_backend())
+        except InvalidVersion as exc:
+            raise ValueError("Certificate in metadata is not a valid X.509 version") from exc
         return CertificateKeyPair(
             certificate_data=raw_cert,
         )
@@ -105,7 +108,10 @@ class ServiceProviderMetadataParser:
             return None
         raw_cert = format_cert(encryption_certs[0])
         # sanity check, make sure the certificate is valid.
-        load_pem_x509_certificate(raw_cert.encode("utf-8"), default_backend())
+        try:
+            load_pem_x509_certificate(raw_cert.encode("utf-8"), default_backend())
+        except InvalidVersion as exc:
+            raise ValueError("Certificate in metadata is not a valid X.509 version") from exc
         return CertificateKeyPair(
             certificate_data=raw_cert,
         )


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
Currently if you have a v2 x509 certificate inside of the metadata, the raised InvalidVersion exception is not caught. This PR catches that exception. 

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
