### PR TITLE
fix: mask username in reputation logs to prevent accidental password logging

### DIFF
--- a/authentik/policies/reputation/signals.py
+++ b/authentik/policies/reputation/signals.py
@@ -20,7 +20,18 @@ from authentik.tenants.utils import get_current_tenant
 LOGGER = get_logger()
 
 
-def update_score(request: HttpRequest, identifier: str, amount: int):
+def mask_identifier(identifier: str) -> str:
+    """Mask identifier for logging to prevent accidental password logging.
+
+    Shows first 2 and last 1 characters, masks the rest.
+    For short identifiers (< 4 chars), masks everything.
+    """
+    if len(identifier) < 4:
+        return "***"
+    return f"{identifier[:2]}***{identifier[-1]}"
+
+
+def update_score(request: HttpRequest, identifier: str, amount: int, *, mask_for_log: bool = False):
     """Update score for IP and User"""
     remote_ip = ClientIPMiddleware.get_client_ip(request)
     tenant = getattr(request, "tenant", get_current_tenant())
@@ -45,20 +56,21 @@ def update_score(request: HttpRequest, identifier: str, amount: int):
             expires=reputation_expiry(),
         )
 
-    LOGGER.info("Updated score", amount=reputation.score, for_user=identifier, for_ip=remote_ip)
+    log_identifier = mask_identifier(identifier) if mask_for_log else identifier
+    LOGGER.info("Updated score", amount=reputation.score, for_user=log_identifier, for_ip=remote_ip)
 
 
 @receiver(login_failed)
 def handle_failed_login(sender, request, credentials, **_):
     """Lower Score for failed login attempts"""
     if "username" in credentials:
-        update_score(request, credentials.get("username"), -1)
+        update_score(request, credentials.get("username"), -1, mask_for_log=True)
 
 
 @receiver(identification_failed)
 def handle_identification_failed(sender, request, uid_field: str, **_):
     """Lower Score for failed identification attempts"""
-    update_score(request, uid_field, -1)
+    update_score(request, uid_field, -1, mask_for_log=True)
 
 
 @receiver(user_logged_in)

--- a/authentik/policies/reputation/tests.py
+++ b/authentik/policies/reputation/tests.py
@@ -6,7 +6,7 @@ from authentik.core.models import User
 from authentik.lib.generators import generate_id
 from authentik.policies.reputation.api import ReputationPolicySerializer
 from authentik.policies.reputation.models import Reputation, ReputationPolicy
-from authentik.policies.reputation.signals import update_score
+from authentik.policies.reputation.signals import mask_identifier, update_score
 from authentik.policies.types import PolicyRequest
 from authentik.stages.password import BACKEND_INBUILT
 from authentik.stages.password.stage import authenticate
@@ -26,6 +26,20 @@ class TestReputationPolicy(TestCase):
         self.user = User.objects.create(username=self.username)
         self.user.set_password(self.password)
         self.backends = [BACKEND_INBUILT]
+
+    def test_mask_identifier_short(self):
+        """test mask_identifier with short strings"""
+        self.assertEqual(mask_identifier("ab"), "***")
+        self.assertEqual(mask_identifier("abc"), "***")
+
+    def test_mask_identifier_long(self):
+        """test mask_identifier with longer strings"""
+        self.assertEqual(mask_identifier("username"), "us***e")
+        self.assertEqual(mask_identifier("my_password_is_here"), "my***e")
+
+    def test_mask_identifier_exactly_four(self):
+        """test mask_identifier with exactly 4 characters"""
+        self.assertEqual(mask_identifier("user"), "us***r")
 
     def test_ip_reputation(self):
         """test IP reputation"""


### PR DESCRIPTION
## Summary

When users accidentally enter their password as the username during failed login attempts, the password was being logged in plain text in the reputation system's log output.

## Changes

- Added `mask_identifier()` function that masks identifiers in logs (shows first 2 and last 1 character, masks the rest)
- Added `mask_for_log` parameter to `update_score()` function
- Failed login and identification attempts now mask the username in logs
- Successful logins remain unmasked (since the username is validated)
- Added tests for the masking functionality

## Security Impact

This prevents accidental password exposure in logs when users mistakenly enter their password in the username field.

Fixes #21138