### PR TITLE
outposts/controllers/k8s: add option to disable strict x509 checks

### DIFF
--- a/authentik/outposts/controllers/k8s/base.py
+++ b/authentik/outposts/controllers/k8s/base.py
@@ -1,10 +1,13 @@
 """Base Kubernetes Reconciler"""
 
+import os
 import re
+import ssl
 from dataclasses import asdict
 from json import dumps
 from typing import TYPE_CHECKING, TypeVar
 
+import urllib3
 from dacite.core import from_dict
 from django.http import HttpResponseNotFound
 from django.utils.text import slugify
@@ -42,6 +45,7 @@ class KubernetesObjectReconciler[T]:
         self.controller = controller
         self.namespace = controller.outpost.config.kubernetes_namespace
         self.logger = get_logger().bind(type=self.__class__.__name__)
+        self.api_client = self.k8s_client()
 
     def get_patch(self):
         """Get any patches that apply to this CRD"""
@@ -92,7 +96,7 @@ class KubernetesObjectReconciler[T]:
         reference = self.get_reference_object()
         patch = self.get_patch()
         try:
-            json = ApiClient().sanitize_for_serialization(reference)
+            json = self.api_client.sanitize_for_serialization(reference)
         # Custom objects will not be known to the clients openapi types
         except AttributeError:
             json = asdict(reference)
@@ -106,7 +110,7 @@ class KubernetesObjectReconciler[T]:
         mock_response.data = dumps(ref)
 
         try:
-            result = ApiClient().deserialize(mock_response, reference.__class__.__name__)
+            result = self.api_client.deserialize(mock_response, reference.__class__.__name__)
         # Custom objects will not be known to the clients openapi types
         except AttributeError:
             result = from_dict(reference.__class__, data=ref)
@@ -186,7 +190,7 @@ class KubernetesObjectReconciler[T]:
         patch = self.get_patch()
         if patch is not None:
             try:
-                current_json = ApiClient().sanitize_for_serialization(current)
+                current_json = self.api_client.sanitize_for_serialization(current)
             except AttributeError:
                 current_json = asdict(current)
             try:
@@ -226,3 +230,26 @@ class KubernetesObjectReconciler[T]:
             },
             **kwargs,
         )
+
+    def k8s_client(self) -> ApiClient:
+        """Get Kubernetes API client"""
+        api_client = ApiClient()
+        if os.getenv("DISABLE_X509_STRICT_VERIFICATION", "false").lower() == "true":
+            self.logger.warning("Disabling strict X.509 certificate verification")
+            # Relax OpenSSL TLS validation to support legacy root CA certificates
+            # (e.g. from Kubernetes <= 1.16) which may not satisfy the stricter
+            # VERIFY_X509_STRICT flags enforced by default in Python 3.13+.
+            # See https://github.com/kubernetes-client/python/issues/2394
+            ctx = ssl.create_default_context()
+            ctx.verify_flags = ctx.verify_flags & ~ssl.VERIFY_X509_STRICT
+
+            # We need to recreate the pool manager with the new SSL context
+            # We try to preserve existing pool manager arguments
+            pool_args = api_client.rest_client.pool_manager.connection_pool_kw
+
+            api_client.rest_client.pool_manager = urllib3.PoolManager(
+                num_pools=4,
+                ssl_context=ctx,
+                **pool_args,
+            )
+        return api_client

--- a/authentik/outposts/controllers/k8s/base.py
+++ b/authentik/outposts/controllers/k8s/base.py
@@ -1,6 +1,5 @@
 """Base Kubernetes Reconciler"""
 
-import os
 import re
 import ssl
 from dataclasses import asdict
@@ -44,6 +43,9 @@ class KubernetesObjectReconciler[T]:
     def __init__(self, controller: KubernetesController):
         self.controller = controller
         self.namespace = controller.outpost.config.kubernetes_namespace
+        self.kubernetes_disable_x509_strict = (
+            controller.outpost.config.kubernetes_disable_x509_strict
+        )
         self.logger = get_logger().bind(type=self.__class__.__name__)
         self.api_client = self.k8s_client()
 
@@ -234,7 +236,7 @@ class KubernetesObjectReconciler[T]:
     def k8s_client(self) -> ApiClient:
         """Get Kubernetes API client"""
         api_client = ApiClient()
-        if os.getenv("DISABLE_X509_STRICT_VERIFICATION", "false").lower() == "true":
+        if self.kubernetes_disable_x509_strict:
             self.logger.warning("Disabling strict X.509 certificate verification")
             # Relax OpenSSL TLS validation to support legacy root CA certificates
             # (e.g. from Kubernetes <= 1.16) which may not satisfy the stricter

--- a/authentik/outposts/models.py
+++ b/authentik/outposts/models.py
@@ -81,6 +81,7 @@ class OutpostConfig:
     kubernetes_disabled_components: list[str] = field(default_factory=list)
     kubernetes_image_pull_secrets: list[str] = field(default_factory=list)
     kubernetes_json_patches: dict[str, list[dict[str, Any]]] | None = field(default=None)
+    kubernetes_disable_x509_strict: bool = field(default=False)
 
 
 class OutpostModel(Model):

--- a/website/docs/add-secure-apps/outposts/_config.md
+++ b/website/docs/add-secure-apps/outposts/_config.md
@@ -92,4 +92,18 @@ kubernetes_ingress_class_name: null
 #         cpu: 4000m
 #         memory: 8000Mi
 kubernetes_json_patches: null
+# Disable strict x509 validation for Kubernetes API server.
+#
+# On some older Kubernetes clusters, the root certificate may have been
+# generated without certain x509 extensions. `urllib3`, which is used in
+# the official kubernetes client, introduced stricter validation for
+# certificates in version 2.4.0 which will cause `certificate verify failed`
+# errors to appear in outpost logs. This option disables the stricter
+# validation and allows the outpost to connect to the Kubernetes API server
+# even with older certificates.
+#
+# It is recommended to only enable this option if you are experiencing
+# certificate validation issues and understand the security implications
+# of disabling strict x509 validation.
+kubernetes_disable_x509_strict: false
 ```

--- a/website/docs/add-secure-apps/outposts/integrations/kubernetes.md
+++ b/website/docs/add-secure-apps/outposts/integrations/kubernetes.md
@@ -2,45 +2,62 @@
 title: Kubernetes
 ---
 
-The kubernetes integration will automatically deploy outposts on any Kubernetes Cluster.
+The Kubernetes integration automatically deploys and manages outposts in a Kubernetes cluster.
 
-This integration has the advantage over manual deployments of automatic updates (whenever authentik is updated, it updates the outposts), and authentik can (in a future version) automatically rotate the token that the outpost uses to communicate with the core authentik server.
+Compared with a [manual Kubernetes deployment](../manual-deploy-kubernetes.md), this integration keeps managed outposts aligned with authentik updates and reduces the amount of cluster-side configuration that you need to maintain.
 
-This integration creates the following objects:
+## Created resources
 
-- Deployment for the outpost container
-- Service for protocol access
-- Service for metrics access
-- Secret to store the token
-- Prometheus ServiceMonitor (if the Prometheus Operator is installed in the target cluster)
-- Ingress (only Proxy outposts)
-- HTTPRoute (only Proxy outposts, when the Gateway API resources are installed in the target cluster, and the `kubernetes_httproute_parent_refs` setting is set, see below)
-- Traefik Middleware (only Proxy outposts with forward auth enabled)
+This integration creates the following Kubernetes resources:
 
-The following outpost settings are used:
+- A `Deployment` for the outpost container.
+- A `Service` for protocol traffic.
+- A `Service` for metrics traffic.
+- A `Secret` that stores the outpost token.
+- A `ServiceMonitor` if the Prometheus Operator is installed in the target cluster.
+- An `Ingress` for proxy outposts.
+- An `HTTPRoute` for proxy outposts if Gateway API resources are installed in the target cluster and `kubernetes_httproute_parent_refs` is configured.
+- A Traefik `Middleware` resource for proxy outposts that use forward auth.
 
-- `object_naming_template`: Configures how the container is called
-- `container_image`: Optionally overwrites the standard container image (see [Configuration](../../../install-config/configuration/configuration.mdx) to configure the global default)
-- `kubernetes_replicas`: Replica count for the deployment of the outpost
-- `kubernetes_namespace`: Namespace to deploy in, defaults to the same namespace authentik is deployed in (if available)
-- `kubernetes_ingress_annotations`: Any additional annotations to add to the ingress object, for example cert-manager
-- `kubernetes_ingress_secret_name`: Name of the secret that is used for TLS connections, can be empty to disable TLS config
-- `kubernetes_ingress_class_name`: Optionally set the ingress class used for the generated ingress, requires authentik 2022.11.0
-- `kubernetes_httproute_parent_refs`: Define which Gateways the HTTPRoute wants to be attached to.
-- `kubernetes_httproute_annotations`: Any additional annotations to add to the HTTPRoute object
-- `kubernetes_service_type`: Service kind created, can be set to LoadBalancer for LDAP outposts for example
-- `kubernetes_disabled_components`: Disable any components of the kubernetes integration, can be any of
-    - 'secret'
-    - 'deployment'
-    - 'service'
-    - 'service-metrics'
-    - 'prometheus servicemonitor'
-    - 'ingress'
-    - 'traefik middleware'
-    - 'httproute'
-- `kubernetes_image_pull_secrets`: If the above docker image is in a private repository, use these secrets to pull. (NOTE: The secret must be created manually in the namespace first.)
-- `kubernetes_json_patches`: Applies an RFC 6902 compliant JSON patch to the Kubernetes objects.
+## Supported settings
+
+These settings control how authentik creates and manages Kubernetes resources. For the full shared outpost configuration reference, see [Outposts configuration](../index.mdx#configuration).
+
+### General settings
+
+- `object_naming_template`: Configures the names of created Kubernetes resources.
+- `container_image`: Overrides the default outpost image. You can also configure the global default in [Configuration](../../../install-config/configuration/configuration.mdx#authentik_outposts).
+- `kubernetes_replicas`: Sets the number of replicas in the generated deployment.
+- `kubernetes_namespace`: Sets the namespace where authentik deploys the outpost. By default, this uses the namespace where authentik is installed, if available.
+- `kubernetes_service_type`: Sets the generated Service type, for example `ClusterIP` or `LoadBalancer`.
+- `kubernetes_image_pull_secrets`: Uses existing image pull secrets for private registries. Create these secrets in the target namespace before you use this setting.
+- `kubernetes_json_patches`: Applies [RFC 6902](https://datatracker.ietf.org/doc/html/rfc6902) JSON patches to generated Kubernetes objects.
 - `kubernetes_disable_x509_strict`: Disable strict X.509 validation for the Kubernetes integration. Enable this setting if your cluster's root CA certificate was generated without certain key usage extensions. Seeing `certificate verify failed` errors in the outpost logs is an indicator that this setting should be set to `true`.
+
+### Ingress settings
+
+- `kubernetes_ingress_annotations`: Adds annotations to the generated Ingress, for example for cert-manager.
+- `kubernetes_ingress_secret_name`: Sets the TLS secret name for the generated Ingress. Leave this empty to disable TLS configuration on the Ingress.
+- `kubernetes_ingress_class_name`: Sets the ingress class for the generated Ingress.
+- `kubernetes_ingress_path_type`: Sets the Ingress `pathType`. If unset, authentik uses the controller default.
+
+### Gateway API settings
+
+- `kubernetes_httproute_parent_refs`: Defines which Gateway resources the generated `HTTPRoute` attaches to.
+- `kubernetes_httproute_annotations`: Adds annotations to the generated `HTTPRoute`.
+
+### Disabled components
+
+Use `kubernetes_disabled_components` to prevent authentik from creating specific resources. Supported values are:
+
+- `secret`
+- `deployment`
+- `service`
+- `service-metrics`
+- `prometheus servicemonitor`
+- `ingress`
+- `traefik middleware`
+- `httproute`
 
 ## Permissions
 

--- a/website/docs/add-secure-apps/outposts/integrations/kubernetes.md
+++ b/website/docs/add-secure-apps/outposts/integrations/kubernetes.md
@@ -2,61 +2,45 @@
 title: Kubernetes
 ---
 
-The Kubernetes integration automatically deploys and manages outposts in a Kubernetes cluster.
+The kubernetes integration will automatically deploy outposts on any Kubernetes Cluster.
 
-Compared with a [manual Kubernetes deployment](../manual-deploy-kubernetes.md), this integration keeps managed outposts aligned with authentik updates and reduces the amount of cluster-side configuration that you need to maintain.
+This integration has the advantage over manual deployments of automatic updates (whenever authentik is updated, it updates the outposts), and authentik can (in a future version) automatically rotate the token that the outpost uses to communicate with the core authentik server.
 
-## Created resources
+This integration creates the following objects:
 
-This integration creates the following Kubernetes resources:
+- Deployment for the outpost container
+- Service for protocol access
+- Service for metrics access
+- Secret to store the token
+- Prometheus ServiceMonitor (if the Prometheus Operator is installed in the target cluster)
+- Ingress (only Proxy outposts)
+- HTTPRoute (only Proxy outposts, when the Gateway API resources are installed in the target cluster, and the `kubernetes_httproute_parent_refs` setting is set, see below)
+- Traefik Middleware (only Proxy outposts with forward auth enabled)
 
-- A `Deployment` for the outpost container.
-- A `Service` for protocol traffic.
-- A `Service` for metrics traffic.
-- A `Secret` that stores the outpost token.
-- A `ServiceMonitor` if the Prometheus Operator is installed in the target cluster.
-- An `Ingress` for proxy outposts.
-- An `HTTPRoute` for proxy outposts if Gateway API resources are installed in the target cluster and `kubernetes_httproute_parent_refs` is configured.
-- A Traefik `Middleware` resource for proxy outposts that use forward auth.
+The following outpost settings are used:
 
-## Supported settings
-
-These settings control how authentik creates and manages Kubernetes resources. For the full shared outpost configuration reference, see [Outposts configuration](../index.mdx#configuration).
-
-### General settings
-
-- `object_naming_template`: Configures the names of created Kubernetes resources.
-- `container_image`: Overrides the default outpost image. You can also configure the global default in [Configuration](../../../install-config/configuration/configuration.mdx#authentik_outposts).
-- `kubernetes_replicas`: Sets the number of replicas in the generated deployment.
-- `kubernetes_namespace`: Sets the namespace where authentik deploys the outpost. By default, this uses the namespace where authentik is installed, if available.
-- `kubernetes_service_type`: Sets the generated Service type, for example `ClusterIP` or `LoadBalancer`.
-- `kubernetes_image_pull_secrets`: Uses existing image pull secrets for private registries. Create these secrets in the target namespace before you use this setting.
-- `kubernetes_json_patches`: Applies [RFC 6902](https://datatracker.ietf.org/doc/html/rfc6902) JSON patches to generated Kubernetes objects.
-
-### Ingress settings
-
-- `kubernetes_ingress_annotations`: Adds annotations to the generated Ingress, for example for cert-manager.
-- `kubernetes_ingress_secret_name`: Sets the TLS secret name for the generated Ingress. Leave this empty to disable TLS configuration on the Ingress.
-- `kubernetes_ingress_class_name`: Sets the ingress class for the generated Ingress.
-- `kubernetes_ingress_path_type`: Sets the Ingress `pathType`. If unset, authentik uses the controller default.
-
-### Gateway API settings
-
-- `kubernetes_httproute_parent_refs`: Defines which Gateway resources the generated `HTTPRoute` attaches to.
-- `kubernetes_httproute_annotations`: Adds annotations to the generated `HTTPRoute`.
-
-### Disabled components
-
-Use `kubernetes_disabled_components` to prevent authentik from creating specific resources. Supported values are:
-
-- `secret`
-- `deployment`
-- `service`
-- `service-metrics`
-- `prometheus servicemonitor`
-- `ingress`
-- `traefik middleware`
-- `httproute`
+- `object_naming_template`: Configures how the container is called
+- `container_image`: Optionally overwrites the standard container image (see [Configuration](../../../install-config/configuration/configuration.mdx) to configure the global default)
+- `kubernetes_replicas`: Replica count for the deployment of the outpost
+- `kubernetes_namespace`: Namespace to deploy in, defaults to the same namespace authentik is deployed in (if available)
+- `kubernetes_ingress_annotations`: Any additional annotations to add to the ingress object, for example cert-manager
+- `kubernetes_ingress_secret_name`: Name of the secret that is used for TLS connections, can be empty to disable TLS config
+- `kubernetes_ingress_class_name`: Optionally set the ingress class used for the generated ingress, requires authentik 2022.11.0
+- `kubernetes_httproute_parent_refs`: Define which Gateways the HTTPRoute wants to be attached to.
+- `kubernetes_httproute_annotations`: Any additional annotations to add to the HTTPRoute object
+- `kubernetes_service_type`: Service kind created, can be set to LoadBalancer for LDAP outposts for example
+- `kubernetes_disabled_components`: Disable any components of the kubernetes integration, can be any of
+    - 'secret'
+    - 'deployment'
+    - 'service'
+    - 'service-metrics'
+    - 'prometheus servicemonitor'
+    - 'ingress'
+    - 'traefik middleware'
+    - 'httproute'
+- `kubernetes_image_pull_secrets`: If the above docker image is in a private repository, use these secrets to pull. (NOTE: The secret must be created manually in the namespace first.)
+- `kubernetes_json_patches`: Applies an RFC 6902 compliant JSON patch to the Kubernetes objects.
+- `kubernetes_disable_x509_strict`: Disable strict X.509 validation for the Kubernetes integration. Enable this setting if your cluster's root CA certificate was generated without certain key usage extensions. Seeing `certificate verify failed` errors in the outpost logs is an indicator that this setting should be set to `true`.
 
 ## Permissions
 


### PR DESCRIPTION
## Details

This PR resolves https://github.com/goauthentik/authentik/issues/15220. On older Kubernetes clusters, the root certificate may have been generated without certain x509 extensions. Notably this includes `Subject Key Identifier` and `Authority Key Identifier` in EKS as well as `Key Usage` in microk8s (and I think k3s).

The issue manifests with workers dropping offline and the following appearing in worker logs:
```
{"event": "Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: CA cert does not include key usage extension (_ssl.c:1081)'))': /version/", "level": "warning", "logger": "urllib3.connectionpool", "timestamp": "2026-03-27T19:05:37.369410"}
```

My change here allows users to provide the `DISABLE_X509_STRICT_VERIFICATION` env var to relax the strict x509 verification. It's almost exactly the same change in https://github.com/kiwigrid/k8s-sidecar/pull/474.

Small note: I wasn't sure how to go about testing this but the scope of the change is so small I don't think there's a huge risk but obviously I'll defer to whatever y'all suggest. Also not sure how this should be documented.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [X] The code has been formatted (`make lint-fix`)

If applicable

-   [x] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
