### PR TITLE
sources/oauth: Allow patching without provider type

### DIFF
--- a/authentik/sources/oauth/api/source.py
+++ b/authentik/sources/oauth/api/source.py
@@ -105,16 +105,15 @@ class OAuthSourceSerializer(SourceSerializer):
             config = jwks_config.json()
             attrs["oidc_jwks"] = config
 
-        provider_type = registry.find_type(attrs.get("provider_type", ""))
         for url in [
             "authorization_url",
             "access_token_url",
             "profile_url",
         ]:
-            if getattr(provider_type, url, None) is None:
+            if getattr(source_type, url, None) is None:
                 if url not in attrs:
                     raise ValidationError(
-                        f"{url} is required for provider {provider_type.verbose_name}"
+                        f"{url} is required for provider {source_type.verbose_name}"
                     )
         return attrs
 

--- a/authentik/sources/oauth/api/source.py
+++ b/authentik/sources/oauth/api/source.py
@@ -59,7 +59,11 @@ class OAuthSourceSerializer(SourceSerializer):
 
     def validate(self, attrs: dict) -> dict:
         session = get_http_session()
-        source_type = registry.find_type(attrs["provider_type"])
+        provider_type_name = attrs.get(
+            "provider_type",
+            self.instance.provider_type if self.instance else None,
+        )
+        source_type = registry.find_type(provider_type_name)
 
         well_known = attrs.get("oidc_well_known_url") or source_type.oidc_well_known_url
         inferred_oidc_jwks_url = None

--- a/authentik/sources/oauth/tests/test_api.py
+++ b/authentik/sources/oauth/tests/test_api.py
@@ -1,0 +1,31 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+from authentik.core.tests.utils import create_test_admin_user
+from authentik.lib.generators import generate_id
+from authentik.sources.oauth.models import OAuthSource
+
+
+class TestOAuthSourceAPI(APITestCase):
+    def setUp(self):
+        self.source = OAuthSource.objects.create(
+            name=generate_id(),
+            slug=generate_id(),
+            provider_type="openidconnect",
+            authorization_url="",
+            profile_url="",
+            consumer_key=generate_id(),
+        )
+        self.user = create_test_admin_user()
+
+    def test_patch_no_type(self):
+        self.client.force_login(self.user)
+        res = self.client.patch(
+            reverse("authentik_api:oauthsource-detail", kwargs={"slug": self.source.slug}),
+            {
+                "authorization_url": f"https://{generate_id()}",
+                "profile_url": f"https://{generate_id()}",
+                "access_token_url": f"https://{generate_id()}",
+            },
+        )
+        self.assertEqual(res.status_code, 200)


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
Checks for provider_type in existing source on sources/oauth/:slug if not provided instead of silently requiring it. Without this, a PATCH that didn't have `provider_type` in the body would only return a 405.

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
    - seg faulted when running the full suite. `ak test authentik/sources/oauth/` passed
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
