### PR TITLE
packages/django-dramatiq-postgres: fix default value for HTTPServerThread

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,9 @@
-packages/client-* linguist-generated
+packages/client-*/** linguist-generated
 web/packages/lex/* linguist-vendored
 web/packages/node-domexception/* linguist-vendored
 web/packages/formdata-polyfill/* linguist-vendored
 web/packages/sfe/vendored/* linguist-vendored
 website/vendored/* linguist-vendored
+website/docs/** linguist-documentation
+website/integrations/** linguist-documentation
+website/api/** linguist-documentation

--- a/packages/django-dramatiq-postgres/django_dramatiq_postgres/middleware.py
+++ b/packages/django-dramatiq-postgres/django_dramatiq_postgres/middleware.py
@@ -27,7 +27,7 @@ class HTTPServerThread(Thread):
     """Base class for a thread which runs an HTTP Server. Mainly used for typing
     the `server` instance variable."""
 
-    server: HTTPServer | None
+    server: HTTPServer | None = None
 
 
 class HTTPServer(BaseHTTPServer):


### PR DESCRIPTION
(also sneakily fix gitattributes)