### PR TITLE
ci: only run selenium for E2E tests when needed

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -211,29 +211,38 @@ jobs:
         job:
           - name: proxy
             glob: tests/e2e/test_provider_proxy*
+            profiles: selenium
           - name: oauth
             glob: tests/e2e/test_provider_oauth2* tests/e2e/test_source_oauth*
+            profiles: selenium
           - name: oauth-oidc
             glob: tests/e2e/test_provider_oidc*
+            profiles: selenium
           - name: saml
             glob: tests/e2e/test_provider_saml* tests/e2e/test_source_saml*
+            profiles: selenium
           - name: ldap
             glob: tests/e2e/test_provider_ldap* tests/e2e/test_source_ldap*
           - name: ws-fed
             glob: tests/e2e/test_provider_ws_fed*
+            profiles: selenium
           - name: radius
             glob: tests/e2e/test_provider_radius*
           - name: scim
             glob: tests/e2e/test_source_scim*
           - name: flows
             glob: tests/e2e/test_flows*
+            profiles: selenium
           - name: endpoints
             glob: tests/e2e/test_endpoints_*
+            profiles: selenium
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
       - name: Setup authentik env
         uses: ./.github/actions/setup
-      - name: Setup e2e env (chrome, etc)
+      - name: Setup e2e env
+        env:
+          COMPOSE_PROFILES: ${{ matrix.job.profiles }}
         run: |
           docker compose -f tests/e2e/compose.yml up -d --quiet-pull
       - id: cache-web

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -282,6 +282,8 @@ jobs:
       - name: Setup authentik env
         uses: ./.github/actions/setup
       - name: Setup e2e env (chrome, etc)
+        env:
+          COMPOSE_PROFILES: selenium
         run: |
           docker compose -f tests/e2e/compose.yml up -d --quiet-pull
       - name: Setup conformance suite

--- a/tests/docker.py
+++ b/tests/docker.py
@@ -87,15 +87,13 @@ class DockerTestCase(TestCase):
         """Output the container logs to our STDOUT"""
         if not container:
             return
-        if IS_CI:
-            image = container.image
-            if image:
-                tags = image.tags[0] if len(image.tags) > 0 else str(image)
-                print(f"::group::Container logs - {tags}")
+        image = container.image
+        if image:
+            tags = image.tags[0] if len(image.tags) > 0 else str(image)
+            print(f"::group::Container logs - {tags}")
         for log in container.logs().decode().split("\n"):
             print(log)
-        if IS_CI:
-            print("::endgroup::")
+        print("::endgroup::")
 
     def tearDown(self) -> None:
         containers: list[Container] = self.docker_client.containers.list(

--- a/tests/e2e/compose.yml
+++ b/tests/e2e/compose.yml
@@ -8,6 +8,8 @@ services:
       - "host.docker.internal:host-gateway"
     labels:
       - io.goauthentik.tests=selenium
+    profiles:
+      - selenium
   mailpit:
     image: docker.io/axllent/mailpit:v1.29.4
     ports:

--- a/tests/e2e/test_provider_ldap.py
+++ b/tests/e2e/test_provider_ldap.py
@@ -14,10 +14,10 @@ from authentik.lib.generators import generate_id
 from authentik.outposts.apps import MANAGED_OUTPOST
 from authentik.outposts.models import Outpost, OutpostConfig, OutpostType
 from authentik.providers.ldap.models import APIAccessMode, LDAPProvider
-from tests.e2e.utils import SeleniumTestCase, retry
+from tests.e2e.utils import E2ETestCase, retry
 
 
-class TestProviderLDAP(SeleniumTestCase):
+class TestProviderLDAP(E2ETestCase):
     """LDAP and Outpost e2e tests"""
 
     def start_ldap(self, outpost: Outpost):

--- a/tests/e2e/test_provider_radius.py
+++ b/tests/e2e/test_provider_radius.py
@@ -13,10 +13,10 @@ from authentik.flows.models import Flow
 from authentik.lib.generators import generate_id, generate_key
 from authentik.outposts.models import Outpost, OutpostConfig, OutpostType
 from authentik.providers.radius.models import RadiusProvider
-from tests.e2e.utils import SeleniumTestCase, retry
+from tests.e2e.utils import E2ETestCase, retry
 
 
-class TestProviderRadius(SeleniumTestCase):
+class TestProviderRadius(E2ETestCase):
     """Radius Outpost e2e tests"""
 
     def setUp(self):

--- a/tests/e2e/test_source_ldap_samba.py
+++ b/tests/e2e/test_source_ldap_samba.py
@@ -12,10 +12,10 @@ from authentik.sources.ldap.sync.groups import GroupLDAPSynchronizer
 from authentik.sources.ldap.sync.membership import MembershipLDAPSynchronizer
 from authentik.sources.ldap.sync.users import UserLDAPSynchronizer
 from authentik.tasks.models import Task
-from tests.e2e.utils import SeleniumTestCase, retry
+from tests.e2e.utils import E2ETestCase, retry
 
 
-class TestSourceLDAPSamba(SeleniumTestCase):
+class TestSourceLDAPSamba(E2ETestCase):
     """test LDAP Source"""
 
     def setUp(self):

--- a/tests/e2e/test_source_scim.py
+++ b/tests/e2e/test_source_scim.py
@@ -8,12 +8,12 @@ from docker.types import Healthcheck
 from authentik.lib.generators import generate_id
 from authentik.lib.utils.http import get_http_session
 from authentik.sources.scim.models import SCIMSource
-from tests.e2e.utils import SeleniumTestCase, retry
+from tests.e2e.utils import E2ETestCase, retry
 
 TEST_POLL_MAX = 25
 
 
-class TestSourceSCIM(SeleniumTestCase):
+class TestSourceSCIM(E2ETestCase):
     """test SCIM Source flow"""
 
     def setUp(self):

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -64,11 +64,8 @@ def get_local_ip(override=True) -> str:
         return "0.0.0.0"
 
 
-class SeleniumTestCase(DockerTestCase, StaticLiveServerTestCase):
-    """StaticLiveServerTestCase which automatically creates a Webdriver instance"""
-
+class E2ETestCase(DockerTestCase, StaticLiveServerTestCase):
     host = get_local_ip()
-    wait_timeout: int
     user: User
 
     def setUp(self):
@@ -77,11 +74,36 @@ class SeleniumTestCase(DockerTestCase, StaticLiveServerTestCase):
         apps.get_app_config("authentik_tenants").ready()
         self.wait_timeout = 60
         self.logger = get_logger()
+        self.user = create_test_admin_user()
+        super().setUp()
+
+    @classmethod
+    def _pre_setup(cls):
+        use_test_broker()
+        return super()._pre_setup()
+
+    def _post_teardown(self):
+        broker = get_broker()
+        broker.flush_all()
+        broker.close()
+        return super()._post_teardown()
+
+    def tearDown(self):
+        if IS_CI:
+            print("::endgroup::", file=stderr)
+        super().tearDown()
+
+
+class SeleniumTestCase(E2ETestCase):
+    """StaticLiveServerTestCase which automatically creates a Webdriver instance"""
+
+    wait_timeout: int
+
+    def setUp(self):
+        super().setUp()
         self.driver = self._get_driver()
         self.driver.implicitly_wait(30)
         self.wait = WebDriverWait(self.driver, self.wait_timeout)
-        self.user = create_test_admin_user()
-        super().setUp()
 
     def _get_driver(self) -> WebDriver:
         count = 0
@@ -135,20 +157,7 @@ class SeleniumTestCase(DockerTestCase, StaticLiveServerTestCase):
     def driver_container(self) -> Container:
         return self.docker_client.containers.list(filters={"label": "io.goauthentik.tests"})[0]
 
-    @classmethod
-    def _pre_setup(cls):
-        use_test_broker()
-        return super()._pre_setup()
-
-    def _post_teardown(self):
-        broker = get_broker()
-        broker.flush_all()
-        broker.close()
-        return super()._post_teardown()
-
     def tearDown(self):
-        if IS_CI:
-            print("::endgroup::", file=stderr)
         super().tearDown()
         if IS_CI:
             print("::group::Browser logs")


### PR DESCRIPTION
extracted from https://github.com/goauthentik/authentik/pull/21212

currently all E2E tests spin up selenium, even for protocols like LDAP and RADIUS where a browser is not needed at all

~~should maybe make CI faster?~~

makes E2E tests that don't need selenium ~1 minute faster