### PR TITLE
web/flows: prefetch flow executor API call during JS bundle download

### DIFF
--- a/authentik/flows/templates/if/flow.html
+++ b/authentik/flows/templates/if/flow.html
@@ -32,6 +32,21 @@
 {% endblock %}
 
 {% block interface_stylesheet %}
+<script data-id="flow-prefetch">
+    "use strict";
+    // Start the flow executor API call immediately while JS bundles are still downloading.
+    // FlowExecutor.ts will consume this promise instead of making its own fetch,
+    // overlapping the ~500ms API wait with JS bundle download time.
+    window.authentik.flowPrefetch = fetch(
+        "{{ base_url_rel }}api/v3/flows/executor/{{ flow.slug }}/" +
+        "?query=" + encodeURIComponent(window.location.search.substring(1)),
+        { credentials: "same-origin", headers: { "Accept": "application/json" } }
+    ).then(function (r) {
+        if (!r.ok) throw new Error(r.status);
+        return r.json();
+    }).catch(function () { return null; });
+</script>
+
 <link rel="stylesheet" type="text/css" href="{% versioned_script 'dist/styles/flow-%v.css' %}" />
 {% endblock %}
 

--- a/web/src/common/global.ts
+++ b/web/src/common/global.ts
@@ -19,6 +19,11 @@ export interface GlobalAuthentik {
         title?: string;
         background?: string;
     };
+    // Prefetched flow executor API response (raw JSON, before SDK deserialization).
+    // Set by the inline <script data-id="flow-prefetch"> in flow.html to overlap
+    // the executor API call with JS bundle download time, reducing LCP by ~500ms.
+    // Consumed and deleted by FlowExecutor.ts refresh() on first use.
+    flowPrefetch?: Promise<Record<string, unknown> | null>;
     config: Config;
     brand: CurrentBrand;
     versionFamily: string;

--- a/web/src/flow/FlowExecutor.ts
+++ b/web/src/flow/FlowExecutor.ts
@@ -38,6 +38,7 @@ import { ConsoleLogger } from "#logger/browser";
 
 import {
     ChallengeTypes,
+    ChallengeTypesFromJSON,
     FlowChallengeResponseRequest,
     FlowErrorChallenge,
     FlowLayoutEnum,
@@ -220,24 +221,46 @@ export class FlowExecutor extends WithBrandConfig(Interface) implements StageHos
 
         this.loading = true;
 
-        return this.#api
-            .flowsExecutorGet({
+        try {
+            // Check for prefetched flow data from the inline <script data-id="flow-prefetch">
+            // in flow.html. The prefetch fires immediately when HTML is parsed, overlapping
+            // the ~500ms API wait with JS bundle download time and reducing LCP.
+            //
+            // The prefetch stores raw JSON (snake_case fields from the API). We must run it
+            // through ChallengeTypesFromJSON() to get the same camelCase object shape that
+            // FlowsApi.flowsExecutorGet() would return — this is what the rest of the code
+            // expects (e.g. challenge.flowInfo, not challenge.flow_info).
+            const ak = globalAK();
+            const prefetchPromise = ak.flowPrefetch;
+
+            if (prefetchPromise) {
+                // Delete immediately so subsequent stage transitions (which call refresh()
+                // again after a flowsExecutorSolve POST) always make a fresh API call.
+                delete ak.flowPrefetch;
+
+                const rawData = await prefetchPromise;
+
+                if (rawData !== null) {
+                    this.challenge = ChallengeTypesFromJSON(rawData);
+                    return;
+                }
+                // rawData is null — prefetch failed silently. Fall through to normal fetch.
+            }
+
+            // Normal fetch path — existing behavior, unchanged.
+            const challenge = await new FlowsApi(DEFAULT_CONFIG).flowsExecutorGet({
                 flowSlug: this.flowSlug,
                 query: window.location.search.substring(1),
-            })
-            .then((challenge) => {
-                this.challenge = challenge;
-                return !!this.challenge;
-            })
-            .catch(async (error) => {
-                const parsedError = await parseAPIResponseError(error);
-                showAPIErrorMessage(parsedError);
-                this.setFlowErrorChallenge(parsedError);
-                return false;
-            })
-            .finally(() => {
-                this.loading = false;
             });
+
+            this.challenge = challenge;
+        } catch (error) {
+            const parsedError = await parseAPIResponseError(error);
+            showAPIErrorMessage(parsedError);
+            this.setFlowErrorChallenge(parsedError);
+        } finally {
+            this.loading = false;
+        }
     };
 
     public async firstUpdated(changed: PropertyValues<this>): Promise<void> {


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->

Start the flow executor API call immediately via an inline script, overlapping the ~400ms server response time with JS bundle downloads. FlowExecutor.ts consumes the prefetched promise on first load and falls back to the normal SDK fetch on failure or subsequent stage transitions.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [X] The code has been formatted (`make lint-fix`)

If changes to the frontend have been made

-   [X] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
