### PR TITLE
providers/oauth2: handle implicit grant types in OAuth2 query response mode

### DIFF
--- a/authentik/providers/oauth2/views/authorize.py
+++ b/authentik/providers/oauth2/views/authorize.py
@@ -614,8 +614,11 @@ class OAuthFulfillmentStage(StageView):
 
             if self.params.response_mode == ResponseMode.QUERY:
                 query_params = parse_qs(uri.query)
-                query_params["code"] = code.code
-                query_params["state"] = [str(self.params.state) if self.params.state else ""]
+                if self.params.grant_type in [GrantTypes.AUTHORIZATION_CODE]:
+                    query_params["code"] = code.code
+                    query_params["state"] = [str(self.params.state) if self.params.state else ""]
+                else:
+                    query_params = self.create_implicit_response(code)
 
                 uri = uri._replace(query=urlencode(query_params, doseq=True))
                 return urlunsplit(uri)


### PR DESCRIPTION
## Summary

Fixes #21112

Closes #25308
The `QUERY` response mode path in `OAuthFulfillmentStage.create_response_uri()` unconditionally accesses `code.code`, causing an `AttributeError: 'NoneType' object has no attribute 'code'` when:
- `response_type=id_token token` (implicit flow, no authorization code)
- `response_mode=query`

This is because `code` is only created for `AUTHORIZATION_CODE` and `HYBRID` grant types (lines 608-613), but the `QUERY` branch doesn't check the grant type before accessing `code.code`.

## Fix

Mirror the pattern already used by the `FRAGMENT` (line 625) and `FORM_POST` (line 639) response modes:
- Check if `grant_type` is `AUTHORIZATION_CODE` before accessing `code.code`
- Otherwise, delegate to `create_implicit_response()` to generate the appropriate token response

## Test plan

- [x] Verify `response_mode=query` with `response_type=code` still works (authorization code flow)
- [ ] Verify `response_mode=query` with `response_type=id_token token` no longer raises `AttributeError`
- [ ] Verify the implicit response parameters are correctly placed in the query string