### PR TITLE
ci: include version family in release build cache (2026.2)

### DIFF
--- a/.github/actions/docker-push-variables/push_vars.py
+++ b/.github/actions/docker-push-variables/push_vars.py
@@ -89,6 +89,8 @@ if should_push:
     _cache_tag = "buildcache"
     if image_arch:
         _cache_tag += f"-{image_arch}"
+    if is_release:
+        _cache_tag += f"-{version_family}"
     cache_to = f"type=registry,ref={get_attest_image_names(image_tags)}:{_cache_tag},mode=max"
 
 


### PR DESCRIPTION
Hopefully fixes the build issues 🤞 