### PR TITLE
web/flow: be more aggressive about checking inspector hide/show status

### DIFF
--- a/web/src/flow/FlowExecutor.ts
+++ b/web/src/flow/FlowExecutor.ts
@@ -316,14 +316,15 @@ export class FlowExecutor
             this.#synchronizeFlowInfo();
         }
 
-        if (
-            changedProperties.has("inspectorOpen") &&
-            this.inspectorOpen &&
-            !this.#inspectorLoaded
-        ) {
-            import("#flow/FlowInspector").then(() => {
-                this.#inspectorLoaded = true;
-            });
+        if (changedProperties.has("inspectorOpen") && this.inspectorOpen) {
+            if (!this.#inspectorLoaded) {
+                import("#flow/FlowInspector").then(() => {
+                    this.#inspectorLoaded = true;
+                    this.hideShowInspector();
+                });
+            } else {
+                this.hideShowInspector();
+            }
         }
     }
 
@@ -535,18 +536,22 @@ export class FlowExecutor
 
     //#region Render Inspector
 
-    @listen(AKFlowInspectorChangeEvent)
-    protected toggleInspector = () => {
-        this.inspectorOpen = !this.inspectorOpen;
-
+    protected hideShowInspector() {
         const drawer = document.getElementById("flow-drawer");
 
         if (!drawer) {
+            this.#logger.debug("Not toggling inspector; inspector not found");
             return;
         }
 
         drawer.classList.toggle("pf-m-expanded", this.inspectorOpen);
         drawer.classList.toggle("pf-m-collapsed", !this.inspectorOpen);
+    }
+
+    @listen(AKFlowInspectorChangeEvent)
+    protected toggleInspector = () => {
+        this.inspectorOpen = !this.inspectorOpen;
+        this.hideShowInspector();
     };
 
     protected renderInspectorButton() {


### PR DESCRIPTION
## Fix Flow Inspector Display in 2026.2

## What

Update the hide/show logic for FlowInspector, making it much more aggressive about checking the state of the inspector when the FlowExecutor first runs and after the FlowInspector is loaded.

Specifically:

1.  Break out the “check if the inspector needs to be hidden or shown” code into its own method. (This was part of the componentization pass done later.)

2.  Call that method on the FlowInspectorChangeEvent as before.

3.  In updated(), *iff* `inspectorOpen` changed:

    - Unchanged: In updated(), if the inspector needs to be loaded then load it, then run the hide/show check.
    - Changed: if the inspector is already loaded, be sure to run the hide/show check; this was not happening in the current code.

## Why

I’m not sure where this happened; bisect shows the code breaking at 08b07979, but the diff that emerges from that with a prior commit affecting FlowExecutor doesn’t match the commit description at all (and it’s one of mine, darnit, and I’m usually good about that). That commit claims to be the one about removing PFBase universally because CSS custom properties don’t need duplication.

- \[🤦🏿‍♀️️\] The code has been formatted (`make web`)

## Issues:

closes #20985