### PR TITLE
website/docs: document Grafana OAuth admin sync workaround

### DIFF
--- a/website/docs/install-config/first-steps/index.mdx
+++ b/website/docs/install-config/first-steps/index.mdx
@@ -64,7 +64,7 @@ authentik supports integration with any application; refer to our [Integrations 
 
 We'll use Grafana as an example application in this guide as it is very common and straightforward to set up.
 
-For more configuration options and full details about integrating with Grafana, refer to our [full integration guide](/integrationsmonitoring/grafana/). The following steps require that you have [a Grafana instance running in Docker](https://grafana.com/docs/grafana/latest/setup-grafana/configure-docker/), and that you can access the authentik Admin interface.
+For more configuration options and full details about integrating with Grafana, refer to our [full integration guide](/integrations/monitoring/grafana/). The following steps require that you have [a Grafana instance running in Docker](https://grafana.com/docs/grafana/latest/setup-grafana/configure-docker/), and that you can access the authentik Admin interface.
 
 </details>
 

--- a/website/integrations/monitoring/grafana/index.mdx
+++ b/website/integrations/monitoring/grafana/index.mdx
@@ -214,3 +214,9 @@ If you get `user does not belong to org` error when trying to log into grafana f
 auto_assign_org = true
 auto_assign_org_id = <id-of-your-default-organization>
 ```
+
+If your first OAuth login fails with a `user.sync` error similar to `cannot remove last grafana admin`, check whether the OAuth user matches an existing local Grafana server admin account by login or email. Grafana can adopt the existing account into the OAuth flow, and if the mapped OAuth role is not a server admin, the login can fail while Grafana tries to remove the last remaining server admin.
+
+For OSS Grafana, the simplest workaround is to keep the existing local admin temporarily, create a separate OAuth-backed user first, grant that new user admin access, and only then remove the old local admin account.
+
+If you are configuring Generic OAuth from the Grafana UI instead of a config file, the `Allow assign Grafana admin` toggle is under `Administration > Authentication > Generic OAuth`. Its config-file equivalent is `allow_assign_grafana_admin`, or `GF_AUTH_GENERIC_OAUTH_ALLOW_ASSIGN_GRAFANA_ADMIN` in Docker-based deployments. This setting is only required if your `role_attribute_path` can return `GrafanaAdmin`; the example role mapping on this page returns `Admin`, `Editor`, or `Viewer`.

--- a/website/integrations/monitoring/grafana/index.mdx
+++ b/website/integrations/monitoring/grafana/index.mdx
@@ -215,7 +215,7 @@ auto_assign_org = true
 auto_assign_org_id = <id-of-your-default-organization>
 ```
 
-If your first OAuth login fails with a `user.sync` error similar to `cannot remove last grafana admin`, check whether the OAuth user matches an existing local Grafana server admin account by login or email. Grafana can adopt the existing account into the OAuth flow, and if the mapped OAuth role is not a server admin, the login can fail while Grafana tries to remove the last remaining server admin.
+If your first OAuth login fails with a `user.sync` error such as `cannot remove last grafana admin`, verify whether the OAuth user's username or email matches that of an existing local Grafana server admin account. In such cases, Grafana attempts to link the local account to the OAuth user. If the OAuth role mapped to that user is not a server admin, the login can fail because Grafana tries to remove the last remaining server admin account.
 
 For OSS Grafana, the simplest workaround is to create a separate OAuth-backed user first, grant that new user admin access, and only then remove the old local admin account.
 

--- a/website/integrations/monitoring/grafana/index.mdx
+++ b/website/integrations/monitoring/grafana/index.mdx
@@ -219,6 +219,6 @@ If your first OAuth login fails with a `user.sync` error such as `cannot remove 
 
 For OSS Grafana, the simplest workaround is to create a separate OAuth-backed user first, grant that new user admin access, and only then remove the old local admin account.
 
-If you are configuring Generic OAuth from the Grafana UI instead of a config file, the `Allow assign Grafana admin` toggle is under **Administration** > **Authentication** > **Generic OAuth**. 
+If you are configuring Generic OAuth from the Grafana UI instead of a config file, the `Allow assign Grafana admin` toggle is under **Administration** > **Authentication** > **Generic OAuth**.
 
 Its config-file equivalent is `allow_assign_grafana_admin`, or `GF_AUTH_GENERIC_OAUTH_ALLOW_ASSIGN_GRAFANA_ADMIN` in Docker-based deployments. This setting is only required if your `role_attribute_path` can return `GrafanaAdmin`; the example role mapping on this page returns `Admin`, `Editor`, or `Viewer`.

--- a/website/integrations/monitoring/grafana/index.mdx
+++ b/website/integrations/monitoring/grafana/index.mdx
@@ -219,4 +219,6 @@ If your first OAuth login fails with a `user.sync` error similar to `cannot remo
 
 For OSS Grafana, the simplest workaround is to keep the existing local admin temporarily, create a separate OAuth-backed user first, grant that new user admin access, and only then remove the old local admin account.
 
-If you are configuring Generic OAuth from the Grafana UI instead of a config file, the `Allow assign Grafana admin` toggle is under `Administration > Authentication > Generic OAuth`. Its config-file equivalent is `allow_assign_grafana_admin`, or `GF_AUTH_GENERIC_OAUTH_ALLOW_ASSIGN_GRAFANA_ADMIN` in Docker-based deployments. This setting is only required if your `role_attribute_path` can return `GrafanaAdmin`; the example role mapping on this page returns `Admin`, `Editor`, or `Viewer`.
+If you are configuring Generic OAuth from the Grafana UI instead of a config file, the `Allow assign Grafana admin` toggle is under **Administration** > **Authentication** > **Generic OAuth**. 
+
+Its config-file equivalent is `allow_assign_grafana_admin`, or `GF_AUTH_GENERIC_OAUTH_ALLOW_ASSIGN_GRAFANA_ADMIN` in Docker-based deployments. This setting is only required if your `role_attribute_path` can return `GrafanaAdmin`; the example role mapping on this page returns `Admin`, `Editor`, or `Viewer`.

--- a/website/integrations/monitoring/grafana/index.mdx
+++ b/website/integrations/monitoring/grafana/index.mdx
@@ -217,7 +217,7 @@ auto_assign_org_id = <id-of-your-default-organization>
 
 If your first OAuth login fails with a `user.sync` error similar to `cannot remove last grafana admin`, check whether the OAuth user matches an existing local Grafana server admin account by login or email. Grafana can adopt the existing account into the OAuth flow, and if the mapped OAuth role is not a server admin, the login can fail while Grafana tries to remove the last remaining server admin.
 
-For OSS Grafana, the simplest workaround is to keep the existing local admin temporarily, create a separate OAuth-backed user first, grant that new user admin access, and only then remove the old local admin account.
+For OSS Grafana, the simplest workaround is to create a separate OAuth-backed user first, grant that new user admin access, and only then remove the old local admin account.
 
 If you are configuring Generic OAuth from the Grafana UI instead of a config file, the `Allow assign Grafana admin` toggle is under **Administration** > **Authentication** > **Generic OAuth**. 
 


### PR DESCRIPTION
Clarify a Grafana Generic OAuth failure mode when an existing local admin account overlaps with the first OAuth login, and document where the Grafana admin assignment toggle lives.

Also fix the broken Grafana integration link in the first-steps guide.

Closes #21249