### PR TITLE
 web: Fix duplicate Turnstile widgets after extended idle

### DIFF
--- a/web/src/flow/stages/captcha/CaptchaStage.ts
+++ b/web/src/flow/stages/captcha/CaptchaStage.ts
@@ -529,6 +529,7 @@ export class CaptchaStage
         const template = iframeTemplate(captchaElement, {
             challengeURL: challengeURL.toString(),
             theme: this.activeTheme,
+            scriptOnLoad: !(controller instanceof TurnstileController),
         });
 
         if (

--- a/web/src/flow/stages/captcha/controllers/turnstile.ts
+++ b/web/src/flow/stages/captcha/controllers/turnstile.ts
@@ -1,7 +1,5 @@
 /* eslint-disable @typescript-eslint/triple-slash-reference */
 /// <reference types="turnstile-types"/>
-import { ifPresent } from "#elements/utils/attributes";
-
 import { CaptchaController } from "#flow/stages/captcha/controllers/CaptchaController";
 
 import { TurnstileObject } from "turnstile-types";
@@ -20,7 +18,16 @@ export class TurnstileController extends CaptchaController {
     public prepareURL = (): URL | null => {
         const input = this.host.challenge?.jsUrl;
 
-        return input && URL.canParse(input) ? new URL(input) : null;
+        if (!input || !URL.canParse(input)) return null;
+
+        const url = new URL(input);
+
+        // Use explicit rendering to prevent Turnstile's 3-hour self-upgrade
+        // from calling implicitRenderAll() and duplicating widgets.
+        url.searchParams.set("render", "explicit");
+        url.searchParams.set("onload", "onTurnstileReady");
+
+        return url;
     };
 
     /**
@@ -33,25 +40,34 @@ export class TurnstileController extends CaptchaController {
     /**
      * Renders the Turnstile captcha frame.
      *
+     * Uses explicit rendering to avoid Turnstile's self-upgrade mechanism
+     * (every ~3 hours) from calling `implicitRenderAll()` and duplicating widgets.
+     *
      * @remarks
      *
-     * Turnstile will log a warning if the `data-language` attribute
+     * Turnstile will log a warning if the `language` option
      * is not in lower-case format.
      *
      * @see {@link https://developers.cloudflare.com/turnstile/reference/supported-languages/ Turnstile Supported Languages}
      */
     public interactive = () => {
-        const languageTag = this.host.activeLanguageTag.toLowerCase();
+        const siteKey = this.host.challenge?.siteKey ?? "";
+        const theme = this.host.activeTheme;
+        const language = this.host.activeLanguageTag.toLowerCase();
 
-        return html`<div
-            id="ak-container"
-            class="cf-turnstile"
-            data-sitekey=${ifPresent(this.host.challenge?.siteKey)}
-            data-theme=${this.host.activeTheme}
-            data-callback="callback"
-            data-size="flexible"
-            data-language=${ifPresent(languageTag)}
-        ></div>`;
+        return html`<div id="ak-container"></div>
+            <script>
+                function onTurnstileReady() {
+                    turnstile.render("#ak-container", {
+                        sitekey: "${siteKey}",
+                        theme: "${theme}",
+                        language: "${language}",
+                        size: "flexible",
+                        callback,
+                    });
+                    loadListener();
+                }
+            </script>`;
     };
 
     public refreshInteractive = async () => {

--- a/web/src/flow/stages/captcha/shared.ts
+++ b/web/src/flow/stages/captcha/shared.ts
@@ -25,6 +25,11 @@ export function themeMeta(theme: ResolvedUITheme) {
 export interface IFrameTemplateInit {
     challengeURL: URL | string;
     theme: ResolvedUITheme;
+    /**
+     * If `true`, the script element will fire `loadListener()` on load.
+     * Defaults to `true`.
+     */
+    scriptOnLoad?: boolean;
 }
 
 /**
@@ -37,7 +42,7 @@ export interface IFrameTemplateInit {
  */
 export function iframeTemplate(
     children: TemplateResult,
-    { challengeURL, theme }: IFrameTemplateInit,
+    { challengeURL, theme, scriptOnLoad = true }: IFrameTemplateInit,
 ) {
     return createDocumentTemplate({
         head: html`
@@ -90,7 +95,7 @@ export function iframeTemplate(
                 }
             </style>
             ${children}
-            <script onload="loadListener()" src="${challengeURL.toString()}"></script>
+            <script ${scriptOnLoad ? 'onload="loadListener()"' : ""} src="${challengeURL.toString()}"></script>
         `,
     });
 }

--- a/web/src/flow/stages/captcha/shared.ts
+++ b/web/src/flow/stages/captcha/shared.ts
@@ -95,7 +95,10 @@ export function iframeTemplate(
                 }
             </style>
             ${children}
-            <script ${scriptOnLoad ? 'onload="loadListener()"' : ""} src="${challengeURL.toString()}"></script>
+            <script
+                ${scriptOnLoad ? 'onload="loadListener()"' : ""}
+                src="${challengeURL.toString()}"
+            ></script>
         `,
     });
 }


### PR DESCRIPTION
## Details

Turnstile's client-side script includes a self-upgrade mechanism that periodically replaces its own `<script>` tag with a fresh version. When the upgraded script loads, it restores its internal widget state and then re-scans the DOM for `.cf-turnstile` elements to implicitly render — even though those containers already have an active widget. This results in duplicate widgets accumulating over time.

This PR changes our Turnstile controller from implicit rendering (via the cf-turnstile class and data-* attributes), to explicit rendering (`?render=explicit` on the script URL + a manual `turnstile.render()` call). With explicit mode, the self-upgrade cycle no longer triggers a DOM scan, so existing widgets aren't duplicated.

Closes #18156