### PR TITLE
sources/oauth: correctly check requests' exception response

### DIFF
--- a/authentik/events/models.py
+++ b/authentik/events/models.py
@@ -456,7 +456,7 @@ class NotificationTransport(TasksModel, SerializerModel):
                 response.raise_for_status()
             except RequestException as exc:
                 raise NotificationTransportError(
-                    exc.response.text if exc.response else str(exc)
+                    exc.response.text if exc.response is not None else str(exc)
                 ) from exc
             return [
                 response.status_code,
@@ -519,7 +519,7 @@ class NotificationTransport(TasksModel, SerializerModel):
             response = get_http_session().post(self.webhook_url, json=body)
             response.raise_for_status()
         except RequestException as exc:
-            text = exc.response.text if exc.response else str(exc)
+            text = exc.response.text if exc.response is not None else str(exc)
             raise NotificationTransportError(text) from exc
         return [
             response.status_code,

--- a/authentik/sources/oauth/api/source.py
+++ b/authentik/sources/oauth/api/source.py
@@ -73,7 +73,7 @@ class OAuthSourceSerializer(SourceSerializer):
                 well_known_config = session.get(well_known)
                 well_known_config.raise_for_status()
             except RequestException as exc:
-                text = exc.response.text if exc.response else str(exc)
+                text = exc.response.text if exc.response is not None else str(exc)
                 raise ValidationError({"oidc_well_known_url": text}) from None
             config = well_known_config.json()
             if "issuer" not in config:
@@ -100,7 +100,7 @@ class OAuthSourceSerializer(SourceSerializer):
                 jwks_config = session.get(jwks_url)
                 jwks_config.raise_for_status()
             except RequestException as exc:
-                text = exc.response.text if exc.response else str(exc)
+                text = exc.response.text if exc.response is not None else str(exc)
                 raise ValidationError({"oidc_jwks_url": text}) from None
             config = jwks_config.json()
             attrs["oidc_jwks"] = config

--- a/authentik/sources/oauth/clients/base.py
+++ b/authentik/sources/oauth/clients/base.py
@@ -47,7 +47,7 @@ class BaseOAuthClient:
             self.logger.warning(
                 "Unable to fetch user profile",
                 exc=exc,
-                response=exc.response.text if exc.response else str(exc),
+                response=exc.response.text if exc.response is not None else str(exc),
             )
             return None
         return response.json()

--- a/authentik/sources/oauth/clients/oauth1.py
+++ b/authentik/sources/oauth/clients/oauth1.py
@@ -45,7 +45,7 @@ class OAuthClient(BaseOAuthClient):
                 LOGGER.warning(
                     "Unable to fetch access token",
                     exc=exc,
-                    response=exc.response.text if exc.response else str(exc),
+                    response=exc.response.text if exc.response is not None else str(exc),
                 )
                 return None
             return self.parse_raw_token(response.text)
@@ -67,7 +67,7 @@ class OAuthClient(BaseOAuthClient):
             response.raise_for_status()
         except RequestException as exc:
             raise OAuthSourceException(
-                exc.response.text if exc.response else str(exc),
+                exc.response.text if exc.response is not None else str(exc),
             ) from exc
         return response.text
 

--- a/authentik/sources/oauth/clients/oauth2.py
+++ b/authentik/sources/oauth/clients/oauth2.py
@@ -121,7 +121,7 @@ class OAuth2Client(BaseOAuthClient):
             LOGGER.warning(
                 "Unable to fetch access token",
                 exc=exc,
-                response=exc.response.text if exc.response else str(exc),
+                response=exc.response.text if exc.response is not None else str(exc),
             )
             return None
         return response.json()
@@ -202,7 +202,7 @@ class UserprofileHeaderAuthClient(OAuth2Client):
             LOGGER.warning(
                 "Unable to fetch user profile from profile_url",
                 exc=exc,
-                response=exc.response.text if exc.response else str(exc),
+                response=exc.response.text if exc.response is not None else str(exc),
             )
             return None
         return response.json()

--- a/authentik/sources/oauth/tasks.py
+++ b/authentik/sources/oauth/tasks.py
@@ -27,7 +27,7 @@ def update_well_known_jwks():
             well_known_config = session.get(source.oidc_well_known_url)
             well_known_config.raise_for_status()
         except RequestException as exc:
-            text = exc.response.text if exc.response else str(exc)
+            text = exc.response.text if exc.response is not None else str(exc)
             LOGGER.warning("Failed to update well_known", source=source, exc=exc, text=text)
             self.info(f"Failed to update OIDC configuration for {source.slug}")
             continue
@@ -65,7 +65,7 @@ def update_well_known_jwks():
             jwks_config = session.get(source.oidc_jwks_url)
             jwks_config.raise_for_status()
         except RequestException as exc:
-            text = exc.response.text if exc.response else str(exc)
+            text = exc.response.text if exc.response is not None else str(exc)
             LOGGER.warning("Failed to update JWKS", source=source, exc=exc, text=text)
             self.info(f"Failed to update JWKS for {source.slug}")
             continue

--- a/authentik/sources/oauth/types/entra_id.py
+++ b/authentik/sources/oauth/types/entra_id.py
@@ -41,7 +41,7 @@ class EntraIDClient(UserprofileHeaderAuthClient):
             LOGGER.warning(
                 "Unable to fetch user profile",
                 exc=exc,
-                response=exc.response.text if exc.response else str(exc),
+                response=exc.response.text if exc.response is not None else str(exc),
             )
             return None
         profile_data["raw_groups"] = group_response.json()


### PR DESCRIPTION
This is something I noticed during https://github.com/goauthentik/authentik/pull/21383

Python requests' `Response` class implements `__bool__`, where it returns `self.ok`, meaning that in an exception, checking if a response is available via `if exc.response ...` will always return false. The correct check is `if exc.response is not None ...`.

...sigh