### PR TITLE
lifecycle: disable gunicorn control socket

### DIFF
--- a/lifecycle/gunicorn.conf.py
+++ b/lifecycle/gunicorn.conf.py
@@ -50,6 +50,7 @@ logconfig_dict = get_logger_config()
 workers = CONFIG.get_int("web.workers", 2)
 threads = CONFIG.get_int("web.threads", 4)
 
+control_socket_disable = True
 
 def post_fork(server: "Arbiter", worker: DjangoUvicornWorker):  # noqa: UP037
     """Tell prometheus to use worker number instead of process ID for multiprocess"""

--- a/lifecycle/gunicorn.conf.py
+++ b/lifecycle/gunicorn.conf.py
@@ -52,6 +52,7 @@ threads = CONFIG.get_int("web.threads", 4)
 
 control_socket_disable = True
 
+
 def post_fork(server: "Arbiter", worker: DjangoUvicornWorker):  # noqa: UP037
     """Tell prometheus to use worker number instead of process ID for multiprocess"""
     from prometheus_client import values


### PR DESCRIPTION
was added in 25.1.0 (https://github.com/goauthentik/authentik/pull/20312)

Currently spams a whole lot of sentry errors: https://authentik-security-inc.sentry.io/issues/7270782847/?project=4504163677503489&query=is%3Aunresolved&referrer=issue-stream