### PR TITLE
internal: fix certificate fallback without SNI

### DIFF
--- a/internal/web/web_tls.go
+++ b/internal/web/web_tls.go
@@ -18,11 +18,7 @@ func (ws *WebServer) GetCertificate() func(ch *tls.ClientHelloInfo) (*tls.Config
 	}
 	return func(ch *tls.ClientHelloInfo) (*tls.Config, error) {
 		cfg := utils.GetTLSConfig()
-		if ch.ServerName == "" {
-			cfg.Certificates = []tls.Certificate{fallback}
-			return cfg, nil
-		}
-		if ws.ProxyServer != nil {
+		if ch.ServerName != "" && ws.ProxyServer != nil {
 			appCert := ws.ProxyServer.GetCertificate(ch.ServerName)
 			if appCert != nil {
 				cfg.Certificates = []tls.Certificate{*appCert}


### PR DESCRIPTION

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

Fixes #21412

## Details

When connecting via IP address (no SNI), `GetCertificate` returned the hardcoded RSA 2048 fallback certificate immediately, skipping the brand TLS check entirely. This caused non-RSA certificates (ECDSA, ED25519,ED448) configured as the default web certificate to be silently ignored.

The fix removes the early return for empty `ServerName` and instead guards only the proxy server lookup (which requires a server name). The brand TLS watcher already handles empty `ServerName` correctly by falling back to the default brand.

**Ex verification & logs:**
<img width="1071" height="85" alt="image" src="https://github.com/user-attachments/assets/8708b760-8193-45be-875a-06d5ad138431" />
<img width="786" height="110" alt="image" src="https://github.com/user-attachments/assets/b39f0931-0895-49f9-b036-ab545a9c7569" />

Closes #21412

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
