### PR TITLE
website/docs: fix typo

### DIFF
--- a/website/docs/releases/2026/v2026.2.md
+++ b/website/docs/releases/2026/v2026.2.md
@@ -344,7 +344,7 @@ helm upgrade authentik authentik/authentik -f values.yaml --version ^2026.2
 - providers/proxy: remove redundant logout event (cherry-pick #20860 to version-2026.2) (#20866)
 - providers/saml: Fix redirect for saml slo (cherry-pick #21258 to version-2026.2) (#21284)
 - providers/scim: fix out-of-scope users and groups not being deleted from destination application (cherry-pick #20742 to version-2026.2) (#20780)
-- proviers/ldap: avoid concurrent header writes in API Client (cherry-pick #21223 to version-2026.2) (#21228)
+- providers/ldap: avoid concurrent header writes in API Client (cherry-pick #21223 to version-2026.2) (#21228)
 - sources/ldap: fix exception in ldap debug endpoint (cherry-pick #21219 to version-2026.2) (#21222)
 - sources/ldap: fix incorrect error response for invalid sync_users_password (cherry-pick #21016 to version-2026.2) (#21039)
 - sources/oauth: Allow patching without provider type (cherry-pick #21211 to version-2026.2) (#21213)


### PR DESCRIPTION
How was this not caught by CI on the PR but was caught by CI on the merge commit?