### PR TITLE
website/integrations: update FortiGate SSLVPN doc

### DIFF
--- a/website/integrations/networking/fortigate-ssl/index.md
+++ b/website/integrations/networking/fortigate-ssl/index.md
@@ -50,7 +50,9 @@ To support the integration of FortiGate SSLVPN with authentik, you need to creat
 - **Configure the Provider**: provide a name (or accept the auto-provided name), and configure the following required settings:
     - Upload the metadata file from FortiGate (you will get this in the FortiGate configuration steps).
     - Set the **ACS URL** to `https://fortigate.company/remote/saml/login`.
+    - Set the **Issuer** to `https://authentik.company/`.
     - Set the **Audience** to `http://fortigate.company/remote/saml/metadata/`.
+    - Set the **SLS URL** to `http://fortigate.company/remote/saml/logout/`.
     - Under **Advanced protocol settings**:
         - Set **Signing certificate** to use any available certificate.
             - Enable both **Sign assertions** and **Sign responses**.
@@ -76,7 +78,7 @@ config user saml
         set entity-id "http://fortigate.company/remote/saml/metadata/"
         set single-sign-on-url "https://fortigate.company/remote/saml/login"
         set single-logout-url "https://fortigate.company/remote/saml/logout"
-        set idp-entity-id "https://authentik.company"
+        set idp-entity-id "https://authentik.company/"
         set idp-single-sign-on-url "https://authentik.company/application/saml/fortigate-sslvpn/sso/binding/redirect/"
         set idp-single-logout-url "https://authentik.company/application/saml/fortigate-sslvpn/slo/binding/redirect/"
         set idp-cert "your-authentik-cert"


### PR DESCRIPTION
## Details

This PR will add more details in the "Integrate with FortiGate SSLVPN" documentation.

"Slash" at the end in the Issuer and in the idp-entity-id is required to that's works.
