### PR TITLE
web/flows: prevent leader tab deadlock in continuous login flow

### DIFF
--- a/web/src/flow/tabs/broadcast.ts
+++ b/web/src/flow/tabs/broadcast.ts
@@ -52,9 +52,14 @@ export class Broadcast extends BroadcastChannel {
         }
     };
 
+    #onPageHide = () => {
+        this.akExitTab();
+    };
+
     constructor() {
         super(BROADCAST_CHANNEL_NAME);
         this.addEventListener("message", this.#onMessage);
+        window.addEventListener("pagehide", this.#onPageHide);
         this.#logger = ConsoleLogger.prefix("mtab/broadcast");
     }
 

--- a/web/src/flow/tabs/orchestrator.ts
+++ b/web/src/flow/tabs/orchestrator.ts
@@ -8,10 +8,9 @@ import { ConsoleLogger } from "#logger/browser";
 const lockKey = "authentik-tab-locked";
 const logger = ConsoleLogger.prefix("mtab/orchestrate");
 
+const TAB_EXIT_TIMEOUT_MS = 3000;
+
 export function multiTabOrchestrateLeave() {
-    if (!globalAK().brand.flags.flowsContinuousLogin) {
-        return;
-    }
     Broadcast.shared.akExitTab();
     TabID.shared.clear();
 }
@@ -36,9 +35,15 @@ export async function multiTabOrchestrateResume() {
         logger.debug("Telling tab to continue", tab);
         Broadcast.shared.akResumeTab(tab);
         const done = Promise.withResolvers<void>();
+        const timeout = setTimeout(() => {
+            logger.warn("Timed out waiting for tab to exit, moving on", tab);
+            clearInterval(checker);
+            done.resolve();
+        }, TAB_EXIT_TIMEOUT_MS);
         const checker = setInterval(() => {
             if (Broadcast.shared.exitedTabIds.includes(tab)) {
                 logger.debug("tab exited", tab);
+                clearTimeout(timeout);
                 setTimeout(() => {
                     logger.debug("continue exited", tab);
                     done.resolve();

--- a/web/src/flow/tabs/orchestrator.ts
+++ b/web/src/flow/tabs/orchestrator.ts
@@ -35,15 +35,11 @@ export async function multiTabOrchestrateResume() {
         logger.debug("Telling tab to continue", tab);
         Broadcast.shared.akResumeTab(tab);
         const done = Promise.withResolvers<void>();
-        const timeout = setTimeout(() => {
-            logger.warn("Timed out waiting for tab to exit, moving on", tab);
-            clearInterval(checker);
-            done.resolve();
-        }, TAB_EXIT_TIMEOUT_MS);
+        const timers: { timeout?: ReturnType<typeof setTimeout> } = {};
         const checker = setInterval(() => {
             if (Broadcast.shared.exitedTabIds.includes(tab)) {
                 logger.debug("tab exited", tab);
-                clearTimeout(timeout);
+                clearTimeout(timers.timeout);
                 setTimeout(() => {
                     logger.debug("continue exited", tab);
                     done.resolve();
@@ -51,6 +47,11 @@ export async function multiTabOrchestrateResume() {
                 clearInterval(checker);
             }
         }, 1);
+        timers.timeout = setTimeout(() => {
+            logger.warn("Timed out waiting for tab to exit, moving on", tab);
+            clearInterval(checker);
+            done.resolve();
+        }, TAB_EXIT_TIMEOUT_MS);
         await done.promise;
         logger.debug("Tab done, continuing", tab);
     }


### PR DESCRIPTION
## Details

When the flowsContinuousLogin flag is enabled, the leader tab (the one completing login) discovers other open tabs via BroadcastChannel, tells them to continue, and waits for each to confirm exit before proceeding. Two issues could cause the leader to hang indefinitely:

1) Flag guard on responder side: multiTabOrchestrateLeave() checked flowsContinuousLogin before sending the exit broadcast. Tabs that loaded before the flag was enabled (or before a deploy with updated code) would receive the continue signal and navigate away successfully, but never send the exit confirmation—leaving the leader stuck in an infinite polling loop with localStorage lock never cleaned up. Removed the flag guard from multiTabOrchestrateLeave(); the flag check in multiTabOrchestrateResume() on the leader side is sufficient to gate the feature.

2) No timeout for unresponsive tabs: Tabs old enough to predate the flag guard fix, or those that crash/close during orchestration, would never send an exit message. Added a 3-second per-tab timeout so the leader logs a warning and moves on rather than waiting forever.

Additionally, added a pagehide event listener in Broadcast that automatically sends the exit message when a page unloads. This provides defense-in-depth for any edge case where a tab navigates away without explicitly calling multiTabOrchestrateLeave().

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
