### PR TITLE
web/e2e: accept options in NavigatorFixture.waitForPathname

### DIFF
--- a/web/e2e/fixtures/NavigatorFixture.ts
+++ b/web/e2e/fixtures/NavigatorFixture.ts
@@ -31,12 +31,15 @@ export class NavigatorFixture extends PageFixture {
      *
      * @param to The pathname or URL to wait for.
      */
-    public waitForPathname = async (to: string | URL): Promise<void> => {
+    public waitForPathname = async (
+        to: string | URL,
+        options?: Parameters<Page["waitForURL"]>[1],
+    ): Promise<void> => {
         const expectedPathname = typeof to === "string" ? to : to.pathname;
 
         this.logger.info(`Waiting for URL to change to ${expectedPathname}`);
 
-        await this.page.waitForURL(`**${expectedPathname}**`);
+        await this.page.waitForURL(`**${expectedPathname}**`, options);
 
         this.logger.info(`URL changed to ${this.page.url()}`);
     };


### PR DESCRIPTION
## Summary
- Forwards an optional `options` parameter from `NavigatorFixture.waitForPathname` to Playwright's `waitForURL`, allowing callers to configure timeout, wait-until strategy, etc.

## Test plan
- [ ] Existing e2e tests pass unchanged (the new parameter is optional with no default change)
*Split from #21206 to ease review.*