### PR TITLE
web/elements: add viewport helpers and extend intersection observer

### DIFF
--- a/web/src/elements/decorators/intersection-observer.ts
+++ b/web/src/elements/decorators/intersection-observer.ts
@@ -2,6 +2,8 @@
  * @file Intersection Observer Decorator for LitElement
  */
 
+import { findNearestBoxTarget, isInViewport } from "#elements/utils/viewport";
+
 import { LitElement } from "lit";
 import { property } from "lit/decorators.js";
 
@@ -9,6 +11,17 @@ import { property } from "lit/decorators.js";
  * Type for the decorator
  */
 export type IntersectionDecorator = <T extends LitElement>(target: T, propertyKey: keyof T) => void;
+
+export interface LitElementWithDisplayBox extends LitElement {
+    displayBox?: "contents" | "block";
+}
+
+export interface IntersectionObserverDecoratorInit extends IntersectionObserverInit {
+    /**
+     * Whether to ascend the DOM tree to find a parent with a layout box (i.e. non "display: contents") and use that as the target for intersection checking.
+     */
+    useAncestorBox?: boolean;
+}
 
 /**
  * A decorator that applies an IntersectionObserver to the element.
@@ -36,21 +49,48 @@ export type IntersectionDecorator = <T extends LitElement>(target: T, propertyKe
  *     }
  * }
  * ```
+ *
+ * @attr display-box If set to "contents", the element will be considered intersecting.
  */
-export function intersectionObserver(init: IntersectionObserverInit = {}): IntersectionDecorator {
-    return <T extends LitElement, K extends keyof T>(target: T, key: K) => {
+export function intersectionObserver({
+    useAncestorBox: initialUseAncestorBox = false,
+    ...init
+}: IntersectionObserverDecoratorInit = {}): IntersectionDecorator {
+    return <T extends LitElementWithDisplayBox, K extends keyof T>(target: T, key: K) => {
         //#region Prepare observer
 
+        let useAncestorBox = initialUseAncestorBox;
+
         property({ attribute: false, useDefault: false })(target, key);
+
+        const boxTargets = new WeakMap<T, Element>();
+
+        function findAndCacheBoxTarget(instance: T): Element {
+            let boxTarget = boxTargets.get(instance);
+
+            if (!boxTarget) {
+                boxTarget = findNearestBoxTarget(instance);
+                boxTargets.set(instance, boxTarget);
+            }
+
+            return boxTarget;
+        }
 
         const observerCallback: IntersectionObserverCallback = (entries) => {
             for (const entry of entries) {
                 const currentTarget = entry.target as T;
+                let intersecting = entry.isIntersecting;
+
+                if (!intersecting && useAncestorBox) {
+                    const boxTarget = findAndCacheBoxTarget(currentTarget);
+                    intersecting = isInViewport(boxTarget);
+                }
+
                 const cachedIntersecting = currentTarget[key];
 
-                if (cachedIntersecting !== entry.isIntersecting) {
+                if (cachedIntersecting !== intersecting) {
                     Object.assign(currentTarget, {
-                        [key]: entry.isIntersecting,
+                        [key]: intersecting,
                     });
 
                     currentTarget.requestUpdate(key, cachedIntersecting);
@@ -74,6 +114,8 @@ export function intersectionObserver(init: IntersectionObserverInit = {}): Inter
         target.connectedCallback = function connectedCallbackWrapper(this: T) {
             connectedCallback?.call(this);
 
+            useAncestorBox = this.displayBox === "contents" || initialUseAncestorBox;
+
             if (this.hasUpdated) {
                 observer.observe(this);
             } else {
@@ -83,7 +125,9 @@ export function intersectionObserver(init: IntersectionObserverInit = {}): Inter
             }
         };
 
-        target.disconnectedCallback = function disconnectedCallbackWrapper(this: LitElement) {
+        target.disconnectedCallback = function disconnectedCallbackWrapper(
+            this: LitElementWithDisplayBox,
+        ) {
             disconnectedCallback?.call(this);
 
             if (observer) {

--- a/web/src/elements/utils/viewport.ts
+++ b/web/src/elements/utils/viewport.ts
@@ -1,0 +1,22 @@
+export function findNearestBoxTarget(element?: Element | null): Element {
+    if (!element) {
+        return document.documentElement;
+    }
+
+    if (element.getClientRects().length) {
+        return element;
+    }
+
+    return findNearestBoxTarget(element.parentElement);
+}
+
+export function isInViewport(element: Element): boolean {
+    const rect = element.getBoundingClientRect();
+
+    return (
+        rect.top < window.innerHeight &&
+        rect.bottom > 0 &&
+        rect.left < window.innerWidth &&
+        rect.right > 0
+    );
+}


### PR DESCRIPTION
## Summary
- Add `elements/utils/viewport.ts` with `findNearestBoxTarget` and `isInViewport` helpers for elements that render with `display: contents`
- Extend the `@intersectionObserver` decorator with an opt-in `useAncestorBox` mode that walks the DOM to find a parent with an actual layout box, fixing false-negative visibility for `display: contents` hosts

## Test plan
- [ ] Existing `@intersectionObserver()` call sites (Tabs, Table, ak-timestamp, FlowExecutor, LibraryPage) continue to work — the new parameter defaults to `false`
- [ ] Verify `display: contents` elements report correct intersection when `useAncestorBox` is enabled
*Split from #21206 to ease review.*