### PR TITLE
web/elements: default @listen target to host element and add split-button Dropdown

### DIFF
--- a/web/src/admin/ak-interface-admin.ts
+++ b/web/src/admin/ak-interface-admin.ts
@@ -108,13 +108,13 @@ export class AdminInterface extends WithCapabilitiesConfig(
     @state()
     protected drawer: DrawerState = readDrawerParams();
 
-    @listen(AKDrawerChangeEvent)
+    @listen(AKDrawerChangeEvent, { target: window })
     protected drawerListener = (event: AKDrawerChangeEvent) => {
         this.drawer = event.drawer;
         persistDrawerParams(event.drawer);
     };
 
-    @listen(LOCALE_STATUS_EVENT)
+    @listen(LOCALE_STATUS_EVENT, { target: window })
     localeStatusListener = (event: CustomEvent<LocaleStatusEventDetail>) => {
         if (event.detail.status === "ready") {
             this.synchronizeSidebarEntries();

--- a/web/src/elements/buttons/Dropdown.ts
+++ b/web/src/elements/buttons/Dropdown.ts
@@ -9,6 +9,9 @@ import { customElement } from "lit/decorators.js";
 
 @customElement("ak-dropdown")
 export class DropdownButton extends AKElement {
+    public static SplitButtonSelector = `.pf-c-dropdown__toggle.pf-m-split-button .pf-c-dropdown__toggle-button:last-child`;
+    public static ToggleButtonSelector = `.pf-c-dropdown__toggle:not(.pf-m-split-button)`;
+
     public static override shadowRootOptions: ShadowRootInit = {
         ...AKElement.shadowRootOptions,
         delegatesFocus: true,
@@ -18,38 +21,40 @@ export class DropdownButton extends AKElement {
         return this;
     }
 
-    #menu: HTMLMenuElement | null = null;
-    #toggleButton: HTMLButtonElement | null = null;
-    #abortController: AbortController | null = null;
+    protected menu: HTMLMenuElement | null = null;
+    protected toggleButton: HTMLButtonElement | null = null;
+    protected abortController: AbortController | null = null;
 
     protected logger = ConsoleLogger.prefix("dropdown");
 
-    @listen(AKRefreshEvent)
+    @listen(AKRefreshEvent, {
+        target: window,
+    })
     public hide = (): void => {
-        if (!this.#menu || !this.#toggleButton) return;
+        if (!this.menu || !this.toggleButton) return;
 
-        this.#menu.hidden = true;
-        this.#toggleButton.ariaExpanded = "false";
+        this.menu.hidden = true;
+        this.toggleButton.ariaExpanded = "false";
     };
 
     public toggleMenu = (event: MouseEvent): void => {
-        if (!this.#menu) return;
+        if (!this.menu) return;
 
         const button = event.currentTarget as HTMLButtonElement;
 
-        this.#menu.hidden = !this.#menu.hidden;
-        button.ariaExpanded = this.#menu.hidden.toString();
+        this.menu.hidden = !this.menu.hidden;
+        button.ariaExpanded = this.menu.hidden.toString();
 
         event.stopPropagation();
     };
 
     @listen("click", {
-        passive: true,
+        target: window,
     })
     protected clickHandler = (event: Event): void => {
-        if (!this.#menu) return;
+        if (!this.menu) return;
 
-        if (this.#menu.hidden) {
+        if (this.menu.hidden) {
             return;
         }
 
@@ -58,11 +63,8 @@ export class DropdownButton extends AKElement {
         }
 
         const target = event.target as HTMLElement;
-        if (this.#menu.contains(target)) {
-            return;
-        }
-        const toggle = this.querySelector<HTMLElement>("button.pf-c-dropdown__toggle");
-        if (toggle && toggle.contains(target)) {
+
+        if (this.menu.contains(target)) {
             return;
         }
 
@@ -72,45 +74,45 @@ export class DropdownButton extends AKElement {
     public override connectedCallback() {
         super.connectedCallback();
 
-        this.#abortController = new AbortController();
+        this.abortController = new AbortController();
 
-        this.#menu = this.querySelector<HTMLMenuElement>("menu.pf-c-dropdown__menu");
+        this.menu = this.querySelector<HTMLMenuElement>("menu.pf-c-dropdown__menu");
 
-        if (!this.#menu) {
+        if (!this.menu) {
             this.logger.warn("No menu found");
             return;
         }
 
-        this.#toggleButton = this.querySelector<HTMLButtonElement>("button.pf-c-dropdown__toggle");
+        this.toggleButton =
+            this.querySelector(DropdownButton.SplitButtonSelector) ||
+            this.querySelector(DropdownButton.ToggleButtonSelector);
 
-        if (!this.#toggleButton) {
+        if (!this.toggleButton) {
             this.logger.warn("No toggle button found");
             return;
         }
 
-        this.#menu.hidden = true;
-        this.#toggleButton.ariaExpanded = "false";
+        this.menu.hidden = true;
+        this.toggleButton.ariaExpanded = "false";
 
-        this.#toggleButton.addEventListener("click", this.toggleMenu, {
+        this.toggleButton.addEventListener("click", this.toggleMenu, {
             capture: true,
-            signal: this.#abortController.signal,
+            signal: this.abortController.signal,
         });
 
-        // TODO: Enable this after native <dialog> modals are used.
-        // If enabled now, this would close the modal since it's technically within the dropdown.
-        // const menuItemButtons = this.querySelectorAll<HTMLElement>(".pf-c-dropdown__menu-item");
+        const menuItemButtons = this.querySelectorAll<HTMLElement>(".pf-c-dropdown__menu-item");
 
-        // for (const menuItemButton of menuItemButtons) {
-        //     menuItemButton.addEventListener("click", this.hide, {
-        //         capture: true,
-        //         signal: this.#abortController.signal,
-        //     });
-        // }
+        for (const menuItemButton of menuItemButtons) {
+            menuItemButton.addEventListener("click", this.hide, {
+                capture: true,
+                signal: this.abortController.signal,
+            });
+        }
     }
 
     public override disconnectedCallback(): void {
         super.disconnectedCallback();
-        this.#abortController?.abort();
+        this.abortController?.abort();
     }
 }
 

--- a/web/src/elements/decorators/intersection-observer.ts
+++ b/web/src/elements/decorators/intersection-observer.ts
@@ -4,7 +4,7 @@
 
 import { findNearestBoxTarget, isInViewport } from "#elements/utils/viewport";
 
-import { LitElement } from "lit";
+import { LitElement, PropertyValues } from "lit";
 import { property } from "lit/decorators.js";
 
 /**
@@ -109,31 +109,51 @@ export function intersectionObserver({
             ...init,
         });
 
-        const { connectedCallback, disconnectedCallback } = target;
+        const synchronizeUseAncestorBox = (nextDisplayBox?: "contents" | "block") => {
+            useAncestorBox = nextDisplayBox === "contents" || initialUseAncestorBox;
+        };
 
-        target.connectedCallback = function connectedCallbackWrapper(this: T) {
-            connectedCallback?.call(this);
+        /**
+         * Applies the necessary lifecycle callback with access to protected properties of the target class.
+         */
+        function applyLifecycleCallbacks(this: T) {
+            const { connectedCallback, disconnectedCallback, updated } = this;
 
-            useAncestorBox = this.displayBox === "contents" || initialUseAncestorBox;
+            this.connectedCallback = function connectedCallbackWrapper(this: T) {
+                connectedCallback?.call(this);
 
-            if (this.hasUpdated) {
-                observer.observe(this);
-            } else {
-                this.updateComplete.then(() => {
+                synchronizeUseAncestorBox(this.displayBox);
+
+                if (this.hasUpdated) {
                     observer.observe(this);
-                });
-            }
-        };
+                } else {
+                    this.updateComplete.then(() => {
+                        observer.observe(this);
+                    });
+                }
+            };
 
-        target.disconnectedCallback = function disconnectedCallbackWrapper(
-            this: LitElementWithDisplayBox,
-        ) {
-            disconnectedCallback?.call(this);
+            this.disconnectedCallback = function disconnectedCallbackWrapper(
+                this: LitElementWithDisplayBox,
+            ) {
+                disconnectedCallback?.call(this);
 
-            if (observer) {
-                observer.disconnect();
-            }
-        };
+                if (observer) {
+                    observer.disconnect();
+                }
+            };
+
+            this.updated = function updatedWrapper(this: T, changedProperties: PropertyValues<T>) {
+                updated?.call(this, changedProperties);
+
+                if (changedProperties.has("displayBox")) {
+                    synchronizeUseAncestorBox(this.displayBox);
+                }
+            };
+        }
+
+        applyLifecycleCallbacks.call(target);
+
         //#endregion
     };
 }

--- a/web/src/elements/decorators/listen.ts
+++ b/web/src/elements/decorators/listen.ts
@@ -18,7 +18,7 @@ export interface ListenDecoratorOptions extends AddEventListenerOptions {
      *
      * @default window
      */
-    target?: EventTarget | null;
+    target?: EventTarget;
 }
 
 /**
@@ -88,7 +88,7 @@ function registerEventCallbacks<T extends ListenerMixin>(target: T): ListenDecor
 
         // Register all listeners
         for (const [propKey, eventType] of propToEventName) {
-            const { target: eventTarget = window, ...options } = propToOptions.get(propKey) || {};
+            const { target: eventTarget = this, ...options } = propToOptions.get(propKey) || {};
             const listener = this[propKey as keyof T];
 
             if (!listener) {
@@ -105,7 +105,7 @@ function registerEventCallbacks<T extends ListenerMixin>(target: T): ListenDecor
                 );
             }
 
-            (eventTarget || this).addEventListener(eventType, listener, {
+            eventTarget.addEventListener(eventType, listener, {
                 passive: true,
                 ...options,
                 signal: abortController.signal,

--- a/web/src/elements/forms/ModelForm.ts
+++ b/web/src/elements/forms/ModelForm.ts
@@ -104,7 +104,7 @@ export abstract class ModelForm<
     }
 
     @listen(AKRefreshEvent, {
-        target: null,
+        target: window,
     })
     protected refresh = async () => {
         await new Promise((resolve) => requestAnimationFrame(resolve));

--- a/web/src/elements/notifications/APIDrawer.ts
+++ b/web/src/elements/notifications/APIDrawer.ts
@@ -78,7 +78,7 @@ export class APIDrawer extends AKElement {
         `,
     ];
 
-    @listen(AKRequestPostEvent)
+    @listen(AKRequestPostEvent, { target: window })
     protected enqueueRequest = ({ requestInfo }: AKRequestPostEvent) => {
         this.requests.push(requestInfo);
 

--- a/web/src/elements/sidebar/SidebarItem.ts
+++ b/web/src/elements/sidebar/SidebarItem.ts
@@ -110,7 +110,7 @@ export class SidebarItem extends WithCapabilitiesConfig(WithLicenseSummary(AKEle
         this.#scrollBehavior ??= "smooth";
     };
 
-    @listen("hashchange")
+    @listen("hashchange", { target: window })
     public synchronize = (): void => {
         const activePath = window.location.hash.slice(1).split(ROUTE_SEPARATOR)[0];
         this.childItems.forEach((item) => {

--- a/web/src/flow/FlowExecutor.ts
+++ b/web/src/flow/FlowExecutor.ts
@@ -194,7 +194,7 @@ export class FlowExecutor extends WithBrandConfig(Interface) implements StageHos
 
     //#region Listeners
 
-    @listen(AKSessionAuthenticatedEvent)
+    @listen(AKSessionAuthenticatedEvent, { target: window })
     protected sessionAuthenticatedListener = () => {
         if (!document.hidden) {
             return;

--- a/web/src/styles/authentik/components/Dropdown/dropdown.css
+++ b/web/src/styles/authentik/components/Dropdown/dropdown.css
@@ -1,3 +1,16 @@
+.pf-c-dropdown {
+    --pf-c-dropdown__toggle--PaddingLeft: var(--pf-global--spacer--md);
+    --pf-c-dropdown__toggle--m-split-button--first-child--PaddingLeft: var(--pf-global--spacer--md);
+    --pf-c-dropdown__toggle--m-split-button--m-action--child--PaddingRight: var(
+        --pf-global--spacer--md
+    );
+
+    --pf-c-dropdown__toggle--m-split-button--last-child--PaddingRight: var(--pf-global--spacer--md);
+    --pf-c-dropdown__toggle--m-split-button--m-action--child--PaddingLeft: var(
+        --pf-global--spacer--md
+    );
+}
+
 .pf-c-dropdown__menu-item[role="contentinfo"] {
     &,
     &:hover,


### PR DESCRIPTION
## Summary
- Change the `@listen` decorator default target from `window` to `this` — host-scoped listeners are the more common case for Lit components
- Add explicit `target: window` to the five existing call sites that dispatch on the window (`ak-interface-admin`, `APIDrawer`, `SidebarItem`, `FlowExecutor`, and Dropdown's own refresh listener)
- Add split-button support to the Dropdown component with `SplitButtonSelector` / `ToggleButtonSelector` statics and corresponding CSS padding variables

## Test plan
- [ ] Verify admin drawer toggle, locale status, API drawer, sidebar hash navigation, and flow session authentication listeners still fire correctly
- [ ] Verify dropdown menus open/close as before
- [ ] Test split-button dropdown rendering (if any admin pages use it)
*Split from #21206 to ease review.*