### PR TITLE
core: add logging when session decode fails

### DIFF
--- a/authentik/core/sessions.py
+++ b/authentik/core/sessions.py
@@ -66,7 +66,7 @@ class SessionStore(SessionBase):
     def decode(self, session_data):
         try:
             return pickle.loads(session_data)  # nosec
-        except (pickle.PickleError, AttributeError, TypeError):
+        except pickle.PickleError, AttributeError, TypeError:
             # PickleError, ValueError - unpickling exceptions
             # AttributeError - can happen when Django model fields (e.g., FileField) are unpickled
             #                  and their descriptors fail to initialize (e.g., missing storage)

--- a/authentik/core/sessions.py
+++ b/authentik/core/sessions.py
@@ -66,12 +66,13 @@ class SessionStore(SessionBase):
     def decode(self, session_data):
         try:
             return pickle.loads(session_data)  # nosec
-        except pickle.PickleError, AttributeError, TypeError:
+        except (pickle.PickleError, AttributeError, TypeError):
             # PickleError, ValueError - unpickling exceptions
             # AttributeError - can happen when Django model fields (e.g., FileField) are unpickled
             #                  and their descriptors fail to initialize (e.g., missing storage)
             # TypeError - can happen with incompatible pickled objects
             # If any of these happen, just return an empty dictionary (an empty session)
+            LOGGER.warning("Failed to decode session data", exc_info=True)
             pass
         return {}
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
When a session decode fails it doesn't log any message making the debug harder. This PR improves logging when the decode fails.
---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
