### PR TITLE
fix(oauth2): replace Python 2 comma-exception syntax with Python 3 form in token endpoint

### DIFF
--- a/authentik/providers/oauth2/views/token.py
+++ b/authentik/providers/oauth2/views/token.py
@@ -333,7 +333,7 @@ class TokenParams:
         try:
             user, _, password = b64decode(self.client_secret).decode("utf-8").partition(":")
             return self.__post_init_client_credentials_creds(request, user, password)
-        except ValueError, Error:
+        except ValueError:
             raise TokenError("invalid_grant") from None
 
     def __post_init_client_credentials_creds(


### PR DESCRIPTION
## Summary

- `authentik/providers/oauth2/views/token.py` line 336 had `except ValueError, Error:` — Python 2 syntax that is a parse-time `SyntaxError` in Python 3, making the entire module unimportable
- Replace with `except ValueError:` (the `Error` name was not defined anywhere in the file, so `ValueError`-only is the correct intent)

## Test plan

- [ ] `python3 -c "import authentik.providers.oauth2.views.token"` — should import without error after this fix
- [ ] OAuth2 `client_credentials` grant with base64-encoded `username:password` as `client_secret` should raise `TokenError("invalid_grant")` on b64decode failure instead of crashing at import time
- [ ] All other grant types (authorization_code, refresh_token, device_code) unaffected

Fixes #21547

🤖 Generated with [Claude Code](https://claude.com/claude-code)