### PR TITLE
core: refresh signed media URLs in flows

### DIFF
--- a/authentik/admin/files/backends/base.py
+++ b/authentik/admin/files/backends/base.py
@@ -106,6 +106,7 @@ class Backend:
         self,
         name: str,
         request: HttpRequest | None = None,
+        use_cache: bool = True,
     ) -> dict[str, str] | None:
         """
         Get URLs for each theme variant when filename contains %(theme)s.
@@ -121,7 +122,7 @@ class Backend:
             return None
 
         return {
-            theme: self.file_url(substitute_theme(name, theme), request, use_cache=True)
+            theme: self.file_url(substitute_theme(name, theme), request, use_cache=use_cache)
             for theme in get_valid_themes()
         }
 

--- a/authentik/admin/files/backends/passthrough.py
+++ b/authentik/admin/files/backends/passthrough.py
@@ -51,6 +51,7 @@ class PassthroughBackend(Backend):
         self,
         name: str,
         request: HttpRequest | None = None,
+        use_cache: bool = True,
     ) -> dict[str, str] | None:
         """Support themed URLs for external URLs with %(theme)s placeholder.
 

--- a/authentik/admin/files/manager.py
+++ b/authentik/admin/files/manager.py
@@ -74,6 +74,10 @@ class FileManager:
     ) -> str:
         """
         Get URL for accessing the file.
+
+        Set ``use_cache=False`` when the caller needs a fresh signed URL instead
+        of a cached one, for example when serializing flow/login payloads that
+        may be refreshed after the previous JWT has expired.
         """
         if not name:
             return ""
@@ -83,7 +87,7 @@ class FileManager:
 
         for backend in self.backends:
             if backend.supports_file(name):
-                return backend.file_url(name, request)
+                return backend.file_url(name, request, use_cache=use_cache)
 
         LOGGER.warning(f"Could not find file backend for file: {name}")
         return ""
@@ -92,9 +96,13 @@ class FileManager:
         self,
         name: str | None,
         request: HttpRequest | Request | None = None,
+        use_cache: bool = True,
     ) -> dict[str, str] | None:
         """
         Get URLs for each theme variant when filename contains %(theme)s.
+
+        ``use_cache`` has the same semantics as ``file_url()`` and allows
+        callers to force regeneration of expiring signed URLs.
 
         Returns dict mapping theme to URL if %(theme)s present, None otherwise.
         """
@@ -106,7 +114,7 @@ class FileManager:
 
         for backend in self.backends:
             if backend.supports_file(name):
-                return backend.themed_urls(name, request)
+                return backend.themed_urls(name, request, use_cache=use_cache)
 
         return None
 

--- a/authentik/admin/files/tests/test_manager.py
+++ b/authentik/admin/files/tests/test_manager.py
@@ -1,6 +1,7 @@
 """Test file service layer"""
 
 from unittest import skipUnless
+from unittest.mock import Mock
 from urllib.parse import urlparse
 
 from django.http import HttpRequest
@@ -52,6 +53,19 @@ class TestResolveFileUrlBasic(TestCase):
         manager = FileManager(FileUsage.MEDIA)
         result = manager.file_url("/static/authentik/sources/icon.svg")
         self.assertEqual(result, "/static/authentik/sources/icon.svg")
+
+    def test_file_url_forwards_use_cache(self):
+        """Test file_url forwards use_cache to backend."""
+        manager = FileManager(FileUsage.MEDIA)
+        backend = Mock()
+        backend.supports_file.return_value = True
+        backend.file_url.return_value = "/files/media/public/test.png?token=fresh"
+        manager.backends = [backend]
+
+        result = manager.file_url("test.png", use_cache=False)
+
+        self.assertEqual(result, "/files/media/public/test.png?token=fresh")
+        backend.file_url.assert_called_once_with("test.png", None, use_cache=False)
 
 
 class TestResolveFileUrlFileBackend(FileTestFileBackendMixin, TestCase):

--- a/authentik/brands/models.py
+++ b/authentik/brands/models.py
@@ -101,13 +101,23 @@ class Brand(SerializerModel):
         """Get themed URLs for branding_favicon if it contains %(theme)s"""
         return get_file_manager(FileUsage.MEDIA).themed_urls(self.branding_favicon)
 
-    def branding_default_flow_background_url(self) -> str:
+    def branding_default_flow_background_url(self, request=None, use_cache: bool = True) -> str:
         """Get branding_default_flow_background URL"""
-        return get_file_manager(FileUsage.MEDIA).file_url(self.branding_default_flow_background)
+        return get_file_manager(FileUsage.MEDIA).file_url(
+            self.branding_default_flow_background,
+            request,
+            use_cache=use_cache,
+        )
 
-    def branding_default_flow_background_themed_urls(self) -> dict[str, str] | None:
+    def branding_default_flow_background_themed_urls(
+        self, request=None, use_cache: bool = True
+    ) -> dict[str, str] | None:
         """Get themed URLs for branding_default_flow_background if it contains %(theme)s"""
-        return get_file_manager(FileUsage.MEDIA).themed_urls(self.branding_default_flow_background)
+        return get_file_manager(FileUsage.MEDIA).themed_urls(
+            self.branding_default_flow_background,
+            request,
+            use_cache=use_cache,
+        )
 
     @property
     def serializer(self) -> type[Serializer]:

--- a/authentik/core/models.py
+++ b/authentik/core/models.py
@@ -951,21 +951,34 @@ class Source(ManagedModel, SerializerModel, PolicyBindingModel):
 
     objects = InheritanceManager()
 
+    def get_icon_url(self, request=None, use_cache: bool = True) -> str | None:
+        """Get the URL to the source icon."""
+        if not self.icon:
+            return None
+        return get_file_manager(FileUsage.MEDIA).file_url(self.icon, request, use_cache=use_cache)
+
     @property
     def icon_url(self) -> str | None:
         """Get the URL to the source icon"""
+        return self.get_icon_url()
+
+    def get_icon_themed_urls(
+        self,
+        request=None,
+        use_cache: bool = True,
+    ) -> dict[str, str] | None:
+        """Get themed URLs for icon if it contains %(theme)s."""
         if not self.icon:
             return None
-
-        return get_file_manager(FileUsage.MEDIA).file_url(self.icon)
+        return get_file_manager(FileUsage.MEDIA).themed_urls(
+            self.icon,
+            request,
+            use_cache=use_cache,
+        )
 
     @property
     def icon_themed_urls(self) -> dict[str, str] | None:
-        """Get themed URLs for icon if it contains %(theme)s"""
-        if not self.icon:
-            return None
-
-        return get_file_manager(FileUsage.MEDIA).themed_urls(self.icon)
+        return self.get_icon_themed_urls()
 
     def get_user_path(self) -> str:
         """Get user path, fallback to default for formatting errors"""

--- a/authentik/core/tests/test_models.py
+++ b/authentik/core/tests/test_models.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from datetime import timedelta
+from unittest.mock import patch
 
 from django.test import RequestFactory, TestCase
 from django.utils.timezone import now
@@ -10,6 +11,7 @@ from guardian.shortcuts import get_anonymous_user
 
 from authentik.core.models import Provider, Source, Token
 from authentik.events.models import Event, EventAction
+from authentik.flows.models import Flow
 from authentik.lib.generators import generate_id
 from authentik.lib.utils.reflection import all_subclasses
 
@@ -45,6 +47,58 @@ class TestModels(TestCase):
         self.assertIsNotNone(event)
         self.assertEqual(
             event.context["deprecation"], "authentik.core.models.Token.filter_not_expired"
+        )
+
+    @patch("authentik.core.models.get_file_manager")
+    def test_source_icon_url_can_bypass_cache(self, get_file_manager):
+        request = RequestFactory().get("/")
+        manager = get_file_manager.return_value
+        manager.file_url.return_value = "/files/media/public/source-icons/icon.svg?token=fresh"
+
+        source = Source(icon="source-icons/icon.svg")
+
+        self.assertEqual(
+            source.get_icon_url(request, use_cache=False),
+            "/files/media/public/source-icons/icon.svg?token=fresh",
+        )
+        manager.file_url.assert_called_once_with(
+            "source-icons/icon.svg",
+            request,
+            use_cache=False,
+        )
+
+    @patch("authentik.flows.models.get_file_manager")
+    def test_flow_background_urls_can_bypass_cache(self, get_file_manager):
+        request = RequestFactory().get("/")
+        manager = get_file_manager.return_value
+        manager.file_url.return_value = "/files/media/public/background.svg?token=fresh"
+        manager.themed_urls.return_value = {
+            "light": "/files/media/public/background-light.svg?token=fresh",
+            "dark": "/files/media/public/background-dark.svg?token=fresh",
+        }
+
+        flow = Flow(background="background-%(theme)s.svg")
+
+        self.assertEqual(
+            flow.background_url(request, use_cache=False),
+            "/files/media/public/background.svg?token=fresh",
+        )
+        self.assertEqual(
+            flow.background_themed_urls(request, use_cache=False),
+            {
+                "light": "/files/media/public/background-light.svg?token=fresh",
+                "dark": "/files/media/public/background-dark.svg?token=fresh",
+            },
+        )
+        manager.file_url.assert_called_once_with(
+            "background-%(theme)s.svg",
+            request,
+            use_cache=False,
+        )
+        manager.themed_urls.assert_called_once_with(
+            "background-%(theme)s.svg",
+            request,
+            use_cache=False,
         )
 
 

--- a/authentik/flows/models.py
+++ b/authentik/flows/models.py
@@ -185,25 +185,47 @@ class Flow(SerializerModel, PolicyBindingModel):
         help_text=_("Required level of authentication and authorization to access a flow."),
     )
 
-    def background_url(self, request: HttpRequest | None = None) -> str:
+    def background_url(
+        self,
+        request: HttpRequest | None = None,
+        use_cache: bool = True,
+    ) -> str:
         """Get the URL to the background image"""
         if not self.background:
             if request:
-                return request.brand.branding_default_flow_background_url()
+                return request.brand.branding_default_flow_background_url(
+                    request,
+                    use_cache=use_cache,
+                )
             return (
                 CONFIG.get("web.path", "/")[:-1] + "/static/dist/assets/images/flow_background.jpg"
             )
 
-        return get_file_manager(FileUsage.MEDIA).file_url(self.background, request)
+        return get_file_manager(FileUsage.MEDIA).file_url(
+            self.background,
+            request,
+            use_cache=use_cache,
+        )
 
-    def background_themed_urls(self, request: HttpRequest | None = None) -> dict[str, str] | None:
+    def background_themed_urls(
+        self,
+        request: HttpRequest | None = None,
+        use_cache: bool = True,
+    ) -> dict[str, str] | None:
         """Get themed URLs for background if it contains %(theme)s"""
         if not self.background:
             if request:
-                return request.brand.branding_default_flow_background_themed_urls()
+                return request.brand.branding_default_flow_background_themed_urls(
+                    request,
+                    use_cache=use_cache,
+                )
             return None
 
-        return get_file_manager(FileUsage.MEDIA).themed_urls(self.background, request)
+        return get_file_manager(FileUsage.MEDIA).themed_urls(
+            self.background,
+            request,
+            use_cache=use_cache,
+        )
 
     stages = models.ManyToManyField(Stage, through="FlowStageBinding", blank=True)
 

--- a/authentik/flows/stage.py
+++ b/authentik/flows/stage.py
@@ -194,12 +194,14 @@ class ChallengeStageView(StageView):
             if not hasattr(challenge, "initial_data"):
                 challenge.initial_data = {}
             if "flow_info" not in challenge.initial_data:
+                # Flow payloads can outlive the previous signed media JWT, so
+                # refreshes must mint fresh URLs instead of reusing cached ones.
                 flow_info = ContextualFlowInfo(
                     data={
                         "title": self.format_title(),
-                        "background": self.executor.flow.background_url(self.request),
+                        "background": self.executor.flow.background_url(use_cache=False),
                         "background_themed_urls": self.executor.flow.background_themed_urls(
-                            self.request
+                            use_cache=False,
                         ),
                         "cancel_url": self.cancel_url,
                         "layout": self.executor.flow.layout,

--- a/authentik/flows/tests/test_inspector.py
+++ b/authentik/flows/tests/test_inspector.py
@@ -33,7 +33,7 @@ class TestFlowInspector(APITestCase):
         FlowStageBinding.objects.create(
             target=flow,
             stage=ident_stage,
-            order=1,
+            order=0,
             invalid_response_action=InvalidResponseAction.RESTART_WITH_CONTEXT,
         )
         dummy_stage = DummyStage.objects.create(name=generate_id())

--- a/authentik/flows/tests/test_stage_views.py
+++ b/authentik/flows/tests/test_stage_views.py
@@ -4,9 +4,14 @@ from collections.abc import Callable
 
 from django.test import RequestFactory, TestCase
 
+from authentik.core.tests.utils import RequestFactory as AuthentikRequestFactory
+from authentik.core.tests.utils import create_test_flow
+from authentik.flows.models import FlowStageBinding
 from authentik.flows.stage import StageView
 from authentik.flows.views.executor import FlowExecutorView
 from authentik.lib.utils.reflection import all_subclasses
+from authentik.stages.dummy.models import DummyStage
+from authentik.stages.dummy.stage import DummyStageView
 
 
 class TestViews(TestCase):
@@ -15,6 +20,27 @@ class TestViews(TestCase):
     def setUp(self) -> None:
         self.factory = RequestFactory()
         self.exec = FlowExecutorView(request=self.factory.get("/"))
+        self.authentik_factory = AuthentikRequestFactory()
+
+    def test_challenge_stage_flow_info_uses_relative_background(self):
+        """Test challenge flow info keeps background URLs app-relative."""
+        flow = create_test_flow()
+        stage = DummyStage.objects.create(name="dummy")
+        FlowStageBinding.objects.create(target=flow, stage=stage, order=0)
+        request = self.authentik_factory.get("/")
+
+        executor = FlowExecutorView(flow=flow, request=request)
+        executor.current_stage = stage
+
+        view = DummyStageView(executor)
+        view.request = request
+
+        challenge = view._get_challenge()
+
+        self.assertEqual(
+            challenge.initial_data["flow_info"]["background"],
+            "/static/dist/assets/images/flow_background.jpg",
+        )
 
 
 def view_tester_factory(view_class: type[StageView]) -> Callable:

--- a/authentik/sources/kerberos/models.py
+++ b/authentik/sources/kerberos/models.py
@@ -168,7 +168,7 @@ class KerberosSource(IncomingSyncSource):
                 }
             ),
             name=self.name,
-            icon_url=self.icon_url,
+            icon_url=self.get_icon_url(request, use_cache=False) or self.icon_url,
             promoted=self.promoted,
         )
 

--- a/authentik/sources/oauth/models.py
+++ b/authentik/sources/oauth/models.py
@@ -136,7 +136,7 @@ class OAuthSource(NonCreatableType, Source):
         return UILoginButton(
             name=self.name,
             challenge=provider.login_challenge(self, request),
-            icon_url=self.icon_url,
+            icon_url=self.get_icon_url(request, use_cache=False) or self.icon_url,
             promoted=self.promoted,
         )
 

--- a/authentik/sources/plex/models.py
+++ b/authentik/sources/plex/models.py
@@ -116,7 +116,7 @@ class PlexSource(ScheduledModel, Source):
                     "slug": self.slug,
                 }
             ),
-            icon_url=self.icon_url,
+            icon_url=self.get_icon_url(request, use_cache=False) or self.icon_url,
             name=self.name,
             promoted=self.promoted,
         )

--- a/authentik/sources/saml/models.py
+++ b/authentik/sources/saml/models.py
@@ -284,7 +284,7 @@ class SAMLSource(Source):
                 }
             ),
             name=self.name,
-            icon_url=self.icon_url,
+            icon_url=self.get_icon_url(request, use_cache=False) or self.icon_url,
             promoted=self.promoted,
         )
 

--- a/authentik/sources/telegram/models.py
+++ b/authentik/sources/telegram/models.py
@@ -66,7 +66,7 @@ class TelegramSource(Source):
                 }
             ),
             name=self.name,
-            icon_url=self.icon_url,
+            icon_url=self.get_icon_url(request, use_cache=False) or self.icon_url,
             promoted=self.promoted,
         )
 


### PR DESCRIPTION
Flow and login payloads can outlive cached signed media URLs. Wire use_cache through the file manager and model helpers, then bypass cache when serializing flow backgrounds and source icons for executor views.

Add focused coverage for cache bypass and manager forwarding.
