### PR TITLE
website/docs: Update unique email expression policy to exclude current user

### DIFF
--- a/website/docs/customize/policies/expression/unique_email.md
+++ b/website/docs/customize/policies/expression/unique_email.md
@@ -10,12 +10,18 @@ The snippet below can be used in an expression policy within enrollment flows. T
 # Ensure this matches the *Field Key* value of the prompt
 field_name = "email"
 email = request.context["prompt_data"][field_name]
+
 pending_user = request.context.get("pending_user")
+current_user = getattr(request, "user", None)
 
 from authentik.core.models import User
+
 query = User.objects.filter(email__iexact=email)
+
 if pending_user:
     query = query.exclude(pk=pending_user.pk)
+elif current_user and current_user.is_authenticated:
+    query = query.exclude(pk=current_user.pk)
 
 if query.exists():
     ak_message("Email address in use")

--- a/website/docs/customize/policies/expression/unique_email.md
+++ b/website/docs/customize/policies/expression/unique_email.md
@@ -12,7 +12,6 @@ field_name = "email"
 email = request.context["prompt_data"][field_name]
 
 pending_user = request.context.get("pending_user")
-current_user = getattr(request, "user", None)
 
 from authentik.core.models import User
 
@@ -20,8 +19,8 @@ query = User.objects.filter(email__iexact=email)
 
 if pending_user:
     query = query.exclude(pk=pending_user.pk)
-elif current_user and current_user.is_authenticated:
-    query = query.exclude(pk=current_user.pk)
+elif request.user and request.user.is_authenticated:
+    query = query.exclude(pk=request.user.pk)
 
 if query.exists():
     ak_message("Email address in use")


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

I've extended the policy code to also exclude the current user if it exists.
This fixes an issue I had where a user cannot update anything on the user settings page because E-Mail validation would fail.

I've tested the code during enrollment and when updating user settings.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
