### PR TITLE
fix: handle Attr objects in config path navigation

### DIFF
--- a/authentik/lib/config.py
+++ b/authentik/lib/config.py
@@ -157,7 +157,10 @@ class ConfigLoader:
         """Recursively update dictionary"""
         for key, raw_value in updatee.items():
             if isinstance(raw_value, Mapping):
-                root[key] = self.update(root.get(key, {}), raw_value)
+                existing = root.get(key, {})
+                if isinstance(existing, Attr) and isinstance(existing.value, dict):
+                    existing = existing.value
+                root[key] = self.update(existing, raw_value)
             else:
                 if isinstance(raw_value, str):
                     value = self.parse_uri(raw_value)
@@ -172,7 +175,9 @@ class ConfigLoader:
 
     def refresh(self, key: str, default=None, sep=".") -> Any:
         """Update a single value"""
-        attr: Attr = get_path_from_dict(self.raw, key, sep=sep, default=Attr(default))
+        attr = get_path_from_dict(self.raw, key, sep=sep, default=Attr(default))
+        if not isinstance(attr, Attr):
+            return attr
         if attr.source_type != Attr.Source.URI:
             return attr.value
         attr.value = self.parse_uri(attr.source).value
@@ -257,8 +262,10 @@ class ConfigLoader:
         # Walk sub_dicts before parsing path
         root = self.raw
         # Walk each component of the path
-        attr: Attr = get_path_from_dict(root, path, sep=sep, default=Attr(default))
-        return attr.value
+        attr = get_path_from_dict(root, path, sep=sep, default=Attr(default))
+        if isinstance(attr, Attr):
+            return attr.value
+        return attr
 
     def get_int(self, path: str, default=0) -> int:
         """Wrapper for get that converts value into int"""
@@ -291,8 +298,12 @@ class ConfigLoader:
     def get_keys(self, path: str, sep=".") -> list[str]:
         """List attribute keys by using yaml path"""
         root = self.raw
-        attr: Attr = get_path_from_dict(root, path, sep=sep, default=Attr({}))
-        return attr.keys()
+        attr = get_path_from_dict(root, path, sep=sep, default=Attr({}))
+        if isinstance(attr, Attr) and isinstance(attr.value, dict):
+            return list(attr.value.keys())
+        if isinstance(attr, dict):
+            return list(attr.keys())
+        return []
 
     def get_dict_from_b64_json(self, path: str, default=None) -> dict:
         """Wrapper for get that converts value from Base64 encoded string into dictionary"""

--- a/authentik/lib/utils/dict.py
+++ b/authentik/lib/utils/dict.py
@@ -1,12 +1,24 @@
 from typing import Any
 
 
+def _unwrap_attr(obj):
+    """If obj is an Attr whose value is a dict, return the dict for path navigation.
+    This is needed because env vars with __ separators (e.g. AUTHENTIK_POSTGRESQL__HOST)
+    create nested config paths where intermediate nodes may be Attr objects wrapping dicts."""
+    from authentik.lib.config import Attr
+
+    if isinstance(obj, Attr) and isinstance(obj.value, dict):
+        return obj.value
+    return obj
+
+
 def get_path_from_dict(root: dict, path: str, sep=".", default=None) -> Any:
     """Recursively walk through `root`, checking each part of `path` separated by `sep`.
     If at any point a dict does not exist, return default"""
     walk: Any = root
     for comp in path.split(sep):
-        if walk and comp in walk:
+        walk = _unwrap_attr(walk)
+        if isinstance(walk, dict) and comp in walk:
             walk = walk.get(comp)
         else:
             return default
@@ -19,9 +31,11 @@ def set_path_in_dict(root: dict, path: str, value: Any, sep="."):
     # Walk each component of the path
     path_parts = path.split(sep)
     for comp in path_parts[:-1]:
+        root = _unwrap_attr(root)
         if comp not in root:
             root[comp] = {}
-        root = root.get(comp, {})
+        root = _unwrap_attr(root.get(comp, {}))
+    root = _unwrap_attr(root)
     root[path_parts[-1]] = value
 
 
@@ -31,9 +45,11 @@ def delete_path_in_dict(root: dict, path: str, sep="."):
     # Walk each component of the path
     path_parts = path.split(sep)
     for comp in path_parts[:-1]:
+        root = _unwrap_attr(root)
         if comp not in root:
             return
-        root = root.get(comp, {})
+        root = _unwrap_attr(root.get(comp, {}))
+    root = _unwrap_attr(root)
     last_path_part = path_parts[-1]
     if last_path_part in root:
         del root[last_path_part]


### PR DESCRIPTION
## Problem

When environment variables with `__` separators (e.g. `AUTHENTIK_POSTGRESQL__HOST`) are processed, they create nested config paths. If a YAML config file has already set a value at an intermediate path, that value is an `Attr` object. The path navigation functions then try to use dict operations on the `Attr` object, causing:

```
TypeError: 'Attr' object does not support item assignment
```

This affects Docker Swarm deployments where all config is passed via environment variables.

## Fix

- `dict.py`: Add `_unwrap_attr()` that extracts `.value` dict from `Attr` objects during path traversal
- `config.py`: Update `update()`, `get()`, `refresh()`, `get_keys()` to handle non-Attr results

Changes: +36 lines, -9 lines across 2 files.

## Testing

Tested on Docker Swarm 3-node cluster with env vars:
AUTHENTIK_POSTGRESQL__HOST, AUTHENTIK_POSTGRESQL__USER, AUTHENTIK_POSTGRESQL__NAME, AUTHENTIK_POSTGRESQL__PASSWORD, AUTHENTIK_REDIS__HOST, AUTHENTIK_SECRET_KEY

PostgreSQL 18 + Valkey 8.