### PR TITLE
High DB Load. Server and worker print loop "Found static bindings"

### DIFF
--- a/authentik/blueprints/apps.py
+++ b/authentik/blueprints/apps.py
@@ -3,7 +3,6 @@
 import traceback
 from collections.abc import Callable
 from importlib import import_module
-from inspect import ismethod
 
 from django.apps import AppConfig
 from django.conf import settings
@@ -72,12 +71,19 @@ class ManagedAppConfig(AppConfig):
 
     def _reconcile(self, prefix: str) -> None:
         for meth_name in dir(self):
-            meth = getattr(self, meth_name)
-            if not ismethod(meth):
+            # Check the attribute on the class to avoid evaluating @property descriptors.
+            # Using getattr(self, ...) on a @property would evaluate it, which can trigger
+            # expensive side effects (e.g. tenant_schedule_specs iterating all providers
+            # and running PolicyEngine queries for every user).
+            class_attr = getattr(type(self), meth_name, None)
+            if class_attr is None or isinstance(class_attr, property):
                 continue
-            category = getattr(meth, "_authentik_managed_reconcile", None)
+            if not callable(class_attr):
+                continue
+            category = getattr(class_attr, "_authentik_managed_reconcile", None)
             if category != prefix:
                 continue
+            meth = getattr(self, meth_name)
             name = meth_name.replace(prefix, "")
             try:
                 self.logger.debug("Starting reconciler", name=name)

--- a/authentik/lib/sync/outgoing/models.py
+++ b/authentik/lib/sync/outgoing/models.py
@@ -1,3 +1,4 @@
+import math
 from typing import Any, Self
 
 import pglock
@@ -68,7 +69,12 @@ class OutgoingSyncProvider(ScheduledModel, Model):
         return Paginator(self.get_object_qs(type), self.sync_page_size)
 
     def get_object_sync_time_limit_ms[T: User | Group](self, type: type[T]) -> int:
-        num_pages: int = self.get_paginator(type).num_pages
+        # Use a simple COUNT(*) on the model instead of materializing get_object_qs(),
+        # which for some providers (e.g. SCIM) runs PolicyEngine per-user and is
+        # extremely expensive. The time limit is an upper-bound estimate, so using
+        # the total count (without policy filtering) is a safe overestimate.
+        total_count = type.objects.count()
+        num_pages = math.ceil(total_count / self.sync_page_size) if total_count > 0 else 1
         page_timeout_ms = timedelta_from_string(self.sync_page_timeout).total_seconds() * 1000
         return int(num_pages * page_timeout_ms * 1.5)
 


### PR DESCRIPTION


<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

During startup, the _reconcile() method in ManagedAppConfig accidentally evaluates @property descriptors by calling getattr() on every attribute. This triggers tenant_schedule_specs, which accesses schedule_specs on each outgoing sync provider (SCIM).

Each provider's schedule_specs calls get_sync_time_limit_ms(), which runs PolicyEngine for every user in the database just to estimate a timeout. With N providers and M users, this results in N × M × 2 database queries during startup.

Fix _reconcile() to check attributes on the class instead of the instance, avoiding accidental property evaluation. Fix get_object_sync_time_limit_ms() to use a simple COUNT(*) query instead of materializing the full policy-filtered queryset.

---

## Checklist

-   [] Local tests pass (`ak test authentik/`)
-   [X] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
