### PR TITLE
chore: fix OCI image labels across all Dockerfiles

### DIFF
--- a/lifecycle/container/Dockerfile
+++ b/lifecycle/container/Dockerfile
@@ -1,0 +1,213 @@
+# syntax=docker/dockerfile:1
+
+# Stage 1: Build webui
+FROM --platform=${BUILDPLATFORM} docker.io/library/node:24-trixie-slim@sha256:9707cd4542f400df5078df04f9652a272429112f15202d22b5b8bdd148df494f AS node-builder
+
+ARG GIT_BUILD_HASH
+ENV GIT_BUILD_HASH=$GIT_BUILD_HASH
+ENV NODE_ENV=production
+
+WORKDIR /work/web
+
+# These files need to be copied and cannot be mounted as `npm ci` will build the client's typescript
+COPY ./packages /work/packages
+COPY ./web/packages /work/web/packages
+
+RUN --mount=type=bind,target=/work/web/package.json,src=./web/package.json \
+    --mount=type=bind,target=/work/web/package-lock.json,src=./web/package-lock.json \
+    --mount=type=bind,target=/work/web/packages/sfe/package.json,src=./web/packages/sfe/package.json \
+    --mount=type=bind,target=/work/web/scripts,src=./web/scripts \
+    --mount=type=cache,id=npm-ak,sharing=shared,target=/root/.npm \
+    npm ci
+
+COPY ./package.json /work
+COPY ./web /work/web/
+# TODO: Update this after moving website to docs
+COPY ./website /work/website/
+
+RUN npm run build && \
+    npm run build:sfe
+
+# Stage 2: Build go proxy
+FROM --platform=${BUILDPLATFORM} docker.io/library/golang:1.26.2-trixie@sha256:da3943074756e8d6f109ce7a84be16e98bffa39e9d369a0447f016b56db84e8f AS go-builder
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+ARG GOOS=$TARGETOS
+ARG GOARCH=$TARGETARCH
+
+WORKDIR /go/src/goauthentik.io
+
+RUN --mount=type=cache,id=apt-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/var/cache/apt \
+    dpkg --add-architecture arm64 && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends crossbuild-essential-arm64 gcc-aarch64-linux-gnu
+
+RUN --mount=type=bind,target=/go/src/goauthentik.io/go.mod,src=./go.mod \
+    --mount=type=bind,target=/go/src/goauthentik.io/go.sum,src=./go.sum \
+    --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+COPY ./cmd /go/src/goauthentik.io/cmd
+COPY ./authentik/lib /go/src/goauthentik.io/authentik/lib
+COPY ./web/static.go /go/src/goauthentik.io/web/static.go
+COPY --from=node-builder /work/web/robots.txt /go/src/goauthentik.io/web/robots.txt
+COPY --from=node-builder /work/web/security.txt /go/src/goauthentik.io/web/security.txt
+COPY ./internal /go/src/goauthentik.io/internal
+COPY ./go.mod /go/src/goauthentik.io/go.mod
+COPY ./go.sum /go/src/goauthentik.io/go.sum
+COPY ./packages/client-go /go/src/goauthentik.io/packages/client-go
+
+RUN --mount=type=cache,sharing=locked,target=/go/pkg/mod \
+    --mount=type=cache,id=go-build-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/root/.cache/go-build \
+    if [ "$TARGETARCH" = "arm64" ]; then export CC=aarch64-linux-gnu-gcc && export CC_FOR_TARGET=gcc-aarch64-linux-gnu; fi && \
+    CGO_ENABLED=1 GOFIPS140=latest GOARM="${TARGETVARIANT#v}" \
+    go build -o /go/authentik ./cmd/server
+
+# Stage 3: MaxMind GeoIP
+FROM --platform=${BUILDPLATFORM} ghcr.io/maxmind/geoipupdate:v7.1.1@sha256:faecdca22579730ab0b7dea5aa9af350bb3c93cb9d39845c173639ead30346d2 AS geoip
+
+ENV GEOIPUPDATE_EDITION_IDS="GeoLite2-City GeoLite2-ASN"
+ENV GEOIPUPDATE_VERBOSE="1"
+ENV GEOIPUPDATE_ACCOUNT_ID_FILE="/run/secrets/GEOIPUPDATE_ACCOUNT_ID"
+
+USER root
+RUN --mount=type=secret,id=GEOIPUPDATE_ACCOUNT_ID \
+    --mount=type=secret,id=GEOIPUPDATE_LICENSE_KEY \
+    mkdir -p /usr/share/GeoIP && \
+    /bin/sh -c "GEOIPUPDATE_LICENSE_KEY_FILE=/run/secrets/GEOIPUPDATE_LICENSE_KEY /usr/bin/entry.sh || echo 'Failed to get GeoIP database, disabling'; exit 0"
+
+# Stage 4: Download uv
+FROM ghcr.io/astral-sh/uv:0.11.5@sha256:555ac94f9a22e656fc5f2ce5dfee13b04e94d099e46bb8dd3a73ec7263f2e484 AS uv
+# Stage 5: Base python image
+FROM ghcr.io/goauthentik/fips-python:3.14.3-slim-trixie-fips@sha256:bf45eb77a010d76fe6abd7ae137d1b0c44b6227cd984945042135fdf05ebf8d9 AS python-base
+
+ENV VENV_PATH="/ak-root/.venv" \
+    PATH="/lifecycle:/ak-root/.venv/bin:$PATH" \
+    UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_NATIVE_TLS=1 \
+    UV_PYTHON_DOWNLOADS=0
+
+WORKDIR /ak-root/
+
+COPY --from=uv /uv /uvx /bin/
+
+# Stage 6: Python dependencies
+FROM python-base AS python-deps
+
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+
+ENV PATH="/root/.cargo/bin:$PATH"
+
+RUN --mount=type=cache,id=apt-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/var/cache/apt \
+    --mount=type=bind,target=rust-toolchain.toml,src=rust-toolchain.toml \
+    apt-get update && \
+    # Required for installing pip packages
+    apt-get install -y --no-install-recommends \
+    # Build essentials
+    build-essential pkg-config libffi-dev git \
+    # cryptography
+    curl \
+    # libxml
+    libxslt-dev zlib1g-dev \
+    # postgresql
+    libpq-dev \
+    # python-kadmin-rs
+    krb5-multidev libkrb5-dev heimdal-multidev libclang-dev \
+    # xmlsec
+    libltdl-dev && \
+    export RUST_TOOLCHAIN="$(awk -F'\"' '/^[[:space:]]*channel[[:space:]]*=/{print $2; exit}' rust-toolchain.toml)" && \
+    curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain "${RUST_TOOLCHAIN}" && \
+    rustup default "${RUST_TOOLCHAIN}" && \
+    rustc --version && \
+    cargo --version
+
+ENV UV_NO_BINARY_PACKAGE="cryptography lxml python-kadmin-rs xmlsec" \
+    # https://github.com/rust-lang/rustup/issues/2949
+    # Fixes issues where the rust version in the build cache is older than latest
+    # and rustup tries to update it, which fails
+    RUSTUP_PERMIT_COPY_RENAME="1"
+
+RUN --mount=type=bind,target=pyproject.toml,src=pyproject.toml \
+    --mount=type=bind,target=uv.lock,src=uv.lock \
+    --mount=type=bind,target=packages,src=packages \
+    --mount=type=bind,target=rust-toolchain.toml,src=rust-toolchain.toml \
+    --mount=type=cache,id=uv-python-deps-$TARGETARCH$TARGETVARIANT,target=/root/.cache/uv \
+    RUSTUP_TOOLCHAIN="$(awk -F'\"' '/^[[:space:]]*channel[[:space:]]*=/{print $2; exit}' rust-toolchain.toml)" \
+    uv sync --frozen --no-install-project --no-dev
+
+# Stage 7: Run
+FROM python-base AS final-image
+
+ARG VERSION
+ARG GIT_BUILD_HASH
+ENV GIT_BUILD_HASH=$GIT_BUILD_HASH
+
+LABEL org.opencontainers.image.authors="Authentik Security Inc." \
+    org.opencontainers.image.source="https://github.com/goauthentik/authentik" \
+    org.opencontainers.image.description="goauthentik.io Main server image, see https://goauthentik.io for more info." \
+    org.opencontainers.image.documentation="https://docs.goauthentik.io" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.revision=${GIT_BUILD_HASH} \
+    org.opencontainers.image.title="authentik server image" \
+    org.opencontainers.image.url="https://goauthentik.io" \
+    org.opencontainers.image.vendor="Authentik Security Inc." \
+    org.opencontainers.image.version=${VERSION}
+
+WORKDIR /
+
+# We cannot cache this layer otherwise we'll end up with a bigger image
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    # Required for runtime
+    apt-get install -y --no-install-recommends \
+    libpq5 libmaxminddb0 ca-certificates \
+    krb5-multidev libkrb5-3 libkdb5-10 libkadm5clnt-mit12 \
+    heimdal-multidev libkadm5clnt7t64-heimdal \
+    libltdl7 libxslt1.1 && \
+    # Required for bootstrap & healtcheck
+    apt-get install -y --no-install-recommends runit && \
+    pip3 install --no-cache-dir --upgrade pip && \
+    apt-get clean && \
+    rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/ && \
+    adduser --system --no-create-home --uid 1000 --group --home /authentik authentik && \
+    mkdir -p /certs /data /media /blueprints && \
+    ln -s /media /data/media && \
+    mkdir -p /authentik/.ssh && \
+    mkdir -p /ak-root && \
+    chown authentik:authentik /certs /data /data/media /media /authentik/.ssh /ak-root
+
+COPY ./authentik/ /authentik
+COPY ./pyproject.toml /
+COPY ./uv.lock /
+COPY ./schemas /schemas
+COPY ./locale /locale
+COPY ./tests /tests
+COPY ./manage.py /
+COPY ./blueprints /blueprints
+COPY ./lifecycle/ /lifecycle
+COPY ./authentik/sources/kerberos/krb5.conf /etc/krb5.conf
+COPY --from=go-builder /go/authentik /bin/authentik
+COPY ./packages/ /ak-root/packages
+RUN  ln -s /ak-root/packages /packages
+COPY --from=python-deps /ak-root/.venv /ak-root/.venv
+COPY --from=node-builder /work/web/dist/ /web/dist/
+COPY --from=node-builder /work/web/authentik/ /web/authentik/
+COPY --from=geoip /usr/share/GeoIP /geoip
+
+USER 1000
+
+ENV TMPDIR=/dev/shm/ \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    GOFIPS=1
+
+HEALTHCHECK --interval=30s --timeout=30s --start-period=60s --retries=3 CMD [ "ak", "healthcheck" ]
+
+ENTRYPOINT [ "dumb-init", "--", "ak" ]

--- a/lifecycle/container/ldap.Dockerfile
+++ b/lifecycle/container/ldap.Dockerfile
@@ -1,0 +1,66 @@
+# syntax=docker/dockerfile:1
+
+# Stage 1: Build
+FROM --platform=${BUILDPLATFORM} docker.io/library/golang:1.26.2-trixie@sha256:da3943074756e8d6f109ce7a84be16e98bffa39e9d369a0447f016b56db84e8f AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+ARG GOOS=$TARGETOS
+ARG GOARCH=$TARGETARCH
+
+WORKDIR /go/src/goauthentik.io
+
+RUN --mount=type=cache,id=apt-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/var/cache/apt \
+    dpkg --add-architecture arm64 && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends crossbuild-essential-arm64 gcc-aarch64-linux-gnu
+
+RUN --mount=type=bind,target=/go/src/goauthentik.io/go.mod,src=./go.mod \
+    --mount=type=bind,target=/go/src/goauthentik.io/go.sum,src=./go.sum \
+    --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+COPY . .
+RUN --mount=type=cache,sharing=locked,target=/go/pkg/mod \
+    --mount=type=cache,id=go-build-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/root/.cache/go-build \
+    if [ "$TARGETARCH" = "arm64" ]; then export CC=aarch64-linux-gnu-gcc && export CC_FOR_TARGET=gcc-aarch64-linux-gnu; fi && \
+    CGO_ENABLED=1 GOFIPS140=latest GOARM="${TARGETVARIANT#v}" \
+    go build -o /go/ldap ./cmd/ldap
+
+# Stage 2: Run
+FROM ghcr.io/goauthentik/fips-debian:trixie-slim-fips@sha256:7726387c78b5787d2146868c2ccc8948a3591d0a5a6436f7780c8c28acc76341
+
+ARG VERSION
+ARG GIT_BUILD_HASH
+ENV GIT_BUILD_HASH=$GIT_BUILD_HASH
+
+LABEL org.opencontainers.image.authors="Authentik Security Inc." \
+    org.opencontainers.image.source="https://github.com/goauthentik/authentik" \
+    org.opencontainers.image.description="goauthentik.io LDAP outpost, see https://goauthentik.io for more info." \
+    org.opencontainers.image.documentation="https://docs.goauthentik.io" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.revision=${GIT_BUILD_HASH} \
+    org.opencontainers.image.title="authentik LDAP outpost image" \
+    org.opencontainers.image.url="https://goauthentik.io" \
+    org.opencontainers.image.vendor="Authentik Security Inc." \
+    org.opencontainers.image.version=${VERSION}
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get clean && \
+    rm -rf /tmp/* /var/lib/apt/lists/*
+
+COPY --from=builder /go/ldap /
+
+HEALTHCHECK --interval=5s --retries=20 --start-period=3s CMD [ "/ldap", "healthcheck" ]
+
+EXPOSE 3389 6636 9300
+
+USER 1000
+
+ENV TMPDIR=/dev/shm/ \
+    GOFIPS=1
+
+ENTRYPOINT ["/ldap"]

--- a/lifecycle/container/proxy.Dockerfile
+++ b/lifecycle/container/proxy.Dockerfile
@@ -1,0 +1,90 @@
+# syntax=docker/dockerfile:1
+
+# Stage 1: Build web
+FROM --platform=${BUILDPLATFORM} docker.io/library/node:24 AS web-builder
+
+ENV NODE_ENV=production
+WORKDIR /static
+
+# These files need to be copied and cannot be mounted as `npm ci` will build the client's typescript
+COPY ./packages /packages
+COPY ./web/packages /static/packages
+
+COPY package.json /
+RUN --mount=type=bind,target=/static/package.json,src=./web/package.json \
+    --mount=type=bind,target=/static/package-lock.json,src=./web/package-lock.json \
+    --mount=type=bind,target=/static/scripts,src=./web/scripts \
+    --mount=type=cache,target=/root/.npm \
+    npm ci
+
+COPY web .
+RUN npm run build-proxy
+
+# Stage 2: Build
+FROM --platform=${BUILDPLATFORM} docker.io/library/golang:1.26.2-trixie@sha256:da3943074756e8d6f109ce7a84be16e98bffa39e9d369a0447f016b56db84e8f AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+ARG GOOS=$TARGETOS
+ARG GOARCH=$TARGETARCH
+
+WORKDIR /go/src/goauthentik.io
+
+RUN --mount=type=cache,id=apt-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/var/cache/apt \
+    dpkg --add-architecture arm64 && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends crossbuild-essential-arm64 gcc-aarch64-linux-gnu
+
+RUN --mount=type=bind,target=/go/src/goauthentik.io/go.mod,src=./go.mod \
+    --mount=type=bind,target=/go/src/goauthentik.io/go.sum,src=./go.sum \
+    --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+COPY . .
+RUN --mount=type=cache,sharing=locked,target=/go/pkg/mod \
+    --mount=type=cache,id=go-build-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/root/.cache/go-build \
+    if [ "$TARGETARCH" = "arm64" ]; then export CC=aarch64-linux-gnu-gcc && export CC_FOR_TARGET=gcc-aarch64-linux-gnu; fi && \
+    CGO_ENABLED=1 GOFIPS140=latest GOARM="${TARGETVARIANT#v}" \
+    go build -o /go/proxy ./cmd/proxy
+
+# Stage 3: Run
+FROM ghcr.io/goauthentik/fips-debian:trixie-slim-fips@sha256:7726387c78b5787d2146868c2ccc8948a3591d0a5a6436f7780c8c28acc76341
+
+ARG VERSION
+ARG GIT_BUILD_HASH
+ENV GIT_BUILD_HASH=$GIT_BUILD_HASH
+
+LABEL org.opencontainers.image.authors="Authentik Security Inc." \
+    org.opencontainers.image.source="https://github.com/goauthentik/authentik" \
+    org.opencontainers.image.description="goauthentik.io Proxy outpost image, see https://goauthentik.io for more info." \
+    org.opencontainers.image.documentation="https://docs.goauthentik.io" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.revision=${GIT_BUILD_HASH} \
+    org.opencontainers.image.title="authentik proxy outpost image" \
+    org.opencontainers.image.url="https://goauthentik.io" \
+    org.opencontainers.image.vendor="Authentik Security Inc." \
+    org.opencontainers.image.version=${VERSION}
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get clean && \
+    rm -rf /tmp/* /var/lib/apt/lists/*
+
+COPY --from=builder /go/proxy /
+COPY --from=web-builder /static/robots.txt /web/robots.txt
+COPY --from=web-builder /static/security.txt /web/security.txt
+COPY --from=web-builder /static/dist/ /web/dist/
+COPY --from=web-builder /static/authentik/ /web/authentik/
+
+HEALTHCHECK --interval=5s --retries=20 --start-period=3s CMD [ "/proxy", "healthcheck" ]
+
+EXPOSE 9000 9300 9443
+
+USER 1000
+
+ENV TMPDIR=/dev/shm/ \
+    GOFIPS=1
+
+ENTRYPOINT ["/proxy"]

--- a/lifecycle/container/rac.Dockerfile
+++ b/lifecycle/container/rac.Dockerfile
@@ -1,0 +1,66 @@
+# syntax=docker/dockerfile:1
+
+# Stage 1: Build
+FROM --platform=${BUILDPLATFORM} docker.io/library/golang:1.26.2-trixie@sha256:da3943074756e8d6f109ce7a84be16e98bffa39e9d369a0447f016b56db84e8f AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+ARG GOOS=$TARGETOS
+ARG GOARCH=$TARGETARCH
+
+WORKDIR /go/src/goauthentik.io
+
+RUN --mount=type=cache,id=apt-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/var/cache/apt \
+    dpkg --add-architecture arm64 && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends crossbuild-essential-arm64 gcc-aarch64-linux-gnu
+
+RUN --mount=type=bind,target=/go/src/goauthentik.io/go.mod,src=./go.mod \
+    --mount=type=bind,target=/go/src/goauthentik.io/go.sum,src=./go.sum \
+    --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+COPY . .
+RUN --mount=type=cache,sharing=locked,target=/go/pkg/mod \
+    --mount=type=cache,id=go-build-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/root/.cache/go-build \
+    if [ "$TARGETARCH" = "arm64" ]; then export CC=aarch64-linux-gnu-gcc && export CC_FOR_TARGET=gcc-aarch64-linux-gnu; fi && \
+    CGO_ENABLED=1 GOFIPS140=latest GOARM="${TARGETVARIANT#v}" \
+    go build -o /go/rac ./cmd/rac
+
+# Stage 2: Run
+FROM ghcr.io/goauthentik/guacd:v1.6.0-ak-p1-fips@sha256:0748e2a430ba39a4c837e0cf8886d831ff5e871875614190783d20b7755d0636
+
+ARG VERSION
+ARG GIT_BUILD_HASH
+ENV GIT_BUILD_HASH=$GIT_BUILD_HASH
+
+LABEL org.opencontainers.image.authors="Authentik Security Inc." \
+    org.opencontainers.image.source="https://github.com/goauthentik/authentik" \
+    org.opencontainers.image.description="goauthentik.io RAC outpost, see https://goauthentik.io for more info." \
+    org.opencontainers.image.documentation="https://docs.goauthentik.io" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.revision=${GIT_BUILD_HASH} \
+    org.opencontainers.image.title="authentik RAC outpost image" \
+    org.opencontainers.image.url="https://goauthentik.io" \
+    org.opencontainers.image.vendor="Authentik Security Inc." \
+    org.opencontainers.image.version=${VERSION}
+
+USER root
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get clean && \
+    rm -rf /tmp/* /var/lib/apt/lists/*
+USER 1000
+
+COPY --from=builder /go/rac /
+
+HEALTHCHECK --interval=5s --retries=20 --start-period=3s CMD [ "/rac", "healthcheck" ]
+
+USER 1000
+
+ENV TMPDIR=/dev/shm/ \
+    GOFIPS=1
+
+ENTRYPOINT ["/rac"]

--- a/lifecycle/container/radius.Dockerfile
+++ b/lifecycle/container/radius.Dockerfile
@@ -1,0 +1,66 @@
+# syntax=docker/dockerfile:1
+
+# Stage 1: Build
+FROM --platform=${BUILDPLATFORM} docker.io/library/golang:1.26.2-trixie@sha256:da3943074756e8d6f109ce7a84be16e98bffa39e9d369a0447f016b56db84e8f AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+ARG GOOS=$TARGETOS
+ARG GOARCH=$TARGETARCH
+
+WORKDIR /go/src/goauthentik.io
+
+RUN --mount=type=cache,id=apt-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/var/cache/apt \
+    dpkg --add-architecture arm64 && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends crossbuild-essential-arm64 gcc-aarch64-linux-gnu
+
+RUN --mount=type=bind,target=/go/src/goauthentik.io/go.mod,src=./go.mod \
+    --mount=type=bind,target=/go/src/goauthentik.io/go.sum,src=./go.sum \
+    --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+COPY . .
+RUN --mount=type=cache,sharing=locked,target=/go/pkg/mod \
+    --mount=type=cache,id=go-build-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/root/.cache/go-build \
+    if [ "$TARGETARCH" = "arm64" ]; then export CC=aarch64-linux-gnu-gcc && export CC_FOR_TARGET=gcc-aarch64-linux-gnu; fi && \
+    CGO_ENABLED=1 GOFIPS140=latest GOARM="${TARGETVARIANT#v}" \
+    go build -o /go/radius ./cmd/radius
+
+# Stage 2: Run
+FROM ghcr.io/goauthentik/fips-debian:trixie-slim-fips@sha256:7726387c78b5787d2146868c2ccc8948a3591d0a5a6436f7780c8c28acc76341
+
+ARG VERSION
+ARG GIT_BUILD_HASH
+ENV GIT_BUILD_HASH=$GIT_BUILD_HASH
+
+LABEL org.opencontainers.image.authors="Authentik Security Inc." \
+    org.opencontainers.image.source="https://github.com/goauthentik/authentik" \
+    org.opencontainers.image.description="goauthentik.io Radius outpost, see https://goauthentik.io for more info." \
+    org.opencontainers.image.documentation="https://docs.goauthentik.io" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.revision=${GIT_BUILD_HASH} \
+    org.opencontainers.image.title="authentik RADIUS outpost image" \
+    org.opencontainers.image.url="https://goauthentik.io" \
+    org.opencontainers.image.vendor="Authentik Security Inc." \
+    org.opencontainers.image.version=${VERSION}
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get clean && \
+    rm -rf /tmp/* /var/lib/apt/lists/*
+
+COPY --from=builder /go/radius /
+
+HEALTHCHECK --interval=5s --retries=20 --start-period=3s CMD [ "/radius", "healthcheck" ]
+
+EXPOSE 1812/udp 9300
+
+USER 1000
+
+ENV TMPDIR=/dev/shm/ \
+    GOFIPS=1
+
+ENTRYPOINT ["/radius"]

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,26 +1,42 @@
-FROM --platform=${BUILDPLATFORM} docker.io/library/node:24-slim AS docs-builder
+FROM --platform=${BUILDPLATFORM} docker.io/library/node:25.9.0-trixie@sha256:f57f0c76da32cc5ea0d50d209cc53fa37fb69954cf61407ec38e8f8591373fdf AS docs-builder
 
 ENV NODE_ENV=production
 
+WORKDIR /work
+
+# TODO: Use setup-corepack.mjs
+RUN --mount=type=bind,target=/work/package.json,src=./package.json \
+    --mount=type=bind,target=/work/package-lock.json,src=./package-lock.json \
+    npm install --force -g corepack@latest && \
+    corepack install -g npm@11.11.0+sha512.f36811c4aae1fde639527368ae44c571d050006a608d67a191f195a801a52637a312d259186254aa3a3799b05335b7390539cf28656d18f0591a1125ba35f973 && \
+    corepack enable
+
 WORKDIR /work/website
 
-RUN --mount=type=bind,target=/work/website/package.json,src=./website/package.json \
+RUN --mount=type=bind,target=/work/package.json,src=./package.json \
+    --mount=type=bind,target=/work/package-lock.json,src=./package-lock.json \
+    --mount=type=bind,target=/work/packages/tsconfig/,src=./packages/tsconfig/ \
+    --mount=type=bind,target=/work/packages/eslint-config/,src=./packages/eslint-config/ \
+    --mount=type=bind,target=/work/packages/prettier-config/,src=./packages/prettier-config/ \
+    --mount=type=bind,target=/work/website/package.json,src=./website/package.json \
     --mount=type=bind,target=/work/website/package-lock.json,src=./website/package-lock.json \
+    --mount=type=bind,target=/work/website/vendored/detect-package-manager,src=./website/vendored/detect-package-manager \
     --mount=type=bind,target=/work/website/docusaurus-theme/package.json,src=./website/docusaurus-theme/package.json \
     --mount=type=bind,target=/work/website/api/package.json,src=./website/api/package.json \
     --mount=type=bind,target=/work/website/integrations/package.json,src=./website/integrations/package.json \
     --mount=type=bind,target=/work/website/docs/package.json,src=./website/docs/package.json \
     --mount=type=cache,id=npm-website,sharing=shared,target=/root/.npm \
-    npm ci --workspaces --include-workspace-root
+    corepack npm ci --workspaces --include-workspace-root
 
 COPY ./website /work/website/
 COPY ./blueprints /work/blueprints/
 COPY ./schema.yml /work/
-COPY ./docker-compose.yml /work/
+COPY ./lifecycle/container/compose.yml /work/lifecycle/container/
 COPY ./SECURITY.md /work/
 
-RUN npm run build
+RUN corepack npm run build
 
-FROM docker.io/library/nginx:1.29.0
+FROM docker.io/library/nginx:1.29-trixie@sha256:7f0adca1fc6c29c8dc49a2e90037a10ba20dc266baaed0988e9fb4d0d8b85ba0
+LABEL org.opencontainers.image.authors="Authentik Security Inc."     org.opencontainers.image.source="https://github.com/goauthentik/authentik"     org.opencontainers.image.description="goauthentik.io documentation site"     org.opencontainers.image.documentation="https://docs.goauthentik.io"     org.opencontainers.image.licenses="MIT"     org.opencontainers.image.title="authentik docs image"     org.opencontainers.image.url="https://goauthentik.io"     org.opencontainers.image.vendor="Authentik Security Inc."
 
 COPY --from=docs-builder /work/website/docs/build /usr/share/nginx/html

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -37,6 +37,13 @@ COPY ./SECURITY.md /work/
 RUN corepack npm run build
 
 FROM docker.io/library/nginx:1.29-trixie@sha256:7f0adca1fc6c29c8dc49a2e90037a10ba20dc266baaed0988e9fb4d0d8b85ba0
-LABEL org.opencontainers.image.authors="Authentik Security Inc."     org.opencontainers.image.source="https://github.com/goauthentik/authentik"     org.opencontainers.image.description="goauthentik.io documentation site"     org.opencontainers.image.documentation="https://docs.goauthentik.io"     org.opencontainers.image.licenses="MIT"     org.opencontainers.image.title="authentik docs image"     org.opencontainers.image.url="https://goauthentik.io"     org.opencontainers.image.vendor="Authentik Security Inc."
+LABEL org.opencontainers.image.authors="Authentik Security Inc." \
+    org.opencontainers.image.source="https://github.com/goauthentik/authentik" \
+    org.opencontainers.image.description="goauthentik.io documentation site" \
+    org.opencontainers.image.documentation="https://docs.goauthentik.io" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.title="authentik docs image" \
+    org.opencontainers.image.url="https://goauthentik.io" \
+    org.opencontainers.image.vendor="Authentik Security Inc."
 
 COPY --from=docs-builder /work/website/docs/build /usr/share/nginx/html


### PR DESCRIPTION
## Context

Fix two issues in the OCI image labels across all Dockerfiles, and add missing labels to the docs image.

## Type

Maintenance — metadata only, no functional changes.

## Changes

### 1. Fix `org.opencontainers.image.licenses` — wrong format (5 Dockerfiles)

The `licenses` label currently uses a URL pointing to the LICENSE file:

```
org.opencontainers.image.licenses="https://github.com/goauthentik/authentik/blob/main/LICENSE"
```

The [OCI Image Spec](https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys) requires this field to be an **SPDX License Expression**, not a URL:

> `org.opencontainers.image.licenses` — License(s) under which contained software is distributed as an [SPDX License Expression](https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60).

Fixed to: `"MIT"`

Affected: `lifecycle/container/Dockerfile`, `proxy.Dockerfile`, `ldap.Dockerfile`, `radius.Dockerfile`, `rac.Dockerfile`

### 2. Remove duplicate `org.opencontainers.image.source` label (5 Dockerfiles)

Each of the above Dockerfiles has `org.opencontainers.image.source` appearing **twice** in the `LABEL` instruction — the second occurrence is a copy-paste artifact. Removed the duplicate.

### 3. Add OCI labels to `website/Dockerfile`

The docs image (`ghcr.io/goauthentik/docs`) had no OCI labels. Added static labels matching the pattern used by the other images.

## Benefits

- **Registry UI**: GHCR and Docker Hub display the correct license identifier rather than a URL string
- **Security scanning**: Trivy, Grype, and similar tools use the SPDX expression to cross-reference license compliance
- **Renovate/Dependabot**: `org.opencontainers.image.source` on the docs image enables changelog links in dependency update PRs
- **Standardization**: Aligns with the OCI Image Spec annotation requirements

## References

- [OCI Image Spec — Annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md)
- [SPDX License List](https://spdx.org/licenses/)