### PR TITLE
lifecycle/container: fix OCI image labels

### DIFF
--- a/lifecycle/container/Dockerfile
+++ b/lifecycle/container/Dockerfile
@@ -155,7 +155,6 @@ LABEL org.opencontainers.image.authors="Authentik Security Inc." \
     org.opencontainers.image.documentation="https://docs.goauthentik.io" \
     org.opencontainers.image.licenses="https://github.com/goauthentik/authentik/blob/main/LICENSE" \
     org.opencontainers.image.revision=${GIT_BUILD_HASH} \
-    org.opencontainers.image.source="https://github.com/goauthentik/authentik" \
     org.opencontainers.image.title="authentik server image" \
     org.opencontainers.image.url="https://goauthentik.io" \
     org.opencontainers.image.vendor="Authentik Security Inc." \

--- a/lifecycle/container/ldap.Dockerfile
+++ b/lifecycle/container/ldap.Dockerfile
@@ -42,7 +42,6 @@ LABEL org.opencontainers.image.authors="Authentik Security Inc." \
     org.opencontainers.image.documentation="https://docs.goauthentik.io" \
     org.opencontainers.image.licenses="https://github.com/goauthentik/authentik/blob/main/LICENSE" \
     org.opencontainers.image.revision=${GIT_BUILD_HASH} \
-    org.opencontainers.image.source="https://github.com/goauthentik/authentik" \
     org.opencontainers.image.title="authentik LDAP outpost image" \
     org.opencontainers.image.url="https://goauthentik.io" \
     org.opencontainers.image.vendor="Authentik Security Inc." \

--- a/lifecycle/container/proxy.Dockerfile
+++ b/lifecycle/container/proxy.Dockerfile
@@ -62,7 +62,6 @@ LABEL org.opencontainers.image.authors="Authentik Security Inc." \
     org.opencontainers.image.documentation="https://docs.goauthentik.io" \
     org.opencontainers.image.licenses="https://github.com/goauthentik/authentik/blob/main/LICENSE" \
     org.opencontainers.image.revision=${GIT_BUILD_HASH} \
-    org.opencontainers.image.source="https://github.com/goauthentik/authentik" \
     org.opencontainers.image.title="authentik proxy outpost image" \
     org.opencontainers.image.url="https://goauthentik.io" \
     org.opencontainers.image.vendor="Authentik Security Inc." \

--- a/lifecycle/container/rac.Dockerfile
+++ b/lifecycle/container/rac.Dockerfile
@@ -42,7 +42,6 @@ LABEL org.opencontainers.image.authors="Authentik Security Inc." \
     org.opencontainers.image.documentation="https://docs.goauthentik.io" \
     org.opencontainers.image.licenses="https://github.com/goauthentik/authentik/blob/main/LICENSE" \
     org.opencontainers.image.revision=${GIT_BUILD_HASH} \
-    org.opencontainers.image.source="https://github.com/goauthentik/authentik" \
     org.opencontainers.image.title="authentik RAC outpost image" \
     org.opencontainers.image.url="https://goauthentik.io" \
     org.opencontainers.image.vendor="Authentik Security Inc." \

--- a/lifecycle/container/radius.Dockerfile
+++ b/lifecycle/container/radius.Dockerfile
@@ -42,7 +42,6 @@ LABEL org.opencontainers.image.authors="Authentik Security Inc." \
     org.opencontainers.image.documentation="https://docs.goauthentik.io" \
     org.opencontainers.image.licenses="https://github.com/goauthentik/authentik/blob/main/LICENSE" \
     org.opencontainers.image.revision=${GIT_BUILD_HASH} \
-    org.opencontainers.image.source="https://github.com/goauthentik/authentik" \
     org.opencontainers.image.title="authentik RADIUS outpost image" \
     org.opencontainers.image.url="https://goauthentik.io" \
     org.opencontainers.image.vendor="Authentik Security Inc." \

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -37,5 +37,14 @@ COPY ./SECURITY.md /work/
 RUN corepack npm run build
 
 FROM docker.io/library/nginx:1.29-trixie@sha256:7f0adca1fc6c29c8dc49a2e90037a10ba20dc266baaed0988e9fb4d0d8b85ba0
+LABEL org.opencontainers.image.authors="Authentik Security Inc." \
+    org.opencontainers.image.source="https://github.com/goauthentik/authentik" \
+    org.opencontainers.image.description="goauthentik.io documentation site" \
+    org.opencontainers.image.documentation="https://docs.goauthentik.io" \
+    org.opencontainers.image.licenses="https://github.com/goauthentik/authentik/blob/main/LICENSE" \
+    org.opencontainers.image.title="authentik docs image" \
+    org.opencontainers.image.url="https://goauthentik.io" \
+    org.opencontainers.image.vendor="Authentik Security Inc."
+
 
 COPY --from=docs-builder /work/website/docs/build /usr/share/nginx/html

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -39,7 +39,7 @@ RUN corepack npm run build
 FROM docker.io/library/nginx:1.29-trixie@sha256:7f0adca1fc6c29c8dc49a2e90037a10ba20dc266baaed0988e9fb4d0d8b85ba0
 LABEL org.opencontainers.image.authors="Authentik Security Inc." \
     org.opencontainers.image.source="https://github.com/goauthentik/authentik" \
-    org.opencontainers.image.description="goauthentik.io documentation site" \
+    org.opencontainers.image.description="authentik product documentation" \
     org.opencontainers.image.documentation="https://docs.goauthentik.io" \
     org.opencontainers.image.licenses="https://github.com/goauthentik/authentik/blob/main/LICENSE" \
     org.opencontainers.image.title="authentik docs image" \


### PR DESCRIPTION
## Context

Fix two issues with OCI image labels across all server/outpost Dockerfiles, and add missing OCI labels to the docs image.

## Changes

### 1. Remove duplicate `org.opencontainers.image.source` label (5 Dockerfiles)

Each Dockerfile has `org.opencontainers.image.source` appearing twice in the `LABEL` instruction — a copy-paste artifact. The second occurrence overrides the first silently.

Affected files:
- `lifecycle/container/Dockerfile`
- `lifecycle/container/proxy.Dockerfile`
- `lifecycle/container/ldap.Dockerfile`
- `lifecycle/container/radius.Dockerfile`
- `lifecycle/container/rac.Dockerfile`

### 2. Add OCI labels to `website/Dockerfile`

The docs image (`ghcr.io/goauthentik/docs`) had no OCI labels. Added static labels matching the style of the other images.

## Benefits

- **Registry compatibility**: GHCR and Docker Hub display these labels in their UI
- **Dependency bot changelogs**: Renovate and Dependabot use `org.opencontainers.image.source` to link release notes in update PRs
- **Image provenance**: consistent metadata across all published authentik images

## References

- [OCI Image Spec — Annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md)
- [Renovate Docker datasource](https://docs.renovatebot.com/modules/datasource/docker/)