### PR TITLE
lib/sync/outgoing: avoid expensive query to get number of sync pages

### DIFF
--- a/authentik/lib/sync/outgoing/models.py
+++ b/authentik/lib/sync/outgoing/models.py
@@ -1,3 +1,4 @@
+import math
 from typing import Any, Self
 
 import pglock
@@ -68,7 +69,12 @@ class OutgoingSyncProvider(ScheduledModel, Model):
         return Paginator(self.get_object_qs(type), self.sync_page_size)
 
     def get_object_sync_time_limit_ms[T: User | Group](self, type: type[T]) -> int:
-        num_pages: int = self.get_paginator(type).num_pages
+        # Use a simple COUNT(*) on the model instead of materializing get_object_qs(),
+        # which for some providers (e.g. SCIM) runs PolicyEngine per-user and is
+        # extremely expensive. The time limit is an upper-bound estimate, so using
+        # the total count (without policy filtering) is a safe overestimate.
+        total_count = type.objects.count()
+        num_pages = math.ceil(total_count / self.sync_page_size) if total_count > 0 else 1
         page_timeout_ms = timedelta_from_string(self.sync_page_timeout).total_seconds() * 1000
         return int(num_pages * page_timeout_ms * 1.5)
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

extracted from #21572

Each provider's schedule_specs calls get_sync_time_limit_ms(), which runs PolicyEngine for every user in the database just to estimate a timeout. With N providers and M users, this results in N × M × 2 database queries during startup.

Fix get_object_sync_time_limit_ms() to use a simple COUNT(*) query instead of materializing the full policy-filtered queryset.

cc. @joaocfernandes 

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
