### PR TITLE
blueprints: fix reconcile calling @property

### DIFF
--- a/authentik/blueprints/apps.py
+++ b/authentik/blueprints/apps.py
@@ -3,7 +3,6 @@
 import traceback
 from collections.abc import Callable
 from importlib import import_module
-from inspect import ismethod
 
 from django.apps import AppConfig
 from django.conf import settings
@@ -72,12 +71,19 @@ class ManagedAppConfig(AppConfig):
 
     def _reconcile(self, prefix: str) -> None:
         for meth_name in dir(self):
-            meth = getattr(self, meth_name)
-            if not ismethod(meth):
+            # Check the attribute on the class to avoid evaluating @property descriptors.
+            # Using getattr(self, ...) on a @property would evaluate it, which can trigger
+            # expensive side effects (e.g. tenant_schedule_specs iterating all providers
+            # and running PolicyEngine queries for every user).
+            class_attr = getattr(type(self), meth_name, None)
+            if class_attr is None or isinstance(class_attr, property):
                 continue
-            category = getattr(meth, "_authentik_managed_reconcile", None)
+            if not callable(class_attr):
+                continue
+            category = getattr(class_attr, "_authentik_managed_reconcile", None)
             if category != prefix:
                 continue
+            meth = getattr(self, meth_name)
             name = meth_name.replace(prefix, "")
             try:
                 self.logger.debug("Starting reconciler", name=name)


### PR DESCRIPTION


<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

extracted from #21572

During startup, the _reconcile() method in ManagedAppConfig accidentally evaluates @property descriptors by calling getattr() on every attribute. This triggers tenant_schedule_specs, which accesses schedule_specs on each outgoing sync provider (SCIM).

Fix _reconcile() to check attributes on the class instead of the instance, avoiding accidental property evaluation.

cc. @joaocfernandes 

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
