### PR TITLE
packages/django-dramatiq-postgres: reset db connections in raise_connection_error

### DIFF
--- a/packages/django-dramatiq-postgres/django_dramatiq_postgres/broker.py
+++ b/packages/django-dramatiq-postgres/django_dramatiq_postgres/broker.py
@@ -62,6 +62,10 @@ def raise_connection_error(func: Callable[P, R]) -> Callable[P, R]:  # noqa: UP0
             return func(*args, **kwargs)
         except DATABASE_ERRORS as exc:
             logger.warning("Database error encountered", exc=exc)
+            try:
+                connections.close_all()
+            except DATABASE_ERRORS:
+                pass
             raise ConnectionError(str(exc)) from exc  # type: ignore[no-untyped-call]
 
     return wrapper


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

When a task finishes running, the worker tries to mark it as done in the database (marking it as done or failed). If the database connection drops at that exact moment, the worker retries every 5 seconds. But the retry never works because the broken connection is never cleaned up between attempts. The worker keeps trying the same dead connection forever.
This leaves the worker process permanently stuck. The only way to recover is to restart the pod.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
