### PR TITLE
web/flows: prevent leader tab deadlock in continuous login flow

### DIFF
--- a/web/src/flow/tabs/broadcast.ts
+++ b/web/src/flow/tabs/broadcast.ts
@@ -52,9 +52,14 @@ export class Broadcast extends BroadcastChannel {
         }
     };
 
+    #onPageHide = () => {
+        this.akExitTab();
+    };
+
     constructor() {
         super(BROADCAST_CHANNEL_NAME);
         this.addEventListener("message", this.#onMessage);
+        window.addEventListener("pagehide", this.#onPageHide);
         this.#logger = ConsoleLogger.prefix("mtab/broadcast");
     }
 

--- a/web/src/flow/tabs/broadcast.ts
+++ b/web/src/flow/tabs/broadcast.ts
@@ -17,16 +17,16 @@ export interface BroadcastMessage {
     [key: string]: unknown;
 }
 
-export class Broadcast extends BroadcastChannel {
+export class Broadcast extends BroadcastChannel implements Disposable {
     static shared = new Broadcast();
 
-    private discoveredTabIds = new Set<string>();
-    exitedTabIds: string[] = [];
+    protected discoveredTabIDs = new Set<string>();
+    public exitedTabIDs: string[] = [];
 
-    #logger: Logger;
+    protected logger: Logger;
 
-    #onMessage = (ev: MessageEvent<BroadcastMessage>) => {
-        this.#logger.debug("broadcast event", ev.data);
+    protected messageListener = (ev: MessageEvent<BroadcastMessage>) => {
+        this.logger.debug("broadcast event", ev.data);
         switch (ev.data.type) {
             case BroadcastMessageType.discover:
                 if (ev.data.sender === TabID.shared.current) {
@@ -38,45 +38,50 @@ export class Broadcast extends BroadcastChannel {
                 });
                 return;
             case BroadcastMessageType.discoverReply:
-                this.discoveredTabIds.add(ev.data.sender as string);
+                this.discoveredTabIDs.add(ev.data.sender as string);
                 return;
             case BroadcastMessageType.exit:
-                this.exitedTabIds.push(ev.data.sender);
+                this.exitedTabIDs.push(ev.data.sender);
                 return;
             case BroadcastMessageType.continue:
                 if (ev.data.target === TabID.shared.current) {
-                    this.#logger.debug("Continuing upon event");
+                    this.logger.debug("Continuing upon event");
                     window.dispatchEvent(new CustomEvent("ak-multitab-continue"));
                 }
                 return;
         }
     };
 
-    #onPageHide = () => {
+    protected pageHideListener = () => {
         this.akExitTab();
     };
 
     constructor() {
         super(BROADCAST_CHANNEL_NAME);
-        this.addEventListener("message", this.#onMessage);
-        window.addEventListener("pagehide", this.#onPageHide);
-        this.#logger = ConsoleLogger.prefix("mtab/broadcast");
+
+        this.addEventListener("message", this.messageListener);
+        window.addEventListener("pagehide", this.pageHideListener);
+
+        this.logger = ConsoleLogger.prefix("mtab/broadcast");
     }
 
     [Symbol.dispose]() {
-        this.removeEventListener("message", this.#onMessage);
+        this.removeEventListener("message", this.messageListener);
     }
 
     async akTabDiscover(): Promise<Set<string>> {
-        this.discoveredTabIds.clear();
+        this.discoveredTabIDs.clear();
+
         this.postMessage({
             type: BroadcastMessageType.discover,
             sender: TabID.shared.current,
         });
+
         await new Promise<void>((r) => {
             setTimeout(r, 20);
         });
-        return this.discoveredTabIds;
+
+        return this.discoveredTabIDs;
     }
 
     akResumeTab(tabId: string) {

--- a/web/src/flow/tabs/orchestrator.ts
+++ b/web/src/flow/tabs/orchestrator.ts
@@ -8,10 +8,9 @@ import { ConsoleLogger } from "#logger/browser";
 const lockKey = "authentik-tab-locked";
 const logger = ConsoleLogger.prefix("mtab/orchestrate");
 
+const TAB_EXIT_TIMEOUT_MS = 3000;
+
 export function multiTabOrchestrateLeave() {
-    if (!globalAK().brand.flags.flowsContinuousLogin) {
-        return;
-    }
     Broadcast.shared.akExitTab();
     TabID.shared.clear();
 }
@@ -36,9 +35,11 @@ export async function multiTabOrchestrateResume() {
         logger.debug("Telling tab to continue", tab);
         Broadcast.shared.akResumeTab(tab);
         const done = Promise.withResolvers<void>();
+        const timers: { timeout?: ReturnType<typeof setTimeout> } = {};
         const checker = setInterval(() => {
             if (Broadcast.shared.exitedTabIds.includes(tab)) {
                 logger.debug("tab exited", tab);
+                clearTimeout(timers.timeout);
                 setTimeout(() => {
                     logger.debug("continue exited", tab);
                     done.resolve();
@@ -46,6 +47,11 @@ export async function multiTabOrchestrateResume() {
                 clearInterval(checker);
             }
         }, 1);
+        timers.timeout = setTimeout(() => {
+            logger.warn("Timed out waiting for tab to exit, moving on", tab);
+            clearInterval(checker);
+            done.resolve();
+        }, TAB_EXIT_TIMEOUT_MS);
         await done.promise;
         logger.debug("Tab done, continuing", tab);
     }

--- a/web/src/flow/tabs/orchestrator.ts
+++ b/web/src/flow/tabs/orchestrator.ts
@@ -19,42 +19,54 @@ export async function multiTabOrchestrateResume() {
     if (!globalAK().brand.flags.flowsContinuousLogin) {
         return;
     }
-    const lockTabId = localStorage.getItem(lockKey);
+
+    const lockTabID = localStorage.getItem(lockKey);
     const tabs = await Broadcast.shared.akTabDiscover();
+
     logger.debug("Got list of tabs", tabs);
 
-    if (lockTabId && tabs.has(lockTabId)) {
+    if (lockTabID && tabs.has(lockTabID)) {
         logger.debug("Tabs locked, leaving.");
         multiTabOrchestrateLeave();
         return;
     }
+
     logger.debug("Locking tabs");
     localStorage.setItem(lockKey, TabID.shared.current);
 
     for (const tab of tabs) {
         logger.debug("Telling tab to continue", tab);
         Broadcast.shared.akResumeTab(tab);
+
         const done = Promise.withResolvers<void>();
-        const timers: { timeout?: ReturnType<typeof setTimeout> } = {};
-        const checker = setInterval(() => {
-            if (Broadcast.shared.exitedTabIds.includes(tab)) {
+
+        let timeout = -1;
+
+        const checker = requestAnimationFrame(() => {
+            if (Broadcast.shared.exitedTabIDs.includes(tab)) {
                 logger.debug("tab exited", tab);
-                clearTimeout(timers.timeout);
-                setTimeout(() => {
+                self.clearTimeout(timeout);
+
+                self.setTimeout(() => {
                     logger.debug("continue exited", tab);
                     done.resolve();
                 }, 1000);
-                clearInterval(checker);
+
+                cancelAnimationFrame(checker);
             }
-        }, 1);
-        timers.timeout = setTimeout(() => {
+        });
+
+        timeout = self.setTimeout(() => {
             logger.warn("Timed out waiting for tab to exit, moving on", tab);
-            clearInterval(checker);
+            cancelAnimationFrame(checker);
             done.resolve();
         }, TAB_EXIT_TIMEOUT_MS);
+
         await done.promise;
+
         logger.debug("Tab done, continuing", tab);
     }
+
     logger.debug("All tabs done.");
     localStorage.removeItem(lockKey);
 }


### PR DESCRIPTION
## Details

When the flowsContinuousLogin flag is enabled, the leader tab (the one completing login) discovers other open tabs via BroadcastChannel, tells them to continue, and waits for each to confirm exit before proceeding. Two issues could cause the leader to hang indefinitely:

1) Flag guard on responder side: multiTabOrchestrateLeave() checked flowsContinuousLogin before sending the exit broadcast. Tabs that loaded before the flag was enabled (or before a deploy with updated code) would receive the continue signal and navigate away successfully, but never send the exit confirmation—leaving the leader stuck in an infinite polling loop with localStorage lock never cleaned up. Removed the flag guard from multiTabOrchestrateLeave(); the flag check in multiTabOrchestrateResume() on the leader side is sufficient to gate the feature.

2) No timeout for unresponsive tabs: Tabs old enough to predate the flag guard fix, or those that crash/close during orchestration, would never send an exit message. Added a 3-second per-tab timeout so the leader logs a warning and moves on rather than waiting forever.

Additionally, added a pagehide event listener in Broadcast that automatically sends the exit message when a page unloads. This provides defense-in-depth for any edge case where a tab navigates away without explicitly calling multiTabOrchestrateLeave().

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
