### PR TITLE
website/docs: Reorganize policy documentation -- Revisions

### DIFF
--- a/website/docs/add-secure-apps/flows-stages/flow/index.md
+++ b/website/docs/add-secure-apps/flows-stages/flow/index.md
@@ -50,7 +50,7 @@ To create a flow, follow these steps:
 
 1. Log in to authentik as an administrator and open the Admin interface.
 2. In the Admin interface, navigate to **Flows and Stages > Flows**.
-3. Click **Create**, define the flow using the [configuration settings](#flow-configuration-options) described below, and then click **Finish**.
+3. Click **New Flow**, define the flow using the [configuration settings](#flow-configuration-options) described below, and then click **Create Flow**.
 
 After creating the flow, you can then [bind specific stages](../stages/index.md#bind-a-stage-to-a-flow) to the flow and [bind policies](../../../customize/policies/bindings.md) to the flow to further customize the user's log in and authentication process.
 

--- a/website/docs/add-secure-apps/flows-stages/stages/consent/index.md
+++ b/website/docs/add-secure-apps/flows-stages/stages/consent/index.md
@@ -33,13 +33,13 @@ Optionally, if you also want to customize the exact wording that appears on the 
 ### 1. Create a Consent stage
 
 1. Log in to authentik as an administrator and open the authentik Admin interface.
-2. Navigate to **Flows and Stages** > **Stages** and click **Create**.
+2. Navigate to **Flows and Stages** > **Stages** and click **New Stage**.
 3. On the **New stage** wizard select **Consent Stage** and then click **Next**.
 4. Provide the following configuration settings:
     - **Name**:
     - **Stage-specific settings**:
         - **Mode**: Select the appropriate [mode](#consent-stage-modes) to use with this stage.
-5. Click **Finish** to save the new stage.
+5. Click **Create Stage** to save the new stage.
 
 ### 2. Bind the Consent stage to an authorization flow
 
@@ -50,7 +50,7 @@ To include the Consent stage in the flow, follow [these directions](../../stages
 If you want to customize the text that appears on the consent prompt, you can create an Expression policy with the exact wording you want, and then bind it to the Consent stage in the flow.
 
 1. Log in to authentik as an administrator and open the authentik Admin interface.
-2. Navigate to **Customization** > **Policies** and click **Create**.
+2. Navigate to **Customization** > **Policies** and click **New Policy**.
 3. On the **New policy** wizard select **Expression Policy** and then click **Next**.
 4. Provide the following configuration settings:
     - **Name**:
@@ -61,7 +61,7 @@ If you want to customize the text that appears on the consent prompt, you can cr
         return True
         ```python
         ````
-5. Click **Finish** to save the policy.
+5. Click **Create Policy** to save the policy.
 
 ### 4. Bind the policy to the Consent stage in the authorization flow (_optional_)
 
@@ -78,4 +78,4 @@ You need to bind the policy to the stage within this flow, so go first to the fl
 5. Click the caret (>) beside the Consent stage to which you want to bind the policy, and expand the stage details.
 6. Click **Bind existing Policy/Group/User**.
 7. In the **Create Binding** dialog, click **Policy** and then select the Expression policy that you created above.
-8. Click **Create** to save the binding.
+8. Click **Create Policy Binding** to save the binding.

--- a/website/docs/customize/policies/types/event-matcher.md
+++ b/website/docs/customize/policies/types/event-matcher.md
@@ -40,9 +40,9 @@ This policy is useful only when an event object is present in the policy context
 
 1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Customization** > **Policies**.
-3. Click **Create** and select **Event Matcher Policy**.
+3. Click **New Policy** and select **Event Matcher Policy**.
 4. Configure the fields you want to match.
-5. Click **Finish**.
+5. Click **Create Policy**.
 
 ## Send notifications about an event match
 

--- a/website/docs/customize/policies/types/geoip.md
+++ b/website/docs/customize/policies/types/geoip.md
@@ -48,9 +48,9 @@ When distance checks are enabled, authentik evaluates the current login against 
 
 1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Customization** > **Policies**.
-3. Click **Create** and select **GeoIP Policy**.
+3. Click **New Policy** and select **GeoIP Policy**.
 4. Configure the country, ASN, and optional distance settings you need.
-5. Click **Finish**.
+5. Click **Create Policy**.
 
 ## Common use
 

--- a/website/docs/customize/policies/types/password-expiry.md
+++ b/website/docs/customize/policies/types/password-expiry.md
@@ -26,9 +26,9 @@ When the configured limit is exceeded, the policy fails. Depending on the policy
 
 1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Customization** > **Policies**.
-3. Click **Create** and select **Password Expiry Policy**.
+3. Click **New Policy** and select **Password Expiry Policy**.
 4. Configure the allowed password age and whether the policy should run in deny-only mode.
-5. Click **Finish**.
+5. Click **Create Policy**.
 
 ## Common use
 

--- a/website/docs/customize/policies/types/password-uniqueness.md
+++ b/website/docs/customize/policies/types/password-uniqueness.md
@@ -44,12 +44,12 @@ For broader password controls, combine it with:
 To create a Password Uniqueness policy:
 
 1. In the Admin interface, navigate to **Customization** > **Policies**.
-2. Click **Create** to define a new Password Uniqueness Policy.
+2. Click **New Policy** to define a new Password Uniqueness Policy.
 3. Configure the policy:
     - **Name**: use a descriptive name.
     - **Password field**: enter the field key that contains the new password. In the default flows this is usually `password`.
     - **Number of previous passwords to check**: choose how many previous passwords authentik should compare against and retain for future checks.
-4. Click **Finish**.
+4. Click **Create Policy**.
 
 ## Attach the policy to password entry
 

--- a/website/docs/customize/policies/types/password.md
+++ b/website/docs/customize/policies/types/password.md
@@ -40,9 +40,9 @@ When the zxcvbn check is enabled, authentik evaluates password strength and can 
 
 1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Customization** > **Policies**.
-3. Click **Create** and select **Password Policy**.
+3. Click **New Policy** and select **Password Policy**.
 4. Configure the password field and validation rules you want to enforce.
-5. Click **Finish**.
+5. Click **Create Policy**.
 
 ## Attach it to password entry
 

--- a/website/docs/customize/policies/types/reputation.md
+++ b/website/docs/customize/policies/types/reputation.md
@@ -33,9 +33,9 @@ The threshold defaults to a low score, so the policy is naturally suited to "tri
 
 1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Customization** > **Policies**.
-3. Click **Create** and select **Reputation Policy**.
+3. Click **New Policy** and select **Reputation Policy**.
 4. Choose whether to check IP, username, or both, and set the threshold.
-5. Click **Finish**.
+5. Click **Create Policy**.
 
 ## Use it on stage bindings
 

--- a/website/docs/customize/policies/working_with_policies.md
+++ b/website/docs/customize/policies/working_with_policies.md
@@ -16,10 +16,10 @@ To create a policy:
 
 1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Customization** > **Policies**.
-3. Click **Create**.
+3. Click **New Policy**.
 4. Select the policy type.
 5. Configure the policy-specific settings.
-6. Click **Finish**.
+6. Click **Create Policy**.
 
 If you are not sure which policy type to choose, see [Types of policies in authentik](./types/index.mdx).
 

--- a/website/docs/install-config/first-steps/index.mdx
+++ b/website/docs/install-config/first-steps/index.mdx
@@ -70,7 +70,7 @@ For more configuration options and full details about integrating with Grafana, 
 
 ### 1. Log in to authentik as an administrator and open the authentik Admin interface.
 
-    **A.** In the Admin interface, navigate to **Applications** > **Applications** and click **Create with Provider** to create an application and provider pair.
+    **A.** In the Admin interface, navigate to **Applications** > **Applications** and click **New Application** to create an application and provider pair.
 
 :::tip About application and provider pairs
 Every application that you add to authentik requires a provider, which is used to configure the specific protocol between the application and authentik, for example OAuth2/OIDC, SAML, LDAP, or others.
@@ -184,7 +184,7 @@ Now that you can access the authentik Admin interface, and you have added an app
     - **Is active**: Define the newly created user account as active.
     - **Attributes**: You can leave this empty for this tutorial. This field can be used to store custom attributes for the user, in YAML or JSON format. These attributes can then be used within property mappings and policies.
 
-    **C.** Click **Create**.
+    **C.** Click **Create User**.
 
 ### 2. Verify that the new user was created
 

--- a/website/docs/sys-mgmt/events/notifications.md
+++ b/website/docs/sys-mgmt/events/notifications.md
@@ -50,9 +50,9 @@ After you've created the policies to match the events you want, create a notific
 
 1. Log in as an administrator, open the authentik Admin interface, and navigate to **Event > Notification Rules**.
 
-2. Click **Create** to add a new notification rule or click the **Edit** icon next to an existing rule to modify it.
+2. Click **New Notification Rule** to add a new notification rule or click the **Edit** icon next to an existing rule to modify it.
 
-3. Define the policy configurations, and then click **Create** or **Update** to save the settings.
+3. Define the policy configurations, and then click **Create Notification Rule** or **Update** to save the settings.
 
 - Note that policies are executed regardless of whether a group is selected. However, notifications are only triggered when a group is selected.
 - You also have to select which [notification transport](./transports.md) should be used to send the notification. Two notification transports are created by default:
@@ -61,7 +61,7 @@ After you've created the policies to match the events you want, create a notific
 
 4. In the list of notification rules, click the arrow in the row of the notification rule to expand the details of the rule.
 
-5. Click **Bind existing Policy/Group/User** and in the **Create Binding** modal, select the policy that you created for this notification rule and then click **Create** to finalize the binding.
+5. Click **Bind existing Policy/Group/User** and in the **Create Binding** modal, select the policy that you created for this notification rule and then click **Create Policy Binding** to finalize the binding.
 
 :::info
 Be aware that policies are executed even when no group is selected.

--- a/website/docs/users-sources/user/invitations.md
+++ b/website/docs/users-sources/user/invitations.md
@@ -58,7 +58,7 @@ We have two pre-defined blueprints, the`Example - Invitation-based Enrollment` b
 ### Step 3. Create the invitation object
 
 1. Log in to authentik as an administrator and open the authentik Admin interface.
-2. Navigate to **Directory** > **Invitations** and click **Create**.
+2. Navigate to **Directory** > **Invitations** and click **New Invitation**.
 
     The Create Invitation box appears.
 
@@ -155,7 +155,7 @@ If you prefer to create your invitation flow manually instead of using a bluepri
 ### Step 1: Create an Invitation stage
 
 1. Log in to authentik as an administrator and open the authentik Admin interface.
-2. Navigate to **Flows and Stages** > **Stages** and click **Create**.
+2. Navigate to **Flows and Stages** > **Stages** and click **New Stage**.
 3. Select **Invitation Stage** from the stage type list.
 4. Configure the stage:
     - **Name**: Provide a descriptive name (e.g., `enrollment-invitation-stage`)
@@ -163,7 +163,7 @@ If you prefer to create your invitation flow manually instead of using a bluepri
         - Set to `false` if you want to require a valid invitation token (recommended for invitation-only flows).
         - Set to `true` if you want to allow both invited and non-invited users to use the same enrollment flow.
 
-5. Click **Create**.
+5. Click **Create Stage**.
 
 :::info
 The **Continue flow without invitation** setting determines whether users can proceed through the flow without a valid invitation token. When set to `false`, only users with valid invitation links can complete enrollment.

--- a/website/docs/users-sources/user/user_basic_operations.md
+++ b/website/docs/users-sources/user/user_basic_operations.md
@@ -12,7 +12,7 @@ The following topics are for the basic management of users: how to create, modif
 
 1. In the Admin interface of your authentik instance, select **Directory** > **Users** in the left side menu.
 2. In the **User folders** area, select the folder where you want to create a user.
-3. Click **Create** (for a default user).
+3. Click **New User** (for a default user).
 4. Fill in the required fields:
 
 - **Username**: This value must be unique across your user folders.
@@ -25,7 +25,7 @@ The following topics are for the basic management of users: how to create, modif
 - **Is active**: Define if the newly created user account is active. Selected by default.
 - **Attributes**: Custom attributes definition for the user, in YAML or JSON format. These attributes can be used to enforce additional prompts on authentication stages or define conditions to enforce specific policies if the current implementation does not fit your use case. The value is an empty dictionary by default.
 
-6. Click **Create**
+6. Click **Create User**
 
 You should see a confirmation pop-up on the top-right of the screen that the user has been created, and see the new user in the user list. You can directly click the username if you want to [modify your user](./user_basic_operations.md#modify-a-user).
 


### PR DESCRIPTION
## Summary

- Update button labels across policy and related docs to match the new modal/wizard invoker phrasing from #21549
- Trigger buttons now documented as "New {Entity}" and submit buttons as "Create {Entity}" instead of the generic "Create" / "Finish"

Targets #21133 (`sdko/policy-docs-reorg`).

| File                      | Old label                  | New label                 |
|---------------------------|----------------------------|----------------------------|
| flow/index.md:53          | Create / Finish            | New Flow / Create Flow     |
| consent/index.md:36       | Stages > Create            | New Stage                  |
| consent/index.md:53       | Policies > Create          | New Policy                 |
| first-steps/index.mdx:73  | Create with Provider       | New Application            |
| notifications.md:55       | Create or Update           | Create Notification Rule   |
| notifications.md:64       | Create (binding submit)    | Create Policy Binding      |
| invitations.md:61         | Invitations > Create       | New Invitation             |
| invitations.md:158        | Stages > Create            | New Stage                  |
| microsoft/index.md:49,73  | Property Mappings > Create | New Property Mapping       |
| microsoft/index.md:88     | Create with Provider       | New Application            |

## Test plan

- [ ] Verify docs build cleanly
- [ ] Spot-check that updated labels match the current UI