### PR TITLE
core: update refresh_groupancestry trigger for supporting logical replication

### DIFF
--- a/authentik/core/migrations/0058_groupparentagenode_enable_always_trigger.py
+++ b/authentik/core/migrations/0058_groupparentagenode_enable_always_trigger.py
@@ -1,0 +1,42 @@
+import pgtrigger.compiler
+import pgtrigger.migrations
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        (
+            "authentik_core",
+            "0057_remove_user_groups_remove_user_user_permissions_and_more",
+        ),
+    ]
+
+    operations = [
+        # Update the trigger function to use the public schema prefix,
+        # ensuring it works correctly when search_path differs.
+        pgtrigger.migrations.RemoveTrigger(
+            model_name="groupparentagenode",
+            name="refresh_groupancestry",
+        ),
+        pgtrigger.migrations.AddTrigger(
+            model_name="groupparentagenode",
+            trigger=pgtrigger.compiler.Trigger(
+                name="refresh_groupancestry",
+                sql=pgtrigger.compiler.UpsertTriggerSql(
+                    func="\n                    REFRESH MATERIALIZED VIEW CONCURRENTLY public.authentik_core_groupancestry;\n                    RETURN NULL;\n                ",
+                    hash="f8a6e3b2c1d4a5907b3e2f1c8d6a4b5e9c7d0f1a",
+                    operation="INSERT OR UPDATE OR DELETE",
+                    pgid="pgtrigger_refresh_groupancestry_62450",
+                    table="authentik_core_groupparentage",
+                    when="AFTER",
+                ),
+            ),
+        ),
+        # Enable the trigger to fire on replicas as well (ALWAYS mode),
+        # so that the materialized view is refreshed when data is
+        # replicated via PostgreSQL logical replication.
+        migrations.RunSQL(
+            sql="ALTER TABLE authentik_core_groupparentage ENABLE ALWAYS TRIGGER pgtrigger_refresh_groupancestry_62450;",
+            reverse_sql="ALTER TABLE authentik_core_groupparentage ENABLE TRIGGER pgtrigger_refresh_groupancestry_62450;",
+        ),
+    ]

--- a/authentik/core/models.py
+++ b/authentik/core/models.py
@@ -278,7 +278,7 @@ class GroupParentageNode(models.Model):
                 operation=pgtrigger.Insert | pgtrigger.Update | pgtrigger.Delete,
                 when=pgtrigger.After,
                 func="""
-                    REFRESH MATERIALIZED VIEW CONCURRENTLY authentik_core_groupancestry;
+                    REFRESH MATERIALIZED VIEW CONCURRENTLY public.authentik_core_groupancestry;
                     RETURN NULL;
                 """,
             ),


### PR DESCRIPTION


<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
When we want to have logical replication on the PostgreSQL database, the trigger must run on the primary instance and on the replica. This PR updates the trigger
---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
