### PR TITLE
website/docs: remove broken version tag from oauth doc

### DIFF
--- a/website/docs/add-secure-apps/providers/oauth2/index.mdx
+++ b/website/docs/add-secure-apps/providers/oauth2/index.mdx
@@ -213,6 +213,6 @@ When a _Signing Key_ is selected in the provider, the JWT will be signed asymmet
 
 When no _Signing Key_ is selected, the JWT will be signed symmetrically with the _Client secret_ of the provider, which can be seen in the provider settings.
 
-### Encryption:ak-version
+### Encryption
 
 authentik can also encrypt JWTs (turning them into JWEs) it issues by selecting an _Encryption Key_ in the provider. When selected, all JWTs will be encrypted symmetrically using the selected certificate. authentik uses the `RSA-OAEP-256` algorithm with the `A256CBC-HS512` encryption method.


### PR DESCRIPTION
## Details

 Removes broken version tag from oauth doc

---

## Checklist


If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
