### PR TITLE
sources/ldap: catch Google LDAP rate-limit errors during schema fetch

### DIFF
--- a/authentik/sources/ldap/models.py
+++ b/authentik/sources/ldap/models.py
@@ -12,7 +12,13 @@ from django.db import connection, models
 from django.templatetags.static import static
 from django.utils.translation import gettext_lazy as _
 from ldap3 import ALL, NONE, RANDOM, Connection, Server, ServerPool, Tls
-from ldap3.core.exceptions import LDAPException, LDAPInsufficientAccessRightsResult, LDAPSchemaError
+from ldap3.core.exceptions import (
+    LDAPAdminLimitExceededResult,
+    LDAPAttributeError,
+    LDAPException,
+    LDAPInsufficientAccessRightsResult,
+    LDAPSchemaError,
+)
 from rest_framework.serializers import Serializer
 from structlog.stdlib import get_logger
 
@@ -278,10 +284,17 @@ class LDAPSource(IncomingSyncSource):
             successful = conn.bind()
             if successful:
                 return conn
-        except (LDAPSchemaError, LDAPInsufficientAccessRightsResult) as exc:
-            # Schema error, so try connecting without schema info
+        except (
+            LDAPSchemaError,
+            LDAPInsufficientAccessRightsResult,
+            LDAPAdminLimitExceededResult,
+            LDAPAttributeError,
+        ) as exc:
+            # Schema error or rate limit during schema fetch, retry without schema info
             # See https://github.com/goauthentik/authentik/issues/4590
             # See also https://github.com/goauthentik/authentik/issues/3399
+            # LDAPAdminLimitExceededResult: Google Secure LDAP rate-limits schema queries
+            # LDAPAttributeError: Google Secure LDAP returns unsupported attrs in schema
             if server_kwargs.get("get_info", ALL) == NONE:
                 LOGGER.warning("Failed to connect after schema downgrade", source=self, exc=exc)
                 raise exc


### PR DESCRIPTION
## Summary

Google Secure LDAP can fail during `bind()` because `ldap3` fetches schema information when the server is created with `get_info=ALL`.

authentik already has a fallback that retries the connection with `get_info=NONE`, but that fallback currently only catches `LDAPSchemaError` and `LDAPInsufficientAccessRightsResult`.

For Google Secure LDAP, two other exceptions can be raised during the schema fetch:

- `LDAPAdminLimitExceededResult` when Google rate-limits schema queries
- `LDAPAttributeError` when Google returns unsupported schema attributes such as `createTimestamp`

Those exceptions currently bypass the fallback and abort the sync.

## Changes

- catch `LDAPAdminLimitExceededResult` in `LDAPSource.connection()`
- catch `LDAPAttributeError` in `LDAPSource.connection()`
- reuse the existing retry path so the connection is downgraded to `get_info=NONE`

## Why This Is Safe

- no behavior change for successful binds
- no new fallback logic is introduced; this only extends the existing downgrade path to equivalent failure cases
- if the downgraded connection also fails, the original exception is still raised

## User Impact

- fixes LDAP federation sync failures against Google Secure LDAP
- prevents sync workers from failing before membership reconciliation can run
- allows missing group memberships to be populated on the next successful sync

## Related

- #4590
- #3399
