### PR TITLE
packages/ak-axum/server: fix unix socket cleanup when allow_failure is unset

### DIFF
--- a/packages/ak-axum/src/server.rs
+++ b/packages/ak-axum/src/server.rs
@@ -84,7 +84,7 @@ pub(crate) async fn run_unix(
         .handle(handle)
         .serve(router.into_make_service())
         .await;
-    if let Some(path) = addr.as_pathname() {
+    if !allow_failure && let Some(path) = addr.as_pathname() {
         trace!(?addr, "removing socket");
         if let Err(err) = std::fs::remove_file(path) {
             trace!(?err, "failed to remove socket, ignoring");


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
