### PR TITLE
fix: worker forks not spawning, causing workers to show 0 in admin UI

### DIFF
--- a/packages/django-dramatiq-postgres/django_dramatiq_postgres/management/commands/worker.py
+++ b/packages/django-dramatiq-postgres/django_dramatiq_postgres/management/commands/worker.py
@@ -16,6 +16,19 @@ from django_dramatiq_postgres.conf import Conf
 class Command(BaseCommand):
     """Run worker"""
 
+    def _collect_forks(self) -> list:
+        import dramatiq
+        forks = []
+        try:
+            broker = dramatiq.get_broker()
+            for middleware in broker.middleware:
+                if hasattr(middleware, 'forks'):
+                    for fork in middleware.forks:
+                        forks.append(f"{fork.__module__}:{fork.__qualname__}")
+        except Exception:
+            pass
+        return forks
+
     def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument(
             "--pid-file",
@@ -49,7 +62,7 @@ class Command(BaseCommand):
             log_file=None,
             skip_logging=True,
             use_spawn=False,
-            forks=[],
+            forks=self._collect_forks(),
             worker_shutdown_timeout=600000,
             watch=None,
             watch_use_polling=False,


### PR DESCRIPTION
## Problem

In authentik 2026.2.2, the admin dashboard shows "0 workers connected. 
Background tasks will not run." even though the worker container is 
healthy and tasks are being enqueued and processed correctly.

## Root Cause

In `packages/django-dramatiq-postgres/django_dramatiq_postgres/management/commands/worker.py`, 
the `forks` argument is hardcoded to an empty list `[]`:

```python
args = Namespace(
    ...
    forks=[],  # fork processes never spawned
    ...
)
```

authentik defines fork processes in middleware classes 
(`WorkerStatusMiddleware`, `WorkerHealthcheckMiddleware`, `MetricsMiddleware`) 
via a `forks` property. Because `forks=[]` is hardcoded, these fork 
processes are never spawned, so:

- `WorkerStatusMiddleware` never runs → worker never registers in `authentik_tasks_workerstatus`
- Admin UI reads from this table → shows 0 workers
- `WorkerHealthcheckMiddleware` never runs → healthcheck fork missing
- `MetricsMiddleware` never runs → Prometheus metrics fork missing

## Fix

Collect fork functions from broker middleware and pass them with the 
correct `module:function` format expected by Dramatiq's `import_object()`:

```python
def _collect_forks(self) -> list:
    import dramatiq
    forks = []
    try:
        broker = dramatiq.get_broker()
        for middleware in broker.middleware:
            if hasattr(middleware, 'forks'):
                for fork in middleware.forks:
                    forks.append(f"{fork.__module__}:{fork.__qualname__}")
    except Exception:
        pass
    return forks
```

Note: the format must be `module:function` not `module.function` — 
Dramatiq's `import_object()` treats dots as module path separators, 
which causes `ModuleNotFoundError` since `forks` is a module file not 
a package.

## Verification

After the fix, all three fork processes start correctly:
Fork process 'authentik.tasks.forks:worker_healthcheck' is ready for action.
Fork process 'authentik.tasks.forks:worker_status' is ready for action.
Fork process 'authentik.tasks.forks:worker_metrics' is ready for action.

And the worker registers in `authentik_tasks_workerstatus`, showing 
correctly in the admin UI.

## Notes

This is different from #20606 which fixed `set_start_method` for macOS. 
That PR did not address the `forks=[]` issue.