### PR TITLE
root: replace Zenko CloudServer with MinIO for local S3

### DIFF
--- a/scripts/compose.yml
+++ b/scripts/compose.yml
@@ -14,16 +14,16 @@ services:
     restart: always
   s3:
     container_name: s3
-    image: docker.io/zenko/cloudserver
+    image: docker.io/minio/minio
+    command: server /data --address ":9000"
     environment:
-      REMOTE_MANAGEMENT_DISABLE: "1"
-      SCALITY_ACCESS_KEY_ID: accessKey1
-      SCALITY_SECRET_ACCESS_KEY: secretKey1
+      MINIO_ROOT_USER: accessKey1
+      MINIO_ROOT_PASSWORD: secretKey1
+      MINIO_BROWSER: "off" # disables Web UI console
     ports:
-      - 8020:8000
+      - 8020:9000
     volumes:
-      - s3-data:/usr/src/app/localData
-      - s3-metadata:/usr/scr/app/localMetadata
+      - s3-data:/data
     restart: always
   spotlight:
     image: ghcr.io/getsentry/spotlight
@@ -42,6 +42,4 @@ volumes:
   db-data:
     driver: local
   s3-data:
-    driver: local
-  s3-metadata:
     driver: local


### PR DESCRIPTION

## Details

Replaces `zenko/cloudserver` with `minio/minio` in the dev compose stack.

Zenko CloudServer is effectively abandoned, only supports AMD64, and has higher memory usage at idle. 
MinIO is ~actively maintained~ _less abandoned_, multi-arch, and leaner. 
The S3 API interface and all existing credentials/endpoint config remain unchanged.

`zenko/cloudserver`:

<img width="1384" height="202" alt="Screenshot 2026-04-17 at 5 01 04 AM" src="https://github.com/user-attachments/assets/2a03392f-d278-4158-939e-f8466be73289" />

`minio/minio`:

<img width="1384" height="202" alt="Screenshot 2026-04-17 at 5 44 21 AM" src="https://github.com/user-attachments/assets/1a98484b-c21d-43e9-b304-330030b35bee" />

better DX :)

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
