### PR TITLE
website/docs: add authorization header info to all proxy configs

### DIFF
--- a/website/docs/add-secure-apps/providers/proxy/_caddy_standalone.md
+++ b/website/docs/add-secure-apps/providers/proxy/_caddy_standalone.md
@@ -13,6 +13,8 @@ app.company {
 
             # capitalization of the headers is important, otherwise they will be empty
             copy_headers X-Authentik-Username X-Authentik-Groups X-Authentik-Entitlements X-Authentik-Email X-Authentik-Name X-Authentik-Uid X-Authentik-Jwt X-Authentik-Meta-Jwks X-Authentik-Meta-Outpost X-Authentik-Meta-Provider X-Authentik-Meta-App X-Authentik-Meta-Version
+            # Add the 'authorization' header to the list if you need proxy providers which
+            # send a custom HTTP-Basic Authentication header based on values from authentik
 
             # optional, in this config trust all private ranges, should probably be set to the outposts IP
             trusted_proxies private_ranges

--- a/website/docs/add-secure-apps/providers/proxy/_envoy_istio.md
+++ b/website/docs/add-secure-apps/providers/proxy/_envoy_istio.md
@@ -20,7 +20,7 @@ spec:
                   headersToUpstreamOnAllow:
                       - set-cookie
                       - x-authentik-*
-                      # Add authorization headers to the allow list if you need proxy providers which
+                      # Add the 'authorization' header to headersToUpstreamOnAllow if you need proxy providers which
                       # send a custom HTTP-Basic Authentication header based on values from authentik
                       # - authorization
                   includeRequestHeadersInCheck:

--- a/website/docs/add-secure-apps/providers/proxy/_nginx_ingress.md
+++ b/website/docs/add-secure-apps/providers/proxy/_nginx_ingress.md
@@ -41,6 +41,8 @@ metadata:
             https://app.company/outpost.goauthentik.io/start?rd=$scheme://$http_host$escaped_request_uri
         nginx.ingress.kubernetes.io/auth-response-headers: |-
             Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-entitlements,X-authentik-email,X-authentik-name,X-authentik-uid
+            # Add the 'authorization' header to auth-response-headers if you need proxy providers which
+            # send a custom HTTP-Basic Authentication header based on values from authentik
         nginx.ingress.kubernetes.io/auth-snippet: |
             proxy_set_header X-Forwarded-Host $http_host;
 ```

--- a/website/docs/add-secure-apps/providers/proxy/_traefik_compose.md
+++ b/website/docs/add-secure-apps/providers/proxy/_traefik_compose.md
@@ -33,6 +33,8 @@ services:
             traefik.http.middlewares.authentik.forwardauth.address: http://authentik-proxy:9000/outpost.goauthentik.io/auth/traefik
             traefik.http.middlewares.authentik.forwardauth.trustForwardHeader: true
             traefik.http.middlewares.authentik.forwardauth.authResponseHeaders: X-authentik-username,X-authentik-groups,X-authentik-entitlements,X-authentik-email,X-authentik-name,X-authentik-uid,X-authentik-jwt,X-authentik-meta-jwks,X-authentik-meta-outpost,X-authentik-meta-provider,X-authentik-meta-app,X-authentik-meta-version
+            # Add the 'authorization' header to authResponseHeaders if you need proxy providers which
+            # send a custom HTTP-Basic Authentication header based on values from authentik
         restart: unless-stopped
 
     whoami:

--- a/website/docs/add-secure-apps/providers/proxy/_traefik_ingress.md
+++ b/website/docs/add-secure-apps/providers/proxy/_traefik_ingress.md
@@ -23,6 +23,9 @@ spec:
             - X-authentik-meta-provider
             - X-authentik-meta-app
             - X-authentik-meta-version
+            # Add the 'authorization' header to authResponseHeaders if you need proxy providers which
+            # send a custom HTTP-Basic Authentication header based on values from authentik
+            # - authorization
 ```
 
 :::info

--- a/website/docs/add-secure-apps/providers/proxy/_traefik_standalone.md
+++ b/website/docs/add-secure-apps/providers/proxy/_traefik_standalone.md
@@ -18,6 +18,9 @@ http:
                     - X-authentik-meta-provider
                     - X-authentik-meta-app
                     - X-authentik-meta-version
+                    # Add the 'authorization' header to authResponseHeaders if you need proxy providers which
+                    # send a custom HTTP-Basic Authentication header based on values from authentik
+                    # - authorization
     routers:
         default-router:
             rule: "Host(`app.company`)"


### PR DESCRIPTION
## Details

Adds authorization header info to all proxy configs. Follow up to #10932

Closes #4379

---

## Checklist

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
