### PR TITLE
core: survive the empty-queryset race in chunked_queryset

### DIFF
--- a/authentik/lib/utils/db.py
+++ b/authentik/lib/utils/db.py
@@ -14,7 +14,16 @@ def chunked_queryset[T: Model](queryset: QuerySet[T], chunk_size: int = 1_000) -
     def get_chunks(qs: QuerySet) -> Generator[QuerySet[T]]:
         qs = qs.order_by("pk")
         pks = qs.values_list("pk", flat=True)
-        start_pk = pks[0]
+        # The outer queryset.exists() guard can race with a concurrent
+        # transaction that deletes the last matching row (or with a
+        # different isolation-level snapshot), so by the time this
+        # generator starts iterating the queryset may be empty and
+        # pks[0] would raise IndexError and crash the caller. Using
+        # .first() returns None on an empty queryset, which we bail
+        # out on cleanly. See goauthentik/authentik#21643.
+        start_pk = pks.first()
+        if start_pk is None:
+            return
         while True:
             try:
                 end_pk = pks.filter(pk__gte=start_pk)[chunk_size]


### PR DESCRIPTION
Fixes #21643.

## Problem

`authentik.lib.utils.db.chunked_queryset` has a race between its outer existence guard and the inner `get_chunks` generator. The outer `if not queryset.exists(): return []` is evaluated eagerly, but `get_chunks` is evaluated lazily by the `for chunk in get_chunks(queryset):` loop. Between the two, a concurrent transaction can delete the last matching row (or a different snapshot can be seen under non-default isolation), which makes `pks[0]` fire `IndexError`:

```
Failed to process message authentik.core.tasks.clean_expired_models()
  File "/authentik/lib/utils/db.py", line 17, in get_chunks
  File ".../django/db/models/query.py", line 438, in __getitem__
IndexError: list index out of range
```

The issue author observed this twice in ~5000 lines of worker logs on a production environment, so the race is rare but reproducible.

## Fix

Swap `pks[0]` for `pks.first()` + explicit `None` check. `QuerySet.first()` returns `None` on an empty queryset rather than raising, which we can bail out on cleanly:

```python
start_pk = pks.first()
if start_pk is None:
    return
```

Behaviour on non-empty querysets is unchanged; the SQL issued for `pks.first()` vs `pks[0]` is equivalent (`LIMIT 1` after the `ORDER BY pk`).

Signed off per DCO.
