### PR TITLE
website/docs: clarify passwordless password stage setup

### DIFF
--- a/website/docs/add-secure-apps/flows-stages/stages/password/index.md
+++ b/website/docs/add-secure-apps/flows-stages/stages/password/index.md
@@ -40,9 +40,9 @@ If you want users to be able to pick a passkey from the browser's passkey/autofi
 
 ### Dynamically skip a Password stage
 
-This pattern keeps a normal identification flow, but skips the Password stage for users who already have a supported authenticator configured.
+This setup keeps a normal identification flow, but skips the Password stage for users who already have a supported authenticator configured.
 
-To configure this pattern:
+To configure this setup:
 
 1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Customization** > **Policies** and create an [Expression Policy](../../../../customize/policies/types/expression/index.mdx).

--- a/website/docs/add-secure-apps/flows-stages/stages/password/index.md
+++ b/website/docs/add-secure-apps/flows-stages/stages/password/index.md
@@ -31,29 +31,62 @@ If you create a service account, that account has an automatically generated App
 
 ## Passwordless login
 
-There are two different ways to configure passwordless authentication;
+There are two different ways to configure passwordless authentication:
 
 - allow users to directly authenticate with their authenticator (only supported for WebAuthn devices), by following [these instructions](../authenticator_validate/index.mdx#passwordless-authentication).
 - dynamically skip a Password stage (depending on the user's device), as documented on this page.
 
 If you want users to be able to pick a passkey from the browser's passkey/autofill UI without entering a username first, configure **Passkey autofill (WebAuthn conditional UI)** in the [Identification stage](../identification/index.mdx#passkey-autofill-webauthn-conditional-ui). This is separate from configuring a dedicated passwordless flow, and can be used alongside normal identification flows.
 
-Depending on what kind of device you want to require the user to have:
+### Dynamically skip a Password stage
+
+This pattern keeps a normal identification flow, but skips the Password stage for users who already have a supported authenticator configured.
+
+To configure this pattern:
+
+1. Log in to authentik as an administrator and open the authentik Admin interface.
+2. Navigate to **Customization** > **Policies** and create an [Expression Policy](../../../../customize/policies/types/expression/index.mdx).
+3. Configure the expression so that it returns `True` only when the Password stage should run. Use one of the expressions below, depending on the authenticator type.
+4. Navigate to **Flows and Stages** > **Flows** and open your authentication flow.
+5. Open the **Stage Bindings** tab, expand the Password stage binding, and bind the Expression Policy there. Do not bind it to the flow itself or directly to the stage object. For more background, see [Bind a policy to a stage binding](../../../../customize/policies/working_with_policies.md#bind-a-policy-to-a-stage-binding).
+6. On the Password stage binding, enable **Evaluate when stage is run**. Disable **Evaluate when flow is planned** unless the user is already known before the flow starts.
 
 #### WebAuthn
 
 ```python
 from authentik.stages.authenticator_webauthn.models import WebAuthnDevice
-return WebAuthnDevice.objects.filter(user=request.context['pending_user'], confirmed=True).exists()
+
+pending_user = request.context.get("pending_user")
+if not pending_user:
+    return True
+
+return not WebAuthnDevice.objects.filter(user=pending_user, confirmed=True).exists()
 ```
 
 #### Duo
 
 ```python
 from authentik.stages.authenticator_duo.models import DuoDevice
-return DuoDevice.objects.filter(user=request.context['pending_user'], confirmed=True).exists()
+
+pending_user = request.context.get("pending_user")
+if not pending_user:
+    return True
+
+return not DuoDevice.objects.filter(user=pending_user, confirmed=True).exists()
 ```
 
-Afterwards, bind the policy you've created to the stage binding of the password stage.
+Because the expression already returns whether the Password stage should run, you do not need to enable **Negate result** on the policy binding.
 
-Make sure to uncheck _Evaluate when flow is planned_ and check _Evaluate when stage is run_, otherwise an invalid result will be cached.
+If the Password stage binding has more than one policy attached, review its **Policy engine mode** carefully:
+
+- With only this policy attached, either mode works.
+- If multiple policies are attached, `all` requires every policy to pass before the Password stage runs.
+- If multiple policies are attached, `any` runs the Password stage when any bound policy passes.
+
+#### Default authentication flow
+
+The built-in `default-authentication-flow` already includes a policy binding on its Password stage, `default-authentication-flow-password-stage`, which controls whether the Password stage should appear.
+
+If you add a second policy to that same Password stage binding, set the stage binding's **Policy engine mode** to `all` so both the built-in policy and your Expression Policy must pass before the Password stage runs.
+
+Keep **Evaluate when stage is run** enabled on that binding. In the default blueprint, this is already configured.


### PR DESCRIPTION
Document how to skip the Password stage with an Expression Policy, where to bind it, and how the default authentication flow's existing binding affects the setup.

Closes: https://github.com/goauthentik/authentik/issues/21418

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
