### PR TITLE
sources/oauth: pick a single pkce method from OIDC discovery, not the whole list

### DIFF
--- a/authentik/sources/oauth/api/source.py
+++ b/authentik/sources/oauth/api/source.py
@@ -95,15 +95,12 @@ class OAuthSourceSerializer(SourceSerializer):
             # and later str() into the authorize URL as "['plain', 'S256']".
             if not attrs.get("pkce"):
                 supported_methods = config.get("code_challenge_methods_supported") or []
+                attrs["pkce"] = PKCEMethod.NONE
                 if isinstance(supported_methods, list):
                     if PKCEMethod.S256 in supported_methods:
                         attrs["pkce"] = PKCEMethod.S256
                     elif PKCEMethod.PLAIN in supported_methods:
                         attrs["pkce"] = PKCEMethod.PLAIN
-                    else:
-                        attrs["pkce"] = PKCEMethod.NONE
-                else:
-                    attrs["pkce"] = PKCEMethod.NONE
             inferred_oidc_jwks_url = config.get("jwks_uri", "")
 
         # Prefer user-entered URL to inferred URL to default URL

--- a/authentik/sources/oauth/api/source.py
+++ b/authentik/sources/oauth/api/source.py
@@ -17,7 +17,7 @@ from authentik.core.api.sources import SourceSerializer
 from authentik.core.api.used_by import UsedByMixin
 from authentik.core.api.utils import PassiveSerializer
 from authentik.lib.utils.http import get_http_session
-from authentik.sources.oauth.models import OAuthSource
+from authentik.sources.oauth.models import OAuthSource, PKCEMethod
 from authentik.sources.oauth.types.registry import SourceType, registry
 
 
@@ -83,13 +83,27 @@ class OAuthSourceSerializer(SourceSerializer):
                 "authorization_url": "authorization_endpoint",
                 "access_token_url": "token_endpoint",
                 "profile_url": "userinfo_endpoint",
-                "pkce": "code_challenge_methods_supported",
             }
             for ak_key, oidc_key in field_map.items():
                 # Don't overwrite user-set values
                 if ak_key in attrs and attrs[ak_key]:
                     continue
                 attrs[ak_key] = config.get(oidc_key, "")
+            # code_challenge_methods_supported is a list per RFC 8414, not a
+            # single method. Pick one (prefer S256, the RFC-recommended method)
+            # rather than letting the list round-trip into the pkce TextField
+            # and later str() into the authorize URL as "['plain', 'S256']".
+            if not attrs.get("pkce"):
+                supported_methods = config.get("code_challenge_methods_supported") or []
+                if isinstance(supported_methods, list):
+                    if PKCEMethod.S256 in supported_methods:
+                        attrs["pkce"] = PKCEMethod.S256
+                    elif PKCEMethod.PLAIN in supported_methods:
+                        attrs["pkce"] = PKCEMethod.PLAIN
+                    else:
+                        attrs["pkce"] = PKCEMethod.NONE
+                else:
+                    attrs["pkce"] = PKCEMethod.NONE
             inferred_oidc_jwks_url = config.get("jwks_uri", "")
 
         # Prefer user-entered URL to inferred URL to default URL

--- a/authentik/sources/oauth/tests/test_views.py
+++ b/authentik/sources/oauth/tests/test_views.py
@@ -79,6 +79,7 @@ class TestOAuthSource(APITestCase):
             "token_endpoint": "http://mock/oauth/token",
             "userinfo_endpoint": "http://mock/oauth/userinfo",
             "jwks_uri": "http://mock/oauth/discovery/keys",
+            "code_challenge_methods_supported": ["S256"],
         }
         jwks_config = {"keys": []}
         with Mocker() as mocker:
@@ -109,6 +110,7 @@ class TestOAuthSource(APITestCase):
                 serializer.validated_data["oidc_jwks_url"], "http://mock/oauth/discovery/keys"
             )
             self.assertEqual(serializer.validated_data["oidc_jwks"], jwks_config)
+            self.assertEqual(serializer.validated_data["pkce"], PKCEMethod.S256)
 
     def test_api_validate_openid_connect_invalid(self):
         """Test API validation (with OIDC endpoints)"""


### PR DESCRIPTION
## What

When an OAuth source is configured with an `oidc_well_known_url`, the API serializer in `authentik/sources/oauth/api/source.py` merges the upstream's OpenID configuration into the source attrs via a plain field_map:

```python
field_map = {
    "authorization_url":  "authorization_endpoint",
    "access_token_url":   "token_endpoint",
    "profile_url":        "userinfo_endpoint",
    "pkce":               "code_challenge_methods_supported",
}
for ak_key, oidc_key in field_map.items():
    if ak_key in attrs and attrs[ak_key]:
        continue
    attrs[ak_key] = config.get(oidc_key, "")
```

`code_challenge_methods_supported` is defined by RFC 8414 as a JSON **array** (e.g. `["plain", "S256"]`), but `attrs["pkce"]` is backed by a `TextField(choices=PKCEMethod.choices)` with values `NONE` / `PLAIN` / `S256`. Django does not validate choices on plain assignment, so the list round-trips into the DB, and later `OAuth2Client.get_redirect_args` formats it as:

```python
args["code_challenge_method"] = str(pkce_mode)
# -> "['plain', 'S256']"
```

which ships on `/authorize` as `code_challenge_method=%5B%27plain%27%2C+%27S256%27%5D`. The upstream has no PKCE state that matches, so the subsequent `/token` exchange returns HTTP 400 and the login fails.

Per #21665.

## Fix

Separate the pkce handling from the rest of the field_map loop and pick a single scalar method:

```python
field_map = {
    "authorization_url": "authorization_endpoint",
    "access_token_url":  "token_endpoint",
    "profile_url":       "userinfo_endpoint",
}
for ak_key, oidc_key in field_map.items():
    if ak_key in attrs and attrs[ak_key]:
        continue
    attrs[ak_key] = config.get(oidc_key, "")

if not attrs.get("pkce"):
    supported_methods = config.get("code_challenge_methods_supported") or []
    if isinstance(supported_methods, list):
        if PKCEMethod.S256 in supported_methods:
            attrs["pkce"] = PKCEMethod.S256
        elif PKCEMethod.PLAIN in supported_methods:
            attrs["pkce"] = PKCEMethod.PLAIN
        else:
            attrs["pkce"] = PKCEMethod.NONE
    else:
        attrs["pkce"] = PKCEMethod.NONE
```

Preference order is `S256` → `PLAIN` → `NONE`. `S256` is the method RFC 7636 lists as MUST-support for public clients and is the recommended default. A user-set `attrs["pkce"]` still wins, matching the existing "don't overwrite user-set values" intent that the old loop encoded.

## Why just the serializer

The related periodic task `sources/oauth/tasks.py::update_well_known_jwks` already has its own, narrower `source_attr_key` map that does not touch `pkce`, so it needs no change. The bug is entirely on the create/update path that goes through this serializer.

## Test plan

- Repro with two authentik instances per the issue steps: downstream hits upstream, login fails with HTTP 400 from `/token`, downstream logs `code_challenge_method=['plain', 'S256']` on `/authorize`.
- Apply patch, recreate the OAuth source (so the API serializer runs), log in again. `/authorize` carries `code_challenge_method=S256` and a valid `code_challenge`; `/token` succeeds.
- Existing PKCE tests in `authentik/providers/oauth2/tests/test_token_pkce.py` still pass.

Fixes #21665