### PR TITLE
providers/oauth2: require client_secret on device_code exchange for confidential clients

### DIFF
--- a/authentik/providers/oauth2/tests/test_token_device.py
+++ b/authentik/providers/oauth2/tests/test_token_device.py
@@ -48,6 +48,7 @@ class TestTokenDeviceCode(OAuthTestCase):
             reverse("authentik_providers_oauth2:token"),
             data={
                 "client_id": self.provider.client_id,
+                "client_secret": self.provider.client_secret,
                 "grant_type": GRANT_TYPE_DEVICE_CODE,
             },
         )
@@ -66,6 +67,7 @@ class TestTokenDeviceCode(OAuthTestCase):
             reverse("authentik_providers_oauth2:token"),
             data={
                 "client_id": self.provider.client_id,
+                "client_secret": self.provider.client_secret,
                 "grant_type": GRANT_TYPE_DEVICE_CODE,
                 "device_code": device_token.device_code,
             },
@@ -73,6 +75,26 @@ class TestTokenDeviceCode(OAuthTestCase):
         self.assertEqual(res.status_code, 400)
         body = loads(res.content.decode())
         self.assertEqual(body["error"], "authorization_pending")
+
+    def test_code_no_auth(self):
+        """Test code with user"""
+        device_token = DeviceToken.objects.create(
+            provider=self.provider,
+            user_code=generate_code_fixed_length(),
+            device_code=generate_id(),
+            user=self.user,
+        )
+        res = self.client.post(
+            reverse("authentik_providers_oauth2:token"),
+            data={
+                "client_id": self.provider.client_id,
+                "grant_type": GRANT_TYPE_DEVICE_CODE,
+                "device_code": device_token.device_code,
+            },
+        )
+        self.assertEqual(res.status_code, 400)
+        body = loads(res.content.decode())
+        self.assertEqual(body["error"], "invalid_client")
 
     def test_code(self):
         """Test code with user"""
@@ -86,6 +108,7 @@ class TestTokenDeviceCode(OAuthTestCase):
             reverse("authentik_providers_oauth2:token"),
             data={
                 "client_id": self.provider.client_id,
+                "client_secret": self.provider.client_secret,
                 "grant_type": GRANT_TYPE_DEVICE_CODE,
                 "device_code": device_token.device_code,
             },
@@ -105,6 +128,7 @@ class TestTokenDeviceCode(OAuthTestCase):
             reverse("authentik_providers_oauth2:token"),
             data={
                 "client_id": self.provider.client_id,
+                "client_secret": self.provider.client_secret,
                 "grant_type": GRANT_TYPE_DEVICE_CODE,
                 "device_code": device_token.device_code,
                 "scope": f"{SCOPE_OPENID} {SCOPE_OPENID_EMAIL} invalid",

--- a/authentik/providers/oauth2/views/token.py
+++ b/authentik/providers/oauth2/views/token.py
@@ -168,12 +168,7 @@ class TokenParams:
         # Confidential clients MUST authenticate to the token endpoint per
         # RFC 6749 §2.3.1. The device code grant (RFC 8628 §3.4) inherits
         # that requirement - the device_code alone is not a substitute for
-        # client credentials, since a victim who completes authorization
-        # for an attacker-generated device_code would otherwise let the
-        # attacker trade that code for an access token without ever proving
-        # ownership of the client. Keycloak and Okta both enforce
-        # client_secret on the device token exchange for confidential
-        # clients; match that.
+        # client credentials.
         if self.grant_type in [
             GRANT_TYPE_AUTHORIZATION_CODE,
             GRANT_TYPE_REFRESH_TOKEN,

--- a/authentik/providers/oauth2/views/token.py
+++ b/authentik/providers/oauth2/views/token.py
@@ -165,7 +165,20 @@ class TokenParams:
                 raise TokenError("invalid_grant")
 
     def __post_init__(self, raw_code: str, raw_token: str, request: HttpRequest):
-        if self.grant_type in [GRANT_TYPE_AUTHORIZATION_CODE, GRANT_TYPE_REFRESH_TOKEN]:
+        # Confidential clients MUST authenticate to the token endpoint per
+        # RFC 6749 §2.3.1. The device code grant (RFC 8628 §3.4) inherits
+        # that requirement - the device_code alone is not a substitute for
+        # client credentials, since a victim who completes authorization
+        # for an attacker-generated device_code would otherwise let the
+        # attacker trade that code for an access token without ever proving
+        # ownership of the client. Keycloak and Okta both enforce
+        # client_secret on the device token exchange for confidential
+        # clients; match that.
+        if self.grant_type in [
+            GRANT_TYPE_AUTHORIZATION_CODE,
+            GRANT_TYPE_REFRESH_TOKEN,
+            GRANT_TYPE_DEVICE_CODE,
+        ]:
             if self.provider.client_type == ClientTypes.CONFIDENTIAL and not compare_digest(
                 self.provider.client_secret, self.client_secret
             ):


### PR DESCRIPTION
## What

`TokenParams.__post_init__` in `authentik/providers/oauth2/views/token.py` only ran the `client_secret` check for the `authorization_code` and `refresh_token` grant types:

```python
if self.grant_type in [GRANT_TYPE_AUTHORIZATION_CODE, GRANT_TYPE_REFRESH_TOKEN]:
    if self.provider.client_type == ClientTypes.CONFIDENTIAL and not compare_digest(
        self.provider.client_secret, self.client_secret,
    ):
        raise TokenError("invalid_client")
```

The device-code path (`__post_init_device_code`) then looked up the `DeviceToken` purely by `device_code` and issued an access token whenever one matched — regardless of whether the caller had proved ownership of the confidential client:

```python
def __post_init_device_code(self, request: HttpRequest):
    device_code = request.POST.get("device_code", "")
    code = DeviceToken.objects.filter(device_code=device_code, provider=self.provider).first()
    if not code:
        raise TokenError("invalid_grant")
    self.device_code = code
```

Per #20828 this is exploitable via the standard device-flow phishing shape (attacker starts device authorization, sends `user_code` to a victim, victim completes authorization, attacker redeems `device_code`): an attacker that only knows `client_id` can redeem a stolen `device_code` without ever proving ownership of the confidential client.

RFC 6749 §2.3.1 requires confidential clients to authenticate to the token endpoint; RFC 8628 §3.4 inherits that. The `device_code` is bearer-shaped but is not a substitute for client credentials. Keycloak and Okta both enforce `client_secret` on the device token exchange for confidential clients.

## Fix

Add `GRANT_TYPE_DEVICE_CODE` to the list that already runs the `compare_digest` check:

```python
if self.grant_type in [
    GRANT_TYPE_AUTHORIZATION_CODE,
    GRANT_TYPE_REFRESH_TOKEN,
    GRANT_TYPE_DEVICE_CODE,
]:
    if self.provider.client_type == ClientTypes.CONFIDENTIAL and not compare_digest(
        self.provider.client_secret, self.client_secret,
    ):
        raise TokenError("invalid_client")
```

- Public clients are unaffected (guard is gated on `ClientTypes.CONFIDENTIAL`).
- `client_credentials` / `password` keep their own client-auth path in `__post_init_client_credentials` (which also enforces the secret, plus supports client assertion).
- `authorization_code` / `refresh_token` paths are unchanged.

## Test plan

- Repro on `main`: configure an OIDC provider with `client_type: confidential`, run a device flow, `POST /application/o/token/` with only `client_id=...&device_code=...&grant_type=urn:ietf:params:oauth:grant-type:device_code` — gets an access token.
- With this patch applied: same request returns `{"error":"invalid_client"}`; the request with the correct `client_secret` (or a valid `Authorization: Basic ...`) still succeeds.
- Public clients: same request without `client_secret` still succeeds (unchanged behaviour).

Fixes #20828