### PR TITLE
providers/oauth2: clip device authorization scope against the provider's ScopeMapping set

### DIFF
--- a/authentik/providers/oauth2/tests/test_device_backchannel.py
+++ b/authentik/providers/oauth2/tests/test_device_backchannel.py
@@ -6,10 +6,11 @@ from urllib.parse import quote
 
 from django.urls import reverse
 
+from authentik.blueprints.tests import apply_blueprint
 from authentik.core.models import Application
 from authentik.core.tests.utils import create_test_flow
 from authentik.lib.generators import generate_id
-from authentik.providers.oauth2.models import OAuth2Provider
+from authentik.providers.oauth2.models import DeviceToken, OAuth2Provider, ScopeMapping
 from authentik.providers.oauth2.tests.utils import OAuthTestCase
 
 
@@ -110,3 +111,57 @@ class TesOAuth2DeviceBackchannel(OAuthTestCase):
         self.assertEqual(res.status_code, 200)
         body = loads(res.content.decode())
         self.assertEqual(body["expires_in"], 60)
+
+    @apply_blueprint("system/providers-oauth2.yaml")
+    def test_backchannel_scopes(self):
+        """Test backchannel"""
+        self.provider.property_mappings.set(
+            ScopeMapping.objects.filter(
+                managed__in=[
+                    "goauthentik.io/providers/oauth2/scope-openid",
+                    "goauthentik.io/providers/oauth2/scope-email",
+                    "goauthentik.io/providers/oauth2/scope-profile",
+                ]
+            )
+        )
+        creds = b64encode(f"{self.provider.client_id}:".encode()).decode()
+        res = self.client.post(
+            reverse("authentik_providers_oauth2:device"),
+            HTTP_AUTHORIZATION=f"Basic {creds}",
+            data={"scope": "openid email"},
+        )
+        self.assertEqual(res.status_code, 200)
+        body = loads(res.content.decode())
+        self.assertEqual(body["expires_in"], 60)
+        token = DeviceToken.objects.filter(device_code=body["device_code"]).first()
+        self.assertIsNotNone(token)
+        self.assertEqual(len(token.scope), 2)
+        self.assertIn("openid", token.scope)
+        self.assertIn("email", token.scope)
+
+    @apply_blueprint("system/providers-oauth2.yaml")
+    def test_backchannel_scopes_extra(self):
+        """Test backchannel"""
+        self.provider.property_mappings.set(
+            ScopeMapping.objects.filter(
+                managed__in=[
+                    "goauthentik.io/providers/oauth2/scope-openid",
+                    "goauthentik.io/providers/oauth2/scope-email",
+                    "goauthentik.io/providers/oauth2/scope-profile",
+                ]
+            )
+        )
+        creds = b64encode(f"{self.provider.client_id}:".encode()).decode()
+        res = self.client.post(
+            reverse("authentik_providers_oauth2:device"),
+            HTTP_AUTHORIZATION=f"Basic {creds}",
+            data={"scope": "openid email foo"},
+        )
+        self.assertEqual(res.status_code, 200)
+        body = loads(res.content.decode())
+        self.assertEqual(body["expires_in"], 60)
+        token = DeviceToken.objects.filter(device_code=body["device_code"]).first()
+        self.assertIsNotNone(token)
+        self.assertEqual(len(token.scope), 2)
+        self.assertIn("openid", token.scope)
+        self.assertIn("email", token.scope)

--- a/authentik/providers/oauth2/views/device_backchannel.py
+++ b/authentik/providers/oauth2/views/device_backchannel.py
@@ -15,7 +15,7 @@ from authentik.core.models import Application
 from authentik.lib.config import CONFIG
 from authentik.lib.utils.time import timedelta_from_string
 from authentik.providers.oauth2.errors import DeviceCodeError
-from authentik.providers.oauth2.models import DeviceToken, OAuth2Provider
+from authentik.providers.oauth2.models import DeviceToken, OAuth2Provider, ScopeMapping
 from authentik.providers.oauth2.utils import TokenResponse, extract_client_auth
 from authentik.providers.oauth2.views.device_init import QS_KEY_CODE
 
@@ -44,7 +44,22 @@ class DeviceView(View):
             raise DeviceCodeError("invalid_client") from None
         self.provider = provider
         self.client_id = client_id
-        self.scopes = self.request.POST.get("scope", "").split(" ")
+        # Only record scopes the provider is actually configured to issue.
+        # Without this filter, a caller can put any scope string (including
+        # offline_access) on the device authorization request, it ends up
+        # verbatim on the DeviceToken, and the token exchange later reads
+        # `SCOPE_OFFLINE_ACCESS in device_code.scope` straight from that
+        # untrusted payload. The other grant types clip their scope against
+        # the provider's ScopeMapping set in TokenParams.__check_scopes,
+        # but the device authorization endpoint runs before TokenParams is
+        # ever constructed, so clip here to match.
+        requested_scopes = {s for s in self.request.POST.get("scope", "").split(" ") if s}
+        allowed_scope_names = set(
+            ScopeMapping.objects.filter(provider__in=[self.provider]).values_list(
+                "scope_name", flat=True
+            )
+        )
+        self.scopes = sorted(requested_scopes & allowed_scope_names)
 
     def dispatch(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
         throttle = AnonRateThrottle()

--- a/authentik/providers/oauth2/views/device_backchannel.py
+++ b/authentik/providers/oauth2/views/device_backchannel.py
@@ -28,7 +28,7 @@ class DeviceView(View):
 
     client_id: str
     provider: OAuth2Provider
-    scopes: list[str] = []
+    scopes: set[str] = []
 
     def parse_request(self):
         """Parse incoming request"""
@@ -44,22 +44,21 @@ class DeviceView(View):
             raise DeviceCodeError("invalid_client") from None
         self.provider = provider
         self.client_id = client_id
-        # Only record scopes the provider is actually configured to issue.
-        # Without this filter, a caller can put any scope string (including
-        # offline_access) on the device authorization request, it ends up
-        # verbatim on the DeviceToken, and the token exchange later reads
-        # `SCOPE_OFFLINE_ACCESS in device_code.scope` straight from that
-        # untrusted payload. The other grant types clip their scope against
-        # the provider's ScopeMapping set in TokenParams.__check_scopes,
-        # but the device authorization endpoint runs before TokenParams is
-        # ever constructed, so clip here to match.
-        requested_scopes = {s for s in self.request.POST.get("scope", "").split(" ") if s}
-        allowed_scope_names = set(
+
+        scopes_to_check = set(self.request.POST.get("scope", "").split())
+        default_scope_names = set(
             ScopeMapping.objects.filter(provider__in=[self.provider]).values_list(
                 "scope_name", flat=True
             )
         )
-        self.scopes = sorted(requested_scopes & allowed_scope_names)
+        self.scopes = scopes_to_check
+        if not scopes_to_check.issubset(default_scope_names):
+            LOGGER.info(
+                "Application requested scopes not configured, setting to overlap",
+                scope_allowed=default_scope_names,
+                scope_given=self.scopes,
+            )
+            self.scopes = self.scopes.intersection(default_scope_names)
 
     def dispatch(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
         throttle = AnonRateThrottle()


### PR DESCRIPTION
## What

`DeviceView.parse_request` in `authentik/providers/oauth2/views/device_backchannel.py` stored the raw request scope straight onto the `DeviceToken`:

```python
self.scopes = self.request.POST.get("scope", "").split(" ")
...
token = DeviceToken.objects.create(..., _scope=" ".join(self.scopes))
```

The token-exchange side then reads those scopes back directly when deciding whether to issue a refresh token:

```python
# authentik/providers/oauth2/views/token.py
if SCOPE_OFFLINE_ACCESS in self.params.device_code.scope:
    refresh_token = RefreshToken(
        user=self.params.device_code.user,
        scope=self.params.device_code.scope,
        ...
    )
```

So a caller that adds `offline_access` to the device authorization request body gets a `refresh_token` at the exchange even when the provider has no `offline_access` `ScopeMapping` configured (#20825).

Every other grant type clips the scope set against `ScopeMapping.objects.filter(provider__in=[self.provider])` inside `TokenParams.__check_scopes`, but the device authorization endpoint runs before `TokenParams` is ever constructed, so the clip never happens for the device flow. Combined with #20828 (device exchange missing client_secret verification for confidential clients — filed separately) and the lack of per-app opt-out for the device flow, this gives anyone who knows the `client_id` a path to an offline refresh token against any OIDC application the deployment exposes.

## Fix

Intersect the requested scope set with the provider's `ScopeMapping` names before we ever persist the `DeviceToken`:

```python
requested_scopes = {s for s in self.request.POST.get("scope", "").split(" ") if s}
allowed_scope_names = set(
    ScopeMapping.objects.filter(provider__in=[self.provider]).values_list(
        "scope_name", flat=True
    )
)
self.scopes = sorted(requested_scopes & allowed_scope_names)
```

- `offline_access` that isn't configured as a `ScopeMapping` on the provider is silently dropped, matching what `__check_scopes` already does for the other grant types and what the expected behaviour is per #20825.
- Configured `offline_access` still flows through end-to-end and a refresh token is still issued.
- Any other scope string that isn't a mapping on the provider is also clipped, which matches the other grant types' contract that you only ever get scopes the provider is configured to issue.

## Test plan

- Repro on `main`: configure an OIDC provider without the `offline_access` scope mapping. Run device flow with `scope=email+profile+openid+offline_access`. Token exchange returns `refresh_token`.
- Patch applied: same flow, token exchange no longer contains `refresh_token`; `scope` in the response is clipped to only the configured mappings.
- Add `offline_access` mapping to the provider: `refresh_token` is issued again.

Fixes #20825