### PR TITLE
sources/ldap: strip NUL bytes from the LDAP password-change error message

### DIFF
--- a/authentik/sources/ldap/signals.py
+++ b/authentik/sources/ldap/signals.py
@@ -52,12 +52,21 @@ def ldap_sync_password(sender, user: User, password: str, **_):
         changer.change_password(user, password)
     except LDAPOperationResult as exc:
         LOGGER.warning("failed to set LDAP password", exc=exc)
+        # Some LDAP servers (notably Active Directory) include NUL bytes in
+        # the result detail string. Postgres rejects NUL bytes inside JSON
+        # text, so saving the Event row fails with
+        #     unsupported Unicode escape sequence ... \u0000 cannot be
+        #     converted to text
+        # which turns an already-failed password change into an uncaught
+        # 500 for the user. Strip NULs before handing the message to the
+        # ORM.
+        message = (
+            "Failed to change password in LDAP source due to remote error: "
+            f"{exc.result}, {exc.message}, {exc.description}"
+        ).replace("\x00", "")
         Event.new(
             EventAction.CONFIGURATION_ERROR,
-            message=(
-                "Failed to change password in LDAP source due to remote error: "
-                f"{exc.result}, {exc.message}, {exc.description}"
-            ),
+            message=message,
             source=source,
         ).set_user(user).save()
         raise ValidationError("Failed to set password") from exc


### PR DESCRIPTION
## What

`ldap_sync_password` catches `LDAPOperationResult` and stores its `result`, `message`, and `description` fields on a `CONFIGURATION_ERROR` Event:

```python
except LDAPOperationResult as exc:
    LOGGER.warning("failed to set LDAP password", exc=exc)
    Event.new(
        EventAction.CONFIGURATION_ERROR,
        message=(
            "Failed to change password in LDAP source due to remote error: "
            f"{exc.result}, {exc.message}, {exc.description}"
        ),
        source=source,
    ).set_user(user).save()
    raise ValidationError("Failed to set password") from exc
```

Active Directory in particular returns payloads like `data 0\x00` for INSUFF_ACCESS_RIGHTS, so `exc.message` carries a raw NUL byte. `Event.context` is a JSONB column and Postgres refuses to store `\u0000` inside JSON text:

```
psycopg.errors.UntranslatableCharacter: unsupported Unicode escape sequence
LINE 1: ...ration_error', 'authentik.sources.ldap.signals', E'{"messag...
                                                                  ^
DETAIL:  \^@ cannot be converted to text.
CONTEXT: JSON data, line 1: ...oblem 4003 (INSUFF_ACCESS_RIGHTS), data 0\n\^@...
```

That exception escapes the `.save()`, never makes it into the audit log, and the enclosing `user_write` stage returns a generic HTTP 500 instead of surfacing the LDAP-side validation error that the `try/except` was designed to report. Per #20491.

## Fix

Drop NUL bytes from the formatted message before the ORM sees it:

```python
message = (
    "Failed to change password in LDAP source due to remote error: "
    f"{exc.result}, {exc.message}, {exc.description}"
).replace("\x00", "")
```

The diagnostic content around the NUL byte stays intact (problem code, description, text), the Event row saves cleanly, and `ValidationError("Failed to set password")` — the user-facing signal the caller actually wants — reaches the flow executor instead of being masked by an uncaught Postgres exception.

Scoped to this one call site: other Event.new() sites in the codebase don't construct messages from LDAP payloads, so they aren't affected.

Fixes #20491