### PR TITLE
blueprints/default: guard oobe password-usable policy against missing akadmin

### DIFF
--- a/blueprints/default/flow-oobe.yaml
+++ b/blueprints/default/flow-oobe.yaml
@@ -75,9 +75,12 @@ entries:
 - attrs:
     expression: |
       # This policy ensures that the setup flow can only be
-      # executed when the admin user doesn''t have a password set
+      # executed when the admin user doesn''t have a password set.
+      # On a brand new deployment the user may not exist yet, in
+      # which case ak_user_by returns None; treat that the same as
+      # "no usable password" so the initial setup flow is reachable.
       akadmin = ak_user_by(username="akadmin")
-      return not akadmin.has_usable_password()
+      return akadmin is None or not akadmin.has_usable_password()
   id: policy-default-oobe-password-usable
   identifiers:
     name: default-oobe-password-usable


### PR DESCRIPTION
## What

`default-oobe-password-usable` in `blueprints/default/flow-oobe.yaml` drove the initial-setup flow with:

```python
akadmin = ak_user_by(username="akadmin")
return not akadmin.has_usable_password()
```

`ak_user_by` returns `None` when the user doesn't exist yet, which is the common case on a fresh Docker Compose deployment: the container comes up, the user visits `/if/flow/initial-setup/`, and the policy evaluator raises:

```
AttributeError: 'NoneType' object has no attribute 'has_usable_password'
```

The flow executor surfaces that as the user-facing `Request has been denied.` error, and first-time users can't reach the initial-setup flow through the documented path. The only workaround (per the "Troubleshooting: Can't access initial setup flow" doc) is setting the akadmin password manually, which the same doc flags as discouraged. Reported in #20625.

## Fix

Short-circuit when `akadmin` is `None`. "User doesn't exist yet" and "user has no usable password" are the same decision for the purpose of enabling the setup flow:

```python
akadmin = ak_user_by(username="akadmin")
return akadmin is None or not akadmin.has_usable_password()
```

When the user does exist, the `has_usable_password()` call runs exactly as before. The policy now returns `True` on the fresh-install path, the initial-setup flow is reachable, and the companion `default-oobe-flow-set-authentication` policy still clamps the flow to `REQUIRE_SUPERUSER` once an admin password has been set.

Fixes #20625