### PR TITLE
core: guard chunked_queryset.get_chunks against the empty-between-checks race

### DIFF
--- a/authentik/lib/utils/db.py
+++ b/authentik/lib/utils/db.py
@@ -14,7 +14,9 @@ def chunked_queryset[T: Model](queryset: QuerySet[T], chunk_size: int = 1_000) -
     def get_chunks(qs: QuerySet) -> Generator[QuerySet[T]]:
         qs = qs.order_by("pk")
         pks = qs.values_list("pk", flat=True)
-        start_pk = pks[0]
+        start_pk = pks.first()
+        if start_pk is None:
+            return
         while True:
             try:
                 end_pk = pks.filter(pk__gte=start_pk)[chunk_size]


### PR DESCRIPTION
Fixes #21643.

`chunked_queryset` does a pre-flight `queryset.exists()` and then yields from an inner `get_chunks` generator. The generator is evaluated lazily, so by the time it actually pulls pks the underlying rows can already be gone: another worker drained the queue, a sibling transaction deleted them, or a different snapshot just sees no rows.

The first line inside the generator is

```python
pks = qs.values_list("pk", flat=True)
start_pk = pks[0]
```

and `pks[0]` raises `IndexError` on an empty result. Nothing above catches it (the loop below only catches `IndexError` from the `[chunk_size]` slice), so it surfaces as an unhandled crash in the calling task. We see this on `core.tasks.clean_expired_models` -> `django_postgres_cache.tasks.clear_expired_cache` in production logs.

This uses `.first()` and returns early when the queryset has become empty between the outer `exists()` and the generator starting. Behaviour is unchanged on any non-empty path; the tight race on the empty path now yields nothing instead of crashing.