### PR TITLE
internal/outpost: serialize websocket writes to prevent panic

### DIFF
--- a/internal/outpost/ak/api.go
+++ b/internal/outpost/ak/api.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"sync"
 	"syscall"
 	"time"
 
@@ -45,6 +46,7 @@ type APIController struct {
 	reloadOffset time.Duration
 
 	eventConn        *websocket.Conn
+	eventConnMu      sync.Mutex
 	lastWsReconnect  time.Time
 	wsIsReconnecting bool
 	eventHandlers    []EventHandler

--- a/internal/outpost/ak/api_event.go
+++ b/internal/outpost/ak/api_event.go
@@ -77,7 +77,12 @@ func (ac *APIController) initEvent(outpostUUID string, attempt int) error {
 		Instruction: EventKindHello,
 		Args:        ac.getEventPingArgs(),
 	}
+	// Serialize this write against concurrent SendEventHello callers (health
+	// ticker, RAC handlers) sharing the same *websocket.Conn. Gorilla's Conn
+	// does not permit concurrent writes.
+	ac.eventConnMu.Lock()
 	err = ws.WriteJSON(msg)
+	ac.eventConnMu.Unlock()
 	if err != nil {
 		ac.logger.WithField("logger", "authentik.outpost.events").WithError(err).Warning("Failed to hello to authentik")
 		return err
@@ -91,7 +96,9 @@ func (ac *APIController) initEvent(outpostUUID string, attempt int) error {
 func (ac *APIController) Shutdown() {
 	// Cleanly close the connection by sending a close message and then
 	// waiting (with timeout) for the server to close the connection.
+	ac.eventConnMu.Lock()
 	err := ac.eventConn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+	ac.eventConnMu.Unlock()
 	if err != nil {
 		ac.logger.WithError(err).Warning("failed to write close message")
 		return
@@ -252,6 +259,10 @@ func (a *APIController) SendEventHello(args map[string]any) error {
 		Instruction: EventKindHello,
 		Args:        allArgs,
 	}
+	// Gorilla *websocket.Conn does not permit concurrent writes. This method
+	// is invoked from the health ticker and from RAC session handlers.
+	a.eventConnMu.Lock()
 	err := a.eventConn.WriteJSON(aliveMsg)
+	a.eventConnMu.Unlock()
 	return err
 }


### PR DESCRIPTION
## Details

Fixes #21727.

The outpost API controller (`internal/outpost/ak.APIController`) shares a single `*websocket.Conn` (`eventConn`) across multiple goroutines with no synchronization:

- `initEvent` — writes the hello frame on (re)connect. Called from `NewAPIController` and concurrently from `recentEvents` in its own goroutine.
- `SendEventHello` — invoked every 10s from the `startEventHealth` ticker, and also from RAC session handlers (`internal/outpost/rac/rac.go:80,87`).
- `Shutdown` — writes the close frame.

[`gorilla/websocket` documents](https://pkg.go.dev/github.com/gorilla/websocket#hdr-Concurrency) that concurrent writers are unsafe, and in production this panics with:

```
panic: concurrent write to websocket connection
  at goauthentik.io/internal/outpost/ak/api_event.go:...
  in (*APIController).initEvent / SendEventHello
```

The panic takes down the `authentik-server` / outpost container. On our cluster (2026.2.2, 2 replicas), each replica accumulated 11–14 restarts over ~6 days, each causing a ~30–60s availability gap that surfaces as 502s and stuck OIDC redirect loops on relying parties.

This has been observed and reported before (#11090 comment chain, 2024 and again 2025) but no fix was merged; #11090 auto-closed as stale.

### Fix

Add a `sync.Mutex` on `APIController` and acquire it around every write path on `eventConn`:

- `initEvent` — the hello `WriteJSON`.
- `Shutdown` — the close `WriteMessage`.
- `SendEventHello` — the alive `WriteJSON`.

Reads (`ReadJSON` in `startEventHandler`) are single-goroutine and don't need the lock — gorilla permits one reader concurrent with one writer.

Writes to `eventConn` are infrequent (one every 10s from the health ticker plus occasional reconnects / RAC events), so contention on the mutex is negligible.

### Scope

Intentionally minimal:

- No API changes.
- No behavior changes beyond serializing writes.
- 13 lines added across 2 files.

A related-but-separate concern — `eventConn` is reassigned in `initEvent` without synchronization while `startEventHandler` reads it — is **not** addressed here to keep the fix focused on the reported panic. Happy to follow up in a second PR if desired.

### Verification

- `go build ./internal/outpost/...` — clean
- `go vet ./internal/outpost/...` — clean
- `go test -race -count=1 ./internal/outpost/ak/...` — passes

---

## Checklist

-   [x] Local tests pass (`go test -race ./internal/outpost/ak/...`)
-   [x] The code has been formatted (`gofmt`; no lint-fix targets touch these files)

If an API change has been made

-   [ ] N/A — no API schema changes

If changes to the frontend have been made

-   [ ] N/A — Go-only change

If applicable

-   [ ] N/A — no docs changes needed