### PR TITLE
core, docs: Fix `mypy` missing local env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -320,6 +320,7 @@ ci--meta-debug:
 	node --version || echo "No node installed"
 
 ci-lint-mypy: ci--meta-debug
+	@test -f local.env.yml || (echo "ERROR: local.env.yml is missing. Run 'make gen-dev-config' first." && exit 1)
 	$(UV) run mypy --strict $(PY_SOURCES)
 
 ci-lint-black: ci--meta-debug

--- a/website/docs/developer-docs/contributing.md
+++ b/website/docs/developer-docs/contributing.md
@@ -122,6 +122,18 @@ authentik can be run locally, although depending on which part you want to work 
 
 This is documented in the [developer docs](./setup/frontend-dev-environment.md).
 
+#### Running Python tooling locally (mypy, tests, linting)
+
+Before running any Python CI targets such as `make lint` or `make ci-lint-mypy`, you must generate a local configuration file:
+
+```shell
+make gen-dev-config
+```
+
+This creates `local.env.yml` in the repository root with a random `secret_key`. It is required because `mypy_django_plugin` initializes Django at startup to introspect models, and Django requires a non-empty `SECRET_KEY`. Without this file (and without an `AUTHENTIK_SECRET_KEY` environment variable), mypy will fail with a confusing internal error.
+
+You only need to run this once per clone. The file is already listed in `.gitignore`.
+
 ### Help with the docs
 
 Contributions to the technical documentation are greatly appreciated. Open a PR if you have improvements to make or new content to add. If you have questions or suggestions about the documentation, open an Issue. No contribution is too small.


### PR DESCRIPTION
- **build: guard ci-lint-mypy against missing local.env.yml**
- **docs: document local.env.yml prerequisite for Python tooling**

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
