### PR TITLE
web: Gracefully handle missing element construction.

### DIFF
--- a/web/src/elements/dialogs/directives.ts
+++ b/web/src/elements/dialogs/directives.ts
@@ -3,6 +3,7 @@ import { checkObjectShallowEquality } from "#common/collections";
 import { AKElement } from "#elements/Base";
 import { asInvoker, type ModalTemplate } from "#elements/dialogs/invokers";
 import type { DialogInit, TransclusionElementConstructor } from "#elements/dialogs/shared";
+import { ElementConstructorBoundary } from "#elements/errors/boundaries";
 import type { LitPropertyRecord } from "#elements/types";
 import { isAKElementConstructor, StrictUnsafe } from "#elements/utils/unsafe";
 
@@ -159,10 +160,22 @@ export function lookupElementConstructor<T extends CustomElementConstructor>(
     tagName: string,
     registry: CustomElementRegistry = window.customElements,
 ): T {
+    if (!tagName) {
+        // eslint-disable-next-line no-console
+        console.trace(
+            "No tag name provided for lookup. Did this value come from a different version of authentik?",
+        );
+
+        return ElementConstructorBoundary as unknown as T;
+    }
+
     const ElementConstructor = registry.get(tagName);
 
     if (!ElementConstructor) {
-        throw new TypeError(`No custom element defined for tag name: ${tagName}`);
+        // eslint-disable-next-line no-console
+        console.trace(`No custom element defined for tag name: ${tagName}`);
+
+        return ElementConstructorBoundary as unknown as T;
     }
 
     return ElementConstructor as unknown as T;

--- a/web/src/elements/errors/boundaries.ts
+++ b/web/src/elements/errors/boundaries.ts
@@ -1,5 +1,9 @@
+import { globalAK } from "#common/global";
+
 import { AKElement } from "#elements/Base";
 import { SlottedTemplateResult } from "#elements/types";
+
+import { CapabilitiesEnum } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
 import { customElement } from "@lit/reactive-element/decorators/custom-element.js";
@@ -16,16 +20,22 @@ export class ElementConstructorBoundary extends AKElement {
     public styles = [PFAlert];
 
     protected override render(): SlottedTemplateResult {
+        const debug = globalAK().config.capabilities.includes(CapabilitiesEnum.CanDebug);
+
+        const description = debug
+            ? msg(
+                  "The element could not be loaded. This may be due to a missing import or a version mismatch.",
+              )
+            : msg(
+                  "An element could not be loaded. Please try refreshing the page or clearing your cache.",
+              );
+
         return html`<div class="pf-c-alert pf-m-danger" role="alert">
             <div class="pf-c-alert__icon">
                 <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
             </div>
             <h4 class="pf-c-alert__title">${msg("Failed to load element")}</h4>
-            <div class="pf-c-alert__description">
-                ${msg(
-                    "The element could not be loaded. This may be due to a missing import or a version mismatch.",
-                )}
-            </div>
+            <div class="pf-c-alert__description">${description}</div>
         </div>`;
     }
 }

--- a/web/src/elements/errors/boundaries.ts
+++ b/web/src/elements/errors/boundaries.ts
@@ -1,0 +1,31 @@
+import { AKElement } from "#elements/Base";
+import { SlottedTemplateResult } from "#elements/types";
+
+import { msg } from "@lit/localize";
+import { customElement } from "@lit/reactive-element/decorators/custom-element.js";
+import { html } from "lit-html";
+
+import PFAlert from "@patternfly/patternfly/components/Alert/alert.css";
+
+/**
+ * A fallback element to render when a custom element fails to load, either due to a missing import,
+ * or a version mismatch between the element's definition and its usage.
+ */
+@customElement("ak-element-missing")
+export class ElementConstructorBoundary extends AKElement {
+    public styles = [PFAlert];
+
+    protected override render(): SlottedTemplateResult {
+        return html`<div class="pf-c-alert pf-m-danger" role="alert">
+            <div class="pf-c-alert__icon">
+                <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
+            </div>
+            <h4 class="pf-c-alert__title">${msg("Failed to load element")}</h4>
+            <div class="pf-c-alert__description">
+                ${msg(
+                    "The element could not be loaded. This may be due to a missing import or a version mismatch.",
+                )}
+            </div>
+        </div>`;
+    }
+}


### PR DESCRIPTION
## Details

This PR introduces a fallback to component tag names which are provided from the server. If the component fails to load, the fallback will render an error message instead of breaking the entire page. 

This can be observed when a stage has been created on another branch:

<img width="1192" height="417" alt="Screenshot 2026-04-23 at 02 38 50" src="https://github.com/user-attachments/assets/5c26b28a-5128-45b0-80f3-8ccdba066c77" />
