### PR TITLE
web: Radio and Checkbox Input Revisions

### DIFF
--- a/web/src/admin/applications/wizard/steps/ak-application-wizard-edit-binding-step.ts
+++ b/web/src/admin/applications/wizard/steps/ak-application-wizard-edit-binding-step.ts
@@ -220,6 +220,7 @@ export class ApplicationWizardEditBindingStep extends ApplicationWizardStep<Poli
                     name="failureResult"
                     label=${msg("Failure result")}
                     .options=${createPassFailOptions}
+                    required
                 ></ak-radio-input>
             </form>`;
     }

--- a/web/src/admin/applications/wizard/steps/ak-application-wizard-edit-binding-step.ts
+++ b/web/src/admin/applications/wizard/steps/ak-application-wizard-edit-binding-step.ts
@@ -201,7 +201,7 @@ export class ApplicationWizardEditBindingStep extends ApplicationWizardStep<Poli
                 <ak-switch-input
                     name="negate"
                     ?checked=${instance?.negate ?? false}
-                    label=${msg("Negate result")}
+                    label=${msg("Negate Result")}
                     help=${msg("Negates the outcome of the binding. Messages are unaffected.")}
                 ></ak-switch-input>
                 <ak-number-input
@@ -218,7 +218,7 @@ export class ApplicationWizardEditBindingStep extends ApplicationWizardStep<Poli
                 ></ak-number-input>
                 <ak-radio-input
                     name="failureResult"
-                    label=${msg("Failure result")}
+                    label=${msg("Failure Result")}
                     .options=${createPassFailOptions}
                     required
                 ></ak-radio-input>

--- a/web/src/admin/policies/PolicyBindingForm.ts
+++ b/web/src/admin/policies/PolicyBindingForm.ts
@@ -293,7 +293,11 @@ export class PolicyBindingForm<T extends PolicyBinding = PolicyBinding> extends 
                     required
                 />
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal name="failureResult" label=${msg("Failure result")}>
+            <ak-form-element-horizontal
+                name="failureResult"
+                label=${msg("Failure result")}
+                required
+            >
                 <ak-radio .options=${createPassFailOptions} .value=${this.instance?.failureResult}>
                 </ak-radio>
                 <p class="pf-c-form__helper-text">

--- a/web/src/admin/policies/PolicyBindingForm.ts
+++ b/web/src/admin/policies/PolicyBindingForm.ts
@@ -272,7 +272,7 @@ export class PolicyBindingForm<T extends PolicyBinding = PolicyBinding> extends 
             </ak-switch-input>
             <ak-switch-input
                 name="negate"
-                label=${msg("Negate result")}
+                label=${msg("Negate Result")}
                 ?checked=${this.instance?.negate ?? false}
                 help=${msg("Negates the outcome of the binding. Messages are unaffected.")}
             >
@@ -295,7 +295,7 @@ export class PolicyBindingForm<T extends PolicyBinding = PolicyBinding> extends 
             </ak-form-element-horizontal>
             <ak-form-element-horizontal
                 name="failureResult"
-                label=${msg("Failure result")}
+                label=${msg("Failure Result")}
                 required
             >
                 <ak-radio .options=${createPassFailOptions} .value=${this.instance?.failureResult}>

--- a/web/src/admin/stages/authenticator_validate/AuthenticatorValidateStageForm.ts
+++ b/web/src/admin/stages/authenticator_validate/AuthenticatorValidateStageForm.ts
@@ -18,6 +18,8 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { DataProvision, DualSelectPair } from "#elements/ak-dual-select/types";
 
+import { AKLabel } from "#components/ak-label";
+
 import { deviceTypeRestrictionPair } from "#admin/stages/authenticator_webauthn/utils";
 import { BaseStageForm } from "#admin/stages/BaseStageForm";
 
@@ -114,11 +116,20 @@ export class AuthenticatorValidateStageForm extends BaseStageForm<AuthenticatorV
             ></ak-text-input>
             <ak-form-group open label="${msg("Stage-specific settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("Device classes")}
-                        required
-                        name="deviceClasses"
-                    >
+                    <ak-form-element-horizontal required name="deviceClasses">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "deviceClasses",
+                                required: true,
+                            },
+                            msg("Device Classes"),
+                        )}
+
+                        <p class="pf-c-form__helper-text">
+                            ${msg("Device classes which can be used to authenticate.")}
+                        </p>
                         <ak-checkbox-group
                             name="users"
                             class="user-field-select"
@@ -129,9 +140,6 @@ export class AuthenticatorValidateStageForm extends BaseStageForm<AuthenticatorV
                                     this.isDeviceClassSelected(name as DeviceClassesEnum),
                                 )}
                         ></ak-checkbox-group>
-                        <p class="pf-c-form__helper-text">
-                            ${msg("Device classes which can be used to authenticate.")}
-                        </p>
                     </ak-form-element-horizontal>
                     <ak-form-element-horizontal
                         label=${msg("Last validation threshold")}

--- a/web/src/admin/stages/identification/IdentificationStageForm.ts
+++ b/web/src/admin/stages/identification/IdentificationStageForm.ts
@@ -11,6 +11,8 @@ import { sourcesProvider, sourcesSelector } from "./IdentificationStageFormHelpe
 import { DEFAULT_CONFIG } from "#common/api/config";
 import { groupBy } from "#common/utils";
 
+import { AKLabel } from "#components/ak-label";
+
 import { BaseStageForm } from "#admin/stages/BaseStageForm";
 
 import {
@@ -87,7 +89,22 @@ export class IdentificationStageForm extends BaseStageForm<IdentificationStage> 
             </ak-form-element-horizontal>
             <ak-form-group open label="${msg("Stage-specific settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal label=${msg("User fields")} name="userFields">
+                    <ak-form-element-horizontal name="userFields">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "userFields",
+                            },
+                            msg("User Fields"),
+                        )}
+
+                        <p class="pf-c-form__helper-text">
+                            ${msg(
+                                "Fields a user can identify themselves with. If no fields are selected, the user will only be able to use sources.",
+                            )}
+                        </p>
+
                         <ak-checkbox-group
                             class="user-field-select"
                             .options=${userSelectFields}
@@ -95,11 +112,6 @@ export class IdentificationStageForm extends BaseStageForm<IdentificationStage> 
                                 .map(({ name }) => name)
                                 .filter((name) => this.isUserFieldSelected(name))}
                         ></ak-checkbox-group>
-                        <p class="pf-c-form__helper-text">
-                            ${msg(
-                                "Fields a user can identify themselves with. If no fields are selected, the user will only be able to use sources.",
-                            )}
-                        </p>
                     </ak-form-element-horizontal>
                     <ak-form-element-horizontal label=${msg("Password stage")} name="passwordStage">
                         <ak-search-select

--- a/web/src/admin/stages/password/PasswordStageForm.ts
+++ b/web/src/admin/stages/password/PasswordStageForm.ts
@@ -6,6 +6,8 @@ import "#elements/forms/SearchSelect/index";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
 
+import { AKLabel } from "#components/ak-label";
+
 import { RenderFlowOption } from "#admin/flows/utils";
 import { BaseStageForm } from "#admin/stages/BaseStageForm";
 
@@ -87,7 +89,20 @@ export class PasswordStageForm extends BaseStageForm<PasswordStage> {
             </ak-form-element-horizontal>
             <ak-form-group open label="${msg("Stage-specific settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal label=${msg("Backends")} required name="backends">
+                    <ak-form-element-horizontal required name="backends">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "backends",
+                                required: true,
+                            },
+                            msg("Backends"),
+                        )}
+                        <p class="pf-c-form__helper-text">
+                            ${msg("Selection of backends to test the password against.")}
+                        </p>
+
                         <ak-checkbox-group
                             class="user-field-select"
                             .options=${backends}
@@ -95,9 +110,6 @@ export class PasswordStageForm extends BaseStageForm<PasswordStage> {
                                 .map(({ name }) => name)
                                 .filter((name) => this.isBackendSelected(name))}
                         ></ak-checkbox-group>
-                        <p class="pf-c-form__helper-text">
-                            ${msg("Selection of backends to test the password against.")}
-                        </p>
                     </ak-form-element-horizontal>
                     <ak-form-element-horizontal
                         label=${msg("Configuration flow")}

--- a/web/src/admin/stages/user_write/UserWriteStageForm.ts
+++ b/web/src/admin/stages/user_write/UserWriteStageForm.ts
@@ -3,9 +3,12 @@ import "#elements/forms/FormGroup";
 import "#elements/forms/HorizontalFormElement";
 import "#elements/forms/Radio";
 import "#components/ak-text-input";
+import "#components/ak-radio-input";
 import "#elements/forms/SearchSelect/index";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
+
+import { RadioOption } from "#elements/forms/Radio";
 
 import { AKLabel } from "#components/ak-label";
 
@@ -109,39 +112,37 @@ export class UserWriteStageForm extends BaseStageForm<UserWriteStage> {
                         ?checked=${this.instance?.createUsersAsInactive ?? true}
                         help=${msg("Mark newly created users as inactive.")}
                     ></ak-switch-input>
-                    <ak-form-element-horizontal label=${msg("User type")} name="userType">
-                        <ak-radio
-                            .options=${[
-                                {
-                                    label: msg("Internal"),
-                                    value: UserTypeEnum.Internal,
-                                    default: true,
-                                    description: html`${msg(
-                                        "Internal users might be users such as company employees, which will get access to the full Enterprise feature set.",
-                                    )}`,
-                                },
-                                {
-                                    label: msg("External"),
-                                    value: UserTypeEnum.External,
-                                    description: html`${msg(
-                                        "External users might be external consultants or B2C customers. These users don't get access to enterprise features.",
-                                    )}`,
-                                },
-                                {
-                                    label: msg("Service account"),
-                                    value: UserTypeEnum.ServiceAccount,
-                                    description: html`${msg(
-                                        "Service accounts should be used for machine-to-machine authentication or other automations.",
-                                    )}`,
-                                },
-                            ]}
-                            .value=${this.instance?.userType}
-                        >
-                        </ak-radio>
-                        <p class="pf-c-form__helper-text">
-                            ${msg("User type used for newly created users.")}
-                        </p>
-                    </ak-form-element-horizontal>
+                    <ak-radio-input
+                        label=${msg("User type")}
+                        name="userType"
+                        help=${msg("User type used for newly created users.")}
+                        .options=${[
+                            {
+                                label: msg("Internal"),
+                                value: UserTypeEnum.Internal,
+                                default: true,
+                                description: html`${msg(
+                                    "Internal users might be users such as company employees, which will get access to the full Enterprise feature set.",
+                                )}`,
+                            },
+                            {
+                                label: msg("External"),
+                                value: UserTypeEnum.External,
+                                description: html`${msg(
+                                    "External users might be external consultants or B2C customers. These users don't get access to enterprise features.",
+                                )}`,
+                            },
+                            {
+                                label: msg("Service account"),
+                                value: UserTypeEnum.ServiceAccount,
+                                description: html`${msg(
+                                    "Service accounts should be used for machine-to-machine authentication or other automations.",
+                                )}`,
+                            },
+                        ] satisfies RadioOption<UserTypeEnum>[]}
+                        .value=${this.instance?.userType}
+                    >
+                    </ak-radio-input>
                     <ak-form-element-horizontal
                         label=${msg("User path template")}
                         name="userPathTemplate"

--- a/web/src/elements/ak-checkbox-group/ak-checkbox-group.css
+++ b/web/src/elements/ak-checkbox-group/ak-checkbox-group.css
@@ -1,0 +1,113 @@
+.pf-c-form__group-control {
+    padding-block: calc(var(--pf-c-form--m-horizontal__group-label--md--PaddingTop) * 1.3);
+    --pf-c-grid__group-control--m-stack--Gap: 0;
+}
+
+label.pf-c-check {
+    --pf-c-check--checkmark--BorderColor: var(--pf-global--BorderColor--100);
+    --pf-c-check--checkmark--Color: transparent;
+    --pf-c-check--BorderColor: transparent;
+
+    --pf-c-check--checked--BackgroundColor: transparent;
+    --pf-c-check--checked--BorderColor: var(--pf-global--active-color--300);
+    --pf-c-check--checked--Hover--BorderColor: var(--pf-global--active-color--400);
+
+    --pf-c-check--hover--BorderColor: var(--pf-global--active-color--200);
+
+    --pf-c-check--disabled--BackgroundColor: var(--pf-global--BackgroundColor--150);
+    transition:
+        border-color 0.2s,
+        color 0.2s;
+
+    padding-inline: var(--pf-global--spacer--form-element);
+    padding-block: var(--pf-global--spacer--sm);
+    cursor: pointer;
+    background-color: var(--pf-c-check--BackgroundColor, transparent);
+    border-radius: var(--pf-global--BorderRadius--sm);
+    position: relative;
+    user-select: none;
+
+    align-content: center;
+    display: grid;
+    grid-template-areas: "input .";
+    grid-template-columns: auto 1fr;
+    column-gap: var(--pf-global--spacer--md);
+    row-gap: 0;
+
+    .pf-c-check__input {
+        grid-area: input;
+        align-self: center;
+        margin-block: 0;
+        appearance: none;
+        content: none;
+
+        width: 1.5em;
+        height: 1.5em;
+        padding: 0.25em;
+        border: 0.5px solid;
+        color: var(--pf-c-check--checkmark--BorderColor, transparent);
+        border-radius: 3px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        z-index: 1;
+        background: color-mix(var(--pf-c-check--checkmark--BorderColor), transparent 84%);
+        box-shadow: inset 0 0 1px
+            color-mix(var(--pf-c-check--checkmark--BorderColor), var(--pf-global--BorderColor--200));
+
+        &::after {
+            font-family: "Font Awesome 5 Free";
+            font-weight: 900;
+
+            content: "\f00c";
+            display: block;
+            line-height: 1;
+            color: var(--pf-c-check--checkmark--Color);
+            transition: color 0.2s;
+
+            filter: drop-shadow(color-mix(currentColor, transparent 50%) 0 0 1px);
+        }
+    }
+
+    &:hover:has(.pf-c-check__input:not(:disabled)) .pf-c-check__label {
+        text-decoration: underline;
+        text-decoration-color: var(--pf-c-check--checked--BorderColor);
+        text-decoration-thickness: 1px;
+    }
+
+    &:has(.pf-c-check__input:checked:not(:disabled)) {
+        --pf-c-check--BackgroundColor: var(--pf-c-check--checked--BackgroundColor);
+        --pf-c-check--BorderColor: var(--pf-c-check--checked--BorderColor);
+        --pf-c-check--checkmark--BorderColor: var(--pf-global--active-color--300);
+        --pf-c-check--checkmark--Color: var(--pf-c-check--checked--BorderColor);
+    }
+
+    &:hover:has(.pf-c-check__input:checked:not(:disabled)) {
+        --pf-c-check--checkmark--BorderColor: var(--pf-c-check--checked--Hover--BorderColor);
+        --pf-c-check--checkmark--Color: var(--pf-c-check--checked--Hover--BorderColor);
+    }
+
+    &:hover:not(:has(.pf-c-check__input:checked)):not(:has(.pf-c-check__input:disabled)) {
+        --pf-c-check--checkmark--BorderColor: var(--pf-c-check--hover--BorderColor);
+        --pf-c-check--checkmark--Color: color-mix(
+            var(--pf-c-check--hover--BorderColor),
+            transparent 75%
+        );
+    }
+
+    &:has(.pf-c-check__input:disabled) {
+        cursor: not-allowed;
+
+        --pf-c-check--BackgroundColor: var(--pf-c-check--disabled--BackgroundColor) !important;
+    }
+
+    .pf-c-check__label {
+        align-self: center;
+        font-weight: var(--pf-global--FontWeight--overpass--semi-bold);
+        font-family: var(--pf-global--FontFamily--redhat-updated--heading--sans-serif);
+    }
+
+    &:has(.pf-c-check__input:last-child) .pf-c-check__label {
+        grid-row: 1 / -1;
+    }
+}

--- a/web/src/elements/ak-checkbox-group/ak-checkbox-group.ts
+++ b/web/src/elements/ak-checkbox-group/ak-checkbox-group.ts
@@ -1,9 +1,11 @@
+import Styles from "#elements/ak-checkbox-group/ak-checkbox-group.css";
 import { AKControlElement } from "#elements/ControlElement";
+import { SlottedTemplateResult } from "#elements/types";
 import { CustomEmitterElement } from "#elements/utils/eventEmitter";
 
 import { msg } from "@lit/localize";
 import { PropertyValues } from "@lit/reactive-element";
-import { css, html, TemplateResult } from "lit";
+import { html, TemplateResult } from "lit";
 import { customElement, property, queryAll, state } from "lit/decorators.js";
 import { map } from "lit/directives/map.js";
 
@@ -14,11 +16,9 @@ type CheckboxKv = { name: string; label: string | TemplateResult };
 type CheckboxPr = [string, string | TemplateResult];
 export type CheckboxPair = CheckboxKv | CheckboxPr;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const isCheckboxPr = (t: any): t is CheckboxPr => Array.isArray(t);
-function* kvToPairs(items: CheckboxPair[]): Iterable<CheckboxPr> {
+function* kvToPairs(items: Iterable<CheckboxPair>): Iterable<CheckboxPr> {
     for (const item of items) {
-        yield isCheckboxPr(item) ? item : [item.name, item.label];
+        yield Array.isArray(item) ? item : [item.name, item.label];
     }
 }
 
@@ -75,51 +75,40 @@ const AkElementWithCustomEvents = CustomEmitterElement(AKControlElement);
  * protocol.
  *
  */
-
 @customElement("ak-checkbox-group")
 export class CheckboxGroup extends AkElementWithCustomEvents {
-    static styles = [
-        PFForm,
-        PFCheck,
-        css`
-            .pf-c-form__group-control {
-                padding-top: calc(
-                    var(--pf-c-form--m-horizontal__group-label--md--PaddingTop) * 1.3
-                );
-            }
-        `,
-    ];
+    static styles = [PFForm, PFCheck, Styles];
 
     static get formAssociated() {
         return true;
     }
 
     @property({ type: Array })
-    options: CheckboxPair[] = [];
+    public options: CheckboxPair[] = [];
 
     @property({ type: Array })
-    value: string[] = [];
+    public value: string[] = [];
 
     @property({ type: String })
     public name: string | null = null;
 
     @property({ type: Boolean })
-    required = false;
+    public required = false;
 
     @queryAll('input[type="checkbox"]')
-    checkboxes!: NodeListOf<HTMLInputElement>;
+    protected checkboxes!: NodeListOf<HTMLInputElement>;
 
     @state()
-    values: string[] = [];
+    protected values: string[] = [];
 
-    internals?: ElementInternals;
-    doneFirstUpdate = false;
+    protected internals?: ElementInternals;
+    protected doneFirstUpdate = false;
 
-    toJSON() {
+    public toJSON() {
         return this.values;
     }
 
-    private get formValue() {
+    protected get formValue() {
         if (typeof this.name !== "string") {
             throw new Error("This cannot be called without having the name set.");
         }
@@ -129,18 +118,16 @@ export class CheckboxGroup extends AkElementWithCustomEvents {
         return entries;
     }
 
-    constructor() {
-        super();
-        this.onClick = this.onClick.bind(this);
-    }
-
-    onClick(ev: Event) {
+    protected clickListener = (ev: Event) => {
         ev.stopPropagation();
+
         this.values = Array.from(this.checkboxes)
             .filter((checkbox) => checkbox.checked)
             .map((checkbox) => checkbox.name);
+
         this.dispatchCustomEvent("change", this.values);
         this.dispatchCustomEvent("input", this.values);
+
         if (this.internals) {
             this.internals.setValidity({});
             if (this.required && this.values.length === 0) {
@@ -154,19 +141,20 @@ export class CheckboxGroup extends AkElementWithCustomEvents {
             }
             this.internals.setFormValue(this.formValue);
         }
+
         // Doing a write-back so anyone examining the checkbox.value field will get something
         // meaningful. Doesn't do anything for anyone, usually, but it's nice to have.
         this.value = this.values;
-    }
+    };
 
-    willUpdate(changed: PropertyValues<this>) {
+    protected override willUpdate(changed: PropertyValues<this>) {
         if (changed.has("value") && !this.doneFirstUpdate) {
             this.doneFirstUpdate = true;
             this.values = this.value;
         }
     }
 
-    connectedCallback() {
+    public override connectedCallback() {
         super.connectedCallback();
         this.dataset.akControl = "true";
         if (this.name && !this.internals) {
@@ -192,32 +180,35 @@ export class CheckboxGroup extends AkElementWithCustomEvents {
         });
     }
 
-    render() {
-        const renderOne = ([name, label]: CheckboxPr) => {
-            const selected = this.values.includes(name);
-            const blockFwd = (e: Event) => {
-                e.stopImmediatePropagation();
-            };
-
-            return html` <div part="checkbox" class="pf-c-check" @click=${this.onClick}>
-                <input
-                    part="input"
-                    @change=${blockFwd}
-                    @input=${blockFwd}
-                    name="${name}"
-                    class="pf-c-check__input"
-                    type="checkbox"
-                    ?checked=${selected}
-                    id="ak-check-${name}"
-                />
-                <label part="label" class="pf-c-check__label" for="ak-check-${name}"
-                    >${label}</label
-                >
-            </div>`;
+    protected renderCheckbox = ([name, label]: CheckboxPr): SlottedTemplateResult => {
+        const selected = this.values.includes(name);
+        const blockFwd = (e: Event) => {
+            e.stopImmediatePropagation();
         };
 
+        return html`<label
+            part="label"
+            for="ak-check-${name}"
+            class="pf-c-check"
+            @click=${this.clickListener}
+        >
+            <input
+                part="input"
+                @change=${blockFwd}
+                @input=${blockFwd}
+                name=${name}
+                class="pf-c-check__input"
+                type="checkbox"
+                ?checked=${selected}
+                id="ak-check-${name}"
+            />
+            <div class="pf-c-check__label">${label}</div>
+        </label>`;
+    };
+
+    protected override render(): SlottedTemplateResult {
         return html`<div part="checkbox-group" class="pf-c-form__group-control pf-m-stack">
-            ${map(kvToPairs(this.options), renderOne)}
+            ${map(kvToPairs(this.options), this.renderCheckbox)}
         </div>`;
     }
 }

--- a/web/src/elements/forms/Radio.ts
+++ b/web/src/elements/forms/Radio.ts
@@ -51,7 +51,7 @@ export class Radio<T extends Jsonifiable = never> extends FormAssociatedElement<
 
     @property()
     public set value(nextValue: T) {
-        if (!nextValue) {
+        if (nextValue === null) {
             return;
         }
 

--- a/web/src/elements/table/TablePage.css
+++ b/web/src/elements/table/TablePage.css
@@ -18,4 +18,5 @@
 .empty-state-primary {
     display: flex;
     gap: var(--pf-global--spacer--sm);
+    justify-content: center;
 }

--- a/web/src/styles/authentik/components/Form/form.css
+++ b/web/src/styles/authentik/components/Form/form.css
@@ -83,6 +83,13 @@
     text-wrap: pretty;
 }
 
+ak-form-element-horizontal:has(.pf-c-form__helper-text + ak-checkbox-group) {
+    .pf-c-form__helper-text {
+        margin-top: var(--pf-c-form--m-horizontal__group-label--md--PaddingTop);
+        line-height: var(--pf-global--LineHeight--sm);
+    }
+}
+
 /* #region Fields */
 
 fieldset {
@@ -178,17 +185,20 @@ label.pf-c-radio {
     --pf-c-radio--checkmark--BorderColor: var(--pf-global--BorderColor--300);
     --pf-c-radio--checkmark--Color: transparent;
     --pf-c-radio--BorderColor: transparent;
-    --pf-c-radio--BoxShadowColor: transparent;
 
     --pf-c-radio--checked--BackgroundColor: transparent;
     --pf-c-radio--checked--BorderColor: var(--pf-global--active-color--300);
+    --pf-c-radio--checked--Hover--BorderColor: var(--pf-global--active-color--400);
     --pf-c-radio--hover--BorderColor: var(--pf-global--active-color--200);
-
     --pf-c-radio--disabled--BackgroundColor: var(--pf-global--BackgroundColor--150);
+    --pf-c-radio__description--Color: var(--pf-global--Color--300);
+
     transition:
+        background-color 0.2s,
         border-color 0.2s,
         color 0.2s;
 
+    margin-block: 0;
     padding-inline: var(--pf-global--spacer--md);
     padding-block: var(--pf-global--spacer--sm);
     cursor: pointer;
@@ -217,7 +227,7 @@ label.pf-c-radio {
         width: 1.5em;
         height: 1.5em;
         padding: 0.25em;
-        border: 1px solid;
+        border: 0.5px solid;
         color: var(--pf-c-radio--checkmark--BorderColor, transparent);
         border-radius: 100%;
         display: flex;
@@ -225,6 +235,8 @@ label.pf-c-radio {
         align-items: center;
         z-index: 1;
         background: color-mix(var(--pf-c-radio--checkmark--BorderColor), transparent 84%);
+        box-shadow: inset 0 0 1px
+            color-mix(var(--pf-c-radio--checkmark--BorderColor), var(--pf-global--BorderColor--200));
 
         &::after {
             font-family: "Font Awesome 5 Free";
@@ -244,25 +256,19 @@ label.pf-c-radio {
         }
     }
 
-    &:not(:last-child) {
-        --pf-c-radio--BoxShadowColor: var(--pf-global--BorderColor--100);
-    }
-
-    &::after {
-        content: "";
-        position: absolute;
-        display: block;
-        background-color: var(--pf-c-radio--BoxShadowColor);
-        height: 0.5px;
-        inset-inline: 0;
-        inset-block-end: 0;
+    &:hover:has(.pf-c-radio__input:not(:disabled)) {
+        --pf-c-radio--BackgroundColor: color-mix(currentColor, transparent 98%);
     }
 
     &:has(.pf-c-radio__input:checked:not(:disabled)) {
-        --pf-c-radio--BackgroundColor: var(--pf-c-radio--checked--BackgroundColor);
         --pf-c-radio--BorderColor: var(--pf-c-radio--checked--BorderColor);
         --pf-c-radio--checkmark--BorderColor: var(--pf-global--active-color--300);
         --pf-c-radio--checkmark--Color: var(--pf-c-radio--checked--BorderColor);
+    }
+
+    &:hover:has(.pf-c-radio__input:checked:not(:disabled)) {
+        --pf-c-radio--checkmark--BorderColor: var(--pf-c-radio--checked--Hover--BorderColor);
+        --pf-c-radio--checkmark--Color: var(--pf-c-radio--checked--Hover--BorderColor);
     }
 
     &:hover:not(:has(.pf-c-radio__input:checked)):not(:has(.pf-c-radio__input:disabled)) {
@@ -282,6 +288,8 @@ label.pf-c-radio {
 
     .pf-c-radio__label {
         align-self: center;
+        font-weight: var(--pf-global--FontWeight--overpass--semi-bold);
+        font-family: var(--pf-global--FontFamily--redhat-updated--heading--sans-serif);
     }
 
     &:has(.pf-c-radio__input:last-child) .pf-c-radio__label {
@@ -303,9 +311,8 @@ label.pf-c-radio {
 /* #endregion */
 
 ak-switch-input {
-    padding-inline: var(--pf-global--spacer--form-element);
     ::part(group-control) {
-        grid-area: control;
+        grid-column: 1 / -1;
     }
 
     .pf-c-switch {
@@ -330,8 +337,10 @@ ak-switch-input {
     }
 
     .pf-c-form__helper-text {
-        padding-inline-end: var(--pf-global--spacer--2xl);
         grid-area: secondary / label / secondary / -1;
+        /* Fallback for browsers that do not support container queries. */
+        max-width: clamp(25cqi, 90%, 90ch);
+        max-width: clamp(25cqi, 90cqi, 90ch);
     }
 }
 


### PR DESCRIPTION
## Details

This PR is a follow up on #21206 and #21588, adding additional UI polish on radio and checkbox inputs.

- Checkbox inputs now use similar style to radios
- Radios and inputs now respond to hover state, even when selected
- Fewer line delimiters on radios and checkboxes to reduce the visual noise on inputs
- Additional font-weight added to radio and checkbox labels to distinguish the content from helper text
- Toggle inputs now use a single column to help visually separate the field from it's preceding sibling field
- Field helper text breaks lines on extra wide viewports, expanding them on mobile/tablet viewports to a comfortable size 

## Screenshots

<img width="1164" height="749" alt="Screenshot 2026-04-23 at 04 47 36" src="https://github.com/user-attachments/assets/3d486c80-8d80-43ca-8513-b52d2768848a" />

<hr />

<img width="1204" height="770" alt="Screenshot 2026-04-23 at 04 47 50" src="https://github.com/user-attachments/assets/c145d960-46d8-42a2-a0f5-d16c143624ef" />

<hr />

<img width="1183" height="757" alt="Screenshot 2026-04-23 at 04 48 03" src="https://github.com/user-attachments/assets/40b2a13c-b537-4dcf-aeec-f48bb42b8f0c" />

<hr />

<img width="1190" height="789" alt="Screenshot 2026-04-23 at 04 48 34" src="https://github.com/user-attachments/assets/44b149ee-77ba-416d-b67f-d2b7c89f82ad" />

<hr />

<img width="1207" height="770" alt="Screenshot 2026-04-23 at 04 47 16" src="https://github.com/user-attachments/assets/40f0c0a8-1e00-4d03-9326-0a831c683a40" />

<hr />

<img width="1175" height="764" alt="Screenshot 2026-04-23 at 04 49 44" src="https://github.com/user-attachments/assets/ca95d72c-ac88-4440-8986-0c87ee72c42d" />

