### PR TITLE
packages/ak-common/config: fix bool and list parsing from env variable

### DIFF
--- a/packages/ak-common/src/config/mod.rs
+++ b/packages/ak-common/src/config/mod.rs
@@ -77,6 +77,7 @@ impl Config {
         }
         builder = builder.add_source(
             config_rs::Environment::with_prefix("AUTHENTIK")
+                .try_parsing(true)
                 .prefix_separator("_")
                 .separator("__"),
         );
@@ -454,5 +455,31 @@ mod tests {
         assert_eq!(super::get().secret_key, String::new());
         super::set(json!({"secret_key": "my_new_secret_key"})).expect("failed to set config");
         assert_eq!(super::get().secret_key, "my_new_secret_key");
+    }
+
+    #[test]
+    fn env_bool_true() {
+        #[expect(unsafe_code, reason = "testing")]
+        // SAFETY: testing
+        unsafe {
+            env::set_var("AUTHENTIK_DEBUG", "true");
+        }
+
+        let (config, config_paths) = super::Config::load(&[], None).expect("failed to load config");
+
+        assert_eq!(config.debug, true);
+    }
+
+    #[test]
+    fn env_bool_false() {
+        #[expect(unsafe_code, reason = "testing")]
+        // SAFETY: testing
+        unsafe {
+            env::set_var("AUTHENTIK_DEBUG", "false");
+        }
+
+        let (config, config_paths) = super::Config::load(&[], None).expect("failed to load config");
+
+        assert_eq!(config.debug, false);
     }
 }

--- a/packages/ak-common/src/config/mod.rs
+++ b/packages/ak-common/src/config/mod.rs
@@ -77,9 +77,10 @@ impl Config {
         }
         builder = builder.add_source(
             config_rs::Environment::with_prefix("AUTHENTIK")
-                .try_parsing(true)
                 .prefix_separator("_")
-                .separator("__"),
+                .separator("__")
+                .try_parsing(true)
+                .list_separator(","),
         );
         if let Some(overrides) = overrides {
             builder = builder.add_source(config_rs::File::from_str(
@@ -465,9 +466,9 @@ mod tests {
             env::set_var("AUTHENTIK_DEBUG", "true");
         }
 
-        let (config, config_paths) = super::Config::load(&[], None).expect("failed to load config");
+        let (config, _) = super::Config::load(&[], None).expect("failed to load config");
 
-        assert_eq!(config.debug, true);
+        assert!(config.debug);
     }
 
     #[test]
@@ -478,8 +479,57 @@ mod tests {
             env::set_var("AUTHENTIK_DEBUG", "false");
         }
 
-        let (config, config_paths) = super::Config::load(&[], None).expect("failed to load config");
+        let (config, _) = super::Config::load(&[], None).expect("failed to load config");
 
-        assert_eq!(config.debug, false);
+        assert!(!config.debug);
+    }
+
+    // See https://github.com/rust-cli/config-rs/issues/443
+    // #[test]
+    // fn env_list_empty() {
+    //     #[expect(unsafe_code, reason = "testing")]
+    //     // SAFETY: testing
+    //     unsafe {
+    //         env::set_var("AUTHENTIK_LISTEN__HTTP", "");
+    //     }
+    //
+    //     let (config, _) = super::Config::load(&[], None).expect("failed to load config");
+    //
+    //     assert_eq!(config.listen.http, []);
+    // }
+
+    #[test]
+    fn env_list_one_element() {
+        #[expect(unsafe_code, reason = "testing")]
+        // SAFETY: testing
+        unsafe {
+            env::set_var("AUTHENTIK_LISTEN__HTTP", "[::1]:9000");
+        }
+
+        let (config, _) = super::Config::load(&[], None).expect("failed to load config");
+
+        assert_eq!(
+            config.listen.http,
+            ["[::1]:9000".parse().expect("infallible")]
+        );
+    }
+
+    #[test]
+    fn env_list_many_elements() {
+        #[expect(unsafe_code, reason = "testing")]
+        // SAFETY: testing
+        unsafe {
+            env::set_var("AUTHENTIK_LISTEN__HTTP", "[::1]:9000,[::1]:9001");
+        }
+
+        let (config, _) = super::Config::load(&[], None).expect("failed to load config");
+
+        assert_eq!(
+            config.listen.http,
+            [
+                "[::1]:9000".parse().expect("infallible"),
+                "[::1]:9001".parse().expect("infallible")
+            ]
+        );
     }
 }


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

currently gets parsed as a string instead of a bool. Fixed and added a test 

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
