### PR TITLE
feat(worker): Separate critical actors from the default queue

### DIFF
--- a/authentik/events/tasks.py
+++ b/authentik/events/tasks.py
@@ -23,7 +23,10 @@ from authentik.tasks.middleware import CurrentTask
 LOGGER = get_logger()
 
 
-@actor(description=_("Dispatch new event notifications."))
+@actor(
+    description=_("Dispatch new event notifications."),
+    queue_name="event_dispatcher",
+)
 def event_trigger_dispatch(event_uuid: UUID):
     for trigger in NotificationRule.objects.all():
         event_trigger_handler.send_with_options(args=(event_uuid, trigger.name), rel_obj=trigger)
@@ -33,7 +36,8 @@ def event_trigger_dispatch(event_uuid: UUID):
     description=_(
         "Check if policies attached to NotificationRule match event "
         "and dispatch notification tasks."
-    )
+    ),
+    queue_name="event_dispatcher",
 )
 def event_trigger_handler(event_uuid: UUID, trigger_name: str):
     """Check if policies attached to NotificationRule match event"""
@@ -97,7 +101,10 @@ def event_trigger_handler(event_uuid: UUID, trigger_name: str):
     self.info(f"Created {count} notification tasks")
 
 
-@actor(description=_("Send notification."))
+@actor(
+    description=_("Send notification."),
+    queue_name="event_dispatcher",
+)
 def notification_transport(transport_pk: int, event_pk: str, user_pk: int, trigger_pk: str):
     """Send notification over specified transport"""
     event = Event.objects.filter(pk=event_pk).first()
@@ -123,7 +130,10 @@ def notification_transport(transport_pk: int, event_pk: str, user_pk: int, trigg
     transport.send(notification)
 
 
-@actor(description=_("Cleanup events for GDPR compliance."))
+@actor(
+    description=_("Cleanup events for GDPR compliance."),
+    queue_name="gdpr_cleanup",
+)
 def gdpr_cleanup(user_pk: int):
     """cleanup events from gdpr_compliance"""
     events = Event.objects.filter(user__pk=user_pk)
@@ -132,7 +142,10 @@ def gdpr_cleanup(user_pk: int):
         event.delete()
 
 
-@actor(description=_("Cleanup seen notifications and notifications whose event expired."))
+@actor(
+    description=_("Cleanup seen notifications and notifications whose event expired."),
+    queue_name="event_dispatcher",
+)
 def notification_cleanup():
     """Cleanup seen notifications and notifications whose event expired."""
     self = CurrentTask.get_task()

--- a/authentik/providers/scim/tasks.py
+++ b/authentik/providers/scim/tasks.py
@@ -9,42 +9,66 @@ from authentik.providers.scim.models import SCIMProvider
 sync_tasks = SyncTasks(SCIMProvider)
 
 
-@actor(description=_("Sync SCIM provider objects."))
+@actor(
+    description=_("Sync SCIM provider objects."),
+    queue_name="scim_provider",
+)
 def scim_sync_objects(*args, **kwargs):
     return sync_tasks.sync_objects(*args, **kwargs)
 
 
-@actor(description=_("Full sync for SCIM provider."))
+@actor(
+    description=_("Full sync for SCIM provider."),
+    queue_name="scim_provider",
+)
 def scim_sync(provider_pk: int, *args, **kwargs):
     """Run full sync for SCIM provider"""
     return sync_tasks.sync(provider_pk, scim_sync_objects)
 
 
-@actor(description=_("Sync a direct object (user, group) for SCIM provider."))
+@actor(
+    description=_("Sync a direct object (user, group) for SCIM provider."),
+    queue_name="scim_provider",
+)
 def scim_sync_direct(*args, **kwargs):
     return sync_tasks.sync_signal_direct(*args, **kwargs)
 
 
-@actor(description=_("Dispatch syncs for a direct object (user, group) for SCIM providers."))
+@actor(
+    description=_("Dispatch syncs for a direct object (user, group) for SCIM providers."),
+    queue_name="scim_provider",
+)
 def scim_sync_direct_dispatch(*args, **kwargs):
     return sync_tasks.sync_signal_direct_dispatch(scim_sync_direct, *args, **kwargs)
 
 
-@actor(description=_("Delete an object (user, group) for SCIM provider."))
+@actor(
+    description=_("Delete an object (user, group) for SCIM provider."),
+    queue_name="scim_provider",
+)
 def scim_sync_delete(*args, **kwargs):
     return sync_tasks.sync_signal_delete(*args, **kwargs)
 
 
-@actor(description=_("Dispatch deletions for an object (user, group) for SCIM providers."))
+@actor(
+    description=_("Dispatch deletions for an object (user, group) for SCIM providers."),
+    queue_name="scim_provider",
+)
 def scim_sync_delete_dispatch(*args, **kwargs):
     return sync_tasks.sync_signal_delete_dispatch(scim_sync_delete, *args, **kwargs)
 
 
-@actor(description=_("Sync a related object (memberships) for SCIM provider."))
+@actor(
+    description=_("Sync a related object (memberships) for SCIM provider."),
+    queue_name="scim_provider",
+)
 def scim_sync_m2m(*args, **kwargs):
     return sync_tasks.sync_signal_m2m(*args, **kwargs)
 
 
-@actor(description=_("Dispatch syncs for a related object (memberships) for SCIM providers."))
+@actor(
+    description=_("Dispatch syncs for a related object (memberships) for SCIM providers."),
+    queue_name="scim_provider",
+)
 def scim_sync_m2m_dispatch(*args, **kwargs):
     return sync_tasks.sync_signal_m2m_dispatch(scim_sync_m2m, *args, **kwargs)

--- a/authentik/sources/ldap/tasks.py
+++ b/authentik/sources/ldap/tasks.py
@@ -36,7 +36,10 @@ CACHE_KEY_PREFIX = "goauthentik.io/sources/ldap/page/"
 CACHE_KEY_STATUS = "goauthentik.io/sources/ldap/status/"
 
 
-@actor(description=_("Check connectivity for LDAP source."))
+@actor(
+    description=_("Check connectivity for LDAP source."),
+    queue_name="ldap_provider",
+)
 def ldap_connectivity_check(pk: str | None = None):
     """Check connectivity for LDAP Sources"""
     timeout = 60 * 60 * 2
@@ -53,6 +56,7 @@ def ldap_connectivity_check(pk: str | None = None):
     # and 0.5x on top of that to give some more leeway
     time_limit=(60 * 60 * CONFIG.get_int("ldap.task_timeout_hours") * 1000) * 3.5,
     description=_("Sync LDAP source."),
+    queue_name="ldap_provider",
 )
 def ldap_sync(source_pk: str):
     """Sync a single source"""
@@ -133,6 +137,7 @@ def ldap_sync_paginator(
 @actor(
     time_limit=60 * 60 * CONFIG.get_int("ldap.task_timeout_hours") * 1000,
     description=_("Sync page for LDAP source."),
+    queue_name="ldap_provider",
 )
 def ldap_sync_page(source_pk: str, sync_class: str, page_cache_key: str):
     """Synchronization of an LDAP Source"""

--- a/authentik/stages/email/tasks.py
+++ b/authentik/stages/email/tasks.py
@@ -52,7 +52,10 @@ def get_email_body(email: EmailMultiAlternatives) -> str:
     return email.body
 
 
-@actor(description=_("Send email."))
+@actor(
+    description=_("Send email."),
+    queue_name="mailer",
+)
 def send_mail(
     message: dict[Any, Any],
     stage_class_path: str | None = None,


### PR DESCRIPTION
## Details

Helps a lot to shape priorities in the queue, whenever long running tasks (like an LDAP Sync/SCIM Sync over a big dataset) span over multiples of the available worker threads.

Also helps alleviate unexpected behaviors like emails not sent and/or SCIM direct syncs [via the UI] not happening on due time as the job was not picked due to an overcrowded queue.

The default worker command will still process _all_ queues. The explicit queue names enable queue-specific workers and thus guarantee that, for example, emails will not be stalled waiting for synchronization tasks to finish.

There's a second side to this PR: Having the rust worker controller pass `argv` to the underlying `python -m worker ...` invocation, not there yet due to lack of rustiness on my side :melting_face: 

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
