### PR TITLE
lifecycle/ak: export LD_LIBRARY_PATH for venv libpython at startup

### DIFF
--- a/lifecycle/ak
+++ b/lifecycle/ak
@@ -4,6 +4,18 @@ set -e -o pipefail
 
 MODE_FILE="$TMPDIR/authentik-mode"
 
+# Ensure the libpython that the Rust binary is dynamically linked against is on
+# the runtime linker path. uv-managed cpython (installed via `uv python install`)
+# lives under a prefix that ldconfig does not index, so the binary fails with
+# "error while loading shared libraries: libpython3.X.so.1.0: cannot open
+# shared object file" the first time it execs. Distro-installed python is
+# unaffected because /usr/lib is already on the linker's default path.
+_ak_pylibdir=$(python -c 'import sysconfig; print(sysconfig.get_config_var("LIBDIR") or "")' 2>/dev/null || true)
+if [[ -n "$_ak_pylibdir" && -d "$_ak_pylibdir" ]]; then
+    export LD_LIBRARY_PATH="${_ak_pylibdir}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+fi
+unset _ak_pylibdir
+
 function log {
     printf '{"event": "%s", "level": "info", "logger": "bootstrap"}\n' "$@" >&2
 }


### PR DESCRIPTION
## This PR is outdated

See #21858 for the merged fix

## Details

When authentik is built against a uv-managed cpython (`uv python install`), the `libpython3.X.so.1.0` the Rust binary is dynamically linked to lives under a prefix that `ldconfig` does not index — typically `~/.local/share/uv/python/cpython-X.Y.Z-linux-x86_64-gnu/lib/`. The first `exec` of the rust binary then fails with:

```
error while loading shared libraries: libpython3.X.so.1.0: cannot open shared object file: No such file or directory
```

`make run-worker` (which calls `uv run ak worker` → `lifecycle/ak worker` → exec the rust binary) crashes with exit 127.

Distro-installed python is unaffected because its libdir is `/usr/lib` (already on the linker's default path), which is why this is invisible until you switch to uv-managed cpython for dev.

## Fix

Resolve `LIBDIR` from `sysconfig` at the top of `lifecycle/ak` and prepend to `LD_LIBRARY_PATH`. No-op when the libdir is already on the linker path.

## Test plan

- `make run-worker` against a checkout where `uv python install` provided cpython: worker starts, no `cannot open shared object file`.
- Same against a system-python checkout: behavior unchanged.

Could be totally wrong about the right fix shape. Maybe a `cargo` build flag that statically links libpython, or a `rpath` hint, or moving this into `make install`. The minimal `lifecycle/ak` change felt right because that's where the binary is exec'd.