### PR TITLE
providers/scim: Expose managerId attribute in Enterprise User Schema

### DIFF
--- a/authentik/providers/scim/clients/schema.py
+++ b/authentik/providers/scim/clients/schema.py
@@ -49,7 +49,7 @@ class Address(BaseModel):
 class Manager(BaseModel):
     value: str | None = Field(
         None,
-        description="The id of the SCIM resource representingthe User's manager.  REQUIRED.",
+        description="The id of the SCIM resource representing the User's manager.  REQUIRED.",
     )
     ref: AnyUrl | None = Field(
         None,
@@ -59,6 +59,13 @@ class Manager(BaseModel):
     displayName: str | None = Field(
         None,
         description="The displayName of the User's manager. OPTIONAL and READ-ONLY.",
+    )
+
+    # Slack expects manager.managerId, while the default SCIM User Schema instead of .value
+    # see: https://docs.slack.dev/reference/scim-api/#post-users-2
+    managerId: str | None = Field(
+        None,
+        description="managerId (used for slack).",
     )
 
 

--- a/authentik/providers/scim/tests/test_schema.py
+++ b/authentik/providers/scim/tests/test_schema.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from pydantic import ValidationError
 
-from authentik.providers.scim.clients.schema import Email
+from authentik.providers.scim.clients.schema import Email, EnterpriseUser
 
 
 class TestSCIMSchema(TestCase):
@@ -11,3 +11,21 @@ class TestSCIMSchema(TestCase):
         Email.model_validate({"value": "username@testipa.local"})
         with self.assertRaises(ValidationError):
             Email.model_validate({"value": "username"})
+
+    def test_slack_manager_id_value(self):
+        """Ensure Manager Id is exposed as "value" and "managerId" [for slack]"""
+        manager = "Ua123561"
+        raw_enterprise_user = {
+            "division": "ITPE - INS",
+            "department": "Finance, IT, Procurement & IR",
+            "costCenter": "212380006",
+            "employeeNumber": "77002753",
+            "organization": "Finance, IT, Procurement & IR",
+            "manager": {"managerId": manager},
+        }
+        result = EnterpriseUser.model_validate(raw_enterprise_user)
+        assert manager == result.manager.managerId, "managerId was not propagated"
+
+        raw_enterprise_user["manager"] = {"value": manager}
+        result = EnterpriseUser.model_validate(raw_enterprise_user)
+        assert manager == result.manager.value, "value was not propagated"


### PR DESCRIPTION
## Details

Slack does not read manager.value from the enterprise user schema, but rather manager.managerId.

[0]: https://docs.slack.dev/reference/scim-api/#post-users-2

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
