### PR TITLE
packages/client-ts: Fix TypeScript config, ESBuild warnings

### DIFF
--- a/packages/client-ts/package.json
+++ b/packages/client-ts/package.json
@@ -8,7 +8,8 @@
         "url": "https://github.com/goauthentik/authentik.git"
     },
     "scripts": {
-        "build": "tsc && tsc -p tsconfig.esm.json",
+        "clean": "tsc -b --clean tsconfig.json tsconfig.esm.json",
+        "build": "npm run clean && tsc -b tsconfig.json tsconfig.esm.json",
         "prepare": "npm run build"
     },
     "main": "./dist/index.js",

--- a/packages/client-ts/templates/tsconfig.mustache
+++ b/packages/client-ts/templates/tsconfig.mustache
@@ -1,9 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/tsconfig",
     "compilerOptions": {
-        "composite": true,
         "isolatedModules": true,
-        "incremental": true,
         "rootDir": "src",
         "strict": true,
         "newLine": "lf",

--- a/packages/client-ts/tsconfig.json
+++ b/packages/client-ts/tsconfig.json
@@ -1,9 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/tsconfig",
     "compilerOptions": {
-        "composite": true,
         "isolatedModules": true,
-        "incremental": true,
         "rootDir": "src",
         "strict": true,
         "newLine": "lf",


### PR DESCRIPTION
## Dependencies

- goauthentik/client-ts#13

## Details

This PR also fixes a regression introduced in #22037:

```
▲ [WARNING] Use "../packages/client-ts/dist/esm/models/RedirectUriTypeEnum.js" instead of "../packages/client-ts/dist/esm/models/RedirectURITypeEnum.js" to avoid issues with case-sensitive file systems [different-path-case]

    ../packages/client-ts/dist/esm/models/index.js:726:21:
      726 │ __exportStar(require("./RedirectURITypeEnum"), exports);
          ╵                      ~~~~~~~~~~~~~~~~~~~~~~~

▲ [WARNING] Use "../packages/client-ts/dist/esm/models/RedirectUriTypeEnum.js" instead of "../packages/client-ts/dist/esm/models/RedirectURITypeEnum.js" to avoid issues with case-sensitive file systems [different-path-case]

    ../packages/client-ts/dist/esm/models/RedirectURI.js:22:38:
      22 │ const RedirectURITypeEnum_1 = require("./RedirectURITypeEnum");
         ╵                                       ~~~~~~~~~~~~~~~~~~~~~~~

▲ [WARNING] Use "../packages/client-ts/dist/esm/models/RedirectUriTypeEnum.js" instead of "../packages/client-ts/dist/esm/models/RedirectURITypeEnum.js" to avoid issues with case-sensitive file systems [different-path-case]

    ../packages/client-ts/dist/esm/models/RedirectURIRequest.js:22:38:
      22 │ const RedirectURITypeEnum_1 = require("./RedirectURITypeEnum");
         ╵                                       ~~~~~~~~~~~~~~~~~~~~~~~
```

This is caused by a lack of `tsc` on build, letting stale references linger between builds.

## TSConfig fixes

Additionally, this PR drops `"composite": true` and `"incremental": true` from the template (and from the regenerated `packages/client-ts/tsconfig.json`).

## Why these flags

In `goauthentik/client-ts` the two flags caused a release-time bug: a stale `.tsbuildinfo` made `tsc` skip emit, so the published npm tarball shipped without `dist/index.{js,d.ts}`. See #13 for the full diagnosis.

In the monorepo the same flags are inert — `packages/client-ts` is a leaf package with no project references, no `tsbuildinfo` round-trip, and no publish step from this tree. Keeping them only invited the same drift if anyone wired the package into a project-reference graph later.

The `tsconfig.json` change is the result of running `make gen-client-ts` after editing the template — same two lines drop out from the generated artifact. `npm --prefix web install` (also part of `gen-client-ts`) produced no lockfile diff.

