### PR TITLE
sources/oauth: ensure user ID is returned as str

### DIFF
--- a/authentik/sources/oauth/views/callback.py
+++ b/authentik/sources/oauth/views/callback.py
@@ -94,7 +94,7 @@ class OAuthCallback(OAuthClientMixin, View):
     def get_user_id(self, info: dict[str, Any]) -> str | None:
         """Return unique identifier from the profile info."""
         if "id" in info:
-            return info["id"]
+            return str(info["id"])
         return None
 
     def handle_login_failure(self, reason: str) -> HttpResponse:


### PR DESCRIPTION
Fix from #12491 for number id

## Details

When oauth profile returns id as number, e.g. "id": "123456", function fails with `return self.handle_login_failure("Could not determine id.")`
#12491
#21865

---

## Checklist

-   [X] Local tests pass (`ak test authentik/`)
-   [X] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [X] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [X] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
