### PR TITLE
providers/oauth2: fix group mapping ignored in JWT client_credentials…

### DIFF
--- a/authentik/providers/oauth2/tests/test_token_cc_jwt_source.py
+++ b/authentik/providers/oauth2/tests/test_token_cc_jwt_source.py
@@ -290,3 +290,135 @@ class TestTokenClientCredentialsJWTSource(OAuthTestCase):
         self.assertEqual(jwt["email"], "test-user@example.com")
         self.assertEqual(jwt["given_name"], "Mapped Test User")
         self.assertEqual(jwt["preferred_username"], test_username)
+
+    def test_successful_group_mapping(self):
+        """Test that groups returned by property mappings are applied to the auto-generated user.
+
+        Regression test: previously, the 'groups' key returned by user property mapping
+        expressions was silently ignored when exchanging a federated JWT (e.g. a SPIRE SVID)
+        for an Authentik access token via the client_credentials grant. Only scalar fields
+        such as username/name/email/attributes were propagated; group membership was not.
+        """
+        from authentik.core.models import SourceGroupMatchingModes
+
+        # Use name_link mode so the pre-existing "Librechat Users" group is found by name,
+        # matching the typical real-world configuration (see authentik.yaml in ai-lab).
+        self.source.group_matching_mode = SourceGroupMatchingModes.NAME_LINK
+        self.source.save()
+        target_group = Group.objects.create(name="Librechat Users")
+        mapping = OAuthSourcePropertyMapping.objects.create(
+            name="spire-group-mapping",
+            expression="""return {
+                "username": info.get("sub"),
+                "name": info.get("sub"),
+                "groups": ["Librechat Users"],
+            }""",
+        )
+        self.source.user_property_mappings.add(mapping)
+
+        token = self.helper_provider.encode(
+            {
+                "sub": "spire-workload//cluster.local/ns/default/sa/myapp",
+                "exp": datetime.now() + timedelta(hours=2),
+            }
+        )
+        response = self.client.post(
+            reverse("authentik_providers_oauth2:token"),
+            {
+                "grant_type": GRANT_TYPE_CLIENT_CREDENTIALS,
+                "scope": f"{SCOPE_OPENID} {SCOPE_OPENID_EMAIL} {SCOPE_OPENID_PROFILE}",
+                "client_id": self.provider.client_id,
+                "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                "client_assertion": token,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+
+        user = User.objects.filter(
+            username="spire-workload//cluster.local/ns/default/sa/myapp"
+        ).first()
+        self.assertIsNotNone(user)
+        self.assertIn(target_group, user.groups.all(), "User should be in mapped group")
+
+    def test_group_mapping_name_link_existing_group(self):
+        """Test that name_link mode correctly links to an existing group without duplicating it."""
+        from authentik.core.models import SourceGroupMatchingModes
+
+        self.source.group_matching_mode = SourceGroupMatchingModes.NAME_LINK
+        self.source.save()
+        existing_group = Group.objects.create(name="Existing Group")
+        mapping = OAuthSourcePropertyMapping.objects.create(
+            name="group-link-mapping",
+            expression="""return {"username": info.get("sub"), "groups": ["Existing Group"]}""",
+        )
+        self.source.user_property_mappings.add(mapping)
+
+        token = self.helper_provider.encode(
+            {"sub": "link-test-user", "exp": datetime.now() + timedelta(hours=2)}
+        )
+        response = self.client.post(
+            reverse("authentik_providers_oauth2:token"),
+            {
+                "grant_type": GRANT_TYPE_CLIENT_CREDENTIALS,
+                "scope": f"{SCOPE_OPENID} {SCOPE_OPENID_EMAIL} {SCOPE_OPENID_PROFILE}",
+                "client_id": self.provider.client_id,
+                "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                "client_assertion": token,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        user = User.objects.filter(username="link-test-user").first()
+        self.assertIsNotNone(user)
+        # Must be the same group object — name_link must not create a duplicate
+        self.assertIn(existing_group, user.groups.all())
+        self.assertEqual(Group.objects.filter(name="Existing Group").count(), 1)
+
+    def test_group_mapping_reruns_update_membership(self):
+        """Test that group membership is updated on subsequent token requests."""
+        from authentik.core.models import SourceGroupMatchingModes
+
+        # Use name_link so that pre-created groups are found by name
+        self.source.group_matching_mode = SourceGroupMatchingModes.NAME_LINK
+        self.source.save()
+
+        group_a = Group.objects.create(name="Group A")
+        group_b = Group.objects.create(name="Group B")
+        mapping = OAuthSourcePropertyMapping.objects.create(
+            name="dynamic-group-mapping",
+            expression="""
+groups = info.get("groups", [])
+return {"username": info.get("sub"), "groups": groups}
+""",
+        )
+        self.source.user_property_mappings.add(mapping)
+
+        def _exchange(groups: list[str]):
+            token = self.helper_provider.encode(
+                {
+                    "sub": "update-test-user",
+                    "groups": groups,
+                    "exp": datetime.now() + timedelta(hours=2),
+                }
+            )
+            return self.client.post(
+                reverse("authentik_providers_oauth2:token"),
+                {
+                    "grant_type": GRANT_TYPE_CLIENT_CREDENTIALS,
+                    "scope": f"{SCOPE_OPENID} {SCOPE_OPENID_EMAIL} {SCOPE_OPENID_PROFILE}",
+                    "client_id": self.provider.client_id,
+                    "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                    "client_assertion": token,
+                },
+            )
+
+        # First request: user should be in Group A only
+        self.assertEqual(_exchange(["Group A"]).status_code, 200)
+        user = User.objects.get(username="update-test-user")
+        self.assertIn(group_a, user.groups.all())
+        self.assertNotIn(group_b, user.groups.all())
+
+        # Second request: user should be in Group B only (Group A removed)
+        self.assertEqual(_exchange(["Group B"]).status_code, 200)
+        user.refresh_from_db()
+        self.assertNotIn(group_a, user.groups.all())
+        self.assertIn(group_b, user.groups.all())

--- a/authentik/providers/oauth2/views/token.py
+++ b/authentik/providers/oauth2/views/token.py
@@ -41,12 +41,14 @@ from authentik.core.models import (
     USER_PATH_SYSTEM_PREFIX,
     USERNAME_MAX_LENGTH,
     Application,
+    Group,
     Token,
     TokenIntents,
     User,
     UserTypes,
 )
 from authentik.core.sources.mapper import SourceMapper
+from authentik.core.sources.matcher import Action, SourceMatcher
 from authentik.events.middleware import audit_ignore
 from authentik.events.models import Event, EventAction
 from authentik.events.signals import get_login_event
@@ -72,7 +74,7 @@ from authentik.providers.oauth2.utils import (
     pkce_s256_challenge,
 )
 from authentik.providers.oauth2.views.authorize import FORBIDDEN_URI_SCHEMES
-from authentik.sources.oauth.models import OAuthSource
+from authentik.sources.oauth.models import GroupOAuthSourceConnection, OAuthSource
 from authentik.stages.password.stage import PLAN_CONTEXT_METHOD, PLAN_CONTEXT_METHOD_ARGS
 
 LOGGER = get_logger()
@@ -550,10 +552,14 @@ class TokenParams:
     ):
         """Create user from JWT"""
         with audit_ignore():
+            mapper = SourceMapper(source)
             # Run the JWT payload through the core mapping engine
-            mapped = SourceMapper(source).build_object_properties(
+            mapped = mapper.build_object_properties(
                 User, request=request, info=token, oauth_userinfo=token
             )
+            # Extract groups before they are used in user creation - groups require
+            # separate handling via SourceMatcher to correctly link to the source
+            group_ids = mapped.pop("groups", [])
 
             self.user, created = User.objects.update_or_create(
                 username=mapped.get("username", f"{self.provider.name}-{token.get('sub')}")[
@@ -577,6 +583,52 @@ class TokenParams:
             if created and exp:
                 self.user.attributes[USER_ATTRIBUTE_EXPIRES] = exp
                 self.user.save()
+
+            # Sync group membership from property mappings
+            self.__sync_groups_from_jwt(mapper, token, source, request, group_ids)
+
+    def __sync_groups_from_jwt(
+        self,
+        mapper: SourceMapper,
+        token: dict[str, Any],
+        source: OAuthSource,
+        request: HttpRequest,
+        group_ids: list[str],
+    ):
+        """Sync user group membership based on group identifiers returned by property mappings."""
+        matcher = SourceMatcher(source, None, GroupOAuthSourceConnection)
+        synced_groups: list[Group] = []
+
+        for group_id in group_ids:
+            group_properties = mapper.build_object_properties(
+                Group, request=request, group_id=group_id, info=token, oauth_userinfo=token
+            )
+            group_properties.setdefault("name", group_id)
+
+            action, connection = matcher.get_group_action(group_id, group_properties)
+            if action == Action.ENROLL:
+                group = Group.objects.create(**group_properties)
+                connection.group = group
+                connection.save()
+                synced_groups.append(group)
+            elif action in (Action.LINK, Action.AUTH):
+                group = connection.group
+                group.update_attributes(group_properties)
+                connection.save()
+                synced_groups.append(group)
+            else:
+                LOGGER.warning(
+                    "Denied group sync for JWT-federated user",
+                    group_id=group_id,
+                    action=action,
+                )
+
+        # Replace source-linked groups with the current mapping result,
+        # leaving groups from other sources untouched.
+        self.user.groups.remove(
+            *self.user.groups.filter(groupsourceconnection__source=source)
+        )
+        self.user.groups.add(*synced_groups)
 
 
 @method_decorator(csrf_exempt, name="dispatch")


### PR DESCRIPTION
… flow

When a federated JWT (e.g. SPIRE SVID) is exchanged for an Authentik access token via the client_credentials grant, __create_user_from_jwt called SourceMapper.build_object_properties which correctly returned a 'groups' key from user property mapping expressions. However the method only consumed username/name/email/path/type/attributes from the result; the 'groups' list was silently discarded, so the auto-generated service account user was never added to any group.

Fix by extracting the group IDs from the mapped result and delegating to a new __sync_groups_from_jwt helper that mirrors the logic in GroupUpdateStage.handle_groups(): for each group identifier it uses SourceMatcher (respecting the source's configured group_matching_mode) to find or create the group via GroupOAuthSourceConnection, then atomically replaces all source-linked groups on the user.

Add three regression tests covering the basic mapping case, name-link deduplication, and idempotent membership updates across requests.

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
