### PR TITLE
feat(csrf): Configurable CSRF Cookie settings

### DIFF
--- a/authentik/root/settings.py
+++ b/authentik/root/settings.py
@@ -34,7 +34,9 @@ AUTH_USER_MODEL = "authentik_core.User"
 
 CSRF_COOKIE_PATH = LANGUAGE_COOKIE_PATH = SESSION_COOKIE_PATH = CONFIG.get("web.path", "/")
 
-CSRF_COOKIE_NAME = "authentik_csrf"
+CSRF_COOKIE_NAME = CONFIG.get("web.csrf_cookie_name", "authentik_csrf")
+CSRF_COOKIE_AGE = CONFIG.get_optional_int("web.csrf_cookie_age", 31449600)
+
 CSRF_HEADER_NAME = "HTTP_X_AUTHENTIK_CSRF"
 LANGUAGE_COOKIE_NAME = "authentik_language"
 SESSION_COOKIE_NAME = "authentik_session"


### PR DESCRIPTION
## Details

Allow configuring CSRF cookie name & age, age can be set to `"null"` (and thus None in python) to enable CSRF Session Cookies.

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
