### PR TITLE
fix(rbac): ensure migration 0056 runs before 0010 removes group field

### DIFF
--- a/authentik/rbac/migrations/0010_remove_role_group_alter_role_name.py
+++ b/authentik/rbac/migrations/0010_remove_role_group_alter_role_name.py
@@ -6,6 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
+        ("authentik_core", "0056_user_roles"),  # must run before group field is removed
         ("authentik_rbac", "0009_remove_initialpermissions_mode"),
     ]
 


### PR DESCRIPTION
## Problem

When upgrading from Authentik 2025.x to 2026.x, the migration executor can schedule `authentik_rbac.0010_remove_role_group` **before** `authentik_core.0056_user_roles`, causing a startup crash:

```
django.core.exceptions.FieldError: Cannot resolve keyword 'group_id' into field.
Choices are: ak_groups, initialpermissions, managed, name, ...
```

Migration `0056` performs a data migration that queries `Role.objects.filter(group_id=...)` to move guardian permissions to RBAC roles. Migration `0010` removes the `group` FK from `Role`. Neither depends on the other — `0056` only declares a dependency on `0008` — so Django is free to run `0010` first.

## Root Cause

The dependency graph is:

```
0008 → 0009 → 0010   (authentik_rbac)
0008 → 0056          (authentik_core, depends on rbac.0008)
```

Without an ordering constraint between `0010` and `0056`, Django's topological sort can produce `0010` before `0056`.

## Fix

Add `("authentik_core", "0056_user_roles")` as a dependency of `0010`. This ensures the data migration that reads `group_id` always completes before the schema migration removes it.

## Reproduction

Upgrade an Authentik `2025.2.4` instance (the last stable 2025.x release as of this writing) to any `2026.x` release. Authentik fails to start with the `FieldError` shown above.

---
🤖 Identified and submitted via [Claude Code](https://claude.ai/claude-code)