### PR TITLE
Allow searching users by posixGroup

### DIFF
--- a/internal/outpost/ldap/constants/constants.go
+++ b/internal/outpost/ldap/constants/constants.go
@@ -81,5 +81,6 @@ func GetVirtualGroupOCs() map[string]bool {
 		OCGroupOfUniqueNames: true,
 		OCGroupOfNames:       true,
 		OCAKVirtualGroup:     true,
+		OCPosixGroup:         true,
 	}
 }


### PR DESCRIPTION
## Details

The current outpost implementation doesn't allow searching for virtual posixGroup objects.
This PR ensures that when searching for posixGroups users are also loaded for the virtual groups.

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [x] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
