### PR TITLE
ci/web: run Playwright e2e suite on every PR

### DIFF
--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -12,6 +12,13 @@ on:
       - main
       - version-*
 
+env:
+  POSTGRES_DB: authentik
+  POSTGRES_USER: authentik
+  POSTGRES_PASSWORD: "EK-5jnKfjrGRm<77"
+  AUTHENTIK_BLUEPRINTS_DIR: "./blueprints"
+  AUTHENTIK_OUTPOSTS__DISABLE_EMBEDDED_OUTPOST: "true"
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -39,6 +46,103 @@ jobs:
       - name: build
         working-directory: web/
         run: corepack npm run build
+  e2e:
+    name: e2e (playwright)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
+      - name: Setup authentik env
+        uses: ./.github/actions/setup
+        with:
+          dependencies: system,python,node,go,rust,runtime
+      - name: Build web UI
+        run: corepack npm run --prefix web build
+      - name: Build authentik server (Go)
+        run: |
+          go build -o ./bin/authentik-server ./cmd/server
+          sudo install -m 0755 ./bin/authentik-server /usr/local/bin/authentik-server
+      - name: Build authentik worker (Rust)
+        run: |
+          cargo build --release --bin authentik
+          sudo install -m 0755 ./target/release/authentik /usr/local/bin/authentik
+      - name: Apply migrations
+        run: uv run python -m lifecycle.migrate
+      - name: Stage test admin blueprint for discovery
+        run: |
+          mkdir -p blueprints/local
+          cp web/test/blueprints/test-admin-user.yaml blueprints/local/test-admin-user.yaml
+      - name: Resolve Playwright version
+        id: playwright-version
+        working-directory: web
+        run: |
+          version=$(node -p "require('@playwright/test/package.json').version")
+          if [ -z "$version" ]; then
+            echo "Failed to resolve @playwright/test version" >&2
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+      - name: Install Playwright browsers
+        working-directory: web
+        run: |
+          if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
+            corepack npm exec -- playwright install-deps chromium
+          else
+            corepack npm exec -- playwright install --with-deps chromium
+          fi
+      - name: Start authentik server and worker
+        run: |
+          mkdir -p /tmp/ak-logs
+          uv run ak server > /tmp/ak-logs/server.log 2>&1 &
+          echo $! > /tmp/ak-logs/server.pid
+          uv run ak worker > /tmp/ak-logs/worker.log 2>&1 &
+          echo $! > /tmp/ak-logs/worker.pid
+      - name: Wait for authentik to be ready
+        run: |
+          set -euo pipefail
+          # Wait for the HTTP server to come up.
+          timeout 240 bash -c 'until curl -fsS http://localhost:9000/-/health/ready/ >/dev/null; do sleep 2; done'
+          # Wait for the worker to discover & apply default blueprints — the
+          # default-authentication-flow URL is the gating prerequisite for the
+          # Playwright login fixture.
+          timeout 300 bash -c 'until [ "$(curl -s -o /dev/null -w "%{http_code}" http://localhost:9000/if/flow/default-authentication-flow/)" = "200" ]; do sleep 3; done'
+      - name: Apply test-admin user blueprint
+        run: uv run ak apply_blueprint local/test-admin-user.yaml
+      - name: Run Playwright tests
+        working-directory: web
+        env:
+          AK_TEST_RUNNER_PAGE_URL: http://localhost:9000
+        run: corepack npm run test:e2e
+      - name: Upload Playwright HTML report
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-report
+          path: web/playwright-report/
+          retention-days: 14
+          if-no-files-found: ignore
+      - name: Upload Playwright traces and videos
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-traces
+          path: web/test-results/
+          retention-days: 14
+          if-no-files-found: ignore
+      - name: Upload authentik server and worker logs
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: authentik-logs
+          path: /tmp/ak-logs/
+          retention-days: 14
+          if-no-files-found: ignore
   ci-web-mark:
     if: always()
     needs:

--- a/web/playwright.config.js
+++ b/web/playwright.config.js
@@ -26,7 +26,11 @@ export default defineConfig({
     retries: CI ? 2 : 0,
     workers: CI ? 1 : undefined,
     reporter: CI
-        ? "github"
+        ? [
+              // ---
+              ["github"],
+              ["html", { open: "never", outputFolder: "playwright-report" }],
+          ]
         : [
               // ---
               ["list", { printSteps: true }],
@@ -36,6 +40,8 @@ export default defineConfig({
         testIdAttribute: "data-test-id",
         baseURL,
         trace: "on-first-retry",
+        screenshot: "only-on-failure",
+        video: CI ? "retain-on-failure" : "off",
         colorScheme: "dark",
         launchOptions: {
             logger: {

--- a/website/docs/developer-docs/setup/full-dev-environment.mdx
+++ b/website/docs/developer-docs/setup/full-dev-environment.mdx
@@ -208,6 +208,13 @@ Copy the generated recovery key and paste it into the URL, after the domain. For
 
 ## End-to-End (E2E) Setup
 
+authentik ships two end-to-end test suites:
+
+- The Django/Selenium suite under `tests/e2e/` — driven by Django's test runner. It is exercised in CI by the `test-e2e` job in `ci-main.yml`.
+- The browser-side Playwright suite under `web/test/browser/` — driven by `web/playwright.config.js`. It is exercised in CI by the `e2e (playwright)` job in `ci-web.yml` and runs against a live authentik server.
+
+### Django/Selenium suite
+
 Start the E2E test services with the following command:
 
 ```shell
@@ -221,6 +228,40 @@ Alternatively, you can connect directly via VNC on port `5900` using the passwor
 :::info
 When using Docker Desktop, host networking needs to be enabled via **Docker Settings** > **Resources** > **Network** > **Enable host networking**.
 :::
+
+### Playwright suite
+
+The Playwright suite assumes that:
+
+- An authentik stack is reachable at `http://localhost:9000` (override with `AK_TEST_RUNNER_PAGE_URL`).
+- The blueprint at `web/test/blueprints/test-admin-user.yaml` has been applied so that the `test-admin@goauthentik.io` user (password `test-runner`) can log in.
+
+Both prerequisites are satisfied by the standard full development environment described above, plus a one-off blueprint apply. From the repository root:
+
+```shell
+# Make the test admin blueprint discoverable by the worker, then start authentik.
+mkdir -p blueprints/local
+cp web/test/blueprints/test-admin-user.yaml blueprints/local/test-admin-user.yaml
+
+# In separate terminals:
+make run-server
+make run-worker
+```
+
+Once the worker has applied the blueprint, install Playwright's browsers (one-time) and run the suite — these are the same npm scripts CI runs:
+
+```shell
+corepack npm exec --prefix web -- playwright install --with-deps chromium
+corepack npm run --prefix web test:e2e
+```
+
+After a failing run, open the HTML report to inspect traces, screenshots, and (in CI) videos:
+
+```shell
+corepack npm exec --prefix web -- playwright show-report
+```
+
+In CI, the same artifacts are uploaded under the `playwright-report` and `playwright-traces` artifact names on the failed workflow run.
 
 ## Contributing code
 


### PR DESCRIPTION
## Summary

Wires up the existing `web/test/browser/` Playwright suite as its own job in `ci-web.yml`, closing #21994.

Boots the full authentik stack from source (postgres + Go server + Rust worker) inside the workflow, applies migrations and the test-admin blueprint, then runs `corepack npm run --prefix web test:e2e` against `http://localhost:9000`. On failure, uploads the HTML report, traces/videos, and server + worker logs as artifacts so reviewers can debug without rerunning locally.

Also enables the HTML reporter and screenshot/video capture on CI in `playwright.config.js`, and updates the full dev-environment docs to point at the same npm scripts CI uses so local and CI runs stay in lockstep.

## Stacking

This PR targets `npm-corepack` (#20400) intentionally — the new job uses `corepack`-prefixed npm calls and the composite `setup-node` action that #20400 introduces. Will rebase onto `main` once #20400 lands.

## Notes for reviewer

- **Mark as ready** once first cold-cache CI run completes — the rust build is the long pole (rough estimate 5-10 min cold, ~1 min warm via `actions-rust-lang/setup-rust-toolchain` cache). 60-min job timeout chosen with that in mind.
- **Not added to `ci-web-mark.needs`** — runs in parallel with lint/build to avoid cascading the heavy job into vitest. Branch protection should add `e2e (playwright)` directly as a required status check after the first green run.
- **No path filter** — consistent with the rest of `ci-web.yml`.
- Existing Django/Selenium suite under `tests/e2e/` is untouched; both suites coexist as the issue requests.

## Test plan

- [ ] First run on this PR completes within the 60-min timeout (validates cold rust build assumption)
- [ ] HTML report + traces + authentik logs are retrievable from a deliberately-failed run's artifacts
- [ ] After merge, branch protection updated to require `e2e (playwright)` status check

Closes #21994

🤖 Generated with [Claude Code](https://claude.com/claude-code)