### PR TITLE
website/integrations: actual budget: add env var 

### DIFF
--- a/website/integrations/miscellaneous/actual-budget/index.mdx
+++ b/website/integrations/miscellaneous/actual-budget/index.mdx
@@ -59,6 +59,7 @@ ACTUAL_OPENID_DISCOVERY_URL=https://authentik.company/application/o/<application
 ACTUAL_OPENID_CLIENT_ID=Your Client ID from authentik
 ACTUAL_OPENID_CLIENT_SECRET=Your Client Secret from authentik
 ACTUAL_OPENID_SERVER_HOSTNAME=https://actual.company
+ACTUAL_OPENID_AUTH_METHOD=oauth2
 ```
 
   </TabItem>


### PR DESCRIPTION
Set auth method to oauth2 to use correct JWT algorithm.  
Simple addition to the documentation, was not able to integrate authentik sso to Actual Budget due to this error: OpenID grant failed: RPError: unexpected JWT alg received, expected RS256, got: HS256  
Fixed by updating the value of the auth method, options are available at the official doc: https://actualbudget.org/docs/config/oauth-auth/#actual_openid_auth_method