### PR TITLE
docs: Improve docs on webauthn authenticator attachment

### DIFF
--- a/website/docs/add-secure-apps/flows-stages/stages/authenticator_webauthn/index.mdx
+++ b/website/docs/add-secure-apps/flows-stages/stages/authenticator_webauthn/index.mdx
@@ -20,7 +20,13 @@ Configure if the created authenticator is stored in the encrypted memory on the 
 
 #### Authenticator Attachment
 
-Configure if authentik will require either a removable device (like a YubiKey, Google Titan, etc) or a non-removable device (like Windows Hello, TouchID or password managers), or not send a requirement.
+Controls the [`authenticatorAttachment`](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialCreationOptions/authenticatorSelection#authenticatorattachment) parameter sent to the browser during WebAuthn registration. The available options are:
+
+- **No preference is sent**: The browser may offer any available authenticator (default).
+- **Platform**: A non-removable authenticator built into the device, such as Touch ID, Face ID, or Windows Hello.
+- **Cross-platform**: A "roaming" authenticator, such as a YubiKey or Google Titan.
+
+If [WebAuthn Hints](#webauthn-hints) are configured and this option is left unset, authentik infers a value from the selected hints for backward compatibility with older browsers.
 
 #### WebAuthn Hints
 


### PR DESCRIPTION

## Details

Improve this section, since #20933 mentions it 
ref:
<img width="882" height="618" alt="image" src="https://github.com/user-attachments/assets/44549190-c71b-4f56-9c9c-96ceafcf4a17" />


If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
