### PR TITLE
web/stages: better wording for webauthn authenticator attachments options

### DIFF
--- a/web/src/admin/stages/authenticator_webauthn/AuthenticatorWebAuthnStageForm.ts
+++ b/web/src/admin/stages/authenticator_webauthn/AuthenticatorWebAuthnStageForm.ts
@@ -158,24 +158,33 @@ export class AuthenticatorWebAuthnStageForm extends BaseStageForm<AuthenticatorW
                         <ak-radio
                             .options=${[
                                 {
-                                    label: msg("No preference is sent"),
+                                    label: msg(
+                                        "No preference: the browser may offer any available authenticator",
+                                    ),
                                     value: null,
                                     default: true,
                                 },
                                 {
                                     label: msg(
-                                        "A non-removable authenticator, like TouchID or Windows Hello",
+                                        "Platform: a non-removable authenticator built into the device, such as Touch ID, Face ID, or Windows Hello",
                                     ),
                                     value: AuthenticatorAttachmentEnum.Platform,
                                 },
                                 {
-                                    label: msg('A "roaming" authenticator, like a YubiKey'),
+                                    label: msg(
+                                        "Cross-platform: a roaming authenticator, such as a YubiKey or Google Titan",
+                                    ),
                                     value: AuthenticatorAttachmentEnum.CrossPlatform,
                                 },
                             ]}
                             .value=${this.instance?.authenticatorAttachment}
                         >
                         </ak-radio>
+                        <p class="pf-c-form__helper-text">
+                            ${msg(
+                                "Controls the authenticatorAttachment parameter sent to the browser during WebAuthn registration. If Hints are configured and this is left as 'No preference', a value is inferred from the selected hints for backward compatibility with older browsers.",
+                            )}
+                        </p>
                     </ak-form-element-horizontal>
                     <ak-form-element-horizontal label=${msg("Hints")} name="hints">
                         <ak-dual-select-provider


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

Better wording for WebAuthn authenticator attachments options that match the documentation after #22045 and reference the interaction with webauthn hints #20700

BEFORE:

<img width="882" height="618" alt="image" src="https://github.com/user-attachments/assets/44549190-c71b-4f56-9c9c-96ceafcf4a17" />

AFTER:

<img width="757" height="549" alt="image" src="https://github.com/user-attachments/assets/d3031e7e-1556-4546-aaf9-cc972d86978c" />



---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
