### PR TITLE
blueprints: fix mismatched API schema and implementation

### DIFF
--- a/authentik/blueprints/api.py
+++ b/authentik/blueprints/api.py
@@ -217,10 +217,7 @@ class BlueprintInstanceViewSet(UsedByMixin, ModelViewSet):
 
     @extend_schema(
         request={"multipart/form-data": BlueprintUploadSerializer},
-        responses={
-            204: BlueprintImportResultSerializer,
-            400: BlueprintImportResultSerializer,
-        },
+        responses={200: BlueprintImportResultSerializer},
     )
     @action(url_path="import", detail=False, methods=["POST"], parser_classes=(MultiPartParser,))
     @validate(
@@ -247,21 +244,13 @@ class BlueprintInstanceViewSet(UsedByMixin, ModelViewSet):
 
         import_response = self.BlueprintImportResultSerializer(
             data={
-                "logs": [],
-                "success": False,
+                "logs": [LogEventSerializer(log).data for log in logs],
+                "success": valid,
             }
         )
         import_response.is_valid(raise_exception=True)
 
-        import_response.initial_data["logs"] = [LogEventSerializer(log).data for log in logs]
-        import_response.initial_data["success"] = valid
-        import_response.is_valid()
-        if not valid:
-            return Response(data=import_response.initial_data, status=200)
-
-        successful = importer.apply()
-        import_response.initial_data["success"] = successful
-        import_response.is_valid()
-        if not successful:
-            return Response(data=import_response.initial_data, status=200)
+        if valid:
+            import_response.initial_data["success"] = importer.apply()
+            import_response.is_valid()
         return Response(data=import_response.initial_data, status=200)

--- a/authentik/blueprints/tests/test_v1_api.py
+++ b/authentik/blueprints/tests/test_v1_api.py
@@ -3,6 +3,7 @@
 from json import dumps, loads
 from tempfile import NamedTemporaryFile, mkdtemp
 
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 from rest_framework.test import APITestCase
 from yaml import dump
@@ -140,6 +141,20 @@ class TestBlueprintsV1API(APITestCase):
                 format="multipart",
             )
         self.assertEqual(res.status_code, 200)
+
+    def test_api_import_invalid_blueprint_returns_result_payload(self):
+        """Invalid blueprint content returns a result payload instead of a 400 response."""
+        file = SimpleUploadedFile("invalid-blueprint.yaml", b'{"version": 3}')
+
+        res = self.client.post(
+            reverse("authentik_api:blueprintinstance-import-"),
+            data={"file": file},
+            format="multipart",
+        )
+
+        self.assertEqual(res.status_code, 200)
+        self.assertFalse(res.json()["success"])
+        self.assertGreater(len(res.json()["logs"]), 0)
 
     def test_api_import_unknown_path(self):
         """Path not in available blueprints is rejected (covers api.py:56)."""

--- a/packages/client-ts/package.json
+++ b/packages/client-ts/package.json
@@ -8,8 +8,8 @@
         "url": "https://github.com/goauthentik/authentik.git"
     },
     "scripts": {
-        "clean": "tsc -b --clean tsconfig.json tsconfig.esm.json",
         "build": "npm run clean && tsc -b tsconfig.json tsconfig.esm.json",
+        "clean": "tsc -b --clean tsconfig.json tsconfig.esm.json",
         "prepare": "npm run build"
     },
     "main": "./dist/index.js",

--- a/schema.yml
+++ b/schema.yml
@@ -9678,18 +9678,14 @@ paths:
       security:
       - authentik: []
       responses:
-        '204':
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/BlueprintImportResult'
           description: ''
         '400':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BlueprintImportResult'
-          description: ''
+          $ref: '#/components/responses/ValidationErrorResponse'
         '403':
           $ref: '#/components/responses/GenericErrorResponse'
   /oauth2/access_tokens/:


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

`POST /blueprints/instances/import/` declared `204`/`400` responses but always returned `200`, with two identical unreachable return statements.

  - Collapse the duplicate return branches into one.
  - Update `@extend_schema` to `responses={200: BlueprintImportResultSerializer}` to match actual behavior.

  Wire response is unchanged (200 with `{success, logs}`), so frontend callers and existing tests are unaffected.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
