### PR TITLE
api: make ordering null-aware

### DIFF
--- a/authentik/api/ordering.py
+++ b/authentik/api/ordering.py
@@ -1,0 +1,34 @@
+from django.db.models import F
+from rest_framework.filters import OrderingFilter
+
+
+class NullsAwareOrderingFilter(OrderingFilter):
+    """OrderingFilter that sorts NULL values consistently.
+
+    For any nullable field, NULLs are treated as the smallest possible value:
+    - ascending  → NULLs appear first  (nulls_first=True)
+    - descending → NULLs appear last   (nulls_last=True)
+    """
+
+    def _nullable_field_names(self, queryset) -> set[str]:
+        return {f.name for f in queryset.model._meta.get_fields() if hasattr(f, "null") and f.null}
+
+    def filter_queryset(self, request, queryset, view):
+        queryset = super().filter_queryset(request, queryset, view)
+        ordering = queryset.query.order_by
+        if not ordering:
+            return queryset
+        nullable = self._nullable_field_names(queryset)
+        new_ordering = []
+        changed = False
+        for term in ordering:
+            name = term.lstrip("-")
+            if name in nullable:
+                changed = True
+                if term.startswith("-"):
+                    new_ordering.append(F(name).desc(nulls_last=True))
+                else:
+                    new_ordering.append(F(name).asc(nulls_first=True))
+            else:
+                new_ordering.append(term)
+        return queryset.order_by(*new_ordering) if changed else queryset

--- a/authentik/api/ordering.py
+++ b/authentik/api/ordering.py
@@ -1,5 +1,7 @@
-from django.db.models import F
+from django.db.models import F, QuerySet
 from rest_framework.filters import OrderingFilter
+from rest_framework.request import Request
+from rest_framework.views import APIView
 
 
 class NullsAwareOrderingFilter(OrderingFilter):
@@ -10,10 +12,10 @@ class NullsAwareOrderingFilter(OrderingFilter):
     - descending → NULLs appear last   (nulls_last=True)
     """
 
-    def _nullable_field_names(self, queryset) -> set[str]:
+    def _nullable_field_names(self, queryset: QuerySet) -> set[str]:
         return {f.name for f in queryset.model._meta.get_fields() if hasattr(f, "null") and f.null}
 
-    def filter_queryset(self, request, queryset, view):
+    def filter_queryset(self, request: Request, queryset: QuerySet, view: APIView):
         queryset = super().filter_queryset(request, queryset, view)
         ordering = queryset.query.order_by
         if not ordering:

--- a/authentik/api/tests/test_ordering.py
+++ b/authentik/api/tests/test_ordering.py
@@ -1,0 +1,59 @@
+from django.db.models import OrderBy
+from django.test import TestCase
+from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory
+
+from authentik.api.ordering import NullsAwareOrderingFilter
+from authentik.core.models import Token, User
+
+
+class MockView:
+    ordering_fields = "__all__"
+    ordering = None
+
+
+class TestNullsAwareOrderingFilter(TestCase):
+
+    def setUp(self):
+        self.filter = NullsAwareOrderingFilter()
+        self.view = MockView()
+        factory = APIRequestFactory()
+        self._req = lambda ordering: Request(factory.get("/", {"ordering": ordering}))
+
+    def _order_by(self, model, ordering):
+        qs = model.objects.all()
+        return self.filter.filter_queryset(self._req(ordering), qs, self.view).query.order_by
+
+    def test_nullable_asc_nulls_first(self):
+        """Ascending sort on a nullable field rewrites to nulls_first=True."""
+        (expr,) = self._order_by(User, "last_login")
+        self.assertIsInstance(expr, OrderBy)
+        self.assertFalse(expr.descending)
+        self.assertTrue(expr.nulls_first)
+
+    def test_nullable_desc_nulls_last(self):
+        """Descending sort on a nullable field rewrites to nulls_last=True."""
+        (expr,) = self._order_by(User, "-last_login")
+        self.assertIsInstance(expr, OrderBy)
+        self.assertTrue(expr.descending)
+        self.assertTrue(expr.nulls_last)
+
+    def test_non_nullable_passes_through(self):
+        """Non-nullable fields are left as plain string terms."""
+        (expr,) = self._order_by(User, "username")
+        self.assertEqual(expr, "username")
+
+    def test_mixed_ordering(self):
+        """Only nullable terms are rewritten; non-nullable terms pass through unchanged."""
+        first, second = self._order_by(User, "username,-last_login")
+        self.assertEqual(first, "username")
+        self.assertIsInstance(second, OrderBy)
+        self.assertTrue(second.descending)
+        self.assertTrue(second.nulls_last)
+
+    def test_expires_nullable(self):
+        """expires on ExpiringModel is nullable and is rewritten correctly."""
+        (expr,) = self._order_by(Token, "-expires")
+        self.assertIsInstance(expr, OrderBy)
+        self.assertTrue(expr.descending)
+        self.assertTrue(expr.nulls_last)

--- a/authentik/root/settings.py
+++ b/authentik/root/settings.py
@@ -221,7 +221,7 @@ REST_FRAMEWORK = {
         "authentik.api.search.ql.QLSearch",
         "authentik.rbac.filters.ObjectFilter",
         "django_filters.rest_framework.DjangoFilterBackend",
-        "rest_framework.filters.OrderingFilter",
+        "authentik.api.ordering.NullsAwareOrderingFilter",
     ],
     "DEFAULT_PERMISSION_CLASSES": ("authentik.rbac.permissions.ObjectPermissions",),
     "DEFAULT_AUTHENTICATION_CLASSES": (

--- a/web/src/admin/users/UserListPage.ts
+++ b/web/src/admin/users/UserListPage.ts
@@ -92,7 +92,7 @@ export class UserListPage extends WithLicenseSummary(
     public pageIcon = "pf-icon pf-icon-user";
 
     @property({ type: String })
-    public order = "last_login";
+    public order = "-last_login";
 
     @property({ type: String })
     public activePath: string;


### PR DESCRIPTION
closes https://github.com/goauthentik/authentik/issues/22086

mainly applies to nullable date-time fields, which are currently always first compared to other values