### PR TITLE
Allow plural groups in LDAP sync

### DIFF
--- a/authentik/sources/ldap/sync/groups.py
+++ b/authentik/sources/ldap/sync/groups.py
@@ -90,6 +90,12 @@ class GroupLDAPSynchronizer(BaseLDAPSynchronizer):
                 if "users" in defaults:
                     del defaults["users"]
                 parent = defaults.pop("parent", None)
+                parents = defaults.pop("parents", None)
+                if parent and parents:
+                    raise FieldError(
+                        "Group property mappings returned both 'parent' and 'parents'; "
+                        "set only one."
+                    )
                 action, connection = self.matcher.get_group_action(uniq, defaults)
 
                 created = False
@@ -124,6 +130,8 @@ class GroupLDAPSynchronizer(BaseLDAPSynchronizer):
 
                 if parent:
                     group.parents.add(parent)
+                elif parents:
+                    group.parents.set(parents)
                 self._logger.debug("Created group with attributes", **defaults)
             except SkipObjectException:
                 continue


### PR DESCRIPTION
Refactor group synchronization logic to handle 'parents' in addition to 'parent'.

## Details

Simply allows `groups` in addition to `group` for source mappings in LDAP

---

## Checklist

-   [x] Local tests pass (`ak test authentik/`)
-   [x] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [x] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
