### PR TITLE
web: drop `packages/` and composite from `tsc -p .` graph

### DIFF
--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -3,6 +3,10 @@
     "extends": "@goauthentik/tsconfig",
     "compilerOptions": {
         "ignoreDeprecations": "6.0",
+        // Nothing references the web package, so it does not need to act as a
+        // composite project. Disabling composite lets us exclude `packages/`
+        // (each subpackage owns its own tsconfig + build) without TS6307.
+        "composite": false,
         "types": ["node"],
         "checkJs": true,
         "allowJs": true,
@@ -67,6 +71,10 @@
         "storybook-static",
         "src/**/*.test.ts",
         "./tests",
+        // Workspace subpackages each own their tsconfig and build. Including
+        // them here pulls ~1k files (notably the OpenAPI client in
+        // packages/client-ts) into every `tsc -p .` for no benefit.
+        "packages",
         // TODO: @lit/localize-tools v0.8.0 has a nullish coalescing typing error.
         // Remove when we upgrade past that.
         "scripts/pseudolocalize.mjs",


### PR DESCRIPTION
Closes #22100.

## Change

`web/tsconfig.json`:
- Exclude `packages/` from the `tsc -p .` include graph.
- Set `composite: false` (the base `@goauthentik/tsconfig` enables it).

## Why

`tsc -p .` was pulling 2719 non-`node_modules` files into the program; 912 of those were generated files in `packages/client-ts/src/`. Each workspace subpackage already type-checks itself via its own composite tsconfig and is consumed by `web` through compiled `.d.ts` outputs (e.g. `@goauthentik/api/dist/*.d.ts`), so they don't need to be re-checked from the top-level program.

Excluding `packages/` triggered TS6307 because the base config sets `composite: true`, and `@goauthentik/core` imports get followed back into `web/packages/core/`. Nothing in the repo references `web` as a project, so disabling `composite` for this leaf is safe. `incremental` is still inherited from the base, so the `.tsbuildinfo` cache continues to drive warm runs.

## Measurements (this branch)

| | before | after | Δ |
|---|---|---|---|
| `tsc -p .` cold | 26.3s | 22.7s | **-14%** |
| `tsc -p .` warm | 4.1s | 3.5s | **-15%** |
| `npm run precommit` warm | 39.9s | 37.9s | -5% |

## Coverage

Unchanged. Each excluded subpackage type-checks itself; stories, tests, and e2e remain in the include set.