### PR TITLE
web: Move command palette invoker to sidebar

### DIFF
--- a/web/src/admin/ak-interface-admin.css
+++ b/web/src/admin/ak-interface-admin.css
@@ -35,8 +35,41 @@ ak-sidebar-item:active ak-sidebar-item::part(list-item) {
     background-color: transparent !important;
 }
 
-.command-palette-trigger {
+[part="command-palette-trigger"] {
+    --BackgroundColor: var(--pf-global--BackgroundColor--150);
+    background: var(--BackgroundColor);
+    border-radius: var(--pf-global--BorderRadius--sm);
+    border: 0.5px solid var(--pf-global--BorderColor--100);
     cursor: pointer;
-
+    display: grid;
+    gap: var(--pf-global--spacer--sm);
+    grid-template-columns: [icon] auto [label] 1fr [shortcut-hint] auto;
+    justify-items: start;
+    align-items: center;
+    margin-block-end: var(--pf-global--spacer--form-element);
+    margin-block-start: var(--pf-global--spacer--sm);
+    margin-inline: var(--pf-global--spacer--sm);
+    padding-block: var(--pf-global--spacer--form-element);
+    padding-inline-start: var(--pf-global--spacer--sm);
+    user-select: none;
+    z-index: 1;
+    color: var(--pf-global--Color--200);
     padding-inline-end: var(--pf-global--spacer--sm);
+    position: relative;
+
+    .placeholder {
+        font-style: italic;
+        font-size: var(--pf-global--FontSize--sm);
+    }
+
+    &:hover {
+        --BackgroundColor: var(--pf-global--BackgroundColor--400);
+    }
+
+    .icon {
+        display: block;
+        height: var(--pf-global--icon--FontSize--md);
+        fill: currentColor;
+        stroke: currentColor;
+    }
 }

--- a/web/src/admin/ak-interface-admin.css
+++ b/web/src/admin/ak-interface-admin.css
@@ -63,7 +63,7 @@ ak-sidebar-item:active ak-sidebar-item::part(list-item) {
     }
 
     &:hover {
-        --BackgroundColor: var(--pf-global--BackgroundColor--400);
+        --BackgroundColor: var(--pf-global--BackgroundColor--200);
     }
 
     .icon {

--- a/web/src/admin/ak-interface-admin.ts
+++ b/web/src/admin/ak-interface-admin.ts
@@ -269,13 +269,12 @@ export class AdminInterface extends WithCapabilitiesConfig(
                         <i aria-hidden="true" class="fas fa-bars"></i>
                     </button>
 
-                    ${this.renderCommandPaletteButton()}
                     <ak-version-banner></ak-version-banner>
                     <ak-enterprise-status interface="admin"></ak-enterprise-status>
                 </ak-page-navbar>
 
-                <ak-sidebar ?hidden=${!this.sidebarOpen} class="${classMap(sidebarClasses)}"
-                    >${renderSidebarItems(this.entries)}
+                <ak-sidebar ?hidden=${!this.sidebarOpen} class="${classMap(sidebarClasses)}">
+                    ${this.renderCommandPaletteButton()} ${renderSidebarItems(this.entries)}
                     ${this.can(CapabilitiesEnum.IsEnterprise)
                         ? renderSidebarItems(createAdminSidebarEnterpriseEntries())
                         : nothing}
@@ -321,36 +320,31 @@ export class AdminInterface extends WithCapabilitiesConfig(
             const primaryModifierKey = macOS ? "⌘" : "Ctrl";
 
             return html`<button
-                slot="nav-buttons"
+                slot="before-items"
+                part="command-palette-trigger"
                 @click=${this.commandPalette.showListener}
-                class="pf-c-button pf-m-plain command-palette-trigger"
+                type="button"
                 aria-label=${msg("Open Command Palette", {
-                    id: "command-palette-trigger-label",
+                    id: "command-palette-trigger-label-mobile",
                     desc: "Label for the button that opens the command palette",
                 })}
             >
-                <pf-tooltip position="top-end">
-                    <div slot="content" class="ak-tooltip__content--inline">
-                        ${msg("Open Command Palette", {
-                            id: "command-palette-trigger-tooltip",
-                            desc: "Tooltip for the button that opens the command palette",
-                        })}
-                        <div class="ak-c-kbd"><kbd>${primaryModifierKey}</kbd> + <kbd>K</kbd></div>
-                    </div>
-
-                    <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        aria-hidden="true"
-                        class="ak-c-vector-icon"
-                        role="img"
-                        viewBox="0 0 32 32"
-                    >
-                        <path
-                            d="M26 4.01H6a2 2 0 0 0-2 2v20a2 2 0 0 0 2 2h20a2 2 0 0 0 2-2v-20a2 2 0 0 0-2-2m0 2v4H6v-4Zm-20 20v-14h20v14Z"
-                        />
-                        <path d="m10.76 16.18 2.82 2.83-2.82 2.83 1.41 1.41 4.24-4.24-4.24-4.24z" />
-                    </svg>
-                </pf-tooltip>
+                <svg
+                    class="icon"
+                    role="img"
+                    aria-hidden="true"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 32 32"
+                >
+                    <path
+                        d="m29 27.586-7.552-7.552a11.018 11.018 0 1 0-1.414 1.414L27.586 29ZM4 13a9 9 0 1 1 9 9 9.01 9.01 0 0 1-9-9"
+                    />
+                </svg>
+                <div class="placeholder">${msg("Search...")}</div>
+                <div class="ak-c-kbd">
+                    <kbd>${primaryModifierKey}</kbd> <span class="ak-c-kbd__plus">+</span>
+                    <kbd>K</kbd>
+                </div>
             </button>`;
         });
     }

--- a/web/src/admin/endpoints/devices/DeviceListPage.ts
+++ b/web/src/admin/endpoints/devices/DeviceListPage.ts
@@ -81,7 +81,7 @@ export class DeviceListPage extends TablePage<EndpointDevice> {
 
     renderSectionBefore() {
         return html`
-            <div class="pf-c-banner pf-m-info">
+            <div class="pf-c-banner pf-m-info ak-m-inset">
                 ${msg("Endpoint Devices are in preview.")}
                 <a href="mailto:hello+feature/platform@goauthentik.io"
                     >${msg("Send us feedback!")}</a

--- a/web/src/admin/lifecycle/LifecyclePreviewBanner.ts
+++ b/web/src/admin/lifecycle/LifecyclePreviewBanner.ts
@@ -13,7 +13,7 @@ export class LifecyclePreviewBanner extends AKElement {
     static styles = [PFBanner];
 
     public render(): TemplateResult {
-        return html`<div class="pf-c-banner pf-m-info">
+        return html`<div class="pf-c-banner pf-m-info ak-m-inset">
             ${msg("Object Lifecycle Management is in preview.")}
             <a href="mailto:hello+feature/lifecycle@goauthentik.io">${msg("Send us feedback!")}</a>
         </div>`;

--- a/web/src/admin/stages/authenticator_endpoint_gdtc/AuthenticatorEndpointGDTCStageForm.ts
+++ b/web/src/admin/stages/authenticator_endpoint_gdtc/AuthenticatorEndpointGDTCStageForm.ts
@@ -37,7 +37,7 @@ export class AuthenticatorEndpointGDTCStageForm extends BaseStageForm<Authentica
     static styles = [...super.styles, PFBanner];
 
     protected override renderForm(): TemplateResult {
-        return html`<div class="pf-c-banner pf-m-info">
+        return html`<div class="pf-c-banner pf-m-info ak-m-inset">
                 ${msg("Endpoint Google Chrome Device Trust is in preview.")}
                 <a href="mailto:hello+feature/gdtc@goauthentik.io">${msg("Send us feedback!")}</a>
             </div>

--- a/web/src/elements/sidebar/Sidebar.css
+++ b/web/src/elements/sidebar/Sidebar.css
@@ -35,7 +35,6 @@
 .pf-c-nav__list {
     flex-grow: 1;
     overflow-y: auto;
-    padding-block-start: var(--pf-global--spacer--sm);
 }
 
 .pf-c-nav__link.pf-m-current::after,

--- a/web/src/elements/sidebar/Sidebar.ts
+++ b/web/src/elements/sidebar/Sidebar.ts
@@ -20,10 +20,22 @@ export class Sidebar extends AKElement {
     ];
 
     @property({ type: Boolean })
-    hidden = false;
+    public hidden = false;
+
+    protected defaultSlot: HTMLSlotElement;
+    protected beforeItemsSlot: HTMLSlotElement;
+
+    constructor() {
+        super();
+
+        this.defaultSlot = this.ownerDocument.createElement("slot");
+        this.beforeItemsSlot = this.ownerDocument.createElement("slot");
+        this.beforeItemsSlot.name = "before-items";
+    }
 
     render(): TemplateResult {
         return html`<div part="nav" class="pf-c-nav" role="presentation">
+            ${this.beforeItemsSlot}
             <ul
                 id="global-nav"
                 ?hidden=${this.hidden}
@@ -32,7 +44,7 @@ export class Sidebar extends AKElement {
                 class="pf-c-nav__list ak-m-thin-scrollbar ak-m-scroll-shadows"
                 part="list"
             >
-                <slot></slot>
+                ${this.defaultSlot}
             </ul>
             <ak-sidebar-version
                 exportparts="trigger:about-dialog-trigger, button-content:about-dialog-button-content, product-name, product-version"

--- a/web/src/styles/authentik/base/common.css
+++ b/web/src/styles/authentik/base/common.css
@@ -91,18 +91,19 @@
 /* #region Keyboard */
 
 .ak-c-kbd {
-    --ak-c-kbd--ShadowColor: var(--pf-global--BackgroundColor--dark-transparent-100);
-    --ak-c-kbd--InsetColor: var(--pf-global--Color--light-300);
+    --ak-c-kbd--ShadowColor: var(--pf-global--BackgroundColor--dark-transparent-200);
+    --ak-c-kbd--InsetColor: var(--pf-global--BackgroundColor--100);
 
     display: flex;
     align-items: center;
     line-height: 1;
+    gap: 0.125em;
 
     kbd {
         user-select: none;
         text-rendering: optimizeLegibility;
         letter-spacing: 0.05em;
-        padding: 0.25rem 0.25rem;
+        padding: 0.25rem 0.5rem;
         border-radius: 3px;
         box-shadow:
             0 1px 1px var(--ak-c-kbd--ShadowColor),
@@ -112,9 +113,15 @@
         font-weight: bold;
         line-height: 1;
         white-space: nowrap;
-        background-color: var(--pf-global--BackgroundColor--light-100);
-        color: var(--pf-global--Color--dark-100);
+        background-color: var(--pf-global--BackgroundColor--150);
+        color: var(--pf-global--Color--200);
         font-family: var(--pf-global--FontFamily--monospace);
+        text-align: center;
+    }
+
+    .ak-c-kbd__plus {
+        font-size: var(--pf-global--FontSize--sm);
+        color: var(--pf-global--Color--dark-200);
     }
 }
 

--- a/web/src/styles/authentik/components/Banner/banner.css
+++ b/web/src/styles/authentik/components/Banner/banner.css
@@ -13,6 +13,14 @@
     }
 }
 
+.pf-c-banner.ak-m-inset {
+    margin-block-start: calc(
+        var(--pf-global--spacer--xs) + (var(--pf-global--spacer--form-element) / 2)
+    );
+    margin-inline: var(--pf-global--spacer--md);
+    border-radius: var(--pf-global--BorderRadius--sm);
+}
+
 :host([theme="dark"]) .pf-c-banner {
     &.pf-m-info,
     &.pf-m-blue,

--- a/web/src/styles/authentik/components/Page/page.css
+++ b/web/src/styles/authentik/components/Page/page.css
@@ -10,6 +10,10 @@
     --pf-c-page__sidebar--m-dark--BackgroundColor: var(--pf-global--BackgroundColor--100);
 
     --pf-c-page__sidebar--BackgroundColor: var(--pf-c-page__sidebar--m-light--BackgroundColor);
+    --pf-c-page__main-section--xl--PaddingTop: var(--pf-global--spacer--md);
+    --pf-c-page__main-section--xl--PaddingLeft: var(--pf-global--spacer--md);
+    --pf-c-page__main-section--xl--PaddingRight: var(--pf-global--spacer--md);
+    --pf-c-page__main-section--xl--PaddingBottom: var(--pf-global--spacer--md);
 }
 
 .pf-c-page__drawer {


### PR DESCRIPTION
## Details

This PR moves the command palette invoker from the top page navigation bar, to the sidebar:


<img width="1840" height="1196" alt="Screenshot 2026-05-07 at 15 15 45" src="https://github.com/user-attachments/assets/df3416fd-8841-46e1-a3ae-60cb7f5b5758" />
<img width="1840" height="1196" alt="Screenshot 2026-05-07 at 15 15 55" src="https://github.com/user-attachments/assets/12cfdc2c-1c50-495e-9fcd-aa7a70ea4ec1" />
<img width="1840" height="1196" alt="Screenshot 2026-05-07 at 15 19 53" src="https://github.com/user-attachments/assets/03104025-af30-44ec-acda-57d5b5927e4f" />
<img width="1840" height="1196" alt="Screenshot 2026-05-07 at 15 20 18" src="https://github.com/user-attachments/assets/0fc12ec7-741a-4a31-924a-4adf2a766db3" />
