### PR TITLE
tenants: fix system flags removeable

### DIFF
--- a/authentik/tenants/api/settings.py
+++ b/authentik/tenants/api/settings.py
@@ -19,6 +19,12 @@ from authentik.tenants.models import Tenant
 
 class FlagJSONField(JSONDictField):
 
+    def to_internal_value(self, data: str):
+        flags =  super().to_internal_value(data)
+        for flag in Flag.available(visibility="system", exclude_system=False):
+            flags[flag().key] = flag.get()
+        return flags
+
     def to_representation(self, value: dict) -> dict:
         """Exclude any system flags that aren't modifiable"""
         new_value = value.copy()
@@ -30,12 +36,9 @@ class FlagJSONField(JSONDictField):
 
     def run_validators(self, value: dict):
         super().run_validators(value)
-        for flag in Flag.available(exclude_system=False):
+        for flag in Flag.available():
             _flag = flag()
             if _flag.key not in value:
-                continue
-            if _flag.visibility == "system":
-                value.pop(_flag.key, None)
                 continue
             flag_value = value.get(_flag.key)
             flag_type = get_args(_flag.__orig_bases__[0])[0]

--- a/authentik/tenants/api/settings.py
+++ b/authentik/tenants/api/settings.py
@@ -20,7 +20,7 @@ from authentik.tenants.models import Tenant
 class FlagJSONField(JSONDictField):
 
     def to_internal_value(self, data: str):
-        flags =  super().to_internal_value(data)
+        flags = super().to_internal_value(data)
         for flag in Flag.available(visibility="system", exclude_system=False):
             flags[flag().key] = flag.get()
         return flags

--- a/authentik/tenants/tests/test_local_settings.py
+++ b/authentik/tenants/tests/test_local_settings.py
@@ -85,10 +85,30 @@ class TestLocalSettingsAPI(APITestCase):
                 "flags": {"tenants_test_flag_sys": 123},
             },
         )
-        print(response.content)
         self.assertEqual(response.status_code, 200)
         self.tenant.refresh_from_db()
-        self.assertEqual(self.tenant.flags, {})
+        self.assertEqual(self.tenant.flags, {"setup": False, "tenants_test_flag_sys": False})
+
+    def test_settings_flags_system_empty_put(self):
+        """Test settings API"""
+        self.tenant.flags = {}
+        self.tenant.save()
+
+        class _TestFlag(Flag[bool], key="tenants_test_flag_sys"):
+
+            default = False
+            visibility = "system"
+
+        self.client.force_login(self.local_admin)
+        response = self.client.patch(
+            reverse("authentik_api:tenant_settings"),
+            data={
+                "flags": {},
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.tenant.refresh_from_db()
+        self.assertEqual(self.tenant.flags, {"setup": False, "tenants_test_flag_sys": False})
 
     def test_command(self):
         self.tenant.flags = {}


### PR DESCRIPTION
when sending a `PUT` request to /system/settings/ with `flags: {}`, it would override system flags too; we only excluded them if you explicitly tried to modify them.
