### PR TITLE
web/admin: legacy modal fixes and fix log viewer in form layout

### DIFF
--- a/web/src/admin/policies/PolicyTestForm.ts
+++ b/web/src/admin/policies/PolicyTestForm.ts
@@ -123,13 +123,7 @@ export class PolicyTestForm extends Form<PolicyTestRequest> {
             </ak-form-element-horizontal>
 
             <ak-form-element-horizontal label=${msg("Log messages")}>
-                <div class="pf-c-form__group-label">
-                    <div class="pf-c-form__horizontal-group ak-policy-test-log-messages">
-                        <dl class="pf-c-description-list pf-m-horizontal">
-                            <ak-log-viewer .items=${this.result?.logMessages}></ak-log-viewer>
-                        </dl>
-                    </div>
-                </div>
+                <ak-log-viewer .items=${this.result?.logMessages}></ak-log-viewer>
             </ak-form-element-horizontal>`;
     }
 

--- a/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderGroupList.ts
+++ b/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderGroupList.ts
@@ -31,7 +31,7 @@ export class GoogleWorkspaceProviderGroupList extends Table<GoogleWorkspaceProvi
     clearOnRefresh = true;
 
     renderToolbar(): TemplateResult {
-        return html`<ak-forms-modal cancelText=${msg("Close")} ?closeAfterSuccessfulSubmit=${false}>
+        return html`<ak-forms-modal cancelText=${msg("Close")} keep-open-after-submit>
                 <span slot="submit">${msg("Sync")}</span>
                 <span slot="header">${msg("Sync Group")}</span>
                 <ak-sync-object-form

--- a/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderUserList.ts
+++ b/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderUserList.ts
@@ -32,7 +32,7 @@ export class GoogleWorkspaceProviderUserList extends Table<GoogleWorkspaceProvid
     clearOnRefresh = true;
 
     renderToolbar(): TemplateResult {
-        return html`<ak-forms-modal cancelText=${msg("Close")} ?closeAfterSuccessfulSubmit=${false}>
+        return html`<ak-forms-modal cancelText=${msg("Close")} keep-open-after-submit>
                 <span slot="submit">${msg("Sync")}</span>
                 <span slot="header">${msg("Sync User")}</span>
                 <ak-sync-object-form

--- a/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderGroupList.ts
+++ b/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderGroupList.ts
@@ -28,7 +28,7 @@ export class MicrosoftEntraProviderGroupList extends Table<MicrosoftEntraProvide
     protected override searchEnabled = true;
 
     renderToolbar(): TemplateResult {
-        return html`<ak-forms-modal cancelText=${msg("Close")} ?closeAfterSuccessfulSubmit=${false}>
+        return html`<ak-forms-modal cancelText=${msg("Close")} keep-open-after-submit>
                 <span slot="submit">${msg("Sync")}</span>
                 <span slot="header">${msg("Sync Group")}</span>
                 <ak-sync-object-form

--- a/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderUserList.ts
+++ b/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderUserList.ts
@@ -32,7 +32,7 @@ export class MicrosoftEntraProviderUserList extends Table<MicrosoftEntraProvider
     clearOnRefresh = true;
 
     renderToolbar(): TemplateResult {
-        return html`<ak-forms-modal cancelText=${msg("Close")} ?closeAfterSuccessfulSubmit=${false}>
+        return html`<ak-forms-modal cancelText=${msg("Close")} keep-open-after-submit>
                 <span slot="submit">${msg("Sync")}</span>
                 <span slot="header">${msg("Sync User")}</span>
                 <ak-sync-object-form

--- a/web/src/admin/providers/scim/SCIMProviderGroupList.ts
+++ b/web/src/admin/providers/scim/SCIMProviderGroupList.ts
@@ -31,7 +31,7 @@ export class SCIMProviderGroupList extends Table<SCIMProviderGroup> {
     clearOnRefresh = true;
 
     renderToolbar(): TemplateResult {
-        return html`<ak-forms-modal cancelText=${msg("Close")} ?closeAfterSuccessfulSubmit=${false}>
+        return html`<ak-forms-modal cancelText=${msg("Close")} keep-open-after-submit>
                 <span slot="submit">${msg("Sync")}</span>
                 <span slot="header">${msg("Sync Group")}</span>
                 <ak-sync-object-form

--- a/web/src/admin/providers/scim/SCIMProviderUserList.ts
+++ b/web/src/admin/providers/scim/SCIMProviderUserList.ts
@@ -32,7 +32,7 @@ export class SCIMProviderUserList extends Table<SCIMProviderUser> {
     clearOnRefresh = true;
 
     renderToolbar(): TemplateResult {
-        return html`<ak-forms-modal cancelText=${msg("Close")} ?closeAfterSuccessfulSubmit=${false}>
+        return html`<ak-forms-modal cancelText=${msg("Close")} keep-open-after-submit>
                 <span slot="submit">${msg("Sync")}</span>
                 <span slot="header">${msg("Sync User")}</span>
                 <ak-sync-object-form

--- a/web/src/admin/sources/ldap/LDAPSourceGroupList.ts
+++ b/web/src/admin/sources/ldap/LDAPSourceGroupList.ts
@@ -41,7 +41,7 @@ export class LDAPSourceGroupList extends Table<GroupLDAPSourceConnection> {
     }
 
     renderToolbar(): TemplateResult {
-        return html`<ak-forms-modal cancelText=${msg("Close")} ?closeAfterSuccessfulSubmit=${false}>
+        return html`<ak-forms-modal cancelText=${msg("Close")} keep-open-after-submit>
                 <span slot="submit">${msg("Connect")}</span>
                 <span slot="header">${msg("Connect Group")}</span>
                 <ak-source-ldap-group-form .source=${this.source} slot="form">

--- a/web/src/admin/sources/ldap/LDAPSourceUserList.ts
+++ b/web/src/admin/sources/ldap/LDAPSourceUserList.ts
@@ -47,7 +47,7 @@ export class LDAPSourceUserList extends Table<UserLDAPSourceConnection> {
     }
 
     renderToolbar(): TemplateResult {
-        return html`<ak-forms-modal cancelText=${msg("Close")} ?closeAfterSuccessfulSubmit=${false}>
+        return html`<ak-forms-modal cancelText=${msg("Close")} keep-open-after-submit>
                 <span slot="submit">${msg("Connect")}</span>
                 <span slot="header">${msg("Connect User")}</span>
                 <ak-source-ldap-user-form .source=${this.source} slot="form">

--- a/web/src/elements/forms/ModalForm.ts
+++ b/web/src/elements/forms/ModalForm.ts
@@ -52,8 +52,8 @@ export class ModalForm extends ModalButton {
 
     //#region Properties
 
-    @property({ type: Boolean })
-    public closeAfterSuccessfulSubmit = true;
+    @property({ type: Boolean, attribute: "keep-open-after-submit" })
+    public keepOpenAfterSubmit = false;
 
     @property({ type: Boolean })
     public showSubmitButton = true;
@@ -98,7 +98,7 @@ export class ModalForm extends ModalButton {
 
         return formPromise
             .then(() => {
-                if (this.closeAfterSuccessfulSubmit) {
+                if (!this.keepOpenAfterSubmit) {
                     this.open = false;
                     form?.reset();
 
@@ -138,7 +138,7 @@ export class ModalForm extends ModalButton {
     protected refreshListener = (e: Event): void => {
         // if the modal should stay open after successful submit, prevent EVENT_REFRESH from bubbling
         // to the parent components (which would cause table refreshes that destroy the modal)
-        if (!this.closeAfterSuccessfulSubmit) {
+        if (this.keepOpenAfterSubmit) {
             e.stopPropagation();
         }
     };

--- a/web/src/elements/sync/SyncObjectForm.ts
+++ b/web/src/elements/sync/SyncObjectForm.ts
@@ -110,13 +110,7 @@ export class SyncObjectForm extends Form<SyncObjectRequest> {
 
     renderResult(): TemplateResult {
         return html`<ak-form-element-horizontal label=${msg("Log messages")}>
-            <div class="pf-c-form__group-label">
-                <div class="c-form__horizontal-group">
-                    <dl class="pf-c-description-list pf-m-horizontal">
-                        <ak-log-viewer .items=${this.result?.messages}></ak-log-viewer>
-                    </dl>
-                </div>
-            </div>
+            <ak-log-viewer .items=${this.result?.messages}></ak-log-viewer>
         </ak-form-element-horizontal> `;
     }
 


### PR DESCRIPTION
`closeAfterSuccessfulSubmit` was broken for some reason, switching it to be false by default seemed to fix it?