### PR TITLE
web/maintenance: bump Typescript compiler to version 7

### DIFF
--- a/packages/logger-js/lib/shared.js
+++ b/packages/logger-js/lib/shared.js
@@ -60,7 +60,7 @@ export const LogLevels = /** @type {Level[]} */ (Object.keys(LogLevelLabel));
 /**
  * @callback LoggerFactory
  * @param {string | null} [prefix]
- * @param {...string} args
+ * @param {...string[]} args
  * @returns {Logger}
  */
 
@@ -207,7 +207,7 @@ export function pinoLight(options) {
  * Creates a logger with the given prefix.
  *
  * @param {string} [prefix]
- * @param {...string} args
+ * @param {...string[]} args
  * @returns {Logger}
  *
  */

--- a/packages/logger-js/package-lock.json
+++ b/packages/logger-js/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@goauthentik/logger-js",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@goauthentik/logger-js",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "license": "MIT",
             "devDependencies": {
                 "@eslint/js": "^9.39.3",
@@ -68,7 +68,7 @@
         },
         "../tsconfig": {
             "name": "@goauthentik/tsconfig",
-            "version": "1.0.8",
+            "version": "1.0.9",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/packages/logger-js/package.json
+++ b/packages/logger-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@goauthentik/logger-js",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "Pino-based logger for authentik",
     "license": "MIT",
     "repository": {

--- a/web/logger/browser.js
+++ b/web/logger/browser.js
@@ -63,7 +63,7 @@ const LogLevelColors = /** @type {const} */ ({
  * Creates a logger with the given prefix.
  *
  * @param {string} [prefix]
- * @param {...string} args
+ * @param {...string[]} args
  * @returns {Logger}
  *
  */

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -57,6 +57,7 @@
                 "@typescript-eslint/eslint-plugin": "^8.57.2",
                 "@typescript-eslint/parser": "^8.57.2",
                 "@typescript-eslint/utils": "^8.57.2",
+                "@typescript/native-preview": "^7.0.0-dev.20260421.2",
                 "@vitest/browser": "^4.1.6",
                 "@vitest/browser-playwright": "^4.1.6",
                 "@webcomponents/webcomponentsjs": "^2.8.0",
@@ -5631,6 +5632,115 @@
             "funding": {
                 "url": "https://opencollective.com/eslint"
             }
+        },
+        "node_modules/@typescript/native-preview": {
+            "version": "7.0.0-dev.20260421.2",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260421.2.tgz",
+            "integrity": "sha512-CmajHI25HpVWE9R1XFoxr+cphJPxoYD3eFioQtAvXYkMFKnLdICMS9pXre9Pybizb75ejRxjKD5/CVG055rEIg==",
+            "license": "Apache-2.0",
+            "bin": {
+                "tsgo": "bin/tsgo.js"
+            },
+            "optionalDependencies": {
+                "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260421.2",
+                "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260421.2",
+                "@typescript/native-preview-linux-arm": "7.0.0-dev.20260421.2",
+                "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260421.2",
+                "@typescript/native-preview-linux-x64": "7.0.0-dev.20260421.2",
+                "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260421.2",
+                "@typescript/native-preview-win32-x64": "7.0.0-dev.20260421.2"
+            }
+        },
+        "node_modules/@typescript/native-preview-darwin-arm64": {
+            "version": "7.0.0-dev.20260421.2",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260421.2.tgz",
+            "integrity": "sha512-fHv1r3ZmVo6zxuAIFmuX3w9QxbcauoG0SsWhmDwm6VmRubLlOJIcmTtlmV3JAb9oOnq8LuzZljzT7Q39fSMQDw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@typescript/native-preview-darwin-x64": {
+            "version": "7.0.0-dev.20260421.2",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260421.2.tgz",
+            "integrity": "sha512-KWTR6xbW9t+JS7D5DQIzo75pqVXVWUxF9PMv/+S6xsnOjCVd6g0ixHcFpFMJMKSUQpGPr8Z5f7b8ks6LHW01jg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@typescript/native-preview-linux-arm": {
+            "version": "7.0.0-dev.20260421.2",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260421.2.tgz",
+            "integrity": "sha512-BWLQO3nemLDSV5PoE5GPHe1dU9Dth77Kv8/cle9Ujcp4LhPo0KincdPqFH/qKeU/xvW25mgFueflZ1nc4rKuww==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@typescript/native-preview-linux-arm64": {
+            "version": "7.0.0-dev.20260421.2",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260421.2.tgz",
+            "integrity": "sha512-VLMEuml3BhUb+jaL0TXQ4xvVODxJF+RhkI+tBWvlynsJI4khTXEiwWh+wPOJrsfBRYFRMXEu28Odl/HXkYze8w==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@typescript/native-preview-linux-x64": {
+            "version": "7.0.0-dev.20260421.2",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260421.2.tgz",
+            "integrity": "sha512-qUrJWTB5/wv4wnRG0TRXElAxc2kykNiRNyEIEqBbLmzDlrcvAW7RRy8MXoY1ZyTiKGMu14itZ3x9oW6+blFpRw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@typescript/native-preview-win32-arm64": {
+            "version": "7.0.0-dev.20260421.2",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260421.2.tgz",
+            "integrity": "sha512-Rc6NsWlZmCs5YUKVzKgwoBOoRUGsPzct4BDMRX0csD1devLBBc4AbUXWKsJRbpwIAnqMO1ld4sNHEb+wXgfNHQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@typescript/native-preview-win32-x64": {
+            "version": "7.0.0-dev.20260421.2",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260421.2.tgz",
+            "integrity": "sha512-GQv1+dya1t6EqF2Cpsb+xoozovdX10JUSf6Kl/8xNkTapzmlHd+uMr+8ku3jIASTxoRGn0Mklgjj3MDKrOTuLg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
         },
         "node_modules/@ungap/structured-clone": {
             "version": "1.3.0",

--- a/web/package.json
+++ b/web/package.json
@@ -133,6 +133,7 @@
         "@typescript-eslint/eslint-plugin": "^8.57.2",
         "@typescript-eslint/parser": "^8.57.2",
         "@typescript-eslint/utils": "^8.57.2",
+        "@typescript/native-preview": "^7.0.0-dev.20260421.2",
         "@vitest/browser": "^4.1.6",
         "@vitest/browser-playwright": "^4.1.6",
         "@webcomponents/webcomponentsjs": "^2.8.0",
@@ -259,10 +260,7 @@
             "command": "lit-analyzer src"
         },
         "lint:types": {
-            "command": "tsc -p .",
-            "env": {
-                "NODE_OPTIONS": "--max_old_space_size=8192"
-            },
+            "command": "tsgo -p .",
             "dependencies": [
                 "build-locales"
             ]
@@ -291,10 +289,7 @@
             }
         },
         "tsc": {
-            "command": "tsc -p .",
-            "env": {
-                "NODE_OPTIONS": "--max_old_space_size=8192"
-            },
+            "command": "tsgo -p .",
             "dependencies": [
                 "build-locales"
             ]

--- a/web/packages/lex/index.js
+++ b/web/packages/lex/index.js
@@ -25,7 +25,7 @@
  *
  * @callback LexerAction
  * @this {Lexer}
- * @param {...string} match
+ * @param {...string[]} match
  * @returns {Token | Token[] | null | void}
  */
 

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -3,6 +3,10 @@
     "extends": "@goauthentik/tsconfig",
     "compilerOptions": {
         "ignoreDeprecations": "6.0",
+        // Nothing references the web package, so it does not need to act as a
+        // composite project. Disabling composite lets us exclude `packages/`
+        // (each subpackage owns its own tsconfig + build) without TS6307.
+        "composite": false,
         "types": ["node"],
         "checkJs": true,
         "allowJs": true,
@@ -68,6 +72,10 @@
         "storybook-static",
         "src/**/*.test.ts",
         "./tests",
+        // Workspace subpackages each own their tsconfig and build. Including
+        // them here pulls ~1k files (notably the OpenAPI client in
+        // packages/client-ts) into every `tsc -p .` for no benefit.
+        "packages",
         // TODO: @lit/localize-tools v0.8.0 has a nullish coalescing typing error.
         // Remove when we upgrade past that.
         "scripts/pseudolocalize.mjs",


### PR DESCRIPTION
This commit bumps the Typescript compiler version to 7.  (Well, 7 beta, but Microsoft promises all tests are passing).

One type bug was found in version seven: The LexerAction parameter is a _rest_ parameter, and those must always be arrays.

-   [⏰] The code has been formatted (`make web`)
