### PR TITLE
providers/saml: Add sls to saml overview

### DIFF
--- a/web/src/admin/providers/saml/SAMLProviderFormForm.ts
+++ b/web/src/admin/providers/saml/SAMLProviderFormForm.ts
@@ -15,6 +15,7 @@ import {
     availableHashes,
     DEFAULT_HASH_ALGORITHM,
     digestAlgorithmOptions,
+    logoutMethodOptions,
     retrieveSignatureAlgorithm,
     SAMLSupportedKeyTypes,
 } from "./SAMLProviderOptions.js";
@@ -29,7 +30,6 @@ import {
     PropertymappingsApi,
     PropertymappingsProviderSamlListRequest,
     SAMLBindingsEnum,
-    SAMLLogoutMethods,
     SAMLNameIDPolicyEnum,
     SAMLPropertyMapping,
     SAMLProvider,
@@ -90,23 +90,6 @@ function renderHasSlsUrl(
     logoutMethod: string,
     setLogoutMethod?: (ev: Event) => void,
 ) {
-    const logoutMethodOptions: RadioOption<string>[] = [
-        {
-            label: msg("Front-channel (Iframe)"),
-            value: SAMLLogoutMethods.FrontchannelIframe,
-            default: true,
-        },
-        {
-            label: msg("Front-channel (Native)"),
-            value: SAMLLogoutMethods.FrontchannelNative,
-        },
-        {
-            label: msg("Back-channel (POST)"),
-            value: SAMLLogoutMethods.Backchannel,
-            disabled: !hasPostBinding,
-        },
-    ];
-
     return html`<ak-radio-input
             label=${msg("SLS Binding")}
             name="slsBinding"
@@ -121,7 +104,7 @@ function renderHasSlsUrl(
         <ak-radio-input
             label=${msg("Logout Method")}
             name="logoutMethod"
-            .options=${logoutMethodOptions}
+            .options=${logoutMethodOptions(hasPostBinding)}
             .value=${logoutMethod}
             help=${msg("Method to use for logout when SLS URL is configured.")}
             @change=${setLogoutMethod}

--- a/web/src/admin/providers/saml/SAMLProviderOptions.ts
+++ b/web/src/admin/providers/saml/SAMLProviderOptions.ts
@@ -2,6 +2,7 @@ import {
     DigestAlgorithmEnum,
     KeyTypeEnum,
     SAMLBindingsEnum,
+    SAMLLogoutMethods,
     SignatureAlgorithmEnum,
 } from "@goauthentik/api";
 
@@ -21,6 +22,38 @@ export const spBindingOptions = toOptions([
     [msg("Redirect"), SAMLBindingsEnum.Redirect, true],
     [msg("Post"), SAMLBindingsEnum.Post],
 ]);
+
+export function logoutMethodLabel(method?: SAMLLogoutMethods | string): string {
+    switch (method) {
+        case SAMLLogoutMethods.FrontchannelIframe:
+            return msg("Front-channel (Iframe)");
+        case SAMLLogoutMethods.FrontchannelNative:
+            return msg("Front-channel (Native)");
+        case SAMLLogoutMethods.Backchannel:
+            return msg("Back-channel (POST)");
+        default:
+            return method ?? "";
+    }
+}
+
+export function logoutMethodOptions(hasPostBinding: boolean) {
+    return [
+        {
+            label: logoutMethodLabel(SAMLLogoutMethods.FrontchannelIframe),
+            value: SAMLLogoutMethods.FrontchannelIframe,
+            default: true,
+        },
+        {
+            label: logoutMethodLabel(SAMLLogoutMethods.FrontchannelNative),
+            value: SAMLLogoutMethods.FrontchannelNative,
+        },
+        {
+            label: logoutMethodLabel(SAMLLogoutMethods.Backchannel),
+            value: SAMLLogoutMethods.Backchannel,
+            disabled: !hasPostBinding,
+        },
+    ];
+}
 
 export const digestAlgorithmOptions = toOptions([
     ["SHA1", DigestAlgorithmEnum.HttpWwwW3Org200009Xmldsigsha1],

--- a/web/src/admin/providers/saml/SAMLProviderViewPage.ts
+++ b/web/src/admin/providers/saml/SAMLProviderViewPage.ts
@@ -152,6 +152,22 @@ export class SAMLProviderViewPage extends AKElement {
         }
     }
 
+    renderLogoutMethod(): string {
+        if (!this.provider?.slsUrl) {
+            return "-";
+        }
+        switch (this.provider.logoutMethod) {
+            case "frontchannel_iframe":
+                return msg("Front-channel (Iframe)");
+            case "frontchannel_native":
+                return msg("Front-channel (Native)");
+            case "backchannel":
+                return msg("Back-channel (POST)");
+            default:
+                return this.provider.logoutMethod ?? "-";
+        }
+    }
+
     renderRelatedObjects(): TemplateResult {
         const relatedObjects = [];
         if (this.provider?.assignedApplicationName) {
@@ -321,18 +337,6 @@ export class SAMLProviderViewPage extends AKElement {
                             <div class="pf-c-description-list__group">
                                 <dt class="pf-c-description-list__term">
                                     <span class="pf-c-description-list__text">${msg(
-                                        "ACS URL",
-                                    )}</span>
-                                </dt>
-                                <dd class="pf-c-description-list__description">
-                                    <div class="pf-c-description-list__text">
-                                        ${this.provider.acsUrl}
-                                    </div>
-                                </dd>
-                            </div>
-                            <div class="pf-c-description-list__group">
-                                <dt class="pf-c-description-list__term">
-                                    <span class="pf-c-description-list__text">${msg(
                                         "Audience",
                                     )}</span>
                                 </dt>
@@ -345,12 +349,36 @@ export class SAMLProviderViewPage extends AKElement {
                             <div class="pf-c-description-list__group">
                                 <dt class="pf-c-description-list__term">
                                     <span class="pf-c-description-list__text">${msg(
-                                        "Issuer",
+                                        "ACS URL",
                                     )}</span>
                                 </dt>
                                 <dd class="pf-c-description-list__description">
                                     <div class="pf-c-description-list__text">
-                                        ${this.provider.issuerOverride}
+                                        ${this.provider.acsUrl}
+                                    </div>
+                                </dd>
+                            </div>
+                            <div class="pf-c-description-list__group">
+                                <dt class="pf-c-description-list__term">
+                                    <span class="pf-c-description-list__text">${msg(
+                                        "SLS URL",
+                                    )}</span>
+                                </dt>
+                                <dd class="pf-c-description-list__description">
+                                    <div class="pf-c-description-list__text">
+                                        ${this.provider.slsUrl || "-"}
+                                    </div>
+                                </dd>
+                            </div>
+                            <div class="pf-c-description-list__group">
+                                <dt class="pf-c-description-list__term">
+                                    <span class="pf-c-description-list__text">${msg(
+                                        "Logout Method",
+                                    )}</span>
+                                </dt>
+                                <dd class="pf-c-description-list__description">
+                                    <div class="pf-c-description-list__text">
+                                        ${this.renderLogoutMethod()}
                                     </div>
                                 </dd>
                             </div>

--- a/web/src/admin/providers/saml/SAMLProviderViewPage.ts
+++ b/web/src/admin/providers/saml/SAMLProviderViewPage.ts
@@ -9,6 +9,8 @@ import "#elements/buttons/ActionButton/index";
 import "#elements/buttons/ModalButton";
 import "#elements/buttons/SpinnerButton/index";
 
+import { logoutMethodLabel } from "./SAMLProviderOptions.js";
+
 import { DEFAULT_CONFIG } from "#common/api/config";
 import { EVENT_REFRESH } from "#common/constants";
 import { MessageLevel } from "#common/messages";
@@ -156,16 +158,7 @@ export class SAMLProviderViewPage extends AKElement {
         if (!this.provider?.slsUrl) {
             return "-";
         }
-        switch (this.provider.logoutMethod) {
-            case "frontchannel_iframe":
-                return msg("Front-channel (Iframe)");
-            case "frontchannel_native":
-                return msg("Front-channel (Native)");
-            case "backchannel":
-                return msg("Back-channel (POST)");
-            default:
-                return this.provider.logoutMethod ?? "-";
-        }
+        return logoutMethodLabel(this.provider.logoutMethod) || "-";
     }
 
     renderRelatedObjects(): TemplateResult {


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
Currently the saml provider overview page has a redundant "entity" section which no longer renders anything (thanks to me not removing it), and I think the section would benefit from highlighting the single logout configuration information 

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
