### PR TITLE
feat(outpost): add configurable TLS ciphers and minimum version

### DIFF
--- a/internal/config/struct.go
+++ b/internal/config/struct.go
@@ -99,9 +99,11 @@ type ErrorReportingConfig struct {
 }
 
 type OutpostConfig struct {
-	ContainerImageBase     string `yaml:"container_image_base" env:"CONTAINER_IMAGE_BASE, overwrite"`
-	Discover               bool   `yaml:"discover" env:"DISCOVER, overwrite"`
-	DisableEmbeddedOutpost bool   `yaml:"disable_embedded_outpost" env:"DISABLE_EMBEDDED_OUTPOST, overwrite"`
+	ContainerImageBase     string   `yaml:"container_image_base" env:"CONTAINER_IMAGE_BASE, overwrite"`
+	Discover               bool     `yaml:"discover" env:"DISCOVER, overwrite"`
+	DisableEmbeddedOutpost bool     `yaml:"disable_embedded_outpost" env:"DISABLE_EMBEDDED_OUTPOST, overwrite"`
+	TLSMinVersion          string   `yaml:"tls_min_version" env:"TLS_MIN_VERSION"`
+	TLSCiphers             []string `yaml:"tls_ciphers" env:"TLS_CIPHERS"`
 }
 
 type WebConfig struct {

--- a/internal/outpost/ak/api_event.go
+++ b/internal/outpost/ak/api_event.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"goauthentik.io/internal/config"
 	"goauthentik.io/internal/constants"
+	"goauthentik.io/internal/utils"
 )
 
 func (ac *APIController) getWebsocketURL(akURL url.URL, outpostUUID string, query url.Values) *url.URL {
@@ -58,9 +59,9 @@ func (ac *APIController) initEvent(outpostUUID string, attempt int) error {
 		akURL.Scheme = "http"
 		akURL.Host = "localhost"
 	} else {
-		dialer.TLSClientConfig = &tls.Config{
-			InsecureSkipVerify: config.Get().AuthentikInsecure,
-		}
+		tlsConfig := utils.GetTLSConfig()
+		tlsConfig.InsecureSkipVerify = config.Get().AuthentikInsecure
+		dialer.TLSClientConfig = tlsConfig
 	}
 
 	wsu := ac.getWebsocketURL(akURL, outpostUUID, query).String()

--- a/internal/outpost/proxyv2/application/mode_proxy.go
+++ b/internal/outpost/proxyv2/application/mode_proxy.go
@@ -16,8 +16,10 @@ import (
 )
 
 func (a *Application) getUpstreamTransport() http.RoundTripper {
+	tlsConfig := utils.GetTLSConfig()
+	tlsConfig.InsecureSkipVerify = !*a.proxyConfig.InternalHostSslValidation
 	return &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: !*a.proxyConfig.InternalHostSslValidation},
+		TLSClientConfig: tlsConfig,
 	}
 }
 

--- a/internal/outpost/proxyv2/postgresstore/postgresstore.go
+++ b/internal/outpost/proxyv2/postgresstore/postgresstore.go
@@ -27,6 +27,7 @@ import (
 	"goauthentik.io/internal/config"
 	"goauthentik.io/internal/outpost/proxyv2/constants"
 	"goauthentik.io/internal/outpost/proxyv2/types"
+	"goauthentik.io/internal/utils"
 )
 
 // PostgresStore stores gorilla sessions in PostgreSQL using GORM
@@ -119,7 +120,8 @@ func BuildConnConfig(cfg config.PostgreSQLConfig) (*pgx.ConnConfig, error) {
 		case "disable":
 			connConfig.TLSConfig = nil
 		case "require", "verify-ca", "verify-full":
-			tlsConfig := &tls.Config{}
+			tlsConfig := utils.GetTLSConfig()
+			tlsConfig.InsecureSkipVerify = false // default, will be changed below
 
 			// Load root CA certificate if provided
 			if cfg.SSLRootCert != "" {

--- a/internal/outpost/rac/connection/connection.go
+++ b/internal/outpost/rac/connection/connection.go
@@ -15,6 +15,7 @@ import (
 	"goauthentik.io/internal/config"
 	"goauthentik.io/internal/constants"
 	"goauthentik.io/internal/outpost/ak"
+	"goauthentik.io/internal/utils"
 )
 
 const guacAddr = "0.0.0.0:4822"
@@ -64,12 +65,13 @@ func (c *Connection) initSocket(forChannel string) error {
 		"User-Agent":    []string{constants.UserAgentOutpost()},
 	}
 
+	tlsConfig := utils.GetTLSConfig()
+	tlsConfig.InsecureSkipVerify = config.Get().AuthentikInsecure
+
 	dialer := websocket.Dialer{
 		Proxy:            http.ProxyFromEnvironment,
 		HandshakeTimeout: 10 * time.Second,
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: config.Get().AuthentikInsecure,
-		},
+		TLSClientConfig:  tlsConfig,
 	}
 
 	url := fmt.Sprintf(pathTemplate, scheme, c.ac.Client.GetConfig().Host, forChannel)

--- a/internal/outpost/radius/handler_eap.go
+++ b/internal/outpost/radius/handler_eap.go
@@ -59,6 +59,10 @@ func (pi *ProviderInstance) GetEAPSettings() protocol.Settings {
 		return settings
 	}
 
+	tlsConfig := utils.GetTLSConfig()
+	tlsConfig.Certificates = []ttls.Certificate{*cert}
+	tlsConfig.ClientAuth = ttls.RequireAnyClientCert
+
 	settings.Protocols = append(settings.Protocols, tls.Protocol, peap.Protocol)
 	settings.ProtocolPriority = []protocol.Type{
 		identity.TypeIdentity,
@@ -66,10 +70,7 @@ func (pi *ProviderInstance) GetEAPSettings() protocol.Settings {
 	}
 	settings.ProtocolSettings = map[protocol.Type]any{
 		tls.TypeTLS: tls.Settings{
-			Config: &ttls.Config{
-				Certificates: []ttls.Certificate{*cert},
-				ClientAuth:   ttls.RequireAnyClientCert,
-			},
+			Config: tlsConfig,
 			HandshakeSuccessful: func(ctx protocol.Context, certs []*x509.Certificate) protocol.Status {
 				ident := ctx.GetProtocolState(identity.TypeIdentity).(*identity.State).Identity
 

--- a/internal/utils/tls.go
+++ b/internal/utils/tls.go
@@ -3,13 +3,29 @@ package utils
 import (
 	"crypto/tls"
 	"slices"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"goauthentik.io/internal/config"
 )
 
 func GetTLSConfig() *tls.Config {
+	minVersion := uint16(tls.VersionTLS12)
+	switch strings.ToUpper(config.Get().Outposts.TLSMinVersion) {
+	case "TLS1.0", "TLSV1", "TLSV1.0", "TLSV1_0", "1.0":
+		minVersion = tls.VersionTLS10
+	case "TLS1.1", "TLSV1.1", "TLSV1_1", "1.1":
+		minVersion = tls.VersionTLS11
+	case "TLS1.2", "TLSV1.2", "TLSV1_2", "1.2":
+		minVersion = tls.VersionTLS12
+	case "TLS1.3", "TLSV1.3", "TLSV1_3", "1.3":
+		minVersion = tls.VersionTLS13
+	}
+
 	// Based on
 	// https://ssl-config.mozilla.org/#server=go&version=1.25&config=intermediate&guideline=5.7
 	tlsConfig := &tls.Config{
-		MinVersion: tls.VersionTLS12,
+		MinVersion: minVersion,
 		CurvePreferences: []tls.CurveID{
 			tls.X25519,
 			tls.CurveP256,
@@ -17,6 +33,28 @@ func GetTLSConfig() *tls.Config {
 		},
 		PreferServerCipherSuites: true,
 		CipherSuites:             []uint16{},
+	}
+
+	configuredCiphers := config.Get().Outposts.TLSCiphers
+	if len(configuredCiphers) > 0 {
+		allCiphers := append(tls.CipherSuites(), tls.InsecureCipherSuites()...)
+		for _, cipherName := range configuredCiphers {
+			found := false
+			for _, cs := range allCiphers {
+				if cs.Name == cipherName {
+					tlsConfig.CipherSuites = append(tlsConfig.CipherSuites, cs.ID)
+					found = true
+					break
+				}
+			}
+			if !found {
+				log.WithField("cipher", cipherName).Warning("Unknown TLS cipher suite configured")
+			}
+		}
+		if len(tlsConfig.CipherSuites) > 0 {
+			return tlsConfig
+		}
+		log.Warning("No valid TLS ciphers parsed from configuration, falling back to defaults")
 	}
 
 	excludedCiphers := []uint16{


### PR DESCRIPTION
## Summary

This PR addresses issue #15699 by introducing configurable TLS cipher suites and a minimum TLS version for all Outpost outbound and inbound connections. 

By exposing `TLS_CIPHERS` and `TLS_MIN_VERSION` in the outpost configuration, Enterprise environments with strict cryptographic compliance policies (such as requiring TLS 1.3 or disabling weak RSA ciphers) can now harden their proxy, radius, and RAC outposts safely.

### Changes:
- Added `TLSMinVersion` and `TLSCiphers` to `OutpostConfig` in `internal/config/struct.go`.
- Refactored `internal/utils/tls.go:GetTLSConfig()` to dynamically parse and enforce the configured version and ciphersuites from the environment (defaulting back to the secure defaults if unconfigured).
- Updated Outpost TLS dialers across Proxyv2, RAC, Radius, and Events to utilize the centralized `GetTLSConfig()` method to ensure enterprise policy is uniformly enforced.

Closes #15699