### PR TITLE
web: brand label factories to prevent silent forgot-to-call bug (refs #22226)

### DIFF
--- a/web/src/components/ak-wizard/shared.ts
+++ b/web/src/components/ak-wizard/shared.ts
@@ -17,6 +17,18 @@ export type NavigableButton = Extract<WizardButton, { destination: string }>;
 
 export type ButtonKind = Extract<WizardButton["kind"], PropertyKey>;
 
+declare const labelFactoryBrand: unique symbol;
+
+// Branded so a forgotten `()` at a call site — e.g. `return record.close;` in a
+// `SlottedTemplateResult`-returning method — is rejected by `tsc` instead of
+// rendering as visible noise in the live UI (see goauthentik/authentik#22222).
+export type LabelFactory = ((verboseName?: string) => SlottedTemplateResult) & {
+    readonly [labelFactoryBrand]: true;
+};
+
+const labelFactory = (fn: (verboseName?: string) => SlottedTemplateResult): LabelFactory =>
+    fn as LabelFactory;
+
 export interface WizardStepLabel {
     label: string;
     id: string;
@@ -41,13 +53,13 @@ export const ButtonKindClassnameRecord = {
 } as const satisfies Record<ButtonKind, string>;
 
 export const ButtonKindLabelRecord = {
-    next: () => {
+    next: labelFactory(() => {
         return html`${msg("Next")}
             <span class="pf-c-button__icon pf-m-end">
                 <i class="fas fa-arrow-right" aria-hidden="true"></i>
             </span>`;
-    },
-    create: (verboseName?: string) => {
+    }),
+    create: labelFactory((verboseName?: string) => {
         const label = verboseName
             ? msg(str`Create ${verboseName}`, {
                   id: "form.create-submit",
@@ -60,20 +72,20 @@ export const ButtonKindLabelRecord = {
             <span class="pf-c-button__icon pf-m-end">
                 <i class="fas fa-check" aria-hidden="true"></i>
             </span>`;
-    },
-    finish: () => {
+    }),
+    finish: labelFactory(() => {
         return html`${msg("Finish")}
             <span class="pf-c-button__icon pf-m-end">
                 <i class="fas fa-check" aria-hidden="true"></i>
             </span>`;
-    },
-    back: () => {
+    }),
+    back: labelFactory(() => {
         return html`<span class="pf-c-button__icon pf-m-start">
                 <i class="fas fa-arrow-left" aria-hidden="true"></i>
             </span>
             ${msg("Back")}`;
-    },
+    }),
 
-    cancel: () => msg("Cancel"),
-    close: () => msg("Close"),
-} as const satisfies Record<ButtonKind, (verboseName?: string) => SlottedTemplateResult>;
+    cancel: labelFactory(() => msg("Cancel")),
+    close: labelFactory(() => msg("Close")),
+} as const satisfies Record<ButtonKind, LabelFactory>;

--- a/web/src/components/ak-wizard/shared.type-fixture.ts
+++ b/web/src/components/ak-wizard/shared.type-fixture.ts
@@ -1,0 +1,28 @@
+// Type-level regression fixture for goauthentik/authentik#22226.
+//
+// `lit-html` ships `DirectiveResult` as an empty interface, which silently
+// accepts any non-nullish value — including a forgotten-`()` label factory
+// reference. The `LabelFactory` brand combined with the `_$litDirective$`
+// augmentation on `DirectiveResult` (see `src/elements/types.ts`) closes that
+// gap. The `@ts-expect-error` lines below pin the closure in place: if either
+// guard regresses, the comments turn into "unused @ts-expect-error" errors and
+// `npm run lint:types` fails.
+//
+// This file is intentionally side-effect-free and is not imported anywhere; it
+// exists solely so `tsc` evaluates the assertions below.
+
+import { SlottedTemplateResult } from "#elements/types";
+
+import { ButtonKindLabelRecord } from "#components/ak-wizard/shared";
+
+function returnsForgottenCall(): SlottedTemplateResult | null {
+    // @ts-expect-error A bare label-factory reference must not be assignable to
+    // `SlottedTemplateResult`; the call site forgot the `()`.
+    return ButtonKindLabelRecord.close;
+}
+
+function returnsCalledFactory(): SlottedTemplateResult | null {
+    return ButtonKindLabelRecord.close();
+}
+
+export const _fixtures = [returnsForgottenCall, returnsCalledFactory] as const;

--- a/web/src/elements/ak-table/ak-simple-table.ts
+++ b/web/src/elements/ak-table/ak-simple-table.ts
@@ -243,7 +243,7 @@ export class SimpleTable
     };
 
     protected renderRowGroups = (rowGroups: TableGroup[]): SlottedTemplateResult => {
-        return map(rowGroups, this.renderRowGroup);
+        return html`${map(rowGroups, this.renderRowGroup)}`;
     };
 
     protected renderBody(): SlottedTemplateResult {

--- a/web/src/elements/types.ts
+++ b/web/src/elements/types.ts
@@ -10,6 +10,20 @@ import type {
 } from "lit";
 import type { DirectiveResult } from "lit-html/directive.js";
 
+// Lit publishes `DirectiveResult` as an empty `{}` interface — its identifying
+// `_$litDirective$` field is marked `@internal` and stripped at build time. An
+// empty interface accepts any non-nullish value, which silently neuters the
+// `DirectiveResult` branch of unions like {@linkcode SlottedTemplateResult}:
+// raw function references and other unintended shapes assign without complaint
+// (see goauthentik/authentik#22222 / #22226). Restoring the field via module
+// augmentation forces real directive results — which carry the property at
+// runtime — to pass while rejecting accidental factory leaks at `tsc` time.
+declare module "lit-html/directive.js" {
+    interface DirectiveResult {
+        readonly ["_$litDirective$"]: unknown;
+    }
+}
+
 //#region HTML Helpers
 
 export const AKElementTagPrefix = `ak-`;
@@ -323,16 +337,20 @@ export type SelectOptions<T = never> = SelectOption<T>[] | GroupedOptions<T>;
 /**
  * A convenience type representing the result of a slotted template, i.e.
  *
- * - A string, which will be rendered as text.
+ * - A string or number, which will be rendered as text.
  * - A TemplateResult, which will be rendered as HTML.
  * - `nothing` or `null`, which will not be rendered.
+ * - An array or iterable of any of the above, which will be rendered in order.
  */
 export type SlottedTemplateResult =
     | string
+    | number
     | TemplateResult
     | typeof nothing
     | null
     | DirectiveResult
-    | HTMLElement;
+    | HTMLElement
+    | readonly SlottedTemplateResult[]
+    | Iterable<SlottedTemplateResult>;
 
 export type Spread = { [key: string]: unknown };


### PR DESCRIPTION
## Summary

- Closes #22226. Type-side guard against the silent "forgot to call the label factory" footgun that produced #22222 — `tsc` did not catch `return ButtonKindLabelRecord.close;` because `lit-html`'s `DirectiveResult` ships as an empty interface at the published-types layer (the identifying `_$litDirective$` field is `@internal` and stripped at build), so its structural typing accepted any non-nullish value and silently swallowed the function reference.
- Module augmentation restores `_$litDirective$` on `DirectiveResult`; `SlottedTemplateResult` is widened to honestly model what lit-html actually renders (`number`, arrays, iterables); `ButtonKindLabelRecord` values get a `LabelFactory` brand via unique symbol so they're provably distinct from any renderable atom; a `@ts-expect-error` fixture pins both guards in place.
- Reverting the one-line fix on `web/src/admin/users/ak-user-wizard.ts:81` now fails `npm run lint:types` with "Did you mean to call this expression?" — exactly the error the original bug needed.

## Test plan

- [ ] `npm run lint:types -w @goauthentik/web` passes on this branch.
- [ ] Reverting `ButtonKindLabelRecord.close()` → `ButtonKindLabelRecord.close` in `ak-user-wizard.ts:81` causes `tsc` to fail with "Did you mean to call this expression?" (verified locally by the agent).
- [ ] `web/src/components/ak-wizard/shared.type-fixture.ts` trips the same guard via `@ts-expect-error` assertions if the brand or augmentation regress.
- [ ] Existing call sites (`Wizard.ts`, `WizardStep.ts`, `ak-user-wizard.ts`) still type-check — already do; the knock-on fix at `web/src/elements/ak-table/ak-simple-table.ts:246` (bare `map()` wrapped in `html\`${...}\``) is the only call-site fallout from tightening `SlottedTemplateResult`.

---

Marked draft pending Teffen's review — please flip to ready when satisfied.
