### PR TITLE
website/docs: fix link in the 2026.8 Rel Notes to upgrade docs

### DIFF
--- a/website/docs/releases/2026/v2026.8.md
+++ b/website/docs/releases/2026/v2026.8.md
@@ -12,7 +12,7 @@ draft: true
 
 ## Upgrading
 
-This release does not introduce any new requirements. You can follow the upgrade instructions below; for more detailed information about upgrading authentik, refer to our [Upgrade documentation](../install-config/upgrade.mdx).
+This release does not introduce any new requirements. You can follow the upgrade instructions below; for more detailed information about upgrading authentik, refer to our [Upgrade documentation](../../install-config/upgrade.mdx).
 
 :::warning
 When you upgrade, be aware that the version of the authentik instance and of any outposts must be the same. We recommend that you always upgrade any outposts at the same time you upgrade your authentik instance.


### PR DESCRIPTION
This PR fixes the link so that `make docs` doesn't choke on every other PR.

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
