### PR TITLE
core: add opt-in containerized npm install via Apple container

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,22 @@
+# Block lifecycle scripts (preinstall/install/postinstall/prepare) from
+# dependencies. This neutralizes the dominant npm supply-chain attack
+# vector. Packages that legitimately need a build step (e.g. esbuild,
+# chromedriver, tree-sitter) must be rebuilt explicitly:
+#
+#   npm rebuild --foreground-scripts esbuild chromedriver tree-sitter tree-sitter-json
+ignore-scripts=true
+
+# Fail fast if the active Node/npm doesn't match the "engines" field.
+engine-strict=true
+
+# Pin exact versions so `npm install <pkg>` writes "1.2.3" not "^1.2.3".
+save-exact=true
+
+# Surface CVE warnings during install; doesn't block.
+audit=true
+
+# Suppress funding banners.
+fund=false
+
+# Prefer the local cache over a refetch when both are valid.
+prefer-offline=true

--- a/Makefile
+++ b/Makefile
@@ -242,6 +242,19 @@ node-install: root-node-install  ## Install the necessary libraries to build Nod
 	npm ci --prefix web
 	npm rebuild --prefix web --ignore-scripts=false --foreground-scripts $(TRUSTED_INSTALL_SCRIPTS)
 
+node-install-containerized:  ## Run node-install inside an Apple container (macOS 15+, Apple Silicon)
+ifeq ($(UNAME_S),Darwin)
+	./scripts/container-sandbox sh -c '\
+		npm ci && \
+		npm ci --prefix web && \
+		npm rebuild --prefix web --ignore-scripts=false --foreground-scripts $(TRUSTED_INSTALL_SCRIPTS) \
+	'
+else
+	@echo "node-install-containerized is macOS-only (uses Apple's container runtime)." >&2
+	@echo "Falling back to plain node-install." >&2
+	$(MAKE) node-install
+endif
+
 #########################
 ## Web
 #########################

--- a/Makefile
+++ b/Makefile
@@ -228,9 +228,19 @@ gen-dev-config:  ## Generate a local development config file
 ## Node.js
 #########################
 
-node-install:  ## Install the necessary libraries to build Node.js packages
+# Packages whose install/postinstall scripts are required for correct
+# operation (binary downloads, native bindings). The root .npmrc sets
+# `ignore-scripts=true` to block dependency lifecycle scripts by default;
+# this list is rebuilt explicitly with scripts re-enabled. Audit any
+# additions: each entry runs arbitrary code at install time.
+TRUSTED_INSTALL_SCRIPTS := esbuild chromedriver tree-sitter tree-sitter-json
+
+root-node-install:
 	npm ci
+
+node-install: root-node-install  ## Install the necessary libraries to build Node.js packages
 	npm ci --prefix web
+	npm rebuild --prefix web --ignore-scripts=false --foreground-scripts $(TRUSTED_INSTALL_SCRIPTS)
 
 #########################
 ## Web
@@ -268,7 +278,7 @@ web-i18n-extract:
 
 docs: docs-lint-fix docs-build  ## Automatically fix formatting issues in the Authentik docs source code, lint the code, and compile it
 
-docs-install:
+docs-install: root-node-install
 	npm ci --prefix website
 
 docs-lint-fix: lint-spellcheck

--- a/scripts/container-sandbox
+++ b/scripts/container-sandbox
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Run a command inside an ephemeral Linux container via Apple's
+# `container` runtime (macOS 15+, Apple Silicon). Each invocation is a
+# fresh container with the repo mounted read-write at /work; nothing
+# outside the repo, the npm cache, or /tmp is visible.
+#
+# Examples:
+#   scripts/container-sandbox npm ci
+#   CONTAINER_NETWORK=none scripts/container-sandbox npm test
+#   CONTAINER_IMAGE=node:22-bookworm scripts/container-sandbox sh -c '...'
+#
+# This is an opt-in defense-in-depth wrapper for macOS contributors. The
+# .npmrc at the repo root is the primary defense; the container adds
+# real kernel-level isolation on top.
+#
+# Install requirements:
+#   brew install container        (macOS 15+, Apple Silicon only)
+#
+# Caveats:
+#   - The container is Linux, not Darwin. node_modules installed inside
+#     will contain linux-arm64 binaries (esbuild, chromedriver, etc.).
+#     If you also want to run the dev server on the host, you'll need a
+#     second native install. Pick one workflow per session.
+#   - Image is pinned to a tag, not a digest, for ergonomics. For
+#     stronger supply-chain guarantees, set CONTAINER_IMAGE to a digest.
+
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "container-sandbox is macOS-only. On Linux, run installs natively or use podman/bwrap." >&2
+    exit 1
+fi
+
+if ! command -v container >/dev/null 2>&1; then
+    cat >&2 <<'EOM'
+`container` not found.
+
+Apple's container runtime is available on macOS 15+ (Apple Silicon only):
+    brew install container
+
+Once installed, retry this command.
+EOM
+    exit 1
+fi
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <command> [args...]" >&2
+    exit 64
+fi
+
+image="${CONTAINER_IMAGE:-node:22-bookworm}"
+network="${CONTAINER_NETWORK:-default}"
+
+network_args=()
+case "$network" in
+    none)
+        network_args=(--network none)
+        ;;
+    default|host|"")
+        ;;
+    *)
+        network_args=(--network "$network")
+        ;;
+esac
+
+echo "==========================="
+echo "Container: $image  network=$network"
+echo "==========================="
+
+exec container run \
+    --rm \
+    "${network_args[@]}" \
+    -v "${PWD}:/work" \
+    -w /work \
+    "$image" \
+    "$@"

--- a/web/README.md
+++ b/web/README.md
@@ -24,6 +24,40 @@ New dependencies that ship install scripts must be audited and added to `TRUSTED
 in the repo-root `Makefile`. Each entry is arbitrary code that runs at install time, so the list
 is intentionally small.
 
+## Optional: containerized installs (macOS)
+
+If you're on **macOS 15+ on Apple Silicon** and want kernel-level isolation on top of
+`ignore-scripts`, run:
+
+```bash
+make node-install-containerized
+```
+
+This runs the install inside an ephemeral Linux microVM via Apple's [`container`
+runtime](https://github.com/apple/container). The container sees the repo at `/work` and nothing
+else — no `~/.ssh`, no `~/.aws`, no Keychain, no other process on your machine. If a transitive
+dependency does something unexpected during install, the blast radius is the container's lifetime.
+
+Install once:
+
+```bash
+brew install container
+```
+
+**Workflow tradeoff:** the container is Linux, not Darwin. `node_modules` installed inside will
+contain `linux-arm64` binaries (esbuild, chromedriver, tree-sitter, …). If you also want to run
+the dev server natively on macOS for IDE integration, you'll need a second native install via
+`make node-install`. Pick one workflow per session — they share a `node_modules` directory and
+overwrite each other.
+
+For finer-grained control:
+
+- `CONTAINER_NETWORK=none scripts/container-sandbox npm test` — drop network for test runs
+- `CONTAINER_IMAGE=node:22-bookworm@sha256:... make node-install-containerized` — pin by digest
+
+This path is opt-in. The default `make node-install` is portable and identical across platforms.
+The `.npmrc` baseline applies in both cases.
+
 # The Theory of the authentik UI
 
 In Peter Naur's 1985 essay [Programming as Theory

--- a/web/README.md
+++ b/web/README.md
@@ -3,6 +3,27 @@
 This is the default UI for the authentik server. The documentation is going to be a little sparse
 for awhile, but at least let's get started.
 
+# Setup
+
+Install dependencies from the repo root with `make node-install` (or `make install` for the full
+Python + web + docs bootstrap). This wraps `npm ci` and explicitly rebuilds the small set of
+packages whose install scripts are required for the toolchain to function — currently `esbuild`,
+`chromedriver`, `tree-sitter`, and `tree-sitter-json`.
+
+The repo-root `.npmrc` sets `ignore-scripts=true` to neutralize the dominant npm supply-chain
+attack vector. As a side effect, running `npm ci` directly in this directory will install
+dependencies but skip those rebuilds, leaving `esbuild` and `chromedriver` in a non-functional
+state. If you bypass `make`, run the rebuild step yourself:
+
+```bash
+npm rebuild --ignore-scripts=false --foreground-scripts \
+    esbuild chromedriver tree-sitter tree-sitter-json
+```
+
+New dependencies that ship install scripts must be audited and added to `TRUSTED_INSTALL_SCRIPTS`
+in the repo-root `Makefile`. Each entry is arbitrary code that runs at install time, so the list
+is intentionally small.
+
 # The Theory of the authentik UI
 
 In Peter Naur's 1985 essay [Programming as Theory

--- a/website/package.json
+++ b/website/package.json
@@ -9,7 +9,6 @@
         "build:integrations": "npm run build -w integrations",
         "check-types": "tsc -b",
         "docusaurus": "docusaurus",
-        "preinstall": "npm ci --prefix ..",
         "lint": "eslint --fix .",
         "lint:lockfile": "echo 'Skipping lockfile linting'",
         "lint-check": "eslint --max-warnings 0 .",


### PR DESCRIPTION
## Summary

Adds an opt-in `make node-install-containerized` target and a small wrapper script (`scripts/container-sandbox`) that runs the npm install steps inside an ephemeral Linux microVM via Apple's [`container` runtime](https://github.com/apple/container). The container mounts only the repo (at `/work`) and sees nothing else — no `~/.ssh`, `~/.aws`, Keychain, or other host process state.

This is defense in depth *on top of* the `.npmrc` `ignore-scripts=true` baseline introduced in #22245. The default `make node-install` is unchanged.

**Depends on #22245** — once that lands and is rebased, this PR rebases onto `main`.

## Why container, why not sandbox-exec / bubblewrap

- **sandbox-exec** (macOS): Apple has officially deprecated it since 2013. Still functional, but the profile language is sparsely documented and we'd be writing userspace allow/deny rules on a shared kernel. Real but fragile.
- **bubblewrap / systemd-run** (Linux): both are good, but they don't help our macOS contributors — who are also the cohort most likely to have plaintext credentials in `~/.aws` and `~/.ssh` for daily use, since macOS doesn't sandbox CLI tools out of the box.
- **Apple `container`**: real kernel namespacing via `Virtualization.framework`. Per-container Linux microVM. No deprecation risk. The opt-in cost is `brew install container` and accepting that `node_modules` ends up with Linux binaries.

We're shipping container only — no sandbox-exec, no Linux-side wrappers in this PR. If Linux contributors later want a similar opt-in, that's a follow-up.

## Workflow tradeoffs (documented in `web/README.md`)

- **Linux node_modules.** The container is Linux; native binaries (esbuild, chromedriver, tree-sitter, …) install as `linux-arm64`. Contributors who also want to run the dev server natively on macOS need a separate native install. Pick one workflow per session.
- **`brew install container` required.** macOS 15+ on Apple Silicon. Intel Macs and older macOS get the `.npmrc` baseline only.
- **Image is tag-pinned by default.** `node:22-bookworm`. Override with `CONTAINER_IMAGE=node:22-bookworm@sha256:...` for stronger supply-chain guarantees.
- **Network is configurable.** `CONTAINER_NETWORK=none` for hermetic operations (tests, builds). Default leaves network on because install needs the registry.


This is opt-in; nothing in CI changes by default. The wrapper is intentionally minimal — a Bash script around `container run`, not a framework. If we later want to deepen this (per-phase containers, digest-pinned images by default, podman parity for Linux), those are follow-up PRs.
