### PR TITLE
web: remove orphaned chromedriver dependency

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -130,8 +130,7 @@
                 "@esbuild/linux-x64": "^0.28.0",
                 "@rollup/rollup-darwin-arm64": "^4.57.1",
                 "@rollup/rollup-linux-arm64-gnu": "^4.57.1",
-                "@rollup/rollup-linux-x64-gnu": "^4.57.1",
-                "chromedriver": "^147.0.4"
+                "@rollup/rollup-linux-x64-gnu": "^4.57.1"
             }
         },
         "node_modules/@adobe/css-tools": {
@@ -4771,13 +4770,6 @@
                 "@swc/counter": "^0.1.3"
             }
         },
-        "node_modules/@testim/chrome-version": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.1.4.tgz",
-            "integrity": "sha512-kIhULpw9TrGYnHp/8VfdcneIcxKnLixmADtukQRtJUmsVlMg0niMkwV0xZmi8hqa57xqilIHjWFA0GKvEjVU5g==",
-            "license": "MIT",
-            "optional": true
-        },
         "node_modules/@testing-library/dom": {
             "version": "10.4.1",
             "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -5312,16 +5304,6 @@
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
             "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
             "license": "MIT"
-        },
-        "node_modules/@types/yauzl": {
-            "version": "2.10.3",
-            "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-            "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@types/node": "*"
-            }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "8.57.2",
@@ -6157,16 +6139,6 @@
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
-        "node_modules/agent-base": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
-            "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">= 20"
-            }
-        },
         "node_modules/ajv": {
             "version": "6.14.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -6434,19 +6406,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/ast-types": {
-            "version": "0.13.4",
-            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
-            "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/astring": {
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
@@ -6589,16 +6548,6 @@
             },
             "engines": {
                 "node": ">=6.0.0"
-            }
-        },
-        "node_modules/basic-ftp": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
-            "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=10.0.0"
             }
         },
         "node_modules/binary-extensions": {
@@ -7181,29 +7130,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/chromedriver": {
-            "version": "147.0.4",
-            "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-147.0.4.tgz",
-            "integrity": "sha512-eRNbfkoTvAsSfFODM4QVhs3cXB/B4/nFHeI6+ycuKan5e3bJrq8njuLTBHHOLbL0dggxEpMHLiczJUQa+Gw3JA==",
-            "hasInstallScript": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "@testim/chrome-version": "^1.1.4",
-                "axios": "^1.15.0",
-                "compare-versions": "^6.1.0",
-                "extract-zip": "^2.0.1",
-                "proxy-agent": "^8.0.1",
-                "proxy-from-env": "^2.0.0",
-                "tcp-port-used": "^1.0.2"
-            },
-            "bin": {
-                "chromedriver": "bin/chromedriver"
-            },
-            "engines": {
-                "node": ">=20"
-            }
-        },
         "node_modules/cliui": {
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -7312,13 +7238,6 @@
             "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
             "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
             "license": "MIT"
-        },
-        "node_modules/compare-versions": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
-            "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
@@ -7937,16 +7856,6 @@
                 "lodash-es": "^4.17.21"
             }
         },
-        "node_modules/data-uri-to-buffer": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-8.0.0.tgz",
-            "integrity": "sha512-6UHfyCux51b8PTGDgveqtz1tvphBku5DrMKKJbFAZAJOI2zsjDpDoYE1+QGj7FOMS4BdTFNJsJiR3zEB0xH0yQ==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">= 20"
-            }
-        },
         "node_modules/data-view-buffer": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -8194,24 +8103,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/degenerator": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-7.0.1.tgz",
-            "integrity": "sha512-ABErK0IefDSyHjlPH7WUEenIAX2rPPnrDcDM+TS3z3+zu9TfyKKi07BQM+8rmxpdE2y1v5fjjdoAS/x4D2U60w==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "ast-types": "^0.13.4",
-                "escodegen": "^2.1.0",
-                "esprima": "^4.0.1"
-            },
-            "engines": {
-                "node": ">= 20"
-            },
-            "peerDependencies": {
-                "quickjs-wasi": "^2.2.0"
             }
         },
         "node_modules/delaunator": {
@@ -8678,38 +8569,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/escodegen": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-            "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-            "license": "BSD-2-Clause",
-            "optional": true,
-            "dependencies": {
-                "esprima": "^4.0.1",
-                "estraverse": "^5.2.0",
-                "esutils": "^2.0.2"
-            },
-            "bin": {
-                "escodegen": "bin/escodegen.js",
-                "esgenerate": "bin/esgenerate.js"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "optionalDependencies": {
-                "source-map": "~0.6.1"
-            }
-        },
-        "node_modules/escodegen/node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/eslint": {
@@ -9274,27 +9133,6 @@
             "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
             "license": "MIT"
         },
-        "node_modules/extract-zip": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-            "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-            "license": "BSD-2-Clause",
-            "optional": true,
-            "dependencies": {
-                "debug": "^4.1.1",
-                "get-stream": "^5.1.0",
-                "yauzl": "^2.10.0"
-            },
-            "bin": {
-                "extract-zip": "cli.js"
-            },
-            "engines": {
-                "node": ">= 10.17.0"
-            },
-            "optionalDependencies": {
-                "@types/yauzl": "^2.9.1"
-            }
-        },
         "node_modules/fast-copy": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.2.tgz",
@@ -9394,16 +9232,6 @@
             "license": "MIT",
             "dependencies": {
                 "walk-up-path": "^4.0.0"
-            }
-        },
-        "node_modules/fd-slicer": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-            "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "pend": "~1.2.0"
             }
         },
         "node_modules/fdir": {
@@ -9923,22 +9751,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/get-stream": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-            "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "pump": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/get-symbol-description": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
@@ -9966,21 +9778,6 @@
             },
             "funding": {
                 "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-            }
-        },
-        "node_modules/get-uri": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-8.0.0.tgz",
-            "integrity": "sha512-CqtZlMKvfJeY0Zxv8wazDwXmSKmnMnsmNy8j8+wudi8EyG/pMUB1NqHc+Tv1QaNtpYsK9nOYjb7r7Ufu32RPSw==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "basic-ftp": "^5.2.0",
-                "data-uri-to-buffer": "8.0.0",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 20"
             }
         },
         "node_modules/git-hooks-list": {
@@ -10496,20 +10293,6 @@
             "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
             "license": "BSD-2-Clause"
         },
-        "node_modules/http-proxy-agent": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-9.0.0.tgz",
-            "integrity": "sha512-FcF8VhXYLQcxWCnt/cCpT2apKsRDUGeVEeMqGu4HSTu29U8Yw0TLOjdYIlDsYk3IkUh+taX4IDWpPcCqKDhCjA==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "agent-base": "9.0.0",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 20"
-            }
-        },
         "node_modules/http2-wrapper": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
@@ -10533,20 +10316,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/https-proxy-agent": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.0.0.tgz",
-            "integrity": "sha512-/MVmHp58WkOypgFhCLk4fzpPcFQvTJ/e6LBI7irpIO2HfxUbpmYoHF+KzipzJpxxzJu7aJNWQ0xojJ/dzV2G5g==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "agent-base": "9.0.0",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 20"
             }
         },
         "node_modules/human-signals": {
@@ -10675,26 +10444,6 @@
             "license": "ISC",
             "engines": {
                 "node": ">=12"
-            }
-        },
-        "node_modules/ip-address": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">= 12"
-            }
-        },
-        "node_modules/ip-regex": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-            "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/is-alphabetical": {
@@ -11209,13 +10958,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/is-url": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-            "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
-            "license": "MIT",
-            "optional": true
-        },
         "node_modules/is-valid-element-name": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-valid-element-name/-/is-valid-element-name-1.0.0.tgz",
@@ -11281,21 +11023,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/is2": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.9.tgz",
-            "integrity": "sha512-rZkHeBn9Zzq52sd9IUIV3a5mfwBY+o2HePMh0wkGBM4z4qjvy2GwVxQ6nNXSfw6MmVP6gf1QIlWjiOavhM3x5g==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "deep-is": "^0.1.3",
-                "ip-regex": "^4.1.0",
-                "is-url": "^1.2.4"
-            },
-            "engines": {
-                "node": ">=v0.10.0"
             }
         },
         "node_modules/isarray": {
@@ -13607,16 +13334,6 @@
                 "node": ">= 10"
             }
         },
-        "node_modules/netmask": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
-            "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">= 0.4.0"
-            }
-        },
         "node_modules/nice-try": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -14358,43 +14075,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/pac-proxy-agent": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-9.0.1.tgz",
-            "integrity": "sha512-3ZOSpLboOlpW4yp8Cuv21KlTULRqyJ5Uuad3wXpSKFrxdNgcHEyoa22GRaZ2UlgCVuR6z+5BiavtYVvbajL/Yw==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "agent-base": "9.0.0",
-                "debug": "^4.3.4",
-                "get-uri": "8.0.0",
-                "http-proxy-agent": "9.0.0",
-                "https-proxy-agent": "9.0.0",
-                "pac-resolver": "9.0.1",
-                "quickjs-wasi": "^2.2.0",
-                "socks-proxy-agent": "10.0.0"
-            },
-            "engines": {
-                "node": ">= 20"
-            }
-        },
-        "node_modules/pac-resolver": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-9.0.1.tgz",
-            "integrity": "sha512-lJbS008tmkj08VhoM8Hzuv/VE5tK9MS0OIQ/7+s0lIF+BYhiQWFYzkSpML7lXs9iBu2jfmzBTLzhe9n6BX+dYw==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "degenerator": "7.0.1",
-                "netmask": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 20"
-            },
-            "peerDependencies": {
-                "quickjs-wasi": "^2.2.0"
-            }
-        },
         "node_modules/package-manager-detector": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
@@ -14956,36 +14636,6 @@
             "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
             "license": "MIT"
         },
-        "node_modules/proxy-agent": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-8.0.1.tgz",
-            "integrity": "sha512-kccqGBqHZXR8onQhY/ganJjoO8QIKKRiFBhPOzbTZK16attzSZ/0XSmp9H7jrRxPKHjhGyx1q32lMPrJ3uLFgA==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "agent-base": "9.0.0",
-                "debug": "^4.3.4",
-                "http-proxy-agent": "9.0.0",
-                "https-proxy-agent": "9.0.0",
-                "lru-cache": "^7.14.1",
-                "pac-proxy-agent": "9.0.1",
-                "proxy-from-env": "^2.0.0",
-                "socks-proxy-agent": "10.0.0"
-            },
-            "engines": {
-                "node": ">= 20"
-            }
-        },
-        "node_modules/proxy-agent/node_modules/lru-cache": {
-            "version": "7.18.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-            "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-            "license": "ISC",
-            "optional": true,
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/proxy-from-env": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -15081,13 +14731,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/quickjs-wasi": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-2.2.0.tgz",
-            "integrity": "sha512-zQxXmQMrEoD3S+jQdYsloq4qAuaxKFHZj6hHqOYGwB2iQZH+q9e/lf5zQPXCKOk0WJuAjzRFbO4KwHIp2D05Iw==",
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/quickselect": {
             "version": "2.0.0",
@@ -16246,17 +15889,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/smart-buffer": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-            "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">= 6.0.0",
-                "npm": ">= 3.0.0"
-            }
-        },
         "node_modules/smob": {
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/smob/-/smob-1.6.1.tgz",
@@ -16276,36 +15908,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/cyyynthia"
-            }
-        },
-        "node_modules/socks": {
-            "version": "2.8.7",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-            "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "ip-address": "^10.0.1",
-                "smart-buffer": "^4.2.0"
-            },
-            "engines": {
-                "node": ">= 10.0.0",
-                "npm": ">= 3.0.0"
-            }
-        },
-        "node_modules/socks-proxy-agent": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-10.0.0.tgz",
-            "integrity": "sha512-pyp2YR3mNxAMu0mGLtzs4g7O3uT4/9sQOLAKcViAkaS9fJWkud7nmaf6ZREFqQEi24IPkBcjfHjXhPTUWjo3uA==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "agent-base": "9.0.0",
-                "debug": "^4.3.4",
-                "socks": "^2.8.3"
-            },
-            "engines": {
-                "node": ">= 20"
             }
         },
         "node_modules/sonic-boom": {
@@ -17459,42 +17061,6 @@
                 "fast-fifo": "^1.2.0",
                 "streamx": "^2.15.0"
             }
-        },
-        "node_modules/tcp-port-used": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-1.0.2.tgz",
-            "integrity": "sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "debug": "4.3.1",
-                "is2": "^2.0.6"
-            }
-        },
-        "node_modules/tcp-port-used/node_modules/debug": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-            "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/tcp-port-used/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/text-decoder": {
             "version": "1.2.7",
@@ -19010,17 +18576,6 @@
             "license": "ISC",
             "engines": {
                 "node": ">=12"
-            }
-        },
-        "node_modules/yauzl": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-            "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "buffer-crc32": "~0.2.3",
-                "fd-slicer": "~1.1.0"
             }
         },
         "node_modules/yocto-queue": {

--- a/web/package.json
+++ b/web/package.json
@@ -202,8 +202,7 @@
         "@esbuild/linux-x64": "^0.28.0",
         "@rollup/rollup-darwin-arm64": "^4.57.1",
         "@rollup/rollup-linux-arm64-gnu": "^4.57.1",
-        "@rollup/rollup-linux-x64-gnu": "^4.57.1",
-        "chromedriver": "^147.0.4"
+        "@rollup/rollup-linux-x64-gnu": "^4.57.1"
     },
     "workspaces": [
         "./packages/*"


### PR DESCRIPTION
## Details

Left over from WebdriverIO, which was replaced by Playwright in #16014, this PR removes `chromedriver` as an optional dependency. Removing it drops 34 transitive packages, including:
 - `basic-ftp`
 - `get-uri`
 - `proxy-agent`
 - `pac-proxy-agent`
 -  and the rest of the proxy-agent chain.

Audit of merged dependabot PRs over the last ~6 months attributes roughly **21 PRs (chromedriver + basic-ftp)** to this dependency thread alone.
