### PR TITLE
core: Defer status posts until GitHub Actions finishes.

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,3 +1,6 @@
+codecov:
+  notify:
+    wait_for_ci: true
 coverage:
   status:
     project:


### PR DESCRIPTION
## Details

This PR defers status posts until GitHub Actions finishes, otherwise the status flips red while partial coverage uploads trickle in from jobs.