### PR TITLE
core: Ensure npm global bin is available for Corepack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,11 @@ BREW_PKG_CONFIG_PATH :=
 
 CARGO := cargo
 UV := uv
+NPM_PREFIX := $(shell npm config get prefix 2>/dev/null || true)
+
+ifneq ($(NPM_PREFIX),)
+	export PATH := $(NPM_PREFIX)/bin:$(PATH)
+endif
 
 # For macOS users, add the libxml2 installed from brew libxmlsec1 to the build path
 # to prevent SAML-related tests from failing and ensure correct pip dependency compilation

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,16 @@ BREW_PKG_CONFIG_PATH :=
 
 CARGO := cargo
 UV := uv
-NPM_PREFIX := $(shell npm config get prefix 2>/dev/null || true)
 
-ifneq ($(NPM_PREFIX),)
-	export PATH := $(NPM_PREFIX)/bin:$(PATH)
+# Global npm installs can land in a user-scoped prefix whose bin/ is not on PATH
+# (common with nix, asdf, volta, or `npm config set prefix ~/.npm-global`). Pull
+# that bin onto PATH so `corepack` etc. resolve in every make recipe.
+NPM_EXISTS := $(shell command -v npm 2> /dev/null)
+ifdef NPM_EXISTS
+	NPM_PREFIX := $(shell npm config get prefix 2> /dev/null)
+	ifneq ($(NPM_PREFIX),)
+		export PATH := $(NPM_PREFIX)/bin:$(PATH)
+	endif
 endif
 
 # For macOS users, add the libxml2 installed from brew libxmlsec1 to the build path

--- a/scripts/node/setup-corepack.mjs
+++ b/scripts/node/setup-corepack.mjs
@@ -5,6 +5,7 @@
  */
 
 import * as fs from "node:fs/promises";
+import { delimiter, join } from "node:path";
 import { parseArgs } from "node:util";
 
 import { ConsoleLogger } from "../../packages/logger-js/lib/node.js";
@@ -19,6 +20,24 @@ import { findNPMPackage, loadJSON, npm } from "./utils/node.mjs";
 const FALLBACK_PACKAGE_MANAGER =
     "npm@11.14.1+sha512.6a8a4d67478497a2dbc6815cad72e64c43f33413717e242756047d466241ab39bee61e691683a64658e94496ec5f1a1c05e4a5ec62dcc773280dfd949443a367";
 const logger = ConsoleLogger.prefix("setup-corepack");
+
+/**
+ * Global npm installs can land outside PATH, especially when npm's prefix is
+ * user-scoped. Add that bin directory before checking for or invoking Corepack.
+ *
+ * @param {string} cwd
+ */
+async function addNPMGlobalBinToPath(cwd) {
+    const npmPrefix = await npm`config get prefix`({ cwd });
+    const npmGlobalBin = join(npmPrefix, "bin");
+    const path = process.env.PATH || "";
+
+    if (path.split(delimiter).includes(npmGlobalBin)) {
+        return;
+    }
+
+    process.env.PATH = [npmGlobalBin, path].filter(Boolean).join(delimiter);
+}
 
 async function main() {
     const parsedArgs = parseArgs({
@@ -40,6 +59,8 @@ async function main() {
     const npmVersion = await npm`--version`({ cwd });
 
     logger.info(`npm ${npmVersion}`);
+
+    await addNPMGlobalBinToPath(cwd);
 
     const corepackVersion = await corepack`--version`({ cwd }).catch(() => null);
 

--- a/scripts/node/utils/commands.mjs
+++ b/scripts/node/utils/commands.mjs
@@ -117,6 +117,21 @@ export function reportAndExit(error, logger = ConsoleLogger) {
 
     if (cause) {
         logger.error(`Caused by: ${cause.message}`);
+
+        // `child_process.exec` attaches stdout/stderr to its rejection as
+        // sibling properties, but the default `message` is just
+        // `Command failed: <cmd>` and drops them. Surface them so the actual
+        // failure (e.g. EACCES on a read-only prefix) is visible.
+        const stdout = /** @type {{ stdout?: unknown }} */ (cause).stdout;
+        const stderr = /** @type {{ stderr?: unknown }} */ (cause).stderr;
+
+        if (typeof stdout === "string" && stdout.trim()) {
+            logger.error(`stdout:\n${stdout.trimEnd()}`);
+        }
+
+        if (typeof stderr === "string" && stderr.trim()) {
+            logger.error(`stderr:\n${stderr.trimEnd()}`);
+        }
     }
 
     process.exit(1);


### PR DESCRIPTION
## Details

`make install` fails during corepack setup on systems where
`npm config get prefix` resolves to a directory whose `bin/` is not
on `PATH` (nix, asdf, volta, manual prefix override). The freshly
installed `corepack` shim is unreachable on the next line.

Fix:

- `Makefile`: prepend `$(npm config get prefix)/bin` to `PATH` for
  every recipe, gated on an `NPM_EXISTS` probe.
- `scripts/node/setup-corepack.mjs`: same adjustment inside the Node
  process so the script also works when invoked directly.
- `scripts/node/utils/commands.mjs`: surface `stdout` / `stderr` from
  failed `exec` calls so the next subprocess failure isn't opaque.

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)