### PR TITLE
website/integrations: fix aws scim mapping wording

### DIFF
--- a/website/integrations/cloud-providers/aws/index.mdx
+++ b/website/integrations/cloud-providers/aws/index.mdx
@@ -102,7 +102,7 @@ To support the integration of AWS with authentik using SCIM, you need to create 
 #### Create property mappings
 
 1. Log in to authentik as an administrator and open the authentik Admin interface.
-2. Navigate to **Customization** > **Property Mappings**, click **Create**, select **SCIM Mapping**, and click **Next**.
+2. Navigate to **Customization** > **Property Mappings**, click **Create**, select **SCIM Provider Mapping**, and click **Next**.
 3. Configure the first _user mapping_ property mapping:
     - **Name**: Provide a name lexically lower than `authentik default` (e.g. `AWS SCIM User mapping`).
     - **Expression**:


### PR DESCRIPTION
## Details

Fixes the wording for scim provider mapping

---

## Checklist

If applicable

-   [x] The documentation has been updated
-   [x] The documentation has been formatted (`make docs`)
