### PR TITLE
flows: remove link to overview for non-internal user

### DIFF
--- a/authentik/flows/challenge.py
+++ b/authentik/flows/challenge.py
@@ -128,6 +128,7 @@ class SessionEndChallenge(WithUserInfoChallenge):
     application_launch_url = CharField(required=False)
 
     invalidation_flow_url = CharField(required=False)
+    overview_url = CharField(required=False)
     brand_name = CharField(required=True)
 
 

--- a/authentik/flows/stage.py
+++ b/authentik/flows/stage.py
@@ -16,7 +16,7 @@ from sentry_sdk import start_span
 from structlog.stdlib import BoundLogger, get_logger
 
 from authentik.common.oauth.constants import PLAN_CONTEXT_POST_LOGOUT_REDIRECT_URI
-from authentik.core.models import Application, User
+from authentik.core.models import Application, User, UserTypes
 from authentik.flows.challenge import (
     AccessDeniedChallenge,
     Challenge,
@@ -331,6 +331,10 @@ class SessionEndStage(ChallengeStageView):
             "component": "ak-stage-session-end",
             "brand_name": self.request.brand.branding_title,
         }
+        if self.get_pending_user().type == UserTypes.INTERNAL:
+            data["overview_url"] = self.request.build_absolute_uri(
+                reverse("authentik_core:root-redirect")
+            )
         if application:
             data["application_name"] = application.name
             data["application_launch_url"] = application.get_launch_url(self.get_pending_user())

--- a/packages/client-go/model_session_end_challenge.go
+++ b/packages/client-go/model_session_end_challenge.go
@@ -29,6 +29,7 @@ type SessionEndChallenge struct {
 	ApplicationName      *string                   `json:"application_name,omitempty"`
 	ApplicationLaunchUrl *string                   `json:"application_launch_url,omitempty"`
 	InvalidationFlowUrl  *string                   `json:"invalidation_flow_url,omitempty"`
+	OverviewUrl          *string                   `json:"overview_url,omitempty"`
 	BrandName            string                    `json:"brand_name"`
 	AdditionalProperties map[string]interface{}
 }
@@ -299,6 +300,38 @@ func (o *SessionEndChallenge) SetInvalidationFlowUrl(v string) {
 	o.InvalidationFlowUrl = &v
 }
 
+// GetOverviewUrl returns the OverviewUrl field value if set, zero value otherwise.
+func (o *SessionEndChallenge) GetOverviewUrl() string {
+	if o == nil || IsNil(o.OverviewUrl) {
+		var ret string
+		return ret
+	}
+	return *o.OverviewUrl
+}
+
+// GetOverviewUrlOk returns a tuple with the OverviewUrl field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *SessionEndChallenge) GetOverviewUrlOk() (*string, bool) {
+	if o == nil || IsNil(o.OverviewUrl) {
+		return nil, false
+	}
+	return o.OverviewUrl, true
+}
+
+// HasOverviewUrl returns a boolean if a field has been set.
+func (o *SessionEndChallenge) HasOverviewUrl() bool {
+	if o != nil && !IsNil(o.OverviewUrl) {
+		return true
+	}
+
+	return false
+}
+
+// SetOverviewUrl gets a reference to the given string and assigns it to the OverviewUrl field.
+func (o *SessionEndChallenge) SetOverviewUrl(v string) {
+	o.OverviewUrl = &v
+}
+
 // GetBrandName returns the BrandName field value
 func (o *SessionEndChallenge) GetBrandName() string {
 	if o == nil {
@@ -352,6 +385,9 @@ func (o SessionEndChallenge) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.InvalidationFlowUrl) {
 		toSerialize["invalidation_flow_url"] = o.InvalidationFlowUrl
+	}
+	if !IsNil(o.OverviewUrl) {
+		toSerialize["overview_url"] = o.OverviewUrl
 	}
 	toSerialize["brand_name"] = o.BrandName
 
@@ -407,6 +443,7 @@ func (o *SessionEndChallenge) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "application_name")
 		delete(additionalProperties, "application_launch_url")
 		delete(additionalProperties, "invalidation_flow_url")
+		delete(additionalProperties, "overview_url")
 		delete(additionalProperties, "brand_name")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/packages/client-rust/src/models/session_end_challenge.rs
+++ b/packages/client-rust/src/models/session_end_challenge.rs
@@ -35,6 +35,8 @@ pub struct SessionEndChallenge {
         skip_serializing_if = "Option::is_none"
     )]
     pub invalidation_flow_url: Option<String>,
+    #[serde(rename = "overview_url", skip_serializing_if = "Option::is_none")]
+    pub overview_url: Option<String>,
     #[serde(rename = "brand_name")]
     pub brand_name: String,
 }
@@ -55,6 +57,7 @@ impl SessionEndChallenge {
             application_name: None,
             application_launch_url: None,
             invalidation_flow_url: None,
+            overview_url: None,
             brand_name,
         }
     }

--- a/packages/client-ts/src/models/SessionEndChallenge.ts
+++ b/packages/client-ts/src/models/SessionEndChallenge.ts
@@ -75,6 +75,12 @@ export interface SessionEndChallenge {
      * @type {string}
      * @memberof SessionEndChallenge
      */
+    overviewUrl?: string;
+    /**
+     *
+     * @type {string}
+     * @memberof SessionEndChallenge
+     */
     brandName: string;
 }
 
@@ -111,6 +117,7 @@ export function SessionEndChallengeFromJSONTyped(
             json["application_launch_url"] == null ? undefined : json["application_launch_url"],
         invalidationFlowUrl:
             json["invalidation_flow_url"] == null ? undefined : json["invalidation_flow_url"],
+        overviewUrl: json["overview_url"] == null ? undefined : json["overview_url"],
         brandName: json["brand_name"],
     };
 }
@@ -136,6 +143,7 @@ export function SessionEndChallengeToJSONTyped(
         application_name: value["applicationName"],
         application_launch_url: value["applicationLaunchUrl"],
         invalidation_flow_url: value["invalidationFlowUrl"],
+        overview_url: value["overviewUrl"],
         brand_name: value["brandName"],
     };
 }

--- a/schema.yml
+++ b/schema.yml
@@ -55963,6 +55963,8 @@ components:
           type: string
         invalidation_flow_url:
           type: string
+        overview_url:
+          type: string
         brand_name:
           type: string
       required:

--- a/web/src/flow/providers/SessionEnd.ts
+++ b/web/src/flow/providers/SessionEnd.ts
@@ -1,8 +1,6 @@
 import "#flow/FormStatic";
 import "#flow/components/ak-flow-card";
 
-import { globalAK } from "#common/global";
-
 import { SlottedTemplateResult } from "#elements/types";
 
 import { FlowUserDetails } from "#flow/FormStatic";
@@ -24,6 +22,19 @@ import PFTitle from "@patternfly/patternfly/components/Title/title.css";
 export class SessionEnd extends BaseStage<SessionEndChallenge, unknown> {
     static styles: CSSResult[] = [PFLogin, PFForm, PFFormControl, PFTitle, PFButton];
 
+    getText(challenge: SessionEndChallenge) {
+        if (challenge.overviewUrl && challenge.invalidationFlowUrl) {
+            return msg(
+                str`You've logged out of ${challenge.applicationName}. You can go back to the overview to launch another application, or log out of your authentik account.`,
+            );
+        } else if (challenge.invalidationFlowUrl) {
+            return msg(
+                str`You've logged out of ${challenge.applicationName}. You can log out of your authentik account.`,
+            );
+        }
+        return msg(str`You've logged out of ${challenge.applicationName}.`);
+    }
+
     protected render(): SlottedTemplateResult {
         const { challenge } = this;
 
@@ -31,18 +42,16 @@ export class SessionEnd extends BaseStage<SessionEndChallenge, unknown> {
             return nothing;
         }
 
-        return html`<ak-flow-card .challenge=${this.challenge}>
+        return html`<ak-flow-card .challenge=${challenge}>
             <form class="pf-c-form">
-                ${FlowUserDetails({ challenge: this.challenge })}
+                ${FlowUserDetails({ challenge: challenge })}
 
-                <p>
-                    ${msg(
-                        str`You've logged out of ${challenge.applicationName}. You can go back to the overview to launch another application, or log out of your authentik account.`,
-                    )}
-                </p>
-                <a href="${globalAK().api.base}" class="pf-c-button pf-m-primary">
-                    ${msg("Go back to overview")}
-                </a>
+                <p>${this.getText(challenge)}</p>
+                ${challenge.overviewUrl
+                    ? html`<a href="${challenge.overviewUrl}" class="pf-c-button pf-m-primary">
+                          ${msg("Go back to overview")}
+                      </a>`
+                    : nothing}
                 ${challenge.invalidationFlowUrl
                     ? html`
                           <a


### PR DESCRIPTION
currently we always include the "Go back to overview" link in the EndSessionStage, even if the user is an external user, in which case the button will only redirect to an error screen. This PR only shows that link if it works, and adds a couple more logic to the text shown