### PR TITLE
core: align django-channels-postgres psycopg[pool] floor with #22201

### DIFF
--- a/packages/django-channels-postgres/pyproject.toml
+++ b/packages/django-channels-postgres/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "django >=4.2,<6.0",
   "django-pgtrigger >=4,<5",
   "msgpack >=1,<2",
-  "psycopg[pool] >=3,<4",
+  "psycopg[pool] >=3.3.4,<4",
   "structlog >=25,<26",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1106,7 +1106,7 @@ requires-dist = [
     { name = "django", specifier = ">=4.2,<6.0" },
     { name = "django-pgtrigger", specifier = ">=4,<5" },
     { name = "msgpack", specifier = ">=1,<2" },
-    { name = "psycopg", extras = ["pool"], specifier = ">=3,<4" },
+    { name = "psycopg", extras = ["pool"], specifier = ">=3.3.4,<4" },
     { name = "structlog", specifier = ">=25,<26" },
 ]
 


### PR DESCRIPTION
## Summary

- Bumps the `psycopg[pool]` floor in the `packages/django-channels-postgres` workspace member from `>=3,<4` to `>=3.3.4,<4`, regenerating `uv.lock` so its `requires-dist` mirror lands consistent.
- Restores the intent of dependabot PR #22201, which moved the top-level floor to `3.3.4` but missed the workspace member. Since the root spec has since tightened to `psycopg[c,pool]==3.3.4`, this further constraint still resolves correctly — and aligning the floor closes the silent-drift class.

## Background

On 2026-05-11 a window of ~7h of CI failures (run-level rate jumped from ~5% to ~12%) traced back to this drift: every job that hit `uv sync --locked` failed with a `requires-dist` mismatch between the workspace member and the lockfile. Main self-recovered on 2026-05-12 when an unrelated PR (`cceb952429`, `web: bump uuid and mermaid`) rebased and regenerated `uv.lock` incidentally. So the immediate CI breakage is gone — this PR closes the loop on the underlying constraint mismatch so the same dependabot interleave can't silently recur.

## Validation

Inside a fresh dev container with `uv` on path:

- `uv lock` — only `uv.lock` line changed is the workspace member's `requires-dist` mirror entry; no broader resolution drift
- `uv lock --check` — exit 0
- `uv sync --locked` — clean resolve

## Reviewer notes

- Worth a quick look that the workspace member's floor doesn't conflict with anything in the recent `psycopg[c,pool]==3.3.4` pin at the root. `>=3.3.4,<4` is satisfied by `3.3.4`, so no resolution change is expected, but a second pair of eyes wouldn't hurt.
- If there's a preferred convention for whether workspace members should pin exactly or use ranges, happy to tighten further.

## Disclosure

Authored by an automated agent (playpen) following up on a CI-flake triage finding from yesterday. A separate read-only investigation agent identified the dependabot+uv-workspace drift as the W19 spike root cause; this PR is the documented two-line follow-up to keep the class of regression from recurring silently. The diff is minimal (2 files, 2 lines); a human operator sanity-checked the change and reviewed `uv.lock` for unexpected drift before push. The `Co-Authored-By` trailer attributes the work to the agent container.