### PR TITLE
web: migrate ak-form-element-horizontal label= to slotted AKLabel (long-tail areas)

### DIFF
--- a/web/src/admin/admin-settings/AdminSettingsForm.ts
+++ b/web/src/admin/admin-settings/AdminSettingsForm.ts
@@ -17,6 +17,8 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { Form } from "#elements/forms/Form";
 import { SlottedTemplateResult } from "#elements/types";
 
+import { AKLabel } from "#components/ak-label";
+
 import { AdminApi, FooterLink, Settings, SettingsRequest } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
@@ -200,8 +202,17 @@ export class AdminSettingsForm extends Form<SettingsRequest> {
                 value="${settings.reputationUpperLimit ?? DEFAULT_REPUTATION_UPPER_LIMIT}"
                 help=${msg("Reputation cannot increase higher than this value. Zero or positive.")}
             ></ak-number-input>
-            <ak-form-element-horizontal label=${msg("Footer links")} name="footerLinks">
+            <ak-form-element-horizontal name="footerLinks">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "footerLinks",
+                    },
+                    msg("Footer links"),
+                )}
                 <ak-array-input
+                    id="footerLinks"
                     .items=${settings.footerLinks ?? []}
                     .newItem=${() => ({ name: "", href: "" })}
                     .row=${(f?: FooterLink) =>

--- a/web/src/admin/blueprints/BlueprintForm.ts
+++ b/web/src/admin/blueprints/BlueprintForm.ts
@@ -11,6 +11,8 @@ import { docLink } from "#common/global";
 
 import { ModelForm } from "#elements/forms/ModelForm";
 
+import { AKLabel } from "#components/ak-label";
+
 import { BlueprintFile, BlueprintInstance, ManagedApi } from "@goauthentik/api";
 
 import YAML from "yaml";
@@ -77,8 +79,18 @@ export class BlueprintForm extends ModelForm<BlueprintInstance, string> {
     }
 
     protected override renderForm(): TemplateResult {
-        return html` <ak-form-element-horizontal label=${msg("Name")} required name="name">
+        return html` <ak-form-element-horizontal required name="name">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "name",
+                        required: true,
+                    },
+                    msg("Name"),
+                )}
                 <input
+                    id="name"
                     type="text"
                     value="${ifDefined(this.instance?.name)}"
                     class="pf-c-form-control"
@@ -107,8 +119,17 @@ export class BlueprintForm extends ModelForm<BlueprintInstance, string> {
                 </div>
                 <div class="pf-c-card__footer">
                     ${this.source === BlueprintSource.File
-                        ? html`<ak-form-element-horizontal label=${msg("Path")} name="path">
+                        ? html`<ak-form-element-horizontal name="path">
+                              ${AKLabel(
+                                  {
+                                      slot: "label",
+                                      className: "pf-c-form__group-label",
+                                      htmlFor: "path",
+                                  },
+                                  msg("Path"),
+                              )}
                               <ak-search-select
+                                  id="path"
                                   .fetchObjects=${async (
                                       query?: string,
                                   ): Promise<BlueprintFile[]> => {
@@ -170,8 +191,17 @@ export class BlueprintForm extends ModelForm<BlueprintInstance, string> {
                           </ak-text-input>`
                         : nothing}
                     ${this.source === BlueprintSource.Internal
-                        ? html`<ak-form-element-horizontal label=${msg("Blueprint")} name="content">
+                        ? html`<ak-form-element-horizontal name="content">
+                              ${AKLabel(
+                                  {
+                                      slot: "label",
+                                      className: "pf-c-form__group-label",
+                                      htmlFor: "content",
+                                  },
+                                  msg("Blueprint"),
+                              )}
                               <ak-codemirror
+                                  id="content"
                                   mode="yaml"
                                   raw
                                   value="${ifDefined(this.instance?.content)}"
@@ -183,8 +213,17 @@ export class BlueprintForm extends ModelForm<BlueprintInstance, string> {
 
             <ak-form-group label="${msg("Additional settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal label=${msg("Context")} name="context">
+                    <ak-form-element-horizontal name="context">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "context",
+                            },
+                            msg("Context"),
+                        )}
                         <ak-codemirror
+                            id="context"
                             mode="yaml"
                             value="${YAML.stringify(this.instance?.context ?? {})}"
                         >

--- a/web/src/admin/blueprints/BlueprintImportForm.ts
+++ b/web/src/admin/blueprints/BlueprintImportForm.ts
@@ -79,8 +79,16 @@ export class BlueprintImportForm extends Form<ManagedBlueprintsImportCreateReque
 
     renderResult(): TemplateResult {
         return html`
-            <ak-form-element-horizontal label=${msg("Successful")}>
-                <div class="pf-c-form__group-label">
+            <ak-form-element-horizontal>
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "import-result",
+                    },
+                    msg("Successful"),
+                )}
+                <div id="import-result" class="pf-c-form__group-label">
                     <div class="c-form__horizontal-group">
                         <span class="pf-c-form__label-text">
                             <ak-status-label ?good=${this.result?.success}></ak-status-label>
@@ -88,8 +96,16 @@ export class BlueprintImportForm extends Form<ManagedBlueprintsImportCreateReque
                     </div>
                 </div>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal label=${msg("Log messages")}>
-                <ak-log-viewer .items=${this.result?.logs}></ak-log-viewer>
+            <ak-form-element-horizontal>
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "import-log-messages",
+                    },
+                    msg("Log messages"),
+                )}
+                <ak-log-viewer id="import-log-messages" .items=${this.result?.logs}></ak-log-viewer>
             </ak-form-element-horizontal>
         `;
     }
@@ -148,8 +164,17 @@ export class BlueprintImportForm extends Form<ManagedBlueprintsImportCreateReque
                   `
                 : null}
             ${this.source === BlueprintSource.File
-                ? html`<ak-form-element-horizontal label=${msg("Path")} name="path">
+                ? html`<ak-form-element-horizontal name="path">
+                      ${AKLabel(
+                          {
+                              slot: "label",
+                              className: "pf-c-form__group-label",
+                              htmlFor: "path",
+                          },
+                          msg("Path"),
+                      )}
                       <ak-search-select
+                          id="path"
                           placeholder=${msg("Select a blueprint...")}
                           .fetchObjects=${async (query?: string): Promise<BlueprintFile[]> => {
                               const items = await new ManagedApi(

--- a/web/src/admin/brands/BrandForm.ts
+++ b/web/src/admin/brands/BrandForm.ts
@@ -202,11 +202,17 @@ export class BrandForm extends ModelForm<Brand, string> {
 
             <ak-form-group label="${msg("External user settings")} ">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("Default application")}
-                        name="defaultApplication"
-                    >
+                    <ak-form-element-horizontal name="defaultApplication">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "defaultApplication",
+                            },
+                            msg("Default application"),
+                        )}
                         <ak-search-select
+                            id="defaultApplication"
                             placeholder=${msg("Select an application...")}
                             blankable
                             .fetchObjects=${async (query?: string): Promise<Application[]> => {
@@ -242,11 +248,17 @@ export class BrandForm extends ModelForm<Brand, string> {
 
             <ak-form-group label="${msg("Default flows")} ">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("Authentication Flow")}
-                        name="flowAuthentication"
-                    >
+                    <ak-form-element-horizontal name="flowAuthentication">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "flowAuthentication",
+                            },
+                            msg("Authentication Flow"),
+                        )}
                         <ak-flow-search
+                            id="flowAuthentication"
                             placeholder=${msg("Select an authentication flow...")}
                             flowType=${FlowDesignationEnum.Authentication}
                             .currentFlow=${this.instance?.flowAuthentication}
@@ -257,11 +269,17 @@ export class BrandForm extends ModelForm<Brand, string> {
                             )}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Invalidation Flow")}
-                        name="flowInvalidation"
-                    >
+                    <ak-form-element-horizontal name="flowInvalidation">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "flowInvalidation",
+                            },
+                            msg("Invalidation Flow"),
+                        )}
                         <ak-flow-search
+                            id="flowInvalidation"
                             placeholder=${msg("Select an invalidation flow...")}
                             flowType=${FlowDesignationEnum.Invalidation}
                             .currentFlow=${this.instance?.flowInvalidation}
@@ -273,18 +291,33 @@ export class BrandForm extends ModelForm<Brand, string> {
                             )}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal label=${msg("Recovery flow")} name="flowRecovery">
+                    <ak-form-element-horizontal name="flowRecovery">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "flowRecovery",
+                            },
+                            msg("Recovery flow"),
+                        )}
                         <ak-flow-search
+                            id="flowRecovery"
                             placeholder=${msg("Select a recovery flow...")}
                             flowType=${FlowDesignationEnum.Recovery}
                             .currentFlow=${this.instance?.flowRecovery}
                         ></ak-flow-search>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Unenrollment flow")}
-                        name="flowUnenrollment"
-                    >
+                    <ak-form-element-horizontal name="flowUnenrollment">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "flowUnenrollment",
+                            },
+                            msg("Unenrollment flow"),
+                        )}
                         <ak-flow-search
+                            id="flowUnenrollment"
                             placeholder=${msg("Select an unenrollment flow...")}
                             flowType=${FlowDesignationEnum.Unenrollment}
                             .currentFlow=${this.instance?.flowUnenrollment}
@@ -295,11 +328,17 @@ export class BrandForm extends ModelForm<Brand, string> {
                             )}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("User settings flow")}
-                        name="flowUserSettings"
-                    >
+                    <ak-form-element-horizontal name="flowUserSettings">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "flowUserSettings",
+                            },
+                            msg("User settings flow"),
+                        )}
                         <ak-flow-search
+                            id="flowUserSettings"
                             placeholder=${msg("Select a user settings flow...")}
                             flowType=${FlowDesignationEnum.StageConfiguration}
                             .currentFlow=${this.instance?.flowUserSettings}
@@ -308,11 +347,17 @@ export class BrandForm extends ModelForm<Brand, string> {
                             ${msg("If set, users are able to configure details of their profile.")}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Device code flow")}
-                        name="flowDeviceCode"
-                    >
+                    <ak-form-element-horizontal name="flowDeviceCode">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "flowDeviceCode",
+                            },
+                            msg("Device code flow"),
+                        )}
                         <ak-flow-search
+                            id="flowDeviceCode"
                             placeholder=${msg("Select a device code flow...")}
                             flowType=${FlowDesignationEnum.StageConfiguration}
                             .currentFlow=${this.instance?.flowDeviceCode}
@@ -323,11 +368,17 @@ export class BrandForm extends ModelForm<Brand, string> {
                             )}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Account lockdown flow")}
-                        name="flowLockdown"
-                    >
+                    <ak-form-element-horizontal name="flowLockdown">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "flowLockdown",
+                            },
+                            msg("Account lockdown flow"),
+                        )}
                         <ak-flow-search
+                            id="flowLockdown"
                             placeholder=${msg("Select an account lockdown flow...")}
                             flowType=${FlowDesignationEnum.StageConfiguration}
                             .currentFlow=${this.instance?.flowLockdown}
@@ -350,19 +401,31 @@ export class BrandForm extends ModelForm<Brand, string> {
             </ak-form-group>
             <ak-form-group label="${msg("Other global settings")} ">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("Web Certificate")}
-                        name="webCertificate"
-                    >
+                    <ak-form-element-horizontal name="webCertificate">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "webCertificate",
+                            },
+                            msg("Web Certificate"),
+                        )}
                         <ak-crypto-certificate-search
+                            id="webCertificate"
                             .certificate=${this.instance?.webCertificate}
                         ></ak-crypto-certificate-search>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Client Certificates")}
-                        name="clientCertificates"
-                    >
+                    <ak-form-element-horizontal name="clientCertificates">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "clientCertificates",
+                            },
+                            msg("Client Certificates"),
+                        )}
                         <ak-dual-select-dynamic-selected
+                            id="clientCertificates"
                             .provider=${certificateProvider}
                             .selector=${certificateSelector(this.instance?.clientCertificates)}
                             available-label=${msg("Available Certificates")}

--- a/web/src/admin/common/ak-flow-search/ak-flow-search.stories.ts
+++ b/web/src/admin/common/ak-flow-search/ak-flow-search.stories.ts
@@ -1,6 +1,8 @@
 import "#admin/common/ak-flow-search/ak-flow-search";
 import "#elements/forms/HorizontalFormElement";
 
+import { AKLabel } from "#components/ak-label";
+
 import { AkFlowSearch } from "#admin/common/ak-flow-search/ak-flow-search";
 
 import { Flow, FlowDesignationEnum } from "@goauthentik/api";
@@ -110,12 +112,18 @@ const displayChange = (ev: any) => {
 
 export const Default = () =>
     container(
-        html` <ak-form-element-horizontal
-            label=${msg("Authorization flow")}
-            required
-            name="authorizationFlow"
-        >
+        html` <ak-form-element-horizontal required name="authorizationFlow">
+            ${AKLabel(
+                {
+                    slot: "label",
+                    className: "pf-c-form__group-label",
+                    htmlFor: "authorizationFlow",
+                    required: true,
+                },
+                msg("Authorization flow"),
+            )}
             <ak-flow-search
+                id="authorizationFlow"
                 flowType=${FlowDesignationEnum.Authorization}
                 @input=${displayChange}
             ></ak-flow-search
@@ -124,12 +132,18 @@ export const Default = () =>
 
 export const WithInitialValue = () =>
     container(
-        html` <ak-form-element-horizontal
-            label=${msg("Authorization flow")}
-            required
-            name="authorizationFlow"
-        >
+        html` <ak-form-element-horizontal required name="authorizationFlow">
+            ${AKLabel(
+                {
+                    slot: "label",
+                    className: "pf-c-form__group-label",
+                    htmlFor: "authorizationFlow",
+                    required: true,
+                },
+                msg("Authorization flow"),
+            )}
             <ak-flow-search
+                id="authorizationFlow"
                 flowType=${FlowDesignationEnum.Authorization}
                 currentFlow="89f57fd8-fd1e-42be-a5fd-abc13b19529b"
                 @input=${displayChange}

--- a/web/src/admin/crypto/CertificateGenerateForm.ts
+++ b/web/src/admin/crypto/CertificateGenerateForm.ts
@@ -7,6 +7,8 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { Form } from "#elements/forms/Form";
 
+import { AKLabel } from "#components/ak-label";
+
 import {
     AlgEnum,
     CertificateGenerationRequest,
@@ -61,8 +63,18 @@ export class CryptoCertificateGenerateForm extends Form<CertificateGenerationReq
                 value="365"
             ></ak-number-input>
 
-            <ak-form-element-horizontal label=${msg("Private key Algorithm")} required name="alg">
+            <ak-form-element-horizontal required name="alg">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "alg",
+                        required: true,
+                    },
+                    msg("Private key Algorithm"),
+                )}
                 <ak-radio
+                    id="alg"
                     .options=${[
                         {
                             label: msg("RSA"),

--- a/web/src/admin/endpoints/connectors/agent/AgentConnectorForm.ts
+++ b/web/src/admin/endpoints/connectors/agent/AgentConnectorForm.ts
@@ -15,6 +15,8 @@ import { ModelForm } from "#elements/forms/ModelForm";
 import { WithBrandConfig } from "#elements/mixins/branding";
 import { ifPresent } from "#elements/utils/attributes";
 
+import { AKLabel } from "#components/ak-label";
+
 import {
     oauth2ProvidersProvider,
     oauth2ProvidersSelector,
@@ -88,11 +90,17 @@ export class AgentConnectorForm extends WithBrandConfig(ModelForm<AgentConnector
             </ak-switch-input>
             <ak-form-group label="${msg("Authentication settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("Authorization Flow")}
-                        name="authorizationFlow"
-                    >
+                    <ak-form-element-horizontal name="authorizationFlow">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "authorizationFlow",
+                            },
+                            msg("Authorization Flow"),
+                        )}
                         <ak-flow-search
+                            id="authorizationFlow"
                             label=${msg("Authorization Flow")}
                             flowType=${FlowDesignationEnum.Authorization}
                             .currentFlow=${this.instance?.authorizationFlow}
@@ -119,11 +127,17 @@ export class AgentConnectorForm extends WithBrandConfig(ModelForm<AgentConnector
                         ?checked=${this.instance?.authTerminateSessionOnExpiry ?? true}
                     >
                     </ak-switch-input>
-                    <ak-form-element-horizontal
-                        label=${msg("Federated OAuth2/OpenID Providers")}
-                        name="jwtFederationProviders"
-                    >
+                    <ak-form-element-horizontal name="jwtFederationProviders">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "jwtFederationProviders",
+                            },
+                            msg("Federated OAuth2/OpenID Providers"),
+                        )}
                         <ak-dual-select-dynamic-selected
+                            id="jwtFederationProviders"
                             .provider=${oauth2ProvidersProvider}
                             .selector=${oauth2ProvidersSelector(
                                 this.instance?.jwtFederationProviders,
@@ -141,11 +155,17 @@ export class AgentConnectorForm extends WithBrandConfig(ModelForm<AgentConnector
             </ak-form-group>
             <ak-form-group label="${msg("Device compliance settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("Challenge certificate")}
-                        name="challengeKey"
-                    >
+                    <ak-form-element-horizontal name="challengeKey">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "challengeKey",
+                            },
+                            msg("Challenge certificate"),
+                        )}
                         <ak-crypto-certificate-search
+                            id="challengeKey"
                             label=${msg("Certificate")}
                             placeholder=${msg("Select a certificate...")}
                             certificate=${ifPresent(this.instance?.challengeKey)}

--- a/web/src/admin/endpoints/connectors/agent/EnrollmentTokenForm.ts
+++ b/web/src/admin/endpoints/connectors/agent/EnrollmentTokenForm.ts
@@ -116,8 +116,17 @@ export class EnrollmentTokenForm extends WithBrandConfig(ModelForm<EnrollmentTok
                 required
                 ?autofocus=${!this.instance}
             ></ak-text-input>
-            <ak-form-element-horizontal label=${msg("Device Access Group")} name="deviceGroup">
+            <ak-form-element-horizontal name="deviceGroup">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "deviceGroup",
+                    },
+                    msg("Device Access Group"),
+                )}
                 <ak-endpoints-device-group-search
+                    id="deviceGroup"
                     .group=${this.instance?.deviceGroup}
                 ></ak-endpoints-device-group-search>
                 <p class="pf-c-form__helper-text">

--- a/web/src/admin/endpoints/connectors/gdtc/GoogleChromeConnectorForm.ts
+++ b/web/src/admin/endpoints/connectors/gdtc/GoogleChromeConnectorForm.ts
@@ -8,6 +8,8 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { ModelForm } from "#elements/forms/ModelForm";
 
+import { AKLabel } from "#components/ak-label";
+
 import { EndpointsApi, GoogleChromeConnector } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
@@ -56,12 +58,18 @@ export class GoogleChromeConnectorForm extends ModelForm<GoogleChromeConnector, 
             ></ak-switch-input>
             <ak-form-group label=${msg("Google settings")} open>
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("Credentials")}
-                        required
-                        name="credentials"
-                    >
+                    <ak-form-element-horizontal required name="credentials">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "credentials",
+                                required: true,
+                            },
+                            msg("Credentials"),
+                        )}
                         <ak-codemirror
+                            id="credentials"
                             mode="javascript"
                             .value="${this.instance?.credentials ?? {}}"
                         ></ak-codemirror>

--- a/web/src/admin/endpoints/devices/DeviceForm.ts
+++ b/web/src/admin/endpoints/devices/DeviceForm.ts
@@ -9,6 +9,8 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { ModelForm } from "#elements/forms/ModelForm";
 
+import { AKLabel } from "#components/ak-label";
+
 import { EndpointDevice, EndpointsApi } from "@goauthentik/api";
 
 import YAML from "yaml";
@@ -47,13 +49,31 @@ export class EndpointDeviceForm extends ModelForm<EndpointDevice, string> {
                 value=${ifDefined(this.instance?.name)}
                 required
             ></ak-text-input>
-            <ak-form-element-horizontal label=${msg("Device Group")} name="accessGroup">
+            <ak-form-element-horizontal name="accessGroup">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "accessGroup",
+                    },
+                    msg("Device Group"),
+                )}
                 <ak-endpoints-device-group-search
+                    id="accessGroup"
                     .group=${this.instance?.accessGroup}
                 ></ak-endpoints-device-group-search>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal label=${msg("Attributes")} name="attributes">
+            <ak-form-element-horizontal name="attributes">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "attributes",
+                    },
+                    msg("Attributes"),
+                )}
                 <ak-codemirror
+                    id="attributes"
                     mode="yaml"
                     value="${YAML.stringify(this.instance?.attributes ?? {})}"
                 >

--- a/web/src/admin/events/RuleForm.ts
+++ b/web/src/admin/events/RuleForm.ts
@@ -13,6 +13,8 @@ import { severityToLabel } from "#common/labels";
 import { ModelForm } from "#elements/forms/ModelForm";
 import { RadioOption } from "#elements/forms/Radio";
 
+import { AKLabel } from "#components/ak-label";
+
 import {
     CoreApi,
     CoreGroupsListRequest,
@@ -74,8 +76,17 @@ export class RuleForm extends ModelForm<NotificationRule, string> {
                 placeholder=${msg("Type a name for this rule...")}
                 value="${ifDefined(this.instance?.name)}"
             ></ak-text-input>
-            <ak-form-element-horizontal label=${msg("Group")} name="destinationGroup">
+            <ak-form-element-horizontal name="destinationGroup">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "destinationGroup",
+                    },
+                    msg("Group"),
+                )}
                 <ak-search-select
+                    id="destinationGroup"
                     placeholder=${msg("Select a group...")}
                     .fetchObjects=${async (query?: string): Promise<Group[]> => {
                         const args: CoreGroupsListRequest = {
@@ -117,8 +128,18 @@ export class RuleForm extends ModelForm<NotificationRule, string> {
                 )}
             >
             </ak-switch-input>
-            <ak-form-element-horizontal label=${msg("Transports")} required name="transports">
+            <ak-form-element-horizontal required name="transports">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "transports",
+                        required: true,
+                    },
+                    msg("Transports"),
+                )}
                 <ak-dual-select-dynamic-selected
+                    id="transports"
                     .provider=${eventTransportsProvider}
                     .selector=${eventTransportsSelector(this.instance?.transports)}
                     available-label="${msg("Available Transports")}"
@@ -130,8 +151,18 @@ export class RuleForm extends ModelForm<NotificationRule, string> {
                     )}
                 </p>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal label=${msg("Severity")} required name="severity">
+            <ak-form-element-horizontal required name="severity">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "severity",
+                        required: true,
+                    },
+                    msg("Severity"),
+                )}
                 <ak-radio
+                    id="severity"
                     .options=${[
                         {
                             label: severityToLabel(SeverityEnum.Alert),

--- a/web/src/admin/events/TransportForm.ts
+++ b/web/src/admin/events/TransportForm.ts
@@ -10,6 +10,8 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { ModelForm } from "#elements/forms/ModelForm";
 
+import { AKLabel } from "#components/ak-label";
+
 import {
     EventsApi,
     NotificationTransport,
@@ -111,8 +113,18 @@ export class TransportForm extends ModelForm<NotificationTransport, string> {
                 )}
             >
             </ak-switch-input>
-            <ak-form-element-horizontal label=${msg("Mode")} required name="mode">
+            <ak-form-element-horizontal required name="mode">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "mode",
+                        required: true,
+                    },
+                    msg("Mode"),
+                )}
                 <ak-radio
+                    id="mode"
                     @change=${(ev: CustomEvent<{ value: TransportModeEnum }>) => {
                         this.onModeChange(ev.detail.value);
                     }}
@@ -148,12 +160,17 @@ export class TransportForm extends ModelForm<NotificationTransport, string> {
                 ?required=${this.showWebhook}
             >
             </ak-hidden-text-input>
-            <ak-form-element-horizontal
-                ?hidden=${!this.showWebhook}
-                label=${msg("Webhook Certificate Authority")}
-                name="webhookCa"
-            >
+            <ak-form-element-horizontal ?hidden=${!this.showWebhook} name="webhookCa">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "webhookCa",
+                    },
+                    msg("Webhook Certificate Authority"),
+                )}
                 <ak-crypto-certificate-search
+                    id="webhookCa"
                     .certificate=${this.instance?.webhookCa}
                 ></ak-crypto-certificate-search>
                 <p class="pf-c-form__helper-text">
@@ -162,12 +179,17 @@ export class TransportForm extends ModelForm<NotificationTransport, string> {
                     )}
                 </p>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal
-                ?hidden=${!this.showWebhook}
-                label=${msg("Webhook Body Mapping")}
-                name="webhookMappingBody"
-            >
+            <ak-form-element-horizontal ?hidden=${!this.showWebhook} name="webhookMappingBody">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "webhookMappingBody",
+                    },
+                    msg("Webhook Body Mapping"),
+                )}
                 <ak-search-select
+                    id="webhookMappingBody"
                     .fetchObjects=${async (
                         query?: string,
                     ): Promise<NotificationWebhookMapping[]> => {
@@ -191,12 +213,17 @@ export class TransportForm extends ModelForm<NotificationTransport, string> {
                 >
                 </ak-search-select>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal
-                ?hidden=${!this.showWebhook}
-                label=${msg("Webhook Header Mapping")}
-                name="webhookMappingHeaders"
-            >
+            <ak-form-element-horizontal ?hidden=${!this.showWebhook} name="webhookMappingHeaders">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "webhookMappingHeaders",
+                    },
+                    msg("Webhook Header Mapping"),
+                )}
                 <ak-search-select
+                    id="webhookMappingHeaders"
                     .fetchObjects=${async (
                         query?: string,
                     ): Promise<NotificationWebhookMapping[]> => {
@@ -225,10 +252,19 @@ export class TransportForm extends ModelForm<NotificationTransport, string> {
             <ak-form-element-horizontal
                 ?hidden=${!this.showEmail}
                 ?required=${this.showEmail}
-                label=${msg("Email Subject Prefix")}
                 name="emailSubjectPrefix"
             >
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "emailSubjectPrefix",
+                        required: this.showEmail,
+                    },
+                    msg("Email Subject Prefix"),
+                )}
                 <input
+                    id="emailSubjectPrefix"
                     type="text"
                     value="${this.instance?.emailSubjectPrefix || "authentik Notification: "}"
                     class="pf-c-form-control"
@@ -239,10 +275,18 @@ export class TransportForm extends ModelForm<NotificationTransport, string> {
             <ak-form-element-horizontal
                 ?hidden=${!this.showEmail}
                 ?required=${this.showEmail}
-                label=${msg("Email Template")}
                 name="emailTemplate"
             >
-                <select name="users" class="pf-c-form-control">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "emailTemplate",
+                        required: this.showEmail,
+                    },
+                    msg("Email Template"),
+                )}
+                <select id="emailTemplate" name="users" class="pf-c-form-control">
                     ${this.templates?.map((template) => {
                         const selected =
                             this.instance?.emailTemplate === template.name ||

--- a/web/src/admin/files/FileUploadForm.ts
+++ b/web/src/admin/files/FileUploadForm.ts
@@ -8,6 +8,8 @@ import { Form } from "#elements/forms/Form";
 import { PreventFormSubmit } from "#elements/forms/helpers";
 import { showMessage } from "#elements/messages/MessageContainer";
 
+import { AKLabel } from "#components/ak-label";
+
 import { AdminApi, UsageEnum } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
@@ -108,7 +110,16 @@ export class FileUploadForm extends Form<Record<string, unknown>> {
     renderForm() {
         return html`
             <form ${ref(this.#formRef)} class="pf-c-form pf-m-horizontal">
-                <ak-form-element-horizontal label=${msg("File")} required>
+                <ak-form-element-horizontal required>
+                    ${AKLabel(
+                        {
+                            slot: "label",
+                            className: "pf-c-form__group-label",
+                            htmlFor: "file-input",
+                            required: true,
+                        },
+                        msg("File"),
+                    )}
                     <input
                         type="file"
                         class="pf-c-form-control"
@@ -117,8 +128,17 @@ export class FileUploadForm extends Form<Record<string, unknown>> {
                         @change=${this.#fileChangeListener}
                     />
                 </ak-form-element-horizontal>
-                <ak-form-element-horizontal label=${msg("File Name")} name="name">
+                <ak-form-element-horizontal name="name">
+                    ${AKLabel(
+                        {
+                            slot: "label",
+                            className: "pf-c-form__group-label",
+                            htmlFor: "name",
+                        },
+                        msg("File Name"),
+                    )}
                     <input
+                        id="name"
                         type="text"
                         class="pf-c-form-control"
                         pattern=${VALID_FILE_NAME_PATTERN_STRING}

--- a/web/src/admin/flows/FlowForm.ts
+++ b/web/src/admin/flows/FlowForm.ts
@@ -243,12 +243,18 @@ export class FlowForm extends WithCapabilitiesConfig(ModelForm<Flow, string>) {
                         )}
                     >
                     </ak-switch-input>
-                    <ak-form-element-horizontal
-                        label=${msg("Denied action")}
-                        required
-                        name="deniedAction"
-                    >
+                    <ak-form-element-horizontal required name="deniedAction">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "deniedAction",
+                                required: true,
+                            },
+                            msg("Denied action"),
+                        )}
                         <ak-radio
+                            id="deniedAction"
                             .options=${[
                                 {
                                     label: "MESSAGE_CONTINUE",
@@ -282,12 +288,18 @@ export class FlowForm extends WithCapabilitiesConfig(ModelForm<Flow, string>) {
                             )}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Policy engine mode")}
-                        required
-                        name="policyEngineMode"
-                    >
+                    <ak-form-element-horizontal required name="policyEngineMode">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "policyEngineMode",
+                                required: true,
+                            },
+                            msg("Policy engine mode"),
+                        )}
                         <ak-radio
+                            id="policyEngineMode"
                             .options=${policyEngineModes}
                             .value=${this.instance?.policyEngineMode}
                         >

--- a/web/src/admin/flows/StageBindingForm.ts
+++ b/web/src/admin/flows/StageBindingForm.ts
@@ -11,6 +11,8 @@ import { ModelForm } from "#elements/forms/ModelForm";
 import { RadioOption } from "#elements/forms/Radio";
 import { SlottedTemplateResult } from "#elements/types";
 
+import { AKLabel } from "#components/ak-label";
+
 import { policyEngineModes } from "#admin/policies/PolicyEngineModes";
 
 import {
@@ -118,8 +120,18 @@ export class StageBindingForm extends ModelForm<FlowStageBinding, string> {
         if (this.instance?.target || this.targetPk) {
             return nothing;
         }
-        return html`<ak-form-element-horizontal label=${msg("Target")} required name="target">
+        return html`<ak-form-element-horizontal required name="target">
+            ${AKLabel(
+                {
+                    slot: "label",
+                    className: "pf-c-form__group-label",
+                    htmlFor: "target",
+                    required: true,
+                },
+                msg("Target"),
+            )}
             <ak-flow-search
+                id="target"
                 flowType=${FlowDesignationEnum.Authorization}
                 .currentFlow=${this.instance?.target}
                 required
@@ -129,8 +141,18 @@ export class StageBindingForm extends ModelForm<FlowStageBinding, string> {
 
     protected override renderForm(): SlottedTemplateResult {
         return html`${this.renderTarget()}
-            <ak-form-element-horizontal label=${msg("Stage")} required name="stage">
+            <ak-form-element-horizontal required name="stage">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "stage",
+                        required: true,
+                    },
+                    msg("Stage"),
+                )}
                 <ak-search-select
+                    id="stage"
                     placeholder=${msg("Select a stage...")}
                     .fetchObjects=${async (query?: string): Promise<Stage[]> => {
                         const args: StagesAllListRequest = {
@@ -155,8 +177,18 @@ export class StageBindingForm extends ModelForm<FlowStageBinding, string> {
                 >
                 </ak-search-select>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal label=${msg("Order")} required name="order">
+            <ak-form-element-horizontal required name="order">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "order",
+                        required: true,
+                    },
+                    msg("Order"),
+                )}
                 <input
+                    id="order"
                     type="number"
                     value="${this.instance?.order ?? this.defaultOrder}"
                     class="pf-c-form-control"
@@ -177,12 +209,18 @@ export class StageBindingForm extends ModelForm<FlowStageBinding, string> {
                 help=${msg("Evaluate policies before the Stage is presented to the user.")}
             >
             </ak-switch-input>
-            <ak-form-element-horizontal
-                label=${msg("Invalid response behavior")}
-                required
-                name="invalidResponseAction"
-            >
+            <ak-form-element-horizontal required name="invalidResponseAction">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "invalidResponseAction",
+                        required: true,
+                    },
+                    msg("Invalid response behavior"),
+                )}
                 <ak-radio
+                    id="invalidResponseAction"
                     .options=${createInvalidResponseOptions()}
                     .value=${this.instance?.invalidResponseAction}
                 >
@@ -193,12 +231,21 @@ export class StageBindingForm extends ModelForm<FlowStageBinding, string> {
                     )}
                 </p>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal
-                label=${msg("Policy engine mode")}
-                required
-                name="policyEngineMode"
-            >
-                <ak-radio .options=${policyEngineModes} .value=${this.instance?.policyEngineMode}>
+            <ak-form-element-horizontal required name="policyEngineMode">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "policyEngineMode",
+                        required: true,
+                    },
+                    msg("Policy engine mode"),
+                )}
+                <ak-radio
+                    id="policyEngineMode"
+                    .options=${policyEngineModes}
+                    .value=${this.instance?.policyEngineMode}
+                >
                 </ak-radio>
             </ak-form-element-horizontal>`;
     }

--- a/web/src/admin/groups/RelatedGroupList.ts
+++ b/web/src/admin/groups/RelatedGroupList.ts
@@ -12,6 +12,8 @@ import { AKFormSubmitEvent, Form } from "#elements/forms/Form";
 import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
 import { SlottedTemplateResult } from "#elements/types";
 
+import { AKLabel } from "#components/ak-label";
+
 import { GroupForm } from "#admin/groups/ak-group-form";
 
 import { CoreApi, Group, User } from "@goauthentik/api";
@@ -66,8 +68,16 @@ export class RelatedGroupAdd extends Form<{ groups: string[] }> {
     };
 
     protected override renderForm(): TemplateResult {
-        return html`<ak-form-element-horizontal label=${msg("Groups to add")} name="groups">
-            <div class="pf-c-input-group">
+        return html`<ak-form-element-horizontal name="groups">
+            ${AKLabel(
+                {
+                    slot: "label",
+                    className: "pf-c-form__group-label",
+                    htmlFor: "groups",
+                },
+                msg("Groups to add"),
+            )}
+            <div id="groups" class="pf-c-input-group">
                 <button
                     class="pf-c-button pf-m-control"
                     type="button"

--- a/web/src/admin/groups/ak-group-form.ts
+++ b/web/src/admin/groups/ak-group-form.ts
@@ -13,6 +13,8 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { DataProvision, DualSelectPair } from "#elements/ak-dual-select/types";
 import { ModelForm } from "#elements/forms/ModelForm";
 
+import { AKLabel } from "#components/ak-label";
+
 import { CoreApi, Group, RbacApi, RelatedGroup, Role } from "@goauthentik/api";
 
 import YAML from "yaml";
@@ -120,8 +122,17 @@ export class GroupForm extends ModelForm<Group, string> {
             >
             </ak-switch-input>
 
-            <ak-form-element-horizontal label=${msg("Parents")} name="parents">
+            <ak-form-element-horizontal name="parents">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "parents",
+                    },
+                    msg("Parents"),
+                )}
                 <ak-dual-select-provider
+                    id="parents"
                     .provider=${this.#fetchGroups}
                     .selected=${(this.instance?.parentsObj ?? []).map(coreGroupPair)}
                     available-label=${msg("Available Groups")}
@@ -131,8 +142,17 @@ export class GroupForm extends ModelForm<Group, string> {
                     ${msg("A group recursively inherits every role from its ancestors.")}
                 </p>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal label=${msg("Roles")} name="roles">
+            <ak-form-element-horizontal name="roles">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "roles",
+                    },
+                    msg("Roles"),
+                )}
                 <ak-dual-select-provider
+                    id="roles"
                     .provider=${this.#fetchRoles}
                     .selected=${(this.instance?.rolesObj ?? []).map(rbacRolePair)}
                     available-label=${msg("Available Roles")}
@@ -144,8 +164,17 @@ export class GroupForm extends ModelForm<Group, string> {
                     )}
                 </p>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal label=${msg("Attributes")} name="attributes">
+            <ak-form-element-horizontal name="attributes">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "attributes",
+                    },
+                    msg("Attributes"),
+                )}
                 <ak-codemirror
+                    id="attributes"
                     mode="yaml"
                     value="${YAML.stringify(this.instance?.attributes ?? {})}"
                 >

--- a/web/src/admin/lifecycle/LifecycleRuleForm.ts
+++ b/web/src/admin/lifecycle/LifecycleRuleForm.ts
@@ -17,6 +17,8 @@ import { RadioChangeEventDetail, RadioOption } from "#elements/forms/Radio";
 import type SearchSelect from "#elements/forms/SearchSelect/SearchSelect";
 import { SlottedTemplateResult } from "#elements/types";
 
+import { AKLabel } from "#components/ak-label";
+
 import { eventTransportsProvider, eventTransportsSelector } from "#admin/events/RuleFormHelpers";
 
 import {
@@ -230,7 +232,15 @@ export class LifecycleRuleForm extends ModelForm<LifecycleRule, string, Lifecycl
                 .bighelp=${html`<ak-utils-time-delta-help></ak-utils-time-delta-help>`}
             ></ak-text-input>
 
-            <ak-form-element-horizontal label=${msg("Reviewer groups")} name="reviewerGroups">
+            <ak-form-element-horizontal name="reviewerGroups">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "reviewerGroups",
+                    },
+                    msg("Reviewer groups"),
+                )}
                 ${this.renderReviewerGroupsSelection()}
             </ak-form-element-horizontal>
             <ak-number-input
@@ -254,7 +264,15 @@ export class LifecycleRuleForm extends ModelForm<LifecycleRule, string, Lifecycl
             >
             </ak-switch-input>
 
-            <ak-form-element-horizontal label=${msg("Reviewers")} name="reviewers">
+            <ak-form-element-horizontal name="reviewers">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "reviewers",
+                    },
+                    msg("Reviewers"),
+                )}
                 ${this.renderReviewerUserSelection()}
             </ak-form-element-horizontal>
             ${this.renderTransportsSelection()} `;
@@ -274,8 +292,17 @@ export class LifecycleRuleForm extends ModelForm<LifecycleRule, string, Lifecycl
     protected renderTargetSelection() {
         return keyed(
             this.selectedContentType,
-            html`<ak-form-element-horizontal label=${msg("Object")} name="objectId">
+            html`<ak-form-element-horizontal name="objectId">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "objectId",
+                    },
+                    msg("Object"),
+                )}
                 <ak-search-select
+                    id="objectId"
                     ${ref(this.#targetSelectRef)}
                     placeholder=${formatContentTypePlaceholder(this.selectedContentType)}
                     .fetchObjects=${this.#loadObjects}
@@ -297,6 +324,7 @@ export class LifecycleRuleForm extends ModelForm<LifecycleRule, string, Lifecycl
 
     protected renderReviewerGroupsSelection(): SlottedTemplateResult {
         return html`<ak-dual-select-provider
+            id="reviewerGroups"
             ${ref(this.#reviewerGroupsSelectRef)}
             .provider=${this.#fetchGroups}
             .selected=${(this.instance?.reviewerGroupsObj ?? []).map(groupToPair)}
@@ -307,6 +335,7 @@ export class LifecycleRuleForm extends ModelForm<LifecycleRule, string, Lifecycl
 
     protected renderReviewerUserSelection(): SlottedTemplateResult {
         return html`<ak-dual-select-provider
+                id="reviewers"
                 ${ref(this.#reviewerUsersSelectRef)}
                 .provider=${this.#fetchUsers}
                 .selected=${(this.instance?.reviewersObj ?? []).map(userToPair)}
@@ -322,12 +351,18 @@ export class LifecycleRuleForm extends ModelForm<LifecycleRule, string, Lifecycl
 
     protected renderTransportsSelection(): SlottedTemplateResult {
         return html`
-            <ak-form-element-horizontal
-                label=${msg("Notification transports")}
-                required
-                name="notificationTransports"
-            >
+            <ak-form-element-horizontal required name="notificationTransports">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "notificationTransports",
+                        required: true,
+                    },
+                    msg("Notification transports"),
+                )}
                 <ak-dual-select-dynamic-selected
+                    id="notificationTransports"
                     .provider=${eventTransportsProvider}
                     .selector=${eventTransportsSelector(this.instance?.notificationTransports)}
                     available-label="${msg("Available Transports")}"

--- a/web/src/admin/outposts/OutpostForm.ts
+++ b/web/src/admin/outposts/OutpostForm.ts
@@ -168,8 +168,18 @@ export class OutpostForm extends ModelForm<Outpost, string> {
                 required
             ></ak-text-input>
 
-            <ak-form-element-horizontal label=${msg("Type")} required name="type">
+            <ak-form-element-horizontal required name="type">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "type",
+                        required: true,
+                    },
+                    msg("Type"),
+                )}
                 <select
+                    id="type"
                     class="pf-c-form-control"
                     @change=${(ev: Event) => {
                         const target = ev.target as HTMLSelectElement;
@@ -249,12 +259,18 @@ export class OutpostForm extends ModelForm<Outpost, string> {
                     </p>
                 </div>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal
-                label=${msg("Applications")}
-                ?required=${!this.embedded}
-                name="providers"
-            >
+            <ak-form-element-horizontal ?required=${!this.embedded} name="providers">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "providers",
+                        required: !this.embedded,
+                    },
+                    msg("Applications"),
+                )}
                 <ak-dual-select-provider
+                    id="providers"
                     .provider=${this.providers}
                     .selected=${(this.instance?.providersObj ?? []).map(dualSelectPairMaker)}
                     available-label="${msg("Available Applications")}"

--- a/web/src/admin/outposts/ServiceConnectionDockerForm.ts
+++ b/web/src/admin/outposts/ServiceConnectionDockerForm.ts
@@ -7,6 +7,8 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { ModelForm } from "#elements/forms/ModelForm";
 
+import { AKLabel } from "#components/ak-label";
+
 import { DockerServiceConnection, OutpostsApi } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
@@ -41,8 +43,18 @@ export class ServiceConnectionDockerForm extends ModelForm<DockerServiceConnecti
     }
 
     protected override renderForm(): TemplateResult {
-        return html` <ak-form-element-horizontal label=${msg("Name")} required name="name">
+        return html` <ak-form-element-horizontal required name="name">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "name",
+                        required: true,
+                    },
+                    msg("Name"),
+                )}
                 <input
+                    id="name"
                     type="text"
                     value="${ifDefined(this.instance?.name)}"
                     class="pf-c-form-control"
@@ -58,8 +70,18 @@ export class ServiceConnectionDockerForm extends ModelForm<DockerServiceConnecti
             >
             </ak-switch-input>
 
-            <ak-form-element-horizontal label=${msg("Docker URL")} required name="url">
+            <ak-form-element-horizontal required name="url">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "url",
+                        required: true,
+                    },
+                    msg("Docker URL"),
+                )}
                 <input
+                    id="url"
                     type="text"
                     value="${ifDefined(this.instance?.url)}"
                     class="pf-c-form-control pf-m-monospace"
@@ -76,11 +98,17 @@ export class ServiceConnectionDockerForm extends ModelForm<DockerServiceConnecti
                     )}
                 </p>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal
-                label=${msg("TLS Verification Certificate")}
-                name="tlsVerification"
-            >
+            <ak-form-element-horizontal name="tlsVerification">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "tlsVerification",
+                    },
+                    msg("TLS Verification Certificate"),
+                )}
                 <ak-crypto-certificate-search
+                    id="tlsVerification"
                     .certificate=${this.instance?.tlsVerification}
                 ></ak-crypto-certificate-search>
                 <p class="pf-c-form__helper-text">
@@ -89,11 +117,17 @@ export class ServiceConnectionDockerForm extends ModelForm<DockerServiceConnecti
                     )}
                 </p>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal
-                label=${msg("TLS Authentication Certificate/SSH Keypair")}
-                name="tlsAuthentication"
-            >
+            <ak-form-element-horizontal name="tlsAuthentication">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "tlsAuthentication",
+                    },
+                    msg("TLS Authentication Certificate/SSH Keypair"),
+                )}
                 <ak-crypto-certificate-search
+                    id="tlsAuthentication"
                     .certificate=${this.instance?.tlsAuthentication}
                 ></ak-crypto-certificate-search>
                 <p class="pf-c-form__helper-text">

--- a/web/src/admin/outposts/ServiceConnectionKubernetesForm.ts
+++ b/web/src/admin/outposts/ServiceConnectionKubernetesForm.ts
@@ -6,6 +6,8 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { ModelForm } from "#elements/forms/ModelForm";
 
+import { AKLabel } from "#components/ak-label";
+
 import { KubernetesServiceConnection, OutpostsApi } from "@goauthentik/api";
 
 import YAML from "yaml";
@@ -45,8 +47,18 @@ export class ServiceConnectionKubernetesForm extends ModelForm<
     }
 
     protected override renderForm(): TemplateResult {
-        return html` <ak-form-element-horizontal label=${msg("Name")} required name="name">
+        return html` <ak-form-element-horizontal required name="name">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "name",
+                        required: true,
+                    },
+                    msg("Name"),
+                )}
                 <input
+                    id="name"
                     type="text"
                     value="${ifDefined(this.instance?.name)}"
                     class="pf-c-form-control"
@@ -60,8 +72,17 @@ export class ServiceConnectionKubernetesForm extends ModelForm<
                 help=${msg("Requires Docker socket/Kubernetes Integration.")}
             >
             </ak-switch-input>
-            <ak-form-element-horizontal label=${msg("Kubeconfig")} name="kubeconfig">
+            <ak-form-element-horizontal name="kubeconfig">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "kubeconfig",
+                    },
+                    msg("Kubeconfig"),
+                )}
                 <ak-codemirror
+                    id="kubeconfig"
                     mode="yaml"
                     value="${YAML.stringify(this.instance?.kubeconfig ?? {})}"
                 >

--- a/web/src/admin/rbac/ak-initial-permissions-form.ts
+++ b/web/src/admin/rbac/ak-initial-permissions-form.ts
@@ -11,6 +11,8 @@ import { PFSize } from "#common/enums";
 import { DataProvision, DualSelectPair } from "#elements/ak-dual-select/types";
 import { ModelForm } from "#elements/forms/ModelForm";
 
+import { AKLabel } from "#components/ak-label";
+
 import {
     InitialPermissions,
     Permission,
@@ -77,8 +79,18 @@ export class InitialPermissionsForm extends ModelForm<InitialPermissions, string
                 value="${ifDefined(this.instance?.name)}"
             >
             </ak-text-input>
-            <ak-form-element-horizontal label=${msg("Role")} required name="role">
+            <ak-form-element-horizontal required name="role">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "role",
+                        required: true,
+                    },
+                    msg("Role"),
+                )}
                 <ak-search-select
+                    id="role"
                     placeholder=${msg("Select a role...")}
                     .fetchObjects=${async (query?: string): Promise<Role[]> => {
                         const args: RbacRolesListRequest = {
@@ -110,8 +122,17 @@ export class InitialPermissionsForm extends ModelForm<InitialPermissions, string
                     )}
                 </p>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal label=${msg("Permissions")} name="permissions">
+            <ak-form-element-horizontal name="permissions">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "permissions",
+                    },
+                    msg("Permissions"),
+                )}
                 <ak-dual-select-provider
+                    id="permissions"
                     .provider=${(page: number, search?: string): Promise<DataProvision> => {
                         return new RbacApi(DEFAULT_CONFIG)
                             .rbacPermissionsList({

--- a/web/src/admin/rbac/ak-rbac-role-object-permission-form.ts
+++ b/web/src/admin/rbac/ak-rbac-role-object-permission-form.ts
@@ -9,6 +9,8 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { ModelForm } from "#elements/forms/ModelForm";
 import { SlottedTemplateResult } from "#elements/types";
 
+import { AKLabel } from "#components/ak-label";
+
 import {
     ModelEnum,
     PaginatedPermissionList,
@@ -96,8 +98,17 @@ export class RoleObjectPermissionForm extends ModelForm<RoleAssignData, number> 
                 )}</span
             >
             <form class="pf-c-form pf-m-horizontal">
-                <ak-form-element-horizontal label=${msg("Role")} name="role">
+                <ak-form-element-horizontal name="role">
+                    ${AKLabel(
+                        {
+                            slot: "label",
+                            className: "pf-c-form__group-label",
+                            htmlFor: "role",
+                        },
+                        msg("Role"),
+                    )}
                     <ak-search-select
+                        id="role"
                         placeholder=${msg("Select a role...")}
                         .fetchObjects=${async (query?: string): Promise<Role[]> => {
                             const args: RbacRolesListRequest = {

--- a/web/src/admin/roles/ak-related-role-table.ts
+++ b/web/src/admin/roles/ak-related-role-table.ts
@@ -15,6 +15,8 @@ import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
 import { SlottedTemplateResult } from "#elements/types";
 import { ifPresent } from "#elements/utils/attributes";
 
+import { AKLabel } from "#components/ak-label";
+
 import { RoleForm } from "#admin/roles/ak-role-form";
 
 import { Group, RbacApi, Role, User } from "@goauthentik/api";
@@ -71,8 +73,16 @@ export class AddRelatedRoleForm extends Form<{ roles: string[] }> {
     };
 
     protected override renderForm(): TemplateResult {
-        return html`<ak-form-element-horizontal label=${msg("Roles to add")} name="roles">
-            <div class="pf-c-input-group">
+        return html`<ak-form-element-horizontal name="roles">
+            ${AKLabel(
+                {
+                    slot: "label",
+                    className: "pf-c-form__group-label",
+                    htmlFor: "roles",
+                },
+                msg("Roles to add"),
+            )}
+            <div id="roles" class="pf-c-input-group">
                 <button
                     class="pf-c-button pf-m-control"
                     type="button"

--- a/web/src/admin/roles/ak-role-permission-form.ts
+++ b/web/src/admin/roles/ak-role-permission-form.ts
@@ -12,6 +12,8 @@ import { renderModal } from "#elements/dialogs";
 import { AKFormSubmitEvent } from "#elements/forms/Form";
 import { ModelForm } from "#elements/forms/ModelForm";
 
+import { AKLabel } from "#components/ak-label";
+
 import { Permission, RbacApi } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
@@ -72,8 +74,16 @@ export class RolePermissionForm extends ModelForm<RolePermissionAssign, number> 
 
     protected override renderForm(): TemplateResult {
         return html`<form class="pf-c-form pf-m-horizontal">
-            <ak-form-element-horizontal label=${msg("Permissions to add")} name="permissions">
-                <div class="pf-c-input-group">
+            <ak-form-element-horizontal name="permissions">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "permissions",
+                    },
+                    msg("Permissions to add"),
+                )}
+                <div id="permissions" class="pf-c-input-group">
                     <button
                         class="pf-c-button pf-m-control"
                         type="button"

--- a/web/src/admin/tokens/TokenForm.ts
+++ b/web/src/admin/tokens/TokenForm.ts
@@ -101,8 +101,18 @@ export class TokenForm extends ModelForm<Token, string> {
                 help=${msg("Unique identifier the token is referenced by.")}
             ></ak-text-input>
 
-            <ak-form-element-horizontal label=${msg("User")} required name="user">
+            <ak-form-element-horizontal required name="user">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "user",
+                        required: true,
+                    },
+                    msg("User"),
+                )}
                 <ak-search-select
+                    id="user"
                     placeholder=${msg("Select a user...")}
                     .fetchObjects=${async (query?: string): Promise<User[]> => {
                         const args: CoreUsersListRequest = {
@@ -141,8 +151,18 @@ export class TokenForm extends ModelForm<Token, string> {
                 >
                 </ak-search-select>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal label=${msg("Intent")} required name="intent">
+            <ak-form-element-horizontal required name="intent">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "intent",
+                        required: true,
+                    },
+                    msg("Intent"),
+                )}
                 <ak-radio
+                    id="intent"
                     .options=${[
                         {
                             label: msg("API Token"),

--- a/web/src/admin/users/UserForm.ts
+++ b/web/src/admin/users/UserForm.ts
@@ -13,6 +13,8 @@ import { ModelForm } from "#elements/forms/ModelForm";
 import { RadioOption } from "#elements/forms/Radio";
 import { SlottedTemplateResult } from "#elements/types";
 
+import { AKLabel } from "#components/ak-label";
+
 import { CoreApi, Group, RbacApi, Role, User, UserTypeEnum } from "@goauthentik/api";
 
 import { match } from "ts-pattern";
@@ -264,8 +266,17 @@ export class UserForm extends ModelForm<User, number> {
                     </p>`}
             ></ak-text-input>
 
-            <ak-form-element-horizontal label=${msg("Attributes")} name="attributes">
+            <ak-form-element-horizontal name="attributes">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "attributes",
+                    },
+                    msg("Attributes"),
+                )}
                 <ak-codemirror
+                    id="attributes"
                     mode="yaml"
                     value="${YAML.stringify(
                         this.instance?.attributes ?? UserForm.defaultUserAttributes,

--- a/web/src/admin/users/UserResetEmailForm.ts
+++ b/web/src/admin/users/UserResetEmailForm.ts
@@ -7,6 +7,8 @@ import { groupBy } from "#common/utils";
 
 import { Form } from "#elements/forms/Form";
 
+import { AKLabel } from "#components/ak-label";
+
 import {
     CoreApi,
     Stage,
@@ -40,12 +42,18 @@ export class UserResetEmailForm extends Form<UserRecoveryEmailRequest> {
     }
 
     protected override renderForm(): TemplateResult {
-        return html`<ak-form-element-horizontal
-                label=${msg("Email stage")}
-                required
-                name="emailStage"
-            >
+        return html`<ak-form-element-horizontal required name="emailStage">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "emailStage",
+                        required: true,
+                    },
+                    msg("Email stage"),
+                )}
                 <ak-search-select
+                    id="emailStage"
                     placeholder=${msg("Select email stage...")}
                     .fetchObjects=${async (query?: string): Promise<Stage[]> => {
                         const args: StagesAllListRequest = {

--- a/web/src/components/ak-multi-select.ts
+++ b/web/src/components/ak-multi-select.ts
@@ -2,6 +2,8 @@ import "#elements/forms/HorizontalFormElement";
 
 import { AKControlElement } from "#elements/ControlElement";
 
+import { AKLabel } from "#components/ak-label";
+
 import { css, html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -118,12 +120,18 @@ export class AkMultiSelect extends AKControlElement {
 
     render() {
         return html` <div class="pf-c-form">
-            <ak-form-element-horizontal
-                label=${this.label}
-                ?required=${this.required}
-                name=${this.name}
-            >
+            <ak-form-element-horizontal ?required=${this.required} name=${this.name}>
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: this.name,
+                        required: this.required,
+                    },
+                    this.label,
+                )}
                 <select
+                    id=${ifDefined(this.name)}
                     part="select"
                     class="pf-c-form-control"
                     name=${ifDefined(this.name)}

--- a/web/src/elements/sync/SyncObjectForm.ts
+++ b/web/src/elements/sync/SyncObjectForm.ts
@@ -7,6 +7,8 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { Form } from "#elements/forms/Form";
 
+import { AKLabel } from "#components/ak-label";
+
 import {
     CoreApi,
     CoreGroupsListRequest,
@@ -58,8 +60,17 @@ export class SyncObjectForm extends Form<SyncObjectRequest> {
     }
 
     renderSelectUser() {
-        return html`<ak-form-element-horizontal label=${msg("User")} name="syncObjectId">
+        return html`<ak-form-element-horizontal name="syncObjectId">
+            ${AKLabel(
+                {
+                    slot: "label",
+                    className: "pf-c-form__group-label",
+                    htmlFor: "syncObjectId",
+                },
+                msg("User"),
+            )}
             <ak-search-select
+                id="syncObjectId"
                 .fetchObjects=${async (query?: string): Promise<User[]> => {
                     const args: CoreUsersListRequest = {
                         ordering: "username",
@@ -85,8 +96,17 @@ export class SyncObjectForm extends Form<SyncObjectRequest> {
     }
 
     renderSelectGroup() {
-        return html` <ak-form-element-horizontal label=${msg("Group")} name="syncObjectId">
+        return html` <ak-form-element-horizontal name="syncObjectId">
+            ${AKLabel(
+                {
+                    slot: "label",
+                    className: "pf-c-form__group-label",
+                    htmlFor: "syncObjectId",
+                },
+                msg("Group"),
+            )}
             <ak-search-select
+                id="syncObjectId"
                 .fetchObjects=${async (query?: string): Promise<Group[]> => {
                     const args: CoreGroupsListRequest = {
                         ordering: "name",
@@ -109,8 +129,16 @@ export class SyncObjectForm extends Form<SyncObjectRequest> {
     }
 
     renderResult(): TemplateResult {
-        return html`<ak-form-element-horizontal label=${msg("Log messages")}>
-            <ak-log-viewer .items=${this.result?.messages}></ak-log-viewer>
+        return html`<ak-form-element-horizontal>
+            ${AKLabel(
+                {
+                    slot: "label",
+                    className: "pf-c-form__group-label",
+                    htmlFor: "sync-log-messages",
+                },
+                msg("Log messages"),
+            )}
+            <ak-log-viewer id="sync-log-messages" .items=${this.result?.messages}></ak-log-viewer>
         </ak-form-element-horizontal> `;
     }
 

--- a/web/src/user/user-settings/mfa/MFADeviceForm.ts
+++ b/web/src/user/user-settings/mfa/MFADeviceForm.ts
@@ -5,6 +5,8 @@ import { SentryIgnoredError } from "#common/sentry/index";
 
 import { ModelForm } from "#elements/forms/ModelForm";
 
+import { AKLabel } from "#components/ak-label";
+
 import { AuthenticatorsApi, Device } from "@goauthentik/api";
 
 import { msg, str } from "@lit/localize";
@@ -75,8 +77,18 @@ export class MFADeviceForm extends ModelForm<Device, string> {
     }
 
     protected override renderForm(): TemplateResult {
-        return html` <ak-form-element-horizontal label=${msg("Name")} required name="name">
+        return html` <ak-form-element-horizontal required name="name">
+            ${AKLabel(
+                {
+                    slot: "label",
+                    className: "pf-c-form__group-label",
+                    htmlFor: "name",
+                    required: true,
+                },
+                msg("Name"),
+            )}
             <input
+                id="name"
                 type="text"
                 value="${ifDefined(this.instance?.name)}"
                 class="pf-c-form-control"

--- a/web/src/user/user-settings/tokens/UserTokenForm.ts
+++ b/web/src/user/user-settings/tokens/UserTokenForm.ts
@@ -71,7 +71,7 @@ export class UserTokenForm extends ModelForm<Token, string> {
             ></ak-text-input>
 
             ${this.intent === IntentEnum.AppPassword
-                ? html`<ak-form-element-horizontal label=${msg("Expiring")} name="expires">
+                ? html`<ak-form-element-horizontal name="expires">
                       ${AKLabel(
                           {
                               slot: "label",


### PR DESCRIPTION
## Summary

First slice of the form-input/label triage from #22389. Mechanical sweep of the deprecated `label="..."` attribute on `<ak-form-element-horizontal>` to the slotted `AKLabel` pattern established by #16119.

- 32 files, ~78 attribute occurrences, long-tail admin areas (brands, groups, users, roles, rbac, flows, events, blueprints, tokens, lifecycle, files, crypto, common, admin-settings, outposts, endpoints) plus user/user-settings, elements/sync, and components/ak-multi-select.
- The deprecated `label` property on `HorizontalFormElement` stays — it's the migration canary tracked in #22389 and gets deleted in the final cleanup slice once every call site is migrated.
- One incidental fix in `user-settings/tokens/UserTokenForm.ts` where a deprecated `label="Expiring"` was overriding the already-slotted `Expires on` AKLabel.

The mechanical pattern:

```diff
- <ak-form-element-horizontal label=${msg("X")} name="N">
-   <control/>
- </…>
+ <ak-form-element-horizontal name="N">
+   ${AKLabel({ slot: "label", className: "pf-c-form__group-label",
+               htmlFor: "N", required: ... }, msg("X"))}
+   <control id="N"/>
+ </…>
```

## Out of scope (deliberately separate slices, see #22389)

- ARIA propagation on the input side (`aria-required`, `aria-describedby`, error wiring) — semantics-focused slice 2.
- Remaining migration buckets: `admin/applications`, `/property-mappings`, `/policies`, `/sources`, `/providers`, `/stages`.
- `ak-*-input` family consolidation, `IDGenerator` centralisation, e2e selector migration, deprecated-prop deletion — all later slices.

## Test plan

- [x] `npm run lint` and `npm run prettier` (precommit hook, exit 0 inside container)
- [x] `tsc --noEmit` against the changed surface (exit 0)
- [ ] Visual smoke against a flow form to confirm label association renders correctly
- [ ] Python `tests/e2e/` selenium suite (uses `name=` selectors — unaffected)
- [ ] Playwright `web/e2e/` suite (already label-based)

## Disclosure

Triaged and authored end-to-end by an agent running in a sandbox against `goauthentik/authentik@main`. Reviewed and shipped by @GirlBossRush.

Refs #22389
