### PR TITLE
web/admin: migrate ak-form-element-horizontal label= to slotted AKLabel (applications + property-mappings)

### DIFF
--- a/web/src/admin/applications/ApplicationCheckAccessForm.ts
+++ b/web/src/admin/applications/ApplicationCheckAccessForm.ts
@@ -11,6 +11,8 @@ import { Form } from "#elements/forms/Form";
 import { SlottedTemplateResult } from "#elements/types";
 import { ifPresent } from "#elements/utils/attributes";
 
+import { AKLabel } from "#components/ak-label";
+
 import {
     Application,
     CoreApi,
@@ -76,8 +78,16 @@ export class ApplicationCheckAccessForm extends Form<{ forUser: number }> {
     protected renderResult(): SlottedTemplateResult {
         const { passing, messages = [], logMessages = [] } = this.result || {};
 
-        return html`<ak-form-element-horizontal label=${msg("Passing")}>
-                <div class="pf-c-form__group-label">
+        return html`<ak-form-element-horizontal>
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "check-access-passing",
+                    },
+                    msg("Passing"),
+                )}
+                <div id="check-access-passing" class="pf-c-form__group-label">
                     <div class="c-form__horizontal-group">
                         <span class="pf-c-form__label-text">
                             <ak-status-label ?good=${ifPresent(passing)}></ak-status-label>
@@ -85,8 +95,16 @@ export class ApplicationCheckAccessForm extends Form<{ forUser: number }> {
                     </div>
                 </div>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal label=${msg("Messages")}>
-                <div class="pf-c-form__group-label">
+            <ak-form-element-horizontal>
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "check-access-messages",
+                    },
+                    msg("Messages"),
+                )}
+                <div id="check-access-messages" class="pf-c-form__group-label">
                     <div class="c-form__horizontal-group">
                         <ul>
                             ${messages.map((m) => {
@@ -98,14 +116,32 @@ export class ApplicationCheckAccessForm extends Form<{ forUser: number }> {
                     </div>
                 </div>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal label=${msg("Log messages")}>
-                <ak-log-viewer .items=${logMessages}></ak-log-viewer>
+            <ak-form-element-horizontal>
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "check-access-log-messages",
+                    },
+                    msg("Log messages"),
+                )}
+                <ak-log-viewer id="check-access-log-messages" .items=${logMessages}></ak-log-viewer>
             </ak-form-element-horizontal>`;
     }
 
     protected override renderForm(): SlottedTemplateResult {
-        return html`<ak-form-element-horizontal label=${msg("User")} required name="forUser">
+        return html`<ak-form-element-horizontal required name="forUser">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "forUser",
+                        required: true,
+                    },
+                    msg("User"),
+                )}
                 <ak-search-select
+                    id="forUser"
                     placeholder=${msg("Select a user...")}
                     .fetchObjects=${async (query?: string): Promise<User[]> => {
                         const args: CoreUsersListRequest = {

--- a/web/src/admin/applications/components/ak-backchannel-input.ts
+++ b/web/src/admin/applications/components/ak-backchannel-input.ts
@@ -9,6 +9,8 @@ import { renderModal } from "#elements/dialogs";
 import { AKFormSubmitEvent } from "#elements/forms/Form";
 import { SlottedTemplateResult } from "#elements/types";
 
+import { AKLabel } from "#components/ak-label";
+
 import { Provider } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
@@ -88,8 +90,16 @@ export class AkBackchannelProvidersInput extends AKElement {
             >`;
 
         return html`
-            <ak-form-element-horizontal label=${this.label} name=${this.name}>
-                <div class="pf-c-input-group">
+            <ak-form-element-horizontal name=${this.name}>
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: this.name,
+                    },
+                    this.label,
+                )}
+                <div id=${this.name} class="pf-c-input-group">
                     <button
                         class="pf-c-button pf-m-control"
                         type="button"

--- a/web/src/admin/applications/entitlements/ApplicationEntitlementForm.ts
+++ b/web/src/admin/applications/entitlements/ApplicationEntitlementForm.ts
@@ -7,6 +7,8 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { ModelForm } from "#elements/forms/ModelForm";
 
+import { AKLabel } from "#components/ak-label";
+
 import { ApplicationEntitlement, CoreApi } from "@goauthentik/api";
 
 import YAML from "yaml";
@@ -53,16 +55,35 @@ export class ApplicationEntitlementForm extends ModelForm<ApplicationEntitlement
     }
 
     protected override renderForm(): TemplateResult {
-        return html` <ak-form-element-horizontal label=${msg("Name")} required name="name">
+        return html` <ak-form-element-horizontal required name="name">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "name",
+                        required: true,
+                    },
+                    msg("Name"),
+                )}
                 <input
+                    id="name"
                     type="text"
                     value="${this.instance?.name ?? ""}"
                     class="pf-c-form-control"
                     required
                 />
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal label=${msg("Attributes")} name="attributes">
+            <ak-form-element-horizontal name="attributes">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "attributes",
+                    },
+                    msg("Attributes"),
+                )}
                 <ak-codemirror
+                    id="attributes"
                     mode="yaml"
                     value="${YAML.stringify(this.instance?.attributes ?? {})}"
                 >

--- a/web/src/admin/applications/wizard/steps/ak-application-wizard-edit-binding-step.ts
+++ b/web/src/admin/applications/wizard/steps/ak-application-wizard-edit-binding-step.ts
@@ -20,6 +20,7 @@ import { ISearchSelectConfig } from "#elements/forms/SearchSelect/ak-search-sele
 import { type SearchSelectBase } from "#elements/forms/SearchSelect/SearchSelect";
 import { withQuery } from "#elements/forms/SearchSelect/utils";
 
+import { AKLabel } from "#components/ak-label";
 import { type NavigableButton, type WizardButton } from "#components/ak-wizard/shared";
 
 import { ApplicationWizardStep } from "#admin/applications/wizard/ApplicationWizardStep";
@@ -157,8 +158,17 @@ export class ApplicationWizardEditBindingStep extends ApplicationWizardStep<Poli
             return nothing;
         }
 
-        return html`<ak-form-element-horizontal label=${title} name=${policyKind}>
+        return html`<ak-form-element-horizontal name=${policyKind}>
+            ${AKLabel(
+                {
+                    slot: "label",
+                    className: "pf-c-form__group-label",
+                    htmlFor: policyKind,
+                },
+                title,
+            )}
             <ak-search-select-ez
+                id=${policyKind}
                 .config=${this.searchSelectConfigs(policyKind)}
                 class="policy-search-select"
                 blankable

--- a/web/src/admin/applications/wizard/steps/providers/ak-application-wizard-provider-for-rac.ts
+++ b/web/src/admin/applications/wizard/steps/providers/ak-application-wizard-provider-for-rac.ts
@@ -4,6 +4,8 @@ import "#components/ak-text-input";
 import "#elements/CodeMirror";
 import "#elements/ak-dual-select/ak-dual-select-dynamic-selected-provider";
 
+import { AKLabel } from "#components/ak-label";
+
 import { ApplicationWizardProviderForm } from "#admin/applications/wizard/steps/providers/ApplicationWizardProviderForm";
 import {
     propertyMappingsProvider,
@@ -32,12 +34,18 @@ export class ApplicationWizardRACProviderForm extends ApplicationWizardProviderF
                     required
                 ></ak-text-input>
 
-                <ak-form-element-horizontal
-                    name="authorizationFlow"
-                    label=${msg("Authorization Flow")}
-                    required
-                >
+                <ak-form-element-horizontal name="authorizationFlow" required>
+                    ${AKLabel(
+                        {
+                            slot: "label",
+                            className: "pf-c-form__group-label",
+                            htmlFor: "authorizationFlow",
+                            required: true,
+                        },
+                        msg("Authorization Flow"),
+                    )}
                     <ak-flow-search
+                        id="authorizationFlow"
                         flowType=${FlowDesignationEnum.Authorization}
                         .currentFlow=${provider.authorizationFlow}
                         required
@@ -60,11 +68,17 @@ export class ApplicationWizardRACProviderForm extends ApplicationWizardProviderF
 
                 <ak-form-group open label="${msg("Protocol settings")}">
                     <div class="pf-c-form">
-                        <ak-form-element-horizontal
-                            label=${msg("Property mappings")}
-                            name="propertyMappings"
-                        >
+                        <ak-form-element-horizontal name="propertyMappings">
+                            ${AKLabel(
+                                {
+                                    slot: "label",
+                                    className: "pf-c-form__group-label",
+                                    htmlFor: "propertyMappings",
+                                },
+                                msg("Property mappings"),
+                            )}
                             <ak-dual-select-dynamic-selected
+                                id="propertyMappings"
                                 .provider=${propertyMappingsProvider}
                                 .selector=${propertyMappingsSelector(provider?.propertyMappings)}
                                 available-label="${msg("Available Property Mappings")}"

--- a/web/src/admin/property-mappings/BasePropertyMappingForm.ts
+++ b/web/src/admin/property-mappings/BasePropertyMappingForm.ts
@@ -6,6 +6,8 @@ import { docLink } from "#common/global";
 import { ModelForm } from "#elements/forms/ModelForm";
 import { SlottedTemplateResult } from "#elements/types";
 
+import { AKLabel } from "#components/ak-label";
+
 import { msg } from "@lit/localize";
 import { html, nothing, TemplateResult } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -45,8 +47,21 @@ export abstract class BasePropertyMappingForm<T extends PropertyMapping> extends
             >
             </ak-text-input>
             ${this.renderExtraFields()}
-            <ak-form-element-horizontal label=${msg("Expression")} required name="expression">
-                <ak-codemirror mode="python" value="${ifDefined(this.instance?.expression)}">
+            <ak-form-element-horizontal required name="expression">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "expression",
+                        required: true,
+                    },
+                    msg("Expression"),
+                )}
+                <ak-codemirror
+                    id="expression"
+                    mode="python"
+                    value="${ifDefined(this.instance?.expression)}"
+                >
                 </ak-codemirror>
                 <p class="pf-c-form__helper-text">
                     ${msg("Expression using Python.")}

--- a/web/src/admin/property-mappings/PropertyMappingProviderRACForm.ts
+++ b/web/src/admin/property-mappings/PropertyMappingProviderRACForm.ts
@@ -8,6 +8,8 @@ import { docLink } from "#common/global";
 
 import type { RadioOption } from "#elements/forms/Radio";
 
+import { AKLabel } from "#components/ak-label";
+
 import { BasePropertyMappingForm } from "#admin/property-mappings/BasePropertyMappingForm";
 
 import { PropertymappingsApi, RACPropertyMapping } from "@goauthentik/api";
@@ -56,8 +58,18 @@ export class PropertyMappingProviderRACForm extends BasePropertyMappingForm<RACP
 
     protected override renderForm(): TemplateResult {
         return html`
-            <ak-form-element-horizontal label=${msg("Name")} required name="name">
+            <ak-form-element-horizontal required name="name">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "name",
+                        required: true,
+                    },
+                    msg("Name"),
+                )}
                 <input
+                    id="name"
                     type="text"
                     value="${ifDefined(this.instance?.name)}"
                     class="pf-c-form-control"
@@ -66,21 +78,33 @@ export class PropertyMappingProviderRACForm extends BasePropertyMappingForm<RACP
             </ak-form-element-horizontal>
             <ak-form-group open label="${msg("General settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("Username")}
-                        name="staticSettings.username"
-                    >
+                    <ak-form-element-horizontal name="staticSettings.username">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "staticSettings.username",
+                            },
+                            msg("Username"),
+                        )}
                         <input
+                            id="staticSettings.username"
                             type="text"
                             value="${ifDefined(this.instance?.staticSettings.username)}"
                             class="pf-c-form-control"
                         />
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Password")}
-                        name="staticSettings.password"
-                    >
+                    <ak-form-element-horizontal name="staticSettings.password">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "staticSettings.password",
+                            },
+                            msg("Password"),
+                        )}
                         <input
+                            id="staticSettings.password"
                             type="password"
                             value="${ifDefined(this.instance?.staticSettings.password)}"
                             class="pf-c-form-control"
@@ -90,41 +114,65 @@ export class PropertyMappingProviderRACForm extends BasePropertyMappingForm<RACP
             </ak-form-group>
             <ak-form-group label="${msg("RDP settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("Ignore server certificate")}
-                        name="staticSettings.ignore-cert"
-                    >
+                    <ak-form-element-horizontal name="staticSettings.ignore-cert">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "staticSettings.ignore-cert",
+                            },
+                            msg("Ignore server certificate"),
+                        )}
                         <ak-radio
+                            id="staticSettings.ignore-cert"
                             .options=${staticSettingOptions}
                             .value=${this.instance?.staticSettings["ignore-cert"]}
                         >
                         </ak-radio>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Enable wallpaper")}
-                        name="staticSettings.enable-wallpaper"
-                    >
+                    <ak-form-element-horizontal name="staticSettings.enable-wallpaper">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "staticSettings.enable-wallpaper",
+                            },
+                            msg("Enable wallpaper"),
+                        )}
                         <ak-radio
+                            id="staticSettings.enable-wallpaper"
                             .options=${staticSettingOptions}
                             .value=${this.instance?.staticSettings["enable-wallpaper"]}
                         >
                         </ak-radio>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Enable font-smoothing")}
-                        name="staticSettings.enable-font-smoothing"
-                    >
+                    <ak-form-element-horizontal name="staticSettings.enable-font-smoothing">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "staticSettings.enable-font-smoothing",
+                            },
+                            msg("Enable font-smoothing"),
+                        )}
                         <ak-radio
+                            id="staticSettings.enable-font-smoothing"
                             .options=${staticSettingOptions}
                             .value=${this.instance?.staticSettings["enable-font-smoothing"]}
                         >
                         </ak-radio>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Enable full window dragging")}
-                        name="staticSettings.enable-full-window-drag"
-                    >
+                    <ak-form-element-horizontal name="staticSettings.enable-full-window-drag">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "staticSettings.enable-full-window-drag",
+                            },
+                            msg("Enable full window dragging"),
+                        )}
                         <ak-radio
+                            id="staticSettings.enable-full-window-drag"
                             .options=${staticSettingOptions}
                             .value=${this.instance?.staticSettings["enable-full-window-drag"]}
                         >
@@ -134,8 +182,17 @@ export class PropertyMappingProviderRACForm extends BasePropertyMappingForm<RACP
             </ak-form-group>
             <ak-form-group label="${msg("Advanced settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal label=${msg("Expression")} name="expression">
+                    <ak-form-element-horizontal name="expression">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "expression",
+                            },
+                            msg("Expression"),
+                        )}
                         <ak-codemirror
+                            id="expression"
                             mode="python"
                             value="${ifDefined(this.instance?.expression)}"
                         >

--- a/web/src/admin/property-mappings/PropertyMappingProviderSAMLForm.ts
+++ b/web/src/admin/property-mappings/PropertyMappingProviderSAMLForm.ts
@@ -3,6 +3,8 @@ import "#elements/forms/HorizontalFormElement";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
 
+import { AKLabel } from "#components/ak-label";
+
 import { BasePropertyMappingForm } from "#admin/property-mappings/BasePropertyMappingForm";
 
 import { PropertymappingsApi, SAMLPropertyMapping } from "@goauthentik/api";
@@ -33,12 +35,18 @@ export class PropertyMappingProviderSAMLForm extends BasePropertyMappingForm<SAM
     }
 
     renderExtraFields(): TemplateResult {
-        return html` <ak-form-element-horizontal
-                label=${msg("SAML Attribute Name")}
-                required
-                name="samlName"
-            >
+        return html` <ak-form-element-horizontal required name="samlName">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "samlName",
+                        required: true,
+                    },
+                    msg("SAML Attribute Name"),
+                )}
                 <input
+                    id="samlName"
                     type="text"
                     value="${ifDefined(this.instance?.samlName)}"
                     class="pf-c-form-control"
@@ -50,8 +58,17 @@ export class PropertyMappingProviderSAMLForm extends BasePropertyMappingForm<SAM
                     )}
                 </p>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal label=${msg("Friendly Name")} name="friendlyName">
+            <ak-form-element-horizontal name="friendlyName">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "friendlyName",
+                    },
+                    msg("Friendly Name"),
+                )}
                 <input
+                    id="friendlyName"
                     type="text"
                     value="${ifDefined(this.instance?.friendlyName || "")}"
                     class="pf-c-form-control"

--- a/web/src/admin/property-mappings/PropertyMappingProviderScopeForm.ts
+++ b/web/src/admin/property-mappings/PropertyMappingProviderScopeForm.ts
@@ -3,6 +3,8 @@ import "#elements/forms/HorizontalFormElement";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
 
+import { AKLabel } from "#components/ak-label";
+
 import { BasePropertyMappingForm } from "#admin/property-mappings/BasePropertyMappingForm";
 
 import { PropertymappingsApi, ScopeMapping } from "@goauthentik/api";
@@ -33,12 +35,18 @@ export class PropertyMappingProviderScopeForm extends BasePropertyMappingForm<Sc
     }
 
     renderExtraFields(): TemplateResult {
-        return html` <ak-form-element-horizontal
-                label=${msg("Scope name")}
-                required
-                name="scopeName"
-            >
+        return html` <ak-form-element-horizontal required name="scopeName">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "scopeName",
+                        required: true,
+                    },
+                    msg("Scope name"),
+                )}
                 <input
+                    id="scopeName"
                     type="text"
                     value="${ifDefined(this.instance?.scopeName)}"
                     class="pf-c-form-control"
@@ -48,8 +56,17 @@ export class PropertyMappingProviderScopeForm extends BasePropertyMappingForm<Sc
                     ${msg("Scope which the client can specify to access these properties.")}
                 </p>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal label=${msg("Description")} name="description">
+            <ak-form-element-horizontal name="description">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "description",
+                    },
+                    msg("Description"),
+                )}
                 <input
+                    id="description"
                     type="text"
                     value="${ifDefined(this.instance?.description)}"
                     class="pf-c-form-control"

--- a/web/src/admin/property-mappings/PropertyMappingTestForm.ts
+++ b/web/src/admin/property-mappings/PropertyMappingTestForm.ts
@@ -178,8 +178,17 @@ export class PropertyMappingTestForm extends Form<PropertyMappingTestRequest> {
     }
 
     protected override renderForm(): SlottedTemplateResult {
-        return html`<ak-form-element-horizontal label=${msg("User")} name="user">
+        return html`<ak-form-element-horizontal name="user">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "user",
+                    },
+                    msg("User"),
+                )}
                 <ak-search-select
+                    id="user"
                     placeholder=${msg("Select a user...")}
                     blankable
                     .fetchObjects=${async (query?: string): Promise<User[]> => {
@@ -207,8 +216,17 @@ export class PropertyMappingTestForm extends Form<PropertyMappingTestRequest> {
                 >
                 </ak-search-select>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal label=${msg("Group")} name="group">
+            <ak-form-element-horizontal name="group">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "group",
+                    },
+                    msg("Group"),
+                )}
                 <ak-search-select
+                    id="group"
                     placeholder=${msg("Select a group...")}
                     blankable
                     .fetchObjects=${async (query?: string): Promise<Group[]> => {


### PR DESCRIPTION
## Summary

Slice 1b of the form-input/label triage from #22389 (follows #22390). Mechanical sweep of the deprecated `label="..."` attribute on `<ak-form-element-horizontal>` across `web/src/admin/applications/` and `web/src/admin/property-mappings/`.

- 10 files, 25 attribute occurrences.
- Same mechanical pattern as #22390: drop `label="X"`, add slotted `${AKLabel({ slot: "label", htmlFor: "name" }, msg("X"))}` child, set `id="name"` on the inner control.
- `BasePropertyMappingForm` is a base class — its migration cascades to the SAML / Scope / RAC variants.
- One id-naming detail: dot-separated names like `staticSettings.ignore-cert` are kept verbatim as id values (valid HTML5; no transformation that would diverge from the `name`).

## Out of scope (other slices, see #22389)

Same exclusions as #22390 — ARIA propagation on the input side, remaining migration buckets (`admin/policies`, `/sources`, `/providers`, `/stages`), `ak-*-input` family consolidation, ID-generator centralisation, e2e selector migration, deprecated-prop deletion.

## Test plan

- [x] `tsc --noEmit` (exit 0)
- [x] precommit (lint + prettier, exit 0)
- [x] `make web-build` (exit 0; verified the new `htmlFor` values appear in the rebuilt bundle)
- [ ] Python `tests/e2e/` selenium — unaffected (selectors use `name=`, which is preserved)
- [ ] Playwright `web/e2e/` — already label-based

## Disclosure

Triaged and authored end-to-end by an agent running in a sandbox against `goauthentik/authentik@main`. Reviewed and shipped by @GirlBossRush.

Refs #22389
