### PR TITLE
web/admin/policies: migrate ak-form-element-horizontal label= to slotted AKLabel

### DIFF
--- a/web/src/admin/policies/PolicyBindingForm.ts
+++ b/web/src/admin/policies/PolicyBindingForm.ts
@@ -14,6 +14,8 @@ import { groupBy } from "#common/utils";
 
 import { ModelForm } from "#elements/forms/ModelForm";
 
+import { AKLabel } from "#components/ak-label";
+
 import {
     CoreApi,
     CoreGroupsListRequest,
@@ -163,11 +165,19 @@ export class PolicyBindingForm<T extends PolicyBinding = PolicyBinding> extends 
 
     protected renderTarget() {
         return html`<ak-form-element-horizontal
-                label=${msg("Policy")}
                 name="policy"
                 ?hidden=${this.policyGroupUser !== PolicyBindingCheckTarget.Policy}
             >
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "policy",
+                    },
+                    msg("Policy"),
+                )}
                 <ak-search-select
+                    id="policy"
                     .groupBy=${(items: Policy[]) => {
                         return groupBy(items, (policy) => policy.verboseNamePlural);
                     }}
@@ -196,11 +206,19 @@ export class PolicyBindingForm<T extends PolicyBinding = PolicyBinding> extends 
                     })}
             </ak-form-element-horizontal>
             <ak-form-element-horizontal
-                label=${msg("Group")}
                 name="group"
                 ?hidden=${this.policyGroupUser !== PolicyBindingCheckTarget.Group}
             >
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "group",
+                    },
+                    msg("Group"),
+                )}
                 <ak-search-select
+                    id="group"
                     .fetchObjects=${async (query?: string): Promise<Group[]> => {
                         const args: CoreGroupsListRequest = {
                             ordering: "name",
@@ -227,11 +245,19 @@ export class PolicyBindingForm<T extends PolicyBinding = PolicyBinding> extends 
                     })}
             </ak-form-element-horizontal>
             <ak-form-element-horizontal
-                label=${msg("User")}
                 name="user"
                 ?hidden=${this.policyGroupUser !== PolicyBindingCheckTarget.User}
             >
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "user",
+                    },
+                    msg("User"),
+                )}
                 <ak-search-select
+                    id="user"
                     .fetchObjects=${async (query?: string): Promise<User[]> => {
                         const args: CoreUsersListRequest = {
                             ordering: "username",
@@ -277,28 +303,57 @@ export class PolicyBindingForm<T extends PolicyBinding = PolicyBinding> extends 
                 help=${msg("Negates the outcome of the binding. Messages are unaffected.")}
             >
             </ak-switch-input>
-            <ak-form-element-horizontal label=${msg("Order")} required name="order">
+            <ak-form-element-horizontal required name="order">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "order",
+                        required: true,
+                    },
+                    msg("Order"),
+                )}
                 <input
+                    id="order"
                     type="number"
                     value="${this.instance?.order ?? this.defaultOrder}"
                     class="pf-c-form-control"
                     required
                 />
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal label=${msg("Timeout")} required name="timeout">
+            <ak-form-element-horizontal required name="timeout">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "timeout",
+                        required: true,
+                    },
+                    msg("Timeout"),
+                )}
                 <input
+                    id="timeout"
                     type="number"
                     value="${this.instance?.timeout ?? 30}"
                     class="pf-c-form-control"
                     required
                 />
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal
-                name="failureResult"
-                label=${msg("Failure Result")}
-                required
-            >
-                <ak-radio .options=${createPassFailOptions} .value=${this.instance?.failureResult}>
+            <ak-form-element-horizontal name="failureResult" required>
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "failureResult",
+                        required: true,
+                    },
+                    msg("Failure Result"),
+                )}
+                <ak-radio
+                    id="failureResult"
+                    .options=${createPassFailOptions}
+                    .value=${this.instance?.failureResult}
+                >
                 </ak-radio>
                 <p class="pf-c-form__helper-text">
                     ${msg("Result used when policy execution fails.")}

--- a/web/src/admin/policies/PolicyTestForm.ts
+++ b/web/src/admin/policies/PolicyTestForm.ts
@@ -95,8 +95,16 @@ export class PolicyTestForm extends Form<PolicyTestRequest> {
     }
 
     protected renderResult(): SlottedTemplateResult {
-        return html`<ak-form-element-horizontal label=${msg("Passing")}>
-                <div class="pf-c-form__group-label">
+        return html`<ak-form-element-horizontal>
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "policy-test-passing",
+                    },
+                    msg("Passing"),
+                )}
+                <div id="policy-test-passing" class="pf-c-form__group-label">
                     <div class="c-form__horizontal-group">
                         <span class="pf-c-form__label-text">
                             <ak-status-label ?good=${this.result?.passing}></ak-status-label>
@@ -104,8 +112,16 @@ export class PolicyTestForm extends Form<PolicyTestRequest> {
                     </div>
                 </div>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal label=${msg("Messages")}>
-                <div class="pf-c-form__group-label">
+            <ak-form-element-horizontal>
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "policy-test-messages",
+                    },
+                    msg("Messages"),
+                )}
+                <div id="policy-test-messages" class="pf-c-form__group-label">
                     <div class="c-form__horizontal-group">
                         <ul>
                             ${(this.result?.messages || []).length > 0
@@ -122,14 +138,35 @@ export class PolicyTestForm extends Form<PolicyTestRequest> {
                 </div>
             </ak-form-element-horizontal>
 
-            <ak-form-element-horizontal label=${msg("Log messages")}>
-                <ak-log-viewer .items=${this.result?.logMessages}></ak-log-viewer>
+            <ak-form-element-horizontal>
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "policy-test-log-messages",
+                    },
+                    msg("Log messages"),
+                )}
+                <ak-log-viewer
+                    id="policy-test-log-messages"
+                    .items=${this.result?.logMessages}
+                ></ak-log-viewer>
             </ak-form-element-horizontal>`;
     }
 
     protected override renderForm(): SlottedTemplateResult {
-        return html`<ak-form-element-horizontal label=${msg("User")} required name="user">
+        return html`<ak-form-element-horizontal required name="user">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "user",
+                        required: true,
+                    },
+                    msg("User"),
+                )}
                 <ak-search-select
+                    id="user"
                     placeholder=${msg("Select a user...")}
                     .fetchObjects=${async (query?: string): Promise<User[]> => {
                         const args: CoreUsersListRequest = {

--- a/web/src/admin/policies/dummy/DummyPolicyForm.ts
+++ b/web/src/admin/policies/dummy/DummyPolicyForm.ts
@@ -5,6 +5,8 @@ import "#elements/forms/HorizontalFormElement";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
 
+import { AKLabel } from "#components/ak-label";
+
 import { BasePolicyForm } from "#admin/policies/BasePolicyForm";
 
 import { DummyPolicy, PoliciesApi } from "@goauthentik/api";
@@ -67,8 +69,18 @@ export class DummyPolicyForm extends BasePolicyForm<DummyPolicy> {
                         ?checked=${this.instance?.result ?? false}
                     >
                     </ak-switch-input>
-                    <ak-form-element-horizontal label=${msg("Wait (min)")} required name="waitMin">
+                    <ak-form-element-horizontal required name="waitMin">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "waitMin",
+                                required: true,
+                            },
+                            msg("Wait (min)"),
+                        )}
                         <input
+                            id="waitMin"
                             type="number"
                             value="${this.instance?.waitMin ?? 1}"
                             class="pf-c-form-control"
@@ -80,8 +92,18 @@ export class DummyPolicyForm extends BasePolicyForm<DummyPolicy> {
                             )}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal label=${msg("Wait (max)")} required name="waitMax">
+                    <ak-form-element-horizontal required name="waitMax">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "waitMax",
+                                required: true,
+                            },
+                            msg("Wait (max)"),
+                        )}
                         <input
+                            id="waitMax"
                             type="number"
                             value="${this.instance?.waitMax ?? 5}"
                             class="pf-c-form-control"

--- a/web/src/admin/policies/event_matcher/EventMatcherPolicyForm.ts
+++ b/web/src/admin/policies/event_matcher/EventMatcherPolicyForm.ts
@@ -6,6 +6,8 @@ import "#elements/forms/SearchSelect/index";
 import { DEFAULT_CONFIG } from "#common/api/config";
 import { docLink } from "#common/global";
 
+import { AKLabel } from "#components/ak-label";
+
 import { BasePolicyForm } from "#admin/policies/BasePolicyForm";
 
 import {
@@ -53,8 +55,18 @@ export class EventMatcherPolicyForm extends BasePolicyForm<EventMatcherPolicy> {
                     "Matches an event against a set of criteria. If any of the configured values match, the policy passes.",
                 )}
             </span>
-            <ak-form-element-horizontal label=${msg("Name")} required name="name">
+            <ak-form-element-horizontal required name="name">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "name",
+                        required: true,
+                    },
+                    msg("Name"),
+                )}
                 <input
+                    id="name"
                     type="text"
                     value="${ifDefined(this.instance?.name || "")}"
                     class="pf-c-form-control"
@@ -72,8 +84,17 @@ export class EventMatcherPolicyForm extends BasePolicyForm<EventMatcherPolicy> {
             </ak-switch-input>
             <ak-form-group open label="${msg("Policy-specific settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal label=${msg("Query")} name="query">
+                    <ak-form-element-horizontal name="query">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "query",
+                            },
+                            msg("Query"),
+                        )}
                         <input
+                            id="query"
                             type="text"
                             value="${ifDefined(this.instance?.query || "")}"
                             class="pf-c-form-control pf-m-monospace"
@@ -91,8 +112,17 @@ export class EventMatcherPolicyForm extends BasePolicyForm<EventMatcherPolicy> {
                             </a>
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal label=${msg("Action")} name="action">
+                    <ak-form-element-horizontal name="action">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "action",
+                            },
+                            msg("Action"),
+                        )}
                         <ak-search-select
+                            id="action"
                             .fetchObjects=${async (query?: string): Promise<TypeCreate[]> => {
                                 const items = await new EventsApi(
                                     DEFAULT_CONFIG,
@@ -121,8 +151,17 @@ export class EventMatcherPolicyForm extends BasePolicyForm<EventMatcherPolicy> {
                             )}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal label=${msg("Client IP")} name="clientIp">
+                    <ak-form-element-horizontal name="clientIp">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "clientIp",
+                            },
+                            msg("Client IP"),
+                        )}
                         <input
+                            id="clientIp"
                             type="text"
                             value="${ifDefined(this.instance?.clientIp || "")}"
                             class="pf-c-form-control pf-m-monospace"
@@ -135,8 +174,17 @@ export class EventMatcherPolicyForm extends BasePolicyForm<EventMatcherPolicy> {
                             )}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal label=${msg("App")} name="app">
+                    <ak-form-element-horizontal name="app">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "app",
+                            },
+                            msg("App"),
+                        )}
                         <ak-search-select
+                            id="app"
                             .fetchObjects=${async (query?: string): Promise<App[]> => {
                                 const items = await new AdminApi(DEFAULT_CONFIG).adminAppsList();
                                 return items.filter((item) =>
@@ -161,8 +209,17 @@ export class EventMatcherPolicyForm extends BasePolicyForm<EventMatcherPolicy> {
                             )}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal label=${msg("Model")} name="model">
+                    <ak-form-element-horizontal name="model">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "model",
+                            },
+                            msg("Model"),
+                        )}
                         <ak-search-select
+                            id="model"
                             .fetchObjects=${async (query?: string): Promise<App[]> => {
                                 const items = await new AdminApi(DEFAULT_CONFIG).adminModelsList();
                                 return items

--- a/web/src/admin/policies/expiry/ExpiryPolicyForm.ts
+++ b/web/src/admin/policies/expiry/ExpiryPolicyForm.ts
@@ -4,6 +4,8 @@ import "#elements/forms/HorizontalFormElement";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
 
+import { AKLabel } from "#components/ak-label";
+
 import { BasePolicyForm } from "#admin/policies/BasePolicyForm";
 
 import { PasswordExpiryPolicy, PoliciesApi } from "@goauthentik/api";
@@ -39,8 +41,18 @@ export class PasswordExpiryPolicyForm extends BasePolicyForm<PasswordExpiryPolic
                     "Checks if the request's user's password has been changed in the last x days, and denys based on settings.",
                 )}
             </span>
-            <ak-form-element-horizontal label=${msg("Name")} required name="name">
+            <ak-form-element-horizontal required name="name">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "name",
+                        required: true,
+                    },
+                    msg("Name"),
+                )}
                 <input
+                    id="name"
                     type="text"
                     value="${ifDefined(this.instance?.name || "")}"
                     class="pf-c-form-control"
@@ -58,12 +70,18 @@ export class PasswordExpiryPolicyForm extends BasePolicyForm<PasswordExpiryPolic
             </ak-switch-input>
             <ak-form-group open label="${msg("Policy-specific settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("Maximum age (in days)")}
-                        required
-                        name="days"
-                    >
+                    <ak-form-element-horizontal required name="days">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "days",
+                                required: true,
+                            },
+                            msg("Maximum age (in days)"),
+                        )}
                         <input
+                            id="days"
                             type="number"
                             value="${ifDefined(this.instance?.days || "")}"
                             class="pf-c-form-control"

--- a/web/src/admin/policies/expression/ExpressionPolicyForm.ts
+++ b/web/src/admin/policies/expression/ExpressionPolicyForm.ts
@@ -6,6 +6,8 @@ import "#elements/forms/HorizontalFormElement";
 import { DEFAULT_CONFIG } from "#common/api/config";
 import { docLink } from "#common/global";
 
+import { AKLabel } from "#components/ak-label";
+
 import { BasePolicyForm } from "#admin/policies/BasePolicyForm";
 
 import { ExpressionPolicy, PoliciesApi } from "@goauthentik/api";
@@ -41,8 +43,18 @@ export class ExpressionPolicyForm extends BasePolicyForm<ExpressionPolicy> {
                     "Executes the python snippet to determine whether to allow or deny a request.",
                 )}
             </span>
-            <ak-form-element-horizontal label=${msg("Name")} required name="name">
+            <ak-form-element-horizontal required name="name">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "name",
+                        required: true,
+                    },
+                    msg("Name"),
+                )}
                 <input
+                    id="name"
                     type="text"
                     value="${ifDefined(this.instance?.name || "")}"
                     class="pf-c-form-control"
@@ -60,12 +72,18 @@ export class ExpressionPolicyForm extends BasePolicyForm<ExpressionPolicy> {
             </ak-switch-input>
             <ak-form-group open label="${msg("Policy-specific settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("Expression")}
-                        required
-                        name="expression"
-                    >
+                    <ak-form-element-horizontal required name="expression">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "expression",
+                                required: true,
+                            },
+                            msg("Expression"),
+                        )}
                         <ak-codemirror
+                            id="expression"
                             mode="python"
                             value="${ifDefined(this.instance?.expression)}"
                         >

--- a/web/src/admin/policies/geoip/GeoIPPolicyForm.ts
+++ b/web/src/admin/policies/geoip/GeoIPPolicyForm.ts
@@ -10,6 +10,8 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { DataProvision, DualSelectPair } from "#elements/ak-dual-select/types";
 
+import { AKLabel } from "#components/ak-label";
+
 import { BasePolicyForm } from "#admin/policies/BasePolicyForm";
 
 import { GeoIPPolicy, GeoIPPolicyCountriesObjInner, PoliciesApi } from "@goauthentik/api";
@@ -54,8 +56,18 @@ export class GeoIPPolicyForm extends BasePolicyForm<GeoIPPolicy> {
                     "Ensure the user satisfies requirements of geography or network topology, based on IP address. If any of the configured values match, the policy passes.",
                 )}
             </span>
-            <ak-form-element-horizontal label=${msg("Name")} required name="name">
+            <ak-form-element-horizontal required name="name">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "name",
+                        required: true,
+                    },
+                    msg("Name"),
+                )}
                 <input
+                    id="name"
                     type="text"
                     value="${this.instance?.name ?? ""}"
                     class="pf-c-form-control"
@@ -82,11 +94,17 @@ export class GeoIPPolicyForm extends BasePolicyForm<GeoIPPolicy> {
                         )}
                     >
                     </ak-switch-input>
-                    <ak-form-element-horizontal
-                        label=${msg("Maximum distance")}
-                        name="historyMaxDistanceKm"
-                    >
+                    <ak-form-element-horizontal name="historyMaxDistanceKm">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "historyMaxDistanceKm",
+                            },
+                            msg("Maximum distance"),
+                        )}
                         <input
+                            id="historyMaxDistanceKm"
                             type="number"
                             min="1"
                             value="${this.instance?.historyMaxDistanceKm ?? 100}"
@@ -98,11 +116,17 @@ export class GeoIPPolicyForm extends BasePolicyForm<GeoIPPolicy> {
                             )}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Distance tolerance")}
-                        name="distanceToleranceKm"
-                    >
+                    <ak-form-element-horizontal name="distanceToleranceKm">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "distanceToleranceKm",
+                            },
+                            msg("Distance tolerance"),
+                        )}
                         <input
+                            id="distanceToleranceKm"
                             type="number"
                             min="1"
                             value="${this.instance?.distanceToleranceKm ?? 50}"
@@ -112,11 +136,17 @@ export class GeoIPPolicyForm extends BasePolicyForm<GeoIPPolicy> {
                             ${msg("Tolerance in checking for distances in kilometers.")}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Historical Login Count")}
-                        name="historyLoginCount"
-                    >
+                    <ak-form-element-horizontal name="historyLoginCount">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "historyLoginCount",
+                            },
+                            msg("Historical Login Count"),
+                        )}
                         <input
+                            id="historyLoginCount"
                             type="number"
                             min="1"
                             value="${this.instance?.historyLoginCount ?? 5}"
@@ -135,11 +165,17 @@ export class GeoIPPolicyForm extends BasePolicyForm<GeoIPPolicy> {
                         )}
                     >
                     </ak-switch-input>
-                    <ak-form-element-horizontal
-                        label=${msg("Impossible travel tolerance")}
-                        name="impossibleToleranceKm"
-                    >
+                    <ak-form-element-horizontal name="impossibleToleranceKm">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "impossibleToleranceKm",
+                            },
+                            msg("Impossible travel tolerance"),
+                        )}
                         <input
+                            id="impossibleToleranceKm"
                             type="number"
                             min="1"
                             value="${this.instance?.impossibleToleranceKm ?? 50}"
@@ -153,8 +189,17 @@ export class GeoIPPolicyForm extends BasePolicyForm<GeoIPPolicy> {
             </ak-form-group>
             <ak-form-group label="${msg("Static rule settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal label=${msg("ASNs")} name="asns">
+                    <ak-form-element-horizontal name="asns">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "asns",
+                            },
+                            msg("ASNs"),
+                        )}
                         <input
+                            id="asns"
                             type="text"
                             value="${this.instance?.asns?.join(",") ?? ""}"
                             class="pf-c-form-control pf-m-monospace"
@@ -167,8 +212,17 @@ export class GeoIPPolicyForm extends BasePolicyForm<GeoIPPolicy> {
                             )}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal label=${msg("Countries")} name="countries">
+                    <ak-form-element-horizontal name="countries">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "countries",
+                            },
+                            msg("Countries"),
+                        )}
                         <ak-dual-select-provider
+                            id="countries"
                             .provider=${(page: number, search?: string): Promise<DataProvision> => {
                                 return countryCache
                                     .getCountries()

--- a/web/src/admin/policies/password/PasswordPolicyForm.ts
+++ b/web/src/admin/policies/password/PasswordPolicyForm.ts
@@ -4,6 +4,8 @@ import "#elements/forms/HorizontalFormElement";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
 
+import { AKLabel } from "#components/ak-label";
+
 import { BasePolicyForm } from "#admin/policies/BasePolicyForm";
 
 import { PasswordPolicy, PoliciesApi } from "@goauthentik/api";
@@ -57,84 +59,126 @@ export class PasswordPolicyForm extends BasePolicyForm<PasswordPolicy> {
     renderStaticRules(): TemplateResult {
         return html` <ak-form-group label="${msg("Static rules")}">
             <div class="pf-c-form">
-                <ak-form-element-horizontal
-                    label=${msg("Minimum length")}
-                    required
-                    name="lengthMin"
-                >
+                <ak-form-element-horizontal required name="lengthMin">
+                    ${AKLabel(
+                        {
+                            slot: "label",
+                            className: "pf-c-form__group-label",
+                            htmlFor: "lengthMin",
+                            required: true,
+                        },
+                        msg("Minimum length"),
+                    )}
                     <input
+                        id="lengthMin"
                         type="number"
                         value="${this.instance?.lengthMin ?? 10}"
                         class="pf-c-form-control"
                         required
                     />
                 </ak-form-element-horizontal>
-                <ak-form-element-horizontal
-                    label=${msg("Minimum amount of Uppercase Characters")}
-                    required
-                    name="amountUppercase"
-                >
+                <ak-form-element-horizontal required name="amountUppercase">
+                    ${AKLabel(
+                        {
+                            slot: "label",
+                            className: "pf-c-form__group-label",
+                            htmlFor: "amountUppercase",
+                            required: true,
+                        },
+                        msg("Minimum amount of Uppercase Characters"),
+                    )}
                     <input
+                        id="amountUppercase"
                         type="number"
                         value="${this.instance?.amountUppercase ?? 2}"
                         class="pf-c-form-control"
                         required
                     />
                 </ak-form-element-horizontal>
-                <ak-form-element-horizontal
-                    label=${msg("Minimum amount of Lowercase Characters")}
-                    required
-                    name="amountLowercase"
-                >
+                <ak-form-element-horizontal required name="amountLowercase">
+                    ${AKLabel(
+                        {
+                            slot: "label",
+                            className: "pf-c-form__group-label",
+                            htmlFor: "amountLowercase",
+                            required: true,
+                        },
+                        msg("Minimum amount of Lowercase Characters"),
+                    )}
                     <input
+                        id="amountLowercase"
                         type="number"
                         value="${this.instance?.amountLowercase ?? 2}"
                         class="pf-c-form-control"
                         required
                     />
                 </ak-form-element-horizontal>
-                <ak-form-element-horizontal
-                    label=${msg("Minimum amount of Digits")}
-                    required
-                    name="amountDigits"
-                >
+                <ak-form-element-horizontal required name="amountDigits">
+                    ${AKLabel(
+                        {
+                            slot: "label",
+                            className: "pf-c-form__group-label",
+                            htmlFor: "amountDigits",
+                            required: true,
+                        },
+                        msg("Minimum amount of Digits"),
+                    )}
                     <input
+                        id="amountDigits"
                         type="number"
                         value="${this.instance?.amountDigits ?? 2}"
                         class="pf-c-form-control"
                         required
                     />
                 </ak-form-element-horizontal>
-                <ak-form-element-horizontal
-                    label=${msg("Minimum amount of Symbols Characters")}
-                    required
-                    name="amountSymbols"
-                >
+                <ak-form-element-horizontal required name="amountSymbols">
+                    ${AKLabel(
+                        {
+                            slot: "label",
+                            className: "pf-c-form__group-label",
+                            htmlFor: "amountSymbols",
+                            required: true,
+                        },
+                        msg("Minimum amount of Symbols Characters"),
+                    )}
                     <input
+                        id="amountSymbols"
                         type="number"
                         value="${this.instance?.amountSymbols ?? 2}"
                         class="pf-c-form-control"
                         required
                     />
                 </ak-form-element-horizontal>
-                <ak-form-element-horizontal
-                    label=${msg("Error message")}
-                    required
-                    name="errorMessage"
-                >
+                <ak-form-element-horizontal required name="errorMessage">
+                    ${AKLabel(
+                        {
+                            slot: "label",
+                            className: "pf-c-form__group-label",
+                            htmlFor: "errorMessage",
+                            required: true,
+                        },
+                        msg("Error message"),
+                    )}
                     <input
+                        id="errorMessage"
                         type="text"
                         value="${ifDefined(this.instance?.errorMessage)}"
                         class="pf-c-form-control"
                         required
                     />
                 </ak-form-element-horizontal>
-                <ak-form-element-horizontal
-                    label=${msg("Symbol charset")}
-                    required
-                    name="symbolCharset"
-                >
+                <ak-form-element-horizontal required name="symbolCharset">
+                    ${AKLabel(
+                        {
+                            slot: "label",
+                            className: "pf-c-form__group-label",
+                            htmlFor: "symbolCharset",
+                            required: true,
+                        },
+                        msg("Symbol charset"),
+                    )}
                     <input
+                        id="symbolCharset"
                         type="text"
                         value="${ifDefined(
                             this.instance?.symbolCharset || "!\\\"#$%&'()*+,-./:;<=>?@[]^_`{|}~ ",
@@ -154,12 +198,18 @@ export class PasswordPolicyForm extends BasePolicyForm<PasswordPolicy> {
         return html`
             <ak-form-group open label="${msg("HaveIBeenPwned settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("Allowed count")}
-                        required
-                        name="hibpAllowedCount"
-                    >
+                    <ak-form-element-horizontal required name="hibpAllowedCount">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "hibpAllowedCount",
+                                required: true,
+                            },
+                            msg("Allowed count"),
+                        )}
                         <input
+                            id="hibpAllowedCount"
                             type="number"
                             value="${this.instance?.hibpAllowedCount ?? 0}"
                             class="pf-c-form-control"
@@ -178,12 +228,18 @@ export class PasswordPolicyForm extends BasePolicyForm<PasswordPolicy> {
         return html`
             <ak-form-group open label="${msg("zxcvbn settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("Score threshold")}
-                        required
-                        name="zxcvbnScoreThreshold"
-                    >
+                    <ak-form-element-horizontal required name="zxcvbnScoreThreshold">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "zxcvbnScoreThreshold",
+                                required: true,
+                            },
+                            msg("Score threshold"),
+                        )}
                         <input
+                            id="zxcvbnScoreThreshold"
                             type="number"
                             value="${this.instance?.zxcvbnScoreThreshold ?? 0}"
                             class="pf-c-form-control"
@@ -229,8 +285,18 @@ export class PasswordPolicyForm extends BasePolicyForm<PasswordPolicy> {
                     "Checks the value from the policy request against several rules, mostly used to ensure password strength.",
                 )}
             </span>
-            <ak-form-element-horizontal label=${msg("Name")} required name="name">
+            <ak-form-element-horizontal required name="name">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "name",
+                        required: true,
+                    },
+                    msg("Name"),
+                )}
                 <input
+                    id="name"
                     type="text"
                     value="${ifDefined(this.instance?.name || "")}"
                     class="pf-c-form-control"
@@ -245,12 +311,18 @@ export class PasswordPolicyForm extends BasePolicyForm<PasswordPolicy> {
                     "When this option is enabled, all executions of this policy will be logged. By default, only execution errors are logged.",
                 )}
             ></ak-switch-input>
-            <ak-form-element-horizontal
-                label=${msg("Password field")}
-                required
-                name="passwordField"
-            >
+            <ak-form-element-horizontal required name="passwordField">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "passwordField",
+                        required: true,
+                    },
+                    msg("Password field"),
+                )}
                 <input
+                    id="passwordField"
                     type="text"
                     value="${ifDefined(this.instance?.passwordField || "password")}"
                     class="pf-c-form-control"

--- a/web/src/admin/policies/reputation/ReputationPolicyForm.ts
+++ b/web/src/admin/policies/reputation/ReputationPolicyForm.ts
@@ -4,6 +4,8 @@ import "#elements/forms/HorizontalFormElement";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
 
+import { AKLabel } from "#components/ak-label";
+
 import { BasePolicyForm } from "#admin/policies/BasePolicyForm";
 
 import { PoliciesApi, ReputationPolicy } from "@goauthentik/api";
@@ -49,8 +51,18 @@ username they are attempting to login as, by one.`,
 doesn't pass when either or both of the selected options are equal or above the threshold.`,
                 )}
             </span>
-            <ak-form-element-horizontal label=${msg("Name")} required name="name">
+            <ak-form-element-horizontal required name="name">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "name",
+                        required: true,
+                    },
+                    msg("Name"),
+                )}
                 <input
+                    id="name"
                     type="text"
                     value="${ifDefined(this.instance?.name || "")}"
                     class="pf-c-form-control"
@@ -80,8 +92,18 @@ doesn't pass when either or both of the selected options are equal or above the 
                         ?checked=${this.instance?.checkUsername ?? false}
                     >
                     </ak-switch-input>
-                    <ak-form-element-horizontal label=${msg("Threshold")} required name="threshold">
+                    <ak-form-element-horizontal required name="threshold">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "threshold",
+                                required: true,
+                            },
+                            msg("Threshold"),
+                        )}
                         <input
+                            id="threshold"
                             type="number"
                             value="${ifDefined(this.instance?.threshold || -5)}"
                             class="pf-c-form-control"

--- a/web/src/admin/policies/unique_password/UniquePasswordPolicyForm.ts
+++ b/web/src/admin/policies/unique_password/UniquePasswordPolicyForm.ts
@@ -4,6 +4,8 @@ import "#elements/forms/HorizontalFormElement";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
 
+import { AKLabel } from "#components/ak-label";
+
 import { BasePolicyForm } from "#admin/policies/BasePolicyForm";
 
 import { PoliciesApi, UniquePasswordPolicy } from "@goauthentik/api";
@@ -39,8 +41,18 @@ export class UniquePasswordPolicyForm extends BasePolicyForm<UniquePasswordPolic
                     "Ensure that the user's new password is different from their previous passwords. The number of past passwords to check is configurable.",
                 )}
             </span>
-            <ak-form-element-horizontal label=${msg("Name")} required name="name">
+            <ak-form-element-horizontal required name="name">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "name",
+                        required: true,
+                    },
+                    msg("Name"),
+                )}
                 <input
+                    id="name"
                     type="text"
                     value="${ifDefined(this.instance?.name || "")}"
                     class="pf-c-form-control"
@@ -56,12 +68,18 @@ export class UniquePasswordPolicyForm extends BasePolicyForm<UniquePasswordPolic
                 )}
             >
             </ak-switch-input>
-            <ak-form-element-horizontal
-                label=${msg("Password field")}
-                required
-                name="passwordField"
-            >
+            <ak-form-element-horizontal required name="passwordField">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "passwordField",
+                        required: true,
+                    },
+                    msg("Password field"),
+                )}
                 <input
+                    id="passwordField"
                     type="text"
                     value="${ifDefined(this.instance?.passwordField || "password")}"
                     class="pf-c-form-control"
@@ -71,12 +89,18 @@ export class UniquePasswordPolicyForm extends BasePolicyForm<UniquePasswordPolic
                     ${msg("Field key to check, field keys defined in Prompt stages are available.")}
                 </p>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal
-                label=${msg("Number of previous passwords to check")}
-                required
-                name="numHistoricalPasswords"
-            >
+            <ak-form-element-horizontal required name="numHistoricalPasswords">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "numHistoricalPasswords",
+                        required: true,
+                    },
+                    msg("Number of previous passwords to check"),
+                )}
                 <input
+                    id="numHistoricalPasswords"
                     type="number"
                     value="${this.instance?.numHistoricalPasswords ?? 1}"
                     class="pf-c-form-control"


### PR DESCRIPTION
## Summary

Slice 1c of the form-input/label triage from #22389 (follows #22390, #22391). Mechanical sweep of the deprecated `label="..."` attribute on `<ak-form-element-horizontal>` across `web/src/admin/policies/`.

- 10 files, 45 attribute occurrences.
- Covers every policy form: PolicyBinding, PolicyTest, Dummy, EventMatcher, Expiry, Expression, GeoIP, Password, Reputation, UniquePassword.
- Same mechanical pattern as #22390 / #22391.

## Out of scope (other slices, see #22389)

Same exclusions as #22390/#22391. Remaining migration buckets: `admin/sources`, `/providers`, `/stages`. Semantics, family consolidation, ID centralisation, e2e selector migration, deprecated-prop deletion all in later slices.

## Test plan

- [x] `tsc --noEmit` (exit 0)
- [x] precommit (exit 0)
- [x] Playwright headless visual smoke against `PasswordPolicyForm` — largest migrated file with 11 attribute occurrences; 13 form-elements bind correctly, 0 deprecated-shadow-label fallbacks, 0 console errors.
- [ ] Python `tests/e2e/` — policies have no `test_policy_*.py` selenium coverage; `name=` selectors elsewhere are unaffected.
- [ ] Playwright `web/e2e/` — already label-based.

## Disclosure

Triaged and authored end-to-end by an agent running in a sandbox against `goauthentik/authentik@main`. Reviewed and shipped by @GirlBossRush.

Refs #22389
