### PR TITLE
web/admin/sources: migrate ak-form-element-horizontal label= to slotted AKLabel

### DIFF
--- a/web/src/admin/sources/kerberos/KerberosSourceForm.ts
+++ b/web/src/admin/sources/kerberos/KerberosSourceForm.ts
@@ -18,6 +18,8 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { RadioOption } from "#elements/forms/Radio";
 
+import { AKLabel } from "#components/ak-label";
+
 import { iconHelperText, placeholderHelperText } from "#admin/helperText";
 import { BaseSourceForm } from "#admin/sources/BaseSourceForm";
 import { GroupMatchingModeToLabel, UserMatchingModeToLabel } from "#admin/sources/oauth/utils";
@@ -152,12 +154,17 @@ export class KerberosSourceForm extends BaseSourceForm<KerberosSource> {
                             "Kerberos 5 configuration. See man krb5.conf(5) for configuration format. If left empty, a default krb5.conf will be used.",
                         )}
                     ></ak-textarea-input>
-                    <ak-form-element-horizontal
-                        label=${msg("User matching mode")}
-                        required
-                        name="userMatchingMode"
-                    >
-                        <select class="pf-c-form-control">
+                    <ak-form-element-horizontal required name="userMatchingMode">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "userMatchingMode",
+                                required: true,
+                            },
+                            msg("User matching mode"),
+                        )}
+                        <select id="userMatchingMode" class="pf-c-form-control">
                             <option
                                 value=${UserMatchingModeEnum.Identifier}
                                 ?selected=${this.instance?.userMatchingMode ===
@@ -195,12 +202,17 @@ export class KerberosSourceForm extends BaseSourceForm<KerberosSource> {
                             </option>
                         </select>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Group matching mode")}
-                        required
-                        name="groupMatchingMode"
-                    >
-                        <select class="pf-c-form-control">
+                    <ak-form-element-horizontal required name="groupMatchingMode">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "groupMatchingMode",
+                                required: true,
+                            },
+                            msg("Group matching mode"),
+                        )}
+                        <select id="groupMatchingMode" class="pf-c-form-control">
                             <option
                                 value=${GroupMatchingModeEnum.Identifier}
                                 ?selected=${this.instance?.groupMatchingMode ===
@@ -228,12 +240,18 @@ export class KerberosSourceForm extends BaseSourceForm<KerberosSource> {
             </ak-form-group>
             <ak-form-group label="${msg("Sync connection settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("KAdmin type")}
-                        required
-                        name="kadminType"
-                    >
+                    <ak-form-element-horizontal required name="kadminType">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "kadminType",
+                                required: true,
+                            },
+                            msg("KAdmin type"),
+                        )}
                         <ak-radio
+                            id="kadminType"
                             .options=${[
                                 {
                                     label: "MIT",
@@ -313,11 +331,17 @@ export class KerberosSourceForm extends BaseSourceForm<KerberosSource> {
             </ak-form-group>
             <ak-form-group label="${msg("Kerberos Attribute mapping")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("User Property Mappings")}
-                        name="userPropertyMappings"
-                    >
+                    <ak-form-element-horizontal name="userPropertyMappings">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "userPropertyMappings",
+                            },
+                            msg("User Property Mappings"),
+                        )}
                         <ak-dual-select-dynamic-selected
+                            id="userPropertyMappings"
                             .provider=${propertyMappingsProvider}
                             .selector=${propertyMappingsSelector(
                                 "user",
@@ -330,11 +354,17 @@ export class KerberosSourceForm extends BaseSourceForm<KerberosSource> {
                             ${msg("Property mappings for user creation.")}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Group Property Mappings")}
-                        name="groupPropertyMappings"
-                    >
+                    <ak-form-element-horizontal name="groupPropertyMappings">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "groupPropertyMappings",
+                            },
+                            msg("Group Property Mappings"),
+                        )}
                         <ak-dual-select-dynamic-selected
+                            id="groupPropertyMappings"
                             .provider=${propertyMappingsProvider}
                             .selector=${propertyMappingsSelector(
                                 "group",
@@ -351,11 +381,17 @@ export class KerberosSourceForm extends BaseSourceForm<KerberosSource> {
             </ak-form-group>
             <ak-form-group label="${msg("Flow settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("Authentication Flow")}
-                        name="authenticationFlow"
-                    >
+                    <ak-form-element-horizontal name="authenticationFlow">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "authenticationFlow",
+                            },
+                            msg("Authentication Flow"),
+                        )}
                         <ak-source-flow-search
+                            id="authenticationFlow"
                             flowType=${FlowDesignationEnum.Authentication}
                             .currentFlow=${this.instance?.authenticationFlow}
                             .instanceId=${this.instance?.pk}
@@ -365,11 +401,17 @@ export class KerberosSourceForm extends BaseSourceForm<KerberosSource> {
                             ${msg("Flow to use when authenticating existing users.")}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Enrollment flow")}
-                        name="enrollmentFlow"
-                    >
+                    <ak-form-element-horizontal name="enrollmentFlow">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "enrollmentFlow",
+                            },
+                            msg("Enrollment flow"),
+                        )}
                         <ak-source-flow-search
+                            id="enrollmentFlow"
                             flowType=${FlowDesignationEnum.Enrollment}
                             .currentFlow=${this.instance?.enrollmentFlow}
                             .instanceId=${this.instance?.pk}

--- a/web/src/admin/sources/ldap/LDAPSourceForm.ts
+++ b/web/src/admin/sources/ldap/LDAPSourceForm.ts
@@ -14,6 +14,8 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { RadioOption } from "#elements/forms/Radio";
 
+import { AKLabel } from "#components/ak-label";
+
 import { placeholderHelperText } from "#admin/helperText";
 import { BaseSourceForm } from "#admin/sources/BaseSourceForm";
 
@@ -78,8 +80,18 @@ export class LDAPSourceForm extends BaseSourceForm<LDAPSource> {
     }
 
     protected override renderForm(): TemplateResult {
-        return html` <ak-form-element-horizontal label=${msg("Name")} required name="name">
+        return html` <ak-form-element-horizontal required name="name">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "name",
+                        required: true,
+                    },
+                    msg("Name"),
+                )}
                 <input
+                    id="name"
                     type="text"
                     value="${ifDefined(this.instance?.name)}"
                     class="pf-c-form-control"
@@ -136,12 +148,18 @@ export class LDAPSourceForm extends BaseSourceForm<LDAPSource> {
             ></ak-switch-input>
             <ak-form-group open label="${msg("Connection settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("Server URI")}
-                        required
-                        name="serverUri"
-                    >
+                    <ak-form-element-horizontal required name="serverUri">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "serverUri",
+                                required: true,
+                            },
+                            msg("Server URI"),
+                        )}
                         <input
+                            id="serverUri"
                             type="text"
                             placeholder="ldap://1.2.3.4"
                             value="${ifDefined(this.instance?.serverUri)}"
@@ -164,11 +182,17 @@ export class LDAPSourceForm extends BaseSourceForm<LDAPSource> {
                         ?checked=${this.instance?.sni ?? false}
                         help=${msg("Required for servers using TLS 1.3+")}
                     ></ak-switch-input>
-                    <ak-form-element-horizontal
-                        label=${msg("TLS Verification Certificate")}
-                        name="peerCertificate"
-                    >
+                    <ak-form-element-horizontal name="peerCertificate">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "peerCertificate",
+                            },
+                            msg("TLS Verification Certificate"),
+                        )}
                         <ak-crypto-certificate-search
+                            id="peerCertificate"
                             .certificate=${this.instance?.peerCertificate}
                             nokey
                         ></ak-crypto-certificate-search>
@@ -178,11 +202,17 @@ export class LDAPSourceForm extends BaseSourceForm<LDAPSource> {
                             )}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("TLS Client authentication certificate")}
-                        name="clientCertificate"
-                    >
+                    <ak-form-element-horizontal name="clientCertificate">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "clientCertificate",
+                            },
+                            msg("TLS Client authentication certificate"),
+                        )}
                         <ak-crypto-certificate-search
+                            id="clientCertificate"
                             .certificate=${this.instance?.clientCertificate}
                         ></ak-crypto-certificate-search>
                         <p class="pf-c-form__helper-text">
@@ -191,8 +221,17 @@ export class LDAPSourceForm extends BaseSourceForm<LDAPSource> {
                             )}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal label=${msg("Bind CN")} name="bindCn">
+                    <ak-form-element-horizontal name="bindCn">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "bindCn",
+                            },
+                            msg("Bind CN"),
+                        )}
                         <input
+                            id="bindCn"
                             type="text"
                             value="${ifDefined(this.instance?.bindCn)}"
                             class="pf-c-form-control"
@@ -203,8 +242,18 @@ export class LDAPSourceForm extends BaseSourceForm<LDAPSource> {
                         name="bindPassword"
                         ?revealed=${!this.instance}
                     ></ak-secret-text-input>
-                    <ak-form-element-horizontal label=${msg("Base DN")} required name="baseDn">
+                    <ak-form-element-horizontal required name="baseDn">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "baseDn",
+                                required: true,
+                            },
+                            msg("Base DN"),
+                        )}
                         <input
+                            id="baseDn"
                             type="text"
                             value="${ifDefined(this.instance?.baseDn)}"
                             class="pf-c-form-control"
@@ -215,11 +264,17 @@ export class LDAPSourceForm extends BaseSourceForm<LDAPSource> {
             </ak-form-group>
             <ak-form-group open label="${msg("LDAP Attribute mapping")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("User Property Mappings")}
-                        name="userPropertyMappings"
-                    >
+                    <ak-form-element-horizontal name="userPropertyMappings">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "userPropertyMappings",
+                            },
+                            msg("User Property Mappings"),
+                        )}
                         <ak-dual-select-dynamic-selected
+                            id="userPropertyMappings"
                             .provider=${propertyMappingsProvider}
                             .selector=${propertyMappingsSelector(
                                 this.instance?.userPropertyMappings,
@@ -231,11 +286,17 @@ export class LDAPSourceForm extends BaseSourceForm<LDAPSource> {
                             ${msg("Property mappings for user creation.")}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Group Property Mappings")}
-                        name="groupPropertyMappings"
-                    >
+                    <ak-form-element-horizontal name="groupPropertyMappings">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "groupPropertyMappings",
+                            },
+                            msg("Group Property Mappings"),
+                        )}
                         <ak-dual-select-dynamic-selected
+                            id="groupPropertyMappings"
                             .provider=${propertyMappingsProvider}
                             .selector=${propertyMappingsSelector(
                                 this.instance?.groupPropertyMappings,
@@ -251,8 +312,17 @@ export class LDAPSourceForm extends BaseSourceForm<LDAPSource> {
             </ak-form-group>
             <ak-form-group label="${msg("Additional settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal label=${msg("Parent Group")} name="syncParentGroup">
+                    <ak-form-element-horizontal name="syncParentGroup">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "syncParentGroup",
+                            },
+                            msg("Parent Group"),
+                        )}
                         <ak-search-select
+                            id="syncParentGroup"
                             .fetchObjects=${async (query?: string): Promise<Group[]> => {
                                 const args: CoreGroupsListRequest = {
                                     ordering: "name",
@@ -282,8 +352,17 @@ export class LDAPSourceForm extends BaseSourceForm<LDAPSource> {
                             ${msg("Parent group for all the groups imported from LDAP.")}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal label=${msg("User path")} name="userPathTemplate">
+                    <ak-form-element-horizontal name="userPathTemplate">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "userPathTemplate",
+                            },
+                            msg("User path"),
+                        )}
                         <input
+                            id="userPathTemplate"
                             type="text"
                             value="${this.instance?.userPathTemplate ??
                             "goauthentik.io/sources/%(slug)s"}"
@@ -291,11 +370,17 @@ export class LDAPSourceForm extends BaseSourceForm<LDAPSource> {
                         />
                         <p class="pf-c-form__helper-text">${placeholderHelperText}</p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Additional User DN")}
-                        name="additionalUserDn"
-                    >
+                    <ak-form-element-horizontal name="additionalUserDn">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "additionalUserDn",
+                            },
+                            msg("Additional User DN"),
+                        )}
                         <input
+                            id="additionalUserDn"
                             type="text"
                             value="${ifDefined(this.instance?.additionalUserDn)}"
                             class="pf-c-form-control"
@@ -304,11 +389,17 @@ export class LDAPSourceForm extends BaseSourceForm<LDAPSource> {
                             ${msg("Additional user DN, prepended to the Base DN.")}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Additional Group DN")}
-                        name="additionalGroupDn"
-                    >
+                    <ak-form-element-horizontal name="additionalGroupDn">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "additionalGroupDn",
+                            },
+                            msg("Additional Group DN"),
+                        )}
                         <input
+                            id="additionalGroupDn"
                             type="text"
                             value="${ifDefined(this.instance?.additionalGroupDn)}"
                             class="pf-c-form-control"
@@ -317,12 +408,18 @@ export class LDAPSourceForm extends BaseSourceForm<LDAPSource> {
                             ${msg("Additional group DN, prepended to the Base DN.")}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("User object filter")}
-                        required
-                        name="userObjectFilter"
-                    >
+                    <ak-form-element-horizontal required name="userObjectFilter">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "userObjectFilter",
+                                required: true,
+                            },
+                            msg("User object filter"),
+                        )}
                         <input
+                            id="userObjectFilter"
                             type="text"
                             value="${this.instance?.userObjectFilter || "(objectClass=person)"}"
                             class="pf-c-form-control"
@@ -332,12 +429,18 @@ export class LDAPSourceForm extends BaseSourceForm<LDAPSource> {
                             ${msg("Consider Objects matching this filter to be Users.")}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Group object filter")}
-                        required
-                        name="groupObjectFilter"
-                    >
+                    <ak-form-element-horizontal required name="groupObjectFilter">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "groupObjectFilter",
+                                required: true,
+                            },
+                            msg("Group object filter"),
+                        )}
                         <input
+                            id="groupObjectFilter"
                             type="text"
                             value="${this.instance?.groupObjectFilter || "(objectClass=group)"}"
                             class="pf-c-form-control"
@@ -347,12 +450,18 @@ export class LDAPSourceForm extends BaseSourceForm<LDAPSource> {
                             ${msg("Consider Objects matching this filter to be Groups.")}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Group membership field")}
-                        required
-                        name="groupMembershipField"
-                    >
+                    <ak-form-element-horizontal required name="groupMembershipField">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "groupMembershipField",
+                                required: true,
+                            },
+                            msg("Group membership field"),
+                        )}
                         <input
+                            id="groupMembershipField"
                             type="text"
                             value="${this.instance?.groupMembershipField || "member"}"
                             class="pf-c-form-control"
@@ -364,12 +473,18 @@ export class LDAPSourceForm extends BaseSourceForm<LDAPSource> {
                             )}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("User membership attribute")}
-                        required
-                        name="userMembershipAttribute"
-                    >
+                    <ak-form-element-horizontal required name="userMembershipAttribute">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "userMembershipAttribute",
+                                required: true,
+                            },
+                            msg("User membership attribute"),
+                        )}
                         <input
+                            id="userMembershipAttribute"
                             type="text"
                             value="${this.instance?.userMembershipAttribute || "distinguishedName"}"
                             class="pf-c-form-control"
@@ -387,12 +502,18 @@ export class LDAPSourceForm extends BaseSourceForm<LDAPSource> {
                             "Field which contains DNs of groups the user is a member of. This field is used to lookup groups from users, e.g. 'memberOf'. To lookup nested groups in an Active Directory environment use 'memberOf:1.2.840.113556.1.4.1941:'.",
                         )}
                     ></ak-switch-input>
-                    <ak-form-element-horizontal
-                        label=${msg("Object uniqueness field")}
-                        required
-                        name="objectUniquenessField"
-                    >
+                    <ak-form-element-horizontal required name="objectUniquenessField">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "objectUniquenessField",
+                                required: true,
+                            },
+                            msg("Object uniqueness field"),
+                        )}
                         <input
+                            id="objectUniquenessField"
                             type="text"
                             value="${this.instance?.objectUniquenessField || "objectSid"}"
                             class="pf-c-form-control"

--- a/web/src/admin/sources/ldap/LDAPSourceGroupForm.ts
+++ b/web/src/admin/sources/ldap/LDAPSourceGroupForm.ts
@@ -6,6 +6,8 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { ModelForm } from "#elements/forms/ModelForm";
 
+import { AKLabel } from "#components/ak-label";
+
 import {
     CoreApi,
     CoreGroupsListRequest,
@@ -43,8 +45,17 @@ export class LDAPSourceGroupForm extends ModelForm<GroupLDAPSourceConnection, nu
     }
 
     renderForm() {
-        return html`<ak-form-element-horizontal label=${msg("Group")} name="group">
+        return html`<ak-form-element-horizontal name="group">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "group",
+                    },
+                    msg("Group"),
+                )}
                 <ak-search-select
+                    id="group"
                     .fetchObjects=${async (query?: string): Promise<Group[]> => {
                         const args: CoreGroupsListRequest = {
                             ordering: "name",

--- a/web/src/admin/sources/ldap/LDAPSourceUserForm.ts
+++ b/web/src/admin/sources/ldap/LDAPSourceUserForm.ts
@@ -6,6 +6,8 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { ModelForm } from "#elements/forms/ModelForm";
 
+import { AKLabel } from "#components/ak-label";
+
 import {
     CoreApi,
     CoreUsersListRequest,
@@ -43,8 +45,17 @@ export class LDAPSourceUserForm extends ModelForm<UserLDAPSourceConnection, numb
     }
 
     renderForm() {
-        return html`<ak-form-element-horizontal label=${msg("User")} name="user">
+        return html`<ak-form-element-horizontal name="user">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "user",
+                    },
+                    msg("User"),
+                )}
                 <ak-search-select
+                    id="user"
                     .fetchObjects=${async (query?: string): Promise<User[]> => {
                         const args: CoreUsersListRequest = {
                             ordering: "username",

--- a/web/src/admin/sources/oauth/OAuthSourceForm.ts
+++ b/web/src/admin/sources/oauth/OAuthSourceForm.ts
@@ -19,6 +19,8 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { SlottedTemplateResult } from "#elements/types";
 import { ifPreviousValue } from "#elements/utils/properties";
 
+import { AKLabel } from "#components/ak-label";
+
 import { iconHelperText, placeholderHelperText } from "#admin/helperText";
 import { policyEngineModes } from "#admin/policies/PolicyEngineModes";
 import { BaseSourceForm } from "#admin/sources/BaseSourceForm";
@@ -131,11 +133,17 @@ export class OAuthSourceForm extends BaseSourceForm<OAuthSource> {
 
         return html`<ak-form-group open label="${msg("URL settings")}">
             <div class="pf-c-form">
-                <ak-form-element-horizontal
-                    label=${msg("Authorization URL")}
-                    name="authorizationUrl"
-                >
+                <ak-form-element-horizontal name="authorizationUrl">
+                    ${AKLabel(
+                        {
+                            slot: "label",
+                            className: "pf-c-form__group-label",
+                            htmlFor: "authorizationUrl",
+                        },
+                        msg("Authorization URL"),
+                    )}
                     <input
+                        id="authorizationUrl"
                         type="text"
                         value="${this.instance?.authorizationUrl ??
                         this.providerType.authorizationUrl ??
@@ -148,8 +156,17 @@ export class OAuthSourceForm extends BaseSourceForm<OAuthSource> {
                         ${msg("URL the user is redirect to to consent the authorization.")}
                     </p>
                 </ak-form-element-horizontal>
-                <ak-form-element-horizontal label=${msg("Access token URL")} name="accessTokenUrl">
+                <ak-form-element-horizontal name="accessTokenUrl">
+                    ${AKLabel(
+                        {
+                            slot: "label",
+                            className: "pf-c-form__group-label",
+                            htmlFor: "accessTokenUrl",
+                        },
+                        msg("Access token URL"),
+                    )}
                     <input
+                        id="accessTokenUrl"
                         type="url"
                         value="${this.instance?.accessTokenUrl ??
                         this.providerType.accessTokenUrl ??
@@ -162,8 +179,17 @@ export class OAuthSourceForm extends BaseSourceForm<OAuthSource> {
                         ${msg("URL used by authentik to retrieve tokens.")}
                     </p>
                 </ak-form-element-horizontal>
-                <ak-form-element-horizontal label=${msg("Profile URL")} name="profileUrl">
+                <ak-form-element-horizontal name="profileUrl">
+                    ${AKLabel(
+                        {
+                            slot: "label",
+                            className: "pf-c-form__group-label",
+                            htmlFor: "profileUrl",
+                        },
+                        msg("Profile URL"),
+                    )}
                     <input
+                        id="profileUrl"
                         type="url"
                         value="${this.instance?.profileUrl ?? this.providerType.profileUrl ?? ""}"
                         class="pf-c-form-control pf-m-monospace"
@@ -175,11 +201,17 @@ export class OAuthSourceForm extends BaseSourceForm<OAuthSource> {
                     </p>
                 </ak-form-element-horizontal>
                 ${this.providerType.requestTokenUrl
-                    ? html`<ak-form-element-horizontal
-                          label=${msg("Request token URL")}
-                          name="requestTokenUrl"
-                      >
+                    ? html`<ak-form-element-horizontal name="requestTokenUrl">
+                          ${AKLabel(
+                              {
+                                  slot: "label",
+                                  className: "pf-c-form__group-label",
+                                  htmlFor: "requestTokenUrl",
+                              },
+                              msg("Request token URL"),
+                          )}
                           <input
+                              id="requestTokenUrl"
                               type="url"
                               value="${this.instance?.requestTokenUrl ?? ""}"
                               class="pf-c-form-control pf-m-monospace"
@@ -194,11 +226,17 @@ export class OAuthSourceForm extends BaseSourceForm<OAuthSource> {
                     : nothing}
                 ${this.providerType.name === ProviderTypeEnum.Openidconnect ||
                 this.providerType.oidcWellKnownUrl !== ""
-                    ? html`<ak-form-element-horizontal
-                          label=${msg("OIDC Well-known URL")}
-                          name="oidcWellKnownUrl"
-                      >
+                    ? html`<ak-form-element-horizontal name="oidcWellKnownUrl">
+                          ${AKLabel(
+                              {
+                                  slot: "label",
+                                  className: "pf-c-form__group-label",
+                                  htmlFor: "oidcWellKnownUrl",
+                              },
+                              msg("OIDC Well-known URL"),
+                          )}
                           <input
+                              id="oidcWellKnownUrl"
                               type="url"
                               value="${this.instance?.oidcWellKnownUrl ??
                               this.providerType.oidcWellKnownUrl ??
@@ -216,11 +254,17 @@ export class OAuthSourceForm extends BaseSourceForm<OAuthSource> {
                     : nothing}
                 ${this.providerType.name === ProviderTypeEnum.Openidconnect ||
                 this.providerType.oidcJwksUrl !== ""
-                    ? html`<ak-form-element-horizontal
-                              label=${msg("OIDC JWKS URL")}
-                              name="oidcJwksUrl"
-                          >
+                    ? html`<ak-form-element-horizontal name="oidcJwksUrl">
+                              ${AKLabel(
+                                  {
+                                      slot: "label",
+                                      className: "pf-c-form__group-label",
+                                      htmlFor: "oidcJwksUrl",
+                                  },
+                                  msg("OIDC JWKS URL"),
+                              )}
                               <input
+                                  id="oidcJwksUrl"
                                   type="url"
                                   value="${this.instance?.oidcJwksUrl ??
                                   this.providerType.oidcJwksUrl ??
@@ -235,8 +279,17 @@ export class OAuthSourceForm extends BaseSourceForm<OAuthSource> {
                                   )}
                               </p>
                           </ak-form-element-horizontal>
-                          <ak-form-element-horizontal label=${msg("OIDC JWKS")} name="oidcJwks">
+                          <ak-form-element-horizontal name="oidcJwks">
+                              ${AKLabel(
+                                  {
+                                      slot: "label",
+                                      className: "pf-c-form__group-label",
+                                      htmlFor: "oidcJwks",
+                                  },
+                                  msg("OIDC JWKS"),
+                              )}
                               <ak-codemirror
+                                  id="oidcJwks"
                                   mode="javascript"
                                   value="${JSON.stringify(this.instance?.oidcJwks ?? {})}"
                               >
@@ -299,12 +352,17 @@ export class OAuthSourceForm extends BaseSourceForm<OAuthSource> {
                     "When enabled, this source will be displayed as a prominent button on the login page, instead of a small icon.",
                 )}
             ></ak-switch-input>
-            <ak-form-element-horizontal
-                label=${msg("User matching mode")}
-                required
-                name="userMatchingMode"
-            >
-                <select class="pf-c-form-control">
+            <ak-form-element-horizontal required name="userMatchingMode">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "userMatchingMode",
+                        required: true,
+                    },
+                    msg("User matching mode"),
+                )}
+                <select id="userMatchingMode" class="pf-c-form-control">
                     <option
                         value=${UserMatchingModeEnum.Identifier}
                         ?selected=${this.instance?.userMatchingMode ===
@@ -342,12 +400,17 @@ export class OAuthSourceForm extends BaseSourceForm<OAuthSource> {
                     </option>
                 </select>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal
-                label=${msg("Group matching mode")}
-                required
-                name="groupMatchingMode"
-            >
-                <select class="pf-c-form-control">
+            <ak-form-element-horizontal required name="groupMatchingMode">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "groupMatchingMode",
+                        required: true,
+                    },
+                    msg("Group matching mode"),
+                )}
+                <select id="groupMatchingMode" class="pf-c-form-control">
                     <option
                         value=${GroupMatchingModeEnum.Identifier}
                         ?selected=${this.instance?.groupMatchingMode ===
@@ -371,8 +434,17 @@ export class OAuthSourceForm extends BaseSourceForm<OAuthSource> {
                     </option>
                 </select>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal label=${msg("User path")} name="userPathTemplate">
+            <ak-form-element-horizontal name="userPathTemplate">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "userPathTemplate",
+                    },
+                    msg("User path"),
+                )}
                 <input
+                    id="userPathTemplate"
                     type="text"
                     value="${this.instance?.userPathTemplate ?? "goauthentik.io/sources/%(slug)s"}"
                     class="pf-c-form-control pf-m-monospace"
@@ -392,12 +464,18 @@ export class OAuthSourceForm extends BaseSourceForm<OAuthSource> {
 
             <ak-form-group open label="${msg("Protocol settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("Consumer key")}
-                        required
-                        name="consumerKey"
-                    >
+                    <ak-form-element-horizontal required name="consumerKey">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "consumerKey",
+                                required: true,
+                            },
+                            msg("Consumer key"),
+                        )}
                         <input
+                            id="consumerKey"
                             type="text"
                             value="${ifDefined(this.instance?.consumerKey)}"
                             class="pf-c-form-control pf-m-monospace"
@@ -415,8 +493,17 @@ export class OAuthSourceForm extends BaseSourceForm<OAuthSource> {
                         ?required=${!this.instance}
                         ?revealed=${!this.instance}
                     ></ak-secret-textarea-input>
-                    <ak-form-element-horizontal label=${msg("Scopes")} name="additionalScopes">
+                    <ak-form-element-horizontal name="additionalScopes">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "additionalScopes",
+                            },
+                            msg("Scopes"),
+                        )}
                         <input
+                            id="additionalScopes"
                             type="text"
                             value="${this.instance?.additionalScopes ?? ""}"
                             class="pf-c-form-control pf-m-monospace"
@@ -434,11 +521,17 @@ export class OAuthSourceForm extends BaseSourceForm<OAuthSource> {
             ${this.renderUrlOptions()}
             <ak-form-group open label="${msg("OAuth Attribute mapping")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("User Property Mappings")}
-                        name="userPropertyMappings"
-                    >
+                    <ak-form-element-horizontal name="userPropertyMappings">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "userPropertyMappings",
+                            },
+                            msg("User Property Mappings"),
+                        )}
                         <ak-dual-select-dynamic-selected
+                            id="userPropertyMappings"
                             .provider=${propertyMappingsProvider}
                             .selector=${propertyMappingsSelector(
                                 this.instance?.userPropertyMappings,
@@ -450,11 +543,17 @@ export class OAuthSourceForm extends BaseSourceForm<OAuthSource> {
                             ${msg("Property mappings for user creation.")}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Group Property Mappings")}
-                        name="groupPropertyMappings"
-                    >
+                    <ak-form-element-horizontal name="groupPropertyMappings">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "groupPropertyMappings",
+                            },
+                            msg("Group Property Mappings"),
+                        )}
                         <ak-dual-select-dynamic-selected
+                            id="groupPropertyMappings"
                             .provider=${propertyMappingsProvider}
                             .selector=${propertyMappingsSelector(
                                 this.instance?.groupPropertyMappings,
@@ -470,11 +569,17 @@ export class OAuthSourceForm extends BaseSourceForm<OAuthSource> {
             </ak-form-group>
             <ak-form-group label="${msg("Flow settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("Authentication Flow")}
-                        name="authenticationFlow"
-                    >
+                    <ak-form-element-horizontal name="authenticationFlow">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "authenticationFlow",
+                            },
+                            msg("Authentication Flow"),
+                        )}
                         <ak-source-flow-search
+                            id="authenticationFlow"
                             flowType=${FlowDesignationEnum.Authentication}
                             .currentFlow=${this.instance?.authenticationFlow}
                             .instanceId=${this.instance?.pk}
@@ -484,11 +589,17 @@ export class OAuthSourceForm extends BaseSourceForm<OAuthSource> {
                             ${msg("Flow to use when authenticating existing users.")}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Enrollment flow")}
-                        name="enrollmentFlow"
-                    >
+                    <ak-form-element-horizontal name="enrollmentFlow">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "enrollmentFlow",
+                            },
+                            msg("Enrollment flow"),
+                        )}
                         <ak-source-flow-search
+                            id="enrollmentFlow"
                             flowType=${FlowDesignationEnum.Enrollment}
                             .currentFlow=${this.instance?.enrollmentFlow}
                             .instanceId=${this.instance?.pk}
@@ -502,12 +613,18 @@ export class OAuthSourceForm extends BaseSourceForm<OAuthSource> {
             </ak-form-group>
             <ak-form-group label=${msg("Advanced settings")}>
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("Policy engine mode")}
-                        required
-                        name="policyEngineMode"
-                    >
+                    <ak-form-element-horizontal required name="policyEngineMode">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "policyEngineMode",
+                                required: true,
+                            },
+                            msg("Policy engine mode"),
+                        )}
                         <ak-radio
+                            id="policyEngineMode"
                             .options=${policyEngineModes}
                             .value=${this.instance?.policyEngineMode}
                         >

--- a/web/src/admin/sources/plex/PlexSourceForm.ts
+++ b/web/src/admin/sources/plex/PlexSourceForm.ts
@@ -16,6 +16,8 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 import { PlexAPIClient, PlexResource, popupCenterScreen } from "#common/helpers/plex";
 import { ascii_letters, digits, randomString } from "#common/utils";
 
+import { AKLabel } from "#components/ak-label";
+
 import { iconHelperText, placeholderHelperText } from "#admin/helperText";
 import { policyEngineModes } from "#admin/policies/PolicyEngineModes";
 import { BaseSourceForm } from "#admin/sources/BaseSourceForm";
@@ -117,12 +119,17 @@ export class PlexSourceForm extends BaseSourceForm<PlexSource> {
                 )}
                 ?checked=${this.instance?.allowFriends ?? true}
             ></ak-switch-input>
-            <ak-form-element-horizontal
-                label=${msg("Allowed servers")}
-                required
-                name="allowedServers"
-            >
-                <select class="pf-c-form-control" multiple>
+            <ak-form-element-horizontal required name="allowedServers">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "allowedServers",
+                        required: true,
+                    },
+                    msg("Allowed servers"),
+                )}
+                <select id="allowedServers" class="pf-c-form-control" multiple>
                     ${this.plexResources?.map((r) => {
                         const selected = Array.from(this.instance?.allowedServers || []).some(
                             (server) => {
@@ -171,12 +178,17 @@ export class PlexSourceForm extends BaseSourceForm<PlexSource> {
                     "When enabled, this source will be displayed as a prominent button on the login page, instead of a small icon.",
                 )}
             ></ak-switch-input>
-            <ak-form-element-horizontal
-                label=${msg("User matching mode")}
-                required
-                name="userMatchingMode"
-            >
-                <select class="pf-c-form-control">
+            <ak-form-element-horizontal required name="userMatchingMode">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "userMatchingMode",
+                        required: true,
+                    },
+                    msg("User matching mode"),
+                )}
+                <select id="userMatchingMode" class="pf-c-form-control">
                     <option
                         value=${UserMatchingModeEnum.Identifier}
                         ?selected=${this.instance?.userMatchingMode ===
@@ -214,12 +226,17 @@ export class PlexSourceForm extends BaseSourceForm<PlexSource> {
                     </option>
                 </select>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal
-                label=${msg("Group matching mode")}
-                required
-                name="groupMatchingMode"
-            >
-                <select class="pf-c-form-control">
+            <ak-form-element-horizontal required name="groupMatchingMode">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "groupMatchingMode",
+                        required: true,
+                    },
+                    msg("Group matching mode"),
+                )}
+                <select id="groupMatchingMode" class="pf-c-form-control">
                     <option
                         value=${GroupMatchingModeEnum.Identifier}
                         ?selected=${this.instance?.groupMatchingMode ===
@@ -243,8 +260,17 @@ export class PlexSourceForm extends BaseSourceForm<PlexSource> {
                     </option>
                 </select>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal label=${msg("User path")} name="userPathTemplate">
+            <ak-form-element-horizontal name="userPathTemplate">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "userPathTemplate",
+                    },
+                    msg("User path"),
+                )}
                 <input
+                    id="userPathTemplate"
                     type="text"
                     value="${this.instance?.userPathTemplate ?? "goauthentik.io/sources/%(slug)s"}"
                     class="pf-c-form-control"
@@ -261,8 +287,18 @@ export class PlexSourceForm extends BaseSourceForm<PlexSource> {
             ></ak-file-search-input>
             <ak-form-group open label="${msg("Protocol settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal label=${msg("Client ID")} required name="clientId">
+                    <ak-form-element-horizontal required name="clientId">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "clientId",
+                                required: true,
+                            },
+                            msg("Client ID"),
+                        )}
                         <input
+                            id="clientId"
                             type="text"
                             value="${this.instance?.clientId ?? ""}"
                             class="pf-c-form-control"
@@ -274,11 +310,17 @@ export class PlexSourceForm extends BaseSourceForm<PlexSource> {
             </ak-form-group>
             <ak-form-group label="${msg("Flow settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("Authentication Flow")}
-                        name="authenticationFlow"
-                    >
+                    <ak-form-element-horizontal name="authenticationFlow">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "authenticationFlow",
+                            },
+                            msg("Authentication Flow"),
+                        )}
                         <ak-source-flow-search
+                            id="authenticationFlow"
                             flowType=${FlowDesignationEnum.Authentication}
                             .currentFlow=${this.instance?.authenticationFlow}
                             .instanceId=${this.instance?.pk}
@@ -288,11 +330,17 @@ export class PlexSourceForm extends BaseSourceForm<PlexSource> {
                             ${msg("Flow to use when authenticating existing users.")}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Enrollment flow")}
-                        name="enrollmentFlow"
-                    >
+                    <ak-form-element-horizontal name="enrollmentFlow">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "enrollmentFlow",
+                            },
+                            msg("Enrollment flow"),
+                        )}
                         <ak-source-flow-search
+                            id="enrollmentFlow"
                             flowType=${FlowDesignationEnum.Enrollment}
                             .currentFlow=${this.instance?.enrollmentFlow}
                             .instanceId=${this.instance?.pk}
@@ -306,11 +354,17 @@ export class PlexSourceForm extends BaseSourceForm<PlexSource> {
             </ak-form-group>
             <ak-form-group open label="${msg("Plex Attribute mapping")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("User Property Mappings")}
-                        name="userPropertyMappings"
-                    >
+                    <ak-form-element-horizontal name="userPropertyMappings">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "userPropertyMappings",
+                            },
+                            msg("User Property Mappings"),
+                        )}
                         <ak-dual-select-dynamic-selected
+                            id="userPropertyMappings"
                             .provider=${propertyMappingsProvider}
                             .selector=${propertyMappingsSelector(
                                 this.instance?.userPropertyMappings,
@@ -322,11 +376,17 @@ export class PlexSourceForm extends BaseSourceForm<PlexSource> {
                             ${msg("Property mappings for user creation.")}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Group Property Mappings")}
-                        name="groupPropertyMappings"
-                    >
+                    <ak-form-element-horizontal name="groupPropertyMappings">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "groupPropertyMappings",
+                            },
+                            msg("Group Property Mappings"),
+                        )}
                         <ak-dual-select-dynamic-selected
+                            id="groupPropertyMappings"
                             .provider=${propertyMappingsProvider}
                             .selector=${propertyMappingsSelector(
                                 this.instance?.groupPropertyMappings,
@@ -342,12 +402,18 @@ export class PlexSourceForm extends BaseSourceForm<PlexSource> {
             </ak-form-group>
             <ak-form-group label=${msg("Advanced settings")}>
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("Policy engine mode")}
-                        required
-                        name="policyEngineMode"
-                    >
+                    <ak-form-element-horizontal required name="policyEngineMode">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "policyEngineMode",
+                                required: true,
+                            },
+                            msg("Policy engine mode"),
+                        )}
                         <ak-radio
+                            id="policyEngineMode"
                             .options=${policyEngineModes}
                             .value=${this.instance?.policyEngineMode}
                         >

--- a/web/src/admin/sources/saml/SAMLSourceForm.ts
+++ b/web/src/admin/sources/saml/SAMLSourceForm.ts
@@ -14,6 +14,8 @@ import { propertyMappingsProvider, propertyMappingsSelector } from "./SAMLSource
 
 import { DEFAULT_CONFIG } from "#common/api/config";
 
+import { AKLabel } from "#components/ak-label";
+
 import { type AkCryptoCertificateSearch } from "#admin/common/ak-crypto-certificate-search";
 import { iconHelperText, placeholderHelperText } from "#admin/helperText";
 import { policyEngineModes } from "#admin/policies/PolicyEngineModes";
@@ -122,12 +124,17 @@ export class SAMLSourceForm extends BaseSourceForm<SAMLSource> {
                     "When enabled, this source will be displayed as a prominent button on the login page, instead of a small icon.",
                 )}
             ></ak-switch-input>
-            <ak-form-element-horizontal
-                label=${msg("User matching mode")}
-                required
-                name="userMatchingMode"
-            >
-                <select class="pf-c-form-control">
+            <ak-form-element-horizontal required name="userMatchingMode">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "userMatchingMode",
+                        required: true,
+                    },
+                    msg("User matching mode"),
+                )}
+                <select id="userMatchingMode" class="pf-c-form-control">
                     <option
                         value=${UserMatchingModeEnum.Identifier}
                         ?selected=${this.instance?.userMatchingMode ===
@@ -165,12 +172,17 @@ export class SAMLSourceForm extends BaseSourceForm<SAMLSource> {
                     </option>
                 </select>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal
-                label=${msg("Group matching mode")}
-                required
-                name="groupMatchingMode"
-            >
-                <select class="pf-c-form-control">
+            <ak-form-element-horizontal required name="groupMatchingMode">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "groupMatchingMode",
+                        required: true,
+                    },
+                    msg("Group matching mode"),
+                )}
+                <select id="groupMatchingMode" class="pf-c-form-control">
                     <option
                         value=${GroupMatchingModeEnum.Identifier}
                         ?selected=${this.instance?.groupMatchingMode ===
@@ -205,8 +217,18 @@ export class SAMLSourceForm extends BaseSourceForm<SAMLSource> {
 
             <ak-form-group open label="${msg("Protocol settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal label=${msg("SSO URL")} required name="ssoUrl">
+                    <ak-form-element-horizontal required name="ssoUrl">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "ssoUrl",
+                                required: true,
+                            },
+                            msg("SSO URL"),
+                        )}
                         <input
+                            id="ssoUrl"
                             type="text"
                             value="${ifDefined(this.instance?.ssoUrl)}"
                             class="pf-c-form-control"
@@ -216,8 +238,17 @@ export class SAMLSourceForm extends BaseSourceForm<SAMLSource> {
                             ${msg("URL that the initial Login request is sent to.")}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal label=${msg("SLO URL")} name="sloUrl">
+                    <ak-form-element-horizontal name="sloUrl">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "sloUrl",
+                            },
+                            msg("SLO URL"),
+                        )}
                         <input
+                            id="sloUrl"
                             type="text"
                             value="${ifDefined(this.instance?.sloUrl || "")}"
                             class="pf-c-form-control"
@@ -226,8 +257,17 @@ export class SAMLSourceForm extends BaseSourceForm<SAMLSource> {
                             ${msg("Optional URL if the IDP supports Single-Logout.")}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal label=${msg("Issuer")} name="issuer">
+                    <ak-form-element-horizontal name="issuer">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "issuer",
+                            },
+                            msg("Issuer"),
+                        )}
                         <input
+                            id="issuer"
                             type="text"
                             value="${ifDefined(this.instance?.issuer)}"
                             class="pf-c-form-control"
@@ -236,12 +276,18 @@ export class SAMLSourceForm extends BaseSourceForm<SAMLSource> {
                             ${msg("Also known as Entity ID. Defaults the Metadata URL.")}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Binding Type")}
-                        required
-                        name="bindingType"
-                    >
+                    <ak-form-element-horizontal required name="bindingType">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "bindingType",
+                                required: true,
+                            },
+                            msg("Binding Type"),
+                        )}
                         <ak-radio
+                            id="bindingType"
                             .options=${[
                                 {
                                     label: msg("Redirect binding"),
@@ -264,8 +310,17 @@ export class SAMLSourceForm extends BaseSourceForm<SAMLSource> {
                         >
                         </ak-radio>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal label=${msg("Signing keypair")} name="signingKp">
+                    <ak-form-element-horizontal name="signingKp">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "signingKp",
+                            },
+                            msg("Signing keypair"),
+                        )}
                         <ak-crypto-certificate-search
+                            id="signingKp"
                             .certificate=${this.instance?.signingKp}
                         ></ak-crypto-certificate-search>
                         <p class="pf-c-form__helper-text">
@@ -274,11 +329,17 @@ export class SAMLSourceForm extends BaseSourceForm<SAMLSource> {
                             )}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Verification Certificate")}
-                        name="verificationKp"
-                    >
+                    <ak-form-element-horizontal name="verificationKp">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "verificationKp",
+                            },
+                            msg("Verification Certificate"),
+                        )}
                         <ak-crypto-certificate-search
+                            id="verificationKp"
                             .certificate=${this.instance?.verificationKp}
                             @input=${this.setHasSigningCert}
                             nokey
@@ -310,12 +371,17 @@ export class SAMLSourceForm extends BaseSourceForm<SAMLSource> {
                             "When enabled, the IdP is requested to force re-authentication of the user, even if the user has an existing session.",
                         )}
                     ></ak-switch-input>
-                    <ak-form-element-horizontal
-                        label=${msg("NameID Policy")}
-                        required
-                        name="nameIdPolicy"
-                    >
-                        <select class="pf-c-form-control">
+                    <ak-form-element-horizontal required name="nameIdPolicy">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "nameIdPolicy",
+                                required: true,
+                            },
+                            msg("NameID Policy"),
+                        )}
+                        <select id="nameIdPolicy" class="pf-c-form-control">
                             <option
                                 value=${SAMLNameIDPolicyEnum.UrnOasisNamesTcSaml20NameidFormatPersistent}
                                 ?selected=${this.instance?.nameIdPolicy ===
@@ -353,8 +419,17 @@ export class SAMLSourceForm extends BaseSourceForm<SAMLSource> {
                             </option>
                         </select>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal label=${msg("User path")} name="userPathTemplate">
+                    <ak-form-element-horizontal name="userPathTemplate">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "userPathTemplate",
+                            },
+                            msg("User path"),
+                        )}
                         <input
+                            id="userPathTemplate"
                             type="text"
                             value="${this.instance?.userPathTemplate ??
                             "goauthentik.io/sources/%(slug)s"}"
@@ -362,12 +437,18 @@ export class SAMLSourceForm extends BaseSourceForm<SAMLSource> {
                         />
                         <p class="pf-c-form__helper-text">${placeholderHelperText}</p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Delete temporary users after")}
-                        required
-                        name="temporaryUserDeleteAfter"
-                    >
+                    <ak-form-element-horizontal required name="temporaryUserDeleteAfter">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "temporaryUserDeleteAfter",
+                                required: true,
+                            },
+                            msg("Delete temporary users after"),
+                        )}
                         <input
+                            id="temporaryUserDeleteAfter"
                             type="text"
                             value="${this.instance?.temporaryUserDeleteAfter || "days=1"}"
                             class="pf-c-form-control"
@@ -380,12 +461,18 @@ export class SAMLSourceForm extends BaseSourceForm<SAMLSource> {
                         </p>
                         <ak-utils-time-delta-help></ak-utils-time-delta-help>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Digest algorithm")}
-                        required
-                        name="digestAlgorithm"
-                    >
+                    <ak-form-element-horizontal required name="digestAlgorithm">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "digestAlgorithm",
+                                required: true,
+                            },
+                            msg("Digest algorithm"),
+                        )}
                         <ak-radio
+                            id="digestAlgorithm"
                             .options=${[
                                 {
                                     label: "SHA1",
@@ -409,12 +496,18 @@ export class SAMLSourceForm extends BaseSourceForm<SAMLSource> {
                         >
                         </ak-radio>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Signature algorithm")}
-                        required
-                        name="signatureAlgorithm"
-                    >
+                    <ak-form-element-horizontal required name="signatureAlgorithm">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "signatureAlgorithm",
+                                required: true,
+                            },
+                            msg("Signature algorithm"),
+                        )}
                         <ak-radio
+                            id="signatureAlgorithm"
                             .options=${[
                                 {
                                     label: "RSA-SHA1",
@@ -442,11 +535,17 @@ export class SAMLSourceForm extends BaseSourceForm<SAMLSource> {
                         >
                         </ak-radio>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Encryption Certificate")}
-                        name="encryptionKp"
-                    >
+                    <ak-form-element-horizontal name="encryptionKp">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "encryptionKp",
+                            },
+                            msg("Encryption Certificate"),
+                        )}
                         <ak-crypto-certificate-search
+                            id="encryptionKp"
                             .certificate=${this.instance?.encryptionKp}
                         ></ak-crypto-certificate-search>
                         <p class="pf-c-form__helper-text">
@@ -459,11 +558,17 @@ export class SAMLSourceForm extends BaseSourceForm<SAMLSource> {
             </ak-form-group>
             <ak-form-group open label="${msg("SAML Attribute mapping")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("User Property Mappings")}
-                        name="userPropertyMappings"
-                    >
+                    <ak-form-element-horizontal name="userPropertyMappings">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "userPropertyMappings",
+                            },
+                            msg("User Property Mappings"),
+                        )}
                         <ak-dual-select-dynamic-selected
+                            id="userPropertyMappings"
                             .provider=${propertyMappingsProvider}
                             .selector=${propertyMappingsSelector(
                                 this.instance?.userPropertyMappings,
@@ -475,11 +580,17 @@ export class SAMLSourceForm extends BaseSourceForm<SAMLSource> {
                             ${msg("Property mappings for user creation.")}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Group Property Mappings")}
-                        name="groupPropertyMappings"
-                    >
+                    <ak-form-element-horizontal name="groupPropertyMappings">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "groupPropertyMappings",
+                            },
+                            msg("Group Property Mappings"),
+                        )}
                         <ak-dual-select-dynamic-selected
+                            id="groupPropertyMappings"
                             .provider=${propertyMappingsProvider}
                             .selector=${propertyMappingsSelector(
                                 this.instance?.groupPropertyMappings,
@@ -495,12 +606,18 @@ export class SAMLSourceForm extends BaseSourceForm<SAMLSource> {
             </ak-form-group>
             <ak-form-group label="${msg("Flow settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("Pre-authentication flow")}
-                        required
-                        name="preAuthenticationFlow"
-                    >
+                    <ak-form-element-horizontal required name="preAuthenticationFlow">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "preAuthenticationFlow",
+                                required: true,
+                            },
+                            msg("Pre-authentication flow"),
+                        )}
                         <ak-source-flow-search
+                            id="preAuthenticationFlow"
                             flowType=${FlowDesignationEnum.StageConfiguration}
                             .currentFlow=${this.instance?.preAuthenticationFlow}
                             .instanceId=${this.instance?.pk}
@@ -510,11 +627,17 @@ export class SAMLSourceForm extends BaseSourceForm<SAMLSource> {
                             ${msg("Flow used before authentication.")}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Authentication Flow")}
-                        name="authenticationFlow"
-                    >
+                    <ak-form-element-horizontal name="authenticationFlow">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "authenticationFlow",
+                            },
+                            msg("Authentication Flow"),
+                        )}
                         <ak-source-flow-search
+                            id="authenticationFlow"
                             flowType=${FlowDesignationEnum.Authentication}
                             .currentFlow=${this.instance?.authenticationFlow}
                             .instanceId=${this.instance?.pk}
@@ -524,11 +647,17 @@ export class SAMLSourceForm extends BaseSourceForm<SAMLSource> {
                             ${msg("Flow to use when authenticating existing users.")}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Enrollment flow")}
-                        name="enrollmentFlow"
-                    >
+                    <ak-form-element-horizontal name="enrollmentFlow">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "enrollmentFlow",
+                            },
+                            msg("Enrollment flow"),
+                        )}
                         <ak-source-flow-search
+                            id="enrollmentFlow"
                             flowType=${FlowDesignationEnum.Enrollment}
                             .currentFlow=${this.instance?.enrollmentFlow}
                             .instanceId=${this.instance?.pk}
@@ -542,12 +671,18 @@ export class SAMLSourceForm extends BaseSourceForm<SAMLSource> {
             </ak-form-group>
             <ak-form-group label=${msg("Advanced settings")}>
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("Policy engine mode")}
-                        required
-                        name="policyEngineMode"
-                    >
+                    <ak-form-element-horizontal required name="policyEngineMode">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "policyEngineMode",
+                                required: true,
+                            },
+                            msg("Policy engine mode"),
+                        )}
                         <ak-radio
+                            id="policyEngineMode"
                             .options=${policyEngineModes}
                             .value=${this.instance?.policyEngineMode}
                         >

--- a/web/src/admin/sources/scim/SCIMSourceForm.ts
+++ b/web/src/admin/sources/scim/SCIMSourceForm.ts
@@ -9,6 +9,8 @@ import { propertyMappingsProvider, propertyMappingsSelector } from "./SCIMSource
 
 import { DEFAULT_CONFIG } from "#common/api/config";
 
+import { AKLabel } from "#components/ak-label";
+
 import { placeholderHelperText } from "#admin/helperText";
 import { BaseSourceForm } from "#admin/sources/BaseSourceForm";
 
@@ -67,11 +69,17 @@ export class SCIMSourceForm extends BaseSourceForm<SCIMSource> {
 
             <ak-form-group open label="${msg("SCIM Attribute mapping")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("User Property Mappings")}
-                        name="userPropertyMappings"
-                    >
+                    <ak-form-element-horizontal name="userPropertyMappings">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "userPropertyMappings",
+                            },
+                            msg("User Property Mappings"),
+                        )}
                         <ak-dual-select-dynamic-selected
+                            id="userPropertyMappings"
                             .provider=${propertyMappingsProvider}
                             .selector=${propertyMappingsSelector(
                                 this.instance?.userPropertyMappings,
@@ -83,11 +91,17 @@ export class SCIMSourceForm extends BaseSourceForm<SCIMSource> {
                             ${msg("Property mappings for user creation.")}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Group Property Mappings")}
-                        name="groupPropertyMappings"
-                    >
+                    <ak-form-element-horizontal name="groupPropertyMappings">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "groupPropertyMappings",
+                            },
+                            msg("Group Property Mappings"),
+                        )}
                         <ak-dual-select-dynamic-selected
+                            id="groupPropertyMappings"
                             .provider=${propertyMappingsProvider}
                             .selector=${propertyMappingsSelector(
                                 this.instance?.groupPropertyMappings,
@@ -103,8 +117,17 @@ export class SCIMSourceForm extends BaseSourceForm<SCIMSource> {
             </ak-form-group>
             <ak-form-group label="${msg("Advanced protocol settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal label=${msg("User path")} name="userPathTemplate">
+                    <ak-form-element-horizontal name="userPathTemplate">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "userPathTemplate",
+                            },
+                            msg("User path"),
+                        )}
                         <input
+                            id="userPathTemplate"
                             type="text"
                             value="${this.instance?.userPathTemplate ??
                             "goauthentik.io/sources/%(slug)s"}"

--- a/web/src/admin/sources/telegram/TelegramSourceForm.ts
+++ b/web/src/admin/sources/telegram/TelegramSourceForm.ts
@@ -10,6 +10,8 @@ import { propertyMappingsProvider, propertyMappingsSelector } from "./TelegramSo
 
 import { DEFAULT_CONFIG } from "#common/api/config";
 
+import { AKLabel } from "#components/ak-label";
+
 import { policyEngineModes } from "#admin/policies/PolicyEngineModes";
 import { BaseSourceForm } from "#admin/sources/BaseSourceForm";
 import { UserMatchingModeToLabel } from "#admin/sources/oauth/utils";
@@ -80,12 +82,17 @@ export class TelegramSourceForm extends BaseSourceForm<TelegramSource> {
                     "When enabled, this source will be displayed as a prominent button on the login page, instead of a small icon.",
                 )}
             ></ak-switch-input>
-            <ak-form-element-horizontal
-                label=${msg("User matching mode")}
-                required
-                name="userMatchingMode"
-            >
-                <select class="pf-c-form-control">
+            <ak-form-element-horizontal required name="userMatchingMode">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "userMatchingMode",
+                        required: true,
+                    },
+                    msg("User matching mode"),
+                )}
+                <select id="userMatchingMode" class="pf-c-form-control">
                     <option
                         value=${UserMatchingModeEnum.Identifier}
                         ?selected=${this.instance?.userMatchingMode ===
@@ -123,8 +130,18 @@ export class TelegramSourceForm extends BaseSourceForm<TelegramSource> {
                     </option>
                 </select>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal label=${msg("Bot username")} required name="botUsername">
+            <ak-form-element-horizontal required name="botUsername">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "botUsername",
+                        required: true,
+                    },
+                    msg("Bot username"),
+                )}
                 <input
+                    id="botUsername"
                     type="text"
                     value="${ifDefined(this.instance?.botUsername)}"
                     class="pf-c-form-control"
@@ -145,12 +162,18 @@ export class TelegramSourceForm extends BaseSourceForm<TelegramSource> {
             ></ak-switch-input>
             <ak-form-group label="${msg("Flow settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("Pre-authentication flow")}
-                        required
-                        name="preAuthenticationFlow"
-                    >
+                    <ak-form-element-horizontal required name="preAuthenticationFlow">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "preAuthenticationFlow",
+                                required: true,
+                            },
+                            msg("Pre-authentication flow"),
+                        )}
                         <ak-source-flow-search
+                            id="preAuthenticationFlow"
                             flowType=${FlowDesignationEnum.StageConfiguration}
                             .currentFlow=${this.instance?.preAuthenticationFlow}
                             .instanceId=${this.instance?.pk}
@@ -160,11 +183,17 @@ export class TelegramSourceForm extends BaseSourceForm<TelegramSource> {
                             ${msg("Flow used before authentication.")}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Authentication Flow")}
-                        name="authenticationFlow"
-                    >
+                    <ak-form-element-horizontal name="authenticationFlow">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "authenticationFlow",
+                            },
+                            msg("Authentication Flow"),
+                        )}
                         <ak-source-flow-search
+                            id="authenticationFlow"
                             flowType=${FlowDesignationEnum.Authentication}
                             .currentFlow=${this.instance?.authenticationFlow}
                             .instanceId=${this.instance?.pk}
@@ -174,11 +203,17 @@ export class TelegramSourceForm extends BaseSourceForm<TelegramSource> {
                             ${msg("Flow to use when authenticating existing users.")}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Enrollment flow")}
-                        name="enrollmentFlow"
-                    >
+                    <ak-form-element-horizontal name="enrollmentFlow">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "enrollmentFlow",
+                            },
+                            msg("Enrollment flow"),
+                        )}
                         <ak-source-flow-search
+                            id="enrollmentFlow"
                             flowType=${FlowDesignationEnum.Enrollment}
                             .currentFlow=${this.instance?.enrollmentFlow}
                             .instanceId=${this.instance?.pk}
@@ -192,11 +227,17 @@ export class TelegramSourceForm extends BaseSourceForm<TelegramSource> {
             </ak-form-group>
             <ak-form-group open label="${msg("Telegram Attribute mapping")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("User Property Mappings")}
-                        name="userPropertyMappings"
-                    >
+                    <ak-form-element-horizontal name="userPropertyMappings">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "userPropertyMappings",
+                            },
+                            msg("User Property Mappings"),
+                        )}
                         <ak-dual-select-dynamic-selected
+                            id="userPropertyMappings"
                             .provider=${propertyMappingsProvider}
                             .selector=${propertyMappingsSelector(
                                 this.instance?.userPropertyMappings,
@@ -208,11 +249,17 @@ export class TelegramSourceForm extends BaseSourceForm<TelegramSource> {
                             ${msg("Property mappings for user creation.")}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Group Property Mappings")}
-                        name="groupPropertyMappings"
-                    >
+                    <ak-form-element-horizontal name="groupPropertyMappings">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "groupPropertyMappings",
+                            },
+                            msg("Group Property Mappings"),
+                        )}
                         <ak-dual-select-dynamic-selected
+                            id="groupPropertyMappings"
                             .provider=${propertyMappingsProvider}
                             .selector=${propertyMappingsSelector(
                                 this.instance?.groupPropertyMappings,
@@ -228,12 +275,18 @@ export class TelegramSourceForm extends BaseSourceForm<TelegramSource> {
             </ak-form-group>
             <ak-form-group label="${msg("Advanced settings")} ">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("Policy engine mode")}
-                        required
-                        name="policyEngineMode"
-                    >
+                    <ak-form-element-horizontal required name="policyEngineMode">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "policyEngineMode",
+                                required: true,
+                            },
+                            msg("Policy engine mode"),
+                        )}
                         <ak-radio
+                            id="policyEngineMode"
                             .options=${policyEngineModes}
                             .value=${this.instance?.policyEngineMode}
                         >


### PR DESCRIPTION
## Summary

Slice 1d of the form-input/label triage from #22389 (follows #22390, #22391, #22392). Mechanical sweep of the deprecated `label="..."` attribute on `<ak-form-element-horizontal>` across `web/src/admin/sources/`.

- 9 files, **84 attribute occurrences** — significantly more than the issue body's ~30 estimate, but still within the per-slice budget and trivially per-file reviewable.
- Covers SAML, OAuth, LDAP (+ user/group sub-forms), Plex, Telegram, Kerberos, SCIM source forms.
- Same mechanical pattern as #22390 / #22391 / #22392.

## Per-file occurrence breakdown

| File | label= occurrences |
|---|---|
| `SAMLSourceForm.ts` | 20 |
| `OAuthSourceForm.ts` | 17 |
| `LDAPSourceForm.ts` | 17 |
| `PlexSourceForm.ts` | 10 |
| `TelegramSourceForm.ts` | 8 |
| `KerberosSourceForm.ts` | 7 |
| `SCIMSourceForm.ts` | 3 |
| `LDAPSourceUserForm.ts` | 1 |
| `LDAPSourceGroupForm.ts` | 1 |

## E2E coverage (`needs_e2e`)

The Python selenium suite at `tests/e2e/test_source_*.py` (OAuth1, OAuth2, SAML, LDAP-Samba, SCIM) tests **source-driven flow execution** — it instantiates source models programmatically and never binds on `name=` selectors against the admin form UI. So this migration is selector-safe by construction; the relevant CI jobs should pass without test changes.

Local selenium run was punted to CI: the docker-compose stack for the source suite (chromium + LDAP samba container + OAuth1 server, etc.) is too heavyweight to spin up in this container for a single slice. Web-side admin smoke via Playwright was attempted but blocked by the SourceWizard's source-type picker (a custom card widget rather than a list of radios), so the SAML/OAuth/LDAP admin forms couldn't be opened through the UI. Bundle inspection confirms migrated `htmlFor` values (`ssoUrl`, `bindingType`, `signingKp`, `baseDn`, `serverUri`, `consumerKey`, etc.) are baked into the rebuilt chunks with the expected slot wiring.

## Out of scope (other slices, see #22389)

- The SourceWizard's card-based source-type picker that blocked UI smoke is a separate concern — likely an interaction for the semantics/ID-generator slices (4) or a follow-up issue, not in scope here.
- Remaining migration buckets: `admin/providers`, `/stages`.
- Slices 2–6 (semantics, family consolidation, ID centralisation, e2e selector migration, deprecated-prop deletion).

## Test plan

- [x] `tsc --noEmit` (exit 0)
- [x] precommit (exit 0)
- [x] `make web-build` — verified migrated `htmlFor` values present in rebuilt chunks
- [ ] Python `tests/e2e/test_source_*.py` — selector-safe by construction; CI will run
- [ ] Playwright `web/e2e/` — already label-based

## Disclosure

Triaged and authored end-to-end by an agent running in a sandbox against `goauthentik/authentik@main`. Reviewed and shipped by @GirlBossRush.

Refs #22389
