### PR TITLE
web/admin/stages: migrate ak-form-element-horizontal label= to slotted AKLabel (authenticators)

### DIFF
--- a/web/src/admin/stages/authenticator_duo/AuthenticatorDuoStageForm.ts
+++ b/web/src/admin/stages/authenticator_duo/AuthenticatorDuoStageForm.ts
@@ -5,6 +5,8 @@ import "#elements/forms/SearchSelect/index";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
 
+import { AKLabel } from "#components/ak-label";
+
 import { RenderFlowOption } from "#admin/flows/utils";
 import { BaseStageForm } from "#admin/stages/BaseStageForm";
 
@@ -48,20 +50,35 @@ export class AuthenticatorDuoStageForm extends BaseStageForm<AuthenticatorDuoSta
                     "Stage used to configure a duo-based authenticator. This stage should be used for configuration flows.",
                 )}
             </span>
-            <ak-form-element-horizontal label=${msg("Name")} required name="name">
+            <ak-form-element-horizontal required name="name">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "name",
+                        required: true,
+                    },
+                    msg("Name"),
+                )}
                 <input
+                    id="name"
                     type="text"
                     value="${this.instance?.name ?? ""}"
                     class="pf-c-form-control"
                     required
                 />
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal
-                label=${msg("Authenticator type name")}
-                ?required=${false}
-                name="friendlyName"
-            >
+            <ak-form-element-horizontal ?required=${false} name="friendlyName">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "friendlyName",
+                    },
+                    msg("Authenticator type name"),
+                )}
                 <input
+                    id="friendlyName"
                     type="text"
                     value="${this.instance?.friendlyName ?? ""}"
                     class="pf-c-form-control"
@@ -72,8 +89,18 @@ export class AuthenticatorDuoStageForm extends BaseStageForm<AuthenticatorDuoSta
                     )}
                 </p>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal label=${msg("API Hostname")} required name="apiHostname">
+            <ak-form-element-horizontal required name="apiHostname">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "apiHostname",
+                        required: true,
+                    },
+                    msg("API Hostname"),
+                )}
                 <input
+                    id="apiHostname"
                     type="text"
                     value="${this.instance?.apiHostname ?? ""}"
                     class="pf-c-form-control pf-m-monospace"
@@ -84,12 +111,18 @@ export class AuthenticatorDuoStageForm extends BaseStageForm<AuthenticatorDuoSta
             </ak-form-element-horizontal>
             <ak-form-group open label="${msg("Duo Auth API")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("Integration key")}
-                        required
-                        name="clientId"
-                    >
+                    <ak-form-element-horizontal required name="clientId">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "clientId",
+                                required: true,
+                            },
+                            msg("Integration key"),
+                        )}
                         <input
+                            id="clientId"
                             type="text"
                             value="${this.instance?.clientId ?? ""}"
                             class="pf-c-form-control"
@@ -112,11 +145,17 @@ export class AuthenticatorDuoStageForm extends BaseStageForm<AuthenticatorDuoSta
                 )}"
             >
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("Integration key")}
-                        name="adminIntegrationKey"
-                    >
+                    <ak-form-element-horizontal name="adminIntegrationKey">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "adminIntegrationKey",
+                            },
+                            msg("Integration key"),
+                        )}
                         <input
+                            id="adminIntegrationKey"
                             type="text"
                             value="${this.instance?.adminIntegrationKey ?? ""}"
                             class="pf-c-form-control pf-m-monospace"
@@ -134,11 +173,17 @@ export class AuthenticatorDuoStageForm extends BaseStageForm<AuthenticatorDuoSta
             </ak-form-group>
             <ak-form-group open label="${msg("Stage-specific settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("Configuration flow")}
-                        name="configureFlow"
-                    >
+                    <ak-form-element-horizontal name="configureFlow">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "configureFlow",
+                            },
+                            msg("Configuration flow"),
+                        )}
                         <ak-search-select
+                            id="configureFlow"
                             .fetchObjects=${async (query?: string): Promise<Flow[]> => {
                                 const args: FlowsInstancesListRequest = {
                                     ordering: "slug",

--- a/web/src/admin/stages/authenticator_duo/DuoDeviceImportForm.ts
+++ b/web/src/admin/stages/authenticator_duo/DuoDeviceImportForm.ts
@@ -12,6 +12,8 @@ import { ModelForm } from "#elements/forms/ModelForm";
 import { showMessage } from "#elements/messages/MessageContainer";
 import { SlottedTemplateResult } from "#elements/types";
 
+import { AKLabel } from "#components/ak-label";
+
 import {
     AuthenticatorDuoStage,
     AuthenticatorDuoStageManualDeviceImportRequest,
@@ -61,8 +63,18 @@ export class DuoDeviceImportForm extends ModelForm<AuthenticatorDuoStage, string
     }
 
     protected renderFormManual(): SlottedTemplateResult {
-        return html`<ak-form-element-horizontal label=${msg("User")} required name="username">
+        return html`<ak-form-element-horizontal required name="username">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "username",
+                        required: true,
+                    },
+                    msg("User"),
+                )}
                 <ak-search-select
+                    id="username"
                     placeholder=${msg("Select a user...")}
                     .fetchObjects=${async (query?: string): Promise<User[]> => {
                         const args: CoreUsersListRequest = {
@@ -103,8 +115,17 @@ export class DuoDeviceImportForm extends ModelForm<AuthenticatorDuoStage, string
     }
 
     renderFormAutomatic(): SlottedTemplateResult {
-        return html`<ak-form-element-horizontal label=${msg("Automatic import")}>
+        return html`<ak-form-element-horizontal>
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "duo-automatic-import",
+                    },
+                    msg("Automatic import"),
+                )}
                 <ak-action-button
+                    id="duo-automatic-import"
                     class="pf-m-primary"
                     .apiRequest=${() => {
                         return new StagesApi(DEFAULT_CONFIG)

--- a/web/src/admin/stages/authenticator_email/AuthenticatorEmailStageForm.ts
+++ b/web/src/admin/stages/authenticator_email/AuthenticatorEmailStageForm.ts
@@ -9,6 +9,8 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { SlottedTemplateResult } from "#elements/types";
 
+import { AKLabel } from "#components/ak-label";
+
 import { RenderFlowOption } from "#admin/flows/utils";
 import { BaseStageForm } from "#admin/stages/BaseStageForm";
 
@@ -64,24 +66,53 @@ export class AuthenticatorEmailStageForm extends BaseStageForm<AuthenticatorEmai
         }
         return html`<ak-form-group open label="${msg("Connection settings")}">
             <div class="pf-c-form">
-                <ak-form-element-horizontal label=${msg("SMTP Host")} required name="host">
+                <ak-form-element-horizontal required name="host">
+                    ${AKLabel(
+                        {
+                            slot: "label",
+                            className: "pf-c-form__group-label",
+                            htmlFor: "host",
+                            required: true,
+                        },
+                        msg("SMTP Host"),
+                    )}
                     <input
+                        id="host"
                         type="text"
                         value="${ifDefined(this.instance?.host || "")}"
                         class="pf-c-form-control"
                         required
                     />
                 </ak-form-element-horizontal>
-                <ak-form-element-horizontal label=${msg("SMTP Port")} required name="port">
+                <ak-form-element-horizontal required name="port">
+                    ${AKLabel(
+                        {
+                            slot: "label",
+                            className: "pf-c-form__group-label",
+                            htmlFor: "port",
+                            required: true,
+                        },
+                        msg("SMTP Port"),
+                    )}
                     <input
+                        id="port"
                         type="number"
                         value="${this.instance?.port ?? 25}"
                         class="pf-c-form-control"
                         required
                     />
                 </ak-form-element-horizontal>
-                <ak-form-element-horizontal label=${msg("SMTP Username")} name="username">
+                <ak-form-element-horizontal name="username">
+                    ${AKLabel(
+                        {
+                            slot: "label",
+                            className: "pf-c-form__group-label",
+                            htmlFor: "username",
+                        },
+                        msg("SMTP Username"),
+                    )}
                     <input
+                        id="username"
                         type="text"
                         value="${ifDefined(this.instance?.username || "")}"
                         class="pf-c-form-control"
@@ -106,20 +137,36 @@ export class AuthenticatorEmailStageForm extends BaseStageForm<AuthenticatorEmai
                     ?checked=${this.instance?.useSsl ?? false}
                 >
                 </ak-switch-input>
-                <ak-form-element-horizontal label=${msg("Timeout")} required name="timeout">
+                <ak-form-element-horizontal required name="timeout">
+                    ${AKLabel(
+                        {
+                            slot: "label",
+                            className: "pf-c-form__group-label",
+                            htmlFor: "timeout",
+                            required: true,
+                        },
+                        msg("Timeout"),
+                    )}
                     <input
+                        id="timeout"
                         type="number"
                         value="${this.instance?.timeout ?? 30}"
                         class="pf-c-form-control"
                         required
                     />
                 </ak-form-element-horizontal>
-                <ak-form-element-horizontal
-                    label=${msg("From address")}
-                    required
-                    name="fromAddress"
-                >
+                <ak-form-element-horizontal required name="fromAddress">
+                    ${AKLabel(
+                        {
+                            slot: "label",
+                            className: "pf-c-form__group-label",
+                            htmlFor: "fromAddress",
+                            required: true,
+                        },
+                        msg("From address"),
+                    )}
                     <input
+                        id="fromAddress"
                         type="text"
                         value="${ifDefined(this.instance?.fromAddress || "system@authentik.local")}"
                         class="pf-c-form-control"
@@ -135,20 +182,35 @@ export class AuthenticatorEmailStageForm extends BaseStageForm<AuthenticatorEmai
 
     protected override renderForm(): TemplateResult {
         return html` <span> ${msg("Stage used to configure an email-based authenticator.")}</span>
-            <ak-form-element-horizontal label=${msg("Name")} required name="name">
+            <ak-form-element-horizontal required name="name">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "name",
+                        required: true,
+                    },
+                    msg("Name"),
+                )}
                 <input
+                    id="name"
                     type="text"
                     value="${this.instance?.name ?? ""}"
                     class="pf-c-form-control"
                     required
                 />
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal
-                label=${msg("Authenticator type name")}
-                ?required=${false}
-                name="friendlyName"
-            >
+            <ak-form-element-horizontal ?required=${false} name="friendlyName">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "friendlyName",
+                    },
+                    msg("Authenticator type name"),
+                )}
                 <input
+                    id="friendlyName"
                     type="text"
                     value="${this.instance?.friendlyName ?? ""}"
                     class="pf-c-form-control"
@@ -174,8 +236,18 @@ export class AuthenticatorEmailStageForm extends BaseStageForm<AuthenticatorEmai
             ${this.renderConnectionSettings()}
             <ak-form-group open label="${msg("Stage-specific settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal label=${msg("Subject")} required name="subject">
+                    <ak-form-element-horizontal required name="subject">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "subject",
+                                required: true,
+                            },
+                            msg("Subject"),
+                        )}
                         <input
+                            id="subject"
                             type="text"
                             value="${this.instance?.subject ?? "authentik Sign-in code"}"
                             class="pf-c-form-control"
@@ -185,12 +257,18 @@ export class AuthenticatorEmailStageForm extends BaseStageForm<AuthenticatorEmai
                             ${msg("Subject of the verification email.")}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Token expiration")}
-                        required
-                        name="tokenExpiry"
-                    >
+                    <ak-form-element-horizontal required name="tokenExpiry">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "tokenExpiry",
+                                required: true,
+                            },
+                            msg("Token expiration"),
+                        )}
                         <input
+                            id="tokenExpiry"
                             type="text"
                             value="${this.instance?.tokenExpiry ?? "minutes=15"}"
                             class="pf-c-form-control"
@@ -202,11 +280,17 @@ export class AuthenticatorEmailStageForm extends BaseStageForm<AuthenticatorEmai
                             )}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Configuration flow")}
-                        name="configureFlow"
-                    >
+                    <ak-form-element-horizontal name="configureFlow">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "configureFlow",
+                            },
+                            msg("Configuration flow"),
+                        )}
                         <ak-search-select
+                            id="configureFlow"
                             .fetchObjects=${async (query?: string): Promise<Flow[]> => {
                                 const args: FlowsInstancesListRequest = {
                                     ordering: "slug",
@@ -241,8 +325,17 @@ export class AuthenticatorEmailStageForm extends BaseStageForm<AuthenticatorEmai
                             )}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal label=${msg("Template")} name="template">
+                    <ak-form-element-horizontal name="template">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "template",
+                            },
+                            msg("Template"),
+                        )}
                         <select
+                            id="template"
                             class="pf-c-form-control"
                             ?disabled=${!this.templates || this.templates.length === 0}
                         >

--- a/web/src/admin/stages/authenticator_endpoint_gdtc/AuthenticatorEndpointGDTCStageForm.ts
+++ b/web/src/admin/stages/authenticator_endpoint_gdtc/AuthenticatorEndpointGDTCStageForm.ts
@@ -4,6 +4,8 @@ import "#elements/forms/HorizontalFormElement";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
 
+import { AKLabel } from "#components/ak-label";
+
 import { BaseStageForm } from "#admin/stages/BaseStageForm";
 
 import { AuthenticatorEndpointGDTCStage, StagesApi } from "@goauthentik/api";
@@ -46,8 +48,18 @@ export class AuthenticatorEndpointGDTCStageForm extends BaseStageForm<Authentica
                     "Stage used to verify users' browsers using Google Chrome Device Trust. This stage can be used in authentication/authorization flows.",
                 )}
             </span>
-            <ak-form-element-horizontal label=${msg("Name")} required name="name">
+            <ak-form-element-horizontal required name="name">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "name",
+                        required: true,
+                    },
+                    msg("Name"),
+                )}
                 <input
+                    id="name"
                     type="text"
                     value="${this.instance?.name ?? ""}"
                     class="pf-c-form-control"
@@ -56,12 +68,18 @@ export class AuthenticatorEndpointGDTCStageForm extends BaseStageForm<Authentica
             </ak-form-element-horizontal>
             <ak-form-group open label="${msg("Google Verified Access API")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("Credentials")}
-                        required
-                        name="credentials"
-                    >
+                    <ak-form-element-horizontal required name="credentials">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "credentials",
+                                required: true,
+                            },
+                            msg("Credentials"),
+                        )}
                         <ak-codemirror
+                            id="credentials"
                             mode="javascript"
                             .value="${this.instance?.credentials ?? {}}"
                         ></ak-codemirror>

--- a/web/src/admin/stages/authenticator_sms/AuthenticatorSMSStageForm.ts
+++ b/web/src/admin/stages/authenticator_sms/AuthenticatorSMSStageForm.ts
@@ -6,6 +6,8 @@ import "#elements/forms/SearchSelect/index";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
 
+import { AKLabel } from "#components/ak-label";
+
 import { RenderFlowOption } from "#admin/flows/utils";
 import { BaseStageForm } from "#admin/stages/BaseStageForm";
 
@@ -60,12 +62,18 @@ export class AuthenticatorSMSStageForm extends BaseStageForm<AuthenticatorSMSSta
     }
 
     renderProviderTwillio(): TemplateResult {
-        return html` <ak-form-element-horizontal
-                label=${msg("Twilio Account SID")}
-                required
-                name="accountSid"
-            >
+        return html` <ak-form-element-horizontal required name="accountSid">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "accountSid",
+                        required: true,
+                    },
+                    msg("Twilio Account SID"),
+                )}
                 <input
+                    id="accountSid"
                     type="text"
                     value="${this.instance?.accountSid ?? ""}"
                     class="pf-c-form-control pf-m-monospace"
@@ -77,8 +85,18 @@ export class AuthenticatorSMSStageForm extends BaseStageForm<AuthenticatorSMSSta
                     ${msg("Get this value from https://console.twilio.com")}
                 </p>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal label=${msg("Twilio Auth Token")} required name="auth">
+            <ak-form-element-horizontal required name="auth">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "auth",
+                        required: true,
+                    },
+                    msg("Twilio Auth Token"),
+                )}
                 <input
+                    id="auth"
                     type="text"
                     value="${this.instance?.auth ?? ""}"
                     class="pf-c-form-control pf-m-monospace"
@@ -95,7 +113,6 @@ export class AuthenticatorSMSStageForm extends BaseStageForm<AuthenticatorSMSSta
     renderProviderGeneric(): TemplateResult {
         return html`
             <ak-form-element-horizontal
-                label=${msg("Authentication Type")}
                 @change=${(ev: Event) => {
                     const current = (ev.target as HTMLInputElement).value;
                     this.authType = current as AuthTypeEnum;
@@ -103,7 +120,17 @@ export class AuthenticatorSMSStageForm extends BaseStageForm<AuthenticatorSMSSta
                 required
                 name="authType"
             >
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "authType",
+                        required: true,
+                    },
+                    msg("Authentication Type"),
+                )}
                 <ak-radio
+                    id="authType"
                     .options=${[
                         {
                             label: msg("Basic Auth"),
@@ -119,8 +146,18 @@ export class AuthenticatorSMSStageForm extends BaseStageForm<AuthenticatorSMSSta
                 >
                 </ak-radio>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal label=${msg("External API URL")} required name="accountSid">
+            <ak-form-element-horizontal required name="accountSid">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "accountSid",
+                        required: true,
+                    },
+                    msg("External API URL"),
+                )}
                 <input
+                    id="accountSid"
                     type="text"
                     value="${this.instance?.accountSid ?? ""}"
                     class="pf-c-form-control pf-m-monospace"
@@ -132,8 +169,18 @@ export class AuthenticatorSMSStageForm extends BaseStageForm<AuthenticatorSMSSta
                     ${msg("This is the full endpoint to send POST requests to.")}
                 </p>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal label=${msg("API Auth Username")} required name="auth">
+            <ak-form-element-horizontal required name="auth">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "auth",
+                        required: true,
+                    },
+                    msg("API Auth Username"),
+                )}
                 <input
+                    id="auth"
                     type="text"
                     value="${this.instance?.auth ?? ""}"
                     class="pf-c-form-control pf-m-monospace"
@@ -146,12 +193,17 @@ export class AuthenticatorSMSStageForm extends BaseStageForm<AuthenticatorSMSSta
                     )}
                 </p>
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal
-                label=${msg("API Auth password")}
-                ?required=${false}
-                name="authPassword"
-            >
+            <ak-form-element-horizontal ?required=${false} name="authPassword">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "authPassword",
+                    },
+                    msg("API Auth password"),
+                )}
                 <input
+                    id="authPassword"
                     type="text"
                     value="${this.instance?.authPassword ?? ""}"
                     class="pf-c-form-control pf-m-monospace"
@@ -169,20 +221,35 @@ export class AuthenticatorSMSStageForm extends BaseStageForm<AuthenticatorSMSSta
         return html` <span>
                 ${msg("Stage used to configure an SMS-based TOTP authenticator.")}
             </span>
-            <ak-form-element-horizontal label=${msg("Name")} required name="name">
+            <ak-form-element-horizontal required name="name">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "name",
+                        required: true,
+                    },
+                    msg("Name"),
+                )}
                 <input
+                    id="name"
                     type="text"
                     value="${this.instance?.name ?? ""}"
                     class="pf-c-form-control"
                     required
                 />
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal
-                label=${msg("Authenticator type name")}
-                ?required=${false}
-                name="friendlyName"
-            >
+            <ak-form-element-horizontal ?required=${false} name="friendlyName">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "friendlyName",
+                    },
+                    msg("Authenticator type name"),
+                )}
                 <input
+                    id="friendlyName"
                     type="text"
                     value="${this.instance?.friendlyName ?? ""}"
                     class="pf-c-form-control"
@@ -195,8 +262,18 @@ export class AuthenticatorSMSStageForm extends BaseStageForm<AuthenticatorSMSSta
             </ak-form-element-horizontal>
             <ak-form-group open label="${msg("Stage-specific settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal label=${msg("Provider")} required name="provider">
+                    <ak-form-element-horizontal required name="provider">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "provider",
+                                required: true,
+                            },
+                            msg("Provider"),
+                        )}
                         <select
+                            id="provider"
                             class="pf-c-form-control"
                             @change=${(ev: Event) => {
                                 const current = (ev.target as HTMLInputElement).value;
@@ -217,12 +294,18 @@ export class AuthenticatorSMSStageForm extends BaseStageForm<AuthenticatorSMSSta
                             </option>
                         </select>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("From number")}
-                        required
-                        name="fromNumber"
-                    >
+                    <ak-form-element-horizontal required name="fromNumber">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "fromNumber",
+                                required: true,
+                            },
+                            msg("From number"),
+                        )}
                         <input
+                            id="fromNumber"
                             type="text"
                             value="${this.instance?.fromNumber ?? ""}"
                             class="pf-c-form-control pf-m-monospace"
@@ -237,8 +320,17 @@ export class AuthenticatorSMSStageForm extends BaseStageForm<AuthenticatorSMSSta
                     ${this.provider === ProviderEnum.Generic
                         ? this.renderProviderGeneric()
                         : this.renderProviderTwillio()}
-                    <ak-form-element-horizontal label=${msg("Mapping")} name="mapping">
+                    <ak-form-element-horizontal name="mapping">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "mapping",
+                            },
+                            msg("Mapping"),
+                        )}
                         <ak-search-select
+                            id="mapping"
                             .fetchObjects=${async (
                                 query?: string,
                             ): Promise<NotificationWebhookMapping[]> => {
@@ -277,11 +369,17 @@ export class AuthenticatorSMSStageForm extends BaseStageForm<AuthenticatorSMSSta
                             "If enabled, only a hash of the phone number will be saved. This can be done for data-protection reasons. Devices created from a stage with this enabled cannot be used with the authenticator validation stage.",
                         )}
                     ></ak-switch-input>
-                    <ak-form-element-horizontal
-                        label=${msg("Configuration flow")}
-                        name="configureFlow"
-                    >
+                    <ak-form-element-horizontal name="configureFlow">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "configureFlow",
+                            },
+                            msg("Configuration flow"),
+                        )}
                         <ak-search-select
+                            id="configureFlow"
                             .fetchObjects=${async (query?: string): Promise<Flow[]> => {
                                 const args: FlowsInstancesListRequest = {
                                     ordering: "slug",

--- a/web/src/admin/stages/authenticator_static/AuthenticatorStaticStageForm.ts
+++ b/web/src/admin/stages/authenticator_static/AuthenticatorStaticStageForm.ts
@@ -3,6 +3,8 @@ import "#elements/forms/SearchSelect/index";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
 
+import { AKLabel } from "#components/ak-label";
+
 import { RenderFlowOption } from "#admin/flows/utils";
 import { BaseStageForm } from "#admin/stages/BaseStageForm";
 
@@ -45,20 +47,35 @@ export class AuthenticatorStaticStageForm extends BaseStageForm<AuthenticatorSta
                     "Stage used to configure a static authenticator (i.e. static tokens). This stage should be used for configuration flows.",
                 )}
             </span>
-            <ak-form-element-horizontal label=${msg("Name")} required name="name">
+            <ak-form-element-horizontal required name="name">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "name",
+                        required: true,
+                    },
+                    msg("Name"),
+                )}
                 <input
+                    id="name"
                     type="text"
                     value="${this.instance?.name ?? ""}"
                     class="pf-c-form-control"
                     required
                 />
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal
-                label=${msg("Authenticator type name")}
-                ?required=${false}
-                name="friendlyName"
-            >
+            <ak-form-element-horizontal ?required=${false} name="friendlyName">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "friendlyName",
+                    },
+                    msg("Authenticator type name"),
+                )}
                 <input
+                    id="friendlyName"
                     type="text"
                     value="${this.instance?.friendlyName ?? ""}"
                     class="pf-c-form-control"
@@ -71,12 +88,18 @@ export class AuthenticatorStaticStageForm extends BaseStageForm<AuthenticatorSta
             </ak-form-element-horizontal>
             <ak-form-group open label="${msg("Stage-specific settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("Token count")}
-                        required
-                        name="tokenCount"
-                    >
+                    <ak-form-element-horizontal required name="tokenCount">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "tokenCount",
+                                required: true,
+                            },
+                            msg("Token count"),
+                        )}
                         <input
+                            id="tokenCount"
                             type="text"
                             value="${this.instance?.tokenCount ?? 6}"
                             class="pf-c-form-control"
@@ -88,12 +111,18 @@ export class AuthenticatorStaticStageForm extends BaseStageForm<AuthenticatorSta
                             )}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Token length")}
-                        required
-                        name="tokenLength"
-                    >
+                    <ak-form-element-horizontal required name="tokenLength">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "tokenLength",
+                                required: true,
+                            },
+                            msg("Token length"),
+                        )}
                         <input
+                            id="tokenLength"
                             type="number"
                             value="${this.instance?.tokenLength ?? 12}"
                             min="1"
@@ -107,11 +136,17 @@ export class AuthenticatorStaticStageForm extends BaseStageForm<AuthenticatorSta
                             )}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Configuration flow")}
-                        name="configureFlow"
-                    >
+                    <ak-form-element-horizontal name="configureFlow">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "configureFlow",
+                            },
+                            msg("Configuration flow"),
+                        )}
                         <ak-search-select
+                            id="configureFlow"
                             .fetchObjects=${async (query?: string): Promise<Flow[]> => {
                                 const args: FlowsInstancesListRequest = {
                                     ordering: "slug",

--- a/web/src/admin/stages/authenticator_totp/AuthenticatorTOTPStageForm.ts
+++ b/web/src/admin/stages/authenticator_totp/AuthenticatorTOTPStageForm.ts
@@ -4,6 +4,8 @@ import "#elements/forms/SearchSelect/index";
 
 import { DEFAULT_CONFIG } from "#common/api/config";
 
+import { AKLabel } from "#components/ak-label";
+
 import { RenderFlowOption } from "#admin/flows/utils";
 import { BaseStageForm } from "#admin/stages/BaseStageForm";
 
@@ -47,20 +49,35 @@ export class AuthenticatorTOTPStageForm extends BaseStageForm<AuthenticatorTOTPS
                     "Stage used to configure a TOTP authenticator (i.e. Authy/Google Authenticator).",
                 )}
             </span>
-            <ak-form-element-horizontal label=${msg("Name")} required name="name">
+            <ak-form-element-horizontal required name="name">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "name",
+                        required: true,
+                    },
+                    msg("Name"),
+                )}
                 <input
+                    id="name"
                     type="text"
                     value="${this.instance?.name ?? ""}"
                     class="pf-c-form-control"
                     required
                 />
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal
-                label=${msg("Authenticator type name")}
-                ?required=${false}
-                name="friendlyName"
-            >
+            <ak-form-element-horizontal ?required=${false} name="friendlyName">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "friendlyName",
+                    },
+                    msg("Authenticator type name"),
+                )}
                 <input
+                    id="friendlyName"
                     type="text"
                     value="${this.instance?.friendlyName ?? ""}"
                     class="pf-c-form-control"
@@ -73,8 +90,17 @@ export class AuthenticatorTOTPStageForm extends BaseStageForm<AuthenticatorTOTPS
             </ak-form-element-horizontal>
             <ak-form-group open label="${msg("Stage-specific settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal label=${msg("Digits")} required name="digits">
-                        <select name="users" class="pf-c-form-control">
+                    <ak-form-element-horizontal required name="digits">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "digits",
+                                required: true,
+                            },
+                            msg("Digits"),
+                        )}
+                        <select id="digits" name="users" class="pf-c-form-control">
                             <option
                                 value="${DigitsEnum._6}"
                                 ?selected=${this.instance?.digits === DigitsEnum._6}
@@ -91,11 +117,17 @@ export class AuthenticatorTOTPStageForm extends BaseStageForm<AuthenticatorTOTPS
                             </option>
                         </select>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Configuration flow")}
-                        name="configureFlow"
-                    >
+                    <ak-form-element-horizontal name="configureFlow">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "configureFlow",
+                            },
+                            msg("Configuration flow"),
+                        )}
                         <ak-search-select
+                            id="configureFlow"
                             .fetchObjects=${async (query?: string): Promise<Flow[]> => {
                                 const args: FlowsInstancesListRequest = {
                                     ordering: "slug",

--- a/web/src/admin/stages/authenticator_validate/AuthenticatorValidateStageForm.ts
+++ b/web/src/admin/stages/authenticator_validate/AuthenticatorValidateStageForm.ts
@@ -141,12 +141,18 @@ export class AuthenticatorValidateStageForm extends BaseStageForm<AuthenticatorV
                                 )}
                         ></ak-checkbox-group>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Last validation threshold")}
-                        required
-                        name="lastAuthThreshold"
-                    >
+                    <ak-form-element-horizontal required name="lastAuthThreshold">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "lastAuthThreshold",
+                                required: true,
+                            },
+                            msg("Last validation threshold"),
+                        )}
                         <input
+                            id="lastAuthThreshold"
                             type="text"
                             value="${this.instance?.lastAuthThreshold || "seconds=0"}"
                             class="pf-c-form-control pf-m-monospace"
@@ -161,12 +167,18 @@ export class AuthenticatorValidateStageForm extends BaseStageForm<AuthenticatorV
                         </p>
                         <ak-utils-time-delta-help></ak-utils-time-delta-help>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Not configured action")}
-                        required
-                        name="notConfiguredAction"
-                    >
+                    <ak-form-element-horizontal required name="notConfiguredAction">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "notConfiguredAction",
+                                required: true,
+                            },
+                            msg("Not configured action"),
+                        )}
                         <select
+                            id="notConfiguredAction"
                             class="pf-c-form-control"
                             @change=${(ev: Event) => {
                                 const target = ev.target as HTMLSelectElement;
@@ -205,11 +217,17 @@ export class AuthenticatorValidateStageForm extends BaseStageForm<AuthenticatorV
                     </ak-form-element-horizontal>
                     ${this.showConfigurationStages
                         ? html`
-                              <ak-form-element-horizontal
-                                  label=${msg("Configuration stages")}
-                                  name="configurationStages"
-                              >
+                              <ak-form-element-horizontal name="configurationStages">
+                                  ${AKLabel(
+                                      {
+                                          slot: "label",
+                                          className: "pf-c-form__group-label",
+                                          htmlFor: "configurationStages",
+                                      },
+                                      msg("Configuration stages"),
+                                  )}
                                   <ak-dual-select-dynamic-selected
+                                      id="configurationStages"
                                       .provider=${stagesProvider}
                                       .selector=${stagesSelector(
                                           this.instance?.configurationStages,
@@ -233,12 +251,18 @@ export class AuthenticatorValidateStageForm extends BaseStageForm<AuthenticatorV
                 </div>
             </ak-form-group>
             <ak-form-group label="${msg("Throttling settings")}">
-                <ak-form-element-horizontal
-                    label=${msg("Email OTP throttling factor")}
-                    required
-                    name="emailOtpThrottlingFactor"
-                >
+                <ak-form-element-horizontal required name="emailOtpThrottlingFactor">
+                    ${AKLabel(
+                        {
+                            slot: "label",
+                            className: "pf-c-form__group-label",
+                            htmlFor: "emailOtpThrottlingFactor",
+                            required: true,
+                        },
+                        msg("Email OTP throttling factor"),
+                    )}
                     <input
+                        id="emailOtpThrottlingFactor"
                         type="number"
                         step="0.1"
                         value=${this.instance?.emailOtpThrottlingFactor || 1}
@@ -249,12 +273,18 @@ export class AuthenticatorValidateStageForm extends BaseStageForm<AuthenticatorV
                     />
                 </ak-form-element-horizontal>
 
-                <ak-form-element-horizontal
-                    label=${msg("SMS OTP throttling factor")}
-                    required
-                    name="smsOtpThrottlingFactor"
-                >
+                <ak-form-element-horizontal required name="smsOtpThrottlingFactor">
+                    ${AKLabel(
+                        {
+                            slot: "label",
+                            className: "pf-c-form__group-label",
+                            htmlFor: "smsOtpThrottlingFactor",
+                            required: true,
+                        },
+                        msg("SMS OTP throttling factor"),
+                    )}
                     <input
+                        id="smsOtpThrottlingFactor"
                         type="number"
                         step="0.1"
                         value=${this.instance?.smsOtpThrottlingFactor || 1}
@@ -264,12 +294,18 @@ export class AuthenticatorValidateStageForm extends BaseStageForm<AuthenticatorV
                         required
                     />
                 </ak-form-element-horizontal>
-                <ak-form-element-horizontal
-                    label=${msg("TOTP throttling factor")}
-                    required
-                    name="totpOtpThrottlingFactor"
-                >
+                <ak-form-element-horizontal required name="totpOtpThrottlingFactor">
+                    ${AKLabel(
+                        {
+                            slot: "label",
+                            className: "pf-c-form__group-label",
+                            htmlFor: "totpOtpThrottlingFactor",
+                            required: true,
+                        },
+                        msg("TOTP throttling factor"),
+                    )}
                     <input
+                        id="totpOtpThrottlingFactor"
                         type="number"
                         step="0.1"
                         value=${this.instance?.totpOtpThrottlingFactor || 1}
@@ -280,12 +316,18 @@ export class AuthenticatorValidateStageForm extends BaseStageForm<AuthenticatorV
                     />
                 </ak-form-element-horizontal>
 
-                <ak-form-element-horizontal
-                    label=${msg("Static OTP throttling factor")}
-                    required
-                    name="staticOtpThrottlingFactor"
-                >
+                <ak-form-element-horizontal required name="staticOtpThrottlingFactor">
+                    ${AKLabel(
+                        {
+                            slot: "label",
+                            className: "pf-c-form__group-label",
+                            htmlFor: "staticOtpThrottlingFactor",
+                            required: true,
+                        },
+                        msg("Static OTP throttling factor"),
+                    )}
                     <input
+                        id="staticOtpThrottlingFactor"
                         type="number"
                         step="0.1"
                         value=${this.instance?.staticOtpThrottlingFactor || 1}
@@ -298,12 +340,18 @@ export class AuthenticatorValidateStageForm extends BaseStageForm<AuthenticatorV
             </ak-form-group>
             <ak-form-group open label="${msg("WebAuthn-specific settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("WebAuthn User verification")}
-                        required
-                        name="webauthnUserVerification"
-                    >
+                    <ak-form-element-horizontal required name="webauthnUserVerification">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "webauthnUserVerification",
+                                required: true,
+                            },
+                            msg("WebAuthn User verification"),
+                        )}
                         <ak-radio
+                            id="webauthnUserVerification"
                             .options=${[
                                 {
                                     label: msg("User verification must occur."),
@@ -325,8 +373,17 @@ export class AuthenticatorValidateStageForm extends BaseStageForm<AuthenticatorV
                         >
                         </ak-radio>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal label=${msg("WebAuthn Hints")} name="webauthnHints">
+                    <ak-form-element-horizontal name="webauthnHints">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "webauthnHints",
+                            },
+                            msg("WebAuthn Hints"),
+                        )}
                         <ak-dual-select-provider
+                            id="webauthnHints"
                             .provider=${(): Promise<DataProvision> => {
                                 return Promise.resolve({
                                     options: allHints,
@@ -345,11 +402,17 @@ export class AuthenticatorValidateStageForm extends BaseStageForm<AuthenticatorV
                             )}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("WebAuthn Device type restrictions")}
-                        name="webauthnAllowedDeviceTypes"
-                    >
+                    <ak-form-element-horizontal name="webauthnAllowedDeviceTypes">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "webauthnAllowedDeviceTypes",
+                            },
+                            msg("WebAuthn Device type restrictions"),
+                        )}
                         <ak-dual-select-provider
+                            id="webauthnAllowedDeviceTypes"
                             .provider=${authenticatorWebauthnDeviceTypesListProvider}
                             .selected=${(this.instance?.webauthnAllowedDeviceTypesObj ?? []).map(
                                 deviceTypeRestrictionPair,

--- a/web/src/admin/stages/authenticator_webauthn/AuthenticatorWebAuthnStageForm.ts
+++ b/web/src/admin/stages/authenticator_webauthn/AuthenticatorWebAuthnStageForm.ts
@@ -9,6 +9,8 @@ import { DEFAULT_CONFIG } from "#common/api/config";
 
 import { DataProvision, DualSelectPair } from "#elements/ak-dual-select/types";
 
+import { AKLabel } from "#components/ak-label";
+
 import { RenderFlowOption } from "#admin/flows/utils";
 import { deviceTypeRestrictionPair } from "#admin/stages/authenticator_webauthn/utils";
 import { BaseStageForm } from "#admin/stages/BaseStageForm";
@@ -66,20 +68,35 @@ export class AuthenticatorWebAuthnStageForm extends BaseStageForm<AuthenticatorW
                     "Stage used to configure a WebAuthn authenticator (i.e. Yubikey, FaceID/Windows Hello).",
                 )}
             </span>
-            <ak-form-element-horizontal label=${msg("Name")} required name="name">
+            <ak-form-element-horizontal required name="name">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "name",
+                        required: true,
+                    },
+                    msg("Name"),
+                )}
                 <input
+                    id="name"
                     type="text"
                     value="${this.instance?.name ?? ""}"
                     class="pf-c-form-control"
                     required
                 />
             </ak-form-element-horizontal>
-            <ak-form-element-horizontal
-                label=${msg("Authenticator type name")}
-                ?required=${false}
-                name="friendlyName"
-            >
+            <ak-form-element-horizontal ?required=${false} name="friendlyName">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "friendlyName",
+                    },
+                    msg("Authenticator type name"),
+                )}
                 <input
+                    id="friendlyName"
                     type="text"
                     value="${this.instance?.friendlyName ?? ""}"
                     class="pf-c-form-control"
@@ -92,12 +109,18 @@ export class AuthenticatorWebAuthnStageForm extends BaseStageForm<AuthenticatorW
             </ak-form-element-horizontal>
             <ak-form-group open label="${msg("Stage-specific settings")}">
                 <div class="pf-c-form">
-                    <ak-form-element-horizontal
-                        label=${msg("User verification")}
-                        required
-                        name="userVerification"
-                    >
+                    <ak-form-element-horizontal required name="userVerification">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "userVerification",
+                                required: true,
+                            },
+                            msg("User verification"),
+                        )}
                         <ak-radio
+                            id="userVerification"
                             .options=${[
                                 {
                                     label: msg("Required: User verification must occur."),
@@ -119,12 +142,18 @@ export class AuthenticatorWebAuthnStageForm extends BaseStageForm<AuthenticatorW
                         >
                         </ak-radio>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Resident key requirement")}
-                        required
-                        name="residentKeyRequirement"
-                    >
+                    <ak-form-element-horizontal required name="residentKeyRequirement">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "residentKeyRequirement",
+                                required: true,
+                            },
+                            msg("Resident key requirement"),
+                        )}
                         <ak-radio
+                            id="residentKeyRequirement"
                             .options=${[
                                 {
                                     label: msg(
@@ -150,12 +179,18 @@ export class AuthenticatorWebAuthnStageForm extends BaseStageForm<AuthenticatorW
                         >
                         </ak-radio>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Authenticator Attachment")}
-                        required
-                        name="authenticatorAttachment"
-                    >
+                    <ak-form-element-horizontal required name="authenticatorAttachment">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "authenticatorAttachment",
+                                required: true,
+                            },
+                            msg("Authenticator Attachment"),
+                        )}
                         <ak-radio
+                            id="authenticatorAttachment"
                             .options=${[
                                 {
                                     label: msg(
@@ -186,8 +221,17 @@ export class AuthenticatorWebAuthnStageForm extends BaseStageForm<AuthenticatorW
                             )}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal label=${msg("Hints")} name="hints">
+                    <ak-form-element-horizontal name="hints">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "hints",
+                            },
+                            msg("Hints"),
+                        )}
                         <ak-dual-select-provider
+                            id="hints"
                             .provider=${(): Promise<DataProvision> => {
                                 return Promise.resolve({
                                     options: allHints,
@@ -223,11 +267,17 @@ export class AuthenticatorWebAuthnStageForm extends BaseStageForm<AuthenticatorW
                             "When enabled, any unique authenticator can only be registered once.",
                         )}
                     ></ak-switch-input>
-                    <ak-form-element-horizontal
-                        label=${msg("Device type restrictions")}
-                        name="deviceTypeRestrictions"
-                    >
+                    <ak-form-element-horizontal name="deviceTypeRestrictions">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "deviceTypeRestrictions",
+                            },
+                            msg("Device type restrictions"),
+                        )}
                         <ak-dual-select-provider
+                            id="deviceTypeRestrictions"
                             .provider=${(page: number, search?: string): Promise<DataProvision> => {
                                 return new StagesApi(DEFAULT_CONFIG)
                                     .stagesAuthenticatorWebauthnDeviceTypesList({
@@ -253,11 +303,17 @@ export class AuthenticatorWebAuthnStageForm extends BaseStageForm<AuthenticatorW
                             )}
                         </p>
                     </ak-form-element-horizontal>
-                    <ak-form-element-horizontal
-                        label=${msg("Configuration flow")}
-                        name="configureFlow"
-                    >
+                    <ak-form-element-horizontal name="configureFlow">
+                        ${AKLabel(
+                            {
+                                slot: "label",
+                                className: "pf-c-form__group-label",
+                                htmlFor: "configureFlow",
+                            },
+                            msg("Configuration flow"),
+                        )}
                         <ak-search-select
+                            id="configureFlow"
                             .fetchObjects=${async (query?: string): Promise<Flow[]> => {
                                 const args: FlowsInstancesListRequest = {
                                     ordering: "slug",


### PR DESCRIPTION
## Summary

Slice 1f-i of the form-input/label triage from #22389 (first of three 1f sub-slices per [the plan posted on the issue](https://github.com/goauthentik/authentik/issues/22389#issuecomment-4467358364); follows #22390, #22391, #22392, #22396, #22397). Mechanical sweep of the deprecated `label="..."` attribute on `<ak-form-element-horizontal>` across the authenticator-stage forms under `web/src/admin/stages/authenticator_*/`.

- 9 files, 60 attribute occurrences.
- Covers every authenticator-stage form (SMS, email, validate, webauthn, duo, static, totp, endpoint_gdtc) plus `DuoDeviceImportForm`.
- Same mechanical pattern as #22390 / #22391 / #22392 / #22396 / #22397.

## Per-file occurrence breakdown

| File | label= occurrences |
|---|---|
| `AuthenticatorSMSStageForm.ts` | 12 |
| `AuthenticatorEmailStageForm.ts` | 11 |
| `AuthenticatorValidateStageForm.ts` | 10 |
| `AuthenticatorWebAuthnStageForm.ts` | 8 |
| `AuthenticatorDuoStageForm.ts` | 6 |
| `AuthenticatorStaticStageForm.ts` | 5 |
| `AuthenticatorTOTPStageForm.ts` | 4 |
| `AuthenticatorEndpointGDTCStageForm.ts` | 2 |
| `authenticator_duo/DuoDeviceImportForm.ts` | 2 |

## E2E coverage (`needs_e2e`)

Same story as #22396 / #22397: the Python selenium suite at `tests/e2e/test_flows_authenticators*.py` (TOTP, WebAuthn, etc.) tests authenticator-driven **flow execution**, not the admin form UI. Selector-safe by construction; CI will run the suite once workflow runs are approved.

**Visual smoke** (Playwright headless against `AuthenticatorTOTPStageForm` via the "New Stage" wizard on `localhost:8000`): all 4 migrated form elements bind correctly to their inner controls (`name`/`friendlyName` → `<input>`, `digits` → `<select>`, `configureFlow` → `<ak-search-select>`). 0 deprecated-shadow-label fallbacks; 0 console errors. The stage-type picker is built from actual `<input type="radio">` elements (unlike the source/provider wizards' custom card widgets), so the wizard was navigable.

## Out of scope (other slices, see #22389)

- Remaining 1f sub-slices: 1f-ii (flow/account stages — 16 files) and 1f-iii (prompt/invitation — 8 files). After 1f-iii lands, the `<ak-form-element-horizontal label=…>` occurrence count should hit zero and the deprecated `@property label` on `HorizontalFormElement` can be deleted in slice 6.
- Slices 2–5 (semantics, family consolidation, ID centralisation, e2e selector migration).

## Test plan

- [x] `tsc --noEmit` (exit 0)
- [x] precommit (exit 0)
- [x] `make web-build` — migrated `htmlFor` values present in rebuilt chunks
- [x] Playwright headless visual smoke against `AuthenticatorTOTPStageForm` via wizard
- [ ] Python `tests/e2e/test_flows_authenticators*.py` — selector-safe by construction; CI will run
- [ ] Playwright `web/e2e/` — already label-based

## Disclosure

Triaged and authored end-to-end by an agent running in a sandbox against `goauthentik/authentik@main`. Reviewed and shipped by @GirlBossRush.

Refs #22389
