### PR TITLE
root: Update CODEOWNERS for spellcheck dictionaries

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -51,7 +51,7 @@ packages/tsconfig                       @goauthentik/frontend
 web/                                    @goauthentik/frontend
 # Locale
 /locale/                                @goauthentik/backend @goauthentik/frontend
-/locale/*/dictionaries                 @goauthentik/frontend @goauthentik/docs
+/locale/*/dictionaries                  @goauthentik/frontend @goauthentik/docs
 web/xliff/                              @goauthentik/backend @goauthentik/frontend
 # Docs
 website/                                @goauthentik/docs

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -51,6 +51,7 @@ packages/tsconfig                       @goauthentik/frontend
 web/                                    @goauthentik/frontend
 # Locale
 /locale/                                @goauthentik/backend @goauthentik/frontend
+/locale/*/dictionaries                 @goauthentik/frontend @goauthentik/docs
 web/xliff/                              @goauthentik/backend @goauthentik/frontend
 # Docs
 website/                                @goauthentik/docs


### PR DESCRIPTION
## Details

Small adjustment to our CODEOWNERS file, allowing the docs team to commit changes to our spellcheck dictionaries. This typically comes up when adding new integrations which often have names not in the base dictionary.