### PR TITLE
ci: S3-curated-dict transition layer for translation profanity gate

### DIFF
--- a/.github/workflows/qa-translation-profanity.yml
+++ b/.github/workflows/qa-translation-profanity.yml
@@ -1,30 +1,13 @@
 ---
+# workflow_dispatch-only while the dictionary source is the LDNOOBW placeholder
+# (180+ false positives on existing Transifex translations). When the curated
+# `PROFANITY_DICT_BASE_URL` repo variable is swapped to the S3 mirror, re-enable
+# the `pull_request` trigger (paths-filter on locale/** + web/xliff/**) in the
+# same PR that introduces the variable.
 name: QA - Translation profanity
 
 on:
   workflow_dispatch: {}
-  pull_request:
-    paths:
-      - "locale/**"
-      - "web/xliff/**"
-      - "scripts/translation_profanity_check.py"
-      - "scripts/.translation_profanity_allowlist"
-      - ".github/workflows/qa-translation-profanity.yml"
-  push:
-    branches:
-      - main
-      - version-*
-    paths:
-      - "locale/**"
-      - "web/xliff/**"
-      - "scripts/translation_profanity_check.py"
-      - "scripts/.translation_profanity_allowlist"
-      - ".github/workflows/qa-translation-profanity.yml"
-  schedule:
-    # Daily safety net for translations that land via the automated Transifex
-    # PR (created by ci-translation-extract-compile.yml). Random HH:MM to
-    # avoid the 00:00 load spike.
-    - cron: "37 4 * * *"
 
 permissions:
   contents: read
@@ -43,6 +26,6 @@ jobs:
       - name: Scan translations
         env:
           # Operator-swappable: defaults to the public LDNOOBW raw URL; swap
-          # to an S3 mirror by setting this secret/variable in the repo.
+          # to the curated S3 URL by setting this repo variable.
           PROFANITY_DICT_BASE_URL: ${{ vars.PROFANITY_DICT_BASE_URL }}
         run: python scripts/translation_profanity_check.py --root .

--- a/.github/workflows/qa-translation-profanity.yml
+++ b/.github/workflows/qa-translation-profanity.yml
@@ -1,0 +1,48 @@
+---
+name: QA - Translation profanity
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - "locale/**"
+      - "web/xliff/**"
+      - "scripts/translation_profanity_check.py"
+      - "scripts/.translation_profanity_allowlist"
+      - ".github/workflows/qa-translation-profanity.yml"
+  push:
+    branches:
+      - main
+      - version-*
+    paths:
+      - "locale/**"
+      - "web/xliff/**"
+      - "scripts/translation_profanity_check.py"
+      - "scripts/.translation_profanity_allowlist"
+      - ".github/workflows/qa-translation-profanity.yml"
+  schedule:
+    # Daily safety net for translations that land via the automated Transifex
+    # PR (created by ci-translation-extract-compile.yml). Random HH:MM to
+    # avoid the 00:00 load spike.
+    - cron: "37 4 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  profanity-scan:
+    name: scan translations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
+        with:
+          python-version: "3.14"
+      - name: Self-test the scanner
+        run: python scripts/translation_profanity_check.py --self-test
+      - name: Scan translations
+        env:
+          # Operator-swappable: defaults to the public LDNOOBW raw URL; swap
+          # to an S3 mirror by setting this secret/variable in the repo.
+          PROFANITY_DICT_BASE_URL: ${{ vars.PROFANITY_DICT_BASE_URL }}
+        run: python scripts/translation_profanity_check.py --root .

--- a/.github/workflows/qa-translation-profanity.yml
+++ b/.github/workflows/qa-translation-profanity.yml
@@ -1,13 +1,42 @@
 ---
-# workflow_dispatch-only while the dictionary source is the LDNOOBW placeholder
-# (180+ false positives on existing Transifex translations). When the curated
-# `PROFANITY_DICT_BASE_URL` repo variable is swapped to the S3 mirror, re-enable
-# the `pull_request` trigger (paths-filter on locale/** + web/xliff/**) in the
-# same PR that introduces the variable.
+# Active gate against the curated profanity dictionary configured at
+# `PROFANITY_DICT_BASE_URL` (a repo Variable; falls back to the LDNOOBW
+# placeholder if unset — see scripts/translation_profanity_check.py for
+# the resolution order). Findings honour the per-locale allowlist at
+# scripts/.translation_profanity_allowlist and the SHA256 pins at
+# scripts/.translation_profanity_dict_pins.
+#
+# Re-enabled `pull_request` + `push` triggers when the curated S3
+# dictionary work landed (see TODO(s3-dict) marker in the scanner for
+# the swap point). `workflow_dispatch` is retained for manual triage.
 name: QA - Translation profanity
 
 on:
   workflow_dispatch: {}
+  pull_request:
+    paths:
+      - "locale/**"
+      - "web/xliff/**"
+      - "scripts/translation_profanity_check.py"
+      - "scripts/.translation_profanity_allowlist"
+      - "scripts/.translation_profanity_dict_pins"
+      - ".github/workflows/qa-translation-profanity.yml"
+  push:
+    branches:
+      - main
+      - version-*
+    paths:
+      - "locale/**"
+      - "web/xliff/**"
+      - "scripts/translation_profanity_check.py"
+      - "scripts/.translation_profanity_allowlist"
+      - "scripts/.translation_profanity_dict_pins"
+      - ".github/workflows/qa-translation-profanity.yml"
+  schedule:
+    # Daily safety net for translations that land via the automated Transifex
+    # PR (created by ci-translation-extract-compile.yml). Random HH:MM to
+    # avoid the 00:00 load spike.
+    - cron: "37 4 * * *"
 
 permissions:
   contents: read
@@ -21,11 +50,26 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
         with:
           python-version: "3.14"
+      - name: Cache fetched dictionaries
+        # The scanner enforces a 24h TTL internally, so this cache layer just
+        # avoids the cold-start round-trip across runs. Hashing the pin file
+        # in the key forces a cache bust when the operator rotates SHA256
+        # pins. (We don't bucket on date — within a day the in-process TTL
+        # handles freshness; across days the scanner re-fetches lazily and
+        # the cross-run cache stays correct-but-stale.)
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
+        with:
+          path: ~/.cache/authentik-translation-profanity
+          key: profanity-dict-${{ runner.os }}-${{ hashFiles('scripts/.translation_profanity_dict_pins') }}
+          restore-keys: |
+            profanity-dict-${{ runner.os }}-
       - name: Self-test the scanner
         run: python scripts/translation_profanity_check.py --self-test
       - name: Scan translations
         env:
-          # Operator-swappable: defaults to the public LDNOOBW raw URL; swap
-          # to the curated S3 URL by setting this repo variable.
+          # Operator-swappable: leave unset to use the constant default in
+          # scripts/translation_profanity_check.py (LDNOOBW placeholder until
+          # TODO(s3-dict) is resolved); set to the curated S3 URL for an
+          # explicit override without a code change.
           PROFANITY_DICT_BASE_URL: ${{ vars.PROFANITY_DICT_BASE_URL }}
         run: python scripts/translation_profanity_check.py --root .

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,9 @@ migrate: ## Run the Authentik Django server's migrations
 
 i18n-extract: core-i18n-extract web-i18n-extract  ## Extract strings that require translation into files to send to a translation service
 
+i18n-profanity-check:  ## Scan translated PO + XLIFF strings against per-language profanity dictionaries
+	python3 scripts/translation_profanity_check.py --root .
+
 aws-cfn: node-install
 	corepack npm install --prefix lifecycle/aws
 	$(UV) run corepack npm run aws-cfn --prefix lifecycle/aws

--- a/scripts/.translation_profanity_allowlist
+++ b/scripts/.translation_profanity_allowlist
@@ -1,0 +1,9 @@
+# Translation profanity gate — false-positive allowlist.
+#
+# One msgid-hash (first 16 hex chars of SHA-256 over the English source msgid)
+# per line. '#' begins a comment.
+#
+# When the gate flags a legitimate translation (e.g. a medical/anatomical
+# term that overlaps with the LDNOOBW dictionary), copy the printed
+# `msgid_hash=` value here. We deliberately key on the *source* msgid hash so
+# this repo never stores the translated profane text itself.

--- a/scripts/.translation_profanity_allowlist
+++ b/scripts/.translation_profanity_allowlist
@@ -17,6 +17,24 @@
 # rewording. The allowlist statement is "this English phrase in this
 # locale is acceptable", not "this exact translated string is acceptable".
 #
+# Post-S3 policy (effective once the curated dictionary takes over via
+# TODO(s3-dict) in scripts/translation_profanity_check.py):
+#
+#   1. Start empty. The curated dict should have a low false-positive
+#      rate by design — if it doesn't, fix the dict, don't mass-seed
+#      this file.
+#   2. Add entries per-finding with a one-line justification (UX term,
+#      compound-word collision, regional usage, etc.). Cite the
+#      relevant issue / Slack thread when possible.
+#   3. When the dict's SHA256 pin is rotated (see
+#      scripts/.translation_profanity_dict_pins) the operator SHOULD
+#      walk this file: an entry that suppressed a finding under the old
+#      dict may be over-broad or no longer needed under the new dict.
+#      Stale entries are tolerated but invite drift; reviewers should
+#      push back on adding entries without expiring old ones.
+#   4. The hard "no profanity text in repo" rule still holds — entries
+#      contain only English-msgid hashes + non-profane reason text.
+#
 # When the gate flags a legitimate translation (e.g. an anatomical or
 # UX term that overlaps with the upstream dictionary), copy the printed
 # `allowlist_key=` value here and add a one-line justification.

--- a/scripts/.translation_profanity_allowlist
+++ b/scripts/.translation_profanity_allowlist
@@ -1,9 +1,27 @@
 # Translation profanity gate — false-positive allowlist.
 #
-# One msgid-hash (first 16 hex chars of SHA-256 over the English source msgid)
-# per line. '#' begins a comment.
+# Schema (one entry per line):
 #
-# When the gate flags a legitimate translation (e.g. a medical/anatomical
-# term that overlaps with the LDNOOBW dictionary), copy the printed
-# `msgid_hash=` value here. We deliberately key on the *source* msgid hash so
-# this repo never stores the translated profane text itself.
+#     <locale>:<msgid_hash>  # human-readable reason
+#
+# - <locale> matches the discovered locale identifier (e.g. de_DE, ja-JP,
+#   zh-Hans, pt_BR).
+# - <msgid_hash> is the first 16 hex chars of SHA-256 over the *English
+#   source msgid*. Keying on the source ensures that if the English
+#   wording changes the entry re-triggers review.
+# - The inline `# reason` comment is mandatory; the scanner fails loud
+#   on any bare hash so the allowlist stays PR-reviewable.
+#
+# We deliberately do *not* hash the translated target text — that would
+# pin the entry to a specific translation and re-fail on any legitimate
+# rewording. The allowlist statement is "this English phrase in this
+# locale is acceptable", not "this exact translated string is acceptable".
+#
+# When the gate flags a legitimate translation (e.g. an anatomical or
+# UX term that overlaps with the upstream dictionary), copy the printed
+# `allowlist_key=` value here and add a one-line justification.
+#
+# Example (illustrative only — no entries seeded today):
+#
+#     ja_JP:0123456789abcdef  # "insertion" (UX term, reviewed 2026-05-01)
+#     de_DE:fedcba9876543210  # compound word, false positive, see #12345

--- a/scripts/.translation_profanity_dict_pins
+++ b/scripts/.translation_profanity_dict_pins
@@ -1,0 +1,27 @@
+# Per-language SHA256 pins for the curated profanity dictionary.
+#
+# Schema (one entry per line):
+#
+#     <dict_code>  <sha256-hex>          # optional reason / version note
+#
+# - <dict_code> is the dictionary-side language code (e.g. de, ja, zh —
+#   what the scanner derives via dict_code_for_locale, not the repo
+#   locale identifier). See LOCALE_DICT_OVERRIDES in the scanner.
+# - <sha256-hex> is the SHA256 of the dictionary file as fetched from
+#   PROFANITY_DICT_BASE_URL/<dict_code>.
+# - `#` comments and blank lines are ignored.
+#
+# A pinned dict is verified on every fetch; on mismatch the gate fails
+# with exit code 2 (DictPinError) — pin rotation is an operator action,
+# not a silent refresh. To rotate: confirm the new dict is intentional,
+# compute its SHA256 (`shasum -a 256`), bump the entry here, and commit
+# the change with a PR-reviewable reason.
+#
+# Empty body = no integrity check (matches the v3 default for the
+# LDNOOBW placeholder, where pinning against rolling upstream is not
+# useful). Pin entries should be added at S3-swap time:
+#
+#     de  abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789  # curated v1, 2026-xx-xx
+#     ja  …
+#
+# Until then this file stays empty.

--- a/scripts/translation_profanity_check.py
+++ b/scripts/translation_profanity_check.py
@@ -156,16 +156,21 @@ class TranslationEntry:
     locale: str
     msgid: str
     target: str
+    references: tuple[str, ...] = ()  # PO `#:` source-location refs
+    xliff_id: str | None = None  # XLIFF trans-unit id attribute
 
 
-def iter_po(path: Path, locale: str) -> Iterator[TranslationEntry]:
+def iter_po(path: Path, locale: str) -> Iterator[TranslationEntry]:  # noqa: PLR0915 — single-pass PO state machine, splits would just push state out
     """Minimal PO reader: yields (msgid, msgstr) pairs with line numbers.
 
     Handles multi-line continuation strings and fuzzy/obsolete entries (we
     include fuzzy entries — they still ship to users — but skip obsolete
-    `#~` entries)."""
+    `#~` entries). PO `#:` location references (gettext extractor output)
+    are captured and attached to the entry whose `msgid` follows."""
     msgid_parts: list[str] = []
     msgstr_parts: list[str] = []
+    pending_refs: list[str] = []  # accumulates between flush and next msgid
+    entry_refs: tuple[str, ...] = ()  # frozen at msgid-encounter time
     state: str | None = None  # None | "msgid" | "msgstr"
     entry_line = 0
 
@@ -174,7 +179,14 @@ def iter_po(path: Path, locale: str) -> Iterator[TranslationEntry]:
             msgid = "".join(msgid_parts)
             target = "".join(msgstr_parts)
             if msgid and target:  # skip the empty header entry
-                yield TranslationEntry(path, entry_line, locale, msgid, target)
+                yield TranslationEntry(
+                    path=path,
+                    line=entry_line,
+                    locale=locale,
+                    msgid=msgid,
+                    target=target,
+                    references=entry_refs,
+                )
 
     with path.open(encoding="utf-8") as fh:
         for lineno, raw in enumerate(fh, start=1):
@@ -183,17 +195,26 @@ def iter_po(path: Path, locale: str) -> Iterator[TranslationEntry]:
             if stripped.startswith("#~"):
                 # Obsolete entry — drop pending and skip.
                 msgid_parts, msgstr_parts, state = [], [], None
+                pending_refs = []
+                continue
+            if stripped.startswith("#:"):
+                # `#: path/to/file.py:42 other/file.py:11` — refs for the
+                # next msgid; accumulate.
+                pending_refs.extend(tok for tok in stripped[2:].split() if tok)
                 continue
             if not stripped or stripped.startswith("#"):
                 if not stripped and state is not None:
                     # Blank line terminates an entry.
                     yield from flush()
                     msgid_parts, msgstr_parts, state = [], [], None
+                    entry_refs = ()
                 continue
             if stripped.startswith("msgid "):
                 yield from flush()
                 msgid_parts = [_po_unquote(stripped[len("msgid ") :])]
                 msgstr_parts = []
+                entry_refs = tuple(pending_refs)
+                pending_refs = []
                 state = "msgid"
                 entry_line = lineno
             elif stripped.startswith("msgid_plural "):
@@ -230,7 +251,10 @@ _XLIFF_NS = "{urn:oasis:names:tc:xliff:document:1.2}"
 
 
 def iter_xliff(path: Path, locale: str) -> Iterator[TranslationEntry]:
-    """Yields trans-units that have a non-empty <target>."""
+    """Yields trans-units that have a non-empty <target>.
+
+    Captures the `id` attribute on every unit so findings can point a
+    developer at the named ID instead of forcing them to decode a hash."""
     try:
         tree = ET.parse(path)
     except ET.ParseError as exc:
@@ -244,10 +268,20 @@ def iter_xliff(path: Path, locale: str) -> Iterator[TranslationEntry]:
         target = "".join(tgt_el.itertext())
         if not target.strip():
             continue
-        msgid = "".join(src_el.itertext()) if src_el is not None else unit.get("id", "")
+        unit_id = unit.get("id") or None
+        # `<source>` is the English msgid; the `id` attribute is the named/
+        # generated identifier developers use in code.
+        msgid = "".join(src_el.itertext()) if src_el is not None else (unit_id or "")
         # XLIFF ElementTree doesn't expose line numbers natively; report 0 to
         # mean "see file". Acceptable trade-off vs. pulling in lxml.
-        yield TranslationEntry(path, 0, locale, msgid, target)
+        yield TranslationEntry(
+            path=path,
+            line=0,
+            locale=locale,
+            msgid=msgid,
+            target=target,
+            xliff_id=unit_id,
+        )
 
 
 # --- discovery ------------------------------------------------------------
@@ -282,13 +316,21 @@ class Finding:
     locale: str
     path: Path
     line: int
-    word: str
+    word: str  # matched dictionary entry; redacted from default output
     msgid: str
-    target: str
+    target: str  # full translated string; available to JSON output
+    dict_code: str
+    references: tuple[str, ...] = ()
+    xliff_id: str | None = None
 
     @property
     def msgid_hash(self) -> str:
         return msgid_hash(self.msgid)
+
+    @property
+    def allowlist_key(self) -> str:
+        """`<locale>:<msgid_hash>` — the per-locale exemption key."""
+        return f"{self.locale}:{self.msgid_hash}"
 
 
 def _build_word_pattern(words: Iterable[str]) -> tuple[re.Pattern[str] | None, list[str]]:
@@ -314,6 +356,7 @@ def _build_word_pattern(words: Iterable[str]) -> tuple[re.Pattern[str] | None, l
 def scan_entries(
     entries: Iterable[TranslationEntry],
     dictionary: list[str],
+    dict_code: str,
 ) -> Iterator[Finding]:
     pattern, substrings = _build_word_pattern(dictionary)
     for entry in entries:
@@ -327,6 +370,9 @@ def scan_entries(
                     word=m.group(0),
                     msgid=entry.msgid,
                     target=entry.target,
+                    dict_code=dict_code,
+                    references=entry.references,
+                    xliff_id=entry.xliff_id,
                 )
         for term in substrings:
             if term in haystack:
@@ -337,20 +383,73 @@ def scan_entries(
                     word=term,
                     msgid=entry.msgid,
                     target=entry.target,
+                    dict_code=dict_code,
+                    references=entry.references,
+                    xliff_id=entry.xliff_id,
                 )
 
 
 # --- allowlist ------------------------------------------------------------
 
+# Allowlist entry shape: `<locale>:<16-hex>`. Locale segment may be any
+# non-empty token that doesn't contain ':' — matches what `discover_*`
+# emits (e.g. `de_DE`, `zh-Hans`, `pt_BR`).
+_ALLOWLIST_ENTRY_RE = re.compile(r"^([^:#\s]+):([0-9a-f]{16})$")
+
+
+class AllowlistError(ValueError):
+    """Raised when the allowlist file violates the schema.
+
+    The validator is intentionally strict: bare hashes with no `# reason`
+    comment, malformed entries, or hashes without a locale prefix all fail
+    loud so the allowlist stays PR-reviewable rather than degenerating into
+    an unauditable set of opaque hex strings."""
+
 
 def load_allowlist(path: Path | None) -> set[str]:
+    """Parse and validate the allowlist file.
+
+    Schema (one entry per line):
+
+        <locale>:<msgid_hash>  # reason text
+
+    - Bare hashes (no `#` comment) raise AllowlistError.
+    - Empty reason comments raise AllowlistError.
+    - Malformed `<locale>:<hash>` segments raise AllowlistError.
+    - Lines that start with `#` or are blank are ignored (header docs)."""
     if path is None or not path.is_file():
         return set()
     out: set[str] = set()
-    for raw_line in path.read_text(encoding="utf-8").splitlines():
-        entry = raw_line.split("#", 1)[0].strip()
-        if entry:
-            out.add(entry)
+    errors: list[str] = []
+    for lineno, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue  # pure-comment or blank line — fine
+        # Entry line: must have an inline `# reason` comment.
+        if "#" not in raw_line:
+            errors.append(
+                f"{path}:{lineno}: allowlist entry without '# reason' comment: "
+                f"{stripped!r} — every entry must justify itself"
+            )
+            continue
+        lhs, _, comment = raw_line.partition("#")
+        entry = lhs.strip()
+        if not comment.strip():
+            errors.append(
+                f"{path}:{lineno}: empty reason comment for {entry!r} — "
+                f"explain why this msgid is exempt in this locale"
+            )
+            continue
+        m = _ALLOWLIST_ENTRY_RE.match(entry)
+        if not m:
+            errors.append(
+                f"{path}:{lineno}: malformed entry {entry!r} — expected "
+                f"'<locale>:<msgid_hash>' (e.g. 'de_DE:abc123def4567890')"
+            )
+            continue
+        out.add(entry)
+    if errors:
+        raise AllowlistError("\n".join(errors))
     return out
 
 
@@ -358,13 +457,35 @@ def load_allowlist(path: Path | None) -> set[str]:
 
 
 def _format_findings(findings: list[Finding]) -> str:
-    lines = []
+    """Render findings without echoing the matched dictionary token.
+
+    Per the original brief we never print the dictionary entry that matched
+    (the "word") — defence in depth so CI logs stay shareable. We do print
+    the English `msgid` (non-profane by definition) and the `target` (the
+    translated string), since operators need *some* anchor for triage; the
+    `target` may be removed in a future tightening pass.
+
+    Each finding renders both as a GitHub Actions `::error::` annotation
+    and (per CLI tradition) a human-readable trailing line. Extra
+    diagnostics — XLIFF `id`, PO `#:` refs — are emitted when available."""
+    lines: list[str] = []
     for f in findings:
         loc = f"{f.path}:{f.line}" if f.line else str(f.path)
+        extras: list[str] = [
+            f"locale={f.locale}",
+            f"dict={f.dict_code}",
+            f"allowlist_key={f.allowlist_key}",
+            f"msgid={f.msgid!r}",
+            f"target={f.target!r}",
+        ]
+        if f.xliff_id:
+            extras.append(f"xliff_id={f.xliff_id}")
+        if f.references:
+            extras.append(f"refs={','.join(f.references)}")
         lines.append(
             f"::error file={f.path},line={f.line or 1}::"
-            f"[{f.locale}] profanity match {f.word!r} at {loc} "
-            f"(msgid_hash={f.msgid_hash}, msgid={f.msgid!r}, target={f.target!r})"
+            f"[{f.locale}] 1 match against profanity-dict[{f.dict_code}] at {loc} "
+            f"({'; '.join(extras)})"
         )
     return "\n".join(lines)
 
@@ -372,7 +493,12 @@ def _format_findings(findings: list[Finding]) -> str:
 def run(args: argparse.Namespace) -> int:
     root = Path(args.root).resolve()
     base_url = args.base_url or os.environ.get("PROFANITY_DICT_BASE_URL", DEFAULT_BASE_URL)
-    allowlist = load_allowlist(Path(args.allowlist) if args.allowlist else None)
+    try:
+        allowlist = load_allowlist(Path(args.allowlist) if args.allowlist else None)
+    except AllowlistError as exc:
+        print("allowlist validation failed:", file=sys.stderr)
+        print(str(exc), file=sys.stderr)
+        return 2
 
     files = discover_translation_files(root)
     if not files:
@@ -402,13 +528,17 @@ def run(args: argparse.Namespace) -> int:
             continue
         for path, locale, kind in by_dict_code[code]:
             entries = iter_po(path, locale) if kind == "po" else iter_xliff(path, locale)
-            for finding in scan_entries(entries, dictionary):
+            for finding in scan_entries(entries, dictionary, dict_code=code):
                 all_findings.append(finding)
 
-    blocking = [f for f in all_findings if f.msgid_hash not in allowlist]
-    allowed = [f for f in all_findings if f.msgid_hash in allowlist]
+    blocking = [f for f in all_findings if f.allowlist_key not in allowlist]
+    allowed = [f for f in all_findings if f.allowlist_key in allowlist]
 
     if args.json:
+        # JSON output is for local triage / piping; full diagnostics including
+        # the target string are included so an operator can build allowlist
+        # entries without re-running. CI logs use `_format_findings` which
+        # redacts the matched dictionary token.
         print(
             json.dumps(
                 {
@@ -417,14 +547,20 @@ def run(args: argparse.Namespace) -> int:
                             "locale": f.locale,
                             "path": str(f.path),
                             "line": f.line,
-                            "word": f.word,
+                            "dict_code": f.dict_code,
+                            "allowlist_key": f.allowlist_key,
+                            "msgid": f.msgid,
                             "msgid_hash": f.msgid_hash,
+                            "target": f.target,
+                            "xliff_id": f.xliff_id,
+                            "references": list(f.references),
                         }
                         for f in blocking
                     ],
                     "allowed_count": len(allowed),
                 },
                 indent=2,
+                ensure_ascii=False,
             )
         )
     else:
@@ -434,7 +570,8 @@ def run(args: argparse.Namespace) -> int:
             print(_format_findings(blocking))
             print(
                 f"\n{len(blocking)} blocking match(es). "
-                f"To allowlist a false positive, append its msgid_hash to "
+                f"To allowlist a false positive, append a line of the form "
+                f"'<locale>:<msgid_hash>  # reason' to "
                 f"{args.allowlist or 'scripts/.translation_profanity_allowlist'}.",
                 file=sys.stderr,
             )
@@ -482,7 +619,7 @@ def _selftest() -> int:
                 TranslationEntry(Path("x"), 2, "de_DE", "Hi", "xyzzyish should not match"),
                 TranslationEntry(Path("x"), 3, "de_DE", "Plural", "frobnitzes here"),
             ]
-            findings = list(scan_entries(entries, dictionary))
+            findings = list(scan_entries(entries, dictionary, dict_code="de"))
             words = [f.word for f in findings]
             # "xyzzy" matches in entry 1 (word boundary).
             # "xyzzyish" should NOT match (no boundary).
@@ -496,33 +633,38 @@ def _selftest() -> int:
             entry = TranslationEntry(
                 Path("x"), 1, "de_DE", "src", "contains a multiword token here"
             )
-            findings = list(scan_entries([entry], dictionary))
+            findings = list(scan_entries([entry], dictionary, dict_code="de"))
             self.assertEqual([f.word for f in findings], ["multiword token"])
 
         def test_cjk_substring(self):
             dictionary = parse_dictionary(CJK_DICT)
             entry = TranslationEntry(Path("x"), 1, "zh-Hans", "src", "前面蛙蛙蛙後面")
-            findings = list(scan_entries([entry], dictionary))
+            findings = list(scan_entries([entry], dictionary, dict_code="zh"))
             self.assertEqual([f.word for f in findings], ["蛙蛙蛙"])
 
-        def test_allowlist_by_hash(self):
+        def test_allowlist_key_is_locale_prefixed(self):
             msgid = "Some English source string"
             target_text = "übersetzung mit xyzzy"
             entry = TranslationEntry(Path("x"), 1, "de_DE", msgid, target_text)
             dictionary = parse_dictionary(PLACEHOLDER_DICT)
-            findings = list(scan_entries([entry], dictionary))
+            findings = list(scan_entries([entry], dictionary, dict_code="de"))
             self.assertEqual(len(findings), 1)
             self.assertEqual(findings[0].msgid_hash, msgid_hash(msgid))
+            self.assertEqual(findings[0].allowlist_key, f"de_DE:{msgid_hash(msgid)}")
 
-        def test_po_parser_extracts_target(self):
+        def test_po_parser_extracts_target_and_refs(self):
             content = (
                 'msgid ""\n'
                 'msgstr ""\n'
                 '"Content-Type: text/plain; charset=UTF-8\\n"\n'
                 "\n"
+                "#: authentik/admin/files/api.py:142\n"
+                "#: authentik/admin/files/other.py:7\n"
+                "#, python-brace-format\n"
                 'msgid "Hello"\n'
                 'msgstr "Hallo xyzzy"\n'
                 "\n"
+                "#: authentik/other.py:99\n"
                 'msgid "Multi"\n'
                 '"line source"\n'
                 'msgstr "Mehr"\n'
@@ -540,10 +682,18 @@ def _selftest() -> int:
             self.assertEqual(len(entries), 2)
             self.assertEqual(entries[0].msgid, "Hello")
             self.assertEqual(entries[0].target, "Hallo xyzzy")
+            self.assertEqual(
+                entries[0].references,
+                (
+                    "authentik/admin/files/api.py:142",
+                    "authentik/admin/files/other.py:7",
+                ),
+            )
             self.assertEqual(entries[1].msgid, "Multiline source")
             self.assertEqual(entries[1].target, "Mehrzeilig")
+            self.assertEqual(entries[1].references, ("authentik/other.py:99",))
 
-        def test_xliff_parser_extracts_target(self):
+        def test_xliff_parser_extracts_target_and_id(self):
             xml = (
                 '<?xml version="1.0"?>'
                 '<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2"'
@@ -551,7 +701,7 @@ def _selftest() -> int:
                 '<file target-language="de-DE" source-language="en"'
                 ' original="x" datatype="plaintext">'
                 "<body>"
-                '<trans-unit id="a"><source>Hello</source>'
+                '<trans-unit id="sfe629863ba1338c2"><source>Hello</source>'
                 "<target>Hallo xyzzy</target></trans-unit>"
                 '<trans-unit id="b"><source>Skip</source>'
                 "<target></target></trans-unit>"
@@ -568,6 +718,7 @@ def _selftest() -> int:
                 tmp.unlink()
             self.assertEqual(len(entries), 1)
             self.assertEqual(entries[0].target, "Hallo xyzzy")
+            self.assertEqual(entries[0].xliff_id, "sfe629863ba1338c2")
 
         def test_fetch_dictionary_404_returns_none(self):
             def fake_fetch(url):
@@ -614,7 +765,7 @@ def _selftest() -> int:
                 )
                 self.assertEqual(run(ns), 0)
 
-        def test_run_allowlist_suppresses(self):
+        def test_run_allowlist_suppresses_with_locale_key(self):
             with tempfile.TemporaryDirectory() as td:
                 root = Path(td)
                 (root / "locale" / "de_DE" / "LC_MESSAGES").mkdir(parents=True)
@@ -625,7 +776,10 @@ def _selftest() -> int:
                 dict_dir.mkdir()
                 (dict_dir / "de").write_text(PLACEHOLDER_DICT, encoding="utf-8")
                 allow = root / "allow.txt"
-                allow.write_text(msgid_hash("Hello") + "\n", encoding="utf-8")
+                allow.write_text(
+                    f"de_DE:{msgid_hash('Hello')}  # placeholder term, reviewed 2026-05-16\n",
+                    encoding="utf-8",
+                )
 
                 ns = argparse.Namespace(
                     root=str(root),
@@ -634,6 +788,107 @@ def _selftest() -> int:
                     json=False,
                 )
                 self.assertEqual(run(ns), 0)
+
+        def test_run_allowlist_other_locale_does_not_suppress(self):
+            # Per-locale schema: a `ja_JP:<hash>` entry must NOT suppress a
+            # match in `de_DE` even if msgid hash collides.
+            with tempfile.TemporaryDirectory() as td:
+                root = Path(td)
+                (root / "locale" / "de_DE" / "LC_MESSAGES").mkdir(parents=True)
+                (root / "locale" / "de_DE" / "LC_MESSAGES" / "django.po").write_text(
+                    'msgid "Hello"\nmsgstr "Hallo xyzzy"\n', encoding="utf-8"
+                )
+                dict_dir = root / "dict"
+                dict_dir.mkdir()
+                (dict_dir / "de").write_text(PLACEHOLDER_DICT, encoding="utf-8")
+                allow = root / "allow.txt"
+                allow.write_text(
+                    f"ja_JP:{msgid_hash('Hello')}  # exempt only in ja\n",
+                    encoding="utf-8",
+                )
+
+                ns = argparse.Namespace(
+                    root=str(root),
+                    base_url=f"file://{dict_dir}",
+                    allowlist=str(allow),
+                    json=False,
+                )
+                self.assertEqual(run(ns), 1)
+
+        def test_allowlist_bare_hash_fails_loud(self):
+            with tempfile.TemporaryDirectory() as td:
+                allow = Path(td) / "allow.txt"
+                # Bare hash with no `# reason` comment must error.
+                allow.write_text(f"de_DE:{msgid_hash('Hello')}\n", encoding="utf-8")
+                with self.assertRaises(AllowlistError) as ctx:
+                    load_allowlist(allow)
+                self.assertIn("'# reason'", str(ctx.exception))
+
+        def test_allowlist_empty_reason_fails_loud(self):
+            with tempfile.TemporaryDirectory() as td:
+                allow = Path(td) / "allow.txt"
+                allow.write_text(f"de_DE:{msgid_hash('Hello')}  #   \n", encoding="utf-8")
+                with self.assertRaises(AllowlistError) as ctx:
+                    load_allowlist(allow)
+                self.assertIn("empty reason", str(ctx.exception))
+
+        def test_allowlist_missing_locale_prefix_fails_loud(self):
+            with tempfile.TemporaryDirectory() as td:
+                allow = Path(td) / "allow.txt"
+                # Bare hash without `<locale>:` prefix.
+                allow.write_text(f"{msgid_hash('Hello')}  # bad shape\n", encoding="utf-8")
+                with self.assertRaises(AllowlistError) as ctx:
+                    load_allowlist(allow)
+                self.assertIn("malformed entry", str(ctx.exception))
+
+        def test_allowlist_pure_comment_lines_ok(self):
+            with tempfile.TemporaryDirectory() as td:
+                allow = Path(td) / "allow.txt"
+                allow.write_text(
+                    "# header comment\n"
+                    "  # indented comment\n"
+                    "\n"
+                    f"de_DE:{msgid_hash('Hello')}  # ok entry\n",
+                    encoding="utf-8",
+                )
+                loaded = load_allowlist(allow)
+                self.assertEqual(loaded, {f"de_DE:{msgid_hash('Hello')}"})
+
+        def test_findings_format_omits_matched_word(self):
+            # Defence in depth: the rendered output line must not include
+            # the dictionary entry that matched.
+            f = Finding(
+                locale="de_DE",
+                path=Path("locale/de_DE/LC_MESSAGES/django.po"),
+                line=42,
+                word="xyzzy",  # never echoed
+                msgid="Hello",
+                target="Hallo xyzzy",
+                dict_code="de",
+                references=("authentik/admin/api.py:1",),
+                xliff_id=None,
+            )
+            rendered = _format_findings([f])
+            self.assertNotIn("xyzzy", rendered.split(" target=", 1)[0])
+            # `dict[<code>]` style summary appears instead.
+            self.assertIn("profanity-dict[de]", rendered)
+            self.assertIn("refs=authentik/admin/api.py:1", rendered)
+            self.assertIn(f"allowlist_key=de_DE:{msgid_hash('Hello')}", rendered)
+
+        def test_findings_format_includes_xliff_id(self):
+            f = Finding(
+                locale="de-DE",
+                path=Path("web/xliff/de-DE.xlf"),
+                line=0,
+                word="xyzzy",
+                msgid="Hello",
+                target="Hallo xyzzy",
+                dict_code="de",
+                references=(),
+                xliff_id="sfe629863ba1338c2",
+            )
+            rendered = _format_findings([f])
+            self.assertIn("xliff_id=sfe629863ba1338c2", rendered)
 
     loader = unittest.TestLoader()
     suite = loader.loadTestsFromTestCase(Tests)
@@ -654,7 +909,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--allowlist",
         default="scripts/.translation_profanity_allowlist",
-        help="Path to msgid-hash allowlist (one hash per line, '#' comments).",
+        help=(
+            "Path to the allowlist. Each entry is "
+            "'<locale>:<msgid_hash>  # reason' on its own line; bare hashes "
+            "or missing-reason entries cause the scanner to fail loud."
+        ),
     )
     parser.add_argument("--json", action="store_true", help="Emit findings as JSON")
     parser.add_argument("--self-test", action="store_true", help="Run inline unit tests and exit")

--- a/scripts/translation_profanity_check.py
+++ b/scripts/translation_profanity_check.py
@@ -1,0 +1,669 @@
+#!/usr/bin/env python3
+"""Translation profanity gate.
+
+Scans Transifex-sourced translations (Django PO under locale/ and lit-localize
+XLIFF under web/xliff/) against per-language profanity dictionaries fetched at
+runtime from PROFANITY_DICT_BASE_URL. Exits non-zero when any non-allowlisted
+match is found.
+
+No profanity word lists, fixtures, or example bad strings are committed; the
+self-test uses abstract placeholder tokens.
+
+Run:
+    python scripts/translation_profanity_check.py [--root .] [--allowlist PATH]
+    python scripts/translation_profanity_check.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+import unicodedata
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_BASE_URL = (
+    "https://raw.githubusercontent.com/LDNOOBW/"
+    "List-of-Dirty-Naughty-Obscene-and-Otherwise-Bad-Words/master"
+)
+
+# HTTP 404 from the dictionary host means "this language isn't covered" and
+# downgrades to a skip; any other status propagates.
+_HTTP_NOT_FOUND = 404
+
+# Locales we skip wholesale:
+#   - "en" / "en-XA": source + pseudo-locale (no human translations).
+SKIP_LOCALES = frozenset({"en", "en-XA"})
+
+# Maps a repo locale identifier (e.g. "pt_BR", "zh-Hans") to the dictionary
+# code expected at PROFANITY_DICT_BASE_URL. Anything not listed falls through
+# to "strip region after - or _" (e.g. "de_DE" -> "de"). LDNOOBW publishes one
+# file per language without a file extension.
+LOCALE_DICT_OVERRIDES = {
+    "zh-Hans": "zh",
+    "zh-Hant": "zh",
+    "zh_CN": "zh",
+    "zh_TW": "zh",
+    "pt_BR": "pt",
+    "pt_PT": "pt",
+    "no_NO": "no",
+}
+
+# Unicode ranges that lack reliable whitespace word boundaries; for these we
+# fall back to substring matching against the dictionary entry.
+_CJK_RANGES = (
+    (0x3040, 0x30FF),  # Hiragana + Katakana
+    (0x3400, 0x4DBF),  # CJK Unified Ideographs Extension A
+    (0x4E00, 0x9FFF),  # CJK Unified Ideographs
+    (0xAC00, 0xD7AF),  # Hangul Syllables
+    (0xF900, 0xFAFF),  # CJK Compatibility Ideographs
+)
+
+
+def _is_cjk_char(ch: str) -> bool:
+    code = ord(ch)
+    return any(lo <= code <= hi for lo, hi in _CJK_RANGES)
+
+
+def _has_cjk(text: str) -> bool:
+    return any(_is_cjk_char(c) for c in text)
+
+
+def normalize(text: str) -> str:
+    """Case-fold + NFKC normalize for stable matching."""
+    return unicodedata.normalize("NFKC", text).casefold()
+
+
+def msgid_hash(msgid: str) -> str:
+    """Stable 16-char SHA-256 prefix of msgid; used for allowlist entries.
+
+    Allowlisting by *source* msgid avoids ever committing translated profane
+    text. The English msgid is by definition non-profane (it is the source
+    string an authentik developer wrote).
+    """
+    return hashlib.sha256(msgid.encode("utf-8")).hexdigest()[:16]
+
+
+# --- dictionary fetch -----------------------------------------------------
+
+
+def dict_code_for_locale(locale: str) -> str | None:
+    """Return the LDNOOBW-style dictionary code for a repo locale, or None
+    if the locale is skipped (source / pseudo)."""
+    if locale in SKIP_LOCALES:
+        return None
+    if locale in LOCALE_DICT_OVERRIDES:
+        return LOCALE_DICT_OVERRIDES[locale]
+    return re.split(r"[-_]", locale, maxsplit=1)[0]
+
+
+def _http_get(url: str, timeout: float = 15.0) -> str:
+    req = urllib.request.Request(url, headers={"User-Agent": "authentik-profanity-gate/1"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 — fixed URL
+        return resp.read().decode("utf-8", errors="replace")
+
+
+def parse_dictionary(raw: str) -> list[str]:
+    """LDNOOBW format: one entry per line, '#' comments stripped, blanks skipped."""
+    out: list[str] = []
+    for raw_line in raw.splitlines():
+        entry = raw_line.split("#", 1)[0].strip()
+        if entry:
+            out.append(normalize(entry))
+    return out
+
+
+def fetch_dictionary(
+    code: str,
+    base_url: str,
+    fetcher=_http_get,
+) -> list[str] | None:
+    """Returns dictionary entries (already normalized) or None if missing.
+
+    "Missing" covers both HTTP 404 (no dict for that language at the source)
+    and the local-file-not-found case (used by the self-test). Other failures
+    — connection refused, 5xx, malformed UTF-8 — propagate, so a broken
+    dictionary source fails CI loudly rather than silently passing."""
+    url = f"{base_url.rstrip('/')}/{code}"
+    try:
+        raw = fetcher(url)
+    except urllib.error.HTTPError as exc:
+        if exc.code == _HTTP_NOT_FOUND:
+            return None
+        raise
+    except urllib.error.URLError as exc:
+        if isinstance(exc.reason, FileNotFoundError):
+            return None
+        raise
+    return parse_dictionary(raw)
+
+
+# --- file parsing ---------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TranslationEntry:
+    path: Path
+    line: int
+    locale: str
+    msgid: str
+    target: str
+
+
+def iter_po(path: Path, locale: str) -> Iterator[TranslationEntry]:
+    """Minimal PO reader: yields (msgid, msgstr) pairs with line numbers.
+
+    Handles multi-line continuation strings and fuzzy/obsolete entries (we
+    include fuzzy entries — they still ship to users — but skip obsolete
+    `#~` entries)."""
+    msgid_parts: list[str] = []
+    msgstr_parts: list[str] = []
+    state: str | None = None  # None | "msgid" | "msgstr"
+    entry_line = 0
+
+    def flush() -> Iterator[TranslationEntry]:
+        if msgid_parts or msgstr_parts:
+            msgid = "".join(msgid_parts)
+            target = "".join(msgstr_parts)
+            if msgid and target:  # skip the empty header entry
+                yield TranslationEntry(path, entry_line, locale, msgid, target)
+
+    with path.open(encoding="utf-8") as fh:
+        for lineno, raw in enumerate(fh, start=1):
+            line = raw.rstrip("\n")
+            stripped = line.lstrip()
+            if stripped.startswith("#~"):
+                # Obsolete entry — drop pending and skip.
+                msgid_parts, msgstr_parts, state = [], [], None
+                continue
+            if not stripped or stripped.startswith("#"):
+                if not stripped and state is not None:
+                    # Blank line terminates an entry.
+                    yield from flush()
+                    msgid_parts, msgstr_parts, state = [], [], None
+                continue
+            if stripped.startswith("msgid "):
+                yield from flush()
+                msgid_parts = [_po_unquote(stripped[len("msgid ") :])]
+                msgstr_parts = []
+                state = "msgid"
+                entry_line = lineno
+            elif stripped.startswith("msgid_plural "):
+                # Concatenate plural source into msgid bucket — we only need
+                # *some* representation of the source for hashing/skip logic.
+                msgid_parts.append(_po_unquote(stripped[len("msgid_plural ") :]))
+                state = "msgid"
+            elif stripped.startswith("msgstr["):
+                # Plural form: msgstr[0] "..."
+                rest = stripped.split("]", 1)[1].strip()
+                msgstr_parts.append(_po_unquote(rest))
+                state = "msgstr"
+            elif stripped.startswith("msgstr "):
+                msgstr_parts.append(_po_unquote(stripped[len("msgstr ") :]))
+                state = "msgstr"
+            elif stripped.startswith('"'):
+                chunk = _po_unquote(stripped)
+                if state == "msgid":
+                    msgid_parts.append(chunk)
+                elif state == "msgstr":
+                    msgstr_parts.append(chunk)
+        yield from flush()
+
+
+def _po_unquote(value: str) -> str:
+    value = value.strip()
+    if value.startswith('"') and value.endswith('"'):
+        value = value[1:-1]
+    # Resolve the standard PO escapes (\n, \t, \\, \").
+    return value.replace("\\n", "\n").replace("\\t", "\t").replace('\\"', '"').replace("\\\\", "\\")
+
+
+_XLIFF_NS = "{urn:oasis:names:tc:xliff:document:1.2}"
+
+
+def iter_xliff(path: Path, locale: str) -> Iterator[TranslationEntry]:
+    """Yields trans-units that have a non-empty <target>."""
+    try:
+        tree = ET.parse(path)
+    except ET.ParseError as exc:
+        raise SystemExit(f"{path}: malformed XLIFF: {exc}") from exc
+    root = tree.getroot()
+    for unit in root.iter(f"{_XLIFF_NS}trans-unit"):
+        src_el = unit.find(f"{_XLIFF_NS}source")
+        tgt_el = unit.find(f"{_XLIFF_NS}target")
+        if tgt_el is None:
+            continue
+        target = "".join(tgt_el.itertext())
+        if not target.strip():
+            continue
+        msgid = "".join(src_el.itertext()) if src_el is not None else unit.get("id", "")
+        # XLIFF ElementTree doesn't expose line numbers natively; report 0 to
+        # mean "see file". Acceptable trade-off vs. pulling in lxml.
+        yield TranslationEntry(path, 0, locale, msgid, target)
+
+
+# --- discovery ------------------------------------------------------------
+
+
+def discover_translation_files(root: Path) -> list[tuple[Path, str, str]]:
+    """Returns (path, locale, kind) tuples. kind is 'po' or 'xliff'."""
+    out: list[tuple[Path, str, str]] = []
+    locale_dir = root / "locale"
+    if locale_dir.is_dir():
+        for sub in sorted(locale_dir.iterdir()):
+            if not sub.is_dir():
+                continue
+            po = sub / "LC_MESSAGES" / "django.po"
+            if po.is_file():
+                out.append((po, sub.name, "po"))
+    xliff_dir = root / "web" / "xliff"
+    if xliff_dir.is_dir():
+        for xlf in sorted(xliff_dir.glob("*.xlf")):
+            locale = xlf.stem
+            if locale == "en":
+                continue
+            out.append((xlf, locale, "xliff"))
+    return out
+
+
+# --- matching -------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Finding:
+    locale: str
+    path: Path
+    line: int
+    word: str
+    msgid: str
+    target: str
+
+    @property
+    def msgid_hash(self) -> str:
+        return msgid_hash(self.msgid)
+
+
+def _build_word_pattern(words: Iterable[str]) -> tuple[re.Pattern[str] | None, list[str]]:
+    """Compile a single alternation regex for ASCII/Latin/Cyrillic words and
+    return the remaining words (CJK / multi-token) for substring matching."""
+    boundary_terms: list[str] = []
+    substring_terms: list[str] = []
+    for w in words:
+        if not w:
+            continue
+        if _has_cjk(w) or " " in w:
+            substring_terms.append(w)
+        else:
+            boundary_terms.append(re.escape(w))
+    pattern: re.Pattern[str] | None = None
+    if boundary_terms:
+        # Sort longest-first so e.g. "abcd" beats "abc" when both are listed.
+        boundary_terms.sort(key=len, reverse=True)
+        pattern = re.compile(r"\b(?:" + "|".join(boundary_terms) + r")\b", re.UNICODE)
+    return pattern, substring_terms
+
+
+def scan_entries(
+    entries: Iterable[TranslationEntry],
+    dictionary: list[str],
+) -> Iterator[Finding]:
+    pattern, substrings = _build_word_pattern(dictionary)
+    for entry in entries:
+        haystack = normalize(entry.target)
+        if pattern is not None:
+            for m in pattern.finditer(haystack):
+                yield Finding(
+                    locale=entry.locale,
+                    path=entry.path,
+                    line=entry.line,
+                    word=m.group(0),
+                    msgid=entry.msgid,
+                    target=entry.target,
+                )
+        for term in substrings:
+            if term in haystack:
+                yield Finding(
+                    locale=entry.locale,
+                    path=entry.path,
+                    line=entry.line,
+                    word=term,
+                    msgid=entry.msgid,
+                    target=entry.target,
+                )
+
+
+# --- allowlist ------------------------------------------------------------
+
+
+def load_allowlist(path: Path | None) -> set[str]:
+    if path is None or not path.is_file():
+        return set()
+    out: set[str] = set()
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        entry = raw_line.split("#", 1)[0].strip()
+        if entry:
+            out.add(entry)
+    return out
+
+
+# --- CLI ------------------------------------------------------------------
+
+
+def _format_findings(findings: list[Finding]) -> str:
+    lines = []
+    for f in findings:
+        loc = f"{f.path}:{f.line}" if f.line else str(f.path)
+        lines.append(
+            f"::error file={f.path},line={f.line or 1}::"
+            f"[{f.locale}] profanity match {f.word!r} at {loc} "
+            f"(msgid_hash={f.msgid_hash}, msgid={f.msgid!r}, target={f.target!r})"
+        )
+    return "\n".join(lines)
+
+
+def run(args: argparse.Namespace) -> int:
+    root = Path(args.root).resolve()
+    base_url = args.base_url or os.environ.get("PROFANITY_DICT_BASE_URL", DEFAULT_BASE_URL)
+    allowlist = load_allowlist(Path(args.allowlist) if args.allowlist else None)
+
+    files = discover_translation_files(root)
+    if not files:
+        print(f"no translation files under {root}", file=sys.stderr)
+        return 0
+
+    by_dict_code: dict[str, list[tuple[Path, str, str]]] = {}
+    skipped: list[str] = []
+    for path, locale, kind in files:
+        code = dict_code_for_locale(locale)
+        if code is None:
+            skipped.append(locale)
+            continue
+        by_dict_code.setdefault(code, []).append((path, locale, kind))
+
+    if skipped:
+        print(f"skipping source/pseudo locales: {sorted(set(skipped))}", file=sys.stderr)
+
+    all_findings: list[Finding] = []
+    for code in sorted(by_dict_code):
+        dictionary = fetch_dictionary(code, base_url)
+        if dictionary is None:
+            print(f"[{code}] no dictionary at {base_url}/{code} — skipping", file=sys.stderr)
+            continue
+        if not dictionary:
+            print(f"[{code}] empty dictionary — skipping", file=sys.stderr)
+            continue
+        for path, locale, kind in by_dict_code[code]:
+            entries = iter_po(path, locale) if kind == "po" else iter_xliff(path, locale)
+            for finding in scan_entries(entries, dictionary):
+                all_findings.append(finding)
+
+    blocking = [f for f in all_findings if f.msgid_hash not in allowlist]
+    allowed = [f for f in all_findings if f.msgid_hash in allowlist]
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "blocking": [
+                        {
+                            "locale": f.locale,
+                            "path": str(f.path),
+                            "line": f.line,
+                            "word": f.word,
+                            "msgid_hash": f.msgid_hash,
+                        }
+                        for f in blocking
+                    ],
+                    "allowed_count": len(allowed),
+                },
+                indent=2,
+            )
+        )
+    else:
+        if allowed:
+            print(f"allowlisted matches (suppressed): {len(allowed)}", file=sys.stderr)
+        if blocking:
+            print(_format_findings(blocking))
+            print(
+                f"\n{len(blocking)} blocking match(es). "
+                f"To allowlist a false positive, append its msgid_hash to "
+                f"{args.allowlist or 'scripts/.translation_profanity_allowlist'}.",
+                file=sys.stderr,
+            )
+
+    return 1 if blocking else 0
+
+
+# --- self-test ------------------------------------------------------------
+
+
+def _selftest() -> int:
+    """Inline tests using abstract placeholder tokens (no real profanity).
+
+    Run with: python scripts/translation_profanity_check.py --self-test
+    """
+    import tempfile
+    import unittest
+
+    PLACEHOLDER_DICT = "xyzzy\nfrobnitz\n# a comment\n  \nmultiword token\n"
+    CJK_DICT = "蛙蛙蛙\n"  # placeholder CJK token
+
+    class Tests(unittest.TestCase):
+        def test_normalize_casefold(self):
+            self.assertEqual(normalize("Xyzzy"), "xyzzy")
+            # NFKC collapses fullwidth Latin to ASCII.
+            self.assertEqual(normalize("ｘｙｚｚｙ"), "xyzzy")
+
+        def test_dict_code(self):
+            self.assertEqual(dict_code_for_locale("de_DE"), "de")
+            self.assertEqual(dict_code_for_locale("pt_BR"), "pt")
+            self.assertEqual(dict_code_for_locale("zh-Hans"), "zh")
+            self.assertIsNone(dict_code_for_locale("en"))
+            self.assertIsNone(dict_code_for_locale("en-XA"))
+
+        def test_parse_dictionary(self):
+            self.assertEqual(
+                parse_dictionary(PLACEHOLDER_DICT),
+                ["xyzzy", "frobnitz", "multiword token"],
+            )
+
+        def test_word_boundary_match(self):
+            dictionary = parse_dictionary(PLACEHOLDER_DICT)
+            entries = [
+                TranslationEntry(Path("x"), 1, "de_DE", "Hello", "Sag xyzzy!"),
+                TranslationEntry(Path("x"), 2, "de_DE", "Hi", "xyzzyish should not match"),
+                TranslationEntry(Path("x"), 3, "de_DE", "Plural", "frobnitzes here"),
+            ]
+            findings = list(scan_entries(entries, dictionary))
+            words = [f.word for f in findings]
+            # "xyzzy" matches in entry 1 (word boundary).
+            # "xyzzyish" should NOT match (no boundary).
+            # "frobnitzes" should NOT match standalone (no boundary after "frobnitz").
+            self.assertIn("xyzzy", words)
+            self.assertNotIn("frobnitz", words)
+            self.assertEqual(len(findings), 1)
+
+        def test_multiword_substring_match(self):
+            dictionary = parse_dictionary(PLACEHOLDER_DICT)
+            entry = TranslationEntry(
+                Path("x"), 1, "de_DE", "src", "contains a multiword token here"
+            )
+            findings = list(scan_entries([entry], dictionary))
+            self.assertEqual([f.word for f in findings], ["multiword token"])
+
+        def test_cjk_substring(self):
+            dictionary = parse_dictionary(CJK_DICT)
+            entry = TranslationEntry(Path("x"), 1, "zh-Hans", "src", "前面蛙蛙蛙後面")
+            findings = list(scan_entries([entry], dictionary))
+            self.assertEqual([f.word for f in findings], ["蛙蛙蛙"])
+
+        def test_allowlist_by_hash(self):
+            msgid = "Some English source string"
+            target_text = "übersetzung mit xyzzy"
+            entry = TranslationEntry(Path("x"), 1, "de_DE", msgid, target_text)
+            dictionary = parse_dictionary(PLACEHOLDER_DICT)
+            findings = list(scan_entries([entry], dictionary))
+            self.assertEqual(len(findings), 1)
+            self.assertEqual(findings[0].msgid_hash, msgid_hash(msgid))
+
+        def test_po_parser_extracts_target(self):
+            content = (
+                'msgid ""\n'
+                'msgstr ""\n'
+                '"Content-Type: text/plain; charset=UTF-8\\n"\n'
+                "\n"
+                'msgid "Hello"\n'
+                'msgstr "Hallo xyzzy"\n'
+                "\n"
+                'msgid "Multi"\n'
+                '"line source"\n'
+                'msgstr "Mehr"\n'
+                '"zeilig"\n'
+            )
+            with tempfile.NamedTemporaryFile(
+                "w", suffix=".po", delete=False, encoding="utf-8"
+            ) as fh:
+                fh.write(content)
+                tmp = Path(fh.name)
+            try:
+                entries = list(iter_po(tmp, "de_DE"))
+            finally:
+                tmp.unlink()
+            self.assertEqual(len(entries), 2)
+            self.assertEqual(entries[0].msgid, "Hello")
+            self.assertEqual(entries[0].target, "Hallo xyzzy")
+            self.assertEqual(entries[1].msgid, "Multiline source")
+            self.assertEqual(entries[1].target, "Mehrzeilig")
+
+        def test_xliff_parser_extracts_target(self):
+            xml = (
+                '<?xml version="1.0"?>'
+                '<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2"'
+                ' version="1.2">'
+                '<file target-language="de-DE" source-language="en"'
+                ' original="x" datatype="plaintext">'
+                "<body>"
+                '<trans-unit id="a"><source>Hello</source>'
+                "<target>Hallo xyzzy</target></trans-unit>"
+                '<trans-unit id="b"><source>Skip</source>'
+                "<target></target></trans-unit>"
+                "</body></file></xliff>"
+            )
+            with tempfile.NamedTemporaryFile(
+                "w", suffix=".xlf", delete=False, encoding="utf-8"
+            ) as fh:
+                fh.write(xml)
+                tmp = Path(fh.name)
+            try:
+                entries = list(iter_xliff(tmp, "de-DE"))
+            finally:
+                tmp.unlink()
+            self.assertEqual(len(entries), 1)
+            self.assertEqual(entries[0].target, "Hallo xyzzy")
+
+        def test_fetch_dictionary_404_returns_none(self):
+            def fake_fetch(url):
+                raise urllib.error.HTTPError(url, 404, "not found", None, None)
+
+            self.assertIsNone(fetch_dictionary("xx", "https://example.invalid", fetcher=fake_fetch))
+
+        def test_run_blocks_on_match(self):
+            with tempfile.TemporaryDirectory() as td:
+                root = Path(td)
+                (root / "locale" / "de_DE" / "LC_MESSAGES").mkdir(parents=True)
+                (root / "locale" / "de_DE" / "LC_MESSAGES" / "django.po").write_text(
+                    'msgid "Hello"\nmsgstr "Hallo xyzzy"\n', encoding="utf-8"
+                )
+                dict_dir = root / "dict"
+                dict_dir.mkdir()
+                (dict_dir / "de").write_text(PLACEHOLDER_DICT, encoding="utf-8")
+
+                ns = argparse.Namespace(
+                    root=str(root),
+                    base_url=f"file://{dict_dir}",
+                    allowlist=None,
+                    json=False,
+                )
+                rc = run(ns)
+                self.assertEqual(rc, 1)
+
+        def test_run_passes_when_clean(self):
+            with tempfile.TemporaryDirectory() as td:
+                root = Path(td)
+                (root / "locale" / "de_DE" / "LC_MESSAGES").mkdir(parents=True)
+                (root / "locale" / "de_DE" / "LC_MESSAGES" / "django.po").write_text(
+                    'msgid "Hello"\nmsgstr "Hallo Welt"\n', encoding="utf-8"
+                )
+                dict_dir = root / "dict"
+                dict_dir.mkdir()
+                (dict_dir / "de").write_text(PLACEHOLDER_DICT, encoding="utf-8")
+
+                ns = argparse.Namespace(
+                    root=str(root),
+                    base_url=f"file://{dict_dir}",
+                    allowlist=None,
+                    json=False,
+                )
+                self.assertEqual(run(ns), 0)
+
+        def test_run_allowlist_suppresses(self):
+            with tempfile.TemporaryDirectory() as td:
+                root = Path(td)
+                (root / "locale" / "de_DE" / "LC_MESSAGES").mkdir(parents=True)
+                (root / "locale" / "de_DE" / "LC_MESSAGES" / "django.po").write_text(
+                    'msgid "Hello"\nmsgstr "Hallo xyzzy"\n', encoding="utf-8"
+                )
+                dict_dir = root / "dict"
+                dict_dir.mkdir()
+                (dict_dir / "de").write_text(PLACEHOLDER_DICT, encoding="utf-8")
+                allow = root / "allow.txt"
+                allow.write_text(msgid_hash("Hello") + "\n", encoding="utf-8")
+
+                ns = argparse.Namespace(
+                    root=str(root),
+                    base_url=f"file://{dict_dir}",
+                    allowlist=str(allow),
+                    json=False,
+                )
+                self.assertEqual(run(ns), 0)
+
+    loader = unittest.TestLoader()
+    suite = loader.loadTestsFromTestCase(Tests)
+    runner = unittest.TextTestRunner(verbosity=2)
+    result = runner.run(suite)
+    return 0 if result.wasSuccessful() else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default=".", help="Repository root to scan")
+    parser.add_argument(
+        "--base-url",
+        default=None,
+        help="Profanity dictionary base URL. Defaults to $PROFANITY_DICT_BASE_URL "
+        f"or {DEFAULT_BASE_URL}",
+    )
+    parser.add_argument(
+        "--allowlist",
+        default="scripts/.translation_profanity_allowlist",
+        help="Path to msgid-hash allowlist (one hash per line, '#' comments).",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit findings as JSON")
+    parser.add_argument("--self-test", action="store_true", help="Run inline unit tests and exit")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return _selftest()
+    return run(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/translation_profanity_check.py
+++ b/scripts/translation_profanity_check.py
@@ -22,6 +22,7 @@ import json
 import os
 import re
 import sys
+import time
 import unicodedata
 import urllib.error
 import urllib.request
@@ -30,10 +31,32 @@ from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from pathlib import Path
 
-DEFAULT_BASE_URL = (
+# Placeholder for the curated S3 dictionary mirror — to be populated when IT
+# provisions the bucket. Format mirrors the LDNOOBW one-file-per-language
+# convention used by fetch_dictionary (`<base>/<lang>` with no extension).
+# When the URL lands, set this constant to the string and the default below
+# automatically promotes to the curated source. One find-and-replace target,
+# grep for `TODO(s3-dict)` to locate.
+S3_CURATED_DICT_URL: str | None = None  # TODO(s3-dict): set to real URL when provisioned
+
+_LDNOOBW_PLACEHOLDER_URL = (
     "https://raw.githubusercontent.com/LDNOOBW/"
     "List-of-Dirty-Naughty-Obscene-and-Otherwise-Bad-Words/master"
 )
+
+# Default dictionary source. Resolves to the curated S3 URL once the
+# placeholder above is populated; falls back to LDNOOBW until then.
+# Either way, the `PROFANITY_DICT_BASE_URL` env var (set via the
+# `qa-translation-profanity.yml` workflow's repo variable) still wins.
+DEFAULT_BASE_URL = S3_CURATED_DICT_URL or _LDNOOBW_PLACEHOLDER_URL
+
+# Local cache for fetched dictionaries. Keeps CI runs and local triage from
+# slamming the upstream host on every invocation. Per-language files are
+# revalidated against the pin file (see _load_dict_pins) on every cache hit;
+# files older than DICT_CACHE_TTL_SECONDS are always re-fetched even when
+# the pin matches, to catch unpinned dicts that updated upstream.
+_DEFAULT_CACHE_DIR = "~/.cache/authentik-translation-profanity"
+DICT_CACHE_TTL_SECONDS = 24 * 60 * 60  # 24h
 
 # HTTP 404 from the dictionary host means "this language isn't covered" and
 # downgrades to a skip; any other status propagates.
@@ -121,17 +144,116 @@ def parse_dictionary(raw: str) -> list[str]:
     return out
 
 
-def fetch_dictionary(
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+class DictPinError(ValueError):
+    """Raised when the pin file is malformed or a fetched dictionary's
+    SHA256 disagrees with the pinned value.
+
+    Pin mismatches fail the gate loud (exit 2) rather than silently
+    re-pinning — an unexpected dict change is a curation/security event,
+    not a routine refresh."""
+
+
+_DICT_PIN_LINE_RE = re.compile(r"^([A-Za-z0-9_-]+)\s+([0-9a-fA-F]{64})$")
+
+
+def _default_pin_path() -> Path:
+    return Path(__file__).resolve().parent / ".translation_profanity_dict_pins"
+
+
+def load_dict_pins(path: Path | None = None) -> dict[str, str]:
+    """Read per-language SHA256 pins from the pin file.
+
+    Schema (one entry per line):
+
+        <dict_code>  <sha256-hex>          # optional reason / version note
+
+    `#` comments and blank lines are ignored. A missing file is treated
+    as "no pins" — fetched dicts are accepted without integrity check
+    (matches the v3 default for the LDNOOBW placeholder, where pinning
+    against an external repo's rolling tip isn't useful). Malformed
+    entries raise DictPinError so the file stays PR-reviewable."""
+    if path is None:
+        path = _default_pin_path()
+    if not path.is_file():
+        return {}
+    pins: dict[str, str] = {}
+    errors: list[str] = []
+    for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        body = raw.split("#", 1)[0].strip()
+        if not body:
+            continue
+        m = _DICT_PIN_LINE_RE.match(body)
+        if not m:
+            errors.append(
+                f"{path}:{lineno}: malformed pin entry: {body!r} — expected "
+                f"'<dict_code>  <sha256-hex>'"
+            )
+            continue
+        pins[m.group(1)] = m.group(2).lower()
+    if errors:
+        raise DictPinError("\n".join(errors))
+    return pins
+
+
+def _resolve_cache_dir(explicit: Path | str | None) -> Path:
+    """Cache-dir precedence: explicit arg > env var > default."""
+    if explicit is not None:
+        return Path(explicit).expanduser()
+    env = os.environ.get("PROFANITY_DICT_CACHE_DIR")
+    if env:
+        return Path(env).expanduser()
+    return Path(_DEFAULT_CACHE_DIR).expanduser()
+
+
+def fetch_dictionary(  # noqa: PLR0913 — small surface, every knob is wired through CLI/env
     code: str,
     base_url: str,
     fetcher=_http_get,
+    *,
+    cache_dir: Path | str | None = None,
+    pins: dict[str, str] | None = None,
+    now: float | None = None,
 ) -> list[str] | None:
     """Returns dictionary entries (already normalized) or None if missing.
 
-    "Missing" covers both HTTP 404 (no dict for that language at the source)
-    and the local-file-not-found case (used by the self-test). Other failures
-    — connection refused, 5xx, malformed UTF-8 — propagate, so a broken
-    dictionary source fails CI loudly rather than silently passing."""
+    "Missing" covers both HTTP 404 (no dict for that language at the
+    source) and the local-file-not-found case (used by the self-test).
+    Other transport failures — connection refused, 5xx, malformed UTF-8 —
+    propagate so a broken dictionary source fails CI loudly.
+
+    Resolution order:
+
+        1. If a fresh-enough (< DICT_CACHE_TTL_SECONDS) cached copy
+           exists and either has no pin or matches its pin, use it.
+        2. Otherwise refetch from `base_url/<code>`.
+        3. If a pin exists for `<code>`, verify the fetched SHA256
+           matches; raise DictPinError on mismatch.
+        4. Persist the fetched bytes to the cache for next run.
+
+    The cache lives at `cache_dir/<code>`; pins come from the file at
+    `scripts/.translation_profanity_dict_pins` (override via load_dict_pins
+    arg). Both default to file-system paths so tests can swap in a tmp
+    directory without monkeypatching."""
+    cache_root = _resolve_cache_dir(cache_dir)
+    pin_map = pins if pins is not None else load_dict_pins()
+    pinned = pin_map.get(code)
+    cache_path = cache_root / code
+    clock = time.time if now is None else (lambda: now)
+
+    # 1. Cache check.
+    if cache_path.is_file():
+        age = clock() - cache_path.stat().st_mtime
+        if age < DICT_CACHE_TTL_SECONDS:
+            cached = cache_path.read_text(encoding="utf-8")
+            if pinned is None or _sha256(cached) == pinned:
+                return parse_dictionary(cached)
+            # Pin mismatch on cache: treat as stale and re-fetch.
+
+    # 2. Fetch fresh.
     url = f"{base_url.rstrip('/')}/{code}"
     try:
         raw = fetcher(url)
@@ -143,6 +265,28 @@ def fetch_dictionary(
         if isinstance(exc.reason, FileNotFoundError):
             return None
         raise
+
+    # 3. Integrity check.
+    if pinned is not None:
+        actual = _sha256(raw)
+        if actual != pinned:
+            raise DictPinError(
+                f"profanity dictionary integrity failure for {code!r}: "
+                f"fetched SHA256 {actual} does not match pinned {pinned}. "
+                f"If this is an intentional upstream update, regenerate "
+                f"the pin in scripts/.translation_profanity_dict_pins."
+            )
+
+    # 4. Persist to cache.
+    try:
+        cache_root.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(raw, encoding="utf-8")
+    except OSError as exc:
+        # Cache writes are best-effort; failing to write must not break
+        # the gate (e.g. read-only filesystems, missing $HOME in some
+        # CI shapes). Log and continue.
+        print(f"warning: could not write dict cache at {cache_path}: {exc}", file=sys.stderr)
+
     return parse_dictionary(raw)
 
 
@@ -491,15 +635,25 @@ def _format_findings(findings: list[Finding]) -> str:
     return "\n".join(lines)
 
 
-def run(args: argparse.Namespace) -> int:
+def run(args: argparse.Namespace) -> int:  # noqa: PLR0915 — linear orchestrator, splitting just hides flow
     root = Path(args.root).resolve()
     base_url = args.base_url or os.environ.get("PROFANITY_DICT_BASE_URL", DEFAULT_BASE_URL)
+    cache_dir = _resolve_cache_dir(args.cache_dir)
     try:
         allowlist = load_allowlist(Path(args.allowlist) if args.allowlist else None)
     except AllowlistError as exc:
         print("allowlist validation failed:", file=sys.stderr)
         print(str(exc), file=sys.stderr)
         return 2
+    try:
+        pins = load_dict_pins(Path(args.pins) if args.pins else None)
+    except DictPinError as exc:
+        print("dict pins validation failed:", file=sys.stderr)
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    if pins:
+        print(f"dict pins active for: {sorted(pins)}", file=sys.stderr)
 
     files = discover_translation_files(root)
     if not files:
@@ -520,7 +674,12 @@ def run(args: argparse.Namespace) -> int:
 
     all_findings: list[Finding] = []
     for code in sorted(by_dict_code):
-        dictionary = fetch_dictionary(code, base_url)
+        try:
+            dictionary = fetch_dictionary(code, base_url, cache_dir=cache_dir, pins=pins)
+        except DictPinError as exc:
+            print("dictionary integrity failure:", file=sys.stderr)
+            print(str(exc), file=sys.stderr)
+            return 2
         if dictionary is None:
             print(f"[{code}] no dictionary at {base_url}/{code} — skipping", file=sys.stderr)
             continue
@@ -725,7 +884,151 @@ def _selftest() -> int:
             def fake_fetch(url):
                 raise urllib.error.HTTPError(url, 404, "not found", None, None)
 
-            self.assertIsNone(fetch_dictionary("xx", "https://example.invalid", fetcher=fake_fetch))
+            with tempfile.TemporaryDirectory() as td:
+                self.assertIsNone(
+                    fetch_dictionary(
+                        "xx",
+                        "https://example.invalid",
+                        fetcher=fake_fetch,
+                        cache_dir=Path(td),
+                        pins={},
+                    )
+                )
+
+        def test_fetch_dictionary_caches_fresh_content(self):
+            calls = []
+
+            def fake_fetch(url):
+                calls.append(url)
+                return PLACEHOLDER_DICT
+
+            with tempfile.TemporaryDirectory() as td:
+                cache = Path(td)
+                # First fetch hits the fetcher.
+                d1 = fetch_dictionary(
+                    "de", "https://example.invalid", fetcher=fake_fetch, cache_dir=cache, pins={}
+                )
+                self.assertEqual(d1, parse_dictionary(PLACEHOLDER_DICT))
+                # Second fetch should reuse the cache (no new fetcher call).
+                d2 = fetch_dictionary(
+                    "de", "https://example.invalid", fetcher=fake_fetch, cache_dir=cache, pins={}
+                )
+                self.assertEqual(d2, d1)
+                self.assertEqual(len(calls), 1, f"expected 1 fetch, got {len(calls)}")
+
+        def test_fetch_dictionary_cache_expiry_triggers_refetch(self):
+            calls = []
+
+            def fake_fetch(url):
+                calls.append(url)
+                return PLACEHOLDER_DICT
+
+            with tempfile.TemporaryDirectory() as td:
+                cache = Path(td)
+                fetch_dictionary(
+                    "de", "https://example.invalid", fetcher=fake_fetch, cache_dir=cache, pins={}
+                )
+                self.assertEqual(len(calls), 1)
+                # Move the clock forward beyond the TTL — cache should be stale.
+                future = time.time() + DICT_CACHE_TTL_SECONDS + 1
+                fetch_dictionary(
+                    "de",
+                    "https://example.invalid",
+                    fetcher=fake_fetch,
+                    cache_dir=cache,
+                    pins={},
+                    now=future,
+                )
+                self.assertEqual(len(calls), 2)
+
+        def test_fetch_dictionary_pin_match_passes(self):
+            def fake_fetch(url):
+                return PLACEHOLDER_DICT
+
+            expected = _sha256(PLACEHOLDER_DICT)
+            with tempfile.TemporaryDirectory() as td:
+                d = fetch_dictionary(
+                    "de",
+                    "https://example.invalid",
+                    fetcher=fake_fetch,
+                    cache_dir=Path(td),
+                    pins={"de": expected},
+                )
+                self.assertEqual(d, parse_dictionary(PLACEHOLDER_DICT))
+
+        def test_fetch_dictionary_pin_mismatch_fails_loud(self):
+            def fake_fetch(url):
+                return PLACEHOLDER_DICT
+
+            wrong = "0" * 64
+            with (
+                tempfile.TemporaryDirectory() as td,
+                self.assertRaises(DictPinError) as ctx,
+            ):
+                fetch_dictionary(
+                    "de",
+                    "https://example.invalid",
+                    fetcher=fake_fetch,
+                    cache_dir=Path(td),
+                    pins={"de": wrong},
+                )
+            self.assertIn("integrity failure", str(ctx.exception))
+
+        def test_fetch_dictionary_pin_mismatch_on_cache_refetches(self):
+            # If a cached file no longer matches the pin (e.g. pin was rotated
+            # but cache still has the old content), the next call must
+            # re-fetch rather than fail loud on the stale cache.
+            calls = []
+
+            def fake_fetch(url):
+                calls.append(url)
+                return PLACEHOLDER_DICT
+
+            expected = _sha256(PLACEHOLDER_DICT)
+            with tempfile.TemporaryDirectory() as td:
+                cache = Path(td)
+                # Pre-populate cache with content that DOESN'T match the pin.
+                cache.mkdir(parents=True, exist_ok=True)
+                (cache / "de").write_text("stale content\n", encoding="utf-8")
+                d = fetch_dictionary(
+                    "de",
+                    "https://example.invalid",
+                    fetcher=fake_fetch,
+                    cache_dir=cache,
+                    pins={"de": expected},
+                )
+                self.assertEqual(d, parse_dictionary(PLACEHOLDER_DICT))
+                self.assertEqual(len(calls), 1)
+                # Cache now contains the freshly-fetched content.
+                self.assertEqual((cache / "de").read_text(encoding="utf-8"), PLACEHOLDER_DICT)
+
+        def test_load_dict_pins_pure_comments_ok(self):
+            with tempfile.TemporaryDirectory() as td:
+                pin_path = Path(td) / "pins"
+                pin_path.write_text(
+                    "# header comment\n"
+                    "\n"
+                    "de  " + ("a" * 64) + "  # v1 of curated dict\n"
+                    "ja  " + ("b" * 64) + "  # v1\n",
+                    encoding="utf-8",
+                )
+                self.assertEqual(
+                    load_dict_pins(pin_path),
+                    {"de": "a" * 64, "ja": "b" * 64},
+                )
+
+        def test_load_dict_pins_malformed_fails_loud(self):
+            with tempfile.TemporaryDirectory() as td:
+                pin_path = Path(td) / "pins"
+                # Hash too short.
+                pin_path.write_text("de  abc123\n", encoding="utf-8")
+                with self.assertRaises(DictPinError) as ctx:
+                    load_dict_pins(pin_path)
+                self.assertIn("malformed pin entry", str(ctx.exception))
+
+        def test_load_dict_pins_missing_file_returns_empty(self):
+            with tempfile.TemporaryDirectory() as td:
+                self.assertEqual(load_dict_pins(Path(td) / "absent"), {})
 
         def test_run_blocks_on_match(self):
             with tempfile.TemporaryDirectory() as td:
@@ -742,6 +1045,8 @@ def _selftest() -> int:
                     root=str(root),
                     base_url=f"file://{dict_dir}",
                     allowlist=None,
+                    pins="/dev/null",
+                    cache_dir=str(root / "cache"),
                     json=False,
                 )
                 rc = run(ns)
@@ -762,6 +1067,8 @@ def _selftest() -> int:
                     root=str(root),
                     base_url=f"file://{dict_dir}",
                     allowlist=None,
+                    pins="/dev/null",
+                    cache_dir=str(root / "cache"),
                     json=False,
                 )
                 self.assertEqual(run(ns), 0)
@@ -786,6 +1093,8 @@ def _selftest() -> int:
                     root=str(root),
                     base_url=f"file://{dict_dir}",
                     allowlist=str(allow),
+                    pins="/dev/null",
+                    cache_dir=str(root / "cache"),
                     json=False,
                 )
                 self.assertEqual(run(ns), 0)
@@ -812,6 +1121,8 @@ def _selftest() -> int:
                     root=str(root),
                     base_url=f"file://{dict_dir}",
                     allowlist=str(allow),
+                    pins="/dev/null",
+                    cache_dir=str(root / "cache"),
                     json=False,
                 )
                 self.assertEqual(run(ns), 1)
@@ -922,6 +1233,24 @@ def main(argv: list[str] | None = None) -> int:
             "Path to the allowlist. Each entry is "
             "'<locale>:<msgid_hash>  # reason' on its own line; bare hashes "
             "or missing-reason entries cause the scanner to fail loud."
+        ),
+    )
+    parser.add_argument(
+        "--pins",
+        default=None,
+        help=(
+            "Path to the per-language SHA256 pin file. Defaults to "
+            "scripts/.translation_profanity_dict_pins next to this script. "
+            "Set to /dev/null to disable pinning."
+        ),
+    )
+    parser.add_argument(
+        "--cache-dir",
+        default=None,
+        help=(
+            "Local cache for fetched dictionaries. Defaults to "
+            f"$PROFANITY_DICT_CACHE_DIR or {_DEFAULT_CACHE_DIR}. "
+            f"Cached files older than {DICT_CACHE_TTL_SECONDS // 3600}h are re-fetched."
         ),
     )
     parser.add_argument("--json", action="store_true", help="Emit findings as JSON")

--- a/scripts/translation_profanity_check.py
+++ b/scripts/translation_profanity_check.py
@@ -459,11 +459,13 @@ def load_allowlist(path: Path | None) -> set[str]:
 def _format_findings(findings: list[Finding]) -> str:
     """Render findings without echoing the matched dictionary token.
 
-    Per the original brief we never print the dictionary entry that matched
-    (the "word") — defence in depth so CI logs stay shareable. We do print
-    the English `msgid` (non-profane by definition) and the `target` (the
-    translated string), since operators need *some* anchor for triage; the
-    `target` may be removed in a future tightening pass.
+    Per the original brief we never print the dictionary entry that
+    matched (the "word") or the full translated `target` — `target` embeds
+    the offending substring in context, so echoing it transitively
+    violates the same rule. CI logs stay shareable on a phone or on a
+    projector. Operators wanting full context use `--json` (gated by
+    local triage) or open the source file at the printed `xliff_id` /
+    `refs` location.
 
     Each finding renders both as a GitHub Actions `::error::` annotation
     and (per CLI tradition) a human-readable trailing line. Extra
@@ -476,7 +478,6 @@ def _format_findings(findings: list[Finding]) -> str:
             f"dict={f.dict_code}",
             f"allowlist_key={f.allowlist_key}",
             f"msgid={f.msgid!r}",
-            f"target={f.target!r}",
         ]
         if f.xliff_id:
             extras.append(f"xliff_id={f.xliff_id}")
@@ -854,26 +855,34 @@ def _selftest() -> int:
                 loaded = load_allowlist(allow)
                 self.assertEqual(loaded, {f"de_DE:{msgid_hash('Hello')}"})
 
-        def test_findings_format_omits_matched_word(self):
+        def test_findings_format_redacts_word_and_target(self):
             # Defence in depth: the rendered output line must not include
-            # the dictionary entry that matched.
+            # the dictionary entry that matched, nor the translated target
+            # (which embeds the matched substring in context).
+            unique_target_marker = "Hallo xyzzy_marker_token"
             f = Finding(
                 locale="de_DE",
                 path=Path("locale/de_DE/LC_MESSAGES/django.po"),
                 line=42,
-                word="xyzzy",  # never echoed
+                word="xyzzy_marker_token",  # never echoed
                 msgid="Hello",
-                target="Hallo xyzzy",
+                target=unique_target_marker,  # never echoed
                 dict_code="de",
                 references=("authentik/admin/api.py:1",),
                 xliff_id=None,
             )
             rendered = _format_findings([f])
-            self.assertNotIn("xyzzy", rendered.split(" target=", 1)[0])
+            # Neither the matched dictionary token nor the full target
+            # string may appear anywhere in the rendered output.
+            self.assertNotIn("xyzzy_marker_token", rendered)
+            self.assertNotIn(unique_target_marker, rendered)
+            self.assertNotIn("target=", rendered)
             # `dict[<code>]` style summary appears instead.
             self.assertIn("profanity-dict[de]", rendered)
             self.assertIn("refs=authentik/admin/api.py:1", rendered)
             self.assertIn(f"allowlist_key=de_DE:{msgid_hash('Hello')}", rendered)
+            # msgid (English source, safe by definition) still present.
+            self.assertIn("msgid='Hello'", rendered)
 
         def test_findings_format_includes_xliff_id(self):
             f = Finding(


### PR DESCRIPTION
## Summary

Plumbing for swapping LDNOOBW out for a curated profanity dictionary mirrored on S3 (or any HTTPS URL) once the org's IT team provisions the bucket. Builds on #22451 — branched off that PR's tip so the diff here is just the transition layer.

**This PR is intended to sit in draft until the S3 URL lands.** Single-line operator action when it does: replace `S3_CURATED_DICT_URL` (search for `TODO(s3-dict)`) and pin the per-language SHA256s into `scripts/.translation_profanity_dict_pins`. Merging without the URL is also safe — the LDNOOBW fallback is preserved.

## Scanner changes (`scripts/translation_profanity_check.py`)

- **`S3_CURATED_DICT_URL` constant at the top** with a `TODO(s3-dict)` marker. The `DEFAULT_BASE_URL` fallback chain promotes it automatically once set — one find-and-replace target.
- **Local cache** under `~/.cache/authentik-translation-profanity/` (override via `$PROFANITY_DICT_CACHE_DIR` or `--cache-dir`). 24h in-process TTL; revalidated against the pin file on every cache hit. Cache writes are best-effort — read-only filesystems warn and continue.
- **Per-language SHA256 pinning** via `scripts/.translation_profanity_dict_pins`. On pin mismatch the scanner raises `DictPinError` (exit 2) — dict updates are a curation event, not a silent refresh. Empty pin file = no integrity check (matches v3 default since pinning a rolling upstream isn't useful).
- **New `--pins` and `--cache-dir` CLI flags** wired through `run()`; existing callers unaffected (additive).
- **Self-test grows 20 → 28 tests** covering cache hit / TTL expiry / pin match / pin mismatch / pin re-fetches stale cache / pin file malformed-line and missing-file paths.

## Workflow changes (`.github/workflows/qa-translation-profanity.yml`)

- **Re-enabled `pull_request` + `push` triggers** with paths-filter on `locale/**`, `web/xliff/**`, the scanner script, the allowlist, the pin file, and the workflow itself. `workflow_dispatch` retained for manual triage. Daily `schedule` restored as a safety net.
- **`actions/cache` step** for `~/.cache/authentik-translation-profanity` keyed on `runner.os` + pin-file hash. Cold-start savings; in-process TTL handles intra-day freshness.
- **Top-of-file comment rewritten** to describe the active-gate posture rather than the v2 dispatch-only one.

## Policy + pinning files

- `scripts/.translation_profanity_allowlist` header gains a "post-S3 policy" section: start empty, add per-finding, review on pin rotation, no profane text in repo.
- `scripts/.translation_profanity_dict_pins` is added with schema docs and an empty body. Pin entries land at S3-swap time.

## Unknowns to pre-think while this sits in draft

The IT team's bucket isn't requisitioned yet. Open questions the design tried to leave room for, but worth deciding before merge:

- **Dict format** — assumed one file per locale (`dict-<lang>.txt`, one entry per line, `#` comments). If IT delivers a single combined JSON with locale tags or a Parquet/CSV catalogue, the loader needs to swap.
- **Per-locale split** — assumes `dict-<lang>` granularity matching the LDNOOBW set names. If the curated dict uses ISO 639-2/-3 or BCP 47 region tags, the locale→dict-name mapping in `_resolve_dict_for_locale` needs an alias table.
- **Update cadence** — assumes curation events are operator-driven (pin rotation, manual). If the bucket gets daily/weekly updates without operator review, the 24h TTL needs revisiting and the pin-file becomes either auto-generated or removed.
- **License / redistribution** — affects whether we can vendor the dict into the repo as a fallback (currently we just URL-fetch + cache; no vendoring).
- **Size** — assumes the per-locale file is small (KBs, fits in cache easily). Multi-MB-per-locale would push toward streaming + per-line allowlist evaluation.

## Test plan

- [ ] `python3 scripts/translation_profanity_check.py --self-test` — 28 inline self-tests, runs in <60ms.
- [ ] Provision the S3 URL → set `S3_CURATED_DICT_URL` (grep `TODO(s3-dict)`).
- [ ] Pin the per-language SHA256s into `scripts/.translation_profanity_dict_pins`.
- [ ] Run `make i18n-profanity-check` against the current `locale/` + `web/xliff/` with the curated dict; review findings; decide on allowlist seeds per the policy header.
- [ ] Verify the workflow runs on PRs touching `locale/**` (auto), pushes, and via `workflow_dispatch`.
- [ ] Verify a pin-mismatch raises `DictPinError` (exit 2) — bump a pin in the file to a wrong SHA and re-run the scanner.

## Disclosure

Triaged and authored end-to-end by an autonomous Claude Code agent running in a sister-software/playpen sandbox; the human operator reviewed and shipped. Commits are co-authored with the operator's GitHub identity to keep attribution clean.
