### PR TITLE
ci: pin github/codeql-action references to commit SHA

### DIFF
--- a/.github/workflows/qa-codeql.yml
+++ b/.github/workflows/qa-codeql.yml
@@ -28,10 +28,10 @@ jobs:
       - name: Setup authentik env
         uses: ./.github/actions/setup
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.35.5
+        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           languages: ${{ matrix.language }}
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4.35.5
+        uses: github/codeql-action/autobuild@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.35.5
+        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5


### PR DESCRIPTION
## Summary

- Replaces the three remaining tag-pinned references to `github/codeql-action@v4.35.5` in `.github/workflows/qa-codeql.yml` (`init`, `autobuild`, `analyze`) with the resolved commit SHA `9e0d7b8d25671d64c341c19c0152d693099fb5ba`.
- Brings these three references in line with the other 132/135 external action references in this repo, which are already SHA-pinned.
- Removes the residual risk that an upstream tag is silently retargeted at a different commit between CI runs.

This is part of a small series of supply-chain hardening PRs prompted by the May 19 npm "Mini Shai-Hulud" incident — none of the affected packages are in our tree, but the audit surfaced a handful of small posture improvements worth landing.

## Test plan

- [ ] CodeQL workflow (`QA - CodeQL`) runs successfully on this PR for `go`, `javascript`, and `python` matrix entries.
- [ ] No behavioral change beyond the reference syntax — same upstream commit, just pinned by SHA with the `# v4.35.5` comment retained for human readability.