### PR TITLE
ci: add qa-npm-signatures workflow

### DIFF
--- a/.github/workflows/qa-npm-signatures.yml
+++ b/.github/workflows/qa-npm-signatures.yml
@@ -1,0 +1,48 @@
+---
+name: QA - npm signatures
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - "**/package.json"
+      - "**/package-lock.json"
+      - .github/workflows/qa-npm-signatures.yml
+  push:
+    branches: [main]
+    paths:
+      - "**/package.json"
+      - "**/package-lock.json"
+      - .github/workflows/qa-npm-signatures.yml
+  schedule:
+    # Run daily so retroactively unpublished/unsigned versions surface
+    # even when no dependency-touching PR is open.
+    - cron: "37 7 * * *"
+
+jobs:
+  audit-signatures:
+    name: audit signatures (${{ matrix.workspace }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        workspace:
+          - "."
+          - web
+          - website
+          - lifecycle/aws
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v4
+        with:
+          node-version-file: ${{ matrix.workspace }}/package.json
+          registry-url: https://registry.npmjs.org
+      - name: npm audit signatures
+        working-directory: ${{ matrix.workspace }}
+        # `npm audit signatures` verifies registry provenance attestations
+        # against the lockfile; it does not require node_modules to be
+        # populated, so this runs without a prior `npm ci`.
+        run: npm audit signatures


### PR DESCRIPTION
## Summary

Adds a new `QA - npm signatures` workflow that runs `npm audit signatures` against each workspace lockfile (root, `web/`, `website/`, `lifecycle/aws/`).

`npm audit signatures` verifies that every package in the lockfile has a valid Sigstore provenance attestation from the npm registry. It catches:

- packages whose signatures don't match (post-publish tampering)
- packages whose signatures disappear between resolution and audit
- new direct/transitive deps with no provenance at all

This is an incremental defense — it does **not** stop a maintainer-account-hijack that publishes a properly signed malicious version (the attack class the recent "Mini Shai-Hulud" incident used). For that, our existing defenses do the heavy lifting:

- `.npmrc` sets `ignore-scripts=true`, neutralizing the `preinstall`/`postinstall` payload vector
- Dependabot npm `cooldown` (3/7/14 days) means we don't pull versions during their first-published window
- `save-exact=true` + `npm ci` keeps the lockfile authoritative

The workflow runs on:

- PRs touching any `package.json` / `package-lock.json`
- pushes to `main` touching the same
- daily on a schedule (so retroactive unpublishes/signature drift surface even without dep-touching PRs)

`npm audit signatures` works directly off the lockfile and does not require `node_modules` to be populated, so the workflow skips `npm ci` entirely — fast and isolated from build concerns.

## Test plan

- [ ] Workflow appears under "Actions" and runs on this PR
- [ ] All four matrix entries (`.`, `web`, `website`, `lifecycle/aws`) pass against current lockfiles
- [ ] The scheduled run fires at 07:37 UTC the day after merge