### PR TITLE
ci: install netlify-cli via npx, pinned to a major

### DIFF
--- a/.github/workflows/ci-docs-source.yml
+++ b/.github/workflows/ci-docs-source.yml
@@ -27,6 +27,8 @@ jobs:
         env:
           NETLIFY_SITE_ID: eb246b7b-1d83-4f69-89f7-01a936b4ca59
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+        # Pinned netlify-cli major. A global `npm install -g` ignores the
+        # repo .npmrc and runs lifecycle scripts; `npx --package` honors
+        # the .npmrc (which sets ignore-scripts=true) and pins the version.
         run: |
-          npm install -g netlify-cli
-          netlify deploy --dir=source_docs --prod
+          npx --yes --package=netlify-cli@26 -- netlify deploy --dir=source_docs --prod


### PR DESCRIPTION
## Summary

Replaces `npm install -g netlify-cli` with `npx --yes --package=netlify-cli@26` in `.github/workflows/ci-docs-source.yml`.

Two reasons:

1. **`-g` installs bypass the project `.npmrc`.** npm walks up from the install cwd, not from the global prefix, so `ignore-scripts=true` and `save-exact=true` (root `.npmrc:1`) don't apply to a `-g` install — lifecycle scripts run and the version is unpinned. `npx` invoked inside the repo honors the project `.npmrc`.
2. **No version pin → resolves `latest` every run.** That's exactly the resolution behavior the recent npm "Mini Shai-Hulud" incident weaponized. Pinning `@26` bounds the major; Dependabot can manage upgrades through the same cooldown window as the rest of the npm deps.

## Test plan

- [ ] The `CI - Source code docs` workflow runs successfully on `main` after merge and publishes to Netlify as before.
- [ ] `npx --yes --package=netlify-cli@26 -- netlify deploy --dir=source_docs --prod` produces a working deploy.

(Workflow triggers only on `push: main`, so the smoke test is post-merge — happy to gate on a dry run first if preferred.)