### PR TITLE
website/docs: document npm install-script blocking

### DIFF
--- a/website/docs/developer-docs/contributing.md
+++ b/website/docs/developer-docs/contributing.md
@@ -120,7 +120,7 @@ When you are creating an enhancement suggestion, please fill in [the template](h
 
 authentik can be run locally, although depending on which part you want to work on, different prerequisites are required.
 
-This is documented in the [developer docs](./setup/frontend-dev-environment.md).
+This is documented in the [developer docs](./setup/frontend-dev-environment.mdx).
 
 ### Help with the docs
 

--- a/website/docs/developer-docs/setup/_npm-install-scripts-admonition.mdx
+++ b/website/docs/developer-docs/setup/_npm-install-scripts-admonition.mdx
@@ -1,13 +1,11 @@
 :::info NPM install scripts are disabled by default
+The repository's NPM runtime configuration file (`.npmrc`) sets `ignore-scripts=true`. This means that `preinstall`/`install`/`postinstall` lifecycle scripts do not run during `npm ci`. This neutralizes a dominant NPM supply-chain attack pattern at the cost of skipping a few legitimate native-binary unpacks.
 
-The repository's `.npmrc` sets `ignore-scripts=true` so `preinstall`/`install`/`postinstall` lifecycle scripts do not run during `npm ci`. This neutralizes a dominant NPM supply-chain attack pattern at the cost of skipping a few legitimate native-binary unpacks.
-
-If the watch build fails because a package needs its install script (commonly `esbuild`, `chromedriver`, `tree-sitter`, or `tree-sitter-json`), rebuild only that package:
+If the watch build fails because a package needs its install script (commonly `esbuild`, `chromedriver`, `tree-sitter`, or `tree-sitter-json`), rebuild only that package, for example:
 
 ```shell
 npm rebuild --foreground-scripts esbuild chromedriver tree-sitter tree-sitter-json
 ```
 
-**Do not** edit `.npmrc` to flip `ignore-scripts` off — that re-introduces the risk repo-wide.
-
+**Do not** edit `.npmrc` to flip `ignore-scripts` off — that re-introduces the risk repository-wide.
 :::

--- a/website/docs/developer-docs/setup/_npm-install-scripts-admonition.mdx
+++ b/website/docs/developer-docs/setup/_npm-install-scripts-admonition.mdx
@@ -1,0 +1,13 @@
+:::info NPM install scripts are disabled by default
+
+The repository's `.npmrc` sets `ignore-scripts=true` so `preinstall`/`install`/`postinstall` lifecycle scripts do not run during `npm ci`. This neutralizes a dominant NPM supply-chain attack pattern at the cost of skipping a few legitimate native-binary unpacks.
+
+If the watch build fails because a package needs its install script (commonly `esbuild`, `chromedriver`, `tree-sitter`, or `tree-sitter-json`), rebuild only that package:
+
+```shell
+npm rebuild --foreground-scripts esbuild chromedriver tree-sitter tree-sitter-json
+```
+
+**Do not** edit `.npmrc` to flip `ignore-scripts` off — that re-introduces the risk repo-wide.
+
+:::

--- a/website/docs/developer-docs/setup/frontend-dev-environment.md
+++ b/website/docs/developer-docs/setup/frontend-dev-environment.md
@@ -55,6 +55,20 @@ If you're focusing solely on frontend development, you can create a minimal deve
     make web-watch
     ```
 
+    :::info npm install scripts are disabled by default
+
+    The repository's `.npmrc` sets `ignore-scripts=true` so `preinstall`/`install`/`postinstall` lifecycle scripts do not run during `npm ci`. This is intentional: it neutralizes the dominant npm supply-chain attack pattern (recent examples: "Shai-Hulud" and "Mini Shai-Hulud") at the cost of skipping a few legitimate native-binary unpacks.
+
+    If the watch build fails because a package needs its install script (commonly `esbuild`, `chromedriver`, `tree-sitter`, or `tree-sitter-json`), rebuild only that package:
+
+    ```shell
+    npm rebuild --foreground-scripts esbuild chromedriver tree-sitter tree-sitter-json
+    ```
+
+    **Do not** edit `.npmrc` to flip `ignore-scripts` off — that re-introduces the risk repo-wide.
+
+    :::
+
 5. In a new terminal, navigate to the cloned repository root and start the backend containers with Docker Compose.
 
     ```shell

--- a/website/docs/developer-docs/setup/frontend-dev-environment.mdx
+++ b/website/docs/developer-docs/setup/frontend-dev-environment.mdx
@@ -8,6 +8,8 @@ tags:
     - docker
 ---
 
+import NPMInstallScriptsAdmonition from "./\_npm-install-scripts-admonition.mdx";
+
 If you're focusing solely on frontend development, you can create a minimal development environment using Docker and Node.js. This setup allows you to make and preview changes to the frontend in real-time, without needing to interact with the backend.
 
 ### Prerequisites
@@ -55,19 +57,7 @@ If you're focusing solely on frontend development, you can create a minimal deve
     make web-watch
     ```
 
-    :::info npm install scripts are disabled by default
-
-    The repository's `.npmrc` sets `ignore-scripts=true` so `preinstall`/`install`/`postinstall` lifecycle scripts do not run during `npm ci`. This is intentional: it neutralizes the dominant npm supply-chain attack pattern (recent examples: "Shai-Hulud" and "Mini Shai-Hulud") at the cost of skipping a few legitimate native-binary unpacks.
-
-    If the watch build fails because a package needs its install script (commonly `esbuild`, `chromedriver`, `tree-sitter`, or `tree-sitter-json`), rebuild only that package:
-
-    ```shell
-    npm rebuild --foreground-scripts esbuild chromedriver tree-sitter tree-sitter-json
-    ```
-
-    **Do not** edit `.npmrc` to flip `ignore-scripts` off — that re-introduces the risk repo-wide.
-
-    :::
+    <NPMInstallScriptsAdmonition />
 
 5. In a new terminal, navigate to the cloned repository root and start the backend containers with Docker Compose.
 

--- a/website/docs/developer-docs/setup/full-dev-environment.mdx
+++ b/website/docs/developer-docs/setup/full-dev-environment.mdx
@@ -11,6 +11,7 @@ tags:
 
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
+import NPMInstallScriptsAdmonition from "./\_npm-install-scripts-admonition.mdx";
 
 ## Prerequisites
 
@@ -126,19 +127,7 @@ Install all required JavaScript and Python dependencies and create an isolated P
 make install
 ```
 
-:::info npm install scripts are disabled by default
-
-The repository's `.npmrc` sets `ignore-scripts=true`, which prevents `preinstall`/`install`/`postinstall` lifecycle scripts from running during `npm ci`. This neutralizes the most common npm supply-chain attack pattern (recent examples: "Shai-Hulud" and "Mini Shai-Hulud") at the cost of skipping legitimate native-binary unpacking for a few packages.
-
-If a build step fails because a package needs its install script (commonly `esbuild`, `chromedriver`, `tree-sitter`, or `tree-sitter-json`), rebuild it explicitly:
-
-```shell
-npm rebuild --foreground-scripts esbuild chromedriver tree-sitter tree-sitter-json
-```
-
-**Do not** edit `.npmrc` to flip `ignore-scripts` off — that re-introduces the risk repo-wide.
-
-:::
+<NPMInstallScriptsAdmonition />
 
 ### Generate development configuration
 

--- a/website/docs/developer-docs/setup/full-dev-environment.mdx
+++ b/website/docs/developer-docs/setup/full-dev-environment.mdx
@@ -126,6 +126,20 @@ Install all required JavaScript and Python dependencies and create an isolated P
 make install
 ```
 
+:::info npm install scripts are disabled by default
+
+The repository's `.npmrc` sets `ignore-scripts=true`, which prevents `preinstall`/`install`/`postinstall` lifecycle scripts from running during `npm ci`. This neutralizes the most common npm supply-chain attack pattern (recent examples: "Shai-Hulud" and "Mini Shai-Hulud") at the cost of skipping legitimate native-binary unpacking for a few packages.
+
+If a build step fails because a package needs its install script (commonly `esbuild`, `chromedriver`, `tree-sitter`, or `tree-sitter-json`), rebuild it explicitly:
+
+```shell
+npm rebuild --foreground-scripts esbuild chromedriver tree-sitter tree-sitter-json
+```
+
+**Do not** edit `.npmrc` to flip `ignore-scripts` off — that re-introduces the risk repo-wide.
+
+:::
+
 ### Generate development configuration
 
 Create a local configuration file that uses the local databases for development:


### PR DESCRIPTION
## Summary

Adds an `:::info` admonition to both contributor setup guides explaining:

- the repo's `.npmrc` sets `ignore-scripts=true` and why (neutralizes the dominant npm supply-chain attack class — "Shai-Hulud" / "Mini Shai-Hulud" payloads run from `preinstall`)
- how to recover when a package's install script is legitimately required: `npm rebuild --foreground-scripts esbuild chromedriver tree-sitter tree-sitter-json`
- the explicit "do not flip `ignore-scripts` off" guidance

Files touched:

- `website/docs/developer-docs/setup/full-dev-environment.mdx` — admonition right after `make install`
- `website/docs/developer-docs/setup/frontend-dev-environment.md` — admonition right after `make node-install`

This is docs-only — no code or config changes. The motivation is that the rationale for `.npmrc` is currently only present as an inline comment in `.npmrc` itself; a contributor whose esbuild build silently fails has no obvious next step except to disable the protection, which is exactly what we want to discourage.

## Test plan

- [ ] Docs build (`make docs` / website preview) passes
- [ ] Both `:::info` admonitions render correctly
- [ ] The shell snippets are accurate against current `web/package.json` / root deps