### PR TITLE
root: bind-mount .npmrc into Dockerfile npm ci stages

### DIFF
--- a/lifecycle/container/Dockerfile
+++ b/lifecycle/container/Dockerfile
@@ -24,7 +24,8 @@ WORKDIR /work/web
 COPY ./packages /work/packages
 COPY ./web/packages /work/web/packages
 
-RUN --mount=type=bind,target=/work/web/package.json,src=./web/package.json \
+RUN --mount=type=bind,target=/work/.npmrc,src=./.npmrc \
+    --mount=type=bind,target=/work/web/package.json,src=./web/package.json \
     --mount=type=bind,target=/work/web/package-lock.json,src=./web/package-lock.json \
     --mount=type=bind,target=/work/web/packages/sfe/package.json,src=./web/packages/sfe/package.json \
     --mount=type=bind,target=/work/web/scripts,src=./web/scripts \

--- a/lifecycle/container/proxy.Dockerfile
+++ b/lifecycle/container/proxy.Dockerfile
@@ -21,7 +21,8 @@ RUN --mount=type=bind,target=/static/package.json,src=./package.json \
 
 COPY package.json /
 
-RUN --mount=type=bind,target=/static/package.json,src=./web/package.json \
+RUN --mount=type=bind,target=/static/.npmrc,src=./.npmrc \
+    --mount=type=bind,target=/static/package.json,src=./web/package.json \
     --mount=type=bind,target=/static/package-lock.json,src=./web/package-lock.json \
     --mount=type=bind,target=/static/scripts,src=./web/scripts \
     --mount=type=cache,target=/root/.npm \

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -17,7 +17,8 @@ RUN --mount=type=bind,target=/work/package.json,src=./package.json \
     node ./scripts/node/setup-corepack.mjs --force && \
     node ./scripts/node/lint-runtime.mjs ./website
 
-RUN --mount=type=bind,target=/work/package.json,src=./package.json \
+RUN --mount=type=bind,target=/work/.npmrc,src=./.npmrc \
+    --mount=type=bind,target=/work/package.json,src=./package.json \
     --mount=type=bind,target=/work/package-lock.json,src=./package-lock.json \
     --mount=type=bind,target=/work/scripts/node/,src=./scripts/node/ \
     --mount=type=bind,target=/work/packages/logger-js/,src=./packages/logger-js/ \


### PR DESCRIPTION
## Summary

Bind-mounts the repo `.npmrc` into the two Dockerfiles that run `npm ci` during image builds:

- `lifecycle/container/Dockerfile` (the web build stage)
- `website/Dockerfile` (the docs build stage)

## Why

`npm` walks up from cwd looking for `.npmrc`. Both Dockerfiles bind-mount `package.json` / `package-lock.json` for the install step, but neither mounts `.npmrc`. As a result the project-level settings are not present inside the build — most importantly:

- `ignore-scripts=true` — without this, a malicious dep's `preinstall`/`postinstall` payload would execute *inside the image build*, which is far worse than executing in CI (it would land in the published artifact)
- `engine-strict=true`
- `audit=true`

Local dev and our existing CI workflows already honor the project `.npmrc` because they invoke `npm ci` from inside the working tree. This PR closes the same gap for the image-build path.

The mount is `type=bind` (read-only by default) and only present during the `npm ci` step, so it adds nothing to the resulting image layers.

## Test plan

- [ ] `make docker` (or the equivalent buildx command for `lifecycle/container/Dockerfile`) succeeds and produces a working web bundle.
- [ ] The website Docker build produces a working docs image (`make website-build` / equivalent).
- [ ] Image size unchanged — no layer impact from the new mount.