### PR TITLE
ci: add step-security/harden-runner to npm publish workflow

### DIFF
--- a/.github/workflows/packages-npm-publish.yml
+++ b/.github/workflows/packages-npm-publish.yml
@@ -32,6 +32,16 @@ jobs:
           - packages/logger-js
           - packages/esbuild-plugin-live-reload
     steps:
+      # Network observability for the highest-value job in this repo: it
+      # exchanges an OIDC token for an npm publish credential and has read
+      # access to a checkout of main. `audit` mode logs every outbound
+      # connection and surfaces anomalous egress in the Step Security
+      # Insights dashboard; promotion to `block` with an explicit
+      # allowed-endpoints list should follow once we have one or two real
+      # publish runs to baseline against.
+      - uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
         with:
           fetch-depth: 2


### PR DESCRIPTION
## Summary

Adds `step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5` (v2.19.3) as the first step of the `publish` job in `.github/workflows/packages-npm-publish.yml`, configured with `egress-policy: audit`.

## Why this workflow specifically

This job is the highest-value target in our CI:

- has `id-token: write` for OIDC trusted publishing against the npm registry
- runs against a checkout of `main`
- publishes to `goauthentik`-owned npm packages used downstream by everything

A compromised transitive dep in any of the publishable packages' graphs could exfiltrate the OIDC token while it's valid, or quietly tamper with the build output between `npm run build` and `npm publish`.

## Why `audit` and not `block` (yet)

`audit` mode does not block any traffic — it logs every outbound connection and surfaces anomalies in the [Step Security Insights dashboard](https://app.stepsecurity.io/). This is the conservative initial posture:

- we get observability immediately (Shai-Hulud-style exfil to an attacker-controlled host would jump out)
- we don't risk breaking a publish from an incomplete allow-list

The follow-up is to promote to `egress-policy: block` with an explicit `allowed-endpoints` list once we've baselined against one or two real publish runs. Happy to file that as a separate issue.

## Test plan

- [ ] Next publish-triggering merge to `main` runs successfully (no behavioral change in `audit` mode).
- [ ] Step Security Insights captures the run; egress endpoints reviewed for follow-up `block`-mode allow-list.