### PR TITLE
ci: add dependency-review workflow

### DIFF
--- a/.github/workflows/qa-dependency-review.yml
+++ b/.github/workflows/qa-dependency-review.yml
@@ -1,0 +1,32 @@
+---
+name: QA - Dependency review
+
+# Blocks PRs that introduce a dependency with a known vulnerability above
+# the configured severity threshold. Covers every ecosystem GitHub's
+# Advisory Database supports — for this repo that's npm, Go modules,
+# Python (pip/uv), and GitHub Actions.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    name: dependency-review
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          # Block PRs that introduce a *new* dependency with a known
+          # high/critical vuln. We don't fail on existing vulns — those are
+          # surfaced separately via Dependabot.
+          fail-on-severity: high
+          # Surface a summary comment on the PR itself, in addition to the
+          # check status, so reviewers can see the diff at a glance.
+          comment-summary-in-pr: on-failure

--- a/.github/workflows/qa-dependency-review.yml
+++ b/.github/workflows/qa-dependency-review.yml
@@ -4,7 +4,7 @@ name: QA - Dependency review
 # Blocks PRs that introduce a dependency with a known vulnerability above
 # the configured severity threshold. Covers every ecosystem GitHub's
 # Advisory Database supports — for this repo that's npm, Go modules,
-# Python (pip/uv), and GitHub Actions.
+# Python (pip/uv), Cargo, and GitHub Actions.
 
 on:
   pull_request:


### PR DESCRIPTION
## Summary

Adds `.github/workflows/qa-dependency-review.yml`, which runs `actions/dependency-review-action@v5.0.0` on every PR targeting `main`.

Blocks PRs that introduce a **new** dependency (direct or transitive, any ecosystem GitHub supports — npm, Go modules, Python, GitHub Actions) with a known **high** or **critical** vulnerability.

## How this fits the rest of the supply-chain hardening

- Dependabot surfaces vulns in **already-merged** deps (the existing flow).
- `dependency-review` catches them at the moment they would be **introduced**, before merge — Dependabot only sees the world after merge.
- It does *not* catch the maintainer-account-hijack-to-malicious-version case directly (no advisory exists yet for those). The defense for that is the existing `.npmrc:1` `ignore-scripts=true` + Dependabot npm cooldown.

This action does not need access to the dependency graph beyond what the PR diff exposes, so the only permission it needs is `pull-requests: write` (to leave the summary comment on failure) plus `contents: read`.

## Config

- `fail-on-severity: high` — block on high/critical only; lower-severity introductions surface in the check summary but don't gate merge
- `comment-summary-in-pr: on-failure` — when the action blocks a PR, post a diff-style summary as a comment so the reviewer sees context, not just a red check

## Test plan

- [ ] Workflow appears on this PR's checks list as `QA - Dependency review / dependency-review`.
- [ ] Passes for this PR (no dependency changes in this diff).
- [ ] On a follow-up PR that bumps a vulnerable package version, the check fails and posts a summary comment.