### PR TITLE
ci: run publish build under Node's permission model (experiment)

### DIFF
--- a/.github/workflows/packages-npm-publish.yml
+++ b/.github/workflows/packages-npm-publish.yml
@@ -47,7 +47,33 @@ jobs:
       - name: Publish package
         if: steps.changed-files.outputs.any_changed == 'true'
         working-directory: ${{ matrix.package }}
+        # Experimental: the build (tsc, plus typedoc for one package) runs
+        # under Node's permission model. fs reads/writes are scoped to the
+        # package working tree; --permission with no other --allow flags
+        # blocks network, child_process, worker_threads, native addons,
+        # and WASI by default.
+        #
+        # Trade-off: env vars are still readable (the permission model
+        # does not gate them), but with no exfil channel — no network,
+        # no subprocess, no write outside $PWD — they cannot leave the
+        # build sandbox. The npm ci and npm publish phases keep their
+        # full capability set since they legitimately need network and
+        # subprocess access.
         run: |
           corepack npm ci
-          corepack npm run build
+
+          WORK="$PWD"
+          node \
+            --permission \
+            --allow-fs-read="$WORK" \
+            --allow-fs-write="$WORK" \
+            ./node_modules/typescript/bin/tsc -p .
+          if [ -x ./node_modules/typedoc/bin/typedoc ]; then
+            node \
+              --permission \
+              --allow-fs-read="$WORK" \
+              --allow-fs-write="$WORK" \
+              ./node_modules/typedoc/bin/typedoc
+          fi
+
           corepack npm publish


### PR DESCRIPTION
## Summary

Wraps the build phase of `.github/workflows/packages-npm-publish.yml` (`tsc -p .`, plus `typedoc` for `packages/esbuild-plugin-live-reload`) in Node 24's permission model.

```bash
node --permission \
     --allow-fs-read="$PWD" \
     --allow-fs-write="$PWD" \
     ./node_modules/typescript/bin/tsc -p .
```

`--permission` with no other `--allow` flags denies by default:

- **network** (`--allow-net` unset)
- **child_process** (`--allow-child-process` unset)
- **worker_threads** (`--allow-worker` unset)
- **native addons**
- **WASI**

fs reads and writes are explicitly scoped to the package working tree.

## Threat model

A malicious devDep (direct or transitive) of one of the six publishable packages that wakes up during `tsc` and tries to do anything beyond compile TypeScript. With this in place it can still read `process.env` (the permission model doesn't gate env vars), but it has no channel to send anything anywhere:

- no network → can't `fetch` an exfil endpoint
- no child_process → can't shell out to `curl`/`nc`/`ssh`
- no fs write outside `$PWD` → can't drop a payload into `~/.ssh`, `/var/tmp`, etc.
- no addons → can't load a native exfil helper

`npm ci` and `npm publish` keep their full capability set. Both legitimately need network and subprocess access, and the runner-level egress defense for `npm publish` lives in #22463 (`step-security/harden-runner`).

## Why this is the right surface

All six publishable packages have build scripts that are either `tsc -p .` or `tsc -p . && typedoc` — pure JS tools with no native addons and no in-build subprocess spawning. The permission allow-list is uniform and the failure mode (build fails noisily) is much preferable to a quiet exfil.

## Caveats

- Marked "experiment" in the commit because Node's permission model is stability 1.1 in v24. The flag surface (`--permission`, `--allow-fs-read`, `--allow-fs-write`, `--allow-net`) is settled, but minor semantics can shift across Node minors.
- If a future package wants broader behavior (`worker_threads`, e.g.), the allow-list widens per-step; the wrapper does not need to be discarded.
- If `tsc` or `typedoc` upstream starts touching paths outside `$PWD`, the build will fail with a permission error; revert is a one-line removal.

## Test plan

- [ ] Trigger the workflow via `workflow_dispatch` against this branch — all six matrix entries' build phase completes under `--permission`.
- [ ] `npm publish` still succeeds end-to-end (capability boundary preserved between phases).
- [ ] If anything fails: error is `ERR_ACCESS_DENIED` with the path that wasn't allowed; we widen the list precisely.