### PR TITLE
outposts: fix stale version in OutpostState

### DIFF
--- a/authentik/outposts/api/outposts.py
+++ b/authentik/outposts/api/outposts.py
@@ -23,6 +23,7 @@ from authentik.lib.utils.time import timedelta_from_string, timedelta_string_val
 from authentik.outposts.api.service_connections import ServiceConnectionSerializer
 from authentik.outposts.apps import MANAGED_OUTPOST, MANAGED_OUTPOST_NAME
 from authentik.outposts.models import (
+    OUR_VERSION,
     Outpost,
     OutpostConfig,
     OutpostType,
@@ -188,7 +189,7 @@ class OutpostViewSet(UsedByMixin, ModelViewSet):
                     "uid": state.uid,
                     "last_seen": state.last_seen,
                     "version": state.version,
-                    "version_should": state.version_should,
+                    "version_should": OUR_VERSION,
                     "version_outdated": state.version_outdated,
                     "build_hash": state.build_hash,
                     "golang_version": state.golang_version,

--- a/authentik/outposts/models.py
+++ b/authentik/outposts/models.py
@@ -13,7 +13,7 @@ from django.db import IntegrityError, models, transaction
 from django.db.models.base import Model
 from django.utils.translation import gettext_lazy as _
 from model_utils.managers import InheritanceManager
-from packaging.version import Version, parse
+from packaging.version import parse
 from rest_framework.serializers import Serializer
 from structlog.stdlib import get_logger
 
@@ -464,7 +464,6 @@ class OutpostState:
     uid: str
     last_seen: datetime | None = field(default=None)
     version: str | None = field(default=None)
-    version_should: Version = field(default=OUR_VERSION)
     build_hash: str = field(default="")
     golang_version: str = field(default="")
     openssl_enabled: bool = field(default=False)


### PR DESCRIPTION
causes the slight issue that currently happens where outpost instances will be correctly listed as out-of-date, however will show the old version as the version they should be on