### PR TITLE
web: adopt @goauthentik/theme tokens in the app styles

### DIFF
--- a/web/docs/arch/2026-06-18-How-CSS-Is-Made-And-Next-Steps.md
+++ b/web/docs/arch/2026-06-18-How-CSS-Is-Made-And-Next-Steps.md
@@ -47,7 +47,7 @@ The `interface.global.css` file is almost entirely imports:
     - borders
     - miscellaneous overrides of Patternfly
     - --ak-\*
-    - --ak-v2-global-\*
+    - @goauthentik/theme tokens + token-bridge.css
 9. ./base/scrollbars.css
 10. ./base/globals.css
 11. ./base/common.css

--- a/web/package.json
+++ b/web/package.json
@@ -6,6 +6,7 @@
     "scripts": {
         "build": "wireit",
         "build:sfe": "pnpm --filter @goauthentik/web-sfe run build",
+        "build:theme": "pnpm --dir ../packages/theme run build",
         "build-locales": "node scripts/build-locales.mjs",
         "build-proxy": "wireit",
         "bundler:watch": "node scripts/build-web.mjs --watch",
@@ -20,12 +21,13 @@
         "prettier": "prettier --cache --write -u .",
         "prettier-check": "prettier --cache --check -u .",
         "pseudolocalize": "node ./scripts/pseudolocalize.mjs",
-        "storybook": "storybook dev -p 6006",
+        "storybook": "run-s build:theme storybook:dev",
         "storybook:build": "wireit",
+        "storybook:dev": "storybook dev -p 6006",
         "test": "vitest",
         "test:e2e": "playwright test",
         "tsc": "wireit",
-        "watch": "run-s build-locales bundler:watch"
+        "watch": "run-s build:theme build-locales bundler:watch"
     },
     "type": "module",
     "exports": {
@@ -214,6 +216,7 @@
         "build": {
             "command": "${NODE_RUNNER} scripts/build-web.mjs",
             "dependencies": [
+                "../packages/theme:build",
                 "build-locales"
             ],
             "files": [
@@ -252,6 +255,7 @@
         "build-proxy": {
             "command": "node scripts/build-web.mjs --styles-only",
             "dependencies": [
+                "../packages/theme:build",
                 "build-locales"
             ]
         },
@@ -280,6 +284,9 @@
         },
         "storybook:build": {
             "command": "storybook build",
+            "dependencies": [
+                "../packages/theme:build"
+            ],
             "env": {
                 "NODE_OPTIONS": "--max_old_space_size=8192"
             }

--- a/web/src/elements/ak-drawer/ak-drawer.root.css
+++ b/web/src/elements/ak-drawer/ak-drawer.root.css
@@ -1,14 +1,26 @@
 /* ----------- CSS Custom Properties for DRAWER  --------------------------- */
 
 :root {
+    /* Component-local directional shadows for the panel's expanded state.
+     * Defined here so the drawer carries its own shadow values rather than
+     * exposing four directional shadow tokens on the public --ak-* surface. */
+    --_drawer-shadow-top: 0 -0.75rem 0.75rem -0.5rem rgba(3, 3, 3, 0.18);
+    --_drawer-shadow-right: 0.75rem 0 0.75rem -0.5rem rgba(3, 3, 3, 0.18);
+    --_drawer-shadow-bottom: 0 0.75rem 0.75rem -0.5rem rgba(3, 3, 3, 0.18);
+    --_drawer-shadow-left: -0.75rem 0 0.75rem -0.5rem rgba(3, 3, 3, 0.18);
+
+    /* Flips translateX() offsets in the RTL-scoped rules of
+     * ak-drawer.styles.ts; only those rules consume it. */
+    --_drawer-inverse-multiplier: -1;
+
     --ak-v2-c-drawer__content--FlexBasis: 100%;
-    --ak-v2-c-drawer__content--BackgroundColor: var(--ak-v2-global--ContentSurface);
-    --ak-v2-c-drawer__content--ZIndex: var(--ak-v2-global--ZIndex--xs, auto);
+    --ak-v2-c-drawer__content--BackgroundColor: var(--ak-color-surface);
+    --ak-v2-c-drawer__content--ZIndex: 100;
     --ak-v2-c-drawer__panel--MinWidth: 50%;
     --ak-v2-c-drawer__panel--MaxHeight: auto;
-    --ak-v2-c-drawer__panel--ZIndex: var(--ak-v2-global--ZIndex--sm);
-    --ak-v2-c-drawer__panel--BackgroundColor: var(--ak-v2-global--ContentSurface);
-    --ak-v2-c-drawer__panel--TransitionDuration: var(--ak-v2-global--TransitionDuration);
+    --ak-v2-c-drawer__panel--ZIndex: 200;
+    --ak-v2-c-drawer__panel--BackgroundColor: var(--ak-color-surface);
+    --ak-v2-c-drawer__panel--TransitionDuration: var(--ak-duration-normal);
     --ak-v2-c-drawer__panel--TransitionProperty: margin, transform, box-shadow, flex-basis;
     --ak-v2-c-drawer__panel--FlexBasis: 100%;
     --ak-v2-c-drawer__panel--md--FlexBasis--min: 1.5rem;
@@ -29,14 +41,14 @@
     --ak-v2-c-drawer--m-panel-bottom__panel--m-resizable--MinHeight: 1.5rem;
     --ak-v2-c-drawer__splitter--Height: 0.5625rem;
     --ak-v2-c-drawer__splitter--Width: 100%;
-    --ak-v2-c-drawer__splitter--BackgroundColor: var(--ak-v2-global--ContentSurface);
+    --ak-v2-c-drawer__splitter--BackgroundColor: var(--ak-color-surface);
     --ak-v2-c-drawer__splitter--Cursor: row-resize;
     --ak-v2-c-drawer__splitter--m-vertical--Height: 100%;
     --ak-v2-c-drawer__splitter--m-vertical--Width: 0.5625rem;
     --ak-v2-c-drawer__splitter--m-vertical--Cursor: col-resize;
     --ak-v2-c-drawer--m-inline__splitter--focus--OutlineOffset: -0.0625rem;
-    --ak-v2-c-drawer__splitter--after--BorderColor: var(--ak-v2-global--BorderColor--100);
-    --ak-v2-c-drawer__splitter--after--border-width--base: var(--ak-v2-global--BorderWidth--sm);
+    --ak-v2-c-drawer__splitter--after--BorderColor: var(--ak-color-border);
+    --ak-v2-c-drawer__splitter--after--border-width--base: var(--ak-border-width-sm);
     --ak-v2-c-drawer__splitter--after--BorderTopWidth: 0;
     --ak-v2-c-drawer__splitter--after--BorderRightWidth: var(
         --ak-v2-c-drawer__splitter--after--border-width--base
@@ -70,26 +82,20 @@
     --ak-v2-c-drawer--m-panel-bottom__splitter-handle--Top: calc(
         50% - var(--ak-v2-c-drawer__splitter--after--border-width--base)
     );
-    --ak-v2-c-drawer__splitter-handle--after--BorderColor: var(--ak-v2-global--Color--200);
-    --ak-v2-c-drawer__splitter-handle--after--BorderTopWidth: var(--ak-v2-global--BorderWidth--sm);
+    --ak-v2-c-drawer__splitter-handle--after--BorderColor: var(--ak-color-text-muted);
+    --ak-v2-c-drawer__splitter-handle--after--BorderTopWidth: var(--ak-border-width-sm);
     --ak-v2-c-drawer__splitter-handle--after--BorderRightWidth: 0;
-    --ak-v2-c-drawer__splitter-handle--after--BorderBottomWidth: var(
-        --ak-v2-global--BorderWidth--sm
-    );
+    --ak-v2-c-drawer__splitter-handle--after--BorderBottomWidth: var(--ak-border-width-sm);
     --ak-v2-c-drawer__splitter-handle--after--BorderLeftWidth: 0;
-    --ak-v2-c-drawer__splitter--hover__splitter-handle--after--BorderColor: var(
-        --ak-v2-global--Color--100
-    );
-    --ak-v2-c-drawer__splitter--focus__splitter-handle--after--BorderColor: var(
-        --ak-v2-global--Color--100
-    );
+    --ak-v2-c-drawer__splitter--hover__splitter-handle--after--BorderColor: var(--ak-color-text);
+    --ak-v2-c-drawer__splitter--focus__splitter-handle--after--BorderColor: var(--ak-color-text);
     --ak-v2-c-drawer__splitter--m-vertical__splitter-handle--after--BorderTopWidth: 0;
     --ak-v2-c-drawer__splitter--m-vertical__splitter-handle--after--BorderRightWidth: var(
-        --ak-v2-global--BorderWidth--sm
+        --ak-border-width-sm
     );
     --ak-v2-c-drawer__splitter--m-vertical__splitter-handle--after--BorderBottomWidth: 0;
     --ak-v2-c-drawer__splitter--m-vertical__splitter-handle--after--BorderLeftWidth: var(
-        --ak-v2-global--BorderWidth--sm
+        --ak-border-width-sm
     );
     --ak-v2-c-drawer__splitter-handle--after--Width: 0.75rem;
     --ak-v2-c-drawer__splitter-handle--after--Height: 0.25rem;
@@ -105,25 +111,19 @@
 
 :root {
     --ak-v2-c-drawer__panel--BoxShadow: none;
-    --ak-v2-c-drawer--m-expanded--m-panel-bottom__panel--BoxShadow: var(
-        --ak-v2-global--BoxShadow--lg-top
-    );
-    --ak-v2-c-drawer--m-expanded__panel--BoxShadow: var(--ak-v2-global--BoxShadow--lg-left);
+    --ak-v2-c-drawer--m-expanded--m-panel-bottom__panel--BoxShadow: var(--_drawer-shadow-top);
+    --ak-v2-c-drawer--m-expanded__panel--BoxShadow: var(--_drawer-shadow-left);
 }
 
 :root {
-    --ak-v2-c-drawer--m-expanded--m-panel-left__panel--BoxShadow: var(
-        --ak-v2-global--BoxShadow--lg-right
-    );
+    --ak-v2-c-drawer--m-expanded--m-panel-left__panel--BoxShadow: var(--_drawer-shadow-right);
 }
 
 :root {
-    --ak-v2-c-drawer__panel--after--Width: var(--ak-v2-global--BorderWidth--sm);
-    --ak-v2-c-drawer--m-panel-bottom__panel--after--Height: var(--ak-v2-global--BorderWidth--sm);
+    --ak-v2-c-drawer__panel--after--Width: var(--ak-border-width-sm);
+    --ak-v2-c-drawer--m-panel-bottom__panel--after--Height: var(--ak-border-width-sm);
     --ak-v2-c-drawer__panel--after--BackgroundColor: transparent;
-    --ak-v2-c-drawer--m-inline--m-expanded__panel--after--BackgroundColor: var(
-        --ak-v2-global--BorderColor--100
-    );
+    --ak-v2-c-drawer--m-inline--m-expanded__panel--after--BackgroundColor: var(--ak-color-border);
     --ak-v2-c-drawer--m-inline__panel--PaddingLeft: var(--ak-v2-c-drawer__panel--after--Width);
     --ak-v2-c-drawer--m-panel-left--m-inline__panel--PaddingRight: var(
         --ak-v2-c-drawer__panel--after--Width
@@ -136,6 +136,12 @@
 html[data-theme="dark"],
 .ak-t-dark,
 .pf-t-dark {
-    --ak-v2-c-drawer__panel--BackgroundColor: var(--ak-v2-global--ContentSurface);
+    --ak-v2-c-drawer__panel--BackgroundColor: var(--ak-color-surface);
     --ak-v2-c-drawer__splitter--BackgroundColor: transparent;
+
+    /* Dark theme: shadows need stronger opacity to read against dark surfaces. */
+    --_drawer-shadow-top: 0 -0.75rem 0.75rem -0.5rem rgba(3, 3, 3, 0.72);
+    --_drawer-shadow-right: 0.75rem 0 0.75rem -0.5rem rgba(3, 3, 3, 0.72);
+    --_drawer-shadow-bottom: 0 0.75rem 0.75rem -0.5rem rgba(3, 3, 3, 0.72);
+    --_drawer-shadow-left: -0.75rem 0 0.75rem -0.5rem rgba(3, 3, 3, 0.72);
 }

--- a/web/src/elements/ak-drawer/ak-drawer.styles.ts
+++ b/web/src/elements/ak-drawer/ak-drawer.styles.ts
@@ -40,7 +40,7 @@ export const styles = css`
         :host([position="left"])
         .ak-v2-c-drawer__main
         > .ak-v2-c-drawer__panel {
-        transform: translateX(calc(-100% * var(--ak-v2-global--inverse--multiplier)));
+        transform: translateX(calc(-100% * var(--_drawer-inverse-multiplier)));
     }
 
     :host([position="left"]) .ak-v2-c-drawer__main > .ak-v2-c-drawer__content {
@@ -68,7 +68,7 @@ export const styles = css`
         :host(:not([inline]):not([static]))
         .ak-v2-c-drawer__main
         > .ak-v2-c-drawer__panel {
-        transform: translateX(calc(100% * var(--ak-v2-global--inverse--multiplier)));
+        transform: translateX(calc(100% * var(--_drawer-inverse-multiplier)));
     }
 
     :host([expanded]:not([inline]):not([static])) .ak-v2-c-drawer__main > .ak-v2-c-drawer__panel {
@@ -87,7 +87,7 @@ export const styles = css`
         :host([position="left"]:not([inline]):not([static]))
         .ak-v2-c-drawer__main
         > .ak-v2-c-drawer__panel {
-        transform: translateX(calc(-100% * var(--ak-v2-global--inverse--multiplier)));
+        transform: translateX(calc(-100% * var(--_drawer-inverse-multiplier)));
     }
 
     :host([expanded][position="left"]:not([inline]):not([static]))
@@ -152,7 +152,7 @@ export const styles = css`
         flex-basis: var(--ak-v2-c-drawer__panel--FlexBasis);
         order: 1;
         max-height: var(--ak-v2-c-drawer__panel--MaxHeight);
-        gap: var(--ak-v2-global--spacer--sm);
+        gap: var(--ak-space-sm);
         overflow: auto;
         background-color: var(--ak-v2-c-drawer__panel--BackgroundColor);
         box-shadow: var(--ak-v2-c-drawer__panel--BoxShadow);
@@ -272,7 +272,7 @@ export const styles = css`
     }
 
     :where(.ak-v2-m-dir-rtl, [dir="rtl"]) .ak-v2-c-drawer__splitter-handle {
-        transform: translate(calc(-50% * var(--ak-v2-global--inverse--multiplier)), -50%);
+        transform: translate(calc(-50% * var(--_drawer-inverse-multiplier)), -50%);
     }
 
     .ak-v2-c-drawer__splitter-handle::after {
@@ -597,7 +597,7 @@ export const styles = css`
         :host([inline])
         .ak-v2-c-drawer__main
         > .ak-v2-c-drawer__panel {
-        transform: translateX(calc(100% * var(--ak-v2-global--inverse--multiplier)));
+        transform: translateX(calc(100% * var(--_drawer-inverse-multiplier)));
     }
 
     :host([inline][expanded]) .ak-v2-c-drawer__main > .ak-v2-c-drawer__panel {
@@ -615,7 +615,7 @@ export const styles = css`
         :host([inline][position="left"])
         .ak-v2-c-drawer__main
         > .ak-v2-c-drawer__panel {
-        transform: translateX(calc(-100% * var(--ak-v2-global--inverse--multiplier)));
+        transform: translateX(calc(-100% * var(--_drawer-inverse-multiplier)));
     }
 
     :host([inline][position="left"][expanded]) .ak-v2-c-drawer__main > .ak-v2-c-drawer__panel {
@@ -678,7 +678,7 @@ export const styles = css`
         :host([inline-on-lg])
         .ak-v2-c-drawer__main
         > .ak-v2-c-drawer__panel {
-        transform: translateX(calc(100% * var(--ak-v2-global--inverse--multiplier)));
+        transform: translateX(calc(100% * var(--_drawer-inverse-multiplier)));
     }
 
     :host([inline-on-lg][expanded]) .ak-v2-c-drawer__main > .ak-v2-c-drawer__panel {
@@ -696,7 +696,7 @@ export const styles = css`
         :host([inline-on-lg][position="left"])
         .ak-v2-c-drawer__main
         > .ak-v2-c-drawer__panel {
-        transform: translateX(calc(-100% * var(--ak-v2-global--inverse--multiplier)));
+        transform: translateX(calc(-100% * var(--_drawer-inverse-multiplier)));
     }
 
     :host([inline-on-lg][position="left"][expanded])
@@ -763,7 +763,7 @@ export const styles = css`
         :host([inline-on-xl])
         .ak-v2-c-drawer__main
         > .ak-v2-c-drawer__panel {
-        transform: translateX(calc(100% * var(--ak-v2-global--inverse--multiplier)));
+        transform: translateX(calc(100% * var(--_drawer-inverse-multiplier)));
     }
 
     :host([inline-on-xl][expanded]) .ak-v2-c-drawer__main > .ak-v2-c-drawer__panel {
@@ -781,7 +781,7 @@ export const styles = css`
         :host([inline-on-xl][position="left"])
         .ak-v2-c-drawer__main
         > .ak-v2-c-drawer__panel {
-        transform: translateX(calc(-100% * var(--ak-v2-global--inverse--multiplier)));
+        transform: translateX(calc(-100% * var(--_drawer-inverse-multiplier)));
     }
 
     :host([inline-on-xl][position="left"][expanded])
@@ -848,7 +848,7 @@ export const styles = css`
         :host([inline-on-2xl])
         .ak-v2-c-drawer__main
         > .ak-v2-c-drawer__panel {
-        transform: translateX(calc(100% * var(--ak-v2-global--inverse--multiplier)));
+        transform: translateX(calc(100% * var(--_drawer-inverse-multiplier)));
     }
 
     :host([inline-on-2xl][expanded]) .ak-v2-c-drawer__main > .ak-v2-c-drawer__panel {
@@ -866,7 +866,7 @@ export const styles = css`
         :host([inline-on-2xl][position="left"])
         .ak-v2-c-drawer__main
         > .ak-v2-c-drawer__panel {
-        transform: translateX(calc(-100% * var(--ak-v2-global--inverse--multiplier)));
+        transform: translateX(calc(-100% * var(--_drawer-inverse-multiplier)));
     }
 
     :host([inline-on-2xl][position="left"][expanded])

--- a/web/src/styles/global/theme/token-bridge.css
+++ b/web/src/styles/global/theme/token-bridge.css
@@ -1,0 +1,114 @@
+/*
+ * Runtime bridge from authentik's public semantic tokens to existing
+ * PatternFly 4 variables. This keeps old component CSS working while new
+ * custom CSS can target the shorter --ak-* surface.
+ *
+ * Each PF variable falls back to a literal copy of the light-theme default
+ * it overrides when the matching --ak-* token is absent, so the bridge
+ * overrides PatternFly only where a token is defined and otherwise preserves
+ * PF's defaults. The literals are spelled out because a var() self-reference
+ * (`--x: var(--token, var(--x))`) is a dependency cycle and computes to
+ * invalid rather than falling through. The font families are the exception:
+ * their defaults are themselves var() references into ./fonts.css, so they
+ * fall back to the same references. (The theme is always loaded in
+ * authentik, so the fallback is a safety net, not the common path.)
+ */
+
+:root,
+:host {
+    /* Legacy authentik bridge */
+    --ak-accent: var(--ak-color-accent, #fd4b2d);
+
+    /* PatternFly 4 compatibility bridge */
+    --pf-global--primary-color--100: var(--ak-color-primary, oklab(0.522 -0.0434 -0.1717));
+    --pf-global--primary-color--200: var(--ak-color-primary-hover, oklab(0.3763 -0.0324 -0.1182));
+    --pf-global--link--Color: var(--ak-color-link, oklab(0.522 -0.0434 -0.1717));
+    --pf-global--link--Color--hover: var(--ak-color-link-hover, oklab(0.3763 -0.0324 -0.1182));
+    --pf-global--link--Color--visited: var(--ak-color-link-visited, oklab(0.3679 0.0535 -0.1797));
+    --pf-global--Color--100: var(--ak-color-text, oklab(0.1957 -0 0));
+    --pf-global--Color--200: var(--ak-color-text-muted, oklab(0.5364 -0.0026 -0.0089));
+    --pf-global--BackgroundColor--100: var(--ak-color-surface, oklab(1 -0 0));
+    --pf-global--BackgroundColor--150: var(--ak-color-surface-raised, oklab(0.9851 -0 0));
+    --pf-global--BackgroundColor--200: var(--ak-color-surface-muted, oklab(0.9551 -0 0));
+    --pf-global--BorderColor--100: var(--ak-color-border, #d2d2d2);
+    --pf-global--BorderColor--200: var(--ak-color-border-strong, #8a8d90);
+    --pf-global--info-color--100: var(--ak-color-info, oklab(0.6689 -0.0608 -0.1513));
+    --pf-global--success-color--100: var(--ak-color-success, oklab(0.5549 -0.1071 0.0852));
+    --pf-global--warning-color--100: var(--ak-color-warning, oklab(0.7864 0.0298 0.1604));
+    --pf-global--danger-color--100: var(--ak-color-danger, oklab(0.5331 0.1798 0.1034));
+    --pf-global--FontFamily--sans-serif: var(
+        --ak-font-family-body,
+        var(--ak-font-family-sans-serif)
+    );
+    --pf-global--FontFamily--heading--sans-serif: var(
+        --ak-font-family-heading,
+        var(--ak-generic-display)
+    );
+    --pf-global--FontFamily--monospace: var(--ak-font-family-code, var(--ak-font-family-monospace));
+    --pf-global--FontSize--xs: var(--ak-font-size-xs, 0.75rem);
+    --pf-global--FontSize--sm: var(--ak-font-size-sm, 0.875rem);
+    --pf-global--FontSize--md: var(--ak-font-size-md, 1rem);
+    --pf-global--FontSize--lg: var(--ak-font-size-lg, 1.125rem);
+    --pf-global--FontSize--xl: var(--ak-font-size-xl, 1.25rem);
+    --pf-global--FontSize--2xl: var(--ak-font-size-2xl, 1.5rem);
+    --pf-global--FontSize--3xl: var(--ak-font-size-3xl, 1.75rem);
+    --pf-global--FontSize--4xl: var(--ak-font-size-4xl, 2.25rem);
+    --pf-global--LineHeight--sm: var(--ak-line-height-sm, 1.3);
+    --pf-global--LineHeight--md: var(--ak-line-height-md, 1.5);
+    --pf-global--spacer--xs: var(--ak-space-xs, 0.25rem);
+    --pf-global--spacer--sm: var(--ak-space-sm, 0.5rem);
+    --pf-global--spacer--md: var(--ak-space-md, 1rem);
+    --pf-global--spacer--lg: var(--ak-space-lg, 1.5rem);
+    --pf-global--spacer--xl: var(--ak-space-xl, 2rem);
+    --pf-global--spacer--2xl: var(--ak-space-2xl, 3rem);
+    --pf-global--spacer--3xl: var(--ak-space-3xl, 4rem);
+    --pf-global--spacer--4xl: var(--ak-space-4xl, 5rem);
+    --pf-global--BorderRadius--sm: var(--ak-radius-sm, 3px);
+    --pf-global--BorderRadius--lg: var(--ak-radius-pill, 30em);
+    --pf-global--BorderWidth--sm: var(--ak-border-width-sm, 1px);
+    --pf-global--BorderWidth--md: var(--ak-border-width-md, 2px);
+    --pf-global--BorderWidth--lg: var(--ak-border-width-lg, 3px);
+    --pf-global--TransitionDuration: var(--ak-duration-normal, 250ms);
+    --pf-global--TimingFunction: var(--ak-easing-standard, cubic-bezier(0.645, 0.045, 0.355, 1));
+
+    /* Shadows. Directional variants (top/right/bottom/left) intentionally
+     * stay on PatternFly's own theme-switched values — they're niche enough
+     * that exposing four extra public tokens per size isn't worth it. */
+    --pf-global--BoxShadow--sm: var(
+        --ak-shadow-sm,
+        0 0.0625rem 0.125rem 0 rgba(3, 3, 3, 0.12),
+        0 0 0.125rem 0 rgba(3, 3, 3, 0.06)
+    );
+    --pf-global--BoxShadow--md: var(
+        --ak-shadow-md,
+        0 0.25rem 0.5rem 0rem rgba(3, 3, 3, 0.12),
+        0 0 0.25rem 0 rgba(3, 3, 3, 0.06)
+    );
+    --pf-global--BoxShadow--lg: var(
+        --ak-shadow-lg,
+        0 0.5rem 1rem 0 rgba(3, 3, 3, 0.16),
+        0 0 0.375rem 0 rgba(3, 3, 3, 0.08)
+    );
+    --pf-global--BoxShadow--xl: var(
+        --ak-shadow-xl,
+        0 1rem 2rem 0 rgba(3, 3, 3, 0.16),
+        0 0 0.5rem 0 rgba(3, 3, 3, 0.1)
+    );
+    --pf-global--BoxShadow--inset: var(--ak-shadow-inset, inset 0 0 0.625rem 0 rgba(3, 3, 3, 0.25));
+
+    /* Font weights. semi-bold is deliberately NOT bridged because PatternFly's
+     * default --pf-global--FontWeight--semi-bold is 700 (same as bold) unless
+     * the Overpass font scale is active. Aliasing it to 600 here would silently
+     * shift every consumer of the PF var. */
+    --pf-global--FontWeight--light: var(--ak-font-weight-light, 300);
+    --pf-global--FontWeight--normal: var(--ak-font-weight-normal, 400);
+    --pf-global--FontWeight--bold: var(--ak-font-weight-bold, 700);
+
+    /* Z-index scale. */
+    --pf-global--ZIndex--xs: var(--ak-z-index-xs, 100);
+    --pf-global--ZIndex--sm: var(--ak-z-index-sm, 200);
+    --pf-global--ZIndex--md: var(--ak-z-index-md, 300);
+    --pf-global--ZIndex--lg: var(--ak-z-index-lg, 400);
+    --pf-global--ZIndex--xl: var(--ak-z-index-xl, 500);
+    --pf-global--ZIndex--2xl: var(--ak-z-index-2xl, 600);
+}

--- a/web/src/styles/global/theme/variables.css
+++ b/web/src/styles/global/theme/variables.css
@@ -5,14 +5,19 @@
 @import "./shadows.css";
 @import "./z-indexes.css";
 @import "./borders.css";
+@import "@goauthentik/theme/index.css";
+@import "./token-bridge.css";
 
 /* #region Miscellaneous */
 
 :root {
     --pf-global--ListStyle: disc outside;
     --pf-global--Transition: all 250ms cubic-bezier(0.42, 0, 0.58, 1);
-    --pf-global--TimingFunction: cubic-bezier(0.645, 0.045, 0.355, 1);
-    --pf-global--TransitionDuration: 250ms;
+    /* --pf-global--TimingFunction and --TransitionDuration are owned by
+     * ./token-bridge.css (mapped onto --ak-easing-standard and
+     * --ak-duration-normal); re-declaring them here would win the cascade
+     * and cut the motion tokens — including the reduced-motion override —
+     * out of the document. */
     --pf-global--arrow--width: 0.9375rem;
     --pf-global--arrow--width-lg: 1.5625rem;
     --pf-global--target-size--MinWidth: 44px;
@@ -26,8 +31,9 @@
 /* #region Root */
 
 :root {
-    --ak-accent: #fd4b2d;
-
+    /* --ak-accent is defined by ./token-bridge.css (mapped onto
+     * --ak-color-accent) so the document and shadow roots resolve it the
+     * same way; do not redefine it here. */
     --ak-dark-foreground: #fafafa;
     --ak-dark-background: #18191a;
     --ak-dark-background-light: #1c1e21;
@@ -44,90 +50,9 @@
     --ak-sidebar--minimum-auto-width: 80rem;
 }
 
-/* #region Root globals, V2 */
-:root {
-    /* ---- Background Colors ---- */
-    --ak-v2-global--BackgroundColor--100: #fff;
-    --ak-v2-global--BorderWidth--sm: 1px;
-
-    /* ---- Text Colors ---------- */
-    --pf-v5-global--Color--100: #151515;
-
-    /* ---- Border Colors -------- */
-    --ak-v2-global--BorderColor--100: #d2d2d2;
-    --ak-v2-global--BorderColor--200: #8a8d90;
-
-    /* ---- Box Shadows ------ */
-    --ak-v2-global--BoxShadow--lg:
-        0 0.5rem 1rem 0 rgba(3, 3, 3, 0.16), 0 0 0.375rem 0 rgba(3, 3, 3, 0.08);
-    --ak-v2-global--BoxShadow--lg-top: 0 -0.75rem 0.75rem -0.5rem rgba(3, 3, 3, 0.18);
-    --ak-v2-global--BoxShadow--lg-right: 0.75rem 0 0.75rem -0.5rem rgba(3, 3, 3, 0.18);
-    --ak-v2-global--BoxShadow--lg-bottom: 0 0.75rem 0.75rem -0.5rem rgba(3, 3, 3, 0.18);
-    --ak-v2-global--BoxShadow--lg-left: -0.75rem 0 0.75rem -0.5rem rgba(3, 3, 3, 0.18);
-
-    /* ---- Spacers -------------- */
-    --ak-v2-global--spacer--xs: 0.25rem;
-    --ak-v2-global--spacer--sm: 0.5rem;
-    --ak-v2-global--spacer--md: 1rem;
-    --ak-v2-global--spacer--lg: 1.5rem;
-    --ak-v2-global--spacer--xl: 2rem;
-    --ak-v2-global--spacer--2xl: 3rem;
-    --ak-v2-global--spacer--3xl: 4rem;
-    --ak-v2-global--spacer--4xl: 5rem;
-    --ak-v2-global--spacer--form-element: 0.375rem;
-    --ak-v2-global--gutter: 1rem;
-    --ak-v2-global--gutter--md: 1.5rem;
-
-    /* ---- Z-Index -------------- */
-    --ak-v2-global--ZIndex--xs: 100;
-    --ak-v2-global--ZIndex--sm: 200;
-
-    /* ---- Animation ------------ */
-    --ak-v2-global--TransitionDuration: 250ms;
-
-    /* ---- Customization Bridge - */
-    --ak-v2-global--dark-background: var(--ak-dark-background);
-}
-
-/* -------- Dark Theme ------------------------------- */
-
-[data-theme="dark"] {
-    /* ---- Background Colors ---- */
-    --ak-v2-global--BackgroundColor--100: #18191a;
-
-    /* ---- Text Colors ---------- */
-    --ak-v2-global--Color--100: #e0e0e0;
-
-    /* ---- Border Colors -------- */
-    --ak-v2-global--BorderColor--100: #444548;
-    --ak-v2-global--BorderColor--200: #444548;
-
-    /* ---- Box Shadows ------ */
-    --ak-v2-global--BoxShadow--lg:
-        0 0.5rem 1rem 0 rgba(3, 3, 3, 0.64), 0 0 0.375rem 0 rgba(3, 3, 3, 0.32);
-    --ak-v2-global--BoxShadow--lg-top: 0 -0.75rem 0.75rem -0.5rem rgba(3, 3, 3, 0.72);
-    --ak-v2-global--BoxShadow--lg-right: 0.75rem 0 0.75rem -0.5rem rgba(3, 3, 3, 0.72);
-    --ak-v2-global--BoxShadow--lg-bottom: 0 0.75rem 0.75rem -0.5rem rgba(3, 3, 3, 0.72);
-    --ak-v2-global--BoxShadow--lg-left: -0.75rem 0 0.75rem -0.5rem rgba(3, 3, 3, 0.72);
-}
-
-/* -------- Semantic Names -------------------------- */
-
-:root {
-    /* ---- Background Colors ---- */
-    --ak-v2-global--ContentSurface: var(--ak-v2-global--BackgroundColor--100);
-    --ak-v2-global--SecondaryContentSurface: var(--ak-v2-global--BackgroundColor--200);
-    /* Not sure what to call this next one; this is the background color Patternfly uses when you hover
-       over something and it changes color to indicate it's interactive in some way. It's the same
-       color as the one above in their default theme. */
-    --ak-v2-global--AffordanceIndicatedSurface: var(--ak-v2-global--BackgroundColor--200);
-
-    /* ---- Text Colors ---- */
-    --ak-v2-global--PrimaryText: var(--ak-v2-global--Color--100);
-
-    /* ---- Border Colors ---- */
-    --ak-v2-global--StandardBorder: var(--pf-v5-global--BorderColor--100);
-    --ak-v2-global--InputAccentBorder: var(--pf-v5-global--BorderColor--200);
-}
+/* The public token bridge (PF4 + legacy --ak-* names mapped to --ak-color-*) lives
+ * in ./token-bridge.css and is imported at the top of this file. Keeping it in
+ * one place means both global stylesheets and per-shadow-root adopted sheets
+ * (via shadow/patternfly-base.css) stay in sync. */
 
 /* #endregion */

--- a/web/src/styles/shadow/patternfly-base.css
+++ b/web/src/styles/shadow/patternfly-base.css
@@ -2,6 +2,7 @@
 @import "@patternfly/patternfly/base/patternfly-globals.css";
 @import "@patternfly/patternfly/base/patternfly-fa-icons.css";
 @import "@patternfly/patternfly/base/patternfly-pf-icons.css";
+@import "#styles/global/theme/token-bridge.css";
 
 a {
     font-weight: var(--pf-global--link--FontWeight);

--- a/website/docs/customize/branding/design-language.mdx
+++ b/website/docs/customize/branding/design-language.mdx
@@ -54,6 +54,15 @@ A few rules keep names predictable. If you're writing custom CSS or generating t
 - **Spelled-out group names.** `z-index`, not `z`. `border-width`, not `bw`. This makes tokens discoverable in IDE autocomplete and brand custom CSS without having to memorize abbreviations.
 - **Private variables use a different prefix.** Variables starting with `--_` or `--ak-c-` are component-local and undocumented. They may change between authentik releases. Avoid targeting them in custom CSS unless a release explicitly documents one as stable.
 
+## What is deliberately not a token
+
+Some categories that design systems commonly tokenize are intentionally absent from the public surface. The set stays small until real customization needs justify growing it (see [Stability](#stability)):
+
+- **Breakpoints.** Components respond to their own container wherever possible — container queries are baseline in every browser authentik supports — so there is no viewport breakpoint scale to share. The media queries that remain follow PatternFly's grid tiers and are implementation detail.
+- **Opacities.** Translucency is baked into the values that need it (shadows, scrims) rather than exposed as a standalone scale. An opacity token invites layering translucent colors, which produces unpredictable results against themed surfaces; override the composed color instead.
+- **Grids and layout.** Column counts, gutters, and page structure are component behavior, not brand identity. Brands adjust `space` tokens; components decide how to lay themselves out.
+- **Gradients.** The gradients in the interface are component implementation details — skeleton shimmer, scroll-edge shadows — composed from the semantic colors, not brandable surfaces in their own right. If a brand-facing gradient enters the design language, it will arrive as a semantic token (for example a hero surface), not as raw color stops.
+
 ## Light and dark themes
 
 The design language ships with two themes out of the box. Both are toggled by the `data-theme` attribute on `html`:

--- a/website/docs/developer-docs/frontend/cascade-layers.md
+++ b/website/docs/developer-docs/frontend/cascade-layers.md
@@ -75,6 +75,7 @@ Because the custom CSS path is adopted last within its shadow root rather than b
 ## Adding CSS
 
 - A new document-level component rule goes in `web/src/styles/authentik/components/<Name>/`, imported into the relevant entrypoint with `layer(components)`.
+- Classes for light-DOM content — markup the document owns even when a component slots and positions it — are document-level component rules too, and go in `layer(components)` with the rest. If this category grows, it may earn a dedicated layer between `components` and `theme` so slotted-content styling can be reasoned about separately; today the volume does not justify extending the layer order.
 - A new design token goes in `web/src/styles/global/theme/`, which is already imported into `layer(theme)`.
 - A light/dark or accessibility override goes in `web/src/styles/global/mode/`.
 - Anything vendored from PatternFly goes through `web/src/styles/global/vendor/patternfly.css`.

--- a/website/docs/developer-docs/frontend/css-architecture.md
+++ b/website/docs/developer-docs/frontend/css-architecture.md
@@ -63,16 +63,18 @@ Most component CSS still reads `--pf-*`. `token-bridge.css` maps the semantic la
 ```css
 :root,
 :host {
-    --pf-global--primary-color--100: var(--ak-color-primary, var(--pf-global--primary-color--100));
-    --pf-global--spacer--md: var(--ak-space-md, var(--pf-global--spacer--md));
+    --pf-global--primary-color--100: var(--ak-color-primary, oklab(0.522 -0.0434 -0.1717));
+    --pf-global--spacer--md: var(--ak-space-md, 1rem);
 }
 ```
 
-Each PatternFly variable falls back to its own prior value, so the bridge only overrides where a token exists. It is imported in two places — `global/theme/variables.css` for the document, and `shadow/patternfly-base.css` for shadow roots — so both cascades resolve the same way.
+Each PatternFly variable falls back to a literal copy of its prior value, so the bridge only overrides where a token exists. The fallback must be a literal: a self-reference like `var(--ak-space-md, var(--pf-global--spacer--md))` is a custom-property dependency cycle, which computes to invalid rather than the prior value. The bridge is imported in two places — `global/theme/variables.css` for the document, and `shadow/patternfly-base.css` for shadow roots — so both cascades resolve the same way.
 
-## Shadow DOM API
+## Styling components
 
-Custom properties are the configuration surface:
+A component exposes three styling surfaces, in order of preference: custom properties, host attributes, and parts.
+
+**Custom properties are the configuration surface:**
 
 ```css
 ak-flow-executor {
@@ -80,15 +82,49 @@ ak-flow-executor {
 }
 ```
 
-`::part()` is for exposed structure, and only where a brand can reasonably style that substructure without coupling to internal DOM:
+**Variants are host attributes, styled with `:host([attribute])`.** A component's visual states — position, size, expanded, resizable — belong on the host element as attributes, with the styling keyed off them inside the shadow root:
+
+```css
+:host([position="left"]) .ak-v2-c-drawer__panel {
+    inset-inline-start: 0;
+}
+```
+
+The variant API stays visible in markup (`<ak-drawer position="left">` documents itself), consumers and tests can target states without knowing shadow internals, and the component avoids maintaining a parallel class vocabulary for its own states.
+
+**Prefer reassigning custom properties over writing alternative concrete stylings.** When a variant only changes values — a width, a color, a shadow — the variant rule should reassign the component-local properties the base rules consume, not repeat the declaration block with different literals:
+
+```css
+.ak-v2-c-drawer__panel {
+    box-shadow: var(--ak-v2-c-drawer__panel--BoxShadow);
+}
+
+:host([position="left"]) {
+    --ak-v2-c-drawer--m-expanded__panel--BoxShadow: var(--_drawer-shadow-right);
+}
+```
+
+One rule owns the layout; variants are data. Reserve separate rule blocks for variants that genuinely change structure.
+
+**Slots are for composition; ownership decides what is slotted.** Content goes in a slot when the consumer owns it — actions, footers, arbitrary body content. It stays in the template when the component owns it — icons, labels bound to properties, structure the component must control to function. A slot is not a styling escape hatch: if the only reason to slot something is to reach it with outside CSS, expose a custom property or a part instead.
+
+**`::slotted()` is a boundary tool — keep it shallow.** It can only select the slotted elements themselves, never their descendants, and it should only declare what a container legitimately owns about its children: layout, spacing, alignment.
+
+```css
+::slotted(*) {
+    margin-block: 0;
+}
+```
+
+Typography and color inside slotted content belong to the document cascade — slotted elements are light DOM, so the global stylesheets and semantic tokens already reach them. If a component needs deep control over slotted content, that content is probably component-owned and should move into the template.
+
+**`::part()` is for exposed structure**, and only where a brand can reasonably style that substructure without coupling to internal DOM:
 
 ```css
 ak-flow-executor::part(locale-select) {
     display: none;
 }
 ```
-
-Slots are for composition, not styling.
 
 ## Accessibility defaults
 
@@ -107,6 +143,7 @@ Prefer semantic tokens that media queries adjust over separate per-variant theme
 
 ## Still to do
 
+- Derive relational colors (hover, tint, and shade variants) algorithmically in OKLCH space instead of hand-picking each value. Colors already emit as `oklch()`, so lightness and chroma are directly adjustable; today every variant is still an explicit stop.
 - Migrate component markup off PatternFly incrementally, starting where styling is already mostly custom.
 - Move component CSS next to the component it styles, rather than under `web/src/styles/authentik/components/`.
 - Generate token reference documentation from the DTCG export instead of maintaining the table by hand.


### PR DESCRIPTION
Adopts the `@goauthentik/theme` tokens in the application styles.

Stacked on #23341 — the base is `slice/theme-package` so the diff here shows only this change. GitHub will retarget to `main` when #23341 merges.

## What this changes

- `web/src/styles/global/theme/token-bridge.css` bridges the package's semantic tokens onto the existing PatternFly 4 variables. Each PF variable falls back to its own prior value where a token is absent.
- `variables.css` imports `@goauthentik/theme/index.css` and the bridge, and drops the hand-rolled `--ak-v2-global--*` block.
- `shadow/patternfly-base.css` imports the bridge too, so per-shadow-root sheets stay in sync with the document cascade.
- `ak-drawer` moves onto the semantic tokens. It was the only consumer of `--ak-v2-global--*`, which is why that block goes in the same commit.

## Rebase notes

The branch predated the styles restructure, so a few things moved rather than merged:

- `styles/authentik/base/` → `styles/global/theme/`, and `styles/patternfly/base.css` → `styles/shadow/patternfly-base.css`.
- The cascade-layer reservation the branch added to the global entrypoints (`@layer reset, base, tokens, components, utilities, overrides`) is **dropped**. Layers shipped for real in #23366 as `@layer reset, vendor, components, theme, mode, brand`; re-declaring a second, different order in the same stylesheet would merge the two and disturb the shipped cascade.

## Value drift

Of the 49 bridged PatternFly variables, 38 are byte-identical and 8 more are the same color expressed differently — main stores the palette as `oklab()`, the theme emits `oklch()` with a hex comment. Converting them agrees exactly (`oklab(0.522 -0.0434 -0.1717)` = `#0066cc` = `--ak-color-primary`, and so on for text, muted text, surface, info, success, warning, danger).

Three are genuine changes:

| Variable | Was | Now |
| --- | --- | --- |
| `--pf-global--BorderRadius--lg` | `30em` | `30rem` |
| `--pf-global--BoxShadow--xl` | `0 1rem 2rem 0 rgba(3,3,3,.16), …` | `0 .75rem 1.5rem 0 rgba(3,3,3,.2), …` |
| dark surface (drawer) | `#18191a` | `#121212` |

## Worth a careful look in review

In dark mode the bridge is layered differently in the two cascade contexts, and the results diverge:

- **Document**: `variables.css` is imported into `layer(theme)`, and `mode.css` into `layer(mode)`, which sorts after it. So `mode.css` still wins and `--pf-global--BackgroundColor--100` stays `#1b1d21`.
- **Shadow roots**: the bridge is adopted unlayered on `:host`, so it wins there and the same variable resolves to `--ak-color-surface`, i.e. `#121212`.

That is a visible dark-mode shift inside every PF-backed component, and it is worth confirming in a browser. If the intent is parity, the theme's dark `color.surface` wants to be `#1b1d21`. Note the token's own source comment says surfaces are "pinned near PatternFly 4's `BackgroundColor--100` (#151515) and the legacy drawer surface (#18191a)" — `#121212` is darker than both, which suggests drift rather than intent.

Co-Authored-By: Ken Sternberg <ken@goauthentik.io>
