### PR TITLE
ci: Fix Node script hang. Add timeouts to docker build, lint, and setup-node install steps

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -54,10 +54,9 @@ runs:
     - name: Install monorepo dependencies
       if: ${{ contains(inputs.dependencies, 'monorepo') }}
       shell: bash
-      timeout-minutes: 5
       run: | #shell
         node ./scripts/node/lint-lockfile.mjs
-        corepack npm ci
+        timeout 5m corepack npm ci
     - name: Setup Node.js (Working Directory)
       if: ${{ contains(inputs.dependencies, 'working-directory') }}
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v4
@@ -68,7 +67,6 @@ runs:
     - name: Install working directory dependencies
       if: ${{ contains(inputs.dependencies, 'working-directory') }}
       shell: bash
-      timeout-minutes: 5
       run: | # shell
         corepack install
 
@@ -76,4 +74,4 @@ runs:
         echo "npm version: $(corepack npm --version)"
 
         node ./scripts/node/lint-lockfile.mjs ${{ inputs.working-directory }}
-        corepack npm ci --prefix ${{ inputs.working-directory }}
+        timeout 5m corepack npm ci --prefix ${{ inputs.working-directory }}

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -54,6 +54,7 @@ runs:
     - name: Install monorepo dependencies
       if: ${{ contains(inputs.dependencies, 'monorepo') }}
       shell: bash
+      timeout-minutes: 5
       run: | #shell
         node ./scripts/node/lint-lockfile.mjs
         corepack npm ci
@@ -67,6 +68,7 @@ runs:
     - name: Install working directory dependencies
       if: ${{ contains(inputs.dependencies, 'working-directory') }}
       shell: bash
+      timeout-minutes: 5
       run: | # shell
         corepack install
 

--- a/.github/workflows/_reusable-docker-build-single.yml
+++ b/.github/workflows/_reusable-docker-build-single.yml
@@ -31,6 +31,7 @@ jobs:
   build:
     name: Build ${{ inputs.image_arch }}
     runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: 30
     outputs:
       image-digest: ${{ steps.push.outputs.digest }}
     permissions:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -50,6 +50,7 @@ jobs:
           - job: rustfmt
             deps: rust-nightly
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
       - name: Setup authentik env

--- a/scripts/node/lint-lockfile.mjs
+++ b/scripts/node/lint-lockfile.mjs
@@ -274,5 +274,7 @@ run()
         } else {
             logger.info("✅ Lockfile is in sync.");
         }
+
+        process.exit(0);
     })
     .catch((error) => reportAndExit(error, logger));

--- a/scripts/node/lint-runtime.mjs
+++ b/scripts/node/lint-runtime.mjs
@@ -110,5 +110,6 @@ async function main() {
 main()
     .then(() => {
         logger.info("✅ Node.js and npm versions are in sync.");
+        process.exit(0);
     })
     .catch((error) => reportAndExit(error, logger));

--- a/scripts/node/setup-corepack.mjs
+++ b/scripts/node/setup-corepack.mjs
@@ -102,9 +102,12 @@ async function main() {
         subcommand = "use";
     }
 
-    await $`corepack ${subcommand} ${packageManager}`({ cwd });
-
-    logger.info("Corepack installed npm successfully");
+    return $`corepack ${subcommand} ${packageManager}`({ cwd });
 }
 
-main().catch((error) => reportAndExit(error, logger));
+main()
+    .then(() => {
+        logger.info("Corepack setup completed successfully");
+        process.exit(0);
+    })
+    .catch((error) => reportAndExit(error, logger));


### PR DESCRIPTION
## Summary

- Add explicit `process.exit(0)` calls to scripts to drain logger.
- Add `timeout-minutes: 30` to `_reusable-docker-build-single.yml` (build job) and the `lint` matrix in `ci-main.yml` — both were relying on GitHub's 6-hour default.
- Add `timeout-minutes: 5` to the two `corepack npm ci` steps in `.github/actions/setup-node` so a hung npm install surfaces as a real failure.

