### PR TITLE
ci: stop pino worker-thread transport hanging lint-lockfile

### DIFF
--- a/packages/logger-js/lib/node.js
+++ b/packages/logger-js/lib/node.js
@@ -37,12 +37,6 @@ const { pino } = await import("pino").catch(() => {
 export const DEFAULT_PINO_LOGGER_OPTIONS = {
     enabled: true,
     level: "info",
-    transport: {
-        target: "./transport.js",
-        options: /** @satisfies {PrettyOptions} */ ({
-            colorize: true,
-        }),
-    },
 };
 
 //#endregion


### PR DESCRIPTION
This should fix the CI hangup at `INFO (lint-runtime): ✅ Node.js and npm versions are in sync.`

The setup-node composite was hanging silently in 'Install working directory dependencies' after lint-lockfile.mjs printed its final 'Lockfile is in sync' message. 

### Root cause

packages/logger-js/lib/node.js configures pino with a worker-thread transport (pino-pretty). When 'await import("pino")' succeeds (i.e. node_modules already populated from a previous npm ci in the same job), pino spawns a worker thread. That worker keeps the Node.js event loop alive after main() returns, so the script process never exits, bash waits forever, and the following 'corepack npm ci' never even starts.