### PR TITLE
providers/radius: fix eap debug logging

### DIFF
--- a/internal/outpost/radius/handler_eap_log.go
+++ b/internal/outpost/radius/handler_eap_log.go
@@ -47,25 +47,28 @@ type logrusAdapter struct {
 	entry *logrus.Entry
 }
 
-func (l *logrusAdapter) Debug(format string, args ...any) {
-	l.entry.Debugf(format, args...)
-}
-func (l *logrusAdapter) Info(format string, args ...any) {
-	l.entry.Infof(format, args...)
-}
-func (l *logrusAdapter) Warn(format string, args ...any) {
-	l.entry.Warnf(format, args...)
-}
-func (l *logrusAdapter) Error(format string, args ...any) {
-	l.entry.Errorf(format, args...)
-}
-func (l *logrusAdapter) With(args ...any) protocol.Logger {
+func (l *logrusAdapter) fields(args ...any) map[string]any {
 	f := make(map[string]any, len(args)/2)
 	i := Fields(args).Iterator()
 	for i.Next() {
 		k, v := i.At()
 		f[k] = v
 	}
-	e := l.entry.WithFields(f)
-	return &logrusAdapter{e}
+	return f
+}
+
+func (l *logrusAdapter) Debug(msg string, args ...any) {
+	l.entry.WithFields(l.fields(args...)).Debug(msg)
+}
+func (l *logrusAdapter) Info(msg string, args ...any) {
+	l.entry.WithFields(l.fields(args...)).Info(msg)
+}
+func (l *logrusAdapter) Warn(msg string, args ...any) {
+	l.entry.WithFields(l.fields(args...)).Warn(msg)
+}
+func (l *logrusAdapter) Error(msg string, args ...any) {
+	l.entry.WithFields(l.fields(args...)).Error(msg)
+}
+func (l *logrusAdapter) With(args ...any) protocol.Logger {
+	return &logrusAdapter{l.entry.WithFields(l.fields(args...))}
 }


### PR DESCRIPTION
Currently causes things like `{"event":"Root-EAP: encapsulated challenge%!(EXTRA string=length, int=4, string=type, string=<nil>)","level":"debug","logger":"authentik.outpost.radius","provider":"Provider for radius-wifi","timestamp":"2026-05-21T22:12:58Z"}`