### PR TITLE
events: fix Event.log_deprecation not checking that cause is a string

### DIFF
--- a/authentik/events/models.py
+++ b/authentik/events/models.py
@@ -258,6 +258,7 @@ class Event(SerializerModel, ExpiringModel):
             action=EventAction.CONFIGURATION_WARNING,
             context__deprecation=identifier,
         )
+        cause = str(cause)
         if cause:
             query &= Q(context__cause=cause)
         if Event.objects.filter(query).exists():

--- a/authentik/events/tests/test_event.py
+++ b/authentik/events/tests/test_event.py
@@ -225,3 +225,14 @@ class TestEvents(TestCase):
 
         new_count = Event.objects.filter(action=EventAction.PASSWORD_SET, user__pk=user.pk).count()
         self.assertEqual(new_count, old_count + 1)
+
+    def test_log_deprecation(self):
+        """Test Event.log_deprecation"""
+        Event.log_deprecation(self.__module__, "Test deprecation")
+        Event.log_deprecation(self.__module__, "Test deprecation")
+        Event.log_deprecation(self.__module__, "Test deprecation")
+        Event.log_deprecation(self.__module__, "Test deprecation", cause=create_test_user())
+        logs = Event.objects.filter(
+            action=EventAction.CONFIGURATION_WARNING, context__deprecation=self.__module__
+        )
+        self.assertEqual(logs.count(), 2)

--- a/authentik/providers/saml/views/flows.py
+++ b/authentik/providers/saml/views/flows.py
@@ -127,7 +127,7 @@ class SAMLFlowFinalView(ChallengeStageView):
                     "Redirect binding for Service Provider binding is deprecated "
                     "and will be removed in a future version. Use Post binding instead."
                 ),
-                cause=provider,
+                cause=provider.name,
             )
             url_args = {
                 REQUEST_KEY_SAML_RESPONSE: deflate_and_base64_encode(response),


### PR DESCRIPTION
closes #22593
