### PR TITLE
web/elements/ak-dual-select: fix inverted pagination arrow colors in dark theme

### DIFF
--- a/web/src/elements/ak-dual-select/components/ak-pagination.ts
+++ b/web/src/elements/ak-dual-select/components/ak-pagination.ts
@@ -18,8 +18,8 @@ export class AkPagination extends CustomEmitterElement<DualSelectEventType>(AKEl
         css`
             :host([theme="dark"]) {
                 .pf-c-pagination__nav-control .pf-c-button {
-                    color: var(--pf-c-button--m-plain--disabled--Color);
-                    --pf-c-button--disabled--Color: var(--pf-c-button--m-plain--Color);
+                    color: var(--pf-c-button--m-plain--Color);
+                    --pf-c-button--disabled--Color: var(--pf-c-button--m-plain--disabled--Color);
                 }
 
                 .pf-c-pagination__nav-control .pf-c-button:disabled {


### PR DESCRIPTION
## Details

The dark-theme overrides in `ak-pagination` (used by every `ak-dual-select` pagination control) assigned the disabled color variable to the active button and the active color variable to the overridden disabled-color custom property. As a result, on the first and last pages of paginated lists the **active** arrow appeared muted while the **disabled** arrow appeared highlighted — the opposite of the intended PatternFly behavior and of the light theme.

This PR swaps the two values so the active arrow uses `--pf-c-button--m-plain--Color` and the disabled custom property keeps `--pf-c-button--m-plain--disabled--Color`. The structural override is preserved; only the values are corrected.

Closes #22607

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [x] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)