### PR TITLE
website/integrations: Dashy

### DIFF
--- a/website/integrations/dashboards/dashy/index.md
+++ b/website/integrations/dashboards/dashy/index.md
@@ -1,0 +1,80 @@
+---
+title: Integrate with Dashy
+sidebar_label: Dashy
+support_level: community
+---
+
+## What is Dashy?
+
+> Dashy is a self-hostable personal dashboard built for you. Includes status-checking, widgets, themes, icon packs, a UI editor and tons more.
+>
+> -- https://github.com/Lissy93/dashy
+
+This guide was tested with Dashy 4.1.15 and authentik 2026.5.0.
+
+## Preparation
+
+The following placeholders are used in this guide:
+
+- `dashy.company` is the FQDN of the Dashy installation.
+- `authentik.company` is the FQDN of the authentik installation.
+
+:::info
+This documentation lists only the settings that you need to change from their default values. Be aware that any changes other than those explicitly mentioned in this guide could cause issues accessing your application.
+:::
+
+## authentik configuration
+
+To support the integration of Dashy with authentik, you need to create an application/provider pair in authentik.
+
+### Create an application and provider in authentik
+
+1. Log in to authentik as an administrator and open the authentik Admin interface.
+2. Navigate to **Applications** > **Applications** and click **New Application** to open the application wizard.
+    - **Application Name**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
+    - **Choose a Provider type**: select **OAuth2/OpenID Connect** as the provider type.
+    - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
+        - Note the **Client ID** and **slug** values because they will be required later.
+        - Set the **Client type** to `Public`. Dashy runs entirely in the browser and does not store a client secret.
+        - Set a `Strict` redirect URI to `https://dashy.company/`.
+        - Select any available signing key.
+    - **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/bindings-overview/) (policy, group, or user) to manage the listing and access to applications on a user's **Application Dashboard** page.
+
+3. Click **Submit** to save the new application and provider.
+
+## Dashy configuration
+
+Dashy can be configured through the web UI under **Config** > **Edit Config** or by editing `conf.yml` directly. The following steps describe the web UI flow.
+
+1. Log in to Dashy as an administrator and click **Config** > **Edit Config**.
+2. Open the **App Config** > **Auth** section.
+3. Check **Enable OIDC?**.
+4. Under **Oidc**:
+    - Set **OIDC Endpoint** to `https://authentik.company/application/o/<application_slug>/`.
+    - Set **OIDC Client Id** to the Client ID from the authentik provider.
+    - Optionally, set **Admin Group** to the name of an authentik group whose members should be granted admin permissions in Dashy (for example, `Dashy-Admins`).
+    - Leave **OIDC Scope** empty to use the default scopes.
+5. Click **Save Changes** and reload Dashy to apply the new authentication settings.
+
+:::info
+The same settings can also be set directly in `conf.yml`:
+
+```yaml title="conf.yml"
+appConfig:
+    auth:
+        enableOidc: true
+        oidc:
+            endpoint: https://authentik.company/application/o/<application_slug>/
+            clientId: <Client ID from authentik>
+            adminGroup: Dashy-Admins
+```
+
+:::
+
+## Configuration verification
+
+To confirm that authentik is properly configured with Dashy, log out of Dashy, then reload the Dashy page and click the **Login with OIDC** button. You should be redirected to authentik to log in, then redirected back to Dashy.
+
+## Resources
+
+- [Dashy OIDC authentication documentation](https://dashy.to/docs/authentication/#oidc)

--- a/website/integrations/dashboards/dashy/index.md
+++ b/website/integrations/dashboards/dashy/index.md
@@ -10,8 +10,6 @@ support_level: community
 >
 > -- https://github.com/Lissy93/dashy
 
-This guide was tested with Dashy 4.1.15 and authentik 2026.5.0.
-
 ## Preparation
 
 The following placeholders are used in this guide:
@@ -27,16 +25,20 @@ This documentation lists only the settings that you need to change from their de
 
 To support the integration of Dashy with authentik, you need to create an application/provider pair in authentik.
 
+If you want to manage Dashy administrator access through authentik, create or choose a group for Dashy administrators and add the appropriate users to it. Note the exact group name because it will be required later.
+
 ### Create an application and provider in authentik
 
 1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **New Application** to open the application wizard.
-    - **Application Name**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
+    - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
     - **Choose a Provider type**: select **OAuth2/OpenID Connect** as the provider type.
     - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
         - Note the **Client ID** and **slug** values because they will be required later.
         - Set the **Client type** to `Public`. Dashy runs entirely in the browser and does not store a client secret.
-        - Set a `Strict` redirect URI to `https://dashy.company/`.
+        - Create two `Strict` redirect URIs:
+            - `https://dashy.company`
+            - `https://dashy.company/`
         - Select any available signing key.
     - **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/bindings-overview/) (policy, group, or user) to manage the listing and access to applications on a user's **Application Dashboard** page.
 
@@ -52,29 +54,36 @@ Dashy can be configured through the web UI under **Config** > **Edit Config** or
 4. Under **Oidc**:
     - Set **OIDC Endpoint** to `https://authentik.company/application/o/<application_slug>/`.
     - Set **OIDC Client Id** to the Client ID from the authentik provider.
-    - Optionally, set **Admin Group** to the name of an authentik group whose members should be granted admin permissions in Dashy (for example, `Dashy-Admins`).
-    - Leave **OIDC Scope** empty to use the default scopes.
-5. Click **Save Changes** and reload Dashy to apply the new authentication settings.
+    - Set **OIDC Scope** to `openid profile email`.
+    - If you use an authentik group for Dashy administrators, set **Admin Group** to the exact name of that group.
+5. If you use an authentik group for Dashy administrators, enable **Disable all UI Config for non admin users.**.
+6. Click **Save Changes** and reload Dashy to apply the new authentication settings.
 
-:::info
-The same settings can also be set directly in `conf.yml`:
+:::info Manual configuration
+The same settings can also be set directly in `conf.yml`.
 
-```yaml title="conf.yml"
+```yaml title="/user-data/conf.yml"
 appConfig:
     auth:
         enableOidc: true
         oidc:
             endpoint: https://authentik.company/application/o/<application_slug>/
             clientId: <Client ID from authentik>
-            adminGroup: Dashy-Admins
+            scope: openid profile email
+            adminGroup: Dashy Admins
+    disableConfigurationForNonAdmin: true
 ```
+
+Replace `Dashy Admins` with the exact name of your authentik group for Dashy administrators.
 
 :::
 
 ## Configuration verification
 
-To confirm that authentik is properly configured with Dashy, log out of Dashy, then reload the Dashy page and click the **Login with OIDC** button. You should be redirected to authentik to log in, then redirected back to Dashy.
+To confirm that authentik is properly configured with Dashy, log out of Dashy, then open Dashy. You should be redirected to authentik to log in, then redirected back to Dashy.
 
 ## Resources
 
-- [Dashy OIDC authentication documentation](https://dashy.to/docs/authentication/#oidc)
+- [Dashy Authentik authentication documentation](https://dashy.to/docs/authentication/authentik/)
+- [Dashy configuration reference](https://dashy.to/docs/configuring/)
+- [Dashy OIDC authentication source](https://github.com/Lissy93/dashy/blob/master/services/auth-oidc.js)


### PR DESCRIPTION
## Details

Adds a new integration guide for **Dashy** (https://github.com/Lissy93/dashy) with OIDC SSO against authentik. The guide covers:

- Creating a **public** OAuth2/OpenID Connect application and provider in authentik (Dashy runs entirely in the browser and does not store a client secret)
- Configuring OIDC in Dashy via the web UI (**Config** > **Edit Config** > **App Config** > **Auth**)
- The equivalent `conf.yml` snippet for users who prefer file-based configuration
- An optional **Admin Group** mapping that grants admin permissions in Dashy to members of a designated authentik group

Tested with **Dashy 4.1.15** and **authentik 2026.5.0**.

The guide is placed under the existing `dashboards` category, alongside Homarr, Linkwarden, and Organizr.

## Checklist

- [ ] Local tests pass (`ak test authentik/`)
- [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

- [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

- [ ] The code has been formatted (`make web`)

If applicable

- [x] The documentation has been updated
- [x] The documentation has been formatted (`make docs`)