### PR TITLE
website/integrations: Veeam Backup & Replication

### DIFF
--- a/website/integrations/infrastructure/veeam-backup-replication/index.md
+++ b/website/integrations/infrastructure/veeam-backup-replication/index.md
@@ -23,15 +23,16 @@ The following placeholders are used in this guide:
 This documentation lists only the settings that you need to change from their default values. Be aware that any changes other than those explicitly mentioned in this guide could cause issues accessing your application.
 :::
 
-You will need one or more existing groups in authentik to assign roles in Veeam Backup & Replication.
+You need one or more existing groups in authentik to assign roles in Veeam Backup & Replication.
 
 ## Veeam Backup & Replication pre-configuration
 
 1. Log in to the Veeam Backup & Replication console as an administrator.
-2. From the main menu, click **Users and Roles**.
+2. From the main menu, select **Users & Roles**.
 3. Open the **Identity Provider** tab.
-4. Check **Enable SAML authentication**.
-5. Under **Backup server configuration**, click **Download** to save the service provider metadata XML file. You will upload this file to authentik in the next section.
+4. Select **Enable SAML authentication**.
+5. Under **Service Provider (SP) information**, click **Install** to select a valid Veeam Backup & Replication server certificate.
+6. Under **Service Provider (SP) information**, click **Download** to save the service provider metadata XML file. You will upload this file to authentik in the next section.
 
 ## authentik configuration
 
@@ -41,34 +42,42 @@ To support the integration of Veeam Backup & Replication with authentik, you nee
 
 1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **New Application** to open the application wizard.
-    - **Application Name**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
+    - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
     - **Choose a Provider type**: select **SAML Provider from Metadata** as the provider type.
-    - **Configure the Provider**: provide the following required configurations.
-        - **Provider Name**: a descriptive name (or accept the auto-provided name).
-        - **Authorization Flow**: the authorization flow to use for this provider.
-        - **Invalidation Flow**: the flow to use when logging out of this provider.
-        - **Metadata**: click **Choose File** and select the SP metadata XML you downloaded from Veeam Backup & Replication during the pre-configuration step. The ACS URL and SP Entity ID are imported from this file.
+    - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configuration:
+        - **Metadata**: select the SP metadata XML you downloaded from Veeam Backup & Replication during the pre-configuration step.
     - **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/bindings-overview/) (policy, group, or user) to manage the listing and access to applications on a user's **Application Dashboard** page.
-
 3. Click **Submit** to save the new application and provider.
-
-4. Locate the new SAML provider in the provider list and click **Download Metadata** to save the identity provider metadata XML file.
+4. Navigate to **Applications** > **Providers** and click the provider you created.
+5. Open the **Metadata** tab and click **Download** to save the identity provider metadata XML file.
 
 ## Veeam Backup & Replication configuration
 
-1. Switch back to the Veeam Backup & Replication console and reopen **Users and Roles** > **Identity Provider**.
-2. Under **Identity provider configuration**, click **Browse...** next to **IdP metadata file** and select the metadata XML you downloaded from authentik in the previous step.
+1. Switch back to the Veeam Backup & Replication console and reopen **Users & Roles** > **Identity Provider**.
+2. Under **Identity provider (IdP) information**, click **Browse** and select the metadata XML you downloaded from authentik in the previous step.
 3. Click **OK** to save the SAML configuration.
 
 ### Map authentik groups to Veeam roles
 
 To grant access to a user, the authentik group the user belongs to must be mapped to a Veeam role.
 
-1. In the Veeam Backup & Replication console, open **Users and Roles** and switch to the **Roles** tab.
-2. Click **Add...** and select **External Group**.
-3. Enter the name of the authentik group whose members should be granted the role, and select the desired Veeam role.
-4. Click **OK** to save the role mapping.
+1. In the Veeam Backup & Replication console, open **Users & Roles** and switch to the **Security** tab.
+2. Click **Add** > **External user or group**.
+3. From the **Type** menu, select **Group**.
+4. In the **Name** field, enter the name of the authentik group whose members should be granted the role.
+5. From the **Role** menu, select the role that you want to assign to members of this group.
+6. Click **OK** to save the role mapping.
+
+:::info Group names
+The group name that you enter in Veeam Backup & Replication must match the authentik group name.
+:::
 
 ## Configuration verification
 
-To confirm that authentik is properly configured with Veeam Backup & Replication, log out of the Veeam Backup & Replication console and click **Single sign-on** on the sign-in screen. You should be redirected to authentik to log in, then redirected back to the Veeam Backup & Replication console.
+To confirm that authentik is properly configured with Veeam Backup & Replication, log out of the Veeam Backup & Replication console and click **Sign in with SSO** on the sign-in screen. You should be redirected to authentik to log in, then redirected back to the Veeam Backup & Replication console.
+
+## Resources
+
+- [Veeam - Veeam Backup & Replication](https://www.veeam.com/products/veeam-data-platform/backup-recovery.html)
+- [Veeam Help Center - SAML Authentication](https://helpcenter.veeam.com/docs/vbr/userguide/identity_provider.html?ver=13)
+- [Veeam Help Center - Logging in to Veeam Backup & Replication](https://helpcenter.veeam.com/docs/vbr/userguide/logon_to_console.html)

--- a/website/integrations/infrastructure/veeam-backup-replication/index.md
+++ b/website/integrations/infrastructure/veeam-backup-replication/index.md
@@ -10,8 +10,6 @@ support_level: community
 >
 > -- https://www.veeam.com/products/veeam-data-platform/backup-recovery.html
 
-This guide was tested with Veeam Backup & Replication 13.0.1 and authentik 2026.5.0.
-
 ## Preparation
 
 The following placeholders are used in this guide:

--- a/website/integrations/infrastructure/veeam-backup-replication/index.md
+++ b/website/integrations/infrastructure/veeam-backup-replication/index.md
@@ -1,0 +1,74 @@
+---
+title: Integrate with Veeam Backup & Replication
+sidebar_label: Veeam Backup & Replication
+support_level: community
+---
+
+## What is Veeam Backup & Replication?
+
+> Veeam Backup & Replication is a comprehensive data protection and disaster recovery solution. It enables image-level backups of virtual, physical, and cloud workloads and supports flexible restore options across the entire environment.
+>
+> -- https://www.veeam.com/products/veeam-data-platform/backup-recovery.html
+
+This guide was tested with Veeam Backup & Replication 13.0.1 and authentik 2026.5.0.
+
+## Preparation
+
+The following placeholders are used in this guide:
+
+- `vbr.company` is the FQDN of the Veeam Backup & Replication server.
+- `authentik.company` is the FQDN of the authentik installation.
+
+:::info
+This documentation lists only the settings that you need to change from their default values. Be aware that any changes other than those explicitly mentioned in this guide could cause issues accessing your application.
+:::
+
+You will need one or more existing groups in authentik to assign roles in Veeam Backup & Replication.
+
+## Veeam Backup & Replication pre-configuration
+
+1. Log in to the Veeam Backup & Replication console as an administrator.
+2. From the main menu, click **Users and Roles**.
+3. Open the **Identity Provider** tab.
+4. Check **Enable SAML authentication**.
+5. Under **Backup server configuration**, click **Download** to save the service provider metadata XML file. You will upload this file to authentik in the next section.
+
+## authentik configuration
+
+To support the integration of Veeam Backup & Replication with authentik, you need to create an application/provider pair in authentik.
+
+### Create an application and provider in authentik
+
+1. Log in to authentik as an administrator and open the authentik Admin interface.
+2. Navigate to **Applications** > **Applications** and click **New Application** to open the application wizard.
+    - **Application Name**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
+    - **Choose a Provider type**: select **SAML Provider from Metadata** as the provider type.
+    - **Configure the Provider**: provide the following required configurations.
+        - **Provider Name**: a descriptive name (or accept the auto-provided name).
+        - **Authorization Flow**: the authorization flow to use for this provider.
+        - **Invalidation Flow**: the flow to use when logging out of this provider.
+        - **Metadata**: click **Choose File** and select the SP metadata XML you downloaded from Veeam Backup & Replication during the pre-configuration step. The ACS URL and SP Entity ID are imported from this file.
+    - **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/bindings-overview/) (policy, group, or user) to manage the listing and access to applications on a user's **Application Dashboard** page.
+
+3. Click **Submit** to save the new application and provider.
+
+4. Locate the new SAML provider in the provider list and click **Download Metadata** to save the identity provider metadata XML file.
+
+## Veeam Backup & Replication configuration
+
+1. Switch back to the Veeam Backup & Replication console and reopen **Users and Roles** > **Identity Provider**.
+2. Under **Identity provider configuration**, click **Browse...** next to **IdP metadata file** and select the metadata XML you downloaded from authentik in the previous step.
+3. Click **OK** to save the SAML configuration.
+
+### Map authentik groups to Veeam roles
+
+To grant access to a user, the authentik group the user belongs to must be mapped to a Veeam role.
+
+1. In the Veeam Backup & Replication console, open **Users and Roles** and switch to the **Roles** tab.
+2. Click **Add...** and select **External Group**.
+3. Enter the name of the authentik group whose members should be granted the role, and select the desired Veeam role.
+4. Click **OK** to save the role mapping.
+
+## Configuration verification
+
+To confirm that authentik is properly configured with Veeam Backup & Replication, log out of the Veeam Backup & Replication console and click **Single sign-on** on the sign-in screen. You should be redirected to authentik to log in, then redirected back to the Veeam Backup & Replication console.


### PR DESCRIPTION
## Details

Adds a new integration guide for **Veeam Backup & Replication** (VBR) with SAML 2.0 SSO against authentik, covering the SAML support that ships in the VBR console under **Users and Roles** > **Identity Provider**.

The guide walks through:

- Enabling SAML authentication in the VBR console and downloading the service provider metadata XML
- Creating an application/provider pair in authentik using the new **SAML Provider from Metadata** wizard, which imports the ACS URL and SP Entity ID directly from the Veeam metadata file
- Importing the resulting authentik identity provider metadata back into VBR
- Mapping authentik groups to Veeam roles via **External Group** entries in the VBR **Roles** tab

Tested with **Veeam Backup & Replication 13.0.1** and **authentik 2026.5.0**.

The guide is placed under the existing `infrastructure` category, next to the existing **Veeam Enterprise Manager** guide, since both products are part of the Veeam Backup suite but are configured through separate consoles.

## Checklist

- [ ] Local tests pass (`ak test authentik/`)
- [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

- [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

- [ ] The code has been formatted (`make web`)

If applicable

- [x] The documentation has been updated
- [x] The documentation has been formatted (`make docs`)