### PR TITLE
website/integrations: Omnissa Workspace ONE Access

### DIFF
--- a/locale/en/dictionaries/integrations.txt
+++ b/locale/en/dictionaries/integrations.txt
@@ -40,6 +40,7 @@ Observium
 Ofair
 Ollama
 Omada
+Omnissa
 omniauth
 openwebui
 OPNsense

--- a/website/integrations/device-management/omnissa-workspace-one-access/index.md
+++ b/website/integrations/device-management/omnissa-workspace-one-access/index.md
@@ -1,0 +1,94 @@
+---
+title: Integrate with Omnissa Workspace ONE Access
+sidebar_label: Omnissa Workspace ONE Access
+support_level: community
+---
+
+## What is Omnissa Workspace ONE Access?
+
+> Omnissa Workspace ONE Access (formerly VMware Workspace ONE Access) is the identity service for the Omnissa Workspace ONE platform. It enables single sign-on into web, virtual, and Workspace ONE UEM-managed mobile applications, and can delegate authentication to external identity providers such as authentik.
+>
+> -- https://www.omnissa.com/products/omnissa-access/
+
+This guide was tested with Omnissa Workspace ONE Access (SaaS) and authentik 2026.5.0.
+
+## Preparation
+
+The following placeholders are used in this guide:
+
+- `authentik.company` is the FQDN of the authentik installation.
+
+The redirect URI that you need to register in authentik is provided by Omnissa Workspace ONE Access itself and follows the form `https://<tenant>.wss.workspaceone.com/federation/auth/response/oauth2`. You can read it from the **Redirect URI** section of the OpenID Connect IDP form (see the Omnissa Workspace ONE Access pre-configuration step below).
+
+:::info
+This documentation lists only the settings that you need to change from their default values. Be aware that any changes other than those explicitly mentioned in this guide could cause issues accessing your application.
+:::
+
+## Omnissa Workspace ONE Access pre-configuration
+
+1. Log in to your Omnissa Workspace ONE Access tenant as an administrator.
+2. Navigate to **Integrations** > **Identity Providers**.
+3. Click **Add** and select **Create OpenID Connect IDP**.
+4. Scroll down to the **Redirect URI** section and note the URL shown under **Integrate with Open ID Connect Provider using Redirect URI below**. This URL must be registered as the redirect URI in authentik.
+
+You can leave the form open in another browser tab while configuring authentik.
+
+## authentik configuration
+
+To support the integration of Omnissa Workspace ONE Access with authentik, you need to create an application/provider pair in authentik.
+
+### Create an application and provider in authentik
+
+1. Log in to authentik as an administrator and open the authentik Admin interface.
+2. Navigate to **Applications** > **Applications** and click **New Application** to open the application wizard.
+    - **Application Name**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
+    - **Choose a Provider type**: select **OAuth2/OpenID Connect** as the provider type.
+    - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
+        - Note the **Client ID**, **Client Secret**, and **slug** values because they will be required later.
+        - Add the following `Strict` redirect URIs:
+            - The URL you noted in the Omnissa Workspace ONE Access pre-configuration step (for example, `https://<tenant>.wss.workspaceone.com/federation/auth/response/oauth2`). This URI is used for web-based logins.
+            - `awgb://oauth2`. This URI is used by the Workspace ONE mobile applications.
+        - Select any available signing key.
+    - **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/bindings-overview/) (policy, group, or user) to manage the listing and access to applications on a user's **Application Dashboard** page.
+
+3. Click **Submit** to save the new application and provider.
+
+## Omnissa Workspace ONE Access configuration
+
+1. Return to the OpenID Connect IDP form you opened during the pre-configuration step (or, if you closed it, navigate again to **Integrations** > **Identity Providers** and click **Add** > **Create OpenID Connect IDP**).
+2. Configure the form as follows:
+    - Under **General Information**:
+        - **Identity Provider Name**: a descriptive name, for example `authentik`.
+    - Under **Authentication Configuration**:
+        - **Configuration Type**: select **Manual Configuration**.
+        - **Authorization Endpoint**: `https://authentik.company/application/o/authorize/`
+        - **Token URL**: `https://authentik.company/application/o/token/`
+        - **Issuer Identifier URL**: `https://authentik.company/application/o/<application_slug>/`
+        - **JWKS URL**: `https://authentik.company/application/o/<application_slug>/jwks/`
+    - Under **Client Details**:
+        - **Client ID**: the Client ID from the authentik provider.
+        - **Client Secret**: the Client Secret from the authentik provider.
+    - Under **User Lookup Attribute**:
+        - **Open ID User Identifier Attribute**: `preferred_username`
+        - **Omnissa Access User Identifier Attribute**: `userName`
+    - Under **Users**: select the directory or directories whose users are allowed to authenticate using authentik.
+    - Under **Network**: select the network ranges from which this identity provider can be used (for example, `ALL RANGES`).
+    - Under **Authentication Method**:
+        - **Authentication Method Name**: a name that you can later select in your access policies, for example `authentik`.
+3. Click **Add** to create the identity provider.
+
+### Add the new authentication method to an access policy
+
+Creating the identity provider alone does not make it usable; you also need to add the new authentication method to one or more **Access Policies** so Omnissa Workspace ONE Access knows when to apply it.
+
+1. Navigate to **Resources** > **Policies**.
+2. Open the access policy that targets the applications you want to use authentik for (typically the **default_access_policy_set**, or an application-specific policy).
+3. Edit the relevant policy rules and add the **Authentication Method Name** you configured above (for example, `authentik`) to the ordered list of authentication methods.
+
+:::info
+The exact policy structure depends on your Omnissa Workspace ONE Access deployment, the network ranges, device types, and user groups you want to target, and is out of scope for this guide. Refer to the Omnissa Workspace ONE Access documentation for details on access policies.
+:::
+
+## Configuration verification
+
+To confirm that authentik is properly configured with Omnissa Workspace ONE Access, log out of Workspace ONE Access (or open the Workspace ONE Intelligent Hub app on a mobile device) and start the login flow. Select the new authentik authentication method when prompted. You should be redirected to authentik to log in, then redirected back to Workspace ONE.

--- a/website/integrations/device-management/omnissa-workspace-one-access/index.md
+++ b/website/integrations/device-management/omnissa-workspace-one-access/index.md
@@ -6,19 +6,15 @@ support_level: community
 
 ## What is Omnissa Workspace ONE Access?
 
-> Omnissa Workspace ONE Access (formerly VMware Workspace ONE Access) is the identity service for the Omnissa Workspace ONE platform. It enables single sign-on into web, virtual, and Workspace ONE UEM-managed mobile applications, and can delegate authentication to external identity providers such as authentik.
+> Omnissa Workspace ONE Access, now Omnissa Access, is the identity and access service for the Omnissa Workspace ONE platform. It provides single sign-on, access policies, and identity federation for applications and devices, and can delegate authentication to external identity providers such as authentik.
 >
 > -- https://www.omnissa.com/products/omnissa-access/
-
-This guide was tested with Omnissa Workspace ONE Access (SaaS) and authentik 2026.5.0.
 
 ## Preparation
 
 The following placeholders are used in this guide:
 
 - `authentik.company` is the FQDN of the authentik installation.
-
-The redirect URI that you need to register in authentik is provided by Omnissa Workspace ONE Access itself and follows the form `https://<tenant>.wss.workspaceone.com/federation/auth/response/oauth2`. You can read it from the **Redirect URI** section of the OpenID Connect IDP form (see the Omnissa Workspace ONE Access pre-configuration step below).
 
 :::info
 This documentation lists only the settings that you need to change from their default values. Be aware that any changes other than those explicitly mentioned in this guide could cause issues accessing your application.
@@ -28,7 +24,7 @@ This documentation lists only the settings that you need to change from their de
 
 1. Log in to your Omnissa Workspace ONE Access tenant as an administrator.
 2. Navigate to **Integrations** > **Identity Providers**.
-3. Click **Add** and select **Create OpenID Connect IDP**.
+3. Click **Add** and select **OpenID Connect IDP**.
 4. Scroll down to the **Redirect URI** section and note the URL shown under **Integrate with Open ID Connect Provider using Redirect URI below**. This URL must be registered as the redirect URI in authentik.
 
 You can leave the form open in another browser tab while configuring authentik.
@@ -41,36 +37,34 @@ To support the integration of Omnissa Workspace ONE Access with authentik, you n
 
 1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **New Application** to open the application wizard.
-    - **Application Name**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
+    - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings. Note the **slug** value because you will use it when configuring Omnissa Workspace ONE Access.
     - **Choose a Provider type**: select **OAuth2/OpenID Connect** as the provider type.
     - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
-        - Note the **Client ID**, **Client Secret**, and **slug** values because they will be required later.
-        - Add the following `Strict` redirect URIs:
-            - The URL you noted in the Omnissa Workspace ONE Access pre-configuration step (for example, `https://<tenant>.wss.workspaceone.com/federation/auth/response/oauth2`). This URI is used for web-based logins.
-            - `awgb://oauth2`. This URI is used by the Workspace ONE mobile applications.
-        - Select any available signing key.
+        - Note the **Client ID** and **Client Secret** values because they will be required later.
+        - **Protocol Settings**:
+            - **Redirect URI**:
+                - Strict: the redirect URI you noted in the Omnissa Workspace ONE Access pre-configuration step.
+                - Strict: `awgb://oauth2`. This URI is used by the Workspace ONE mobile applications.
+            - **Signing Key**: select any available signing key.
     - **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/bindings-overview/) (policy, group, or user) to manage the listing and access to applications on a user's **Application Dashboard** page.
 
 3. Click **Submit** to save the new application and provider.
 
 ## Omnissa Workspace ONE Access configuration
 
-1. Return to the OpenID Connect IDP form you opened during the pre-configuration step (or, if you closed it, navigate again to **Integrations** > **Identity Providers** and click **Add** > **Create OpenID Connect IDP**).
+1. Return to the OpenID Connect IDP form you opened during the pre-configuration step. If you closed it, navigate again to **Integrations** > **Identity Providers**, click **Add**, and select **OpenID Connect IDP**.
 2. Configure the form as follows:
     - Under **General Information**:
         - **Identity Provider Name**: a descriptive name, for example `authentik`.
     - Under **Authentication Configuration**:
-        - **Configuration Type**: select **Manual Configuration**.
-        - **Authorization Endpoint**: `https://authentik.company/application/o/authorize/`
-        - **Token URL**: `https://authentik.company/application/o/token/`
-        - **Issuer Identifier URL**: `https://authentik.company/application/o/<application_slug>/`
-        - **JWKS URL**: `https://authentik.company/application/o/<application_slug>/jwks/`
+        - **Configuration Type**: select **Automatic Discovery**.
+        - **Configuration URL**: `https://authentik.company/application/o/<application_slug>/.well-known/openid-configuration`
     - Under **Client Details**:
         - **Client ID**: the Client ID from the authentik provider.
         - **Client Secret**: the Client Secret from the authentik provider.
     - Under **User Lookup Attribute**:
-        - **Open ID User Identifier Attribute**: `preferred_username`
-        - **Omnissa Access User Identifier Attribute**: `userName`
+        - **Open ID User Identifier Attribute**: the authentik claim that matches the users in Omnissa Workspace ONE Access, for example `preferred_username`.
+        - **Omnissa Access User Identifier Attribute**: the matching Omnissa Access user attribute, for example `userName`.
     - Under **Users**: select the directory or directories whose users are allowed to authenticate using authentik.
     - Under **Network**: select the network ranges from which this identity provider can be used (for example, `ALL RANGES`).
     - Under **Authentication Method**:
@@ -92,3 +86,9 @@ The exact policy structure depends on your Omnissa Workspace ONE Access deployme
 ## Configuration verification
 
 To confirm that authentik is properly configured with Omnissa Workspace ONE Access, log out of Workspace ONE Access (or open the Workspace ONE Intelligent Hub app on a mobile device) and start the login flow. Select the new authentik authentication method when prompted. You should be redirected to authentik to log in, then redirected back to Workspace ONE.
+
+## Resources
+
+- [Omnissa Access](https://www.omnissa.com/products/omnissa-access/)
+- [Omnissa Product Documentation - Add and Configure an OpenID Connect Third-Party Identity Provider in Omnissa Access](https://docs.omnissa.com/bundle/workspace-one-access-managing-authentication-guideVSaaS/page/AddandConfigureanOpenIDConnectThird-PartyIdentityProviderinWorkspaceONEAccessCloudOnly.html)
+- [Omnissa Product Documentation - Managing Access Policies in the Omnissa Access Service](https://docs.omnissa.com/bundle/workspace-one-access-managing-authentication-guideVSaaS/page/ManagingAccessPoliciesintheWorkspaceONEAccessService.html)


### PR DESCRIPTION
## Details

Adds a new integration guide for **Omnissa Workspace ONE Access** (formerly VMware Workspace ONE Access, https://www.omnissa.com/products/omnissa-access/) with OIDC SSO against authentik. With this integration, end users can sign in to the Workspace ONE portal and the Workspace ONE mobile applications (Intelligent Hub, Boxer, Web, etc.) using their authentik credentials.

The guide covers:

- Creating an OAuth2/OpenID Connect application and provider in authentik with two redirect URIs:
    - The tenant-specific web redirect URI (`https://<tenant>.wss.workspaceone.com/federation/auth/response/oauth2`)
    - The mobile deep-link redirect URI `awgb://oauth2` used by the Workspace ONE mobile applications
- Adding authentik as an OpenID Connect identity provider in Omnissa Workspace ONE Access under **Integrations** > **Identity Providers**, including the manual endpoint configuration (Authorization, Token, Issuer, JWKS), client credentials, and the `preferred_username` to `userName` user lookup attribute mapping
- A short pointer to wiring the new authentication method into the relevant **Access Policies** under **Resources** > **Policies** (the policy specifics themselves are intentionally out of scope, since they depend heavily on the customer deployment)

Tested with **Omnissa Workspace ONE Access (SaaS)** and **authentik 2026.5.0**.

The guide is placed under the existing `device-management` category, since the primary use case is end-user authentication into Workspace ONE UEM-managed mobile applications.

In addition, `Omnissa` is added to `locale/en/dictionaries/integrations.txt` so the spell-checker recognizes the vendor name.

## Checklist

- [ ] Local tests pass (`ak test authentik/`)
- [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

- [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

- [ ] The code has been formatted (`make web`)

If applicable

- [x] The documentation has been updated
- [x] The documentation has been formatted (`make docs`)