### PR TITLE
website: sync docusaurus theme lockfile

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -322,7 +322,7 @@
                 "fast-glob": "^3.3.3",
                 "remark-directive": "^4.0.0",
                 "remark-github": "^12.0.0",
-                "semver": "7.8.1",
+                "semver": "^7.8.1",
                 "typescript": "^6.0.3",
                 "unist-util-visit": "^5.0.0"
             }


### PR DESCRIPTION
## Summary

Regenerates the website lockfile so the docusaurus theme workspace entry matches its package metadata for the `semver` dependency.

## Validation

- `corepack npm ci --prefix website`
- `corepack npm run prettier-check --prefix website`
