### PR TITLE
providers/oauth: skip post logout redirect matching if none are saved on the provider

### DIFF
--- a/authentik/providers/oauth2/views/end_session.py
+++ b/authentik/providers/oauth2/views/end_session.py
@@ -84,8 +84,7 @@ class EndSessionView(PolicyAccessView):
                     "id_token_hint_decode_failed"
                 ) from None
 
-        # Validate post_logout_redirect_uri against registered URIs
-        if request_redirect_uri:
+        if request_redirect_uri and self.provider.post_logout_redirect_uris:
             # OIDC Certification: id_token_hint required with post_logout_redirect_uri
             if not id_token_hint:
                 raise TokenError("invalid_request").with_cause("id_token_hint_missing")


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
Currently, the validation check for post logout redirect uri's is too strict, and fails if none are present. It should be fully ignored if none are saved and logout should continue

Ref #22603
Ref #22572
Ref #22904

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
