### PR TITLE
tests: avoid fixed proxy e2e ports

### DIFF
--- a/blueprints/schema.json
+++ b/blueprints/schema.json
@@ -12110,11 +12110,6 @@
         "model_authentik_sources_kerberos.groupkerberossourceconnection": {
             "type": "object",
             "properties": {
-                "group": {
-                    "type": "string",
-                    "format": "uuid",
-                    "title": "Group"
-                },
                 "source": {
                     "type": "string",
                     "format": "uuid",
@@ -12408,10 +12403,6 @@
         "model_authentik_sources_kerberos.userkerberossourceconnection": {
             "type": "object",
             "properties": {
-                "user": {
-                    "type": "integer",
-                    "title": "User"
-                },
                 "source": {
                     "type": "string",
                     "format": "uuid",
@@ -12454,11 +12445,6 @@
         "model_authentik_sources_ldap.groupldapsourceconnection": {
             "type": "object",
             "properties": {
-                "group": {
-                    "type": "string",
-                    "format": "uuid",
-                    "title": "Group"
-                },
                 "source": {
                     "type": "string",
                     "format": "uuid",
@@ -12783,10 +12769,6 @@
         "model_authentik_sources_ldap.userldapsourceconnection": {
             "type": "object",
             "properties": {
-                "user": {
-                    "type": "integer",
-                    "title": "User"
-                },
                 "source": {
                     "type": "string",
                     "format": "uuid",
@@ -12829,11 +12811,6 @@
         "model_authentik_sources_oauth.groupoauthsourceconnection": {
             "type": "object",
             "properties": {
-                "group": {
-                    "type": "string",
-                    "format": "uuid",
-                    "title": "Group"
-                },
                 "source": {
                     "type": "string",
                     "format": "uuid",
@@ -13151,10 +13128,6 @@
         "model_authentik_sources_oauth.useroauthsourceconnection": {
             "type": "object",
             "properties": {
-                "user": {
-                    "type": "integer",
-                    "title": "User"
-                },
                 "source": {
                     "type": "string",
                     "format": "uuid",
@@ -13209,11 +13182,6 @@
         "model_authentik_sources_plex.groupplexsourceconnection": {
             "type": "object",
             "properties": {
-                "group": {
-                    "type": "string",
-                    "format": "uuid",
-                    "title": "Group"
-                },
                 "source": {
                     "type": "string",
                     "format": "uuid",
@@ -13454,10 +13422,6 @@
         "model_authentik_sources_plex.userplexsourceconnection": {
             "type": "object",
             "properties": {
-                "user": {
-                    "type": "integer",
-                    "title": "User"
-                },
                 "source": {
                     "type": "string",
                     "format": "uuid",
@@ -13505,11 +13469,6 @@
         "model_authentik_sources_saml.groupsamlsourceconnection": {
             "type": "object",
             "properties": {
-                "group": {
-                    "type": "string",
-                    "format": "uuid",
-                    "title": "Group"
-                },
                 "source": {
                     "type": "string",
                     "format": "uuid",
@@ -13837,10 +13796,6 @@
         "model_authentik_sources_saml.usersamlsourceconnection": {
             "type": "object",
             "properties": {
-                "user": {
-                    "type": "integer",
-                    "title": "User"
-                },
                 "source": {
                     "type": "string",
                     "format": "uuid",
@@ -14003,11 +13958,6 @@
         "model_authentik_sources_telegram.grouptelegramsourceconnection": {
             "type": "object",
             "properties": {
-                "group": {
-                    "type": "string",
-                    "format": "uuid",
-                    "title": "Group"
-                },
                 "source": {
                     "type": "string",
                     "format": "uuid",
@@ -14234,10 +14184,6 @@
         "model_authentik_sources_telegram.usertelegramsourceconnection": {
             "type": "object",
             "properties": {
-                "user": {
-                    "type": "integer",
-                    "title": "User"
-                },
                 "source": {
                     "type": "string",
                     "format": "uuid",

--- a/packages/client-ts/src/models/GroupKerberosSourceConnection.ts
+++ b/packages/client-ts/src/models/GroupKerberosSourceConnection.ts
@@ -32,7 +32,7 @@ export interface GroupKerberosSourceConnection {
      * @type {string}
      * @memberof GroupKerberosSourceConnection
      */
-    group: string;
+    readonly group: string;
     /**
      *
      * @type {string}
@@ -110,7 +110,7 @@ export function GroupKerberosSourceConnectionToJSON(json: any): GroupKerberosSou
 export function GroupKerberosSourceConnectionToJSONTyped(
     value?: Omit<
         GroupKerberosSourceConnection,
-        "pk" | "source_obj" | "created" | "last_updated"
+        "pk" | "group" | "source_obj" | "created" | "last_updated"
     > | null,
     ignoreDiscriminator: boolean = false,
 ): any {
@@ -119,7 +119,6 @@ export function GroupKerberosSourceConnectionToJSONTyped(
     }
 
     return {
-        group: value["group"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/GroupKerberosSourceConnectionRequest.ts
+++ b/packages/client-ts/src/models/GroupKerberosSourceConnectionRequest.ts
@@ -23,12 +23,6 @@ export interface GroupKerberosSourceConnectionRequest {
      * @type {string}
      * @memberof GroupKerberosSourceConnectionRequest
      */
-    group: string;
-    /**
-     *
-     * @type {string}
-     * @memberof GroupKerberosSourceConnectionRequest
-     */
     source: string;
     /**
      *
@@ -44,7 +38,6 @@ export interface GroupKerberosSourceConnectionRequest {
 export function instanceOfGroupKerberosSourceConnectionRequest(
     value: object,
 ): value is GroupKerberosSourceConnectionRequest {
-    if (!("group" in value) || value["group"] === undefined) return false;
     if (!("source" in value) || value["source"] === undefined) return false;
     if (!("identifier" in value) || value["identifier"] === undefined) return false;
     return true;
@@ -64,7 +57,6 @@ export function GroupKerberosSourceConnectionRequestFromJSONTyped(
         return json;
     }
     return {
-        group: json["group"],
         source: json["source"],
         identifier: json["identifier"],
     };
@@ -85,7 +77,6 @@ export function GroupKerberosSourceConnectionRequestToJSONTyped(
     }
 
     return {
-        group: value["group"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/GroupLDAPSourceConnection.ts
+++ b/packages/client-ts/src/models/GroupLDAPSourceConnection.ts
@@ -34,7 +34,7 @@ export interface GroupLDAPSourceConnection {
      * @type {string}
      * @memberof GroupLDAPSourceConnection
      */
-    group: string;
+    readonly group: string;
     /**
      *
      * @type {string}
@@ -120,7 +120,7 @@ export function GroupLDAPSourceConnectionToJSON(json: any): GroupLDAPSourceConne
 export function GroupLDAPSourceConnectionToJSONTyped(
     value?: Omit<
         GroupLDAPSourceConnection,
-        "pk" | "source_obj" | "created" | "last_updated" | "group_obj"
+        "pk" | "group" | "source_obj" | "created" | "last_updated" | "group_obj"
     > | null,
     ignoreDiscriminator: boolean = false,
 ): any {
@@ -129,7 +129,6 @@ export function GroupLDAPSourceConnectionToJSONTyped(
     }
 
     return {
-        group: value["group"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/GroupLDAPSourceConnectionRequest.ts
+++ b/packages/client-ts/src/models/GroupLDAPSourceConnectionRequest.ts
@@ -23,12 +23,6 @@ export interface GroupLDAPSourceConnectionRequest {
      * @type {string}
      * @memberof GroupLDAPSourceConnectionRequest
      */
-    group: string;
-    /**
-     *
-     * @type {string}
-     * @memberof GroupLDAPSourceConnectionRequest
-     */
     source: string;
     /**
      *
@@ -44,7 +38,6 @@ export interface GroupLDAPSourceConnectionRequest {
 export function instanceOfGroupLDAPSourceConnectionRequest(
     value: object,
 ): value is GroupLDAPSourceConnectionRequest {
-    if (!("group" in value) || value["group"] === undefined) return false;
     if (!("source" in value) || value["source"] === undefined) return false;
     if (!("identifier" in value) || value["identifier"] === undefined) return false;
     return true;
@@ -64,7 +57,6 @@ export function GroupLDAPSourceConnectionRequestFromJSONTyped(
         return json;
     }
     return {
-        group: json["group"],
         source: json["source"],
         identifier: json["identifier"],
     };
@@ -85,7 +77,6 @@ export function GroupLDAPSourceConnectionRequestToJSONTyped(
     }
 
     return {
-        group: value["group"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/GroupOAuthSourceConnection.ts
+++ b/packages/client-ts/src/models/GroupOAuthSourceConnection.ts
@@ -32,7 +32,7 @@ export interface GroupOAuthSourceConnection {
      * @type {string}
      * @memberof GroupOAuthSourceConnection
      */
-    group: string;
+    readonly group: string;
     /**
      *
      * @type {string}
@@ -110,7 +110,7 @@ export function GroupOAuthSourceConnectionToJSON(json: any): GroupOAuthSourceCon
 export function GroupOAuthSourceConnectionToJSONTyped(
     value?: Omit<
         GroupOAuthSourceConnection,
-        "pk" | "source_obj" | "created" | "last_updated"
+        "pk" | "group" | "source_obj" | "created" | "last_updated"
     > | null,
     ignoreDiscriminator: boolean = false,
 ): any {
@@ -119,7 +119,6 @@ export function GroupOAuthSourceConnectionToJSONTyped(
     }
 
     return {
-        group: value["group"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/GroupOAuthSourceConnectionRequest.ts
+++ b/packages/client-ts/src/models/GroupOAuthSourceConnectionRequest.ts
@@ -23,12 +23,6 @@ export interface GroupOAuthSourceConnectionRequest {
      * @type {string}
      * @memberof GroupOAuthSourceConnectionRequest
      */
-    group: string;
-    /**
-     *
-     * @type {string}
-     * @memberof GroupOAuthSourceConnectionRequest
-     */
     source: string;
     /**
      *
@@ -44,7 +38,6 @@ export interface GroupOAuthSourceConnectionRequest {
 export function instanceOfGroupOAuthSourceConnectionRequest(
     value: object,
 ): value is GroupOAuthSourceConnectionRequest {
-    if (!("group" in value) || value["group"] === undefined) return false;
     if (!("source" in value) || value["source"] === undefined) return false;
     if (!("identifier" in value) || value["identifier"] === undefined) return false;
     return true;
@@ -64,7 +57,6 @@ export function GroupOAuthSourceConnectionRequestFromJSONTyped(
         return json;
     }
     return {
-        group: json["group"],
         source: json["source"],
         identifier: json["identifier"],
     };
@@ -85,7 +77,6 @@ export function GroupOAuthSourceConnectionRequestToJSONTyped(
     }
 
     return {
-        group: value["group"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/GroupPlexSourceConnection.ts
+++ b/packages/client-ts/src/models/GroupPlexSourceConnection.ts
@@ -32,7 +32,7 @@ export interface GroupPlexSourceConnection {
      * @type {string}
      * @memberof GroupPlexSourceConnection
      */
-    group: string;
+    readonly group: string;
     /**
      *
      * @type {string}
@@ -110,7 +110,7 @@ export function GroupPlexSourceConnectionToJSON(json: any): GroupPlexSourceConne
 export function GroupPlexSourceConnectionToJSONTyped(
     value?: Omit<
         GroupPlexSourceConnection,
-        "pk" | "source_obj" | "created" | "last_updated"
+        "pk" | "group" | "source_obj" | "created" | "last_updated"
     > | null,
     ignoreDiscriminator: boolean = false,
 ): any {
@@ -119,7 +119,6 @@ export function GroupPlexSourceConnectionToJSONTyped(
     }
 
     return {
-        group: value["group"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/GroupPlexSourceConnectionRequest.ts
+++ b/packages/client-ts/src/models/GroupPlexSourceConnectionRequest.ts
@@ -23,12 +23,6 @@ export interface GroupPlexSourceConnectionRequest {
      * @type {string}
      * @memberof GroupPlexSourceConnectionRequest
      */
-    group: string;
-    /**
-     *
-     * @type {string}
-     * @memberof GroupPlexSourceConnectionRequest
-     */
     source: string;
     /**
      *
@@ -44,7 +38,6 @@ export interface GroupPlexSourceConnectionRequest {
 export function instanceOfGroupPlexSourceConnectionRequest(
     value: object,
 ): value is GroupPlexSourceConnectionRequest {
-    if (!("group" in value) || value["group"] === undefined) return false;
     if (!("source" in value) || value["source"] === undefined) return false;
     if (!("identifier" in value) || value["identifier"] === undefined) return false;
     return true;
@@ -64,7 +57,6 @@ export function GroupPlexSourceConnectionRequestFromJSONTyped(
         return json;
     }
     return {
-        group: json["group"],
         source: json["source"],
         identifier: json["identifier"],
     };
@@ -85,7 +77,6 @@ export function GroupPlexSourceConnectionRequestToJSONTyped(
     }
 
     return {
-        group: value["group"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/GroupSAMLSourceConnection.ts
+++ b/packages/client-ts/src/models/GroupSAMLSourceConnection.ts
@@ -32,7 +32,7 @@ export interface GroupSAMLSourceConnection {
      * @type {string}
      * @memberof GroupSAMLSourceConnection
      */
-    group: string;
+    readonly group: string;
     /**
      *
      * @type {string}
@@ -110,7 +110,7 @@ export function GroupSAMLSourceConnectionToJSON(json: any): GroupSAMLSourceConne
 export function GroupSAMLSourceConnectionToJSONTyped(
     value?: Omit<
         GroupSAMLSourceConnection,
-        "pk" | "source_obj" | "created" | "last_updated"
+        "pk" | "group" | "source_obj" | "created" | "last_updated"
     > | null,
     ignoreDiscriminator: boolean = false,
 ): any {
@@ -119,7 +119,6 @@ export function GroupSAMLSourceConnectionToJSONTyped(
     }
 
     return {
-        group: value["group"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/GroupSAMLSourceConnectionRequest.ts
+++ b/packages/client-ts/src/models/GroupSAMLSourceConnectionRequest.ts
@@ -23,12 +23,6 @@ export interface GroupSAMLSourceConnectionRequest {
      * @type {string}
      * @memberof GroupSAMLSourceConnectionRequest
      */
-    group: string;
-    /**
-     *
-     * @type {string}
-     * @memberof GroupSAMLSourceConnectionRequest
-     */
     source: string;
     /**
      *
@@ -44,7 +38,6 @@ export interface GroupSAMLSourceConnectionRequest {
 export function instanceOfGroupSAMLSourceConnectionRequest(
     value: object,
 ): value is GroupSAMLSourceConnectionRequest {
-    if (!("group" in value) || value["group"] === undefined) return false;
     if (!("source" in value) || value["source"] === undefined) return false;
     if (!("identifier" in value) || value["identifier"] === undefined) return false;
     return true;
@@ -64,7 +57,6 @@ export function GroupSAMLSourceConnectionRequestFromJSONTyped(
         return json;
     }
     return {
-        group: json["group"],
         source: json["source"],
         identifier: json["identifier"],
     };
@@ -85,7 +77,6 @@ export function GroupSAMLSourceConnectionRequestToJSONTyped(
     }
 
     return {
-        group: value["group"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/GroupSourceConnection.ts
+++ b/packages/client-ts/src/models/GroupSourceConnection.ts
@@ -32,7 +32,7 @@ export interface GroupSourceConnection {
      * @type {string}
      * @memberof GroupSourceConnection
      */
-    group: string;
+    readonly group: string;
     /**
      *
      * @type {string}
@@ -106,7 +106,10 @@ export function GroupSourceConnectionToJSON(json: any): GroupSourceConnection {
 }
 
 export function GroupSourceConnectionToJSONTyped(
-    value?: Omit<GroupSourceConnection, "pk" | "source_obj" | "created" | "last_updated"> | null,
+    value?: Omit<
+        GroupSourceConnection,
+        "pk" | "group" | "source_obj" | "created" | "last_updated"
+    > | null,
     ignoreDiscriminator: boolean = false,
 ): any {
     if (value == null) {
@@ -114,7 +117,6 @@ export function GroupSourceConnectionToJSONTyped(
     }
 
     return {
-        group: value["group"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/GroupSourceConnectionRequest.ts
+++ b/packages/client-ts/src/models/GroupSourceConnectionRequest.ts
@@ -23,12 +23,6 @@ export interface GroupSourceConnectionRequest {
      * @type {string}
      * @memberof GroupSourceConnectionRequest
      */
-    group: string;
-    /**
-     *
-     * @type {string}
-     * @memberof GroupSourceConnectionRequest
-     */
     source: string;
     /**
      *
@@ -44,7 +38,6 @@ export interface GroupSourceConnectionRequest {
 export function instanceOfGroupSourceConnectionRequest(
     value: object,
 ): value is GroupSourceConnectionRequest {
-    if (!("group" in value) || value["group"] === undefined) return false;
     if (!("source" in value) || value["source"] === undefined) return false;
     if (!("identifier" in value) || value["identifier"] === undefined) return false;
     return true;
@@ -62,7 +55,6 @@ export function GroupSourceConnectionRequestFromJSONTyped(
         return json;
     }
     return {
-        group: json["group"],
         source: json["source"],
         identifier: json["identifier"],
     };
@@ -81,7 +73,6 @@ export function GroupSourceConnectionRequestToJSONTyped(
     }
 
     return {
-        group: value["group"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/GroupTelegramSourceConnection.ts
+++ b/packages/client-ts/src/models/GroupTelegramSourceConnection.ts
@@ -32,7 +32,7 @@ export interface GroupTelegramSourceConnection {
      * @type {string}
      * @memberof GroupTelegramSourceConnection
      */
-    group: string;
+    readonly group: string;
     /**
      *
      * @type {string}
@@ -110,7 +110,7 @@ export function GroupTelegramSourceConnectionToJSON(json: any): GroupTelegramSou
 export function GroupTelegramSourceConnectionToJSONTyped(
     value?: Omit<
         GroupTelegramSourceConnection,
-        "pk" | "source_obj" | "created" | "last_updated"
+        "pk" | "group" | "source_obj" | "created" | "last_updated"
     > | null,
     ignoreDiscriminator: boolean = false,
 ): any {
@@ -119,7 +119,6 @@ export function GroupTelegramSourceConnectionToJSONTyped(
     }
 
     return {
-        group: value["group"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/GroupTelegramSourceConnectionRequest.ts
+++ b/packages/client-ts/src/models/GroupTelegramSourceConnectionRequest.ts
@@ -23,12 +23,6 @@ export interface GroupTelegramSourceConnectionRequest {
      * @type {string}
      * @memberof GroupTelegramSourceConnectionRequest
      */
-    group: string;
-    /**
-     *
-     * @type {string}
-     * @memberof GroupTelegramSourceConnectionRequest
-     */
     source: string;
     /**
      *
@@ -44,7 +38,6 @@ export interface GroupTelegramSourceConnectionRequest {
 export function instanceOfGroupTelegramSourceConnectionRequest(
     value: object,
 ): value is GroupTelegramSourceConnectionRequest {
-    if (!("group" in value) || value["group"] === undefined) return false;
     if (!("source" in value) || value["source"] === undefined) return false;
     if (!("identifier" in value) || value["identifier"] === undefined) return false;
     return true;
@@ -64,7 +57,6 @@ export function GroupTelegramSourceConnectionRequestFromJSONTyped(
         return json;
     }
     return {
-        group: json["group"],
         source: json["source"],
         identifier: json["identifier"],
     };
@@ -85,7 +77,6 @@ export function GroupTelegramSourceConnectionRequestToJSONTyped(
     }
 
     return {
-        group: value["group"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/PatchedGroupKerberosSourceConnectionRequest.ts
+++ b/packages/client-ts/src/models/PatchedGroupKerberosSourceConnectionRequest.ts
@@ -23,12 +23,6 @@ export interface PatchedGroupKerberosSourceConnectionRequest {
      * @type {string}
      * @memberof PatchedGroupKerberosSourceConnectionRequest
      */
-    group?: string;
-    /**
-     *
-     * @type {string}
-     * @memberof PatchedGroupKerberosSourceConnectionRequest
-     */
     source?: string;
     /**
      *
@@ -61,7 +55,6 @@ export function PatchedGroupKerberosSourceConnectionRequestFromJSONTyped(
         return json;
     }
     return {
-        group: json["group"] == null ? undefined : json["group"],
         source: json["source"] == null ? undefined : json["source"],
         identifier: json["identifier"] == null ? undefined : json["identifier"],
     };
@@ -82,7 +75,6 @@ export function PatchedGroupKerberosSourceConnectionRequestToJSONTyped(
     }
 
     return {
-        group: value["group"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/PatchedGroupLDAPSourceConnectionRequest.ts
+++ b/packages/client-ts/src/models/PatchedGroupLDAPSourceConnectionRequest.ts
@@ -23,12 +23,6 @@ export interface PatchedGroupLDAPSourceConnectionRequest {
      * @type {string}
      * @memberof PatchedGroupLDAPSourceConnectionRequest
      */
-    group?: string;
-    /**
-     *
-     * @type {string}
-     * @memberof PatchedGroupLDAPSourceConnectionRequest
-     */
     source?: string;
     /**
      *
@@ -61,7 +55,6 @@ export function PatchedGroupLDAPSourceConnectionRequestFromJSONTyped(
         return json;
     }
     return {
-        group: json["group"] == null ? undefined : json["group"],
         source: json["source"] == null ? undefined : json["source"],
         identifier: json["identifier"] == null ? undefined : json["identifier"],
     };
@@ -82,7 +75,6 @@ export function PatchedGroupLDAPSourceConnectionRequestToJSONTyped(
     }
 
     return {
-        group: value["group"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/PatchedGroupOAuthSourceConnectionRequest.ts
+++ b/packages/client-ts/src/models/PatchedGroupOAuthSourceConnectionRequest.ts
@@ -23,12 +23,6 @@ export interface PatchedGroupOAuthSourceConnectionRequest {
      * @type {string}
      * @memberof PatchedGroupOAuthSourceConnectionRequest
      */
-    group?: string;
-    /**
-     *
-     * @type {string}
-     * @memberof PatchedGroupOAuthSourceConnectionRequest
-     */
     source?: string;
     /**
      *
@@ -61,7 +55,6 @@ export function PatchedGroupOAuthSourceConnectionRequestFromJSONTyped(
         return json;
     }
     return {
-        group: json["group"] == null ? undefined : json["group"],
         source: json["source"] == null ? undefined : json["source"],
         identifier: json["identifier"] == null ? undefined : json["identifier"],
     };
@@ -82,7 +75,6 @@ export function PatchedGroupOAuthSourceConnectionRequestToJSONTyped(
     }
 
     return {
-        group: value["group"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/PatchedGroupPlexSourceConnectionRequest.ts
+++ b/packages/client-ts/src/models/PatchedGroupPlexSourceConnectionRequest.ts
@@ -23,12 +23,6 @@ export interface PatchedGroupPlexSourceConnectionRequest {
      * @type {string}
      * @memberof PatchedGroupPlexSourceConnectionRequest
      */
-    group?: string;
-    /**
-     *
-     * @type {string}
-     * @memberof PatchedGroupPlexSourceConnectionRequest
-     */
     source?: string;
     /**
      *
@@ -61,7 +55,6 @@ export function PatchedGroupPlexSourceConnectionRequestFromJSONTyped(
         return json;
     }
     return {
-        group: json["group"] == null ? undefined : json["group"],
         source: json["source"] == null ? undefined : json["source"],
         identifier: json["identifier"] == null ? undefined : json["identifier"],
     };
@@ -82,7 +75,6 @@ export function PatchedGroupPlexSourceConnectionRequestToJSONTyped(
     }
 
     return {
-        group: value["group"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/PatchedGroupSAMLSourceConnectionRequest.ts
+++ b/packages/client-ts/src/models/PatchedGroupSAMLSourceConnectionRequest.ts
@@ -23,12 +23,6 @@ export interface PatchedGroupSAMLSourceConnectionRequest {
      * @type {string}
      * @memberof PatchedGroupSAMLSourceConnectionRequest
      */
-    group?: string;
-    /**
-     *
-     * @type {string}
-     * @memberof PatchedGroupSAMLSourceConnectionRequest
-     */
     source?: string;
     /**
      *
@@ -61,7 +55,6 @@ export function PatchedGroupSAMLSourceConnectionRequestFromJSONTyped(
         return json;
     }
     return {
-        group: json["group"] == null ? undefined : json["group"],
         source: json["source"] == null ? undefined : json["source"],
         identifier: json["identifier"] == null ? undefined : json["identifier"],
     };
@@ -82,7 +75,6 @@ export function PatchedGroupSAMLSourceConnectionRequestToJSONTyped(
     }
 
     return {
-        group: value["group"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/PatchedGroupSourceConnectionRequest.ts
+++ b/packages/client-ts/src/models/PatchedGroupSourceConnectionRequest.ts
@@ -23,12 +23,6 @@ export interface PatchedGroupSourceConnectionRequest {
      * @type {string}
      * @memberof PatchedGroupSourceConnectionRequest
      */
-    group?: string;
-    /**
-     *
-     * @type {string}
-     * @memberof PatchedGroupSourceConnectionRequest
-     */
     source?: string;
     /**
      *
@@ -61,7 +55,6 @@ export function PatchedGroupSourceConnectionRequestFromJSONTyped(
         return json;
     }
     return {
-        group: json["group"] == null ? undefined : json["group"],
         source: json["source"] == null ? undefined : json["source"],
         identifier: json["identifier"] == null ? undefined : json["identifier"],
     };
@@ -82,7 +75,6 @@ export function PatchedGroupSourceConnectionRequestToJSONTyped(
     }
 
     return {
-        group: value["group"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/PatchedGroupTelegramSourceConnectionRequest.ts
+++ b/packages/client-ts/src/models/PatchedGroupTelegramSourceConnectionRequest.ts
@@ -23,12 +23,6 @@ export interface PatchedGroupTelegramSourceConnectionRequest {
      * @type {string}
      * @memberof PatchedGroupTelegramSourceConnectionRequest
      */
-    group?: string;
-    /**
-     *
-     * @type {string}
-     * @memberof PatchedGroupTelegramSourceConnectionRequest
-     */
     source?: string;
     /**
      *
@@ -61,7 +55,6 @@ export function PatchedGroupTelegramSourceConnectionRequestFromJSONTyped(
         return json;
     }
     return {
-        group: json["group"] == null ? undefined : json["group"],
         source: json["source"] == null ? undefined : json["source"],
         identifier: json["identifier"] == null ? undefined : json["identifier"],
     };
@@ -82,7 +75,6 @@ export function PatchedGroupTelegramSourceConnectionRequestToJSONTyped(
     }
 
     return {
-        group: value["group"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/PatchedUserKerberosSourceConnectionRequest.ts
+++ b/packages/client-ts/src/models/PatchedUserKerberosSourceConnectionRequest.ts
@@ -20,12 +20,6 @@
 export interface PatchedUserKerberosSourceConnectionRequest {
     /**
      *
-     * @type {number}
-     * @memberof PatchedUserKerberosSourceConnectionRequest
-     */
-    user?: number;
-    /**
-     *
      * @type {string}
      * @memberof PatchedUserKerberosSourceConnectionRequest
      */
@@ -61,7 +55,6 @@ export function PatchedUserKerberosSourceConnectionRequestFromJSONTyped(
         return json;
     }
     return {
-        user: json["user"] == null ? undefined : json["user"],
         source: json["source"] == null ? undefined : json["source"],
         identifier: json["identifier"] == null ? undefined : json["identifier"],
     };
@@ -82,7 +75,6 @@ export function PatchedUserKerberosSourceConnectionRequestToJSONTyped(
     }
 
     return {
-        user: value["user"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/PatchedUserLDAPSourceConnectionRequest.ts
+++ b/packages/client-ts/src/models/PatchedUserLDAPSourceConnectionRequest.ts
@@ -20,12 +20,6 @@
 export interface PatchedUserLDAPSourceConnectionRequest {
     /**
      *
-     * @type {number}
-     * @memberof PatchedUserLDAPSourceConnectionRequest
-     */
-    user?: number;
-    /**
-     *
      * @type {string}
      * @memberof PatchedUserLDAPSourceConnectionRequest
      */
@@ -61,7 +55,6 @@ export function PatchedUserLDAPSourceConnectionRequestFromJSONTyped(
         return json;
     }
     return {
-        user: json["user"] == null ? undefined : json["user"],
         source: json["source"] == null ? undefined : json["source"],
         identifier: json["identifier"] == null ? undefined : json["identifier"],
     };
@@ -82,7 +75,6 @@ export function PatchedUserLDAPSourceConnectionRequestToJSONTyped(
     }
 
     return {
-        user: value["user"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/PatchedUserOAuthSourceConnectionRequest.ts
+++ b/packages/client-ts/src/models/PatchedUserOAuthSourceConnectionRequest.ts
@@ -20,12 +20,6 @@
 export interface PatchedUserOAuthSourceConnectionRequest {
     /**
      *
-     * @type {number}
-     * @memberof PatchedUserOAuthSourceConnectionRequest
-     */
-    user?: number;
-    /**
-     *
      * @type {string}
      * @memberof PatchedUserOAuthSourceConnectionRequest
      */
@@ -73,7 +67,6 @@ export function PatchedUserOAuthSourceConnectionRequestFromJSONTyped(
         return json;
     }
     return {
-        user: json["user"] == null ? undefined : json["user"],
         source: json["source"] == null ? undefined : json["source"],
         identifier: json["identifier"] == null ? undefined : json["identifier"],
         accessToken: json["access_token"] == null ? undefined : json["access_token"],
@@ -96,7 +89,6 @@ export function PatchedUserOAuthSourceConnectionRequestToJSONTyped(
     }
 
     return {
-        user: value["user"],
         source: value["source"],
         identifier: value["identifier"],
         access_token: value["accessToken"],

--- a/packages/client-ts/src/models/PatchedUserPlexSourceConnectionRequest.ts
+++ b/packages/client-ts/src/models/PatchedUserPlexSourceConnectionRequest.ts
@@ -20,12 +20,6 @@
 export interface PatchedUserPlexSourceConnectionRequest {
     /**
      *
-     * @type {number}
-     * @memberof PatchedUserPlexSourceConnectionRequest
-     */
-    user?: number;
-    /**
-     *
      * @type {string}
      * @memberof PatchedUserPlexSourceConnectionRequest
      */
@@ -67,7 +61,6 @@ export function PatchedUserPlexSourceConnectionRequestFromJSONTyped(
         return json;
     }
     return {
-        user: json["user"] == null ? undefined : json["user"],
         source: json["source"] == null ? undefined : json["source"],
         identifier: json["identifier"] == null ? undefined : json["identifier"],
         plexToken: json["plex_token"] == null ? undefined : json["plex_token"],
@@ -89,7 +82,6 @@ export function PatchedUserPlexSourceConnectionRequestToJSONTyped(
     }
 
     return {
-        user: value["user"],
         source: value["source"],
         identifier: value["identifier"],
         plex_token: value["plexToken"],

--- a/packages/client-ts/src/models/PatchedUserSAMLSourceConnectionRequest.ts
+++ b/packages/client-ts/src/models/PatchedUserSAMLSourceConnectionRequest.ts
@@ -20,12 +20,6 @@
 export interface PatchedUserSAMLSourceConnectionRequest {
     /**
      *
-     * @type {number}
-     * @memberof PatchedUserSAMLSourceConnectionRequest
-     */
-    user?: number;
-    /**
-     *
      * @type {string}
      * @memberof PatchedUserSAMLSourceConnectionRequest
      */
@@ -61,7 +55,6 @@ export function PatchedUserSAMLSourceConnectionRequestFromJSONTyped(
         return json;
     }
     return {
-        user: json["user"] == null ? undefined : json["user"],
         source: json["source"] == null ? undefined : json["source"],
         identifier: json["identifier"] == null ? undefined : json["identifier"],
     };
@@ -82,7 +75,6 @@ export function PatchedUserSAMLSourceConnectionRequestToJSONTyped(
     }
 
     return {
-        user: value["user"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/PatchedUserSourceConnectionRequest.ts
+++ b/packages/client-ts/src/models/PatchedUserSourceConnectionRequest.ts
@@ -20,12 +20,6 @@
 export interface PatchedUserSourceConnectionRequest {
     /**
      *
-     * @type {number}
-     * @memberof PatchedUserSourceConnectionRequest
-     */
-    user?: number;
-    /**
-     *
      * @type {string}
      * @memberof PatchedUserSourceConnectionRequest
      */
@@ -61,7 +55,6 @@ export function PatchedUserSourceConnectionRequestFromJSONTyped(
         return json;
     }
     return {
-        user: json["user"] == null ? undefined : json["user"],
         source: json["source"] == null ? undefined : json["source"],
         identifier: json["identifier"] == null ? undefined : json["identifier"],
     };
@@ -82,7 +75,6 @@ export function PatchedUserSourceConnectionRequestToJSONTyped(
     }
 
     return {
-        user: value["user"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/PatchedUserTelegramSourceConnectionRequest.ts
+++ b/packages/client-ts/src/models/PatchedUserTelegramSourceConnectionRequest.ts
@@ -20,12 +20,6 @@
 export interface PatchedUserTelegramSourceConnectionRequest {
     /**
      *
-     * @type {number}
-     * @memberof PatchedUserTelegramSourceConnectionRequest
-     */
-    user?: number;
-    /**
-     *
      * @type {string}
      * @memberof PatchedUserTelegramSourceConnectionRequest
      */
@@ -61,7 +55,6 @@ export function PatchedUserTelegramSourceConnectionRequestFromJSONTyped(
         return json;
     }
     return {
-        user: json["user"] == null ? undefined : json["user"],
         source: json["source"] == null ? undefined : json["source"],
         identifier: json["identifier"] == null ? undefined : json["identifier"],
     };
@@ -82,7 +75,6 @@ export function PatchedUserTelegramSourceConnectionRequestToJSONTyped(
     }
 
     return {
-        user: value["user"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/UserKerberosSourceConnection.ts
+++ b/packages/client-ts/src/models/UserKerberosSourceConnection.ts
@@ -32,7 +32,7 @@ export interface UserKerberosSourceConnection {
      * @type {number}
      * @memberof UserKerberosSourceConnection
      */
-    user: number;
+    readonly user: number;
     /**
      *
      * @type {string}
@@ -110,7 +110,7 @@ export function UserKerberosSourceConnectionToJSON(json: any): UserKerberosSourc
 export function UserKerberosSourceConnectionToJSONTyped(
     value?: Omit<
         UserKerberosSourceConnection,
-        "pk" | "source_obj" | "created" | "last_updated"
+        "pk" | "user" | "source_obj" | "created" | "last_updated"
     > | null,
     ignoreDiscriminator: boolean = false,
 ): any {
@@ -119,7 +119,6 @@ export function UserKerberosSourceConnectionToJSONTyped(
     }
 
     return {
-        user: value["user"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/UserKerberosSourceConnectionRequest.ts
+++ b/packages/client-ts/src/models/UserKerberosSourceConnectionRequest.ts
@@ -20,12 +20,6 @@
 export interface UserKerberosSourceConnectionRequest {
     /**
      *
-     * @type {number}
-     * @memberof UserKerberosSourceConnectionRequest
-     */
-    user: number;
-    /**
-     *
      * @type {string}
      * @memberof UserKerberosSourceConnectionRequest
      */
@@ -44,7 +38,6 @@ export interface UserKerberosSourceConnectionRequest {
 export function instanceOfUserKerberosSourceConnectionRequest(
     value: object,
 ): value is UserKerberosSourceConnectionRequest {
-    if (!("user" in value) || value["user"] === undefined) return false;
     if (!("source" in value) || value["source"] === undefined) return false;
     if (!("identifier" in value) || value["identifier"] === undefined) return false;
     return true;
@@ -64,7 +57,6 @@ export function UserKerberosSourceConnectionRequestFromJSONTyped(
         return json;
     }
     return {
-        user: json["user"],
         source: json["source"],
         identifier: json["identifier"],
     };
@@ -85,7 +77,6 @@ export function UserKerberosSourceConnectionRequestToJSONTyped(
     }
 
     return {
-        user: value["user"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/UserLDAPSourceConnection.ts
+++ b/packages/client-ts/src/models/UserLDAPSourceConnection.ts
@@ -34,7 +34,7 @@ export interface UserLDAPSourceConnection {
      * @type {number}
      * @memberof UserLDAPSourceConnection
      */
-    user: number;
+    readonly user: number;
     /**
      *
      * @type {string}
@@ -120,7 +120,7 @@ export function UserLDAPSourceConnectionToJSON(json: any): UserLDAPSourceConnect
 export function UserLDAPSourceConnectionToJSONTyped(
     value?: Omit<
         UserLDAPSourceConnection,
-        "pk" | "source_obj" | "created" | "last_updated" | "user_obj"
+        "pk" | "user" | "source_obj" | "created" | "last_updated" | "user_obj"
     > | null,
     ignoreDiscriminator: boolean = false,
 ): any {
@@ -129,7 +129,6 @@ export function UserLDAPSourceConnectionToJSONTyped(
     }
 
     return {
-        user: value["user"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/UserLDAPSourceConnectionRequest.ts
+++ b/packages/client-ts/src/models/UserLDAPSourceConnectionRequest.ts
@@ -20,12 +20,6 @@
 export interface UserLDAPSourceConnectionRequest {
     /**
      *
-     * @type {number}
-     * @memberof UserLDAPSourceConnectionRequest
-     */
-    user: number;
-    /**
-     *
      * @type {string}
      * @memberof UserLDAPSourceConnectionRequest
      */
@@ -44,7 +38,6 @@ export interface UserLDAPSourceConnectionRequest {
 export function instanceOfUserLDAPSourceConnectionRequest(
     value: object,
 ): value is UserLDAPSourceConnectionRequest {
-    if (!("user" in value) || value["user"] === undefined) return false;
     if (!("source" in value) || value["source"] === undefined) return false;
     if (!("identifier" in value) || value["identifier"] === undefined) return false;
     return true;
@@ -64,7 +57,6 @@ export function UserLDAPSourceConnectionRequestFromJSONTyped(
         return json;
     }
     return {
-        user: json["user"],
         source: json["source"],
         identifier: json["identifier"],
     };
@@ -83,7 +75,6 @@ export function UserLDAPSourceConnectionRequestToJSONTyped(
     }
 
     return {
-        user: value["user"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/UserOAuthSourceConnection.ts
+++ b/packages/client-ts/src/models/UserOAuthSourceConnection.ts
@@ -32,7 +32,7 @@ export interface UserOAuthSourceConnection {
      * @type {number}
      * @memberof UserOAuthSourceConnection
      */
-    user: number;
+    readonly user: number;
     /**
      *
      * @type {string}
@@ -117,7 +117,7 @@ export function UserOAuthSourceConnectionToJSON(json: any): UserOAuthSourceConne
 export function UserOAuthSourceConnectionToJSONTyped(
     value?: Omit<
         UserOAuthSourceConnection,
-        "pk" | "source_obj" | "created" | "last_updated"
+        "pk" | "user" | "source_obj" | "created" | "last_updated"
     > | null,
     ignoreDiscriminator: boolean = false,
 ): any {
@@ -126,7 +126,6 @@ export function UserOAuthSourceConnectionToJSONTyped(
     }
 
     return {
-        user: value["user"],
         source: value["source"],
         identifier: value["identifier"],
         expires: value["expires"] == null ? value["expires"] : value["expires"].toISOString(),

--- a/packages/client-ts/src/models/UserOAuthSourceConnectionRequest.ts
+++ b/packages/client-ts/src/models/UserOAuthSourceConnectionRequest.ts
@@ -20,12 +20,6 @@
 export interface UserOAuthSourceConnectionRequest {
     /**
      *
-     * @type {number}
-     * @memberof UserOAuthSourceConnectionRequest
-     */
-    user: number;
-    /**
-     *
      * @type {string}
      * @memberof UserOAuthSourceConnectionRequest
      */
@@ -56,7 +50,6 @@ export interface UserOAuthSourceConnectionRequest {
 export function instanceOfUserOAuthSourceConnectionRequest(
     value: object,
 ): value is UserOAuthSourceConnectionRequest {
-    if (!("user" in value) || value["user"] === undefined) return false;
     if (!("source" in value) || value["source"] === undefined) return false;
     if (!("identifier" in value) || value["identifier"] === undefined) return false;
     return true;
@@ -76,7 +69,6 @@ export function UserOAuthSourceConnectionRequestFromJSONTyped(
         return json;
     }
     return {
-        user: json["user"],
         source: json["source"],
         identifier: json["identifier"],
         accessToken: json["access_token"] == null ? undefined : json["access_token"],
@@ -99,7 +91,6 @@ export function UserOAuthSourceConnectionRequestToJSONTyped(
     }
 
     return {
-        user: value["user"],
         source: value["source"],
         identifier: value["identifier"],
         access_token: value["accessToken"],

--- a/packages/client-ts/src/models/UserPlexSourceConnection.ts
+++ b/packages/client-ts/src/models/UserPlexSourceConnection.ts
@@ -32,7 +32,7 @@ export interface UserPlexSourceConnection {
      * @type {number}
      * @memberof UserPlexSourceConnection
      */
-    user: number;
+    readonly user: number;
     /**
      *
      * @type {string}
@@ -108,7 +108,10 @@ export function UserPlexSourceConnectionToJSON(json: any): UserPlexSourceConnect
 }
 
 export function UserPlexSourceConnectionToJSONTyped(
-    value?: Omit<UserPlexSourceConnection, "pk" | "source_obj" | "created" | "last_updated"> | null,
+    value?: Omit<
+        UserPlexSourceConnection,
+        "pk" | "user" | "source_obj" | "created" | "last_updated"
+    > | null,
     ignoreDiscriminator: boolean = false,
 ): any {
     if (value == null) {
@@ -116,7 +119,6 @@ export function UserPlexSourceConnectionToJSONTyped(
     }
 
     return {
-        user: value["user"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/UserPlexSourceConnectionRequest.ts
+++ b/packages/client-ts/src/models/UserPlexSourceConnectionRequest.ts
@@ -20,12 +20,6 @@
 export interface UserPlexSourceConnectionRequest {
     /**
      *
-     * @type {number}
-     * @memberof UserPlexSourceConnectionRequest
-     */
-    user: number;
-    /**
-     *
      * @type {string}
      * @memberof UserPlexSourceConnectionRequest
      */
@@ -50,7 +44,6 @@ export interface UserPlexSourceConnectionRequest {
 export function instanceOfUserPlexSourceConnectionRequest(
     value: object,
 ): value is UserPlexSourceConnectionRequest {
-    if (!("user" in value) || value["user"] === undefined) return false;
     if (!("source" in value) || value["source"] === undefined) return false;
     if (!("identifier" in value) || value["identifier"] === undefined) return false;
     if (!("plexToken" in value) || value["plexToken"] === undefined) return false;
@@ -71,7 +64,6 @@ export function UserPlexSourceConnectionRequestFromJSONTyped(
         return json;
     }
     return {
-        user: json["user"],
         source: json["source"],
         identifier: json["identifier"],
         plexToken: json["plex_token"],
@@ -91,7 +83,6 @@ export function UserPlexSourceConnectionRequestToJSONTyped(
     }
 
     return {
-        user: value["user"],
         source: value["source"],
         identifier: value["identifier"],
         plex_token: value["plexToken"],

--- a/packages/client-ts/src/models/UserSAMLSourceConnection.ts
+++ b/packages/client-ts/src/models/UserSAMLSourceConnection.ts
@@ -32,7 +32,7 @@ export interface UserSAMLSourceConnection {
      * @type {number}
      * @memberof UserSAMLSourceConnection
      */
-    user: number;
+    readonly user: number;
     /**
      *
      * @type {string}
@@ -108,7 +108,10 @@ export function UserSAMLSourceConnectionToJSON(json: any): UserSAMLSourceConnect
 }
 
 export function UserSAMLSourceConnectionToJSONTyped(
-    value?: Omit<UserSAMLSourceConnection, "pk" | "source_obj" | "created" | "last_updated"> | null,
+    value?: Omit<
+        UserSAMLSourceConnection,
+        "pk" | "user" | "source_obj" | "created" | "last_updated"
+    > | null,
     ignoreDiscriminator: boolean = false,
 ): any {
     if (value == null) {
@@ -116,7 +119,6 @@ export function UserSAMLSourceConnectionToJSONTyped(
     }
 
     return {
-        user: value["user"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/UserSAMLSourceConnectionRequest.ts
+++ b/packages/client-ts/src/models/UserSAMLSourceConnectionRequest.ts
@@ -20,12 +20,6 @@
 export interface UserSAMLSourceConnectionRequest {
     /**
      *
-     * @type {number}
-     * @memberof UserSAMLSourceConnectionRequest
-     */
-    user: number;
-    /**
-     *
      * @type {string}
      * @memberof UserSAMLSourceConnectionRequest
      */
@@ -44,7 +38,6 @@ export interface UserSAMLSourceConnectionRequest {
 export function instanceOfUserSAMLSourceConnectionRequest(
     value: object,
 ): value is UserSAMLSourceConnectionRequest {
-    if (!("user" in value) || value["user"] === undefined) return false;
     if (!("source" in value) || value["source"] === undefined) return false;
     if (!("identifier" in value) || value["identifier"] === undefined) return false;
     return true;
@@ -64,7 +57,6 @@ export function UserSAMLSourceConnectionRequestFromJSONTyped(
         return json;
     }
     return {
-        user: json["user"],
         source: json["source"],
         identifier: json["identifier"],
     };
@@ -83,7 +75,6 @@ export function UserSAMLSourceConnectionRequestToJSONTyped(
     }
 
     return {
-        user: value["user"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/UserSourceConnection.ts
+++ b/packages/client-ts/src/models/UserSourceConnection.ts
@@ -32,7 +32,7 @@ export interface UserSourceConnection {
      * @type {number}
      * @memberof UserSourceConnection
      */
-    user: number;
+    readonly user: number;
     /**
      *
      * @type {string}
@@ -106,7 +106,10 @@ export function UserSourceConnectionToJSON(json: any): UserSourceConnection {
 }
 
 export function UserSourceConnectionToJSONTyped(
-    value?: Omit<UserSourceConnection, "pk" | "source_obj" | "created" | "last_updated"> | null,
+    value?: Omit<
+        UserSourceConnection,
+        "pk" | "user" | "source_obj" | "created" | "last_updated"
+    > | null,
     ignoreDiscriminator: boolean = false,
 ): any {
     if (value == null) {
@@ -114,7 +117,6 @@ export function UserSourceConnectionToJSONTyped(
     }
 
     return {
-        user: value["user"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/UserSourceConnectionRequest.ts
+++ b/packages/client-ts/src/models/UserSourceConnectionRequest.ts
@@ -20,12 +20,6 @@
 export interface UserSourceConnectionRequest {
     /**
      *
-     * @type {number}
-     * @memberof UserSourceConnectionRequest
-     */
-    user: number;
-    /**
-     *
      * @type {string}
      * @memberof UserSourceConnectionRequest
      */
@@ -44,7 +38,6 @@ export interface UserSourceConnectionRequest {
 export function instanceOfUserSourceConnectionRequest(
     value: object,
 ): value is UserSourceConnectionRequest {
-    if (!("user" in value) || value["user"] === undefined) return false;
     if (!("source" in value) || value["source"] === undefined) return false;
     if (!("identifier" in value) || value["identifier"] === undefined) return false;
     return true;
@@ -62,7 +55,6 @@ export function UserSourceConnectionRequestFromJSONTyped(
         return json;
     }
     return {
-        user: json["user"],
         source: json["source"],
         identifier: json["identifier"],
     };
@@ -81,7 +73,6 @@ export function UserSourceConnectionRequestToJSONTyped(
     }
 
     return {
-        user: value["user"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/UserTelegramSourceConnection.ts
+++ b/packages/client-ts/src/models/UserTelegramSourceConnection.ts
@@ -32,7 +32,7 @@ export interface UserTelegramSourceConnection {
      * @type {number}
      * @memberof UserTelegramSourceConnection
      */
-    user: number;
+    readonly user: number;
     /**
      *
      * @type {string}
@@ -110,7 +110,7 @@ export function UserTelegramSourceConnectionToJSON(json: any): UserTelegramSourc
 export function UserTelegramSourceConnectionToJSONTyped(
     value?: Omit<
         UserTelegramSourceConnection,
-        "pk" | "source_obj" | "created" | "last_updated"
+        "pk" | "user" | "source_obj" | "created" | "last_updated"
     > | null,
     ignoreDiscriminator: boolean = false,
 ): any {
@@ -119,7 +119,6 @@ export function UserTelegramSourceConnectionToJSONTyped(
     }
 
     return {
-        user: value["user"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/packages/client-ts/src/models/UserTelegramSourceConnectionRequest.ts
+++ b/packages/client-ts/src/models/UserTelegramSourceConnectionRequest.ts
@@ -20,12 +20,6 @@
 export interface UserTelegramSourceConnectionRequest {
     /**
      *
-     * @type {number}
-     * @memberof UserTelegramSourceConnectionRequest
-     */
-    user: number;
-    /**
-     *
      * @type {string}
      * @memberof UserTelegramSourceConnectionRequest
      */
@@ -44,7 +38,6 @@ export interface UserTelegramSourceConnectionRequest {
 export function instanceOfUserTelegramSourceConnectionRequest(
     value: object,
 ): value is UserTelegramSourceConnectionRequest {
-    if (!("user" in value) || value["user"] === undefined) return false;
     if (!("source" in value) || value["source"] === undefined) return false;
     if (!("identifier" in value) || value["identifier"] === undefined) return false;
     return true;
@@ -64,7 +57,6 @@ export function UserTelegramSourceConnectionRequestFromJSONTyped(
         return json;
     }
     return {
-        user: json["user"],
         source: json["source"],
         identifier: json["identifier"],
     };
@@ -85,7 +77,6 @@ export function UserTelegramSourceConnectionRequestToJSONTyped(
     }
 
     return {
-        user: value["user"],
         source: value["source"],
         identifier: value["identifier"],
     };

--- a/schema.yml
+++ b/schema.yml
@@ -40517,6 +40517,7 @@ components:
         group:
           type: string
           format: uuid
+          readOnly: true
         source:
           type: string
           format: uuid
@@ -40546,9 +40547,6 @@ components:
       type: object
       description: Group Source Connection
       properties:
-        group:
-          type: string
-          format: uuid
         source:
           type: string
           format: uuid
@@ -40556,7 +40554,6 @@ components:
           type: string
           minLength: 1
       required:
-      - group
       - identifier
       - source
     GroupLDAPSourceConnection:
@@ -40570,6 +40567,7 @@ components:
         group:
           type: string
           format: uuid
+          readOnly: true
         source:
           type: string
           format: uuid
@@ -40604,9 +40602,6 @@ components:
       type: object
       description: Group Source Connection
       properties:
-        group:
-          type: string
-          format: uuid
         source:
           type: string
           format: uuid
@@ -40614,7 +40609,6 @@ components:
           type: string
           minLength: 1
       required:
-      - group
       - identifier
       - source
     GroupMatchingModeEnum:
@@ -40634,6 +40628,7 @@ components:
         group:
           type: string
           format: uuid
+          readOnly: true
         source:
           type: string
           format: uuid
@@ -40663,9 +40658,6 @@ components:
       type: object
       description: Group Source Connection
       properties:
-        group:
-          type: string
-          format: uuid
         source:
           type: string
           format: uuid
@@ -40673,7 +40665,6 @@ components:
           type: string
           minLength: 1
       required:
-      - group
       - identifier
       - source
     GroupPlexSourceConnection:
@@ -40687,6 +40678,7 @@ components:
         group:
           type: string
           format: uuid
+          readOnly: true
         source:
           type: string
           format: uuid
@@ -40716,9 +40708,6 @@ components:
       type: object
       description: Group Source Connection
       properties:
-        group:
-          type: string
-          format: uuid
         source:
           type: string
           format: uuid
@@ -40726,7 +40715,6 @@ components:
           type: string
           minLength: 1
       required:
-      - group
       - identifier
       - source
     GroupRequest:
@@ -40769,6 +40757,7 @@ components:
         group:
           type: string
           format: uuid
+          readOnly: true
         source:
           type: string
           format: uuid
@@ -40798,9 +40787,6 @@ components:
       type: object
       description: Group Source Connection
       properties:
-        group:
-          type: string
-          format: uuid
         source:
           type: string
           format: uuid
@@ -40808,7 +40794,6 @@ components:
           type: string
           minLength: 1
       required:
-      - group
       - identifier
       - source
     GroupSourceConnection:
@@ -40822,6 +40807,7 @@ components:
         group:
           type: string
           format: uuid
+          readOnly: true
         source:
           type: string
           format: uuid
@@ -40851,9 +40837,6 @@ components:
       type: object
       description: Group Source Connection
       properties:
-        group:
-          type: string
-          format: uuid
         source:
           type: string
           format: uuid
@@ -40861,7 +40844,6 @@ components:
           type: string
           minLength: 1
       required:
-      - group
       - identifier
       - source
     GroupTelegramSourceConnection:
@@ -40875,6 +40857,7 @@ components:
         group:
           type: string
           format: uuid
+          readOnly: true
         source:
           type: string
           format: uuid
@@ -40904,9 +40887,6 @@ components:
       type: object
       description: Group Source Connection
       properties:
-        group:
-          type: string
-          format: uuid
         source:
           type: string
           format: uuid
@@ -40914,7 +40894,6 @@ components:
           type: string
           minLength: 1
       required:
-      - group
       - identifier
       - source
     Hardware:
@@ -48962,9 +48941,6 @@ components:
       type: object
       description: Group Source Connection
       properties:
-        group:
-          type: string
-          format: uuid
         source:
           type: string
           format: uuid
@@ -48975,9 +48951,6 @@ components:
       type: object
       description: Group Source Connection
       properties:
-        group:
-          type: string
-          format: uuid
         source:
           type: string
           format: uuid
@@ -48988,9 +48961,6 @@ components:
       type: object
       description: Group Source Connection
       properties:
-        group:
-          type: string
-          format: uuid
         source:
           type: string
           format: uuid
@@ -49001,9 +48971,6 @@ components:
       type: object
       description: Group Source Connection
       properties:
-        group:
-          type: string
-          format: uuid
         source:
           type: string
           format: uuid
@@ -49041,9 +49008,6 @@ components:
       type: object
       description: Group Source Connection
       properties:
-        group:
-          type: string
-          format: uuid
         source:
           type: string
           format: uuid
@@ -49054,9 +49018,6 @@ components:
       type: object
       description: Group Source Connection
       properties:
-        group:
-          type: string
-          format: uuid
         source:
           type: string
           format: uuid
@@ -49067,9 +49028,6 @@ components:
       type: object
       description: Group Source Connection
       properties:
-        group:
-          type: string
-          format: uuid
         source:
           type: string
           format: uuid
@@ -51443,8 +51401,6 @@ components:
       type: object
       description: User source connection
       properties:
-        user:
-          type: integer
         source:
           type: string
           format: uuid
@@ -51455,8 +51411,6 @@ components:
       type: object
       description: User source connection
       properties:
-        user:
-          type: integer
         source:
           type: string
           format: uuid
@@ -51510,8 +51464,6 @@ components:
       type: object
       description: User source connection
       properties:
-        user:
-          type: integer
         source:
           type: string
           format: uuid
@@ -51529,8 +51481,6 @@ components:
       type: object
       description: User source connection
       properties:
-        user:
-          type: integer
         source:
           type: string
           format: uuid
@@ -51588,8 +51538,6 @@ components:
       type: object
       description: User source connection
       properties:
-        user:
-          type: integer
         source:
           type: string
           format: uuid
@@ -51600,8 +51548,6 @@ components:
       type: object
       description: User source connection
       properties:
-        user:
-          type: integer
         source:
           type: string
           format: uuid
@@ -51612,8 +51558,6 @@ components:
       type: object
       description: User source connection
       properties:
-        user:
-          type: integer
         source:
           type: string
           format: uuid
@@ -57796,6 +57740,7 @@ components:
           title: ID
         user:
           type: integer
+          readOnly: true
         source:
           type: string
           format: uuid
@@ -57825,8 +57770,6 @@ components:
       type: object
       description: User source connection
       properties:
-        user:
-          type: integer
         source:
           type: string
           format: uuid
@@ -57836,7 +57779,6 @@ components:
       required:
       - identifier
       - source
-      - user
     UserLDAPSourceConnection:
       type: object
       description: User source connection
@@ -57847,6 +57789,7 @@ components:
           title: ID
         user:
           type: integer
+          readOnly: true
         source:
           type: string
           format: uuid
@@ -57881,8 +57824,6 @@ components:
       type: object
       description: User source connection
       properties:
-        user:
-          type: integer
         source:
           type: string
           format: uuid
@@ -57892,7 +57833,6 @@ components:
       required:
       - identifier
       - source
-      - user
     UserLoginChallenge:
       type: object
       description: Empty challenge
@@ -58098,6 +58038,7 @@ components:
           title: ID
         user:
           type: integer
+          readOnly: true
         source:
           type: string
           format: uuid
@@ -58130,8 +58071,6 @@ components:
       type: object
       description: User source connection
       properties:
-        user:
-          type: integer
         source:
           type: string
           format: uuid
@@ -58148,7 +58087,6 @@ components:
       required:
       - identifier
       - source
-      - user
     UserPasswordHashSetRequest:
       type: object
       description: Payload to set a users' password hash directly
@@ -58187,6 +58125,7 @@ components:
           title: ID
         user:
           type: integer
+          readOnly: true
         source:
           type: string
           format: uuid
@@ -58216,8 +58155,6 @@ components:
       type: object
       description: User source connection
       properties:
-        user:
-          type: integer
         source:
           type: string
           format: uuid
@@ -58232,7 +58169,6 @@ components:
       - identifier
       - plex_token
       - source
-      - user
     UserRecoveryEmailRequest:
       type: object
       description: Payload to create and email a recovery link
@@ -58308,6 +58244,7 @@ components:
           title: ID
         user:
           type: integer
+          readOnly: true
         source:
           type: string
           format: uuid
@@ -58337,8 +58274,6 @@ components:
       type: object
       description: User source connection
       properties:
-        user:
-          type: integer
         source:
           type: string
           format: uuid
@@ -58348,7 +58283,6 @@ components:
       required:
       - identifier
       - source
-      - user
     UserSelf:
       type: object
       description: User Serializer for information a user can retrieve about themselves
@@ -58511,6 +58445,7 @@ components:
           title: ID
         user:
           type: integer
+          readOnly: true
         source:
           type: string
           format: uuid
@@ -58540,8 +58475,6 @@ components:
       type: object
       description: User source connection
       properties:
-        user:
-          type: integer
         source:
           type: string
           format: uuid
@@ -58551,7 +58484,6 @@ components:
       required:
       - identifier
       - source
-      - user
     UserTelegramSourceConnection:
       type: object
       description: User source connection
@@ -58562,6 +58494,7 @@ components:
           title: ID
         user:
           type: integer
+          readOnly: true
         source:
           type: string
           format: uuid
@@ -58591,8 +58524,6 @@ components:
       type: object
       description: User source connection
       properties:
-        user:
-          type: integer
         source:
           type: string
           format: uuid
@@ -58602,7 +58533,6 @@ components:
       required:
       - identifier
       - source
-      - user
     UserTypeEnum:
       enum:
       - internal

--- a/tests/docker.py
+++ b/tests/docker.py
@@ -1,5 +1,6 @@
 """authentik e2e testing utilities"""
 
+from socket import socket
 from time import sleep
 from typing import Any
 from unittest.case import TestCase
@@ -38,6 +39,12 @@ class DockerTestCase(TestCase):
     @property
     def docker_labels(self) -> dict[str, str]:
         return {"io.goauthentik.test": self.__label_id}
+
+    def get_free_port(self) -> int:
+        """Find an unused local TCP port for a later container bind."""
+        with socket() as sock:
+            sock.bind(("0.0.0.0", 0))  # nosec: test-only local port discovery.
+            return sock.getsockname()[1]
 
     def wait_for_container(self, container: Container) -> Container:
         """Check that container is health"""
@@ -94,7 +101,7 @@ class DockerTestCase(TestCase):
 
     def tearDown(self) -> None:
         containers: list[Container] = self.docker_client.containers.list(
-            filters={"label": ",".join(f"{x}={y}" for x, y in self.docker_labels.items())}
+            all=True, filters={"label": ",".join(f"{x}={y}" for x, y in self.docker_labels.items())}
         )
         for container in containers:
             self.output_container_logs(container)

--- a/tests/e2e/proxy_forward_auth/envoy_single/envoy.yaml
+++ b/tests/e2e/proxy_forward_auth/envoy_single/envoy.yaml
@@ -52,7 +52,7 @@ static_resources:
                   name: local_route
                   virtual_hosts:
                     - name: local_service
-                      domains: ["localhost"]
+                      domains: ["localhost", "localhost:*"]
                       routes:
                         - match:
                             prefix: "/outpost.goauthentik.io"

--- a/tests/e2e/test_provider_proxy.py
+++ b/tests/e2e/test_provider_proxy.py
@@ -24,24 +24,27 @@ class TestProviderProxy(SeleniumTestCase):
 
     def setUp(self):
         super().setUp()
-        self.run_container(
+        self.upstream = self.run_container(
             image="traefik/whoami:latest",
-            ports={
-                "80": "80",
-            },
         )
 
-    def start_proxy(self, outpost: Outpost):
+    @property
+    def upstream_host(self) -> str:
+        """URL for the upstream app from inside the test Docker network."""
+        return f"http://{self.upstream.name}"
+
+    def start_proxy(self, outpost: Outpost, proxy_port: int) -> str:
         """Start proxy container based on outpost created"""
         self.run_container(
             image=self.get_container_image("ghcr.io/goauthentik/dev-proxy"),
             ports={
-                "9000": "9000",
+                "9000": proxy_port,
             },
             environment={
                 "AUTHENTIK_TOKEN": outpost.token.key,
             },
         )
+        return f"http://localhost:{proxy_port}"
 
     @retry()
     @apply_blueprint(
@@ -62,6 +65,7 @@ class TestProviderProxy(SeleniumTestCase):
         # set additionalHeaders to test later
         self.user.attributes["additionalHeaders"] = {"X-Foo": "bar"}
         self.user.save()
+        proxy_port = self.get_free_port()
 
         proxy: ProxyProvider = ProxyProvider.objects.create(
             name=generate_id(),
@@ -69,8 +73,8 @@ class TestProviderProxy(SeleniumTestCase):
                 slug="default-provider-authorization-implicit-consent"
             ),
             invalidation_flow=Flow.objects.get(slug="default-provider-invalidation-flow"),
-            internal_host=f"http://{self.host}",
-            external_host="http://localhost:9000",
+            internal_host=self.upstream_host,
+            external_host=f"http://localhost:{proxy_port}",
         )
         # Ensure OAuth2 Params are set
         proxy.set_oauth_defaults()
@@ -84,11 +88,11 @@ class TestProviderProxy(SeleniumTestCase):
         outpost.providers.add(proxy)
         outpost.build_user_permissions(outpost.user)
 
-        self.start_proxy(outpost)
+        proxy_url = self.start_proxy(outpost, proxy_port)
 
         sleep(5)
 
-        self.driver.get("http://localhost:9000/api")
+        self.driver.get(f"{proxy_url}/api")
         self.login()
         sleep(1)
 
@@ -112,7 +116,7 @@ class TestProviderProxy(SeleniumTestCase):
         self.assertIsNotNone(jwt["sid"], "Missing 'sid' in JWT")
         self.assertIsNotNone(jwt["ak_proxy"], "Missing 'ak_proxy' in JWT")
 
-        self.driver.get("http://localhost:9000/outpost.goauthentik.io/sign_out")
+        self.driver.get(f"{proxy_url}/outpost.goauthentik.io/sign_out")
         sleep(2)
 
         flow_executor = self.get_shadow_root("ak-flow-executor")
@@ -147,6 +151,7 @@ class TestProviderProxy(SeleniumTestCase):
         self.user.attributes["basic-username"] = cred
         self.user.attributes[attr] = cred
         self.user.save()
+        proxy_port = self.get_free_port()
 
         proxy: ProxyProvider = ProxyProvider.objects.create(
             name=generate_id(),
@@ -154,8 +159,8 @@ class TestProviderProxy(SeleniumTestCase):
                 slug="default-provider-authorization-implicit-consent"
             ),
             invalidation_flow=Flow.objects.get(slug="default-provider-invalidation-flow"),
-            internal_host=f"http://{self.host}",
-            external_host="http://localhost:9000",
+            internal_host=self.upstream_host,
+            external_host=f"http://localhost:{proxy_port}",
             basic_auth_enabled=True,
             basic_auth_user_attribute="basic-username",
             basic_auth_password_attribute=attr,
@@ -172,11 +177,11 @@ class TestProviderProxy(SeleniumTestCase):
         outpost.providers.add(proxy)
         outpost.build_user_permissions(outpost.user)
 
-        self.start_proxy(outpost)
+        proxy_url = self.start_proxy(outpost, proxy_port)
 
         sleep(5)
 
-        self.driver.get("http://localhost:9000/api")
+        self.driver.get(f"{proxy_url}/api")
         self.login()
         sleep(1)
 
@@ -198,7 +203,7 @@ class TestProviderProxy(SeleniumTestCase):
             f"Authorization header mismatch at {self.driver.current_url}: {snippet}",
         )
 
-        self.driver.get("http://localhost:9000/outpost.goauthentik.io/sign_out")
+        self.driver.get(f"{proxy_url}/outpost.goauthentik.io/sign_out")
         sleep(2)
 
         flow_executor = self.get_shadow_root("ak-flow-executor")
@@ -227,13 +232,14 @@ class TestProviderProxyConnect(ChannelsE2ETestCase):
     @reconcile_app("authentik_crypto")
     def test_proxy_connectivity(self):
         """Test proxy connectivity over websocket"""
+        proxy_port = self.get_free_port()
         proxy: ProxyProvider = ProxyProvider.objects.create(
             name=generate_id(),
             authorization_flow=Flow.objects.get(
                 slug="default-provider-authorization-implicit-consent"
             ),
             internal_host="http://localhost",
-            external_host="http://localhost:9000",
+            external_host=f"http://localhost:{proxy_port}",
         )
         # Ensure OAuth2 Params are set
         proxy.set_oauth_defaults()
@@ -252,7 +258,7 @@ class TestProviderProxyConnect(ChannelsE2ETestCase):
         self.run_container(
             image=self.get_container_image("ghcr.io/goauthentik/dev-proxy"),
             ports={
-                "9000": "9000",
+                "9000": proxy_port,
             },
             environment={
                 "AUTHENTIK_TOKEN": outpost.token.key,

--- a/tests/e2e/test_provider_proxy_forward.py
+++ b/tests/e2e/test_provider_proxy_forward.py
@@ -31,9 +31,6 @@ class TestProviderProxyForward(SeleniumTestCase):
         """Start proxy container based on outpost created"""
         self.run_container(
             image=self.get_container_image("ghcr.io/goauthentik/dev-proxy"),
-            ports={
-                "9000": "9000",
-            },
             environment={
                 "AUTHENTIK_TOKEN": outpost.token.key,
             },
@@ -53,7 +50,7 @@ class TestProviderProxyForward(SeleniumTestCase):
         "system/providers-proxy.yaml",
     )
     @reconcile_app("authentik_crypto")
-    def prepare(self):
+    def prepare(self, external_host: str):
         proxy: ProxyProvider = ProxyProvider.objects.create(
             name=generate_id(),
             mode=ProxyMode.FORWARD_SINGLE,
@@ -62,7 +59,7 @@ class TestProviderProxyForward(SeleniumTestCase):
             ),
             invalidation_flow=Flow.objects.get(slug="default-provider-invalidation-flow"),
             internal_host=f"http://{self.host}",
-            external_host="http://localhost",
+            external_host=external_host,
         )
         # Ensure OAuth2 Params are set
         proxy.set_oauth_defaults()
@@ -81,13 +78,15 @@ class TestProviderProxyForward(SeleniumTestCase):
     @retry()
     def test_traefik(self):
         """Test traefik"""
+        proxy_port = self.get_free_port()
+        proxy_url = f"http://localhost:{proxy_port}"
         local_config_path = (
             Path(__file__).parent / "proxy_forward_auth" / "traefik_single" / "config-static.yaml"
         )
         self.run_container(
             image="docker.io/library/traefik:3.1",
             ports={
-                "80": "80",
+                "80": proxy_port,
             },
             volumes={
                 local_config_path: {
@@ -96,9 +95,9 @@ class TestProviderProxyForward(SeleniumTestCase):
             },
         )
 
-        self.prepare()
+        self.prepare(proxy_url)
 
-        self.driver.get("http://localhost/api")
+        self.driver.get(f"{proxy_url}/api")
         self.login()
         sleep(1)
 
@@ -111,7 +110,7 @@ class TestProviderProxyForward(SeleniumTestCase):
             f"X-Authentik-Username header mismatch at {self.driver.current_url}: {snippet}",
         )
 
-        self.driver.get("http://localhost/outpost.goauthentik.io/sign_out")
+        self.driver.get(f"{proxy_url}/outpost.goauthentik.io/sign_out")
         sleep(2)
         flow_executor = self.get_shadow_root("ak-flow-executor")
         session_end_stage = self.get_shadow_root("ak-stage-session-end", flow_executor)
@@ -123,22 +122,24 @@ class TestProviderProxyForward(SeleniumTestCase):
     @retry()
     def test_nginx(self):
         """Test nginx"""
-        self.prepare()
+        proxy_port = self.get_free_port()
+        proxy_url = f"http://localhost:{proxy_port}"
+        self.prepare(proxy_url)
 
         # Start nginx last so all hosts are resolvable, otherwise nginx exits
         self.run_container(
             image="docker.io/library/nginx:1.27",
             ports={
-                "80": "80",
+                "80": proxy_port,
             },
             volumes={
-                f"{Path(__file__).parent / "proxy_forward_auth" / "nginx_single" / "nginx.conf"}": {
+                f"{Path(__file__).parent / 'proxy_forward_auth' / 'nginx_single' / 'nginx.conf'}": {
                     "bind": "/etc/nginx/conf.d/default.conf",
                 }
             },
         )
 
-        self.driver.get("http://localhost/api")
+        self.driver.get(f"{proxy_url}/api")
         self.login()
         sleep(1)
 
@@ -151,7 +152,7 @@ class TestProviderProxyForward(SeleniumTestCase):
             f"X-Authentik-Username header mismatch at {self.driver.current_url}: {snippet}",
         )
 
-        self.driver.get("http://localhost/outpost.goauthentik.io/sign_out")
+        self.driver.get(f"{proxy_url}/outpost.goauthentik.io/sign_out")
         sleep(2)
         flow_executor = self.get_shadow_root("ak-flow-executor")
         session_end_stage = self.get_shadow_root("ak-stage-session-end", flow_executor)
@@ -162,21 +163,23 @@ class TestProviderProxyForward(SeleniumTestCase):
     @retry()
     def test_envoy(self):
         """Test envoy"""
+        proxy_port = self.get_free_port()
+        proxy_url = f"http://localhost:{proxy_port}"
         self.run_container(
             image="docker.io/envoyproxy/envoy:v1.25-latest",
             ports={
-                "10000": "80",
+                "10000": proxy_port,
             },
             volumes={
-                f"{Path(__file__).parent / "proxy_forward_auth" / "envoy_single" / "envoy.yaml"}": {
+                f"{Path(__file__).parent / 'proxy_forward_auth' / 'envoy_single' / 'envoy.yaml'}": {
                     "bind": "/etc/envoy/envoy.yaml",
                 }
             },
         )
 
-        self.prepare()
+        self.prepare(proxy_url)
 
-        self.driver.get("http://localhost/api")
+        self.driver.get(f"{proxy_url}/api")
         self.login()
         sleep(1)
 
@@ -189,7 +192,7 @@ class TestProviderProxyForward(SeleniumTestCase):
             f"X-Authentik-Username header mismatch at {self.driver.current_url}: {snippet}",
         )
 
-        self.driver.get("http://localhost/outpost.goauthentik.io/sign_out")
+        self.driver.get(f"{proxy_url}/outpost.goauthentik.io/sign_out")
         sleep(2)
         flow_executor = self.get_shadow_root("ak-flow-executor")
         session_end_stage = self.get_shadow_root("ak-stage-session-end", flow_executor)
@@ -200,13 +203,15 @@ class TestProviderProxyForward(SeleniumTestCase):
     @retry()
     def test_caddy(self):
         """Test caddy"""
+        proxy_port = self.get_free_port()
+        proxy_url = f"http://localhost:{proxy_port}"
         local_config_path = (
             Path(__file__).parent / "proxy_forward_auth" / "caddy_single" / "Caddyfile"
         )
         self.run_container(
             image="docker.io/library/caddy:2.8",
             ports={
-                "80": "80",
+                "80": proxy_port,
             },
             volumes={
                 local_config_path: {
@@ -215,9 +220,9 @@ class TestProviderProxyForward(SeleniumTestCase):
             },
         )
 
-        self.prepare()
+        self.prepare(proxy_url)
 
-        self.driver.get("http://localhost/api")
+        self.driver.get(f"{proxy_url}/api")
         self.login()
         sleep(1)
 
@@ -230,7 +235,7 @@ class TestProviderProxyForward(SeleniumTestCase):
             f"X-Authentik-Username header mismatch at {self.driver.current_url}: {snippet}",
         )
 
-        self.driver.get("http://localhost/outpost.goauthentik.io/sign_out")
+        self.driver.get(f"{proxy_url}/outpost.goauthentik.io/sign_out")
         sleep(2)
         flow_executor = self.get_shadow_root("ak-flow-executor")
         session_end_stage = self.get_shadow_root("ak-stage-session-end", flow_executor)


### PR DESCRIPTION
## Summary
Fix proxy e2e failures caused by tests binding containers to fixed host ports. The tests now allocate per-test host ports and still route container-to-container traffic over Docker DNS where possible.

The shared Docker cleanup also removes stopped labelled containers, so a failed container start does not leave names behind and cascade into later test failures.

## Related
The separate endpoint e2e failure from blank agent OS versions is handled in goauthentik/platform#960.

## Validation
- `uv run ruff check tests/docker.py tests/e2e/test_provider_proxy.py tests/e2e/test_provider_proxy_forward.py`
- `uv run ruff format --check tests/docker.py tests/e2e/test_provider_proxy.py tests/e2e/test_provider_proxy_forward.py`
- `git diff --check`