### PR TITLE
ci: explicitly exit Node lint scripts to fix CI hang

### DIFF
--- a/scripts/node/lint-lockfile.mjs
+++ b/scripts/node/lint-lockfile.mjs
@@ -274,5 +274,7 @@ run()
         } else {
             logger.info("✅ Lockfile is in sync.");
         }
+
+        process.exit(0);
     })
     .catch((error) => reportAndExit(error, logger));

--- a/scripts/node/lint-runtime.mjs
+++ b/scripts/node/lint-runtime.mjs
@@ -110,5 +110,6 @@ async function main() {
 main()
     .then(() => {
         logger.info("✅ Node.js and npm versions are in sync.");
+        process.exit(0);
     })
     .catch((error) => reportAndExit(error, logger));

--- a/scripts/node/setup-corepack.mjs
+++ b/scripts/node/setup-corepack.mjs
@@ -102,9 +102,12 @@ async function main() {
         subcommand = "use";
     }
 
-    await $`corepack ${subcommand} ${packageManager}`({ cwd });
-
-    logger.info("Corepack installed npm successfully");
+    return $`corepack ${subcommand} ${packageManager}`({ cwd });
 }
 
-main().catch((error) => reportAndExit(error, logger));
+main()
+    .then(() => {
+        logger.info("Corepack setup completed successfully");
+        process.exit(0);
+    })
+    .catch((error) => reportAndExit(error, logger));


### PR DESCRIPTION
## Summary

The three Node scripts wired into `.github/actions/setup-node` finish their main
work but the Node process does not exit on its own — something in the event
loop (logger transport / upstream child-process handle) keeps the process alive
until GitHub Actions' six-hour default timeout fires. The result is a CI step
that "succeeds" but never returns control to the runner.

The fix is a single explicit `process.exit(0)` after the success path in each
script:

- `scripts/node/lint-lockfile.mjs` — exit `0` after the "lockfile is in sync"
  log.
- `scripts/node/lint-runtime.mjs` — exit `0` after the "node/npm versions are in
  sync" log.
- `scripts/node/setup-corepack.mjs` — `main()` now returns the `corepack` shell
  promise; the "Corepack setup completed successfully" log moves into `.then()`
  immediately before the exit so the message ordering stays deterministic.

This is the load-bearing fix for the CI hang. The timeout-additions discussed
on #22533 are split into a separate PR ("ci: add timeouts to docker build,
lint, and setup-node install steps") per @rissson's request — that PR is an
independent defense-in-depth measure and does not block this one.

Closes #22533 (in favor of this PR + the timeouts PR).

## Test plan

- [x] Each script runs locally and exits promptly:
  - `node ./scripts/node/lint-runtime.mjs` → exit 0
  - `node ./scripts/node/lint-lockfile.mjs` → exit 0
  - `node ./scripts/node/setup-corepack.mjs` → exit 0
- [x] No behavioural change on the success path beyond the explicit exit; the
      `.catch(reportAndExit)` error path is unchanged in all three files.
- [ ] CI green on this branch.

## Disclosure

Triaged and authored end-to-end by an agent running in a sandbox against
`goauthentik/authentik@main`. Reviewed and shipped by @GirlBossRush.
