### PR TITLE
ci: add timeouts to docker build, lint, and setup-node install steps

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -56,7 +56,7 @@ runs:
       shell: bash
       run: | #shell
         node ./scripts/node/lint-lockfile.mjs
-        corepack npm ci
+        timeout 5m corepack npm ci
     - name: Setup Node.js (Working Directory)
       if: ${{ contains(inputs.dependencies, 'working-directory') }}
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v4
@@ -74,4 +74,4 @@ runs:
         echo "npm version: $(corepack npm --version)"
 
         node ./scripts/node/lint-lockfile.mjs ${{ inputs.working-directory }}
-        corepack npm ci --prefix ${{ inputs.working-directory }}
+        timeout 5m corepack npm ci --prefix ${{ inputs.working-directory }}

--- a/.github/workflows/_reusable-docker-build-single.yml
+++ b/.github/workflows/_reusable-docker-build-single.yml
@@ -31,6 +31,7 @@ jobs:
   build:
     name: Build ${{ inputs.image_arch }}
     runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: 30
     outputs:
       image-digest: ${{ steps.push.outputs.digest }}
     permissions:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -50,6 +50,7 @@ jobs:
           - job: rustfmt
             deps: rust-nightly
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
       - name: Setup authentik env


### PR DESCRIPTION
## Summary

Three places where CI could previously hang indefinitely now have an explicit
upper bound. This is the timeouts-only half of #22533, split out per
@rissson's request; the actual Node-script hang fix lives in the
sibling PR (`ci/fix-node-lint-script-hang`).

- **`.github/workflows/ci-main.yml`** — the main lint/test job picks up a
  job-level `timeout-minutes: 30`. Previously fell back to GitHub's six-hour
  default.
- **`.github/workflows/_reusable-docker-build-single.yml`** — the per-arch
  container `build` job picks up the same `timeout-minutes: 30`.
- **`.github/actions/setup-node/action.yml`** — both `corepack npm ci`
  invocations are wrapped with `timeout 5m`. See "On the `setup-node` timeout"
  below for why this is a `timeout(1)` shell wrapper rather than a step-level
  `timeout-minutes`.

Closes #22533 (in favor of this PR + the hang-fix PR).

## On the `setup-node` timeout (reply to @rissson)

> Should this be a timeout on that step instead? If that's supported, I'm not
> 100% on that

It is not supported. `.github/actions/setup-node/action.yml` is a **composite
action**, and GitHub Actions does not currently allow `timeout-minutes` on
individual steps inside `runs.steps` of a composite action. The supported keys
on a composite action step are limited to: `run`, `shell`, `if`, `name`, `id`,
`env`, `working-directory`, `uses`, `with`, and `continue-on-error` — per the
official action metadata syntax reference:
<https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions>.

The long-standing tracking issue is
[actions/runner#1979](https://github.com/actions/runner/issues/1979)
("Support timeout-minutes in composite-actions"), open since 2022 and still
unresolved — the GitHub Actions team has deferred it pending a future ADR.

So `timeout 5m corepack npm ci` (using coreutils `timeout(1)`) is the right
workaround today: a hung `npm ci` surfaces as a real step failure within 5
minutes instead of relying on the outer 6-hour job default. If `timeout-minutes`
on composite-action steps lands upstream, we can swap this out for the more
idiomatic form in a follow-up.

## Test plan

- [x] YAML changes are purely additive — no other lines touched, no formatting
      churn (the `.github/**` tree is in `.prettierignore`).
- [x] `timeout-minutes: 30` is set at the **job** level (where it is
      supported); `timeout 5m` is only used inside the composite action.
- [x] CI green on this branch.

## Disclosure

Triaged and authored end-to-end by an agent running in a sandbox against
`goauthentik/authentik@main`. Reviewed and shipped by @GirlBossRush.
