### PR TITLE
website: address PR #22454 Podman/Quadlet review feedback

### DIFF
--- a/website/docs/add-secure-apps/outposts/integrations/docker.md
+++ b/website/docs/add-secure-apps/outposts/integrations/docker.md
@@ -41,37 +41,23 @@ authentik requires the following permissions from the Docker API:
 
 ## Podman
 
-Podman exposes a Docker-compatible REST API, so the Docker integration works against Podman with no code changes — point the integration at Podman's socket.
+Podman exposes a Docker-compatible REST API, so the Docker integration works against Podman's socket. The socket lives at a different path depending on whether Podman is running rootful or rootless:
 
-You can enable the API socket on the host system-wide:
+- Rootful (system-wide): `/run/podman/podman.sock`
+- Rootless (per-user): `$XDG_RUNTIME_DIR/podman/podman.sock` (typically `/run/user/<uid>/podman/podman.sock`)
+
+Enable the API socket:
 
 ```shell
-# Rootful (system-wide)
+# Rootful
 sudo systemctl enable --now podman.socket
-```
 
-Or on a per-user basis:
-
-```
-# Rootless (per-user)
+# Rootless
 systemctl --user enable --now podman.socket
 loginctl enable-linger "$USER"
 ```
 
-The socket is located at:
-
-- Rootful: `/run/podman/podman.sock`
-- Rootless: `$XDG_RUNTIME_DIR/podman/podman.sock` (typically `/run/user/<uid>/podman/podman.sock`)
-
-If the authentik worker runs on the same host (a typical Quadlet or `podman compose` deployment), bind-mount the socket into the worker container. From authentik 2026.8 onwards, the startup discovery task auto-creates a local service connection when it finds either `/var/run/docker.sock` or `/run/podman/podman.sock`. On 2026.5 and earlier, mount the Podman socket to the Docker path inside the worker:
-
-```
-/run/podman/podman.sock:/var/run/docker.sock
-```
-
-Or set `DOCKER_HOST=unix:///run/podman/podman.sock` in the worker environment — the Docker SDK that the outpost controller uses honors this variable.
-
-For a step-by-step walkthrough, see the [Podman with Quadlet installation](../../../install-config/install/podman-quadlet.mdx) guide.
+In authentik 2026.8, the worker's startup discovery task scans a candidate list of socket paths _inside the container_ — `/var/run/docker.sock`, `/run/podman/podman.sock`, and `$XDG_RUNTIME_DIR/podman/podman.sock` — and creates a local service connection for the first one it finds. Mount your Podman socket into the worker at any of those paths; you no longer need to remap it to `/var/run/docker.sock` or set `DOCKER_HOST`.
 
 ## Docker Socket Proxy
 

--- a/website/docs/install-config/install/docker-compose.mdx
+++ b/website/docs/install-config/install/docker-compose.mdx
@@ -10,7 +10,7 @@ This installation method is for test setups and small-scale production setups.
 - Podman or Docker Compose (Compose v2, see [instructions for upgrade](https://docs.docker.com/compose/migrate/))
 
 :::info Podman Quadlet installation
-If you are running on Podman and want systemd integration, see the [Podman with Quadlet installation](./podman-quadlet.mdx) guide instead — it deploys authentik as native `.service` units without `podman compose`.
+If you are running on Podman and want systemd integration, see the [Podman with Quadlet installation](./podman-quadlet.mdx) guide instead.
 :::
 
 ## Video
@@ -60,7 +60,7 @@ echo "PG_PASS=$(openssl rand -base64 36 | tr -d '\n')" >> .env
 echo "AUTHENTIK_SECRET_KEY=$(openssl rand -base64 60 | tr -d '\n')" >> .env
 ```
 
-:::info PostgreSQL password length limitation
+:::info
 Because of a PostgreSQL limitation, passwords longer than 99 characters are not supported. See the [PostgreSQL mailing list discussion](https://www.postgresql.org/message-id/09512C4F-8CB9-4021-B455-EF4C4F0D55A0@amazon.com).
 :::
 

--- a/website/docs/install-config/install/podman-quadlet.mdx
+++ b/website/docs/install-config/install/podman-quadlet.mdx
@@ -2,11 +2,11 @@
 title: Podman with Quadlet installation
 ---
 
-This installation method runs authentik as a set of systemd-managed Podman containers using [Quadlet](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html). Quadlet ships with Podman 4.4 and later and is the recommended way to run long-lived Podman workloads under systemd.
+This installation method runs authentik as a [Quadlet](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html)-managed Podman pod. Quadlet ships with Podman 4.4 and later and turns container, pod, volume, and network definitions into native systemd units.
 
 Compared to running `podman compose`, Quadlet provides:
 
-- First-class systemd integration: each container is a native `.service` unit with restart policies, dependencies, journald logs, and `systemctl` controls.
+- First-class systemd integration: each unit is a real `.service` with restart policies, dependencies, journald logs, and `systemctl` controls.
 - No `podman-compose` runtime dependency.
 - The same unit files work for rootful (`/etc/containers/systemd/`) and rootless (`~/.config/containers/systemd/`) deployments.
 
@@ -15,7 +15,7 @@ This guide covers a single-host deployment suitable for small-scale production o
 ## Requirements
 
 - A host with at least 2 CPU cores and 2 GB of RAM
-- Podman 4.4 or later with Quadlet support (5.0 or later is recommended)
+- Podman 4.4 or later with Quadlet support (5.0 or later is recommended for `.pod` files)
 - systemd 250 or later
 - A user account, either:
     - `root` for a system-wide (rootful) deployment
@@ -33,22 +33,25 @@ podman --version
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 
-Choose one mode and stick with it. The unit content is identical; only the installation paths and socket locations differ.
+Choose one mode and stay with it. The unit content is identical; only the install paths, socket locations, and `systemctl` invocation differ.
 
-| Aspect                               | Rootful                                         | Rootless                                          |
-| ------------------------------------ | ----------------------------------------------- | ------------------------------------------------- |
-| Unit directory                       | `/etc/containers/systemd/`                      | `~/.config/containers/systemd/`                   |
-| Reload command                       | `sudo systemctl daemon-reload`                  | `systemctl --user daemon-reload`                  |
-| Start command                        | `sudo systemctl start authentik-server.service` | `systemctl --user start authentik-server.service` |
-| Podman API socket path               | `/run/podman/podman.sock`                       | `$XDG_RUNTIME_DIR/podman/podman.sock`             |
-| Support for Outpost auto-deploy      | Yes, out of the box                             | Yes, with `loginctl enable-linger`                |
-| Support for binding ports below 1024 | Yes                                             | Requires `net.ipv4.ip_unprivileged_port_start`    |
+| Aspect                          | Rootful                                         | Rootless                                                  |
+| ------------------------------- | ----------------------------------------------- | --------------------------------------------------------- |
+| Unit directory                  | `/etc/containers/systemd/`                      | `~/.config/containers/systemd/`                           |
+| Reload command                  | `sudo systemctl daemon-reload`                  | `systemctl --user daemon-reload`                          |
+| Start command                   | `sudo systemctl start authentik-server.service` | `systemctl --user start authentik-server.service`         |
+| Podman API socket path          | `/run/podman/podman.sock`                       | `$XDG_RUNTIME_DIR/podman/podman.sock`                     |
+| Support for Outpost auto-deploy | Yes                                             | Yes, with `loginctl enable-linger`                        |
+| Binding ports below 1024        | Yes                                             | Requires sysctl, firewall, socket activation, or an LB    |
 
-If you are unsure, prefer rootful. The rest of this guide uses rootful paths; for rootless, substitute the paths from the table above.
+Every command in this guide is shown for both modes — pick the tab that matches your deployment.
 
 ## Prepare the host
 
 Create a state directory for the containers to mount, and generate a PostgreSQL password and an authentik secret key:
+
+<Tabs groupId="install-mode">
+<TabItem value="rootful" label="Rootful" default>
 
 ```shell
 sudo mkdir -p /var/lib/authentik/{data,certs,custom-templates}
@@ -61,42 +64,82 @@ EOF
 sudo chmod 600 /etc/authentik/authentik.env
 ```
 
-:::info PostgreSQL password length limitation
-Because of a PostgreSQL limitation, passwords longer than 99 characters are not supported. See the [PostgreSQL mailing list discussion](https://www.postgresql.org/message-id/09512C4F-8CB9-4021-B455-EF4C4F0D55A0@amazon.com).
-:::
+</TabItem>
+<TabItem value="rootless" label="Rootless">
+
+```shell
+mkdir -p ~/.local/share/authentik/{data,certs,custom-templates}
+mkdir -p ~/.config/authentik
+tee ~/.config/authentik/authentik.env > /dev/null <<EOF
+PG_PASS=$(openssl rand -base64 36 | tr -d '\n')
+AUTHENTIK_SECRET_KEY=$(openssl rand -base64 60 | tr -d '\n')
+AUTHENTIK_ERROR_REPORTING__ENABLED=true
+EOF
+chmod 600 ~/.config/authentik/authentik.env
+```
+
+</TabItem>
+</Tabs>
 
 Enable the Podman API socket so the authentik worker can deploy outposts:
+
+<Tabs groupId="install-mode">
+<TabItem value="rootful" label="Rootful" default>
 
 ```shell
 sudo systemctl enable --now podman.socket
 ```
 
-## Create the Quadlet units
+</TabItem>
+<TabItem value="rootless" label="Rootless">
 
-Each `.container` file below maps roughly to a service in our [Docker Compose file](./docker-compose.mdx). Place all of them in `/etc/containers/systemd/` (rootful) or `~/.config/containers/systemd/` (rootless).
-
-### Shared network
-
-Create a private network so the containers can reach each other by name:
-
-```ini title="/etc/containers/systemd/authentik.network"
-[Network]
-NetworkName=authentik
+```shell
+systemctl --user enable --now podman.socket
 ```
 
-### PostgreSQL
+</TabItem>
+</Tabs>
 
-```ini title="/etc/containers/systemd/authentik-postgresql.container"
+## Create the Quadlet units
+
+All units below live in `/etc/containers/systemd/` (rootful) or `~/.config/containers/systemd/` (rootless). Each `.container` file maps roughly to a service in the [Docker Compose file](./docker-compose.mdx).
+
+The deployment uses a single pod that hosts PostgreSQL, the server, and the worker so they can reach each other on `localhost` without a custom network.
+
+### Pod
+
+```ini title="authentik.pod"
+[Unit]
+Description=authentik pod
+
+[Pod]
+PodName=authentik
+PublishPort=9000:9000
+PublishPort=9443:9443
+
+[Install]
+WantedBy=default.target
+```
+
+### PostgreSQL volume
+
+```ini title="authentik-database.volume"
+[Volume]
+VolumeName=authentik-database
+```
+
+### PostgreSQL container
+
+```ini title="authentik-postgresql.container"
 [Unit]
 Description=authentik PostgreSQL
-Wants=network-online.target
-After=network-online.target
 
 [Container]
 ContainerName=authentik-postgresql
-Image=docker.io/library/postgres:16-alpine
-Network=authentik.network
-Volume=authentik-database.volume:/var/lib/postgresql/data
+Image=docker.io/library/postgres:18-alpine
+AutoUpdate=registry
+Pod=authentik.pod
+Volume=authentik-database.volume:/var/lib/postgresql
 EnvironmentFile=/etc/authentik/authentik.env
 Environment=POSTGRES_DB=authentik
 Environment=POSTGRES_USER=authentik
@@ -111,34 +154,27 @@ HealthRetries=5
 Restart=unless-stopped
 
 [Install]
-WantedBy=multi-user.target default.target
-```
-
-```ini title="/etc/containers/systemd/authentik-database.volume"
-[Volume]
-VolumeName=authentik-database
+WantedBy=default.target
 ```
 
 ### authentik server
 
-```ini title="/etc/containers/systemd/authentik-server.container"
+```ini title="authentik-server.container"
 [Unit]
 Description=authentik server
-Wants=network-online.target
-After=network-online.target authentik-postgresql.service
-Requires=authentik-postgresql.service
+Requires=authentik-postgresql.container
+After=authentik-postgresql.container
 
 [Container]
 ContainerName=authentik-server
-Image=ghcr.io/goauthentik/server:latest
+Image=ghcr.io/goauthentik/server:2026.8
+AutoUpdate=registry
+Pod=authentik.pod
 Exec=server
-Network=authentik.network
 EnvironmentFile=/etc/authentik/authentik.env
-Environment=AUTHENTIK_POSTGRESQL__HOST=authentik-postgresql
+Environment=AUTHENTIK_POSTGRESQL__HOST=localhost
 Environment=AUTHENTIK_POSTGRESQL__NAME=authentik
 Environment=AUTHENTIK_POSTGRESQL__USER=authentik
-PublishPort=9000:9000
-PublishPort=9443:9443
 Volume=/var/lib/authentik/data:/data:Z
 Volume=/var/lib/authentik/custom-templates:/templates:Z
 PodmanArgs=--shm-size=512m
@@ -147,30 +183,32 @@ PodmanArgs=--shm-size=512m
 Restart=unless-stopped
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 ```
 
 ### authentik worker
 
-The worker is what talks to the Podman API to deploy outposts, so it mounts the Podman socket. authentik 2026.8 and newer auto-detects `/run/podman/podman.sock`; on 2026.5 and older you must bind-mount it to `/var/run/docker.sock` instead (see [Older versions](#older-versions-20265-and-earlier)).
+The worker shares the pod with the server. Because both default to listening on `:9000` (HTTP) and `:9300` (metrics), shift the worker to a different pair so they do not collide inside the pod's network namespace. The worker also mounts the Podman API socket so it can deploy outposts.
 
-```ini title="/etc/containers/systemd/authentik-worker.container"
+```ini title="authentik-worker.container"
 [Unit]
 Description=authentik worker
-Wants=network-online.target
-After=network-online.target authentik-postgresql.service podman.socket
-Requires=authentik-postgresql.service
+Requires=authentik-postgresql.container
+After=authentik-postgresql.container
 
 [Container]
 ContainerName=authentik-worker
-Image=ghcr.io/goauthentik/server:latest
+Image=ghcr.io/goauthentik/server:2026.8
+AutoUpdate=registry
+Pod=authentik.pod
 Exec=worker
-Network=authentik.network
+User=0:0
 EnvironmentFile=/etc/authentik/authentik.env
-Environment=AUTHENTIK_POSTGRESQL__HOST=authentik-postgresql
+Environment=AUTHENTIK_POSTGRESQL__HOST=localhost
 Environment=AUTHENTIK_POSTGRESQL__NAME=authentik
 Environment=AUTHENTIK_POSTGRESQL__USER=authentik
-User=0:0
+Environment=AUTHENTIK_LISTEN__HTTP=0.0.0.0:9001
+Environment=AUTHENTIK_LISTEN__METRICS=0.0.0.0:9301
 Volume=/run/podman/podman.sock:/run/podman/podman.sock:Z
 Volume=/var/lib/authentik/data:/data:Z
 Volume=/var/lib/authentik/certs:/certs:Z
@@ -181,7 +219,7 @@ PodmanArgs=--shm-size=512m
 Restart=unless-stopped
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 ```
 
 For a rootless deployment, replace the socket volume line with:
@@ -196,43 +234,43 @@ Volume=%t/podman/podman.sock:/run/podman/podman.sock:Z
 
 Reload systemd so Quadlet generates the service units, then start everything:
 
+<Tabs groupId="install-mode">
+<TabItem value="rootful" label="Rootful" default>
+
 ```shell
 sudo systemctl daemon-reload
 sudo systemctl start authentik-server.service authentik-worker.service
 ```
 
+</TabItem>
+<TabItem value="rootless" label="Rootless">
+
+```shell
+systemctl --user daemon-reload
+systemctl --user start authentik-server.service authentik-worker.service
+```
+
+</TabItem>
+</Tabs>
+
 Quadlet pulls images lazily on first start, so the initial run may take a few minutes. Tail the logs to watch the migration:
+
+<Tabs groupId="install-mode">
+<TabItem value="rootful" label="Rootful" default>
 
 ```shell
 journalctl -u authentik-server.service -f
 ```
 
-## Custom ports
-
-To bind on ports 80/443 instead of 9000/9443, edit the `PublishPort=` lines in `authentik-server.container` and reload:
-
-```ini
-PublishPort=80:9000
-PublishPort=443:9443
-```
+</TabItem>
+<TabItem value="rootless" label="Rootless">
 
 ```shell
-sudo systemctl daemon-reload
-sudo systemctl restart authentik-server.service
+journalctl --user -u authentik-server.service -f
 ```
 
-For rootless deployments, lower `net.ipv4.ip_unprivileged_port_start` via sysctl before privileged ports will bind.
-
-## Upgrading
-
-Quadlet does not automatically pull new images on restart. To upgrade authentik:
-
-```shell
-sudo podman pull ghcr.io/goauthentik/server:latest
-sudo systemctl restart authentik-server.service authentik-worker.service
-```
-
-For pinned versions, edit the `Image=` line to a specific tag (for example `ghcr.io/goauthentik/server:2026.5.0`) and `systemctl daemon-reload && systemctl restart`.
+</TabItem>
+</Tabs>
 
 ## Access authentik
 
@@ -243,6 +281,57 @@ You are then prompted to set a password for the `akadmin` user (the default user
 :::info Issues with initial setup
 If you run into issues, refer to our [troubleshooting docs](../../troubleshooting/login.md#cant-access-initial-setup-flow-during-installation-steps).
 :::
+
+## Privileged ports (below 1024)
+
+The pod's `PublishPort=` lines bind on the host's network namespace, so any option that lets a rootless process reach ports 80/443 works here. Pick whichever fits your environment:
+
+- **Reverse proxy / load balancer**: terminate TLS at nginx, Caddy, Traefik, or HAProxy and forward to authentik on the high ports. This is the typical production option — certificate renewal, request logging, and host-level routing are already solved there.
+- **Firewall port-forwarding**: redirect `80 → 9000` and `443 → 9443` at the host firewall (`iptables`, `nftables`, or `firewalld`).
+- **systemd socket activation**: have systemd bind the privileged socket and pass it into the pod.
+- **Lower the unprivileged port floor**: `sudo sysctl net.ipv4.ip_unprivileged_port_start=80`, persisted in `/etc/sysctl.d/`. This relaxes the system-wide guard rail; see the [Rootless Privileged Ports discussion](https://tangentsoft.com/podman/wiki?name=Rootless+Privileged+Ports&p) for the trade-offs.
+
+## Upgrading
+
+With `AutoUpdate=registry` set on each `.container` (as shown above), Podman's built-in updater handles image pulls and container restarts. Enable the timer once:
+
+<Tabs groupId="install-mode">
+<TabItem value="rootful" label="Rootful" default>
+
+```shell
+sudo systemctl enable --now podman-auto-update.timer
+```
+
+</TabItem>
+<TabItem value="rootless" label="Rootless">
+
+```shell
+systemctl --user enable --now podman-auto-update.timer
+```
+
+</TabItem>
+</Tabs>
+
+To upgrade on demand:
+
+<Tabs groupId="install-mode">
+<TabItem value="rootful" label="Rootful" default>
+
+```shell
+sudo podman auto-update
+```
+
+</TabItem>
+<TabItem value="rootless" label="Rootless">
+
+```shell
+podman auto-update
+```
+
+</TabItem>
+</Tabs>
+
+For pinned upgrades, edit the `Image=` line on each container to the desired tag (for example `ghcr.io/goauthentik/server:2026.9`), then `daemon-reload && restart`.
 
 ## SELinux
 

--- a/website/docs/releases/2026/v2026.8.md
+++ b/website/docs/releases/2026/v2026.8.md
@@ -10,7 +10,7 @@ draft: true
 
 ## New features and improvements
 
-- **Podman socket auto-detection for outposts**: the startup discovery task now also picks up Podman's rootful (`/run/podman/podman.sock`) and rootless (`$XDG_RUNTIME_DIR/podman/podman.sock`) sockets, in addition to `/var/run/docker.sock`. A fresh install on a Podman host now gets a working local service connection without bind-mount workarounds. See the new [Podman with Quadlet installation](../../install-config/install/podman-quadlet.mdx) guide.
+- **Podman support**: authentik 2026.8 documents a fully-supported [Podman with Quadlet installation](../../install-config/install/podman-quadlet.mdx) path, and the outpost startup discovery task now auto-detects Podman's rootful (`/run/podman/podman.sock`) and rootless (`$XDG_RUNTIME_DIR/podman/podman.sock`) sockets alongside `/var/run/docker.sock`. A fresh install on a Podman host now gets a working local service connection without bind-mount workarounds.
 
 ## Upgrading
 


### PR DESCRIPTION
Quadlet guide:
- restructure as a single pod (server, worker, postgres on localhost) instead of a shared network
- drop network-online.target dependencies (unneeded inside a pod)
- express inter-container deps via .container, not raw .service names
- WantedBy=default.target only (per thmo)
- bump PostgreSQL to 18-alpine, mount volume at /var/lib/postgresql
- pin server image to :2026.8, postgres to :18-alpine (no :latest)
- add rootless variants of every podman/systemctl/journalctl command via Tabs (commands previously assumed rootful)
- shift worker to AUTHENTIK_LISTEN__HTTP=9001 and AUTHENTIK_LISTEN__METRICS=9301 so it can co-exist with server in the pod
- replace the single sysctl workaround for privileged ports with a menu: reverse proxy/LB, firewall port-forward, socket activation, unprivileged port floor (linking the tangentsoft discussion)
- add an Upgrading section that uses AutoUpdate=registry + podman-auto-update.timer; keep the manual pinned-tag flow
- use dewi-tik's verbatim lazy-pull wording
- drop the off-topic PG password-length admonition

docker.md Podman section:
- rewrite around the candidate-list framing in tasks.py:192-214: the worker scans /var/run/docker.sock, /run/podman/podman.sock, and XDG_RUNTIME_DIR/podman/podman.sock inside the container, so mounting the socket at its native path is enough
- drop the "no code changes" mention and the trailing em-dash clause
- drop the deployment paragraph (cross-link, historical fallback, and DOCKER_HOST workaround) - those live in the install guide
- state version concretely (2026.8) instead of "onwards"
- clarify rootful vs rootless socket paths up-front

docker-compose.mdx:
- trim em-dash clause from the Quadlet admonition
- revert unrelated edit to the PostgreSQL password info heading

v2026.8.md:
- reframe the bullet as "Podman support" calling out both the new install guide and the socket auto-detection

<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ IMPORTANT: Make sure you are opening this PR from a FEATURE BRANCH, not from your main branch!
If you opened this PR from your main branch, please close it and create a new feature branch instead.
For more information, see: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->
REPLACE ME

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
