### PR TITLE
website/docs: clarify Google Workspace signed response setting

### DIFF
--- a/website/docs/users-sources/sources/social-logins/google/workspace/index.md
+++ b/website/docs/users-sources/sources/social-logins/google/workspace/index.md
@@ -74,6 +74,7 @@ authentik is acting as both a Service Provider (SP) to Google and an Identity Pr
     - Set **ACS URL** to `https://authentik.company/source/saml/<google-slug>/acs/`.
     - Set **Entity ID** to `https://authentik.company/source/saml/<google-slug>/metadata/`.
     - Set **Start URL** to `https://authentik.company`.
+    - Enable **Signed response**.
     - Set **Name ID format** to `EMAIL`.
     - Set **Name ID** to `Basic Information > Primary Email`.
 2. Click **Continue**.
@@ -112,8 +113,8 @@ authentik is acting as both a Service Provider (SP) to Google and an Identity Pr
     - Set **SSO URL** to the SSO URL from Google Workspace.
     - Set **Issuer** to `https://authentik.company/source/saml/<google-slug>/metadata/`.
     - Set **Verification Certificate** to the Google Workspace certificate you uploaded earlier.
-      :::warning Disable Verify Assertion Signature
-      If you do not disable the following option, your integration with Google Workspace will not work.
+      :::warning Signed response required
+      These verification settings expect Google Workspace to sign the SAML response. Make sure **Signed response** is enabled in the Google Workspace SAML app.
       :::
     - Disable **Verify Assertion Signature**.
     - Enable **Verify Response Signature**.
@@ -133,6 +134,7 @@ For instructions on embedding the new source within a flow, such as an authoriza
 
 - **`403 app_not_configured_for_user`**: Ensure the Entity ID matches between Google Workspace and authentik. The Entity ID must be identical in both configurations.
 - **`403 app_not_enabled_for_user`**: Enable the application for your organization in the Google Workspace Admin Console under **Apps** > **Web and mobile apps**.
+- **`Expected exactly one Signature in the Response element`**: Enable **Signed response** in the Google Workspace Admin Console under **Apps** > **Web and mobile apps** > your SAML app, for example `authentik`. If this option is disabled, Google Workspace signs only the SAML assertion instead of the outer SAML response.
 
 ## Resources
 


### PR DESCRIPTION
Closes #22811 

## Details

Clarifies the Google Workspace SAML setup guide by explicitly instructing users to enable **Signed response** in the Google Workspace SAML app.

The documented authentik SAML Source settings use response signature verification:

```text
Verify Assertion Signature: disabled
Verify Response Signature: enabled
````

This requires Google Workspace to sign the outer SAML response. Google Workspace custom SAML apps leave **Signed response** disabled by default; when disabled, Google signs only the SAML assertion instead. This can cause authentik to fail response signature verification with:

```text
Expected exactly one Signature in the Response element
```

This PR adds **Signed response** to the Google Workspace Service Provider details, updates the existing warning in the authentik SAML Source configuration section, and adds a troubleshooting note for the response signature error.

## Testing

Tested the documented configuration manually with:

```text
Google Workspace Signed response: enabled
authentik Verify Assertion Signature: disabled
authentik Verify Response Signature: enabled
```

Login succeeded with this configuration.

I did not run the local docs build because my local Windows environment does not currently have `make` available; I will rely on CI and fix any formatting/build issues if they appear.

---

## Checklist

* [ ] Local tests pass (`ak test authentik/`)
* [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

* [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

* [ ] The code has been formatted (`make web`)

If applicable

* [x] The documentation has been updated
* [ ] The documentation has been formatted (`make docs`)