### PR TITLE
core, internal, packages: fix British spellings flagged by cspell

### DIFF
--- a/authentik/core/templates/base/skeleton.html
+++ b/authentik/core/templates/base/skeleton.html
@@ -12,7 +12,7 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-        {# Darkreader breaks the site regardless of theme as its not compatible with webcomponents, and we default to a dark theme based on preferred colour-scheme #}
+        {# Darkreader breaks the site regardless of theme as its not compatible with webcomponents, and we default to a dark theme based on preferred color-scheme #}
         <meta name="darkreader-lock">
         <title>{% block title %}{% trans title|default:brand.branding_title %}{% endblock %}</title>
         <link rel="icon" href="{{ brand.branding_favicon_url }}">

--- a/authentik/flows/views/executor.py
+++ b/authentik/flows/views/executor.py
@@ -196,7 +196,7 @@ class FlowExecutorView(APIView):
                     return self.handle_invalid_flow(exc)
                 except EmptyFlowException as exc:
                     self._logger.warning("f(exec): Flow is empty", exc=exc)
-                    # To match behaviour with loading an empty flow plan from cache,
+                    # To match behavior with loading an empty flow plan from cache,
                     # we don't show an error message here, but rather call _flow_done()
                     return self._flow_done()
             # We don't save the Plan after getting the next stage

--- a/authentik/lib/avatars.py
+++ b/authentik/lib/avatars.py
@@ -59,7 +59,7 @@ def avatar_mode_gravatar(user: User, mode: str) -> str | None:
 
 
 def generate_colors(text: str) -> tuple[str, str]:
-    """Generate colours based on `text`"""
+    """Generate colors based on `text`"""
     color = (
         int(md5(text.lower().encode("utf-8"), usedforsecurity=False).hexdigest(), 16) % 0xFFFFFF
     )  # nosec

--- a/authentik/providers/ldap/api.py
+++ b/authentik/providers/ldap/api.py
@@ -91,7 +91,7 @@ class LDAPOutpostConfigSerializer(ModelSerializer):
     unbind_flow_slug = SerializerMethodField()
 
     def get_application_slug(self, instance: LDAPProvider) -> str:
-        """Prioritise backchannel slug over direct application slug"""
+        """Prioritize backchannel slug over direct application slug"""
         if instance.backchannel_application:
             return instance.backchannel_application.slug
         return instance.application.slug

--- a/authentik/rbac/permissions.py
+++ b/authentik/rbac/permissions.py
@@ -22,7 +22,7 @@ class ObjectPermissions(DjangoObjectPermissions):
         lookup = getattr(view, "lookup_url_kwarg", None) or getattr(view, "lookup_field", None)
         if lookup and lookup in view.kwargs:
             return True
-        # Legacy behaviour:
+        # Legacy behavior:
         # Allow creation of objects even without explicit permission
         queryset = self._queryset(view)
         required_perms = self.get_required_permissions(request.method, queryset.model)

--- a/authentik/sources/oauth/types/github.py
+++ b/authentik/sources/oauth/types/github.py
@@ -76,7 +76,7 @@ class GitHubType(SourceType):
         chosen_email = info.get("email")
         if not chosen_email:
             # The GitHub Userprofile API only returns an email address if the profile
-            # has a public email address set (despite us asking for user:email, this behaviour
+            # has a public email address set (despite us asking for user:email, this behavior
             # doesn't change.). So we fetch all the user's email addresses
             emails = client.get_github_emails(token)
             for email in emails:

--- a/authentik/stages/authenticator/models.py
+++ b/authentik/stages/authenticator/models.py
@@ -291,7 +291,7 @@ class VerifyNotAllowed:
 
 class ThrottlingMixin(models.Model):
     """
-    Mixin class for models that want throttling behaviour.
+    Mixin class for models that want throttling behavior.
 
     This implements exponential back-off for verifying tokens. Subclasses must
     implement :meth:`get_throttle_factor`, and must use the

--- a/authentik/stages/authenticator_sms/tests.py
+++ b/authentik/stages/authenticator_sms/tests.py
@@ -362,7 +362,7 @@ class AuthenticatorSMSStageTests(FlowTestCase):
 
 
 class TestSMSDeviceThrottling(ThrottlingTestMixin, TestCase):
-    """Test ThrottlingMixin behaviour on SMSDevice.verify_token"""
+    """Test ThrottlingMixin behavior on SMSDevice.verify_token"""
 
     def setUp(self):
         super().setUp()

--- a/authentik/stages/invitation/stage.py
+++ b/authentik/stages/invitation/stage.py
@@ -18,7 +18,7 @@ PLAN_CONTEXT_INVITATION = "invitation"
 
 
 class InvitationStageView(StageView):
-    """Finalise Authentication flow by logging the user in"""
+    """Finalize Authentication flow by logging the user in"""
 
     def get_token(self) -> str | None:
         """Get token from saved get-arguments or prompt_data"""

--- a/authentik/stages/user_delete/stage.py
+++ b/authentik/stages/user_delete/stage.py
@@ -10,7 +10,7 @@ from authentik.flows.stage import StageView
 
 
 class UserDeleteStageView(StageView):
-    """Finalise unenrollment flow by deleting the user object."""
+    """Finalize unenrollment flow by deleting the user object."""
 
     def dispatch(self, request: HttpRequest) -> HttpResponse:
         """Delete currently pending user"""

--- a/authentik/stages/user_login/stage.py
+++ b/authentik/stages/user_login/stage.py
@@ -50,7 +50,7 @@ class UserLoginChallengeResponse(ChallengeResponse):
 
 
 class UserLoginStageView(ChallengeStageView):
-    """Finalise Authentication flow by logging the user in"""
+    """Finalize Authentication flow by logging the user in"""
 
     response_class = UserLoginChallengeResponse
 

--- a/authentik/stages/user_write/stage.py
+++ b/authentik/stages/user_write/stage.py
@@ -30,7 +30,7 @@ PLAN_CONTEXT_USER_PATH = "user_path"
 
 
 class UserWriteStageView(StageView):
-    """Finalise Enrollment flow by creating a user object."""
+    """Finalize Enrollment flow by creating a user object."""
 
     def __init__(self, executor: FlowExecutorView, **kwargs):
         super().__init__(executor, **kwargs)

--- a/internal/outpost/ak/api.go
+++ b/internal/outpost/ak/api.go
@@ -55,7 +55,7 @@ type APIController struct {
 	instanceUUID uuid.UUID
 }
 
-// NewAPIController initialise new API Controller instance from URL and API token
+// NewAPIController initialize new API Controller instance from URL and API token
 func NewAPIController(akURL url.URL, token string) *APIController {
 	rsp := sentry.StartSpan(context.Background(), "authentik.outposts.init")
 	log := log.WithField("logger", "authentik.outpost.ak-api-controller")

--- a/internal/outpost/ak/global.go
+++ b/internal/outpost/ak/global.go
@@ -60,7 +60,7 @@ func doGlobalSetup(outpost api.Outpost, globalConfig *api.Config) {
 				},
 			})
 			if err != nil {
-				l.WithField("env", globalConfig.ErrorReporting.Environment).WithError(err).Warning("Failed to initialise sentry")
+				l.WithField("env", globalConfig.ErrorReporting.Environment).WithError(err).Warning("Failed to initialize sentry")
 			}
 		}
 	}

--- a/internal/outpost/ldap/bind/direct/direct.go
+++ b/internal/outpost/ldap/bind/direct/direct.go
@@ -24,7 +24,7 @@ func NewDirectBinder(si server.LDAPServerInstance) *DirectBinder {
 		si:  si,
 		log: log.WithField("logger", "authentik.outpost.ldap.binder.direct"),
 	}
-	db.log.Info("initialised direct binder")
+	db.log.Info("initialized direct binder")
 	return db
 }
 

--- a/internal/outpost/ldap/bind/memory/memory.go
+++ b/internal/outpost/ldap/bind/memory/memory.go
@@ -32,14 +32,14 @@ func NewSessionBinder(si server.LDAPServerInstance, oldBinder bind.Binder) *Sess
 		if oldSb, ok := oldBinder.(*SessionBinder); ok {
 			sb.DirectBinder = oldSb.DirectBinder
 			sb.sessions = oldSb.sessions
-			sb.log.Debug("re-initialised session binder")
+			sb.log.Debug("re-initialized session binder")
 			return sb
 		}
 	}
 	sb.sessions = ttlcache.New(ttlcache.WithDisableTouchOnHit[Credentials, ldap.LDAPResultCode]())
 	sb.DirectBinder = *direct.NewDirectBinder(si)
 	go sb.sessions.Start()
-	sb.log.Debug("initialised session binder")
+	sb.log.Debug("initialized session binder")
 	return sb
 }
 

--- a/internal/outpost/ldap/search/memory/memory.go
+++ b/internal/outpost/ldap/search/memory/memory.go
@@ -42,12 +42,12 @@ func NewMemorySearcher(si server.LDAPServerInstance, existing search.Searcher) *
 		if ems, ok := existing.(*MemorySearcher); ok {
 			ems.si = si
 			ems.fetch()
-			ems.log.Debug("re-initialised memory searcher")
+			ems.log.Debug("re-initialized memory searcher")
 			return ems
 		}
 	}
 	ms.fetch()
-	ms.log.Debug("initialised memory searcher")
+	ms.log.Debug("initialized memory searcher")
 	return ms
 }
 

--- a/packages/ak-common/src/arbiter.rs
+++ b/packages/ak-common/src/arbiter.rs
@@ -210,7 +210,7 @@ impl Arbiter {
     /// Consumers listening on this must also listen on [`Arbiter::graceful_shutdown`], as only one
     /// of those is set upon shutdown.
     ///
-    /// It is also possible to use [`Arbiter::shutdown`] when the behaviour is the same between a
+    /// It is also possible to use [`Arbiter::shutdown`] when the behavior is the same between a
     /// fast and a graceful shutdown.
     pub fn fast_shutdown(&self) -> WaitForCancellationFuture<'_> {
         self.fast_shutdown.cancelled()
@@ -221,7 +221,7 @@ impl Arbiter {
     /// Consumers listening on this must also listen on [`Arbiter::fast_shutdown`], as only one
     /// of those is set upon shutdown.
     ///
-    /// It is also possible to use [`Arbiter::shutdown`] when the behaviour is the same between a
+    /// It is also possible to use [`Arbiter::shutdown`] when the behavior is the same between a
     /// fast and a graceful shutdown.
     pub fn graceful_shutdown(&self) -> WaitForCancellationFuture<'_> {
         self.graceful_shutdown.cancelled()

--- a/packages/client-go/model_ldap_outpost_config.go
+++ b/packages/client-go/model_ldap_outpost_config.go
@@ -28,7 +28,7 @@ type LDAPOutpostConfig struct {
 	BindFlowSlug string  `json:"bind_flow_slug"`
 	// Get slug for unbind flow, defaulting to brand's default flow.
 	UnbindFlowSlug NullableString `json:"unbind_flow_slug"`
-	// Prioritise backchannel slug over direct application slug
+	// Prioritize backchannel slug over direct application slug
 	ApplicationSlug string         `json:"application_slug"`
 	Certificate     NullableString `json:"certificate,omitempty"`
 	TlsServerName   *string        `json:"tls_server_name,omitempty"`

--- a/packages/client-rust/src/models/ldap_outpost_config.rs
+++ b/packages/client-rust/src/models/ldap_outpost_config.rs
@@ -25,7 +25,7 @@ pub struct LdapOutpostConfig {
     /// Get slug for unbind flow, defaulting to brand's default flow.
     #[serde(rename = "unbind_flow_slug", deserialize_with = "Option::deserialize")]
     pub unbind_flow_slug: Option<String>,
-    /// Prioritise backchannel slug over direct application slug
+    /// Prioritize backchannel slug over direct application slug
     #[serde(rename = "application_slug")]
     pub application_slug: String,
     #[serde(

--- a/packages/client-ts/src/models/LDAPOutpostConfig.ts
+++ b/packages/client-ts/src/models/LDAPOutpostConfig.ts
@@ -52,7 +52,7 @@ export interface LDAPOutpostConfig {
      */
     readonly unbindFlowSlug: string | null;
     /**
-     * Prioritise backchannel slug over direct application slug
+     * Prioritize backchannel slug over direct application slug
      * @type {string}
      * @memberof LDAPOutpostConfig
      */

--- a/schema.yml
+++ b/schema.yml
@@ -41922,7 +41922,7 @@ components:
           readOnly: true
         application_slug:
           type: string
-          description: Prioritise backchannel slug over direct application slug
+          description: Prioritize backchannel slug over direct application slug
           readOnly: true
         certificate:
           type: string


### PR DESCRIPTION
Part of enabling a cspell rule that rejects British spellings in favor of American variants.

This PR fixes the **backend** (`@goauthentik/backend`) portion: 18 files across `authentik/` (Python docstrings/comments, a Django template comment), `internal/` (Go log messages), and `packages/ak-common/` (a Rust doc comment) — `behaviour`→`behavior`, `initialise`→`initialize`, `finalise`→`finalize`, etc. Comments/strings only, no identifier or behavior changes.

### Merge order
This is one of three independent cleanup PRs (docs / backend / frontend). They can merge in any order. The PR that actually **activates** the cspell rule (#ENABLE) must merge **last**, after all three cleanups land, or CI will fail on pre-existing British spellings.


## Related PRs

- #22818
- #22821

