### PR TITLE
web: fix British spellings flagged by cspell

### DIFF
--- a/web/src/admin/admin-settings/AdminSettingsForm.ts
+++ b/web/src/admin/admin-settings/AdminSettingsForm.ts
@@ -277,7 +277,7 @@ export class AdminSettingsForm extends Form<SettingsRequest> {
             <ak-form-group
                 label=${msg("Flags")}
                 description=${msg(
-                    "Flags allow you to enable new functionality and behaviour in authentik early.",
+                    "Flags allow you to enable new functionality and behavior in authentik early.",
                 )}
             >
                 <div class="pf-c-form">

--- a/web/src/admin/enterprise/EnterpriseStatusCard.ts
+++ b/web/src/admin/enterprise/EnterpriseStatusCard.ts
@@ -31,7 +31,7 @@ export class EnterpriseStatusCard extends AKElement {
             case LicenseSummaryStatusEnum.ExpirySoon:
                 return html`<ak-label color=${PFColor.Orange}>${msg("Expiring soon")}</ak-label>`;
             case LicenseSummaryStatusEnum.Unlicensed:
-                return html`<ak-label color=${PFColor.Grey}>${msg("Unlicensed")}</ak-label>`;
+                return html`<ak-label color=${PFColor.Gray}>${msg("Unlicensed")}</ak-label>`;
             case LicenseSummaryStatusEnum.ReadOnly:
                 return html`<ak-label color=${PFColor.Red}>${msg("Read Only")}</ak-label>`;
             case LicenseSummaryStatusEnum.Valid:

--- a/web/src/admin/events/DataExportListPage.ts
+++ b/web/src/admin/events/DataExportListPage.ts
@@ -87,7 +87,7 @@ export class DataExportListPage extends TablePage<DataExport> {
             Timestamp(item.requestedOn),
             html`${item.completed
                 ? html`<ak-label color=${PFColor.Green}>${msg("Finished")}</ak-label>`
-                : html`<ak-label color=${PFColor.Grey}>${msg("Queued")}</ak-label>`}`,
+                : html`<ak-label color=${PFColor.Gray}>${msg("Queued")}</ak-label>`}`,
             item.completed && item.fileUrl
                 ? html`<div>
                       <a href="${item.fileUrl}">

--- a/web/src/admin/lifecycle/utils.ts
+++ b/web/src/admin/lifecycle/utils.ts
@@ -28,7 +28,7 @@ export const LifecycleIterationStatus: LitFC<LifecycleIterationStatusProps> = ({
         )
         .with(
             LifecycleIterationStateEnum.Canceled,
-            () => html`<ak-label color=${PFColor.Grey}>${msg("Canceled")}</ak-label>`,
+            () => html`<ak-label color=${PFColor.Gray}>${msg("Canceled")}</ak-label>`,
         )
-        .otherwise(() => html`<ak-label color=${PFColor.Grey}>${msg("Unknown")}</ak-label>`);
+        .otherwise(() => html`<ak-label color=${PFColor.Gray}>${msg("Unknown")}</ak-label>`);
 };

--- a/web/src/admin/outposts/OutpostHealthSimple.ts
+++ b/web/src/admin/outposts/OutpostHealthSimple.ts
@@ -52,7 +52,7 @@ export class OutpostHealthSimpleElement extends AKElement {
             return html`<ak-spinner></ak-spinner>`;
         }
         if (!this.outpostHealths || this.outpostHealths.length === 0) {
-            return html`<ak-label color=${PFColor.Grey}>${msg("Not available")}</ak-label>`;
+            return html`<ak-label color=${PFColor.Gray}>${msg("Not available")}</ak-label>`;
         }
         const outdatedOutposts = this.outpostHealths.filter((h) => h.versionOutdated);
         if (outdatedOutposts.length > 0) {

--- a/web/src/admin/sources/SourceListPage.ts
+++ b/web/src/admin/sources/SourceListPage.ts
@@ -100,7 +100,7 @@ export class SourceListPage extends TablePage<Source> {
         return [
             html`<div>
                 <div>${item.name}</div>
-                <ak-label color=${PFColor.Grey} compact> ${msg("Built-in")}</ak-label>
+                <ak-label color=${PFColor.Gray} compact> ${msg("Built-in")}</ak-label>
             </div>`,
             html`${msg("Built-in")}`,
             nothing,

--- a/web/src/components/ak-status-label.ts
+++ b/web/src/components/ak-status-label.ts
@@ -34,8 +34,8 @@ const statusToDetails = new Map<P4Disposition, [string, string]>([
  *
  * - type="error" (default): A Red ✖
  * - type="warning" An orange ⚠
- * - type="info" A grey ⓘ
- * - type="neutral" A grey ✖
+ * - type="info" A gray ⓘ
+ * - type="neutral" A gray ✖
  *
  * By default, the messages for "good" and "other" are "Yes" and "No" respectively, but these can be
  * customized with the attributes `good-label` and `bad-label`.

--- a/web/src/elements/Label.ts
+++ b/web/src/elements/Label.ts
@@ -14,7 +14,7 @@ export enum PFColor {
     Orange = "pf-m-orange",
     Red = "pf-m-red",
     Blue = "pf-m-blue",
-    Grey = "",
+    Gray = "",
 }
 
 export const levelNames = ["warning", "info", "success", "danger"];
@@ -26,7 +26,7 @@ const chromeList: Chrome[] = [
     ["warning", PFColor.Orange, "pf-m-orange", "fa-exclamation-triangle"],
     ["success", PFColor.Green, "pf-m-green", "fa-check"],
     ["running", PFColor.Blue, "pf-m-blue", "fa-clock"],
-    ["info", PFColor.Grey, "pf-m-grey", "fa-info-circle"],
+    ["info", PFColor.Gray, "pf-m-grey", "fa-info-circle"],
 ];
 
 export interface ILabel {
@@ -38,7 +38,7 @@ export interface ILabel {
 @customElement("ak-label")
 export class Label extends AKElement implements ILabel {
     @property()
-    color: PFColor = PFColor.Grey;
+    color: PFColor = PFColor.Gray;
 
     @property()
     icon?: string;

--- a/web/src/elements/charts/Chart.ts
+++ b/web/src/elements/charts/Chart.ts
@@ -41,8 +41,8 @@ Chart.register(LineController, BarController, DoughnutController);
 Chart.register(ArcElement, BarElement, PointElement, LineElement);
 Chart.register(TimeScale, TimeSeriesScale, LinearScale, Filler);
 
-export const FONT_COLOUR_DARK_MODE = "#fafafa";
-export const FONT_COLOUR_LIGHT_MODE = "#151515";
+export const FONT_COLOR_DARK_MODE = "#fafafa";
+export const FONT_COLOR_LIGHT_MODE = "#151515";
 
 export abstract class AKChart<T> extends AKElement {
     public role = "figure";
@@ -59,7 +59,7 @@ export abstract class AKChart<T> extends AKElement {
     @property()
     centerText?: string;
 
-    fontColour = FONT_COLOUR_LIGHT_MODE;
+    fontColor = FONT_COLOR_LIGHT_MODE;
 
     static styles: CSSResult[] = [
         css`
@@ -91,9 +91,9 @@ export abstract class AKChart<T> extends AKElement {
         this.addEventListener(EVENT_REFRESH, this.refreshHandler);
         this.addEventListener(ThemeChangeEvent.eventName, ((ev: CustomEvent<UiThemeEnum>) => {
             if (ev.detail === UiThemeEnum.Light) {
-                this.fontColour = FONT_COLOUR_LIGHT_MODE;
+                this.fontColor = FONT_COLOR_LIGHT_MODE;
             } else {
-                this.fontColour = FONT_COLOUR_DARK_MODE;
+                this.fontColor = FONT_COLOR_DARK_MODE;
             }
             this.chart?.update();
         }) as EventListener);

--- a/web/src/elements/tasks/TaskStatus.ts
+++ b/web/src/elements/tasks/TaskStatus.ts
@@ -22,7 +22,7 @@ export class TaskStatus extends AKElement {
         switch (this.status) {
             case TaskAggregatedStatusEnum.Queued:
             case LastTaskStatusEnum.Queued:
-                return html`<ak-label color=${PFColor.Grey}>${msg("Waiting to run")}</ak-label>`;
+                return html`<ak-label color=${PFColor.Gray}>${msg("Waiting to run")}</ak-label>`;
             case TaskAggregatedStatusEnum.Consumed:
             case LastTaskStatusEnum.Consumed:
                 return html`<ak-label color=${PFColor.Blue}>${msg("Consumed")}</ak-label>`;
@@ -49,7 +49,7 @@ export class TaskStatus extends AKElement {
             case LastTaskStatusEnum.Error:
                 return html`<ak-label color=${PFColor.Red}>${msg("Error")}</ak-label>`;
             default:
-                return html`<ak-label color=${PFColor.Grey}>${msg("Unknown")}</ak-label>`;
+                return html`<ak-label color=${PFColor.Gray}>${msg("Unknown")}</ak-label>`;
         }
     }
 }


### PR DESCRIPTION
Part of enabling a cspell rule that rejects British spellings in favor of American variants.

This PR fixes the **frontend** (`@goauthentik/frontend`) portion: 10 files under `web/`.

- Renames the `PFColor.Grey` enum member to `Gray` (all references updated) and the `FONT_COLOUR_*` / `fontColour` chart identifiers to `FONT_COLOR_*` / `fontColor`.
- PatternFly's upstream `pf-m-grey` CSS class string is intentionally left unchanged.
- American spellings in comments and one UI label string.

`tsc --noEmit` passes; renames are self-contained within `web/`.

### Merge order
This is one of three independent cleanup PRs (docs / backend / frontend). They can merge in any order. The PR that actually **activates** the cspell rule (#ENABLE) must merge **last**, after all three cleanups land, or CI will fail on pre-existing British spellings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)