### PR TITLE
enterprise/providers/scim: fix interactive OAuth overriding refresh_token

### DIFF
--- a/authentik/enterprise/providers/scim/auth_oauth2.py
+++ b/authentik/enterprise/providers/scim/auth_oauth2.py
@@ -74,7 +74,7 @@ class SCIMOAuthAuth:
             user=self.user,
             defaults={
                 "access_token": access_token,
-                "refresh_token": token.get("refresh_token"),
+                "refresh_token": token.get("refresh_token") or conn.refresh_token,
                 "expires": now() + timedelta(seconds=expires_in),
                 # When using `update_or_create`, `last_updated` is not updated
                 "last_updated": now(),

--- a/authentik/enterprise/providers/scim/auth_oauth2.py
+++ b/authentik/enterprise/providers/scim/auth_oauth2.py
@@ -68,13 +68,16 @@ class SCIMOAuthAuth:
             return conn
         token = self.retrieve_token(conn)
         access_token = token["access_token"]
+        refresh_token = token.get("refresh_token")
+        if not refresh_token and conn:
+            refresh_token = conn.refresh_token
         expires_in = int(token.get("expires_in", 0))
         token, _ = UserOAuthSourceConnection.objects.update_or_create(
             source=self.provider.auth_oauth,
             user=self.user,
             defaults={
                 "access_token": access_token,
-                "refresh_token": token.get("refresh_token") or conn.refresh_token,
+                "refresh_token": refresh_token,
                 "expires": now() + timedelta(seconds=expires_in),
                 # When using `update_or_create`, `last_updated` is not updated
                 "last_updated": now(),

--- a/authentik/enterprise/providers/scim/tests/test_token.py
+++ b/authentik/enterprise/providers/scim/tests/test_token.py
@@ -104,6 +104,7 @@ class TestSCIMOAuthToken(APITestCase):
             source=self.source,
             user=self.provider.auth_oauth_user,
         ).first()
+        self.assertEqual(conn.refresh_token, refresh_token)
         self.assertIsNotNone(conn)
         self.assertTrue(conn.is_valid)
         auth = (


### PR DESCRIPTION
we incorrectly assumed that renewing the access token would always give us a new refresh token, which isn't the case