### PR TITLE
ci: remove redundant if in cherry-pick action

### DIFF
--- a/.github/actions/cherry-pick/action.yml
+++ b/.github/actions/cherry-pick/action.yml
@@ -134,12 +134,7 @@ runs:
 
         # Determine which labels to process
         if [ "${REASON}" = "label_added_to_merged_pr" ]; then
-          # Only process the specific label that was just added
-          if [ "$EVENT_NAME" = "issues" ]; then
-            LABEL_NAME="$LABEL_NAME_CTX"
-          else
-            LABEL_NAME="$LABEL_NAME_CTX"
-          fi
+          LABEL_NAME="$LABEL_NAME_CTX"
 
           if [[ "$LABEL_NAME" =~ ^backport/(.+)$ ]]; then
             echo "labels=$LABEL_NAME" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Remove redundant `if` clause. Noticed in https://github.com/goauthentik/authentik/pull/22828#discussion_r3350547257

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
