### PR TITLE
website/docs: Document WebAuthn device restrictions

### DIFF
--- a/website/docs/add-secure-apps/flows-stages/stages/authenticator_validate/index.md
+++ b/website/docs/add-secure-apps/flows-stages/stages/authenticator_validate/index.md
@@ -129,7 +129,11 @@ If the user has multiple compatible authenticators, authentik lets them choose o
 
 ### WebAuthn authenticator type restrictions
 
-If you restrict allowed WebAuthn authenticator types, those restrictions only apply to WebAuthn authenticators that authentik knows how to classify. This is useful when you need to limit authentication to specific hardware families or compliance profiles.
+**WebAuthn device type restrictions** are an allowlist for already-enrolled WebAuthn authenticators. When no device types are selected, any enrolled WebAuthn authenticator that matches the stage's **Device classes** can be used. When one or more device types are selected, authentik only allows WebAuthn authentication from enrolled devices whose recorded device type matches one of the selected entries.
+
+The available device-type entries are populated from the FIDO Alliance Metadata Service data and additional AAGUID metadata bundled with the authentik release. This is useful when you need to limit authentication to specific hardware families or compliance profiles.
+
+These restrictions only apply to WebAuthn devices that have a stored device type. Devices enrolled in authentik 2024.4 or later store this information when the authenticator returns a known AAGUID. Older WebAuthn enrollments or devices without a stored type cannot be matched by this filter. To enforce a device-type policy for enrollment and later authentication, configure the same allowlist on the [WebAuthn / FIDO2 / Passkeys Authenticator setup stage](../authenticator_webauthn/index.md) and have users re-enroll devices that predate stored device types.
 
 ### Throttling
 

--- a/website/docs/add-secure-apps/flows-stages/stages/authenticator_validate/index.md
+++ b/website/docs/add-secure-apps/flows-stages/stages/authenticator_validate/index.md
@@ -131,7 +131,7 @@ If the user has multiple compatible authenticators, authentik lets them choose o
 
 **WebAuthn device type restrictions** are an allowlist for already-enrolled WebAuthn authenticators. When no device types are selected, any enrolled WebAuthn authenticator that matches the stage's **Device classes** can be used. When one or more device types are selected, authentik only allows WebAuthn authentication from enrolled devices whose recorded device type matches one of the selected entries.
 
-The available device-type entries are populated from the FIDO Alliance Metadata Service data and additional AAGUID metadata bundled with the authentik release. This is useful when you need to limit authentication to specific hardware families or compliance profiles.
+The available device-type entries are populated from the [FIDO Alliance Metadata Service](https://fidoalliance.org/metadata/) data and additional AAGUID metadata bundled with the authentik release. This is useful when you need to limit authentication to specific hardware families or compliance profiles.
 
 These restrictions only apply to WebAuthn devices that have a stored device type. Devices enrolled in authentik 2024.4 or later store this information when the authenticator returns a known AAGUID. Older WebAuthn enrollments or devices without a stored type cannot be matched by this filter. To enforce a device-type policy for enrollment and later authentication, configure the same allowlist on the [WebAuthn / FIDO2 / Passkeys Authenticator setup stage](../authenticator_webauthn/index.md) and have users re-enroll devices that predate stored device types.
 

--- a/website/docs/add-secure-apps/flows-stages/stages/authenticator_webauthn/index.md
+++ b/website/docs/add-secure-apps/flows-stages/stages/authenticator_webauthn/index.md
@@ -80,4 +80,12 @@ For backward compatibility with older browsers that do not support hints, authen
 
 **Prevent duplicate devices** can only be enforced when the authenticator exposes a unique attestation certificate.
 
-If **Device type restrictions** are enabled, authentik can also allow the special built-in type `authentik: Unknown devices` for authenticators whose AAGUID is not otherwise known.
+### Device type restrictions
+
+**Device type restrictions** are an allowlist for WebAuthn registration. When no device types are selected, authentik allows any WebAuthn authenticator that the browser and authenticator can register. When one or more device types are selected, authentik only allows registration when the authenticator returns an AAGUID that matches one of the selected entries.
+
+The available device-type entries are populated from the FIDO Alliance Metadata Service data and additional AAGUID metadata bundled with the authentik release. This lets you restrict enrollment to specific hardware families or passkey providers listed in that metadata.
+
+If you select specific device types, newly added metadata entries are not allowed automatically. Review this allowlist after authentik upgrades if your compliance policy should include newly recognized authenticators.
+
+authentik also includes the special built-in type `authentik: Unknown devices`. Select it only when you want to allow authenticators that return an AAGUID that is not present in authentik's device-type metadata. Authenticators that do not return an AAGUID cannot satisfy a device-type restriction.

--- a/website/docs/add-secure-apps/flows-stages/stages/authenticator_webauthn/index.md
+++ b/website/docs/add-secure-apps/flows-stages/stages/authenticator_webauthn/index.md
@@ -84,8 +84,8 @@ For backward compatibility with older browsers that do not support hints, authen
 
 **Device type restrictions** are an allowlist for WebAuthn registration. When no device types are selected, authentik allows any WebAuthn authenticator that the browser and authenticator can register. When one or more device types are selected, authentik only allows registration when the authenticator returns an AAGUID that matches one of the selected entries.
 
-The available device-type entries are populated from the FIDO Alliance Metadata Service data and additional AAGUID metadata bundled with the authentik release. This lets you restrict enrollment to specific hardware families or passkey providers listed in that metadata.
+The available device-type entries are populated from the [FIDO Alliance Metadata Service](https://fidoalliance.org/metadata/) data and additional AAGUID metadata bundled with the authentik release. This lets you restrict enrollment to specific hardware families or passkey providers listed in that metadata.
 
 If you select specific device types, newly added metadata entries are not allowed automatically. Review this allowlist after authentik upgrades if your compliance policy should include newly recognized authenticators.
 
-authentik also includes the special built-in type `authentik: Unknown devices`. Select it only when you want to allow authenticators that return an AAGUID that is not present in authentik's device-type metadata. Authenticators that do not return an AAGUID cannot satisfy a device-type restriction.
+authentik also includes the special device-type `authentik: Unknown devices`. Select it only when you want to allow authenticators that return an AAGUID that is not present in authentik's device-type metadata. Authenticators that do not return an AAGUID cannot satisfy a device-type restriction.


### PR DESCRIPTION
## Details

Clarifies that WebAuthn device type restrictions are allowlists for registration and authentication, backed by FIDO Alliance Metadata Service data and bundled AAGUID metadata.

Documents the behavior for newly recognized device types, `authentik: Unknown devices`, authenticators without AAGUIDs, and older enrollments without stored device-type data.

Closes #22230

## Validation

- `make docs`
