### PR TITLE
website/integrations: fix Node-RED OIDC username docs

### DIFF
--- a/website/integrations/development/node-red/index.md
+++ b/website/integrations/development/node-red/index.md
@@ -82,9 +82,6 @@ adminAuth: {
                         callbackURL: 'https://nodered.company/auth/strategy/callback/',
                         scope: ['email', 'profile', 'openid'],
                         proxy: true,
-                        verify: function(context, issuer, profile, done) {
-                                return done(null, profile);
-                        },
                 }
         },
         users: function(user) {


### PR DESCRIPTION
## Summary
Remove the custom Node-RED `verify` callback from the integration sample so Node-RED and Passport use the parsed OpenID Connect profile normally.

Closes #22689

## Validation
- `make integrations`
- `git diff --check`