### PR TITLE
website/docs: update binding wizard labels

### DIFF
--- a/website/docs/add-secure-apps/applications/manage_apps.mdx
+++ b/website/docs/add-secure-apps/applications/manage_apps.mdx
@@ -49,7 +49,7 @@ The most common ways to control access to an application by using bindings are:
 
 ### Policy-driven authorization
 
-To use a [policy](../../customize/policies/index.md) to control which users or groups can access an application, click on an application in the applications list, click the **Policy/Group/User Bindings** tab, and then select **Policy** from the **Policy/Group/User Bindings** options.
+To use a [policy](../../customize/policies/index.md) to control which users or groups can access an application, click an application in the applications list, open the **Policy / Group / User Bindings** tab, and click **Create or bind...**. You can then create a new policy and bind it to the application, or select **Bind an existing policy** under **Bind Existing...**.
 
 ### Bind a user or group to an application
 
@@ -57,11 +57,11 @@ You can bind a user or group to an application either when you create a new appl
 
 #### When creating an application and provider
 
-Follow the instructions for [creating a new application and provider](#create-an-application-and-provider-pair). On the **Policy/Group/User Bindings** tab at the top of the page, you can select **Group** or \*User\*\* to bind a specific group or userto the application.
+Follow the instructions for [creating a new application and provider](#create-an-application-and-provider-pair). On the **Configure Bindings** step, click **Bind existing policy/group/user**. Select **Group** or **User**, choose the group or user to bind to the application, configure any additional binding settings, and then click **Save Binding**.
 
 #### Add binding to an existing application
 
-To bind a user or group to an existing application, click on an application in the applications list, select **Group** or **User** from the **Policy/Group/User Bindings** options, and then select the group or user that you want to bind to the application.
+To bind a user or group to an existing application, click the application in the applications list, open the **Policy / Group / User Bindings** tab, and click **Create or bind...**. Under **Bind Existing...**, select **Bind a user** or **Bind a group**, choose the user or group to bind to the application, configure any additional binding settings, and then click **Create**.
 
 ## Application Entitlements
 
@@ -105,8 +105,8 @@ return {
 2. Click the name of the application for which you want to create an entitlement.
 3. Click the **Application entitlements** tab at the top of the page, and then click **New Entitlement**. Provide a name for the entitlement, enter any optional **Attributes**, and then click **Create**.
 4. In the list locate the entitlement to which you want to bind a user or group, and then **click the caret (>) to expand the entitlement details.**
-5. In the expanded area, click **Bind existing Group/User**.
-6. In the **New Binding** box, select either the tab for **Group** or **User**, and then in the drop-down list, select the group or user.
+5. In the expanded area, click **Bind existing group/user**.
+6. In the binding modal, select **Group** or **User**, and then select the group or user.
 7. Optionally, configure additional settings for the binding, and then click **Create** to create the binding and close the box.
 
 ## Hide applications

--- a/website/docs/add-secure-apps/providers/rac/rac_credentials_prompt.md
+++ b/website/docs/add-secure-apps/providers/rac/rac_credentials_prompt.md
@@ -55,7 +55,7 @@ You can optionally add other prompt fields such as `domain` (e.g. `connection_se
 1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Flows and Stages** > **Flows**.
 3. Click the name of the newly created authorization flow.
-4. Click on **Stage bindings**, click **New Stage**, and enter the following required settings:
+4. Click **Stage Bindings**, click **Create or bind...**, select **New Stage**, and enter the following required settings:
     - **Select Type**: Select `Prompt stage` as the prompt type.
     - **Create Prompt Stage**:
         - **Name**: Enter a name for the prompt stage.

--- a/website/docs/customize/policies/working_with_policies.md
+++ b/website/docs/customize/policies/working_with_policies.md
@@ -49,8 +49,8 @@ These bindings control which users can access a flow.
 1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Flows and Stages** > **Flows**.
 3. In the list of flows, click on the name of the flow to which you want to bind a policy.
-4. Click on the **Policy/Group/User Bindings** tab at the top of the page.
-5. Either create a new policy and bind it immediately with **Create and bind Policy**, or attach an existing policy, group, or user with **Bind existing policy/group/user**.
+4. Click on the **Policy / Group / User Bindings** tab at the top of the page.
+5. Click **Create or bind...**. You can then create a new policy and bind it to the flow, or select **Bind an existing policy** under **Bind Existing...**.
 
 ### Bind a policy to a stage binding
 
@@ -76,8 +76,8 @@ These bindings control which users or groups can access an application.
 1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications**.
 3. In the list of applications, click on the name of the application to which you want to bind a policy.
-4. Click on the **Policy/Group/User Bindings** tab at the top of the page.
-5. Either create and bind a new policy, or bind an existing policy, group, or user.
+4. Click on the **Policy / Group / User Bindings** tab at the top of the page.
+5. Click **Create or bind...**. You can then create a new policy and bind it to the application, or select **Bind an existing policy** under **Bind Existing...**.
 
 ### Bind a policy to a source
 

--- a/website/docs/sys-mgmt/events/notifications.md
+++ b/website/docs/sys-mgmt/events/notifications.md
@@ -61,7 +61,7 @@ After you've created the policies to match the events you want, create a notific
 
 4. In the list of notification rules, click the arrow in the row of the notification rule to expand the details of the rule.
 
-5. Click **Bind existing Policy/Group/User** and in the **Create Binding** modal, select the policy that you created for this notification rule and then click **Create Policy Binding** to finalize the binding.
+5. Click **Create or bind...**. Under **Bind Existing...**, select **Bind an existing policy**. In the **Create Binding** modal, select the policy that you created for this notification rule, and then click **Create** to finalize the binding.
 
 :::info
 Be aware that policies are executed even when no group is selected.


### PR DESCRIPTION
Refresh the remaining binding instructions to match the current Create or bind wizard labels and application binding flow. This covers application access bindings, policy binding docs, notification rule bindings, and the RAC prompt-stage flow.

Closes #22272

Validation:
- make docs