### PR TITLE
website/docs: remove stale SFE version badge

### DIFF
--- a/website/docs/add-secure-apps/flows-stages/flow/executors/sfe.md
+++ b/website/docs/add-secure-apps/flows-stages/flow/executors/sfe.md
@@ -1,6 +1,5 @@
 ---
 title: Simplified flow executor
-authentik_version: "2024.6.1"
 ---
 
 A simplified web-based flow executor that authentik automatically uses for older browsers that do not support modern web technologies.


### PR DESCRIPTION
```
⚠️ Outdated Markdown frontmatter for document `add-secure-apps/flows-stages/flow/executors/sfe`: To fix this error, remove `authentik_version: 2024.6.1` from the Markdown frontmatter:

 Semver version 2024.5 is older than 2 years. Error: Semver version 2024.5 is older than 2 years.
    at assertVersionSupported (/Users/dominic/Developer/goauthentik/authentik4/website/docs/build/__server/assets/js/17896441.40918d5c.js:7770:15)
    at VersionBadge (/Users/dominic/Developer/goauthentik/authentik4/website/docs/build/__server/assets/js/17896441.40918d5c.js:2933:108)
    at renderWithHooks (server.bundle.js:14683:18)
    at renderElement (server.bundle.js:14821:14)
    at retryNode (server.bundle.js:15539:16)
    at renderNodeDestructive (server.bundle.js:15333:7)
    at renderElement (server.bundle.js:14938:9)
    at retryNode (server.bundle.js:15539:16)
    at renderNodeDestructive (server.bundle.js:15333:7)
    at renderNode (server.bundle.js:15900:14)
```