### PR TITLE
lifecycle/quadlet: restore worker User=0:0 (round-4 reviewer retraction)

### DIFF
--- a/lifecycle/quadlet/authentik-worker.container
+++ b/lifecycle/quadlet/authentik-worker.container
@@ -9,6 +9,8 @@ Image=ghcr.io/goauthentik/server:2026.8.0-rc1
 AutoUpdate=registry
 Pod=authentik.pod
 Exec=worker
+# Run as root: the worker reads the root-owned podman/docker socket (mounted below) to deploy outposts; a non-root process can't.
+User=0:0
 EnvironmentFile=/etc/authentik/authentik.env
 Environment=AUTHENTIK_POSTGRESQL__HOST=localhost
 Environment=AUTHENTIK_POSTGRESQL__NAME=authentik

--- a/lifecycle/quadlet/rootless/authentik-worker.container
+++ b/lifecycle/quadlet/rootless/authentik-worker.container
@@ -9,6 +9,8 @@ Image=ghcr.io/goauthentik/server:2026.8.0-rc1
 AutoUpdate=registry
 Pod=authentik.pod
 Exec=worker
+# Run as root: the worker reads the root-owned podman/docker socket (mounted below) to deploy outposts; a non-root process can't.
+User=0:0
 EnvironmentFile=%h/.config/authentik/authentik.env
 Environment=AUTHENTIK_POSTGRESQL__HOST=localhost
 Environment=AUTHENTIK_POSTGRESQL__NAME=authentik

--- a/scripts/generate_quadlet.py
+++ b/scripts/generate_quadlet.py
@@ -145,6 +145,12 @@ def worker_container(env_file: str, data_dir: str, podman_sock_dir: str) -> Unit
             ("AutoUpdate", "registry"),
             ("Pod", "authentik.pod"),
             ("Exec", "worker"),
+            (
+                COMMENT,
+                "Run as root: the worker reads the root-owned podman/docker socket "
+                "(mounted below) to deploy outposts; a non-root process can't.",
+            ),
+            ("User", "0:0"),
             ("EnvironmentFile", env_file),
             ("Environment", "AUTHENTIK_POSTGRESQL__HOST=localhost"),
             ("Environment", "AUTHENTIK_POSTGRESQL__NAME=authentik"),


### PR DESCRIPTION
Round 3 dropped `User=0:0` from the worker container after thmo asked for it. thmo has since walked that back, confirming the worker really does need root for the documented outpost auto-deploy flow.

The worker bind-mounts the host podman socket
(`/run/podman/podman.sock` for rootful, `%t/podman/podman.sock` for rootless) so authentik can deploy outposts. The socket is root-owned at `0660`, and the authentik server image runs the worker as a non-root user, so without `User=0:0` the worker can't read it and outpost deployment fails. In a rootless deployment, container UID 0 maps back to the socket-owning host user via the user namespace, so this stays safe.

The fix lives in `scripts/generate_quadlet.py`; both worker variants also get an inline comment above the `User=` line explaining why root is required, so a future pass doesn't quietly drop it again. Server and PostgreSQL units are untouched. Running `make gen-quadlet` reproduces the committed units exactly.
