### PR TITLE
stages/authenticator_validate, web: show SMS delivery method and masked number in challenge

### DIFF
--- a/authentik/lib/tests/test_utils_sms.py
+++ b/authentik/lib/tests/test_utils_sms.py
@@ -1,0 +1,24 @@
+"""Test SMS utils"""
+
+from django.test import TestCase
+
+from authentik.lib.utils.sms import mask_phone_number
+
+
+class TestSMSUtils(TestCase):
+    """Test SMS utils"""
+
+    def test_mask_phone_number(self):
+        """Test mask_phone_number"""
+        self.assertEqual(mask_phone_number("+12025550173"), "+*******0173")
+        self.assertEqual(mask_phone_number("2025550173"), "******0173")
+
+    def test_mask_phone_number_short(self):
+        """Test mask_phone_number with numbers shorter than the visible window"""
+        self.assertEqual(mask_phone_number("123"), "***")
+        self.assertEqual(mask_phone_number("+123"), "+***")
+
+    def test_mask_phone_number_empty(self):
+        """Test mask_phone_number with empty input"""
+        self.assertIsNone(mask_phone_number(None))
+        self.assertIsNone(mask_phone_number(""))

--- a/authentik/lib/utils/sms.py
+++ b/authentik/lib/utils/sms.py
@@ -1,0 +1,33 @@
+"""SMS utility functions"""
+
+# Number of trailing digits kept visible when masking a phone number.
+PHONE_NUMBER_VISIBLE_DIGITS = 4
+
+
+def mask_phone_number(phone_number: str | None) -> str | None:
+    """Mask a phone number for privacy, keeping only the trailing digits visible.
+
+    A leading "+" is preserved so that international numbers remain recognisable.
+
+    Args:
+        phone_number: Phone number to mask.
+    Returns:
+        Masked phone number, or None if input is None or empty.
+    Example:
+        mask_phone_number("+12025550173")
+        '+*******0173'
+    """
+    if not phone_number:
+        return None
+
+    prefix = ""
+    digits = phone_number
+    if digits.startswith("+"):
+        prefix = "+"
+        digits = digits[1:]
+
+    if len(digits) <= PHONE_NUMBER_VISIBLE_DIGITS:
+        return prefix + "*" * len(digits)
+
+    masked_length = len(digits) - PHONE_NUMBER_VISIBLE_DIGITS
+    return prefix + "*" * masked_length + digits[-PHONE_NUMBER_VISIBLE_DIGITS:]

--- a/authentik/stages/authenticator_validate/challenge.py
+++ b/authentik/stages/authenticator_validate/challenge.py
@@ -28,6 +28,7 @@ from authentik.events.models import Event, EventAction
 from authentik.flows.planner import PLAN_CONTEXT_APPLICATION
 from authentik.flows.stage import StageView
 from authentik.lib.utils.email import mask_email
+from authentik.lib.utils.sms import mask_phone_number
 from authentik.lib.utils.time import timedelta_from_string
 from authentik.root.middleware import ClientIPMiddleware
 from authentik.stages.authenticator import devices_for_user
@@ -63,8 +64,26 @@ def get_challenge_for_device(
         return get_webauthn_challenge(stage_view, stage, device)
     if isinstance(device, EmailDevice):
         return {"email": mask_email(device.email)}
+    if isinstance(device, SMSDevice):
+        return get_sms_challenge(device)
     # Code-based challenges have no hints
     return {}
+
+
+def get_sms_challenge(device: SMSDevice) -> dict:
+    """Generate hints for an SMS device.
+
+    Surfaces the (masked) destination and the configured delivery method so the
+    user can tell where a code was sent. Multiple SMS stages can use distinct
+    friendly names (e.g. "SMS", "WhatsApp") to differentiate delivery channels.
+    """
+    challenge: dict = {}
+    # A hashed phone number cannot be masked into anything meaningful.
+    if not device.is_hashed:
+        challenge["phone_number"] = mask_phone_number(device.phone_number)
+    if device.stage.friendly_name:
+        challenge["delivery_method"] = device.stage.friendly_name
+    return challenge
 
 
 def get_webauthn_challenge_without_user(

--- a/authentik/stages/authenticator_validate/tests/test_sms.py
+++ b/authentik/stages/authenticator_validate/tests/test_sms.py
@@ -9,6 +9,7 @@ from authentik.core.tests.utils import create_test_admin_user, create_test_flow
 from authentik.flows.models import FlowStageBinding, NotConfiguredAction
 from authentik.flows.tests import FlowTestCase
 from authentik.lib.generators import generate_id
+from authentik.lib.utils.sms import mask_phone_number
 from authentik.stages.authenticator_sms.models import AuthenticatorSMSStage, SMSDevice, SMSProviders
 from authentik.stages.authenticator_validate.models import AuthenticatorValidateStage, DeviceClasses
 from authentik.stages.authenticator_validate.stage import COOKIE_NAME_MFA
@@ -153,3 +154,49 @@ class AuthenticatorValidateStageSMSTests(FlowTestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertStageResponse(response, flow, self.user, component="ak-stage-access-denied")
+
+    def test_device_challenge_hints(self):
+        """Test that the device challenge surfaces the masked phone number and delivery method"""
+        self.stage.friendly_name = "WhatsApp"
+        self.stage.save()
+        ident_stage = IdentificationStage.objects.create(
+            name=generate_id(),
+            user_fields=[
+                UserFields.USERNAME,
+            ],
+        )
+        device: SMSDevice = SMSDevice.objects.create(
+            user=self.user,
+            confirmed=True,
+            stage=self.stage,
+            phone_number="+12025550173",
+        )
+
+        stage = AuthenticatorValidateStage.objects.create(
+            name=generate_id(),
+            not_configured_action=NotConfiguredAction.CONFIGURE,
+            device_classes=[DeviceClasses.SMS],
+        )
+        stage.configuration_stages.set([ident_stage])
+        flow = create_test_flow()
+        FlowStageBinding.objects.create(target=flow, stage=ident_stage, order=0)
+        FlowStageBinding.objects.create(target=flow, stage=stage, order=1)
+
+        response = self.client.post(
+            reverse("authentik_api:flow-executor", kwargs={"flow_slug": flow.slug}),
+            {"uid_field": self.user.username},
+            follow=True,
+        )
+        response_data = self.assertStageResponse(
+            response, flow, self.user, component="ak-stage-authenticator-validate"
+        )
+        device_challenge = response_data["device_challenges"][0]
+        self.assertEqual(device_challenge["device_class"], "sms")
+        self.assertEqual(device_challenge["device_uid"], str(device.pk))
+        self.assertEqual(
+            device_challenge["challenge"],
+            {
+                "phone_number": mask_phone_number(device.phone_number),
+                "delivery_method": "WhatsApp",
+            },
+        )

--- a/web/src/common/labels.ts
+++ b/web/src/common/labels.ts
@@ -102,8 +102,23 @@ export function formatDeviceChallengeMessage(deviceChallenge?: DeviceChallenge |
                 ? msg(str`A code has been sent to your address: ${email}`)
                 : msg("A code has been sent to your email address.");
         }
-        case DeviceClassesEnum.Sms:
+        case DeviceClassesEnum.Sms: {
+            const { phone_number: phoneNumber, delivery_method: deliveryMethod } =
+                deviceChallenge.challenge;
+
+            if (deliveryMethod && phoneNumber) {
+                return msg(str`A code has been sent via ${deliveryMethod} to ${phoneNumber}.`);
+            }
+            if (deliveryMethod) {
+                return msg(str`A code has been sent to you via ${deliveryMethod}.`);
+            }
+            if (phoneNumber) {
+                return msg(
+                    str`A one-time use code has been sent to you via SMS to ${phoneNumber}.`,
+                );
+            }
             return msg("A one-time use code has been sent to you via SMS text message.");
+        }
         case DeviceClassesEnum.Totp:
             return msg("Open your authenticator app to retrieve a one-time use code.");
         case DeviceClassesEnum.Static:

--- a/website/docs/add-secure-apps/flows-stages/stages/authenticator_sms/index.md
+++ b/website/docs/add-secure-apps/flows-stages/stages/authenticator_sms/index.md
@@ -20,7 +20,7 @@ In normal mode, the enrolled phone number can later be used with the [Authentica
 - **Auth type**: choose **Basic** or **Bearer** authentication for the generic provider.
 - **Verify only**: verify phone ownership during enrollment without storing the plain phone number for later MFA use.
 - **Mapping**: optional webhook mapping used to customize the payload sent to custom providers.
-- **Authenticator type name**: optional friendly name shown to the user in self-service settings.
+- **Authenticator type name**: optional friendly name shown to the user in self-service settings and as the delivery method during [authenticator validation](../authenticator_validate/index.md#sms-delivery-hints). When you run multiple SMS stages for different delivery channels (for example SMS and WhatsApp), set a distinct name on each so users can tell where their code was sent.
 - **Configuration flow**: optional authenticated flow that lets users enroll this authenticator from user settings.
 
 ## Flow integration

--- a/website/docs/add-secure-apps/flows-stages/stages/authenticator_validate/index.md
+++ b/website/docs/add-secure-apps/flows-stages/stages/authenticator_validate/index.md
@@ -127,6 +127,14 @@ The order of selected hints matters. For example, selecting **Security key** bef
 
 If the user has multiple compatible authenticators, authentik lets them choose one. After a successful validation, the last-used authenticator is automatically preferred the next time this stage runs.
 
+### SMS delivery hints
+
+When an SMS device is validated, authentik shows where the code was sent: the destination phone number (masked for privacy) and, if configured, the delivery method.
+
+The delivery method is taken from the **Authenticator type name** of the [SMS Authenticator Setup stage](../authenticator_sms/index.md) that enrolled the device. Because every SMS device shares the `sms` device class, setting a distinct name on each SMS stage (for example `SMS` and `WhatsApp`) is the recommended way to differentiate delivery channels in the validation prompt.
+
+Phone numbers stored as a hash (when the setup stage uses **Verify only**) are not shown.
+
 ### WebAuthn authenticator type restrictions
 
 **WebAuthn device type restrictions** are an allowlist for already-enrolled WebAuthn authenticators. When no device types are selected, any enrolled WebAuthn authenticator that matches the stage's **Device classes** can be used. When one or more device types are selected, authentik only allows WebAuthn authentication from enrolled devices whose recorded device type matches one of the selected entries.


### PR DESCRIPTION
## Details

### What does this PR change?

When validating an SMS authenticator device, the flow always rendered a
fixed message: *"A one-time use code has been sent to you via SMS text
message."* This PR surfaces two optional hints in the SMS device
challenge so the user can see **where** their code was sent, mirroring
the existing email challenge that already returns a masked address:

- `phone_number` — the destination number, masked for privacy
  (e.g. `+*******0173`)
- `delivery_method` — the stage's configured friendly name, so admins can
  label a channel (e.g. `SMS`, `WhatsApp`)

The web flow (`formatDeviceChallengeMessage`) renders whichever hints are
present:

| Hints present | Message |
| --- | --- |
| method + number | `A code has been sent via WhatsApp to +*******0173.` |
| method only | `A code has been sent to you via WhatsApp.` |
| number only | `A one-time use code has been sent to you via SMS to +*******0173.` |
| none | `A one-time use code has been sent to you via SMS text message.` (unchanged) |

A new `mask_phone_number` helper lives in `authentik/lib/utils/sms.py`,
alongside the existing `mask_email` util.

### Why is this change needed?

A common deployment pattern is to run more than one SMS stage to deliver
codes over different channels (for example a text-message provider and a
WhatsApp provider). Because every SMS device reports the same `sms`
device class, the picker and the challenge screen are identical for both,
and users cannot tell which channel a code was actually sent to. Showing
the configured delivery method and a masked destination removes that
ambiguity and brings SMS in line with the email challenge.

### How was this tested?

- New unit tests for `mask_phone_number`
  (`authentik/lib/tests/test_utils_sms.py`).
- New flow test asserting the SMS device challenge contains the masked
  number and delivery method
  (`authentik/stages/authenticator_validate/tests/test_sms.py::test_device_challenge_hints`).
- `ruff check` and `ruff format --check` pass on the changed files.

The challenge payload is a free-form dict (`JSONDictField`), so no API
schema regeneration is required. New user-facing strings are picked up by
the existing translation extraction automation.

### Linked issues

<!-- N/A -->

---

## Checklist

- [x] The project has been linted (ruff) on the changed files
- [x] The documentation has been updated and formatted (`make docs`)