### PR TITLE
stages/email: Read binary file as an actual binary file.

### DIFF
--- a/authentik/stages/email/templatetags/authentik_stages_email.py
+++ b/authentik/stages/email/templatetags/authentik_stages_email.py
@@ -1,5 +1,6 @@
 """authentik core inlining template tags"""
 
+import mimetypes
 from base64 import b64encode
 from pathlib import Path
 
@@ -13,7 +14,13 @@ register = template.Library()
 def inline_static_ascii(path: str) -> str:
     """Inline static asset. Doesn't check file contents, plain text is assumed.
     If no file could be found, original path is returned"""
-    result = Path(finders.find(path))
+    result = finders.find(path)
+
+    if result is None:
+        return path
+
+    result = Path(result)
+
     if result:
         with open(result, encoding="utf8") as _file:
             return _file.read()
@@ -24,11 +31,23 @@ def inline_static_ascii(path: str) -> str:
 def inline_static_binary(path: str) -> str:
     """Inline static asset. Uses file extension for base64 block. If no file could be found,
     path is returned."""
-    result = Path(finders.find(path))
-    if result and result.is_file():
-        with open(result, encoding="utf8") as _file:
-            b64content = b64encode(_file.read().encode())
-            return f"data:image/{result.suffix};base64,{b64content.decode('utf-8')}"
+    result = finders.find(path)
+
+    if result is None:
+        return path
+
+    result = Path(result)
+
+    if result.is_file():
+        type, _ = mimetypes.guess_file_type(result)
+
+        if type is None:
+            type = "application/octet-stream"
+
+        with open(result, "rb") as _file:
+            b64content = b64encode(_file.read())
+            return f"data:{type};base64,{b64content.decode('utf-8')}"
+
     return path
 
 

--- a/authentik/stages/email/templatetags/tests/test_tags.py
+++ b/authentik/stages/email/templatetags/tests/test_tags.py
@@ -1,0 +1,28 @@
+"""template function tests"""
+
+from django.test import TestCase
+
+from authentik.stages.email.templatetags.authentik_stages_email import inline_static_binary
+
+
+class TestTemplateTags(TestCase):
+    """Template tag tests"""
+
+    def test_inline_static_binary_does_not_exist(self):
+        """Test inlining binary file"""
+        filename = "this_file_should_not_exist.png"
+        result = inline_static_binary(filename)
+        self.assertEqual(result, filename)
+
+    def test_inline_png(self):
+        """Test inlining png"""
+        result = inline_static_binary("src/assets/images/user_default.png")
+        self.assertEqual(
+            result,
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGP6zwAAAgcBApocMXEAAAAASUVORK5CYII=",
+        )
+
+    def test_inline_textfile(self):
+        """Test inlining binary textfile"""
+        result = inline_static_binary("robots.txt")
+        self.assertEqual(result, "data:text/plain;base64,VXNlci1hZ2VudDogKgpEaXNhbGxvdzogLwo=")

--- a/website/docs/add-secure-apps/flows-stages/stages/email/index.md
+++ b/website/docs/add-secure-apps/flows-stages/stages/email/index.md
@@ -123,6 +123,10 @@ These templates are rendered with Django's templating engine, so you can also us
 
 ![](./custom_template.png)
 
+### Custom template tags
+
+- `inline_static_binary`: Inlines an image as a data-url.
+
 ### Example template
 
 Templates can extend the base email template and use standard Django template tags. For example:


### PR DESCRIPTION
## Details

Allow inlining images in e-mails.

### What does this PR change?

Fixes the existing inline_static_binary tag so that it can actually read binary files that are not valid UTF-8 strings.

### Why is this change needed?

Existing implementation was broken.

### How was this tested?
Added new unit tests.

---

## Checklist

-   [x] The project has been linted, built, and tested (`make all`)
-   [x] The documentation has been updated and formatted (`make docs`)
