### PR TITLE
web: pass theme=auto to Turnstile when brand UI theme is automatic

### DIFF
--- a/web/src/flow/stages/captcha/controllers/turnstile.ts
+++ b/web/src/flow/stages/captcha/controllers/turnstile.ts
@@ -1,6 +1,10 @@
 /* eslint-disable @typescript-eslint/triple-slash-reference */
 /// <reference types="turnstile-types"/>
+import { globalAK } from "#common/global";
+
 import { CaptchaController } from "#flow/stages/captcha/controllers/CaptchaController";
+
+import { UiThemeEnum } from "@goauthentik/api";
 
 import { TurnstileObject } from "turnstile-types";
 
@@ -10,6 +14,24 @@ declare global {
     interface Window {
         turnstile: TurnstileObject;
     }
+}
+
+/**
+ * Resolve the theme value to pass to the Turnstile widget.
+ *
+ * Turnstile supports three theme values: `"light"`, `"dark"`, and `"auto"`.
+ * When the brand's `uiTheme` is set to `Automatic`, return `"auto"` so the
+ * widget tracks the user's OS color-scheme preference natively (including
+ * after the page has loaded). Otherwise fall back to the host's resolved
+ * `activeTheme` so explicit light/dark preferences propagate to the widget.
+ *
+ * @see {@link https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/widget-configurations/ Turnstile widget configurations}
+ */
+function resolveTurnstileTheme(host: { activeTheme: "light" | "dark" }): "light" | "dark" | "auto" {
+    if (globalAK().brand.uiTheme === UiThemeEnum.Automatic) {
+        return "auto";
+    }
+    return host.activeTheme;
 }
 
 export class TurnstileController extends CaptchaController {
@@ -52,7 +74,7 @@ export class TurnstileController extends CaptchaController {
      */
     public interactive = () => {
         const siteKey = this.host.challenge?.siteKey ?? "";
-        const theme = this.host.activeTheme;
+        const theme = resolveTurnstileTheme(this.host);
         const language = this.host.activeLanguageTag.toLowerCase();
 
         return html`<div id="ak-container"></div>
@@ -79,7 +101,7 @@ export class TurnstileController extends CaptchaController {
             "sitekey": this.host.challenge?.siteKey ?? "",
             "callback": this.host.onTokenChange,
             "error-callback": this.#delegateError,
-            "theme": this.host.activeTheme,
+            "theme": resolveTurnstileTheme(this.host),
         });
     };
 


### PR DESCRIPTION
## Details

### What does this PR change?

When a brand is configured with `uiTheme = Automatic`, the Turnstile captcha widget now receives `theme: "auto"` (Turnstile's native auto value) instead of a resolved `"light"` or `"dark"`.

Explicit light or dark brand preferences continue to flow through unchanged via the existing `host.activeTheme` path. hCaptcha and reCAPTCHA controllers are intentionally left as-is.

### Why is this change needed?

The Turnstile widget currently receives a theme value computed once at render time from `host.activeTheme`, which resolves `Automatic` to either `"light"` or `"dark"` based on the user's OS preference at that exact moment.

If the user changes their OS color-scheme after the page has rendered (e.g. macOS automatic light/dark switching at sunset, or toggling the OS theme manually), the rest of the Authentik UI follows the new preference but the Turnstile widget stays in its old theme until the next full page reload.

Turnstile [supports `theme: "auto"` natively](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/widget-configurations/) for exactly this use case. Passing that value through when the brand `uiTheme` is `Automatic` lets the widget honour `prefers-color-scheme` directly and track changes live without reloads.

The other captcha providers don't share this issue:

- **hCaptcha** doesn't have an `auto` value (only `light` and `dark`)
- **reCAPTCHA v2** takes its theme via a `data-theme` attribute on the mount element rather than a render option

So this change is scoped to the Turnstile controller only.

### How was this tested?

- `npx tsc --noEmit -p tsconfig.json` clean for the changed file (existing errors in `packages/lex`, `prettier.config.mjs`, `src/common/ui/locale/definitions.ts`, and `test/unit/lexer.test.ts` are pre-existing on `main` and unrelated)
- `npx eslint src/flow/stages/captcha/controllers/turnstile.ts` clean
- `npx prettier --check src/flow/stages/captcha/controllers/turnstile.ts` clean
- No-op verification: with brand `uiTheme = Light` or `Dark`, the resolved value path is identical to before (`host.activeTheme` is returned unchanged).

### Linked issues

No existing issue; opening this PR directly. Discovered while working on a Cloudflare deployment of Authentik where the brand was set to `Automatic` and the Turnstile widget was the only element on the page not tracking OS theme changes.

---

## Checklist

-   [x] The project has been linted (lint clean for the changed file, tsc clean for the changed file)
-   [x] The documentation has been updated and formatted (no docs needed for a behaviour-preserving widget option)
