### PR TITLE
core: add development database seeding command

### DIFF
--- a/authentik/core/management/commands/seed_database.py
+++ b/authentik/core/management/commands/seed_database.py
@@ -1,0 +1,141 @@
+"""Seed development databases with core objects."""
+
+from argparse import ArgumentParser
+from random import Random
+
+from django.conf import settings
+from django.contrib.auth.hashers import make_password
+from django.core.management.base import CommandError
+
+from authentik.core.management.seed_database.config import (
+    DEFAULT_BATCH_SIZE,
+    DEFAULT_PASSWORD,
+    DEFAULT_PREFIX,
+    SIZE_PRESETS,
+    STATIC_SEED,
+    resolve_seed_size,
+    validate_seed_size,
+)
+from authentik.core.management.seed_database.names import SeedNamer, seed_prefix
+from authentik.core.management.seed_database.progress import SeedProgress
+from authentik.core.management.seed_database.seeder import SEED_PHASES, DatabaseSeeder
+from authentik.tenants.management import TenantCommand
+
+
+class Command(TenantCommand):
+    """Seed a development database with core data."""
+
+    help = (
+        "Seed a development database with users, groups, applications, and providers. "
+        "Requires DEBUG or TEST and an explicit risk acknowledgement."
+    )
+
+    def add_arguments(self, parser: ArgumentParser):
+        parser.add_argument(
+            "--ack-risk",
+            action="store_true",
+            help="Acknowledge that this command creates many database rows.",
+        )
+        parser.add_argument(
+            "--size",
+            choices=SIZE_PRESETS.keys(),
+            default="s",
+            type=str.lower,
+            help="Seed size preset.",
+        )
+        parser.add_argument(
+            "--mode",
+            choices=["static", "random"],
+            default="static",
+            help="Generate repeatable static data or randomized data.",
+        )
+        parser.add_argument(
+            "--seed",
+            type=int,
+            default=None,
+            help="Seed used for random mode. Static mode always uses a stable seed.",
+        )
+        parser.add_argument(
+            "--prefix",
+            default=DEFAULT_PREFIX,
+            help="Prefix for generated usernames and group names.",
+        )
+        parser.add_argument(
+            "--password",
+            default=DEFAULT_PASSWORD,
+            help="Password assigned to generated users.",
+        )
+        parser.add_argument("--users", type=int, default=None, help="Override user count.")
+        parser.add_argument("--groups", type=int, default=None, help="Override group count.")
+        parser.add_argument(
+            "--superuser-groups",
+            type=int,
+            default=None,
+            help="Override the number of generated superuser groups.",
+        )
+        parser.add_argument(
+            "--memberships-per-user",
+            type=int,
+            default=None,
+            help="Override generated memberships per user.",
+        )
+        parser.add_argument(
+            "--apps",
+            type=int,
+            default=None,
+            help="Override generated application and OAuth2 provider count.",
+        )
+        parser.add_argument(
+            "--entitlements-per-app",
+            type=int,
+            default=None,
+            help="Override generated application entitlements per application.",
+        )
+        parser.add_argument(
+            "--app-group-bindings-per-app",
+            type=int,
+            default=None,
+            help="Override generated group policy bindings per application.",
+        )
+        parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=DEFAULT_BATCH_SIZE,
+            help="Batch size for bulk database writes.",
+        )
+        parser.add_argument(
+            "--no-progress",
+            action="store_true",
+            help="Disable progress output.",
+        )
+
+    def handle_per_tenant(self, *args, **options):
+        """Seed users, groups, applications, providers, and memberships for the selected tenant."""
+        if not options["ack_risk"]:
+            raise CommandError("Pass --ack-risk to acknowledge that this command creates data.")
+        if not settings.DEBUG and not getattr(settings, "TEST", False):
+            raise CommandError("This command can only run with DEBUG or TEST enabled.")
+
+        size = resolve_seed_size(options)
+        mode = options["mode"]
+        seed = STATIC_SEED if mode == "static" else options["seed"]
+        rng = Random(seed)  # nosec B311
+        namer = SeedNamer(seed_prefix(options["prefix"], mode, rng))
+        password_hash = make_password(options["password"], salt="authentik_seed")
+        batch_size = options["batch_size"]
+        validate_seed_size(size, namer, batch_size)
+
+        result = DatabaseSeeder(
+            size=size,
+            namer=namer,
+            mode=mode,
+            rng=rng,
+            password_hash=password_hash,
+            batch_size=batch_size,
+            progress=SeedProgress(
+                self.stdout,
+                SEED_PHASES,
+                enabled=not options["no_progress"] and int(options.get("verbosity", 1)) > 0,
+            ),
+        ).seed()
+        self.stdout.write(self.style.SUCCESS(result.message()))

--- a/authentik/core/management/seed_database/__init__.py
+++ b/authentik/core/management/seed_database/__init__.py
@@ -1,0 +1,13 @@
+"""Utilities for seeding development databases."""
+
+from authentik.core.management.seed_database.config import SIZE_PRESETS, SeedSize
+from authentik.core.management.seed_database.names import SEED_ATTRIBUTE
+from authentik.core.management.seed_database.seeder import DatabaseSeeder, SeedResult
+
+__all__ = [
+    "DatabaseSeeder",
+    "SEED_ATTRIBUTE",
+    "SIZE_PRESETS",
+    "SeedResult",
+    "SeedSize",
+]

--- a/authentik/core/management/seed_database/config.py
+++ b/authentik/core/management/seed_database/config.py
@@ -1,0 +1,132 @@
+"""Configuration for development database seeding."""
+
+from dataclasses import dataclass
+from typing import Any
+
+from django.core.management.base import CommandError
+
+from authentik.core.management.seed_database.names import SeedNamer
+from authentik.core.models import USERNAME_MAX_LENGTH
+
+STATIC_SEED = 1
+DEFAULT_PREFIX = "ak-seed"
+DEFAULT_PASSWORD = "ak-seed-password"  # nosec
+DEFAULT_BATCH_SIZE = 1_000
+
+
+@dataclass(frozen=True)
+class SeedSize:
+    """Counts for a seed size preset."""
+
+    users: int
+    groups: int
+    superuser_groups: int
+    memberships_per_user: int
+    apps: int
+    entitlements_per_app: int
+    app_group_bindings_per_app: int
+
+
+SIZE_PRESETS = {
+    "s": SeedSize(
+        users=25,
+        groups=5,
+        superuser_groups=1,
+        memberships_per_user=2,
+        apps=5,
+        entitlements_per_app=2,
+        app_group_bindings_per_app=2,
+    ),
+    "m": SeedSize(
+        users=250,
+        groups=25,
+        superuser_groups=2,
+        memberships_per_user=3,
+        apps=25,
+        entitlements_per_app=3,
+        app_group_bindings_per_app=3,
+    ),
+    "l": SeedSize(
+        users=1_000,
+        groups=100,
+        superuser_groups=5,
+        memberships_per_user=5,
+        apps=100,
+        entitlements_per_app=5,
+        app_group_bindings_per_app=5,
+    ),
+    "xl": SeedSize(
+        users=10_000,
+        groups=500,
+        superuser_groups=10,
+        memberships_per_user=8,
+        apps=250,
+        entitlements_per_app=8,
+        app_group_bindings_per_app=8,
+    ),
+}
+
+
+def resolve_seed_size(options: dict[str, Any]) -> SeedSize:
+    """Resolve a size preset with any explicit CLI count overrides."""
+    preset = SIZE_PRESETS[options["size"]]
+    return SeedSize(
+        users=options["users"] if options["users"] is not None else preset.users,
+        groups=options["groups"] if options["groups"] is not None else preset.groups,
+        superuser_groups=(
+            options["superuser_groups"]
+            if options["superuser_groups"] is not None
+            else preset.superuser_groups
+        ),
+        memberships_per_user=(
+            options["memberships_per_user"]
+            if options["memberships_per_user"] is not None
+            else preset.memberships_per_user
+        ),
+        apps=options["apps"] if options["apps"] is not None else preset.apps,
+        entitlements_per_app=(
+            options["entitlements_per_app"]
+            if options["entitlements_per_app"] is not None
+            else preset.entitlements_per_app
+        ),
+        app_group_bindings_per_app=(
+            options["app_group_bindings_per_app"]
+            if options["app_group_bindings_per_app"] is not None
+            else preset.app_group_bindings_per_app
+        ),
+    )
+
+
+def validate_seed_size(size: SeedSize, namer: SeedNamer, batch_size: int):
+    """Validate requested seed counts before writing any rows."""
+    if size.users < 1:
+        raise CommandError("User count must be at least 1.")
+    if size.groups < 1:
+        raise CommandError("Group count must be at least 1.")
+    if size.superuser_groups < 0:
+        raise CommandError("Superuser group count cannot be negative.")
+    if size.superuser_groups > size.groups:
+        raise CommandError("Superuser group count cannot be greater than group count.")
+    if size.memberships_per_user < 0:
+        raise CommandError("Memberships per user cannot be negative.")
+    if size.memberships_per_user > size.groups:
+        raise CommandError("Memberships per user cannot be greater than group count.")
+    if size.apps < 0:
+        raise CommandError("Application count cannot be negative.")
+    if size.entitlements_per_app < 0:
+        raise CommandError("Entitlements per application cannot be negative.")
+    if size.app_group_bindings_per_app < 0:
+        raise CommandError("Application group bindings per application cannot be negative.")
+    if size.app_group_bindings_per_app > size.groups:
+        raise CommandError(
+            "Application group bindings per application cannot be greater than group count."
+        )
+    if batch_size < 1:
+        raise CommandError("Batch size must be at least 1.")
+
+    username = namer.username(size.users - 1)
+    if len(username) > USERNAME_MAX_LENGTH:
+        raise CommandError(
+            f"Prefix is too long. Longest generated username would be {len(username)} "
+            f"characters, but the limit is {USERNAME_MAX_LENGTH}."
+        )

--- a/authentik/core/management/seed_database/names.py
+++ b/authentik/core/management/seed_database/names.py
@@ -1,0 +1,48 @@
+"""Name helpers for development seed data."""
+
+from dataclasses import dataclass
+from random import Random
+
+from authentik.core.models import USER_PATH_SYSTEM_PREFIX
+
+SEED_ATTRIBUTE = f"{USER_PATH_SYSTEM_PREFIX}/seed"
+
+
+def seed_prefix(prefix: str, mode: str, rng: Random) -> str:
+    """Return the static prefix or a randomized run-specific prefix."""
+    if mode == "static":
+        return prefix
+    run_id = "".join(rng.choice("abcdefghijklmnopqrstuvwxyz0123456789") for _ in range(8))
+    return f"{prefix}-{run_id}"
+
+
+@dataclass(frozen=True)
+class SeedNamer:
+    """Generate consistent seed object names from a prefix."""
+
+    prefix: str
+
+    def attributes(self, mode: str, index: int) -> dict:
+        """Return the common seed marker used by models with attributes."""
+        return {
+            SEED_ATTRIBUTE: {
+                "command": "seed_database",
+                "mode": mode,
+                "index": index,
+            },
+        }
+
+    def username(self, index: int) -> str:
+        return f"{self.prefix}-user-{index + 1:06d}"
+
+    def group_name(self, index: int) -> str:
+        return f"{self.prefix}-group-{index + 1:04d}"
+
+    def provider_name(self, index: int) -> str:
+        return f"{self.prefix}-provider-{index + 1:04d}"
+
+    def application_slug(self, index: int) -> str:
+        return f"{self.prefix}-app-{index + 1:04d}"
+
+    def entitlement_name(self, index: int) -> str:
+        return f"{self.prefix}-entitlement-{index + 1:04d}"

--- a/authentik/core/management/seed_database/progress.py
+++ b/authentik/core/management/seed_database/progress.py
@@ -1,0 +1,28 @@
+"""Progress reporting for development database seeding."""
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class ProgressWriter(Protocol):
+    """Small subset of Django's OutputWrapper used by the progress reporter."""
+
+    def write(self, msg: str = "", style_func=None, ending: str | None = None): ...
+
+
+@dataclass
+class SeedProgress:
+    """Render phase progress for seed operations."""
+
+    writer: ProgressWriter
+    total: int
+    enabled: bool = True
+    width: int = 24
+
+    def update(self, current: int, label: str):
+        """Write progress for the current phase."""
+        if not self.enabled:
+            return
+        filled = int(self.width * current // self.total)
+        bar = "#" * filled + "-" * (self.width - filled)
+        self.writer.write(f"Seeding |{bar}| {current}/{self.total} {label}")

--- a/authentik/core/management/seed_database/seeder.py
+++ b/authentik/core/management/seed_database/seeder.py
@@ -1,0 +1,316 @@
+"""Database writes for development seed data."""
+
+from dataclasses import asdict, dataclass
+from random import Random
+
+from django.db import transaction
+
+from authentik.core.management.seed_database.config import SeedSize
+from authentik.core.management.seed_database.names import SeedNamer
+from authentik.core.management.seed_database.progress import SeedProgress
+from authentik.core.models import Application, ApplicationEntitlement, Group, User, UserTypes
+from authentik.flows.models import Flow, FlowAuthenticationRequirement, FlowDesignation
+from authentik.policies.models import PolicyBinding
+from authentik.providers.oauth2.models import (
+    ClientType,
+    GrantType,
+    OAuth2Provider,
+    RedirectURI,
+    RedirectURIMatchingMode,
+)
+
+DEFAULT_AUTHORIZATION_FLOW_SLUG = "default-provider-authorization-implicit-consent"
+SEED_PHASES = 7
+
+
+@dataclass(frozen=True)
+class SeedResult:
+    """Counts for objects ensured by a seed run."""
+
+    users: int
+    groups: int
+    memberships: int
+    providers: int
+    applications: int
+    entitlements: int
+    policy_bindings: int
+
+    def message(self) -> str:
+        """Return the CLI success message."""
+        return (
+            f"Ensured {self.users} users, {self.groups} groups, {self.memberships} memberships, "
+            f"{self.providers} providers, {self.applications} applications, "
+            f"{self.entitlements} entitlements, and {self.policy_bindings} policy bindings."
+        )
+
+
+class DatabaseSeeder:
+    """Seed users, groups, applications, providers, and related bindings."""
+
+    def __init__(
+        self,
+        size: SeedSize,
+        namer: SeedNamer,
+        mode: str,
+        rng: Random,
+        password_hash: str,
+        batch_size: int,
+        progress: SeedProgress | None = None,
+    ):
+        self.size = size
+        self.namer = namer
+        self.mode = mode
+        self.rng = rng
+        self.password_hash = password_hash
+        self.batch_size = batch_size
+        self.progress = progress
+        self.progress_current = 0
+
+    def seed(self) -> SeedResult:
+        """Seed all supported object types."""
+        if self.progress:
+            self.progress.update(0, "starting")
+        with transaction.atomic():
+            groups = self.seed_groups()
+            self.advance_progress("groups")
+            users = self.seed_users()
+            self.advance_progress("users")
+            memberships = self.seed_memberships(users, groups)
+            self.advance_progress("memberships")
+            authorization_flow = self.authorization_flow()
+            self.advance_progress("authorization flow")
+            providers, apps = self.seed_applications(authorization_flow)
+            self.advance_progress("applications and providers")
+            entitlements = self.seed_application_entitlements(apps)
+            self.advance_progress("entitlements")
+            policy_bindings = self.seed_policy_bindings(apps, entitlements, groups)
+            self.advance_progress("policy bindings")
+
+        return SeedResult(
+            users=len(users),
+            groups=len(groups),
+            memberships=memberships,
+            providers=len(providers),
+            applications=len(apps),
+            entitlements=len(entitlements),
+            policy_bindings=policy_bindings,
+        )
+
+    def advance_progress(self, label: str):
+        """Report that a seed phase has completed."""
+        self.progress_current += 1
+        if self.progress:
+            self.progress.update(self.progress_current, label)
+
+    def seed_groups(self) -> list[Group]:
+        """Seed groups."""
+        groups = [
+            Group(
+                name=self.namer.group_name(index),
+                is_superuser=index < self.size.superuser_groups,
+                attributes=self.namer.attributes(self.mode, index),
+            )
+            for index in range(self.size.groups)
+        ]
+        Group.objects.bulk_create(
+            groups,
+            batch_size=self.batch_size,
+            update_conflicts=True,
+            update_fields=["is_superuser", "attributes"],
+            unique_fields=["name"],
+        )
+        names = [group.name for group in groups]
+        return list(Group.objects.filter(name__in=names).order_by("name"))
+
+    def seed_users(self) -> list[User]:
+        """Seed users."""
+        users = [
+            User(
+                username=self.namer.username(index),
+                name=f"Seed User {index + 1:06d}",
+                email=f"{self.namer.username(index)}@seed.localhost",
+                path=f"seed/{self.namer.prefix}",
+                type=UserTypes.INTERNAL,
+                is_active=True,
+                password=self.password_hash,
+                attributes=self.namer.attributes(self.mode, index),
+            )
+            for index in range(self.size.users)
+        ]
+        User.objects.bulk_create(
+            users,
+            batch_size=self.batch_size,
+            update_conflicts=True,
+            update_fields=["name", "email", "path", "type", "is_active", "password", "attributes"],
+            unique_fields=["username"],
+        )
+        usernames = [user.username for user in users]
+        return list(User.objects.filter(username__in=usernames).order_by("username"))
+
+    def seed_memberships(self, users: list[User], groups: list[Group]) -> int:
+        """Seed user group memberships."""
+        if self.size.memberships_per_user == 0:
+            return 0
+
+        through = User.groups.through
+        memberships = []
+        group_count = len(groups)
+        for user_index, user in enumerate(users):
+            if self.mode == "static":
+                user_groups = [
+                    groups[(user_index + offset * 7) % group_count]
+                    for offset in range(self.size.memberships_per_user)
+                ]
+            else:
+                user_groups = self.rng.sample(groups, self.size.memberships_per_user)
+            memberships.extend(through(user=user, group=group) for group in user_groups)
+
+        through.objects.bulk_create(memberships, batch_size=self.batch_size, ignore_conflicts=True)
+        return len(memberships)
+
+    def authorization_flow(self) -> Flow:
+        """Return the default authorization flow or create a minimal seed flow."""
+        flow = Flow.objects.filter(slug=DEFAULT_AUTHORIZATION_FLOW_SLUG).first()
+        if flow:
+            return flow
+        flow, _ = Flow.objects.update_or_create(
+            slug=f"{self.namer.prefix}-provider-authorization",
+            defaults={
+                "name": "Seed provider authorization",
+                "title": "Authorize seeded application",
+                "designation": FlowDesignation.AUTHORIZATION,
+                "authentication": FlowAuthenticationRequirement.REQUIRE_AUTHENTICATED,
+            },
+        )
+        return flow
+
+    def seed_applications(
+        self,
+        authorization_flow: Flow,
+    ) -> tuple[list[OAuth2Provider], list[Application]]:
+        """Seed OAuth2 provider/application pairs."""
+        providers = []
+        apps = []
+        for index in range(self.size.apps):
+            provider = self.seed_provider(index, authorization_flow)
+            providers.append(provider)
+            apps.append(self.seed_application(index, provider))
+
+        if self.mode == "random":
+            self.rng.shuffle(apps)
+        return providers, apps
+
+    def seed_provider(
+        self,
+        index: int,
+        authorization_flow: Flow,
+    ) -> OAuth2Provider:
+        """Seed an OAuth2 provider."""
+        slug = self.namer.application_slug(index)
+        redirect_uri = RedirectURI(
+            RedirectURIMatchingMode.STRICT,
+            f"https://{slug}.seed.localhost/callback",
+        )
+        provider, _ = OAuth2Provider.objects.update_or_create(
+            name=self.namer.provider_name(index),
+            defaults={
+                "authorization_flow": authorization_flow,
+                "client_type": ClientType.CONFIDENTIAL,
+                "client_id": f"{self.namer.prefix}-client-{index + 1:06d}",
+                "client_secret": f"{self.namer.prefix}-client-secret-{index + 1:06d}",
+                "grant_types": [GrantType.AUTHORIZATION_CODE, GrantType.REFRESH_TOKEN],
+                "_redirect_uris": [asdict(redirect_uri)],
+            },
+        )
+        return provider
+
+    def seed_application(
+        self,
+        index: int,
+        provider: OAuth2Provider,
+    ) -> Application:
+        """Seed an application assigned to a provider."""
+        app, _ = Application.objects.update_or_create(
+            slug=self.namer.application_slug(index),
+            defaults={
+                "name": f"Seed Application {index + 1:04d}",
+                "group": f"Seeded {self.namer.prefix}",
+                "provider": provider,
+                "meta_launch_url": (f"https://{self.namer.application_slug(index)}.seed.localhost"),
+                "meta_description": "Seeded development application",
+            },
+        )
+        return app
+
+    def seed_application_entitlements(
+        self,
+        apps: list[Application],
+    ) -> list[ApplicationEntitlement]:
+        """Seed application entitlements."""
+        entitlements = []
+        for app_index, app in enumerate(apps):
+            for entitlement_index in range(self.size.entitlements_per_app):
+                ent, _ = ApplicationEntitlement.objects.update_or_create(
+                    app=app,
+                    name=self.namer.entitlement_name(entitlement_index),
+                    defaults={
+                        "attributes": self.namer.attributes(
+                            self.mode,
+                            app_index * self.size.entitlements_per_app + entitlement_index,
+                        )
+                    },
+                )
+                entitlements.append(ent)
+        return entitlements
+
+    def seed_policy_bindings(
+        self,
+        apps: list[Application],
+        entitlements: list[ApplicationEntitlement],
+        groups: list[Group],
+    ) -> int:
+        """Seed group bindings for applications and entitlements."""
+        policy_bindings = 0
+        group_count = len(groups)
+        entitlements_by_app = {}
+        for entitlement in entitlements:
+            entitlements_by_app.setdefault(entitlement.app_id, []).append(entitlement)
+
+        for app_index, app in enumerate(apps):
+            if self.mode == "static":
+                app_groups = [
+                    groups[(app_index + offset * 3) % group_count]
+                    for offset in range(self.size.app_group_bindings_per_app)
+                ]
+            else:
+                app_groups = self.rng.sample(groups, self.size.app_group_bindings_per_app)
+            for order, group in enumerate(app_groups):
+                self.seed_group_binding(app, group, order)
+                policy_bindings += 1
+
+            for entitlement_index, entitlement in enumerate(entitlements_by_app.get(app.pk, [])):
+                if self.mode == "static":
+                    group = groups[(app_index + entitlement_index * 5) % group_count]
+                else:
+                    group = self.rng.choice(groups)
+                self.seed_group_binding(entitlement, group, 0)
+                policy_bindings += 1
+        return policy_bindings
+
+    def seed_group_binding(
+        self,
+        target: Application | ApplicationEntitlement,
+        group: Group,
+        order: int,
+    ):
+        """Seed a group policy binding on a target."""
+        PolicyBinding.objects.update_or_create(
+            target=target,
+            policy=None,
+            user=None,
+            order=order,
+            defaults={
+                "enabled": True,
+                "group": group,
+            },
+        )

--- a/authentik/core/tests/test_seed_database_command.py
+++ b/authentik/core/tests/test_seed_database_command.py
@@ -1,0 +1,112 @@
+"""Tests for seed_database management command."""
+
+from io import StringIO
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase, override_settings
+
+from authentik.core.management.seed_database import SEED_ATTRIBUTE
+from authentik.core.models import Application, ApplicationEntitlement, Group, User
+from authentik.policies.models import PolicyBinding
+from authentik.providers.oauth2.models import OAuth2Provider
+
+
+class TestSeedDatabaseCommand(TestCase):
+    """Test seed_database management command."""
+
+    def test_requires_risk_acknowledgement(self):
+        """Test that the command requires explicit acknowledgement."""
+        with self.assertRaises(CommandError) as ctx:
+            call_command("seed_database")
+
+        self.assertIn("--ack-risk", str(ctx.exception))
+
+    @override_settings(DEBUG=False, TEST=False)
+    def test_requires_debug_or_test_mode(self):
+        """Test that the command refuses non-development settings."""
+        with self.assertRaises(CommandError) as ctx:
+            call_command("seed_database", ack_risk=True)
+
+        self.assertIn("DEBUG or TEST", str(ctx.exception))
+
+    @override_settings(DEBUG=False, TEST=True)
+    def test_seeds_users_groups_and_memberships(self):
+        """Test that users, groups, and memberships are created."""
+        out = StringIO()
+
+        call_command(
+            "seed_database",
+            ack_risk=True,
+            prefix="seed-test",
+            users=4,
+            groups=3,
+            superuser_groups=1,
+            memberships_per_user=2,
+            apps=2,
+            entitlements_per_app=2,
+            app_group_bindings_per_app=1,
+            stdout=out,
+        )
+
+        users = User.objects.filter(username__startswith="seed-test-user-").order_by("username")
+        groups = Group.objects.filter(name__startswith="seed-test-group-").order_by("name")
+        providers = OAuth2Provider.objects.filter(name__startswith="seed-test-provider-")
+        apps = Application.objects.filter(slug__startswith="seed-test-app-").order_by("slug")
+        entitlements = ApplicationEntitlement.objects.filter(app__in=apps)
+
+        self.assertEqual(users.count(), 4)
+        self.assertEqual(groups.count(), 3)
+        self.assertEqual(groups.filter(is_superuser=True).count(), 1)
+        self.assertEqual(User.groups.through.objects.filter(user__in=users).count(), 8)
+        self.assertEqual(providers.count(), 2)
+        self.assertEqual(apps.count(), 2)
+        self.assertTrue(all(app.provider for app in apps))
+        self.assertEqual(entitlements.count(), 4)
+        self.assertEqual(
+            PolicyBinding.objects.filter(target__in=[*apps, *entitlements]).count(),
+            6,
+        )
+        self.assertTrue(all(user.attributes[SEED_ATTRIBUTE]["mode"] == "static" for user in users))
+        self.assertIn("Seeding |", out.getvalue())
+        self.assertIn("7/7 policy bindings", out.getvalue())
+        self.assertIn(
+            "Ensured 4 users, 3 groups, 8 memberships, 2 providers, "
+            "2 applications, 4 entitlements, and 6 policy bindings.",
+            out.getvalue(),
+        )
+
+    @override_settings(DEBUG=False, TEST=True)
+    def test_static_mode_is_idempotent(self):
+        """Test that static seed data can be rerun without duplicates."""
+        options = {
+            "ack_risk": True,
+            "prefix": "seed-idempotent",
+            "users": 3,
+            "groups": 2,
+            "superuser_groups": 1,
+            "memberships_per_user": 1,
+            "apps": 2,
+            "entitlements_per_app": 1,
+            "app_group_bindings_per_app": 1,
+        }
+
+        call_command("seed_database", **options)
+        call_command("seed_database", **options)
+
+        users = User.objects.filter(username__startswith="seed-idempotent-user-")
+        groups = Group.objects.filter(name__startswith="seed-idempotent-group-")
+        providers = OAuth2Provider.objects.filter(name__startswith="seed-idempotent-provider-")
+        apps = Application.objects.filter(slug__startswith="seed-idempotent-app-")
+        entitlements = ApplicationEntitlement.objects.filter(app__in=apps)
+
+        self.assertEqual(users.count(), 3)
+        self.assertEqual(groups.count(), 2)
+        self.assertEqual(User.groups.through.objects.filter(user__in=users).count(), 3)
+        self.assertEqual(providers.count(), 2)
+        self.assertEqual(apps.count(), 2)
+        self.assertEqual(entitlements.count(), 2)
+        self.assertEqual(
+            PolicyBinding.objects.filter(target__in=[*apps, *entitlements]).count(),
+            4,
+        )

--- a/website/docs/developer-docs/setup/database-seeding.md
+++ b/website/docs/developer-docs/setup/database-seeding.md
@@ -1,0 +1,82 @@
+---
+title: Database seeding
+sidebar_label: Database seeding
+tags:
+    - development
+    - contributor
+    - backend
+---
+
+Use the `seed_database` management command to add local development users, groups, memberships, applications, OAuth2 providers, entitlements, and group bindings to an authentik database.
+
+The command only runs when `DEBUG` or `TEST` is enabled, and it requires `--ack-risk` so that it cannot be run accidentally. It is intended for local development and test data, not production systems.
+
+## Seed a local database
+
+Run the command from the project root after your development database has been migrated.
+
+```shell
+uv run python manage.py seed_database --ack-risk
+```
+
+By default, the command uses the `s` size preset and static mode. Static mode is repeatable: running the command again with the same options updates the same users, groups, providers, applications, and entitlements, and it does not create duplicate memberships or bindings.
+
+To seed a larger dataset, choose a size preset.
+
+```shell
+uv run python manage.py seed_database --ack-risk --size m
+```
+
+The available presets are:
+
+| Size |  Users | Groups | Superuser groups | Memberships per user | Applications | Entitlements per app | App group bindings per app |
+| ---- | -----: | -----: | ---------------: | -------------------: | -----------: | -------------------: | -------------------------: |
+| `s`  |     25 |      5 |                1 |                    2 |            5 |                    2 |                          2 |
+| `m`  |    250 |     25 |                2 |                    3 |           25 |                    3 |                          3 |
+| `l`  |  1,000 |    100 |                5 |                    5 |          100 |                    5 |                          5 |
+| `xl` | 10,000 |    500 |               10 |                    8 |          250 |                    8 |                          8 |
+
+You can override individual counts instead of using the preset values.
+
+```shell
+uv run python manage.py seed_database \
+    --ack-risk \
+    --users 100 \
+    --groups 20 \
+    --superuser-groups 2 \
+    --memberships-per-user 3 \
+    --apps 10 \
+    --entitlements-per-app 2 \
+    --app-group-bindings-per-app 2
+```
+
+For a tenant schema other than `public`, pass the tenant schema name.
+
+```shell
+uv run python manage.py seed_database --ack-risk --schema tenant1
+```
+
+## Static and random data
+
+Static mode creates predictable names from the configured prefix:
+
+- Users are named `ak-seed-user-000001`, `ak-seed-user-000002`, and so on.
+- Groups are named `ak-seed-group-0001`, `ak-seed-group-0002`, and so on.
+- Providers and applications are named from `ak-seed-provider-0001` and `ak-seed-app-0001`.
+- Group memberships are assigned deterministically.
+
+Random mode appends a generated run ID to the prefix and randomly assigns memberships. Use `--seed` to make random mode repeatable.
+
+```shell
+uv run python manage.py seed_database --ack-risk --mode random --seed 1234
+```
+
+Use `--prefix` to create a separate set of seed data.
+
+```shell
+uv run python manage.py seed_database --ack-risk --prefix my-feature
+```
+
+Generated users receive the password `ak-seed-password` unless you pass `--password`.
+
+The command prints progress while each seed phase is applied. Use `--no-progress` to only print the final summary.

--- a/website/docs/sidebar.mjs
+++ b/website/docs/sidebar.mjs
@@ -931,6 +931,7 @@ const items = [
                     "developer-docs/setup/full-dev-environment",
                     "developer-docs/setup/frontend-dev-environment",
                     "developer-docs/setup/debugging",
+                    "developer-docs/setup/database-seeding",
                 ],
             },
             {


### PR DESCRIPTION
Add a guarded development-only `seed_database` management command for repeatable local datasets, covering users, groups, memberships, OAuth2 provider/application pairs, entitlements, and group policy bindings.

The implementation is split into `authentik.core.management.seed_database` helpers so the seeding logic is reusable outside the CLI wrapper, including future API tests or other developer tooling.

The command requires `--ack-risk`, only runs with `DEBUG` or `TEST`, supports static/random sizing controls, and reports progress while applying seed phases.

Closes: #18680

## Validation
- `make lint-fix`
- `git diff --check`
- `uv run python manage.py seed_database --help`
- `uv run python manage.py seed_database --ack-risk --users 2 --groups 2 --superuser-groups 1 --memberships-per-user 1 --apps 1 --entitlements-per-app 1 --app-group-bindings-per-app 1 --prefix codex-seed-progress`
- `make lint` reached Bandit, mypy, cargo-deny, and cargo-machete successfully; golangci-lint failed on ignored local `node_modules/flatted` Go files, then the rerun with those local dirs moved aside was interrupted by request.
