### PR TITLE
Per-request DB query reductions

### DIFF
--- a/authentik/brands/tests.py
+++ b/authentik/brands/tests.py
@@ -2,13 +2,17 @@
 
 from json import loads
 
+from django.http import HttpRequest
+from django.test import TestCase
 from django.urls import reverse
 from rest_framework.test import APITestCase
 
 from authentik.blueprints.tests import apply_blueprint
 from authentik.brands.models import Brand
+from authentik.brands.utils import _BRAND_RELATED_FK_FIELDS, get_brand_for_request
 from authentik.core.models import Application
-from authentik.core.tests.utils import create_test_admin_user, create_test_brand
+from authentik.core.tests.utils import create_test_admin_user, create_test_brand, create_test_flow
+from authentik.flows.models import FlowDesignation
 from authentik.lib.generators import generate_id
 from authentik.providers.oauth2.models import OAuth2Provider
 from authentik.providers.saml.models import SAMLProvider
@@ -297,3 +301,73 @@ class TestBrands(APITestCase):
         res = self.client.get(reverse("authentik_core:if-user"))
         self.assertEqual(res.status_code, 200)
         self.assertIn(brand.branding_custom_css, res.content.decode())
+
+
+class TestGetBrandForRequestSelectRelated(TestCase):
+    """``get_brand_for_request`` must hydrate the FK fields read on the
+    request hot path so later access doesn't trigger lazy loads."""
+
+    def setUp(self):
+        Brand.objects.all().delete()
+        self.flow_auth = create_test_flow(designation=FlowDesignation.AUTHENTICATION)
+        self.brand = Brand.objects.create(
+            domain="select-related-test.example.com",
+            flow_authentication=self.flow_auth,
+        )
+
+    def _make_request(self, host: str) -> HttpRequest:
+        request = HttpRequest()
+        request.META["HTTP_HOST"] = host
+        return request
+
+    def test_brand_fks_are_loaded_in_single_query(self):
+        """Brand FK access after ``get_brand_for_request`` must not trigger
+        extra queries."""
+        request = self._make_request("select-related-test.example.com")
+        with self.assertNumQueries(1):
+            brand = get_brand_for_request(request)
+            _ = brand.flow_authentication
+            _ = brand.flow_authentication.slug if brand.flow_authentication else None
+            _ = brand.flow_invalidation
+            _ = brand.flow_recovery
+            _ = brand.flow_unenrollment
+            _ = brand.flow_user_settings
+            _ = brand.flow_device_code
+            _ = brand.flow_lockdown
+            _ = brand.default_application
+
+    def test_brand_related_fk_list_complete(self):
+        """``_BRAND_RELATED_FK_FIELDS`` covers every Flow/Application FK on
+        Brand — fails loud when a new FK is added but not registered here."""
+        actual_fks = {
+            f.name
+            for f in Brand._meta.get_fields()
+            if f.many_to_one and f.related_model is not None
+        }
+        relevant_fks = {
+            name for name in actual_fks if name.startswith("flow_") or name == "default_application"
+        }
+        declared = set(_BRAND_RELATED_FK_FIELDS)
+        missing = relevant_fks - declared
+        self.assertFalse(
+            missing,
+            f"Brand FK fields {missing} aren't in _BRAND_RELATED_FK_FIELDS — "
+            "add them or the request hot path will incur extra queries.",
+        )
+
+    def test_brand_related_fks_all_exist_on_model(self):
+        """Every entry in ``_BRAND_RELATED_FK_FIELDS`` is a real FK on Brand.
+        ``select_related`` raises ``FieldError`` at first use if any entry
+        is stale, which would break every request."""
+        actual_fks = {
+            f.name
+            for f in Brand._meta.get_fields()
+            if f.many_to_one and f.related_model is not None
+        }
+        declared = set(_BRAND_RELATED_FK_FIELDS)
+        extraneous = declared - actual_fks
+        self.assertFalse(
+            extraneous,
+            f"_BRAND_RELATED_FK_FIELDS contains {extraneous} which don't "
+            f"exist on Brand (actual FKs: {sorted(actual_fks)}).",
+        )

--- a/authentik/brands/utils.py
+++ b/authentik/brands/utils.py
@@ -16,12 +16,26 @@ from authentik.tenants.models import Tenant
 _q_default = Q(default=True)
 DEFAULT_BRAND = Brand(domain="fallback")
 
+# Brand FKs read on the request hot path. select_related pulls them into the
+# same SELECT to avoid N+1 lazy loads; CurrentBrandSerializer alone reads 7.
+_BRAND_RELATED_FK_FIELDS = (
+    "flow_authentication",
+    "flow_invalidation",
+    "flow_recovery",
+    "flow_unenrollment",
+    "flow_user_settings",
+    "flow_device_code",
+    "flow_lockdown",
+    "default_application",
+)
+
 
 def get_brand_for_request(request: HttpRequest) -> Brand:
     """Get brand object for current request"""
 
     brand = (
-        Brand.objects.annotate(
+        Brand.objects.select_related(*_BRAND_RELATED_FK_FIELDS)
+        .annotate(
             host_domain=Value(request.get_host()),
             domain_length=Length("domain"),
             match_priority=Case(

--- a/authentik/root/settings.py
+++ b/authentik/root/settings.py
@@ -147,6 +147,12 @@ TENANT_CREATION_FAKES_MIGRATIONS = True
 TENANT_BASE_SCHEMA = "template"
 PUBLIC_SCHEMA_NAME = CONFIG.get("postgresql.default_schema")
 
+# Issue `SET search_path` only when the schema actually changes for a given
+# connection instead of before every cursor. Roughly halves statement count on
+# request hot paths. Requires a stable PG session — safe behind a transaction
+# pooler only if the LISTEN/lock subsystems are routed via ``postgresql.direct.*``.
+TENANT_LIMIT_SET_CALLS = True
+
 GUARDIAN_GROUP_MODEL = "authentik_core.Group"
 GUARDIAN_ROLE_MODEL = "authentik_rbac.Role"
 

--- a/authentik/tenants/tests/test_utils.py
+++ b/authentik/tenants/tests/test_utils.py
@@ -1,0 +1,76 @@
+"""Tests for `authentik.tenants.utils.get_current_tenant` memoization."""
+
+from django.core.signals import request_started
+from django.db import connection
+from django.test import TestCase
+
+from authentik.tenants.models import Tenant
+from authentik.tenants.utils import _TENANT_CACHE_ATTR, get_current_tenant
+
+
+class TestGetCurrentTenantMemoization(TestCase):
+    """Per-connection memoization with ``(schema_name, frozenset(only))`` key."""
+
+    def _clear_cache(self):
+        if hasattr(connection, _TENANT_CACHE_ATTR):
+            delattr(connection, _TENANT_CACHE_ATTR)
+
+    def setUp(self):
+        # Tests share a connection; clear cache to start from a known state.
+        self._clear_cache()
+
+    def test_first_call_hits_db_subsequent_calls_with_same_only_do_not(self):
+        """First call: 1 query. Subsequent calls with same ``only``: 0."""
+        with self.assertNumQueries(1):
+            t1 = get_current_tenant()
+        with self.assertNumQueries(0):
+            t2 = get_current_tenant()
+            t3 = get_current_tenant()
+        self.assertIs(t1, t2)
+        self.assertIs(t2, t3)
+
+    def test_calls_with_different_only_are_separate_cache_entries(self):
+        """``only`` is part of the cache key. Calls during migrations may
+        pass narrow ``only`` sets when the schema doesn't yet have all
+        columns; respecting the key keeps each SELECT scoped correctly."""
+        with self.assertNumQueries(1):
+            t1 = get_current_tenant()  # only=[]
+        with self.assertNumQueries(1):
+            t2 = get_current_tenant(["flags"])
+        with self.assertNumQueries(0):
+            t3 = get_current_tenant(["flags"])
+        self.assertIs(t2, t3)
+        self.assertIsNot(t1, t2)
+
+    def test_cache_cleared_on_request_start(self):
+        """The ``request_started`` signal handler clears the cache so stale
+        data can't survive a request boundary on persistent-connection
+        deployments. Calls the handler directly (the real signal would
+        also fire ``close_old_connections``, closing our test connection)."""
+        from authentik.tenants.utils import _clear_current_tenant_cache
+
+        get_current_tenant()
+        self.assertTrue(hasattr(connection, _TENANT_CACHE_ATTR))
+        _clear_current_tenant_cache(sender=None)
+        self.assertFalse(hasattr(connection, _TENANT_CACHE_ATTR))
+
+    def test_cache_clear_handler_registered_for_request_started(self):
+        """The cache-clear handler is connected to ``request_started``."""
+        receivers = request_started._live_receivers(sender=None)
+        all_repr = "\n".join(str(r) for r in receivers)
+        self.assertIn("_clear_current_tenant_cache", all_repr)
+
+    def test_cache_keyed_on_schema_name(self):
+        """Schema change mid-request invalidates the cache and forces a
+        refetch. Simulates ``set_tenant`` to a non-existent schema; the
+        refetch raises ``Tenant.DoesNotExist`` as expected."""
+        tenant_public = get_current_tenant()
+        original = connection.schema_name
+        try:
+            connection.schema_name = "_test_other_schema_does_not_exist"
+            with self.assertRaises(Tenant.DoesNotExist):
+                get_current_tenant()
+        finally:
+            connection.schema_name = original
+        tenant_again = get_current_tenant()
+        self.assertEqual(tenant_again.schema_name, tenant_public.schema_name)

--- a/authentik/tenants/utils.py
+++ b/authentik/tenants/utils.py
@@ -1,5 +1,6 @@
 """Tenant utils"""
 
+from django.core.signals import request_started
 from django.db import connection
 from django_tenants.utils import get_public_schema_name
 
@@ -7,12 +8,53 @@ from authentik.lib.config import CONFIG
 from authentik.root.install_id import get_install_id
 from authentik.tenants.models import Tenant
 
+# Per-connection memoization for ``get_current_tenant``. Cache lives on the
+# Django connection (thread-local); key is ``(schema_name, frozenset(only))``.
+# Tenant switches via django_tenants update ``schema_name`` and naturally
+# invalidate. The ``only`` argument is part of the key so calls during
+# migrations (where the Tenant table may not yet have all columns) stay
+# correct — different callers pass different ``only`` sets.
+_TENANT_CACHE_ATTR = "_authentik_current_tenant"
+
 
 def get_current_tenant(only: list[str] | None = None) -> Tenant:
-    """Get tenant for current request"""
+    """Get tenant for current request.
+
+    Memoized per Django connection by ``(schema_name, frozenset(only or []))``.
+    With the authentik default ``CONN_MAX_AGE=0`` the connection closes at
+    request end, so the cache is effectively per-request. With persistent
+    connections, the ``request_started`` signal handler below clears the
+    cache at request boundaries as defense-in-depth.
+    """
+    schema = connection.schema_name
     if only is None:
         only = []
-    return Tenant.objects.only(*only).get(schema_name=connection.schema_name)
+    cache_key = (schema, frozenset(only))
+
+    cached = getattr(connection, _TENANT_CACHE_ATTR, None)
+    if cached is not None:
+        cached_key, cached_tenant = cached
+        if cached_key == cache_key:
+            return cached_tenant
+
+    tenant = Tenant.objects.only(*only).get(schema_name=schema)
+    setattr(connection, _TENANT_CACHE_ATTR, (cache_key, tenant))
+    return tenant
+
+
+def _clear_current_tenant_cache(sender, **kwargs):
+    """Clear the per-connection tenant cache at request boundaries. Ensures
+    the cache cannot survive a request even on deployments with persistent
+    Django connections (``CONN_MAX_AGE>0``).
+    """
+    if hasattr(connection, _TENANT_CACHE_ATTR):
+        try:
+            delattr(connection, _TENANT_CACHE_ATTR)
+        except AttributeError:
+            pass
+
+
+request_started.connect(_clear_current_tenant_cache, dispatch_uid="authentik_tenants_utils")
 
 
 def get_unique_identifier() -> str:


### PR DESCRIPTION
## Why

Two small, independent optimizations that compound under load. Each
removes queries from the request hot path without changing behavior.

## What

### `TENANT_LIMIT_SET_CALLS = True`

`django_tenants` issues `SET search_path` before every cursor by default.
Setting this flag makes it issue the `SET` only when the schema actually
changes for a given connection. Roughly halves the statement count on
request hot paths. Safe for both single-tenant and multi-tenant setups
as long as the PG session is stable across statements.

### `select_related` for Brand FKs in `get_brand_for_request`

`get_brand_for_request` is called from `BrandMiddleware` on every
request. `CurrentBrandSerializer` then reads 7 Flow FK fields on the
brand (`flow_authentication`, `flow_invalidation`, `flow_recovery`,
`flow_unenrollment`, `flow_user_settings`, `flow_device_code`,
`flow_lockdown`) plus `default_application`. Without `select_related`,
each access is a lazy load — up to 8 extra queries per HTML render of
`/if/flow/<slug>/`. With it, all 8 hydrate in the same SELECT.

A regression test guards against future additions to the FK set being
missed (and against the symmetric "this list contains a field that no
longer exists, causing FieldError" failure mode).

### Memoize `get_current_tenant` per Django connection

`get_current_tenant()` is called multiple times per request (once per
public flag from `Flag.get()` in `CurrentBrandSerializer.get_flags()`,
plus a handful of other call sites). Each call without memoization is a
separate `SELECT ... FROM authentik_tenants_tenant WHERE schema_name = $1`.
Memoization keyed on `(schema_name, frozenset(only))` turns N=5+ queries
into 1.

The `only` argument is part of the key for migration safety — different
callers pass different `only` sets (notably `Flag.get` uses
`only=["flags"]`), and during migrations the Tenant table may not yet
have all columns. A `request_started` signal handler clears the cache at
request boundaries as defense-in-depth for persistent-connection
deployments.

## Tests

- `test_brand_fks_are_loaded_in_single_query` — `assertNumQueries(1)`
  while accessing every brand FK.
- `test_brand_related_fk_list_complete` — fails CI if a new FK is added
  to the Brand model without being included in `_BRAND_RELATED_FK_FIELDS`.
- `test_brand_related_fks_all_exist_on_model` — fails CI if a stale FK
  is in the list (would cause `FieldError` on every request).
- 5 tests for `get_current_tenant` memoization, including signal-handler
  registration and `schema_name`-based invalidation.


---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
