### PR TITLE
Eliminate hot DB queries on metrics scrape and login paths

### DIFF
--- a/authentik/policies/signals.py
+++ b/authentik/policies/signals.py
@@ -29,8 +29,18 @@ def monitoring_set_policies(sender, **kwargs):
 @receiver(post_save, sender=PolicyBindingModel)
 @receiver(post_save, sender=Group)
 @receiver(post_save, sender=User)
-def invalidate_policy_cache(sender, instance, **_):
-    """Invalidate Policy cache when policy is updated"""
+def invalidate_policy_cache(sender, instance, update_fields=None, **_):
+    """Invalidate Policy cache when policy is updated.
+
+    Skips when the save touched only ``last_login`` — Django's auth flow runs
+    ``user.save(update_fields=["last_login"])`` on every successful login, and
+    the broad invalidation below would otherwise issue a full-table cache
+    scan on every login. ``last_login`` doesn't affect policy evaluation or
+    application access, so there's nothing to invalidate.
+    """
+    if sender == User and update_fields and set(update_fields) <= {"last_login"}:
+        return
+
     if sender == Policy:
         total = 0
         for binding in PolicyBinding.objects.filter(policy=instance):

--- a/authentik/policies/tests/test_signals.py
+++ b/authentik/policies/tests/test_signals.py
@@ -1,0 +1,105 @@
+"""Tests for ``authentik.policies.signals.invalidate_policy_cache``.
+
+Regression guards for the per-login cache-invalidation skip. ``last_login``-
+only User saves must not trigger the broad ``cache.keys(...)`` invalidation.
+"""
+
+from unittest import TestCase, mock
+
+
+class _FakeUser:
+    pk = 1
+
+
+class _FakePolicy:
+    pk = "fake-policy-pk"
+
+
+class TestInvalidatePolicyCacheSkipsLastLoginOnly(TestCase):
+    """The handler must NOT touch the cache when a User save is purely a
+    ``last_login`` update."""
+
+    def _run_handler(self, sender, instance, update_fields):
+        """Run the handler with mocked cache/PolicyBinding; return the
+        cache mock for assertions."""
+        from authentik.policies import signals
+
+        with (
+            mock.patch.object(signals, "cache") as mock_cache,
+            mock.patch.object(signals, "PolicyBinding") as mock_pb,
+        ):
+            mock_cache.keys.return_value = []
+            mock_pb.objects.filter.return_value = []
+            signals.invalidate_policy_cache(
+                sender=sender,
+                instance=instance,
+                update_fields=update_fields,
+            )
+            return mock_cache
+
+    def test_user_save_with_only_last_login_does_not_invalidate(self):
+        """User save with update_fields=["last_login"] is the per-login hot
+        path. The handler must short-circuit without touching the cache."""
+        from authentik.core.models import User
+
+        mock_cache = self._run_handler(
+            sender=User, instance=_FakeUser(), update_fields=["last_login"]
+        )
+        mock_cache.keys.assert_not_called()
+        mock_cache.delete_many.assert_not_called()
+
+    def test_user_save_with_last_login_as_set_does_not_invalidate(self):
+        """``update_fields`` may be a set (Django supports any iterable).
+        The handler must treat ``{"last_login"}`` identically to
+        ``["last_login"]``."""
+        from authentik.core.models import User
+
+        mock_cache = self._run_handler(
+            sender=User, instance=_FakeUser(), update_fields={"last_login"}
+        )
+        mock_cache.keys.assert_not_called()
+
+    def test_user_save_with_other_fields_still_invalidates(self):
+        """A User save that updates ``email`` (or any non-last_login field)
+        must still invalidate the cache — those updates can affect policy
+        evaluation, group membership computation, etc."""
+        from authentik.core.models import User
+
+        mock_cache = self._run_handler(sender=User, instance=_FakeUser(), update_fields=["email"])
+        mock_cache.keys.assert_called()
+        mock_cache.delete_many.assert_called()
+
+    def test_user_save_with_last_login_plus_other_fields_invalidates(self):
+        """If ``update_fields`` contains ``last_login`` plus anything else,
+        we must invalidate — the other field could have policy implications."""
+        from authentik.core.models import User
+
+        mock_cache = self._run_handler(
+            sender=User,
+            instance=_FakeUser(),
+            update_fields=["last_login", "email"],
+        )
+        mock_cache.keys.assert_called()
+
+    def test_user_save_without_update_fields_invalidates(self):
+        """``update_fields=None`` means a full save — anything could have
+        changed, so we conservatively invalidate."""
+        from authentik.core.models import User
+
+        mock_cache = self._run_handler(sender=User, instance=_FakeUser(), update_fields=None)
+        mock_cache.keys.assert_called()
+
+    def test_policy_save_still_invalidates(self):
+        """Non-User senders are unaffected by the new short-circuit.
+        Policy/PolicyBinding/PolicyBindingModel/Group saves must continue to
+        invalidate as before — those changes affect access decisions for
+        every user."""
+        from authentik.policies.models import Policy
+
+        mock_cache = self._run_handler(
+            sender=Policy,
+            instance=_FakePolicy(),
+            update_fields=["last_login"],  # irrelevant — sender isn't User
+        )
+        mock_cache.keys.assert_called()
+        mock_cache.delete_many.assert_called()

--- a/authentik/tasks/signals.py
+++ b/authentik/tasks/signals.py
@@ -6,6 +6,7 @@ from django.db.models import Count
 from django.dispatch import receiver
 from django.utils.timezone import now
 from django_dramatiq_postgres.models import TaskState
+from dramatiq.broker import get_broker
 from packaging.version import parse
 from prometheus_client import Gauge
 
@@ -46,9 +47,17 @@ def monitoring_set_workers(sender, **kwargs):
 
 @receiver(monitoring_set)
 def monitoring_set_queued_tasks(sender, **kwargs):
-    """Set number of queued tasks"""
-    for stats in Task.objects.values("queue_name", "actor_name").distinct():
-        GAUGE_TASKS_QUEUED.labels(stats["queue_name"], stats["actor_name"]).set(0)
+    """Set the queued-tasks gauge for every registered actor.
+
+    Enumerates ``(queue_name, actor_name)`` combinations from the dramatiq
+    broker's in-memory actor registry rather than via
+    ``SELECT DISTINCT ... FROM authentik_tasks_task`` — the latter forces a
+    full-table scan on every Prometheus scrape and becomes a top CPU consumer
+    under sustained load as the task table grows.
+    """
+    broker = get_broker()
+    for actor in broker.actors.values():
+        GAUGE_TASKS_QUEUED.labels(actor.queue_name, actor.actor_name).set(0)
     for stats in (
         Task.objects.filter(state=TaskState.QUEUED)
         .values("queue_name", "actor_name")

--- a/authentik/tasks/tests/test_signals.py
+++ b/authentik/tasks/tests/test_signals.py
@@ -1,0 +1,93 @@
+"""Tests for ``authentik.tasks.signals.monitoring_set_queued_tasks``.
+
+Regression guards: the handler must enumerate ``(queue_name, actor_name)``
+from the in-memory dramatiq broker registry, not via a
+``SELECT DISTINCT ... FROM authentik_tasks_task`` full-table scan.
+
+Pure unit tests — ``Task.objects`` and ``get_broker`` are mocked so no DB
+connection is required.
+"""
+
+from unittest import TestCase, mock
+
+
+class _FakeActor:
+    def __init__(self, queue_name: str, actor_name: str):
+        self.queue_name = queue_name
+        self.actor_name = actor_name
+
+
+class TestMonitoringSetQueuedTasksDoesNotScan(TestCase):
+    """The handler must not full-scan ``authentik_tasks_task``."""
+
+    def _run_handler(self, fake_actors, task_objects_mock):
+        """Run the handler with mocked broker, Task.objects, and gauge.
+        Returns (broker_mock, task_mock, gauge_mock)."""
+        from authentik.tasks import signals
+
+        with (
+            mock.patch.object(signals, "get_broker") as mock_get_broker,
+            mock.patch.object(signals, "Task") as mock_task,
+            mock.patch.object(signals, "GAUGE_TASKS_QUEUED") as mock_gauge,
+        ):
+            mock_get_broker.return_value.actors = fake_actors
+            mock_task.objects = task_objects_mock
+            signals.monitoring_set_queued_tasks(sender=self)
+            return mock_get_broker, mock_task, mock_gauge
+
+    def test_does_not_call_values_distinct_on_task_objects(self):
+        """Direct ``Task.objects.values(...).distinct()`` (the old DB-hot path)
+        must never be called."""
+        fake_actors = {
+            "a": _FakeActor("default", "a"),
+            "b": _FakeActor("default", "b"),
+        }
+        task_objects = mock.MagicMock()
+        # Empty result for the remaining filter-based query.
+        task_objects.filter.return_value.values.return_value.annotate.return_value = []
+
+        _, mock_task, _ = self._run_handler(fake_actors, task_objects)
+
+        # ``values`` called without going through ``filter`` first means
+        # something is enumerating the whole table.
+        for call in mock_task.objects.values.call_args_list:
+            self.fail(
+                f"Task.objects.values{call} was called directly — "
+                "this would issue a full-table SELECT DISTINCT."
+            )
+
+    def test_gauges_set_for_every_registered_actor(self):
+        """Every actor registered with the broker has its gauge initialized
+        to 0 so prometheus shows the actor's existence even when no tasks
+        are queued for it."""
+        fake_actors = {
+            "actor_a": _FakeActor("queue_x", "actor_a"),
+            "actor_b": _FakeActor("queue_y", "actor_b"),
+            "actor_c": _FakeActor("queue_x", "actor_c"),
+        }
+        task_objects = mock.MagicMock()
+        task_objects.filter.return_value.values.return_value.annotate.return_value = []
+
+        _, _, mock_gauge = self._run_handler(fake_actors, task_objects)
+
+        labeled_combos = {(c.args[0], c.args[1]) for c in mock_gauge.labels.call_args_list}
+        expected_combos = {(actor.queue_name, actor.actor_name) for actor in fake_actors.values()}
+        self.assertEqual(labeled_combos, expected_combos)
+        for child_call in mock_gauge.labels.return_value.set.call_args_list:
+            self.assertEqual(child_call.args, (0,))
+
+    def test_queued_count_query_uses_filter_state_queued(self):
+        """The remaining DB query goes through ``.filter(state=QUEUED)`` so
+        it can use the ``(queue_name, state)`` index."""
+        from django_dramatiq_postgres.models import TaskState
+
+        fake_actors = {"a": _FakeActor("default", "a")}
+        task_objects = mock.MagicMock()
+        task_objects.filter.return_value.values.return_value.annotate.return_value = [
+            {"queue_name": "default", "actor_name": "a", "count": 5},
+        ]
+
+        _, mock_task, mock_gauge = self._run_handler(fake_actors, task_objects)
+
+        mock_task.objects.filter.assert_called_once_with(state=TaskState.QUEUED)
+        mock_gauge.labels.return_value.set.assert_any_call(5)

--- a/packages/django-postgres-cache/django_postgres_cache/backend.py
+++ b/packages/django-postgres-cache/django_postgres_cache/backend.py
@@ -175,14 +175,24 @@ class DatabaseCache(BaseCache):
         CacheEntry.objects.truncate()
 
     def keys(self, keys_pattern: str, version: int | None = None) -> list[str]:
-        keys_pattern = self.make_key(keys_pattern.replace("*", ".*"), version=version)
+        """Return cache keys matching a glob pattern (``*`` wildcard).
 
-        return [
-            self.reverse_key_func(key)
-            for key in CacheEntry.objects.filter(
-                cache_key__regex=keys_pattern,
-            ).values_list(
-                "cache_key",
-                flat=True,
-            )
-        ]
+        Simple ``prefix*`` patterns use Django's ``__startswith`` lookup
+        (``LIKE 'prefix%'``), which can be answered by a B-tree index on
+        ``cache_key`` and is dramatically cheaper than the regex path even
+        without one. No-wildcard patterns reduce to primary-key equality.
+        Complex patterns (wildcards in non-suffix position, multiple
+        wildcards) fall back to ``__regex``.
+        """
+        wildcard_count = keys_pattern.count("*")
+        if wildcard_count == 0:
+            key = self.make_key(keys_pattern, version=version)
+            qs = CacheEntry.objects.filter(cache_key=key)
+        elif wildcard_count == 1 and keys_pattern.endswith("*"):
+            prefix = self.make_key(keys_pattern[:-1], version=version)
+            qs = CacheEntry.objects.filter(cache_key__startswith=prefix)
+        else:
+            regex = self.make_key(keys_pattern.replace("*", ".*"), version=version)
+            qs = CacheEntry.objects.filter(cache_key__regex=regex)
+
+        return [self.reverse_key_func(key) for key in qs.values_list("cache_key", flat=True)]

--- a/packages/django-postgres-cache/tests/test_keys_method.py
+++ b/packages/django-postgres-cache/tests/test_keys_method.py
@@ -1,0 +1,68 @@
+"""Tests for ``DatabaseCache.keys`` glob-to-SQL translation.
+
+``cache.keys("prefix*")`` must use ``__startswith`` (LIKE), not the regex
+path. Pure unit tests — ``CacheEntry.objects`` is mocked.
+"""
+
+from typing import Any, cast
+from unittest import TestCase, mock
+
+from django_postgres_cache.backend import DatabaseCache
+
+
+def _make_cache() -> DatabaseCache:
+    """Construct a ``DatabaseCache`` without Django settings or a real DB."""
+    cache = DatabaseCache.__new__(DatabaseCache)
+    cache.key_prefix = ""
+    cache.version = 1
+    cache.key_func = lambda key, key_prefix, version: f":{version}:{key}"
+    # Reverse-key is not invoked in these tests (filter mocks return []), so
+    # an identity function is enough.
+    cache.reverse_key_func = lambda k: k
+    return cache
+
+
+class TestKeysGlobToLookup(TestCase):
+    """The SQL lookup chosen for each glob pattern shape."""
+
+    def _captured_filter_kwargs(self, pattern: str) -> dict[str, Any]:
+        """Run ``cache.keys(pattern)`` and return the kwargs passed to
+        ``CacheEntry.objects.filter(...)``."""
+        cache = _make_cache()
+        with mock.patch("django_postgres_cache.backend.CacheEntry") as mock_entry:
+            mock_entry.objects.filter.return_value.values_list.return_value = []
+            cache.keys(pattern)
+            self.assertEqual(mock_entry.objects.filter.call_count, 1)
+            return cast(dict[str, Any], mock_entry.objects.filter.call_args.kwargs)
+
+    def test_simple_prefix_glob_uses_startswith(self) -> None:
+        """``cache.keys("foo*")`` uses ``__startswith``, not ``__regex``."""
+        kwargs = self._captured_filter_kwargs("foo*")
+        self.assertIn("cache_key__startswith", kwargs)
+        self.assertNotIn("cache_key__regex", kwargs)
+        self.assertNotIn("cache_key", kwargs)
+
+    def test_realistic_authentik_prefix_glob_uses_startswith(self) -> None:
+        """The actual hot-query pattern from the bug report uses ``__startswith``."""
+        kwargs = self._captured_filter_kwargs("goauthentik.io/policies/app_access/*")
+        self.assertIn("cache_key__startswith", kwargs)
+        self.assertNotIn("cache_key__regex", kwargs)
+
+    def test_exact_match_uses_equality(self) -> None:
+        """No-wildcard patterns use primary-key equality."""
+        kwargs = self._captured_filter_kwargs("exact")
+        self.assertIn("cache_key", kwargs)
+        self.assertNotIn("cache_key__startswith", kwargs)
+        self.assertNotIn("cache_key__regex", kwargs)
+
+    def test_complex_glob_falls_back_to_regex(self) -> None:
+        """Multiple wildcards or non-suffix wildcards fall back to ``__regex``."""
+        kwargs = self._captured_filter_kwargs("foo*bar*")
+        self.assertIn("cache_key__regex", kwargs)
+        self.assertNotIn("cache_key__startswith", kwargs)
+
+    def test_leading_wildcard_falls_back_to_regex(self) -> None:
+        """A leading wildcard cannot reduce to LIKE — fall back to ``__regex``."""
+        kwargs = self._captured_filter_kwargs("*foo")
+        self.assertIn("cache_key__regex", kwargs)
+        self.assertNotIn("cache_key__startswith", kwargs)


### PR DESCRIPTION
## Why

Three full-table scans against the task and cache tables were the top
CPU consumers under sustained load:

1. `SELECT DISTINCT queue_name, actor_name FROM authentik_tasks_task`
   issued on every Prometheus scrape per server pod.
   Scans the entire task table to recover a tiny set of strings that are statically known
   from the dramatiq actor registry.

2. `SELECT cache_key FROM django_postgres_cache_cacheentry WHERE
   cache_key::text ~ $1` issued on every successful login. Django's
   `update_last_login` fires `post_save(User)`; `invalidate_policy_cache`
   responds with a regex full-table scan of the cache table — even
   though `last_login` doesn't affect policy evaluation or application
   access at all.

3. The cache backend's `keys()` method translates every glob pattern to
   a regex, forcing PostgreSQL into per-row regex evaluation. Even after
   2) is fixed, the remaining `cache.keys(...)` callers (admin actions,
   monitoring scrapes, the other signal handlers in `policies/signals.py`
   and `flows/signals.py`) all benefit from a cheaper path.

## What

### `authentik/tasks/signals.py` — `monitoring_set_queued_tasks`

Replaces `Task.objects.values("queue_name", "actor_name").distinct()`
with iteration over `dramatiq.broker.get_broker().actors.values()`. The
set of `(queue_name, actor_name)` combinations is defined at process
startup when actors register with the broker; the database is the wrong
source. The remaining query (the `WHERE state = QUEUED` count) uses the
existing `(queue_name, state)` index and only touches active rows.

### `authentik/policies/signals.py` — `invalidate_policy_cache`

Adds an early return when a User save touches only the `last_login`
field. Django's `update_last_login` calls
`user.save(update_fields=["last_login"])` on every successful login;
detecting this case skips the broad cache invalidation entirely.
Profile updates, password changes, group membership changes, and
Policy/PolicyBinding/Group saves continue to invalidate as before.

### `packages/django-postgres-cache` — `DatabaseCache.keys`

Detects simple `prefix*` glob patterns and uses Django's `__startswith`
lookup (translates to `LIKE 'prefix%'`) instead of `__regex`. Patterns
without any wildcard reduce to primary-key equality. Complex patterns
(wildcards in non-suffix position, multiple wildcards) fall back to the
original regex path — preserving the public method contract.

All authentik `cache.keys()` call sites use the simple `prefix*`
pattern, so they all take the fast path.

## Performance characteristics

- For databases with a B-tree index using `text_pattern_ops` on
  `cache_key`: `LIKE 'prefix%'` becomes an index-only scan.
- Without such an index (default Cloud SQL with non-C collation): `LIKE`
  still requires a sequential scan, but the per-row cost is dramatically
  lower than regex automaton evaluation.
- Exact-equality reduces to a primary-key lookup.

## Tests

14 new tests across three files. Of particular note:

- `test_does_not_call_values_distinct_on_task_objects` — regression
  guard that fails if anything reintroduces a direct
  `Task.objects.values(...).distinct()` on the table.
- `test_user_save_with_only_last_login_does_not_invalidate` — regression
  guard for the per-login hot path. Confirmed to fail against the
  pre-fix code path with the exact symptom (`cache.keys` called).
- `test_simple_prefix_glob_uses_startswith` — verifies the SQL lookup
  chosen for each pattern shape.


---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
