### PR TITLE
web/elements: add past-tense submitted formatter to Form

### DIFF
--- a/web/src/elements/forms/Form.ts
+++ b/web/src/elements/forms/Form.ts
@@ -148,6 +148,13 @@ export class Form<T = Record<string, unknown>, D = T>
         id: "form.submit.verb.creating",
     });
 
+    /**
+     * The past-tense verb to use in the default success message, e.g. "Created" or "Updated".
+     */
+    public static submittedVerb: string = msg("Created", {
+        id: "form.submit.verb.created",
+    });
+
     //#region Modal helpers
 
     public [TransclusionChildSymbol] = true;
@@ -239,6 +246,14 @@ export class Form<T = Record<string, unknown>, D = T>
      */
     @property({ type: String, attribute: "submitting-label", useDefault: true })
     public submittingLabel: string | null = null;
+
+    /**
+     * The message shown after the form has been successfully submitted. If not provided,
+     * a default label will be generated based on `submittedVerb` and `verboseName`,
+     * falling back to "Created".
+     */
+    @property({ type: String, attribute: "submitted-label", useDefault: true })
+    public submittedLabel: string | null = null;
 
     @property({ type: String, attribute: "cancel-label", useDefault: true })
     public cancelButtonLabel: string | null = msg("Cancel");
@@ -425,6 +440,26 @@ export class Form<T = Record<string, unknown>, D = T>
             id: "form.submitting",
             desc: "The message shown while a form is being submitted.",
         });
+    }
+
+    /**
+     * An overridable method for formatting the message shown after the form has been
+     * successfully submitted.
+     */
+    protected formatSubmittedLabel(submittedLabel = this.submittedLabel): string {
+        if (submittedLabel) {
+            return submittedLabel;
+        }
+
+        const noun = this.verboseName;
+        const verb = (this.constructor as typeof Form).submittedVerb;
+
+        return noun
+            ? msg(str`${verb} ${noun}`, {
+                  id: "form.submitted.verb-entity",
+                  desc: "The message shown after a form is successfully submitted.",
+              })
+            : verb;
     }
 
     //#endregion

--- a/web/src/elements/forms/ModelForm.ts
+++ b/web/src/elements/forms/ModelForm.ts
@@ -71,6 +71,14 @@ export abstract class ModelForm<
     });
 
     /**
+     * The message shown after the form has been successfully submitted when
+     * editing an instance, e.g. "Changes Saved".
+     */
+    public static savedLabel: string | null = msg("Changes Saved", {
+        id: "form.submit.changes-saved",
+    });
+
+    /**
      * A helper method to create an invoker for editing an instance of this form.
      *
      * The invoker will look for a `data-pk` attribute on the clicked element to determine which instance to load.
@@ -180,6 +188,16 @@ export abstract class ModelForm<
         }
 
         return super.formatSubmittingLabel(submittingLabel);
+    }
+
+    protected override formatSubmittedLabel(submittedLabel?: string): string {
+        const { savedLabel } = this.constructor as typeof ModelForm;
+
+        if (this.instancePk && savedLabel) {
+            return savedLabel;
+        }
+
+        return super.formatSubmittedLabel(submittedLabel);
     }
 
     protected override formatHeadline(modifier?: string | null): string {


### PR DESCRIPTION
Closes #22900

## What

Adds past-tense success-message support to the `Form` base class, complementing the existing `submitVerb` / `formatLabel` machinery.

**`Form`** (`web/src/elements/forms/Form.ts`):
- `static submittedVerb` — past-tense verb shown after submission (default: `"Created"`, i18n id `form.submit.verb.created`)
- `submittedLabel` property — optional explicit override (attribute `submitted-label`)
- `formatSubmittedLabel()` — resolves the post-submit success message: explicit label → `"${verb} ${noun}"` → bare verb

**`ModelForm`** (`web/src/elements/forms/ModelForm.ts`):
- `static savedLabel` — shown when editing an existing instance (default: `"Changes Saved"`, i18n id `form.submit.changes-saved`)
- `override formatSubmittedLabel()` — returns `savedLabel` when `instancePk` is set, otherwise delegates to `Form`

## Why

The existing `formatLabel` / `submitVerb` pattern covered the in-progress state ("Creating…" / "Saving…") but had no past-tense counterpart. Any subclass wanting a post-submit label had to inline its own strings (as PR #22897's `getSuccessMessage()` did). This gives all forms a consistent, overridable hook.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run build` passes

---

Triaged and authored end-to-end by an AI agent (playpen). Changes reviewed by @GirlBossRush.