### PR TITLE
core: fix Invitation Emails Ignoring Selected Template

### DIFF
--- a/web/src/admin/stages/invitation/InvitationSendEmailForm.ts
+++ b/web/src/admin/stages/invitation/InvitationSendEmailForm.ts
@@ -21,7 +21,7 @@ interface InvitationSendEmailRequestWithTemplate {
     emailAddresses: string;
     ccAddresses?: string;
     bccAddresses?: string;
-    template?: TypeCreate;
+    template?: string;
 }
 
 @customElement("ak-invitation-send-email-form")
@@ -84,7 +84,7 @@ export class InvitationSendEmailForm extends Form<InvitationSendEmailRequestWith
                     emailAddresses: addresses,
                     ccAddresses: ccAddresses.length > 0 ? ccAddresses : undefined,
                     bccAddresses: bccAddresses.length > 0 ? bccAddresses : undefined,
-                    template: data.template?.name,
+                    template: data.template,
                 },
             });
 


### PR DESCRIPTION
## Details

Closes #22584

The `<select name="template">` serializes to a string, but the send handler read `data.template?.name`, which is undefined on a string, so template never made it into the payload. Now passes the value through directly.

