### PR TITLE
web: Recovery Token CSS Safe Mode 

### DIFF
--- a/authentik/brands/api.py
+++ b/authentik/brands/api.py
@@ -20,6 +20,7 @@ from rest_framework.validators import UniqueValidator
 from rest_framework.viewsets import ModelViewSet
 
 from authentik.brands.models import Brand
+from authentik.brands.utils import session_safe_mode
 from authentik.core.api.used_by import UsedByMixin
 from authentik.core.api.utils import ModelSerializer, PassiveSerializer, ThemedUrlsSerializer
 from authentik.rbac.filters import SecretKeyFilter
@@ -129,6 +130,15 @@ class CurrentBrandSerializer(PassiveSerializer):
         for flag in Flag.available(visibility="public"):
             values[flag().key] = flag.get()
         return values
+
+    def to_representation(self, instance: Brand) -> dict[str, Any]:
+        data = super().to_representation(instance)
+        # Suppress custom CSS for safe-mode sessions (e.g. recovery links) so that
+        # misconfigured branding cannot prevent a user from reaching the UI to fix it.
+        request = self.context.get("request")
+        if request is not None and session_safe_mode(request):
+            data["branding_custom_css"] = ""
+        return data
 
 
 class BrandViewSet(UsedByMixin, ModelViewSet):

--- a/authentik/brands/models.py
+++ b/authentik/brands/models.py
@@ -17,6 +17,9 @@ from authentik.lib.models import SerializerModel
 
 LOGGER = get_logger()
 
+# Session flag marking a "safe mode" session (e.g. one created via a recovery link).
+SESSION_KEY_BRAND_SAFE_MODE = "authentik/brands/safe_mode"
+
 
 # Brand FKs read on the request hot path. select_related pulls them into the
 # same SELECT to avoid N+1 lazy loads; CurrentBrandSerializer alone reads 7.

--- a/authentik/brands/tests/test_brands.py
+++ b/authentik/brands/tests/test_brands.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from rest_framework.test import APITestCase
 
 from authentik.blueprints.tests import apply_blueprint
-from authentik.brands.models import Brand
+from authentik.brands.models import SESSION_KEY_BRAND_SAFE_MODE, Brand
 from authentik.core.models import Application
 from authentik.core.tests.utils import create_test_admin_user, create_test_brand
 from authentik.lib.generators import generate_id
@@ -297,3 +297,33 @@ class TestBrands(APITestCase):
         res = self.client.get(reverse("authentik_core:if-user"))
         self.assertEqual(res.status_code, 200)
         self.assertIn(brand.branding_custom_css, res.content.decode())
+
+    def test_custom_css_safe_mode(self):
+        """Custom CSS is suppressed and the safe-mode class is set for safe-mode sessions"""
+        brand = create_test_brand()
+        brand.branding_custom_css = """* {
+            font-family: "Foo bar";
+        }"""
+        brand.save()
+        session = self.client.session
+        session[SESSION_KEY_BRAND_SAFE_MODE] = True
+        session.save()
+        res = self.client.get(reverse("authentik_core:if-user"))
+        self.assertEqual(res.status_code, 200)
+        body = res.content.decode()
+        self.assertNotIn(brand.branding_custom_css, body)
+        self.assertIn("ak-m-safe-mode", body)
+        # A banner is surfaced informing the user that branding is suppressed.
+        self.assertIn("ak-c-safe-mode", body)
+        self.assertIn("Recovery session is active. Custom branding is disabled.", body)
+
+    def test_current_brand_safe_mode(self):
+        """Current brand API suppresses custom CSS for safe-mode sessions"""
+        brand = create_test_brand()
+        brand.branding_custom_css = "* { color: red; }"
+        brand.save()
+        session = self.client.session
+        session[SESSION_KEY_BRAND_SAFE_MODE] = True
+        session.save()
+        response = loads(self.client.get(reverse("authentik_api:brand-current")).content.decode())
+        self.assertEqual(response["branding_custom_css"], "")

--- a/authentik/brands/utils.py
+++ b/authentik/brands/utils.py
@@ -9,12 +9,21 @@ from django.utils.html import _json_script_escapes
 from django.utils.safestring import mark_safe
 
 from authentik import authentik_full_version
-from authentik.brands.models import _BRAND_RELATED_FK_FIELDS, Brand
+from authentik.brands.models import _BRAND_RELATED_FK_FIELDS, SESSION_KEY_BRAND_SAFE_MODE, Brand
 from authentik.lib.sentry import get_http_meta
 from authentik.tenants.models import Tenant
 
 _q_default = Q(default=True)
 DEFAULT_BRAND = Brand(domain="fallback")
+
+
+def session_safe_mode(request: HttpRequest) -> bool:
+    """Whether the current session is in brand "safe mode" (e.g. created via a recovery
+    link), in which case lock-out-prone customization such as custom CSS are suppressed."""
+    session = getattr(request, "session", None)
+    if session is None:
+        return False
+    return bool(session.get(SESSION_KEY_BRAND_SAFE_MODE))
 
 
 def get_brand_for_request(request: HttpRequest) -> Brand:
@@ -57,13 +66,18 @@ def context_processor(request: HttpRequest) -> dict[str, Any]:
     """Context Processor that injects brand object into every template"""
     brand = getattr(request, "brand", DEFAULT_BRAND)
     tenant = getattr(request, "tenant", Tenant())
+    # Suppress custom CSS for safe-mode sessions so misconfigured branding can't lock a
+    # user out of the UI needed to fix it.
+    safe_mode = session_safe_mode(request)
+    custom_css = "" if safe_mode else str(brand.branding_custom_css)
     # similarly to `json_script` we escape everything HTML-related, however django
     # only directly exposes this as a function that also wraps it in a <script> tag
     # which we dont want for CSS
-    brand_css = mark_safe(str(brand.branding_custom_css).translate(_json_script_escapes))  # nosec
+    brand_css = mark_safe(custom_css.translate(_json_script_escapes))  # nosec
     return {
         "brand": brand,
         "brand_css": brand_css,
+        "safe_mode": safe_mode,
         "footer_links": tenant.footer_links,
         "html_meta": {**get_http_meta()},
         "version": authentik_full_version(),

--- a/authentik/core/templates/base/skeleton.html
+++ b/authentik/core/templates/base/skeleton.html
@@ -6,6 +6,7 @@
 <!DOCTYPE html>
 <html
     lang="{{ LANGUAGE_CODE }}"
+    {% if safe_mode %}class="{% if ui_theme == "dark" %}pf-theme-dark{% endif %} ak-m-safe-mode"{% endif %}
     data-theme="{% if ui_theme == "dark" %}dark{% else %}light{% endif %}"
     data-theme-choice="{% if ui_theme == "dark" %}dark{% elif ui_theme == "light" %}light{% else %}auto{% endif %}"
 >
@@ -40,5 +41,13 @@
         {% endblock %}
         {% block scripts %}
         {% endblock %}
+        {% if safe_mode %}
+        <div class="pf-c-banner pf-m-warning ak-c-safe-mode">
+            <i class="fas fa-info-circle" aria-hidden="true"></i>
+            <p>
+            {% trans "Recovery session is active. Custom branding is disabled." %}
+            </p>
+        </div>
+        {% endif %}
     </body>
 </html>

--- a/authentik/core/templates/base/theme.html
+++ b/authentik/core/templates/base/theme.html
@@ -14,32 +14,37 @@
 
     (function () {
         try {
+          const { documentElement } = document;
+
             /* Ignore older theme names */
             let locallyStoredTheme = window.localStorage?.getItem("theme") || null;
+
             if (typeof locallyStoredTheme === "string") {
                 locallyStoredTheme = locallyStoredTheme.trim();
             }
             if (!(["auto", "light", "dark"].includes(locallyStoredTheme))) {
                 locallyStoredTheme = null;
             }
-            
+
             const initialThemeChoice =
                 new URLSearchParams(window.location.search).get("theme") || locallyStoredTheme;
 
             const themeChoice =
-                initialThemeChoice || document.documentElement.dataset.themeChoice || "auto";
+                initialThemeChoice || documentElement.dataset.themeChoice || "auto";
 
-            document.documentElement.dataset.themeChoice = themeChoice;
+            documentElement.dataset.themeChoice = themeChoice;
 
             if (themeChoice === "auto") {
-                document.documentElement.dataset.theme = window.matchMedia(
+                documentElement.dataset.theme = window.matchMedia(
                     "(prefers-color-scheme: dark)",
                 ).matches
                     ? "dark"
                     : "light";
             } else {
-                document.documentElement.dataset.theme = themeChoice;
+                documentElement.dataset.theme = themeChoice;
             }
+
+            documentElement.classList.toggle("pf-theme-dark", documentElement.dataset.theme === "dark");
         } catch (e) {
             console.error("Failed to apply theme", e);
         }

--- a/authentik/core/views/interface.py
+++ b/authentik/core/views/interface.py
@@ -55,7 +55,7 @@ class InterfaceView(TemplateView):
     """Base interface view"""
 
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
-        brand = CurrentBrandSerializer(self.request.brand)
+        brand = CurrentBrandSerializer(self.request.brand, context={"request": self.request})
         kwargs["config_json"] = dumps(ConfigView.get_config(self.request).data)
         kwargs["ui_theme"] = brand.data["ui_theme"]
         kwargs["brand_json"] = dumps(brand.data)

--- a/authentik/recovery/tests.py
+++ b/authentik/recovery/tests.py
@@ -9,6 +9,7 @@ from django.urls import reverse
 from django.utils.timezone import now
 from django_tenants.utils import get_public_schema_name
 
+from authentik.brands.models import SESSION_KEY_BRAND_SAFE_MODE
 from authentik.core.models import Token, TokenIntents, User
 
 
@@ -54,6 +55,20 @@ class TestRecovery(TestCase):
         token = Token.objects.get(intent=TokenIntents.INTENT_RECOVERY, user=self.user)
         self.client.get(reverse("authentik_recovery:use-token", kwargs={"key": token.key}))
         self.assertEqual(self.client.session["authenticatedsession"].user.pk, token.user.pk)
+
+    def test_recovery_view_safe_mode(self):
+        """Test recovery view enables brand safe mode on the session"""
+        out = StringIO()
+        call_command(
+            "create_recovery_key",
+            "10",
+            self.user.username,
+            schema=get_public_schema_name(),
+            stdout=out,
+        )
+        token = Token.objects.get(intent=TokenIntents.INTENT_RECOVERY, user=self.user)
+        self.client.get(reverse("authentik_recovery:use-token", kwargs={"key": token.key}))
+        self.assertTrue(self.client.session[SESSION_KEY_BRAND_SAFE_MODE])
 
     def test_recovery_view_invalid(self):
         """Test recovery view with invalid token"""

--- a/authentik/recovery/views.py
+++ b/authentik/recovery/views.py
@@ -8,6 +8,7 @@ from django.shortcuts import redirect
 from django.utils.translation import gettext as _
 from django.views import View
 
+from authentik.brands.models import SESSION_KEY_BRAND_SAFE_MODE
 from authentik.core.models import Token, TokenIntents
 from authentik.stages.password import BACKEND_INBUILT
 
@@ -24,9 +25,14 @@ class UseTokenView(View):
                 .select_related("user")
             )
             token = tokens.first()
+
             if token is None:
                 raise Http404
+
             login(request, token.user, backend=BACKEND_INBUILT)
             token.delete()
+
+        request.session[SESSION_KEY_BRAND_SAFE_MODE] = True
+
         messages.warning(request, _("Used recovery-link to authenticate."))
         return redirect("authentik_core:if-user")

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -589,6 +589,10 @@ msgstr ""
 msgid "Remove temporary users created by SAML Sources."
 msgstr ""
 
+#: authentik/core/templates/base/skeleton.html
+msgid "Recovery session is active. Custom branding is disabled."
+msgstr ""
+
 #: authentik/core/templates/if/error.html
 #: authentik/policies/templates/policies/denied.html
 msgid "Go home"

--- a/web/src/common/theme.ts
+++ b/web/src/common/theme.ts
@@ -178,7 +178,9 @@ export function createUIThemeEffect(
     };
 
     const themeChoiceListener = () => {
-        let theme = formatColorScheme(document.documentElement.dataset.themeChoice);
+        const { documentElement } = document;
+
+        let theme = formatColorScheme(documentElement.dataset.themeChoice);
 
         if (theme === "auto") {
             theme = mediaQueryList.matches
@@ -186,7 +188,8 @@ export function createUIThemeEffect(
                 : UIThemeInversion[colorSchemeTarget];
         }
 
-        document.documentElement.dataset.theme = theme;
+        documentElement.dataset.theme = theme;
+        documentElement.classList.toggle("pf-theme-dark", theme === "dark");
 
         effect(theme);
     };
@@ -280,6 +283,7 @@ export const applyDocumentTheme = ((
     }
 
     ownerDocument.documentElement.dataset.theme = currentUITheme;
+    document.documentElement.classList.toggle("pf-theme-dark", currentUITheme === "dark");
 
     console.debug(`authentik/theme (document): switching to ${currentUITheme} theme`);
 
@@ -308,6 +312,7 @@ export function applyThemeChoice(hint?: CSSColorSchemeValue, doc: Document = doc
     const themeChoice = !hint || hint === "auto" ? "auto" : resolveUITheme(hint);
 
     doc.documentElement.dataset.themeChoice = themeChoice;
+    document.documentElement.classList.toggle("pf-theme-dark", themeChoice === "dark");
 }
 
 /**

--- a/web/src/stories/flow-interface.ts
+++ b/web/src/stories/flow-interface.ts
@@ -29,7 +29,11 @@ export class StoryFlowInterface extends AKElement {
     public challenge: ChallengeTypes | null = null;
 
     #synchronizeTheme = () => {
-        this.ownerDocument.documentElement.dataset.themeChoice = resolveUITheme(this.activeTheme);
+        const themeChoice = resolveUITheme(this.activeTheme);
+        const { documentElement } = this.ownerDocument;
+
+        documentElement.dataset.themeChoice = themeChoice;
+        documentElement.classList.toggle("pf-theme-dark", themeChoice === "dark");
     };
 
     public override updated(changed: PropertyValues<this>): void {

--- a/web/src/styles/authentik/base/globals.css
+++ b/web/src/styles/authentik/base/globals.css
@@ -37,21 +37,33 @@ body {
 }
 
 .ak-c-safe-mode {
+    --pf-c-banner--md--PaddingLeft: var(--pf-global--spacer--md);
+    --pf-c-banner--md--PaddingRight: var(--pf-global--spacer--md);
+
     position: fixed;
     z-index: 9999999;
     inset-block-end: 0;
     inset-inline-end: 0;
-    pointer-events: none;
+    border-start-start-radius: var(--pf-global--BorderRadius--sm);
     display: flex;
     align-items: center;
-    justify-content: center;
-    font-size: var(--pf-global--FontSize--sm, 0.75rem);
-    font-weight: bold;
-    color: var(--pf-global--Color--100, CanvasText);
-    background-color: var(--pf-global--BackgroundColor--200, Canvas);
-    opacity: 0.75;
-    padding: var(--pf-global--spacer--sm, 0.5rem);
-    border-start-start-radius: 8px;
+    font-weight: var(--pf-global--FontWeight--normal);
+    gap: var(--pf-global--spacer--md);
+    animation: ak-safe-mode-fade-out 1s ease-in-out 0.5s forwards;
+
+    &:hover {
+        animation-direction: reverse;
+        animation-duration: 0.5s;
+    }
+}
+
+@keyframes ak-safe-mode-fade-out {
+    0% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0.4;
+    }
 }
 
 /* #endregion */

--- a/web/src/styles/authentik/components/Banner/banner.css
+++ b/web/src/styles/authentik/components/Banner/banner.css
@@ -8,11 +8,13 @@
     a {
         text-decoration-color: color-mix(in srgb, currentColor 30%, transparent 70%);
     }
+
     a:hover {
         text-decoration-color: currentColor;
     }
 }
 
+html[theme="dark"] .pf-c-banner,
 :host([theme="dark"]) .pf-c-banner {
     &.pf-m-info,
     &.pf-m-blue,

--- a/web/src/styles/authentik/interface.global.css
+++ b/web/src/styles/authentik/interface.global.css
@@ -4,6 +4,8 @@
 @import "@patternfly/patternfly/base/patternfly-fa-icons.css";
 @import "@patternfly/patternfly/base/patternfly-pf-icons.css";
 @import "@patternfly/patternfly/components/Spinner/spinner.css";
+@import "@patternfly/patternfly/components/Banner/banner.css";
+@import "./components/Banner/banner.css";
 @import "#fonts/RedHat/faces.css";
 @import "./base/fonts.css";
 @import "./base/variables.css";

--- a/website/docs/developer-docs/setup/full-dev-environment.mdx
+++ b/website/docs/developer-docs/setup/full-dev-environment.mdx
@@ -206,6 +206,12 @@ Copy the generated recovery key and paste it into the URL, after the domain. For
 
 `http://localhost:9000/recovery/use-token/ChFk2nJKJKJKY9OdIc8yv6RCgpGYp5rdndBhR6qHoHoJoWDdlvLuvU/`
 
+:::info
+
+The recovery token is valid for a short time, but anyone can use it to log in as the admin user. Using the recovery token will also disable custom CSS in case you've accidentally locked yourself out of the admin interface with a broken theme.
+
+:::
+
 ## End-to-end (E2E) setup
 
 Start the E2E test services with the following command:

--- a/website/docs/sys-mgmt/brands/custom-css.mdx
+++ b/website/docs/sys-mgmt/brands/custom-css.mdx
@@ -225,3 +225,17 @@ If you're still having trouble, the issue may stem from your CDN or reverse prox
 There's currently no comprehensive documentation on available CSS variables and parts in authentik. You can inspect the rendered HTML using browser developer tools to identify the CSS variables and parts applied to various elements.
 
 Look for CSS variables prefixed with `--ak-` and `--pf-` to identify those defined by authentik and Patternfly respectively. HTML elements with the `part="..."` attribute indicate which parts are available for styling.
+
+### The UI looks broken after upgrading authentik. What should I do?
+
+The upgrade may have introduced changes to the base theme, which could conflict with your custom CSS. In addition to reviewing the release notes for any changes, you may need to adjust your custom CSS to accommodate the new base styles. Avoiding direct element styling and instead relying on CSS variables and parts can help reduce the likelihood of breakage after upgrades.
+
+### I've locked myself out of authentik with a broken theme. How do I recover?
+
+If you've locked yourself out of authentik due to a broken theme, you can use the recovery token to regain access. To generate a recovery token, run the following command in your terminal:
+
+```sh
+uv run ak create_recovery_key 10 akadmin
+```
+
+Using a recovery token will disable custom CSS, allowing you to log in, navigate to the **System** > **Brands** page, and remove or fix the broken custom CSS.


### PR DESCRIPTION
## Details
Custom brand CSS can hide login/form controls and soft-lock users out with no way to reach the UI to fix it. Recovery sessions now run in a "safe mode" that suppresses custom CSS.

### Changes

- **Recovery sessions opt into safe mode** — `UseTokenView` sets a `authentik/brands/safe_mode` session flag after recovery login; new `session_safe_mode()` helper.
- **CSS suppressed on every path** — the server-rendered `<style>` (context processor) and `CurrentBrandSerializer` (the `brands/current/` API + `window.authentik.brand`) both return empty in safe mode, so broken CSS never reaches the browser.
- **Tests + docs** — brands/recovery coverage, and a recovery FAQ in `custom-css.mdx`.
- Fix for pf-theme-dark theme variable overrides for non-shadow elements, such as the recover mode banner. 

<img width="1158" height="1006" alt="Screenshot 2026-06-17 at 04 11 05" src="https://github.com/user-attachments/assets/7cd7446b-6ea3-4d71-9f7e-66548eb19a00" />

Closes #22330
Closes #21822
Closes #20576