### PR TITLE
website/integrations: microsoft 365: add missing msgraph scope

### DIFF
--- a/website/integrations/platforms/microsoft/index.md
+++ b/website/integrations/platforms/microsoft/index.md
@@ -196,7 +196,7 @@ Domain creation and DNS verification are outside the scope of this guide. Ensure
 
 ```powershell showLineNumbers
 # 1. Connect to Microsoft Graph
-Connect-MgGraph -Scopes "Domain.ReadWrite.All"
+Connect-MgGraph -Scopes "Domain.ReadWrite.All", "Directory.AccessAsUser.All"
 
 # 2. Define all variables
 $domain = "domain.company"


### PR DESCRIPTION
## Details

### What does this PR change?

Adds a missing scope to the PowerShell connection command when setting up M365.

### Why is this change needed?

I got a 403 "Insufficient privileges to complete the operation." error without it.  A [Reddit comment](https://www.reddit.com/r/Office365/comments/13d04sy/comment/jjryyjz/) pointed out that this additional scope is required for managing federation.

### How was this tested?

I followed the rest of the guide successfully and set up M365 integration.

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
