### PR TITLE
WIP: fix custom attributes breaking wizard

### DIFF
--- a/web/src/admin/stages/invitation/wizard/InvitationWizardDetailsStep.ts
+++ b/web/src/admin/stages/invitation/wizard/InvitationWizardDetailsStep.ts
@@ -13,6 +13,7 @@ import {
 import { MessageLevel } from "#common/messages";
 import { dateTimeLocal } from "#common/temporal";
 
+import type { CodeMirrorTextarea } from "#elements/CodeMirror";
 import { showMessage } from "#elements/messages/MessageContainer";
 import { WizardPage } from "#elements/wizard/WizardPage";
 
@@ -227,9 +228,10 @@ export class InvitationWizardDetailsStep extends WizardPage {
             <ak-form-element-horizontal label=${msg("Custom attributes")}>
                 <ak-codemirror
                     mode="yaml"
+                    raw
                     .value=${this.fixedDataRaw}
-                    @change=${(ev: CustomEvent) => {
-                        this.fixedDataRaw = ev.detail.value;
+                    @change=${(ev: Event) => {
+                        this.fixedDataRaw = (ev.target as CodeMirrorTextarea).value;
                         this.validate();
                     }}
                 >


### PR DESCRIPTION
Fixes #22637

The codemirror change handler read `ev.detail.value`, but detail is the editor view, so fixedDataRaw became undefined and YAML.parse threw, leaving Next disabled. Now it reads .value off the target with raw set.

<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
