### PR TITLE
packages/django-postgres-cache: remove custom get_or_set implementation

### DIFF
--- a/packages/django-postgres-cache/django_postgres_cache/backend.py
+++ b/packages/django-postgres-cache/django_postgres_cache/backend.py
@@ -112,34 +112,6 @@ class DatabaseCache(BaseCache):
             result[key_map[entry.cache_key]] = self._unmake_value(entry.value)
         return result
 
-    def get_or_set(
-        self,
-        key: Any,
-        default: Any | None,
-        timeout: float | None = DEFAULT_TIMEOUT,
-        version: int | None = None,
-    ) -> Any | None:
-        key = self.make_and_validate_key(key, version=version)
-        if callable(default):
-            default = default()
-        default = self._make_value(default)
-        expiry = self._make_expiry(timeout)
-        entry = CacheEntry.objects.on_conflict(
-            ["cache_key"],
-            ConflictAction.NOTHING,
-        ).insert_and_get(
-            cache_key=key,
-            value=default,
-            expires=expiry,
-        )
-        # If the row already existed, nothing is returned
-        if entry is None:
-            entry = CacheEntry.objects.filter(cache_key=key).first()
-        # Sanity check, should not happen
-        if entry is None:
-            return None
-        return self._unmake_value(entry.value)
-
     def has_key(self, key: Any, version: int | None = None) -> bool:
         key = self.make_and_validate_key(key, version=version)
         return bool(CacheEntry.objects.filter(cache_key=key, expires__gte=now()).exists())


### PR DESCRIPTION
<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?

Removing the `get_or_set` override in `django-postgres-cache` lets us fall back to the django default `get_or_set` implementation within BaseCache

### Why is this change needed?

This version (introduced in fd3196744e6662692f23f6267d4421265c2adddc) does not correctly implement the `get_or_set` contract (it does not replace expired entries).

### How was this tested?

### Linked issues

<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

Closes #23170

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
