### PR TITLE
lib/sync: add Sync base model for storing past sync history

### DIFF
--- a/authentik/core/tasks.py
+++ b/authentik/core/tasks.py
@@ -15,6 +15,7 @@ from authentik.core.models import (
     ExpiringModel,
     User,
 )
+from authentik.lib.sync.models import Sync
 from authentik.lib.utils.db import chunked_queryset
 from authentik.tasks.middleware import CurrentTask
 
@@ -25,7 +26,6 @@ LOGGER = get_logger()
 def clean_expired_models():
     self = CurrentTask.get_task()
     for cls in ExpiringModel.__subclasses__():
-        cls: ExpiringModel
         objects = (
             cls.objects.including_expired()
             .all()
@@ -45,6 +45,9 @@ def clean_expired_models():
             obj.delete()
         LOGGER.debug("Expired models", model=cls, amount=amount)
         self.info(f"Expired {amount} {cls._meta.verbose_name_plural}")
+    for cls in Sync.__subclasses__():
+        amount = cls.cleanup()
+        LOGGER.debug("Expired models", model=cls, amount=amount)
 
 
 @actor(description=_("Remove temporary users created by SAML Sources."))

--- a/authentik/lib/sync/api.py
+++ b/authentik/lib/sync/api.py
@@ -1,6 +1,7 @@
 from rest_framework.fields import BooleanField, ChoiceField, DateTimeField
 
-from authentik.core.api.utils import PassiveSerializer
+from authentik.core.api.utils import ModelSerializer, PassiveSerializer
+from authentik.lib.sync.models import Sync
 from authentik.tasks.models import TaskStatus
 
 
@@ -10,3 +11,15 @@ class SyncStatusSerializer(PassiveSerializer):
     is_running = BooleanField()
     last_successful_sync = DateTimeField(required=False)
     last_sync_status = ChoiceField(required=False, choices=TaskStatus.choices)
+
+
+class SyncSerializer(ModelSerializer):
+    class Meta:
+        model = Sync
+        fields = [
+            "pk",
+            "tasks",
+            "started_at",
+            "finished_at",
+            "status",
+        ]

--- a/authentik/lib/sync/models.py
+++ b/authentik/lib/sync/models.py
@@ -1,0 +1,91 @@
+from datetime import datetime
+from uuid import uuid4
+
+from django.db import models
+from django_dramatiq_postgres.models import TaskState
+from dramatiq.broker import get_broker
+from dramatiq.message import Message
+
+from authentik.lib.models import InternallyManagedMixin
+from authentik.tasks.models import Task, TaskStatus
+
+
+class SyncStatus(models.TextChoices):
+    RUNNING = TaskStatus.RUNNING
+    ERROR = TaskStatus.ERROR
+    WARNING = TaskStatus.WARNING
+    DONE = TaskStatus.DONE
+
+
+class Sync(InternallyManagedMixin, models.Model):
+    uuid = models.UUIDField(primary_key=True, editable=False, default=uuid4)
+
+    # Must be defined by subclasses with a through model
+    # tasks = models.ManyToManyField(Task, related_name="+")
+    tasks: models.ManyToManyField
+
+    started_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        abstract = True
+
+    @classmethod
+    def cleanup(cls) -> int:
+        count = cls.objects.filter(tasks__count=0).delete()[0]
+        count += cls.objects.exclude(pk__in=cls.objects.order_by("-started_at")[:20]).delete()[0]
+        return count
+
+    @property
+    def done(self) -> bool:
+        return not any(
+            state not in (TaskState.DONE, TaskState.REJECTED)
+            for state in self.tasks.values_list("state", flat=True)
+        )
+
+    @property
+    def finished_at(self) -> datetime | None:
+        last_task = self.tasks.order_by("-mtime").first()
+        if last_task:
+            return last_task.mtime
+        return None
+
+    @property
+    def status(self) -> SyncStatus:
+        states = self.tasks.values_list("aggregated_status", flat=True)
+        if any(
+            state
+            in (
+                TaskStatus.WAITING_FOR_DEPENDENCIES,
+                TaskStatus.QUEUED,
+                TaskStatus.CONSUMED,
+                TaskStatus.PREPROCESS,
+                TaskStatus.RUNNING,
+                TaskStatus.POSTPROCESS,
+            )
+            for state in states
+        ):
+            return SyncStatus.RUNNING
+        if any(
+            state
+            in (
+                TaskStatus.REJECTED,
+                TaskStatus.ERROR,
+            )
+            for state in states
+        ):
+            return SyncStatus.ERROR
+        if any(state == TaskStatus.WARNING for state in states):
+            return SyncStatus.WARNING
+        return SyncStatus.DONE
+
+    def enqueue(self, messages: list[Message], existing_tasks_as_dependencies: bool = True) -> None:
+        broker = get_broker()
+        if existing_tasks_as_dependencies:
+            dependencies = self.tasks.values_list("pk", flat=True)
+            for message in messages:
+                message.options.setdefault("dependencies", []).extend(dependencies)
+        new_tasks: list[Task] = []
+        for message in messages:
+            new_message = broker.enqueue(message)
+            new_tasks.append(new_message.options["task"])
+        self.tasks.add(*new_tasks)


### PR DESCRIPTION


## Details

### What does this PR change?

Extracted from https://github.com/goauthentik/authentik/pull/23126

Add a `Sync` model (looking for feedback on the name) that can store past sync statuses and related tasks. See the above PR for use case.

Currently 20 syncs are kept, but I am also looking for feedback regarding that, especially since we might create Sync objects for partial syncs (in SCIM providers for instance).

### Why is this change needed?

Relying on past tasks is flaky and hard to correctly track. A persistent model to store that state is better suited for that task.

### How was this tested?

### Linked issues

<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
