### PR TITLE
web/stages/identification: Fix passkey autofill dropdown not showing on the identification stage

### DIFF
--- a/web/src/flow/stages/identification/controllers/WebauthnController.ts
+++ b/web/src/flow/stages/identification/controllers/WebauthnController.ts
@@ -54,11 +54,13 @@ export class WebauthnController implements ReactiveController {
     }
 
     public hostUpdated() {
+        // Only (re)start when the challenge changes; restarting on every re-render would abort
+        // the pending request and the passkey autofill dropdown would never appear.
         if (this.passkey !== this.#hostPasskey) {
             this.passkey = this.#hostPasskey;
-        }
-        if (this.passkey) {
-            this.#startConditionalWebAuthn(this.passkey);
+            if (this.passkey) {
+                this.#startConditionalWebAuthn(this.passkey);
+            }
         }
     }
 


### PR DESCRIPTION
The conditional WebAuthn request was being restarted on every re-render of the identification stage (captcha loading, remember-me, autofocus, etc.). Each restart aborts the in-flight request, so the browser's passkey autofill dropdown never gets a chance to appear.

Only start the request when the passkey challenge actually changes, so it stays pending like it used to.

Regression from #20578.

closes #22601

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
