### PR TITLE
tests: add security regression tests for OAuth JWT-bearer and flow session handling

### DIFF
--- a/authentik/providers/oauth2/tests/test_token_jwt_alg_confusion.py
+++ b/authentik/providers/oauth2/tests/test_token_jwt_alg_confusion.py
@@ -1,18 +1,8 @@
-"""Security regression tests for JWT algorithm-confusion attacks against the
-client_credentials JWT-bearer grant.
-
-These cover the negative path where an attacker crafts a JWT whose ``alg`` header
-does not match the algorithm the configured source JWK is meant to be verified
-with. References: RFC 9700 §4.5 (algorithm confusion), the "alg:none" signature
-bypass class (CVE-2015-9235 and relatives), and the asymmetric/HMAC key-confusion
-pattern (using a published RSA public key as an HMAC secret).
-
-The verification path under test is
-``TokenParams._TokenParams__validate_jwt_from_source`` in
-``authentik/providers/oauth2/views/token.py``. Note that when a source JWK omits
-the optional ``alg`` member, verification falls back to the (attacker controlled)
-algorithm from the JWT header -- exactly the precondition for a confusion attack.
-These tests assert the forgeries are rejected regardless.
+"""Security regression tests for JWT algorithm-confusion against the
+client_credentials JWT-bearer grant (RFC 9700 §4.5, CVE-2015-9235): alg:none,
+HS/RS key confusion (RSA public key used as an HMAC secret), and kid swapping.
+Assert the forgeries are rejected, including when the source JWK omits ``alg``
+and verification falls back to the attacker-controlled header algorithm.
 """
 
 import hashlib

--- a/authentik/providers/oauth2/tests/test_token_jwt_alg_confusion.py
+++ b/authentik/providers/oauth2/tests/test_token_jwt_alg_confusion.py
@@ -1,0 +1,185 @@
+"""Security regression tests for JWT algorithm-confusion attacks against the
+client_credentials JWT-bearer grant.
+
+These cover the negative path where an attacker crafts a JWT whose ``alg`` header
+does not match the algorithm the configured source JWK is meant to be verified
+with. References: RFC 9700 §4.5 (algorithm confusion), the "alg:none" signature
+bypass class (CVE-2015-9235 and relatives), and the asymmetric/HMAC key-confusion
+pattern (using a published RSA public key as an HMAC secret).
+
+The verification path under test is
+``TokenParams._TokenParams__validate_jwt_from_source`` in
+``authentik/providers/oauth2/views/token.py``. Note that when a source JWK omits
+the optional ``alg`` member, verification falls back to the (attacker controlled)
+algorithm from the JWT header -- exactly the precondition for a confusion attack.
+These tests assert the forgeries are rejected regardless.
+"""
+
+import hashlib
+import hmac
+from base64 import urlsafe_b64encode
+from copy import deepcopy
+from datetime import datetime, timedelta
+from json import dumps, loads
+
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+from django.test import RequestFactory
+from django.urls import reverse
+from jwt import encode
+
+from authentik.blueprints.tests import apply_blueprint
+from authentik.common.oauth.constants import (
+    CLIENT_ASSERTION_TYPE_JWT,
+    GRANT_TYPE_CLIENT_CREDENTIALS,
+    SCOPE_OPENID,
+    SCOPE_OPENID_EMAIL,
+    SCOPE_OPENID_PROFILE,
+)
+from authentik.core.models import Application, User
+from authentik.core.tests.utils import create_test_cert, create_test_flow
+from authentik.lib.generators import generate_id
+from authentik.providers.oauth2.models import (
+    GrantType,
+    OAuth2Provider,
+    RedirectURI,
+    RedirectURIMatchingMode,
+    ScopeMapping,
+)
+from authentik.providers.oauth2.tests.utils import OAuthTestCase
+from authentik.providers.oauth2.views.jwks import JWKSView
+from authentik.sources.oauth.models import OAuthSource
+
+
+class TestTokenJWTAlgConfusion(OAuthTestCase):
+    """Algorithm-confusion negative-path tests for the JWT-bearer grant."""
+
+    @apply_blueprint("system/providers-oauth2.yaml")
+    def setUp(self) -> None:
+        super().setUp()
+        self.factory = RequestFactory()
+        # Cert whose public key backs the trusted source JWK -- an attacker can
+        # read this public key from the source's JWKS endpoint.
+        self.source_cert = create_test_cert()
+        self.provider_cert = create_test_cert()
+
+        jwk = JWKSView().get_jwk_for_key(self.source_cert, "sig")
+        self.source: OAuthSource = OAuthSource.objects.create(
+            name=generate_id(),
+            slug=generate_id(),
+            provider_type="openidconnect",
+            consumer_key=generate_id(),
+            consumer_secret=generate_id(),
+            authorization_url="http://foo",
+            access_token_url=f"http://{generate_id()}",
+            profile_url="http://foo",
+            oidc_well_known_url="",
+            oidc_jwks_url="",
+            oidc_jwks={"keys": [jwk]},
+        )
+
+        self.provider: OAuth2Provider = OAuth2Provider.objects.create(
+            name=generate_id(),
+            authorization_flow=create_test_flow(),
+            redirect_uris=[RedirectURI(RedirectURIMatchingMode.STRICT, "http://testserver")],
+            signing_key=self.provider_cert,
+            grant_types=[GrantType.CLIENT_CREDENTIALS],
+        )
+        self.provider.jwt_federation_sources.add(self.source)
+        self.provider.property_mappings.set(ScopeMapping.objects.all())
+        self.app = Application.objects.create(
+            name=generate_id(), slug=generate_id(), provider=self.provider
+        )
+
+    def _source_public_key_pem(self) -> bytes:
+        """The trusted source's public key, as an attacker would scrape it from
+        the JWKS endpoint -- used as the forged HMAC secret."""
+        return self.source_cert.public_key.public_bytes(
+            Encoding.PEM, PublicFormat.SubjectPublicKeyInfo
+        )
+
+    @staticmethod
+    def _forge_hs256(payload: dict, secret: bytes, kid: str) -> str:
+        """Hand-craft an HS256-signed JWT. PyJWT's ``encode`` refuses to use an
+        asymmetric key as an HMAC secret, so -- like jwt_tool and other offensive
+        tooling -- we build the token manually to faithfully simulate the attack."""
+
+        def segment(data: bytes) -> bytes:
+            return urlsafe_b64encode(data).rstrip(b"=")
+
+        header = segment(dumps({"alg": "HS256", "typ": "JWT", "kid": kid}).encode())
+        body = segment(dumps(payload).encode())
+        signing_input = header + b"." + body
+        signature = segment(hmac.new(secret, signing_input, hashlib.sha256).digest())
+        return (signing_input + b"." + signature).decode()
+
+    @staticmethod
+    def _exp() -> int:
+        return int((datetime.now() + timedelta(hours=2)).timestamp())
+
+    def _post_assertion(self, assertion: str):
+        return self.client.post(
+            reverse("authentik_providers_oauth2:token"),
+            {
+                "grant_type": GRANT_TYPE_CLIENT_CREDENTIALS,
+                "scope": f"{SCOPE_OPENID} {SCOPE_OPENID_EMAIL} {SCOPE_OPENID_PROFILE}",
+                "client_id": self.provider.client_id,
+                "client_assertion_type": CLIENT_ASSERTION_TYPE_JWT,
+                "client_assertion": assertion,
+            },
+        )
+
+    def _assert_rejected(self, response):
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(loads(response.content.decode())["error"], "invalid_grant")
+        # A rejected assertion must not auto-provision a user as a side effect
+        self.assertIsNone(User.objects.filter(username=f"{self.provider.name}-foo").first())
+
+    def test_alg_none(self):
+        """An unsigned (alg:none) assertion with a valid kid must be rejected."""
+        forged = encode(
+            {"sub": "foo", "exp": self._exp()},
+            key="",
+            algorithm="none",
+            headers={"kid": self.source_cert.kid},
+        )
+        self._assert_rejected(self._post_assertion(forged))
+
+    def test_hs256_confusion_with_alg_in_jwk(self):
+        """HS256 forgery signed with the source's RSA public key, against a JWK
+        that pins alg=RS256. The header-declared HS256 must not be honored."""
+        forged = self._forge_hs256(
+            {"sub": "foo", "exp": self._exp()},
+            secret=self._source_public_key_pem(),
+            kid=self.source_cert.kid,
+        )
+        self._assert_rejected(self._post_assertion(forged))
+
+    def test_hs256_confusion_without_alg_in_jwk(self):
+        """The dangerous case: when the source JWK omits ``alg``, verification
+        falls back to the attacker-controlled header algorithm. An HS256 forgery
+        signed with the RSA public key must still be rejected (PyJWT refuses to
+        use an asymmetric key as an HMAC secret)."""
+        # Rebuild the source's JWK set without the alg member to force the fallback
+        jwks = deepcopy(self.source.oidc_jwks)
+        for key in jwks["keys"]:
+            key.pop("alg", None)
+        self.source.oidc_jwks = jwks
+        self.source.save()
+
+        forged = self._forge_hs256(
+            {"sub": "foo", "exp": self._exp()},
+            secret=self._source_public_key_pem(),
+            kid=self.source_cert.kid,
+        )
+        self._assert_rejected(self._post_assertion(forged))
+
+    def test_kid_swapped_to_unrelated_key(self):
+        """A token signed with an unrelated key but carrying a kid that matches a
+        trusted source JWK must not verify."""
+        forged = encode(
+            {"sub": "foo", "exp": self._exp()},
+            key=self.provider_cert.private_key,  # not the source's key
+            algorithm="RS256",
+            headers={"kid": self.source_cert.kid},
+        )
+        self._assert_rejected(self._post_assertion(forged))

--- a/authentik/providers/oauth2/tests/test_token_jwt_alg_confusion.py
+++ b/authentik/providers/oauth2/tests/test_token_jwt_alg_confusion.py
@@ -91,26 +91,14 @@ class TestTokenJWTAlgConfusion(OAuthTestCase):
         )
 
     def _public_key_secret_candidates(self) -> dict[str, bytes]:
-        """The trusted source's public key, as an attacker would scrape it from
-        the JWKS endpoint -- used as the forged HMAC secret."""
+        """The public-key byte representations a real attacker would scrape from
+        the published JWKS/cert and try as the forged HMAC secret. These are the
+        two representations actual tooling (e.g. jwt_tool) uses for HS/RS
+        confusion: the bare public key PEM and the x5c certificate PEM."""
         public_key = self.source_cert.public_key
-        public_numbers = public_key.public_numbers()
-        modulus = public_numbers.n
-        # All the byte representations of the public key an attacker can derive
-        # from the published JWKS/cert and would try as the HMAC secret. The
-        # classic HS/RS confusion only succeeds if the server's HMAC secret bytes
-        # match one of these exactly, so probing all of them turns the test into
-        # a real regression guard rather than a single lucky-shot probe.
         return {
             "spki_pem": public_key.public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo),
-            "spki_pem_no_trailing_newline": public_key.public_bytes(
-                Encoding.PEM, PublicFormat.SubjectPublicKeyInfo
-            ).rstrip(b"\n"),
-            "spki_der": public_key.public_bytes(Encoding.DER, PublicFormat.SubjectPublicKeyInfo),
-            "pkcs1_pem": public_key.public_bytes(Encoding.PEM, PublicFormat.PKCS1),
-            "pkcs1_der": public_key.public_bytes(Encoding.DER, PublicFormat.PKCS1),
             "cert_pem": self.source_cert.certificate.public_bytes(Encoding.PEM),
-            "raw_modulus": modulus.to_bytes((modulus.bit_length() + 7) // 8, "big"),
         }
 
     @staticmethod

--- a/authentik/providers/oauth2/tests/test_token_jwt_alg_confusion.py
+++ b/authentik/providers/oauth2/tests/test_token_jwt_alg_confusion.py
@@ -90,12 +90,28 @@ class TestTokenJWTAlgConfusion(OAuthTestCase):
             name=generate_id(), slug=generate_id(), provider=self.provider
         )
 
-    def _source_public_key_pem(self) -> bytes:
+    def _public_key_secret_candidates(self) -> dict[str, bytes]:
         """The trusted source's public key, as an attacker would scrape it from
         the JWKS endpoint -- used as the forged HMAC secret."""
-        return self.source_cert.public_key.public_bytes(
-            Encoding.PEM, PublicFormat.SubjectPublicKeyInfo
-        )
+        public_key = self.source_cert.public_key
+        public_numbers = public_key.public_numbers()
+        modulus = public_numbers.n
+        # All the byte representations of the public key an attacker can derive
+        # from the published JWKS/cert and would try as the HMAC secret. The
+        # classic HS/RS confusion only succeeds if the server's HMAC secret bytes
+        # match one of these exactly, so probing all of them turns the test into
+        # a real regression guard rather than a single lucky-shot probe.
+        return {
+            "spki_pem": public_key.public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo),
+            "spki_pem_no_trailing_newline": public_key.public_bytes(
+                Encoding.PEM, PublicFormat.SubjectPublicKeyInfo
+            ).rstrip(b"\n"),
+            "spki_der": public_key.public_bytes(Encoding.DER, PublicFormat.SubjectPublicKeyInfo),
+            "pkcs1_pem": public_key.public_bytes(Encoding.PEM, PublicFormat.PKCS1),
+            "pkcs1_der": public_key.public_bytes(Encoding.DER, PublicFormat.PKCS1),
+            "cert_pem": self.source_cert.certificate.public_bytes(Encoding.PEM),
+            "raw_modulus": modulus.to_bytes((modulus.bit_length() + 7) // 8, "big"),
+        }
 
     @staticmethod
     def _forge_hs256(payload: dict, secret: bytes, kid: str) -> str:
@@ -146,19 +162,23 @@ class TestTokenJWTAlgConfusion(OAuthTestCase):
 
     def test_hs256_confusion_with_alg_in_jwk(self):
         """HS256 forgery signed with the source's RSA public key, against a JWK
-        that pins alg=RS256. The header-declared HS256 must not be honored."""
-        forged = self._forge_hs256(
-            {"sub": "foo", "exp": self._exp()},
-            secret=self._source_public_key_pem(),
-            kid=self.source_cert.kid,
-        )
-        self._assert_rejected(self._post_assertion(forged))
+        that pins alg=RS256. The header-declared HS256 must not be honored, for
+        any public-key byte representation the attacker might use as the secret."""
+        for label, secret in self._public_key_secret_candidates().items():
+            with self.subTest(secret=label):
+                forged = self._forge_hs256(
+                    {"sub": "foo", "exp": self._exp()},
+                    secret=secret,
+                    kid=self.source_cert.kid,
+                )
+                self._assert_rejected(self._post_assertion(forged))
 
     def test_hs256_confusion_without_alg_in_jwk(self):
         """The dangerous case: when the source JWK omits ``alg``, verification
         falls back to the attacker-controlled header algorithm. An HS256 forgery
         signed with the RSA public key must still be rejected (PyJWT refuses to
-        use an asymmetric key as an HMAC secret)."""
+        use an asymmetric key as an HMAC secret) -- for every public-key byte
+        representation the attacker might try as the secret."""
         # Rebuild the source's JWK set without the alg member to force the fallback
         jwks = deepcopy(self.source.oidc_jwks)
         for key in jwks["keys"]:
@@ -166,12 +186,14 @@ class TestTokenJWTAlgConfusion(OAuthTestCase):
         self.source.oidc_jwks = jwks
         self.source.save()
 
-        forged = self._forge_hs256(
-            {"sub": "foo", "exp": self._exp()},
-            secret=self._source_public_key_pem(),
-            kid=self.source_cert.kid,
-        )
-        self._assert_rejected(self._post_assertion(forged))
+        for label, secret in self._public_key_secret_candidates().items():
+            with self.subTest(secret=label):
+                forged = self._forge_hs256(
+                    {"sub": "foo", "exp": self._exp()},
+                    secret=secret,
+                    kid=self.source_cert.kid,
+                )
+                self._assert_rejected(self._post_assertion(forged))
 
     def test_kid_swapped_to_unrelated_key(self):
         """A token signed with an unrelated key but carrying a kid that matches a

--- a/authentik/stages/user_login/tests.py
+++ b/authentik/stages/user_login/tests.py
@@ -71,6 +71,43 @@ class TestUserLoginStage(FlowTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertStageRedirects(response, reverse("authentik_core:root-redirect"))
 
+    def test_session_fixation_key_rotated_on_login(self):
+        """Security regression (CWE-384): the session key must rotate on login
+        so a pre-login session identifier known to an attacker can't be reused.
+        Django's ``login()`` provides this via ``cycle_key()``; pinned here
+        end-to-end through the flow executor and custom session backend."""
+        plan = FlowPlan(flow_pk=self.flow.pk.hex, bindings=[self.binding], markers=[StageMarker()])
+        plan.context[PLAN_CONTEXT_PENDING_USER] = self.user
+        session = self.client.session
+        session[SESSION_KEY_PLAN] = plan
+        session.save()
+        pre_login_key = session.session_key
+        self.assertIsNotNone(pre_login_key)
+        # Unauthenticated session persisted before login...
+        self.assertTrue(Session.objects.filter(session_key=pre_login_key).exists())
+
+        response = self.client.post(
+            reverse("authentik_api:flow-executor", kwargs={"flow_slug": self.flow.slug})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertStageRedirects(response, reverse("authentik_core:root-redirect"))
+
+        post_login_key = self.client.session.session_key
+        # ...the identifier must change on authentication...
+        self.assertIsNotNone(post_login_key)
+        self.assertNotEqual(pre_login_key, post_login_key)
+        # ...the pre-login key must no longer exist...
+        self.assertFalse(Session.objects.filter(session_key=pre_login_key).exists())
+        self.assertFalse(
+            AuthenticatedSession.objects.filter(session__session_key=pre_login_key).exists()
+        )
+        # ...and only the rotated key may be bound to the authenticated user.
+        self.assertTrue(
+            AuthenticatedSession.objects.filter(
+                session__session_key=post_login_key, user=self.user
+            ).exists()
+        )
+
     def test_terminate_other_sessions(self):
         """Test terminate_other_sessions"""
         self.stage.terminate_other_sessions = True

--- a/authentik/stages/user_logout/tests.py
+++ b/authentik/stages/user_logout/tests.py
@@ -2,6 +2,7 @@
 
 from django.urls import reverse
 
+from authentik.core.models import AuthenticatedSession, Session
 from authentik.core.tests.utils import create_test_admin_user, create_test_flow
 from authentik.flows.markers import StageMarker
 from authentik.flows.models import FlowDesignation, FlowStageBinding
@@ -55,3 +56,37 @@ class TestUserLogoutStage(FlowTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertStageRedirects(response, reverse("authentik_core:root-redirect"))
+
+    def test_logout_destroys_server_side_session(self):
+        """Security regression (CWE-613): logout must delete the server-side
+        AuthenticatedSession/Session rows, not just clear the cookie, so a
+        captured cookie cannot be replayed."""
+        # Establish a real authenticated session bound to the client's cookie.
+        self.client.force_login(self.user)
+        session_key = self.client.session.session_key
+        self.assertIsNotNone(session_key)
+        self.assertTrue(
+            AuthenticatedSession.objects.filter(
+                session__session_key=session_key, user=self.user
+            ).exists()
+        )
+        self.assertTrue(Session.objects.filter(session_key=session_key).exists())
+
+        plan = FlowPlan(flow_pk=self.flow.pk.hex, bindings=[self.binding], markers=[StageMarker()])
+        plan.context[PLAN_CONTEXT_PENDING_USER] = self.user
+        plan.context[PLAN_CONTEXT_AUTHENTICATION_BACKEND] = BACKEND_INBUILT
+        session = self.client.session
+        session[SESSION_KEY_PLAN] = plan
+        session.save()
+
+        response = self.client.post(
+            reverse("authentik_api:flow-executor", kwargs={"flow_slug": self.flow.slug})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertStageRedirects(response, reverse("authentik_core:root-redirect"))
+
+        # Server-side rows gone -> a captured cookie can't be replayed.
+        self.assertFalse(
+            AuthenticatedSession.objects.filter(session__session_key=session_key).exists()
+        )
+        self.assertFalse(Session.objects.filter(session_key=session_key).exists())


### PR DESCRIPTION
These cover existing protections that aren't currently tested, so we'd catch a regression (or a dependency behaviour change) if one slipped in. No production code changes.

  - JWT algorithm confusion: asserts the client_credentials JWT-bearer grant rejects alg:none, HS/RS key confusion (RSA public key used as an HMAC secret, with and without alg in the source JWK), and kid-swapped tokens.
  - Session fixation: the session key must rotate on login so a pre-login identifier can't be reused.
  - Logout: logout deletes the server-side AuthenticatedSession/Session rows, not just the cookie, so a captured cookie can't be replayed.

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
