### PR TITLE
providers/saml: support wildcard * in ACS URL

### DIFF
--- a/authentik/lib/models.py
+++ b/authentik/lib/models.py
@@ -94,6 +94,13 @@ class DomainlessURLValidator(URLValidator):
         super().__call__(value)
 
 
+class WildcardDomainlessURLValidator(DomainlessURLValidator):
+    """Like DomainlessURLValidator but allows '*' wildcards in the URL."""
+
+    def __call__(self, value: str):
+        super().__call__(value.replace("*", "wildcard"))
+
+
 class DomainlessFormattedURLValidator(DomainlessURLValidator):
     """URL validator which allows for python format strings"""
 

--- a/authentik/providers/saml/models.py
+++ b/authentik/providers/saml/models.py
@@ -33,7 +33,7 @@ from authentik.core.models import (
     User,
 )
 from authentik.crypto.models import CertificateKeyPair
-from authentik.lib.models import DomainlessURLValidator, InternallyManagedMixin, SerializerModel
+from authentik.lib.models import DomainlessURLValidator, InternallyManagedMixin, SerializerModel, WildcardDomainlessURLValidator
 from authentik.lib.utils.time import timedelta_string_validator
 from authentik.sources.saml.models import SAMLNameIDPolicy
 
@@ -59,7 +59,8 @@ class SAMLProvider(Provider):
     """SAML 2.0 Endpoint for applications which support SAML."""
 
     acs_url = models.TextField(
-        validators=[DomainlessURLValidator(schemes=("http", "https"))], verbose_name=_("ACS URL")
+        validators=[WildcardDomainlessURLValidator(schemes=("http", "https"))],
+        verbose_name=_("ACS URL"),
     )
     sp_binding = models.TextField(
         choices=SAMLBindings.choices,

--- a/authentik/providers/saml/processors/assertion.py
+++ b/authentik/providers/saml/processors/assertion.py
@@ -315,7 +315,7 @@ class AssertionProcessor:
         if self.auth_n_request.id:
             subject_confirmation_data.attrib["InResponseTo"] = self.auth_n_request.id
         subject_confirmation_data.attrib["NotOnOrAfter"] = self._valid_not_on_or_after
-        subject_confirmation_data.attrib["Recipient"] = self.provider.acs_url
+        subject_confirmation_data.attrib["Recipient"] = self.auth_n_request.acs_url or self.provider.acs_url
         return subject
 
     def get_assertion(self) -> Element:
@@ -350,7 +350,7 @@ class AssertionProcessor:
         response = Element(f"{{{NS_SAML_PROTOCOL}}}Response", nsmap=NS_MAP)
         response.attrib["Version"] = "2.0"
         response.attrib["IssueInstant"] = self._issue_instant
-        response.attrib["Destination"] = self.provider.acs_url
+        response.attrib["Destination"] = self.auth_n_request.acs_url or self.provider.acs_url
         response.attrib["ID"] = self._response_id
         if self.auth_n_request.id:
             response.attrib["InResponseTo"] = self.auth_n_request.id

--- a/authentik/providers/saml/processors/authn_request_parser.py
+++ b/authentik/providers/saml/processors/authn_request_parser.py
@@ -2,6 +2,7 @@
 
 from base64 import b64decode
 from dataclasses import dataclass
+from fnmatch import fnmatch
 from urllib.parse import quote_plus
 from xml.etree.ElementTree import ParseError  # nosec
 
@@ -44,6 +45,8 @@ class AuthNRequest:
 
     force_authn: bool = False
 
+    acs_url: str | None = None
+
 
 class AuthNRequestParser:
     """AuthNRequest Parser"""
@@ -61,14 +64,20 @@ class AuthNRequestParser:
         # `AssertionConsumerServiceURL` can be omitted, and we should fallback to the
         # default ACS URL
         if "AssertionConsumerServiceURL" not in root.attrib:
-            request_acs_url = self.provider.acs_url.lower()
+            request_acs_url = self.provider.acs_url
         else:
             request_acs_url = root.attrib["AssertionConsumerServiceURL"]
 
-        if self.provider.acs_url.lower() != request_acs_url.lower():
+        provider_acs_url = self.provider.acs_url
+        if "*" in provider_acs_url:
+            matched = fnmatch(request_acs_url.lower(), provider_acs_url.lower())
+        else:
+            matched = provider_acs_url.lower() == request_acs_url.lower()
+
+        if not matched:
             msg = (
                 f"ACS URL of {request_acs_url} doesn't match Provider "
-                f"ACS URL of {self.provider.acs_url}."
+                f"ACS URL of {provider_acs_url}."
             )
             self.logger.warning(msg)
             raise CannotHandleAssertion(msg)
@@ -81,6 +90,7 @@ class AuthNRequestParser:
         auth_n_request = AuthNRequest(
             id=root.attrib["ID"], relay_state=relay_state, force_authn=force_authn
         )
+        auth_n_request.acs_url = request_acs_url
 
         # Check if AuthnRequest has a NameID Policy object
         name_id_policies = root.findall(f"{{{NS_SAML_PROTOCOL}}}NameIDPolicy")

--- a/authentik/providers/saml/views/flows.py
+++ b/authentik/providers/saml/views/flows.py
@@ -119,7 +119,7 @@ class SAMLFlowFinalView(ChallengeStageView):
                         PLAN_CONTEXT_TITLE,
                         _("Redirecting to {app}...".format_map({"app": application.name})),
                     ),
-                    "url": provider.acs_url,
+                    "url": auth_n_request.acs_url or provider.acs_url,
                     "attrs": form_attrs,
                 },
             )
@@ -142,12 +142,12 @@ class SAMLFlowFinalView(ChallengeStageView):
                 return HttpChallengeResponse(
                     RedirectChallenge(
                         instance={
-                            "to": f"{provider.acs_url}?{querystring}",
+                            "to": f"{auth_n_request.acs_url or provider.acs_url}?{querystring}",
                             "final_redirect": True,
                         }
                     )
                 )
-            return redirect(f"{provider.acs_url}?{querystring}")
+            return redirect(f"{auth_n_request.acs_url or provider.acs_url}?{querystring}")
         return bad_request_message(request, "Invalid sp_binding specified")
 
     def get_challenge(self, *args, **kwargs) -> Challenge:


### PR DESCRIPTION
## Details

### What does this PR change?
Allows SAML providers to configure a wildcard ACS URL (e.g. https://*.example.com/saml/acs) to handle multiple subdomains without creating one provider per host.

- Adds `WildcardDomainlessURLValidator` to `authentik/lib/models.py`. accepts * in URLs by substituting it before URL format validation
- Updates `SAMLProvider.acs_url` to use the new validator
- Replaces the exact-match ACS URL check in `authn_request_parser.py` with `fnmatch` glob matching when the configured URL contains `*`; stores the resolved concrete URL on `AuthNRequest`
- `assertion.py` and `flows.py` now use the resolved concrete URL (not the pattern) in Recipient, Destination, and POST/Redirect binding targets

### Why is this change needed?
Support handling multiple subdomains without creating one provider per host.

### How was this tested?
I tested and deployed it in my homelab.

### Linked issues



## Checklist

-   [] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
