### PR TITLE
packages/django-dramatiq-postgres/broker: fix race condition in broker causing completed tasks to be repeated

### DIFF
--- a/authentik/tasks/tests/test_broker.py
+++ b/authentik/tasks/tests/test_broker.py
@@ -1,0 +1,95 @@
+from unittest.mock import MagicMock
+
+from django.test import SimpleTestCase
+from django_dramatiq_postgres.broker import PostgresBroker
+from django_dramatiq_postgres.models import TaskState
+from dramatiq.broker import MessageProxy
+from dramatiq.message import Message
+
+
+class TestPostgresConsumer(SimpleTestCase):
+    @staticmethod
+    def _consumer():
+        consumer = object.__new__(PostgresBroker().consumer_class)
+        consumer.logger = MagicMock()
+        consumer.broker = MagicMock()
+        consumer.in_processing = set()
+        consumer.to_unlock = set()
+        return consumer
+
+    @staticmethod
+    def _message(message_id="00000000-0000-0000-0000-000000000001"):
+        return MessageProxy(
+            Message(
+                queue_name="default",
+                actor_name="test.actor",
+                args=(),
+                kwargs={},
+                options={"task": MagicMock()},
+                message_id=message_id,
+            )
+        )
+
+    def test_post_process_marks_terminal_before_unlocking(self):
+        consumer = self._consumer()
+        message = self._message()
+        consumer.in_processing.add(message.message_id)
+        update = consumer.query_set.filter.return_value.exclude.return_value.update
+
+        def assert_still_processing(*args, **kwargs):
+            self.assertIn(message.message_id, consumer.in_processing)
+            self.assertNotIn(message.message_id, consumer.to_unlock)
+
+        update.side_effect = assert_still_processing
+
+        consumer._post_process_message(message, TaskState.DONE)
+
+        consumer.query_set.filter.assert_called_once_with(
+            message_id=message.message_id,
+            queue_name=message.queue_name,
+        )
+        consumer.query_set.filter.return_value.exclude.assert_called_once_with(
+            state=TaskState.QUEUED,
+        )
+        self.assertEqual(update.call_args.kwargs["state"], TaskState.DONE)
+        self.assertEqual(update.call_args.kwargs["message"], b"")
+        self.assertNotIn(message.message_id, consumer.in_processing)
+        self.assertIn(message.message_id, consumer.to_unlock)
+
+    def test_post_process_keeps_message_locked_when_update_fails(self):
+        consumer = self._consumer()
+        message = self._message()
+        task = message.options["task"]
+        consumer.in_processing.add(message.message_id)
+        update = consumer.query_set.filter.return_value.exclude.return_value.update
+        update.side_effect = RuntimeError("boom")
+
+        with self.assertRaises(RuntimeError):
+            consumer._post_process_message(message, TaskState.DONE)
+
+        self.assertIs(message.options["task"], task)
+        self.assertIn(message.message_id, consumer.in_processing)
+        self.assertNotIn(message.message_id, consumer.to_unlock)
+
+    def test_requeue_does_not_requeue_terminal_messages(self):
+        consumer = self._consumer()
+        first_message = self._message("00000000-0000-0000-0000-000000000001")
+        second_message = self._message("00000000-0000-0000-0000-000000000002")
+        consumer.in_processing.add(first_message.message_id)
+
+        consumer.requeue(message for message in (first_message, second_message))
+
+        consumer.query_set.filter.assert_called_once_with(
+            message_id__in=[first_message.message_id, second_message.message_id],
+        )
+        consumer.query_set.filter.return_value.exclude.assert_called_once_with(
+            state__in=(TaskState.DONE, TaskState.REJECTED),
+        )
+        consumer.query_set.filter.return_value.exclude.return_value.update.assert_called_once_with(
+            state=TaskState.QUEUED,
+        )
+        self.assertEqual(
+            consumer.to_unlock,
+            {first_message.message_id, second_message.message_id},
+        )
+        self.assertNotIn(first_message.message_id, consumer.in_processing)

--- a/packages/django-dramatiq-postgres/django_dramatiq_postgres/broker.py
+++ b/packages/django-dramatiq-postgres/django_dramatiq_postgres/broker.py
@@ -507,25 +507,28 @@ class _PostgresConsumer(Consumer):
 
     def _post_process_message(self, message: MessageProxy, state: TaskState) -> None:
         self.logger.debug("Post-processing message", message=message.message_id, state=state)
+        task = message.options.pop("task", None)
+        try:
+            m = b"" if state == TaskState.DONE else message.encode()
+            self.query_set.filter(
+                message_id=message.message_id,
+                queue_name=message.queue_name,
+            ).exclude(
+                state=TaskState.QUEUED,
+            ).update(
+                state=state,
+                message=m,
+                mtime=timezone.now(),
+                eta=None,
+            )
+        finally:
+            message.options["task"] = task
+
         try:
             self.in_processing.remove(str(message.message_id))
         except KeyError:
             pass
         self.to_unlock.add(str(message.message_id))
-        task = message.options.pop("task", None)
-        m = b"" if state == TaskState.DONE else message.encode()
-        self.query_set.filter(
-            message_id=message.message_id,
-            queue_name=message.queue_name,
-        ).exclude(
-            state=TaskState.QUEUED,
-        ).update(
-            state=state,
-            message=m,
-            mtime=timezone.now(),
-            eta=None,
-        )
-        message.options["task"] = task
 
     @raise_broker_connection_error
     def ack(self, message: MessageProxy) -> None:
@@ -553,14 +556,17 @@ class _PostgresConsumer(Consumer):
 
     @raise_broker_connection_error
     def requeue(self, messages: Iterable[MessageProxy]) -> None:
+        messages = list(messages)
         self.query_set.filter(
             message_id__in=[message.message_id for message in messages],
+        ).exclude(
+            state__in=(TaskState.DONE, TaskState.REJECTED),
         ).update(
             state=TaskState.QUEUED,
         )
         for message in messages:
             self.to_unlock.add(str(message.message_id))
-            self.in_processing.remove(str(message.message_id))
+            self.in_processing.discard(str(message.message_id))
 
     def _scheduler(self) -> None:
         if not self.scheduler:


### PR DESCRIPTION
## Details

Fixes a race in the Postgres Dramatiq broker where a completed task could be picked up again immediately after successful processing.

`_post_process_message()` removed the task from `in_processing` and queued its advisory lock for release before updating the DB row to `DONE`/`REJECTED`. Under load, the consumer could briefly see the same non-terminal row again, consume it, and then fail to decode it after the original ack cleared `message` to `b""`.

This showed up in worker logs as:

```text
Failed to decode task, rejecting
```

For affected rows, the task logs showed Task finished processing without errors immediately before the decode failure, and the DB row had octet_length(message) = 0.
This also hardens requeue() so it does not move already terminal DONE/REJECTED rows back to QUEUED.

## History
The underlying race appears to have been introduced by #17335, which added the current post-processing flow and removed tasks from in_processing before the terminal DB update.
The visible zero-byte decode symptom became possible after #19340, which intentionally clears successful task messages by storing message = b"".
The current log message was added by #22110, which catches decode failures and rejects the task instead of letting task processing stop.
## Changes
- Update task DB state before removing the message from in_processing.
- Keep the message in processing if the terminal DB update fails.
- Prevent requeue() from requeueing terminal rows.
- Add regression tests for post-processing ordering and terminal requeue handling.


---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
