### PR TITLE
core: preserve encoded avatar URLs

### DIFF
--- a/authentik/core/tests/test_users_avatars.py
+++ b/authentik/core/tests/test_users_avatars.py
@@ -109,6 +109,25 @@ class TestUsersAvatars(APITestCase):
             body["user"]["avatar"], f"https://example.com/avatar/{self.admin.username}"
         )
 
+    def test_avatars_custom_url_encoded(self):
+        """Test custom avatar URL with percent-encoded characters"""
+        cache.clear()
+        avatar_url = (
+            "https://example.com/avatar%2Ffoo.png?"
+            "next=https%3A%2F%2Fcdn.example.com%2Favatar.png"
+        )
+        self.set_avatar_mode(avatar_url)
+        self.client.force_login(self.admin)
+        with Mocker() as mocker:
+            mocker.head(
+                avatar_url,
+                headers={"Content-Type": "image/png"},
+            )
+            response = self.client.get(reverse("authentik_api:user-me"))
+        self.assertEqual(response.status_code, 200)
+        body = loads(response.content.decode())
+        self.assertEqual(body["user"]["avatar"], avatar_url)
+
     def test_avatars_custom_content_type_invalid(self):
         """Test custom avatar URL with invalid Content-Type falls back"""
         cache.clear()

--- a/authentik/lib/avatars.py
+++ b/authentik/lib/avatars.py
@@ -155,15 +155,24 @@ def avatar_mode_generated(user: User, mode: str) -> str | None:
     return f"data:image/svg+xml;base64,{b64encode(svg.encode('utf-8')).decode('utf-8')}"
 
 
+def format_avatar_url(user: User, mode: str) -> str:
+    """Format avatar URL placeholders while preserving URL percent-encoding."""
+    mail_hash = md5(user.email.lower().encode("utf-8"), usedforsecurity=False).hexdigest()  # nosec
+    replacements = {
+        "%(username)s": user.username,
+        "%(mail_hash)s": mail_hash,
+        "%(upn)s": str(user.attributes.get("upn", "")),
+    }
+    formatted_url = mode
+    for placeholder, value in replacements.items():
+        formatted_url = formatted_url.replace(placeholder, value)
+    return formatted_url
+
+
 def avatar_mode_url(user: User, mode: str) -> str | None:
     """Format url"""
     mail_hash = md5(user.email.lower().encode("utf-8"), usedforsecurity=False).hexdigest()  # nosec
-
-    formatted_url = mode % {
-        "username": user.username,
-        "mail_hash": mail_hash,
-        "upn": user.attributes.get("upn", ""),
-    }
+    formatted_url = format_avatar_url(user, mode)
 
     hostname = urlparse(formatted_url).hostname
     cache_key_hostname_available = f"goauthentik.io/lib/avatars/{hostname}/available"


### PR DESCRIPTION
Custom avatar URLs currently go through Python `%` formatting, so normal URL escapes like `%2F` can be interpreted as format tokens and raise while the user avatar is serialized.

This changes avatar URL formatting to replace only the supported placeholders:

```text
%(username)s
%(mail_hash)s
%(upn)s
```

Everything else is left as-is, so encoded URLs stay valid.

Repro:

1. Set **System → Settings → Avatars** to:

   ```text
   https://example.com/avatar%2Ffoo.png?next=https%3A%2F%2Fcdn.example.com%2Favatar.png
   ```

2. Load `/api/v3/core/users/me/`.

Before this change, that can 500 while formatting the avatar URL. With this change it returns the encoded URL normally.

Validation:

```text
uv run coverage run manage.py test --keepdb authentik/core/tests/test_users_avatars.py
```
