### PR TITLE
web: Fix outline selector, lack of outline on focused checkboxes.

### DIFF
--- a/web/src/styles/global/mode/contrast.css
+++ b/web/src/styles/global/mode/contrast.css
@@ -9,7 +9,9 @@
 }
 
 @media (not (prefers-contrast: more)) {
-    input {
+    /* Unifies the PF outline behavior, fixing what appears to be a "double outline" */
+    input:not([type="checkbox"]):not([type="radio"]),
+    textarea {
         outline: none;
     }
 }


### PR DESCRIPTION
## Details

Small fix, this PR adjusts the CSS selector used to avoid “double outlines” on Patternfly text input elements. Previously this selector affected other input elements such as checkboxes and radio inputs. This prevented visual feedback on the login flow when tabbing between elements and focusing on the “Remember Me” field.