### PR TITLE
core, flows: drop maximum-scale=1 from viewport meta

### DIFF
--- a/authentik/core/templates/base/skeleton.html
+++ b/authentik/core/templates/base/skeleton.html
@@ -11,7 +11,7 @@
 >
     <head>
         <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         {# Darkreader breaks the site regardless of theme as its not compatible with webcomponents, and we default to a dark theme based on preferred color-scheme #}
         <meta name="darkreader-lock">
         <title>{% block title %}{% trans title|default:brand.branding_title %}{% endblock %}</title>

--- a/authentik/flows/templates/if/flow-sfe.html
+++ b/authentik/flows/templates/if/flow-sfe.html
@@ -7,7 +7,7 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>{% block title %}{% trans title|default:brand.branding_title %}{% endblock %}</title>
         <link rel="icon" href="{{ brand.branding_favicon_url }}">
         <link rel="shortcut icon" href="{{ brand.branding_favicon_url }}">


### PR DESCRIPTION
## Details

### What does this PR change?

Drops `maximum-scale=1` from the viewport meta tag in the two Django
templates that emit it for flow and interface pages:

- `authentik/core/templates/base/skeleton.html`, the shared base every
  in-app interface (`admin`, `user`, `flow`, `rac`, `login`, and the API
  browser) extends via `{% extends "base/skeleton.html" %}`.
- `authentik/flows/templates/if/flow-sfe.html`, the simple flow-executor
  fallback page that does not inherit from the skeleton.

Both now emit:

```html
<meta name="viewport" content="width=device-width, initial-scale=1">
```

`user-scalable=no` was not present on either tag, so nothing else needed
to change.

### Why is this change needed?

`maximum-scale=1` blocks pinch-to-zoom on touch devices and prevents
browser zoom for low-vision users. That fails WCAG 2.1 SC 1.4.4 (Resize
Text) and is a Section 508 blocker, and an axe-core scan flags it as
`meta-viewport` (impact: moderate) on every flow page.

The companion findings from the same audit (unlabelled identification
stage `<input>`s, and an `aria-required` attribute on a `<label>`) are
tracked under #22389 and stay out of this PR so the two efforts do not
collide.

### Linked issues

Closes #23048
Refs #22389

## Disclosure

Triaged and authored end-to-end by an agent running in a sandbox against
`goauthentik/authentik@main`.
