### PR TITLE
web: fix email angle brackets rendering as HTML entities in localized UI

### DIFF
--- a/web/src/common/users.ts
+++ b/web/src/common/users.ts
@@ -82,12 +82,10 @@ export function formatDisambiguatedUserDisplayName(
         }
     }
     if (email && email !== username) {
-        segments.push(
-            msg(str`<${email}>`, {
-                id: "user.display.emailInAngleBrackets",
-                desc: "The user's email in angle brackets, used when the email is different from the username",
-            }),
-        );
+        // Angle brackets are kept outside `msg(str...)` because lit-localize-tools'
+        // template-literal escape pass converts `<` and `>` to `&lt;` / `&gt;` in
+        // every non-source locale, producing literal entity text on the page.
+        segments.push(`<${email}>`);
     }
 
     if (!segments.length) {

--- a/web/xliff/cs-CZ.xlf
+++ b/web/xliff/cs-CZ.xlf
@@ -10808,10 +10808,6 @@ Vazby na skupiny/uživatele jsou kontrolovány vůči uživateli události.</tar
   <source>No <x id="0" equiv-text="${verboseNamePlural.toLocaleLowerCase(this.activeLanguageTag)}"/> found.</source>
   <note from="lit-localize">The message to show when a table has no content. The placeholder {0} is replaced with the pluralized name of the type of entity being shown in the table.</note>
 </trans-unit>
-<trans-unit id="user.display.emailInAngleBrackets">
-  <source>&lt;<x id="0" equiv-text="${email}"/>&gt;</source>
-  <note from="lit-localize">The user's email in angle brackets, used when the email is different from the username</note>
-</trans-unit>
 <trans-unit id="user.display.nameInParens">
   <source>(<x id="0" equiv-text="${name}"/>)</source>
   <note from="lit-localize">The user's name in parentheses, used when the name is different from the username</note>

--- a/web/xliff/de-DE.xlf
+++ b/web/xliff/de-DE.xlf
@@ -10840,10 +10840,6 @@ Bindings zu Gruppen/Benutzern werden mit dem Benutzer des Ereignisses abgegliche
   <source>No <x id="0" equiv-text="${verboseNamePlural.toLocaleLowerCase(this.activeLanguageTag)}"/> found.</source>
   <note from="lit-localize">The message to show when a table has no content. The placeholder {0} is replaced with the pluralized name of the type of entity being shown in the table.</note>
 </trans-unit>
-<trans-unit id="user.display.emailInAngleBrackets">
-  <source>&lt;<x id="0" equiv-text="${email}"/>&gt;</source>
-  <note from="lit-localize">The user's email in angle brackets, used when the email is different from the username</note>
-</trans-unit>
 <trans-unit id="user.display.nameInParens">
   <source>(<x id="0" equiv-text="${name}"/>)</source>
   <note from="lit-localize">The user's name in parentheses, used when the name is different from the username</note>

--- a/web/xliff/en.xlf
+++ b/web/xliff/en.xlf
@@ -8833,10 +8833,6 @@ Bindings to groups/users are checked against the user of the event.</source>
   <source>No <x id="0" equiv-text="${verboseNamePlural.toLocaleLowerCase(this.activeLanguageTag)}"/> found.</source>
   <note from="lit-localize">The message to show when a table has no content. The placeholder {0} is replaced with the pluralized name of the type of entity being shown in the table.</note>
 </trans-unit>
-<trans-unit id="user.display.emailInAngleBrackets">
-  <source>&lt;<x id="0" equiv-text="${email}"/>&gt;</source>
-  <note from="lit-localize">The user's email in angle brackets, used when the email is different from the username</note>
-</trans-unit>
 <trans-unit id="user.display.nameInParens">
   <source>(<x id="0" equiv-text="${name}"/>)</source>
   <note from="lit-localize">The user's name in parentheses, used when the name is different from the username</note>

--- a/web/xliff/es-ES.xlf
+++ b/web/xliff/es-ES.xlf
@@ -10767,10 +10767,6 @@ Las vinculaciones a grupos/usuarios se verifican en función del usuario del eve
   <source>No <x id="0" equiv-text="${verboseNamePlural.toLocaleLowerCase(this.activeLanguageTag)}"/> found.</source>
   <note from="lit-localize">The message to show when a table has no content. The placeholder {0} is replaced with the pluralized name of the type of entity being shown in the table.</note>
 </trans-unit>
-<trans-unit id="user.display.emailInAngleBrackets">
-  <source>&lt;<x id="0" equiv-text="${email}"/>&gt;</source>
-  <note from="lit-localize">The user's email in angle brackets, used when the email is different from the username</note>
-</trans-unit>
 <trans-unit id="user.display.nameInParens">
   <source>(<x id="0" equiv-text="${name}"/>)</source>
   <note from="lit-localize">The user's name in parentheses, used when the name is different from the username</note>

--- a/web/xliff/fi-FI.xlf
+++ b/web/xliff/fi-FI.xlf
@@ -11006,10 +11006,6 @@ Liitokset käyttäjiin/ryhmiin tarkistetaan tapahtuman käyttäjästä.</target>
   <source>No <x id="0" equiv-text="${verboseNamePlural.toLocaleLowerCase(this.activeLanguageTag)}"/> found.</source>
   <note from="lit-localize">The message to show when a table has no content. The placeholder {0} is replaced with the pluralized name of the type of entity being shown in the table.</note>
 </trans-unit>
-<trans-unit id="user.display.emailInAngleBrackets">
-  <source>&lt;<x id="0" equiv-text="${email}"/>&gt;</source>
-  <note from="lit-localize">The user's email in angle brackets, used when the email is different from the username</note>
-</trans-unit>
 <trans-unit id="user.display.nameInParens">
   <source>(<x id="0" equiv-text="${name}"/>)</source>
   <note from="lit-localize">The user's name in parentheses, used when the name is different from the username</note>

--- a/web/xliff/fr-FR.xlf
+++ b/web/xliff/fr-FR.xlf
@@ -10995,10 +10995,6 @@ Les liaisons avec les groupes/utilisateurs sont vérifiées par rapport à l'uti
   <source>No <x id="0" equiv-text="${verboseNamePlural.toLocaleLowerCase(this.activeLanguageTag)}"/> found.</source>
   <note from="lit-localize">The message to show when a table has no content. The placeholder {0} is replaced with the pluralized name of the type of entity being shown in the table.</note>
 </trans-unit>
-<trans-unit id="user.display.emailInAngleBrackets">
-  <source>&lt;<x id="0" equiv-text="${email}"/>&gt;</source>
-  <note from="lit-localize">The user's email in angle brackets, used when the email is different from the username</note>
-</trans-unit>
 <trans-unit id="user.display.nameInParens">
   <source>(<x id="0" equiv-text="${name}"/>)</source>
   <note from="lit-localize">The user's name in parentheses, used when the name is different from the username</note>

--- a/web/xliff/it-IT.xlf
+++ b/web/xliff/it-IT.xlf
@@ -10716,10 +10716,6 @@ Bindings to groups/users are checked against the user of the event.</source>
   <source>No <x id="0" equiv-text="${verboseNamePlural.toLocaleLowerCase(this.activeLanguageTag)}"/> found.</source>
   <note from="lit-localize">The message to show when a table has no content. The placeholder {0} is replaced with the pluralized name of the type of entity being shown in the table.</note>
 </trans-unit>
-<trans-unit id="user.display.emailInAngleBrackets">
-  <source>&lt;<x id="0" equiv-text="${email}"/>&gt;</source>
-  <note from="lit-localize">The user's email in angle brackets, used when the email is different from the username</note>
-</trans-unit>
 <trans-unit id="user.display.nameInParens">
   <source>(<x id="0" equiv-text="${name}"/>)</source>
   <note from="lit-localize">The user's name in parentheses, used when the name is different from the username</note>

--- a/web/xliff/ja-JP.xlf
+++ b/web/xliff/ja-JP.xlf
@@ -10996,10 +10996,6 @@ Bindings to groups/users are checked against the user of the event.</source>
   <source>No <x id="0" equiv-text="${verboseNamePlural.toLocaleLowerCase(this.activeLanguageTag)}"/> found.</source>
   <note from="lit-localize">The message to show when a table has no content. The placeholder {0} is replaced with the pluralized name of the type of entity being shown in the table.</note>
 </trans-unit>
-<trans-unit id="user.display.emailInAngleBrackets">
-  <source>&lt;<x id="0" equiv-text="${email}"/>&gt;</source>
-  <note from="lit-localize">The user's email in angle brackets, used when the email is different from the username</note>
-</trans-unit>
 <trans-unit id="user.display.nameInParens">
   <source>(<x id="0" equiv-text="${name}"/>)</source>
   <note from="lit-localize">The user's name in parentheses, used when the name is different from the username</note>

--- a/web/xliff/ko-KR.xlf
+++ b/web/xliff/ko-KR.xlf
@@ -10368,10 +10368,6 @@ Bindings to groups/users are checked against the user of the event.</source>
   <source>No <x id="0" equiv-text="${verboseNamePlural.toLocaleLowerCase(this.activeLanguageTag)}"/> found.</source>
   <note from="lit-localize">The message to show when a table has no content. The placeholder {0} is replaced with the pluralized name of the type of entity being shown in the table.</note>
 </trans-unit>
-<trans-unit id="user.display.emailInAngleBrackets">
-  <source>&lt;<x id="0" equiv-text="${email}"/>&gt;</source>
-  <note from="lit-localize">The user's email in angle brackets, used when the email is different from the username</note>
-</trans-unit>
 <trans-unit id="user.display.nameInParens">
   <source>(<x id="0" equiv-text="${name}"/>)</source>
   <note from="lit-localize">The user's name in parentheses, used when the name is different from the username</note>

--- a/web/xliff/nl-NL.xlf
+++ b/web/xliff/nl-NL.xlf
@@ -10054,10 +10054,6 @@ Bindingen naar groepen/gebruikers worden gecontroleerd tegen de gebruiker van de
   <source>No <x id="0" equiv-text="${verboseNamePlural.toLocaleLowerCase(this.activeLanguageTag)}"/> found.</source>
   <note from="lit-localize">The message to show when a table has no content. The placeholder {0} is replaced with the pluralized name of the type of entity being shown in the table.</note>
 </trans-unit>
-<trans-unit id="user.display.emailInAngleBrackets">
-  <source>&lt;<x id="0" equiv-text="${email}"/>&gt;</source>
-  <note from="lit-localize">The user's email in angle brackets, used when the email is different from the username</note>
-</trans-unit>
 <trans-unit id="user.display.nameInParens">
   <source>(<x id="0" equiv-text="${name}"/>)</source>
   <note from="lit-localize">The user's name in parentheses, used when the name is different from the username</note>

--- a/web/xliff/pl-PL.xlf
+++ b/web/xliff/pl-PL.xlf
@@ -10392,10 +10392,6 @@ Powiązania z grupami/użytkownikami są sprawdzane względem użytkownika zdarz
   <source>No <x id="0" equiv-text="${verboseNamePlural.toLocaleLowerCase(this.activeLanguageTag)}"/> found.</source>
   <note from="lit-localize">The message to show when a table has no content. The placeholder {0} is replaced with the pluralized name of the type of entity being shown in the table.</note>
 </trans-unit>
-<trans-unit id="user.display.emailInAngleBrackets">
-  <source>&lt;<x id="0" equiv-text="${email}"/>&gt;</source>
-  <note from="lit-localize">The user's email in angle brackets, used when the email is different from the username</note>
-</trans-unit>
 <trans-unit id="user.display.nameInParens">
   <source>(<x id="0" equiv-text="${name}"/>)</source>
   <note from="lit-localize">The user's name in parentheses, used when the name is different from the username</note>

--- a/web/xliff/pt-BR.xlf
+++ b/web/xliff/pt-BR.xlf
@@ -10988,10 +10988,6 @@ por exemplo: <x id="0" equiv-text="&lt;code&gt;"/>oci://registry.domain.tld/path
   <source>No <x id="0" equiv-text="${verboseNamePlural.toLocaleLowerCase(this.activeLanguageTag)}"/> found.</source>
   <note from="lit-localize">The message to show when a table has no content. The placeholder {0} is replaced with the pluralized name of the type of entity being shown in the table.</note>
 </trans-unit>
-<trans-unit id="user.display.emailInAngleBrackets">
-  <source>&lt;<x id="0" equiv-text="${email}"/>&gt;</source>
-  <note from="lit-localize">The user's email in angle brackets, used when the email is different from the username</note>
-</trans-unit>
 <trans-unit id="user.display.nameInParens">
   <source>(<x id="0" equiv-text="${name}"/>)</source>
   <note from="lit-localize">The user's name in parentheses, used when the name is different from the username</note>

--- a/web/xliff/ru-RU.xlf
+++ b/web/xliff/ru-RU.xlf
@@ -10478,10 +10478,6 @@ Bindings to groups/users are checked against the user of the event.</source>
   <source>No <x id="0" equiv-text="${verboseNamePlural.toLocaleLowerCase(this.activeLanguageTag)}"/> found.</source>
   <note from="lit-localize">The message to show when a table has no content. The placeholder {0} is replaced with the pluralized name of the type of entity being shown in the table.</note>
 </trans-unit>
-<trans-unit id="user.display.emailInAngleBrackets">
-  <source>&lt;<x id="0" equiv-text="${email}"/>&gt;</source>
-  <note from="lit-localize">The user's email in angle brackets, used when the email is different from the username</note>
-</trans-unit>
 <trans-unit id="user.display.nameInParens">
   <source>(<x id="0" equiv-text="${name}"/>)</source>
   <note from="lit-localize">The user's name in parentheses, used when the name is different from the username</note>

--- a/web/xliff/tr-TR.xlf
+++ b/web/xliff/tr-TR.xlf
@@ -10468,10 +10468,6 @@ Gruplara/kullanıcılara yapılan bağlamalar, etkinliğin kullanıcısına kar�
   <source>No <x id="0" equiv-text="${verboseNamePlural.toLocaleLowerCase(this.activeLanguageTag)}"/> found.</source>
   <note from="lit-localize">The message to show when a table has no content. The placeholder {0} is replaced with the pluralized name of the type of entity being shown in the table.</note>
 </trans-unit>
-<trans-unit id="user.display.emailInAngleBrackets">
-  <source>&lt;<x id="0" equiv-text="${email}"/>&gt;</source>
-  <note from="lit-localize">The user's email in angle brackets, used when the email is different from the username</note>
-</trans-unit>
 <trans-unit id="user.display.nameInParens">
   <source>(<x id="0" equiv-text="${name}"/>)</source>
   <note from="lit-localize">The user's name in parentheses, used when the name is different from the username</note>

--- a/web/xliff/zh-Hans.xlf
+++ b/web/xliff/zh-Hans.xlf
@@ -11285,10 +11285,6 @@ Bindings to groups/users are checked against the user of the event.</source>
   <source>No <x id="0" equiv-text="${verboseNamePlural.toLocaleLowerCase(this.activeLanguageTag)}"/> found.</source>
   <note from="lit-localize">The message to show when a table has no content. The placeholder {0} is replaced with the pluralized name of the type of entity being shown in the table.</note>
 </trans-unit>
-<trans-unit id="user.display.emailInAngleBrackets">
-  <source>&lt;<x id="0" equiv-text="${email}"/>&gt;</source>
-  <note from="lit-localize">The user's email in angle brackets, used when the email is different from the username</note>
-</trans-unit>
 <trans-unit id="user.display.nameInParens">
   <source>(<x id="0" equiv-text="${name}"/>)</source>
   <note from="lit-localize">The user's name in parentheses, used when the name is different from the username</note>

--- a/web/xliff/zh-Hant.xlf
+++ b/web/xliff/zh-Hant.xlf
@@ -10106,10 +10106,6 @@ Bindings to groups/users are checked against the user of the event.</source>
   <source>No <x id="0" equiv-text="${verboseNamePlural.toLocaleLowerCase(this.activeLanguageTag)}"/> found.</source>
   <note from="lit-localize">The message to show when a table has no content. The placeholder {0} is replaced with the pluralized name of the type of entity being shown in the table.</note>
 </trans-unit>
-<trans-unit id="user.display.emailInAngleBrackets">
-  <source>&lt;<x id="0" equiv-text="${email}"/>&gt;</source>
-  <note from="lit-localize">The user's email in angle brackets, used when the email is different from the username</note>
-</trans-unit>
 <trans-unit id="user.display.nameInParens">
   <source>(<x id="0" equiv-text="${name}"/>)</source>
   <note from="lit-localize">The user's name in parentheses, used when the name is different from the username</note>


### PR DESCRIPTION
## What changed

`formatDisambiguatedUserDisplayName` built the email segment by wrapping the angle brackets in a localizable message:

```ts
msg(str`<${email}>`, { id: "user.display.emailInAngleBrackets", ... })
```

The brackets are now emitted directly, outside any `msg()`:

```ts
segments.push(`<${email}>`);
```

The orphaned `user.display.emailInAngleBrackets` trans-unit was then swept from every XLIFF file via `npm run extract-locales`.

### Why is this change needed?

On the user details page, a user's email rendered as literal `&lt;user@example.com&gt;` in every non-English locale (German, Dutch, and others) instead of `<user@example.com>`. English was unaffected.

When `@lit/localize-tools` exports messages to XLIFF, `escapeTextContentToEmbedInTemplateLiteral` HTML-escapes `<`, `>`, and `&` for every message, not only `html`-tagged ones. The source (English) locale renders from the original TypeScript template and stays correct; non-source locales render the escaped XLIFF text, so the entities surface verbatim.

The angle brackets are structural punctuation, not translatable copy, so the fix is to keep them out of the localization pipeline entirely.

### Follow-ups (out of scope)

- The same over-escaping affects translator-supplied entities elsewhere (e.g. `&amp;quot;`). A lint over the compiled `web/src/locales/*.ts` that flags `&lt;` / `&gt;` / `&amp;quot;` inside `str` templates would catch this class before it ships.
- The durable fix lives upstream: restrict `escapeTextContentToEmbedInTemplateLiteral` to `html`-tagged messages.

### Linked issues

Closes #22857

## Disclosure

Triaged and authored end-to-end by an agent running in a sandbox against `goauthentik/authentik@main`.
