### PR TITLE
root: assign packages/theme to @goauthentik/frontend

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -46,6 +46,7 @@ packages/esbuild-plugin-live-reload     @goauthentik/frontend
 packages/eslint-config                  @goauthentik/frontend
 packages/prettier-config                @goauthentik/frontend
 packages/logger-js                      @goauthentik/frontend
+packages/theme                          @goauthentik/frontend
 packages/tsconfig                       @goauthentik/frontend
 # Web
 web/                                    @goauthentik/frontend


### PR DESCRIPTION
Gives the new design-system package an explicit frontend owner instead of falling through to the catch-all backend and frontend rule.

Best merged once the package itself lands (#23341).