### PR TITLE
web: fix slug auto-fill dropping letters after leading capitals

### DIFF
--- a/web/src/components/ak-slug-input.ts
+++ b/web/src/components/ak-slug-input.ts
@@ -93,19 +93,7 @@ export class AkSlugInput extends HorizontalLightComponent<string> {
             return;
         }
 
-        // A very primitive heuristic: if the previous iteration of the slug and the current
-        // iteration are *similar enough*, set the input value. "Similar enough" here is defined as
-        // "any event which adds or removes a character but leaves the rest of the slug looking like
-        // the previous iteration, set it to the current iteration."
-
         const newSlug = slugify(ev.target.value);
-        const oldSlug = this.input.value;
-        const [shorter, longer] =
-            newSlug.length < oldSlug.length ? [newSlug, oldSlug] : [oldSlug, newSlug];
-
-        if (longer.substring(0, shorter.length) !== shorter) {
-            return;
-        }
 
         // The browser, as a security measure, sets the originating HTML object to be the
         // target; developers cannot change it. In order to provide a meaningful value

--- a/web/test/browser/700-applications.test.ts
+++ b/web/test/browser/700-applications.test.ts
@@ -187,4 +187,39 @@ test.describe("Applications", () => {
             await expect($app, "Application is visible in the table").toBeVisible();
         });
     });
+
+    test("Application name beginning with consecutive capitals fills a complete slug", async ({
+        session,
+        pointer,
+        page,
+    }) => {
+        const { click } = pointer;
+
+        await test.step("Authenticate", async () => {
+            await session.login({ to: "/if/admin/#/core/applications" });
+        });
+
+        const wizardDialog = page.getByRole("dialog", { name: "New Application Wizard" });
+
+        await test.step("Open wizard", async () => {
+            await expect(wizardDialog, "Wizard is initially closed").toBeHidden();
+
+            await click("New Application", "button");
+
+            await expect(wizardDialog, "Wizard opens").toBeVisible();
+        });
+
+        await test.step("Type a name with leading consecutive capitals", async () => {
+            // Press one key at a time: the regression (#17958) only surfaces per-keystroke,
+            // so a bulk fill() would set the final value in one event and miss the bug.
+            await wizardDialog
+                .getByRole("textbox", { name: /Application Name/ })
+                .pressSequentially("OAuth Demo");
+
+            await expect(
+                wizardDialog.getByRole("textbox", { name: "Slug" }),
+                "Slug includes the full name, not just the leading capitals",
+            ).toHaveValue("o-auth-demo");
+        });
+    });
 });


### PR DESCRIPTION
Closes #17958

The slug input mirrored the name only when the new slug still had the previous slug as a prefix. Typing `OAuth`: `OA`→`oa`, then `OAu`→`o-au` no longer starts with `oa`, so mirroring stopped permanently and the slug froze at `oa`. The `#touched` flag already guards hand-edited slugs, so the prefix heuristic only caused this bug — removed it.

Added a wizard regression test; it uses `pressSequentially` because the bug only reproduces per-keystroke.