### PR TITLE
website/docs: sources: remove support_level labels from docs

### DIFF
--- a/website/docs/users-sources/sources/directory-sync/active-directory/index.md
+++ b/website/docs/users-sources/sources/directory-sync/active-directory/index.md
@@ -1,6 +1,5 @@
 ---
 title: Active Directory
-support_level: community
 ---
 
 ## Preparation

--- a/website/docs/users-sources/sources/directory-sync/freeipa/index.md
+++ b/website/docs/users-sources/sources/directory-sync/freeipa/index.md
@@ -1,6 +1,5 @@
 ---
 title: FreeIPA
-support_level: community
 ---
 
 ## Preparation

--- a/website/docs/users-sources/sources/social-logins/telegram/index.md
+++ b/website/docs/users-sources/sources/social-logins/telegram/index.md
@@ -1,7 +1,6 @@
 ---
 title: Log in with Telegram
 sidebar_label: Telegram
-support_level: community
 ---
 
 Configuring Telegram as a source allows users to authenticate within authentik using their Telegram account credentials.


### PR DESCRIPTION
## Details

### What does this PR change?

Removes `support_level` labels from source docs: active directory, freeipa and telegram

### Why is this change needed?

The labels are wrong

---

## Checklist

-   [x] The project has been linted, built, and tested (`make all`)
-   [x] The documentation has been updated and formatted (`make docs`)
