### PR TITLE
providers/scim: sync policy group membership changes

### DIFF
--- a/authentik/lib/sync/outgoing/signals.py
+++ b/authentik/lib/sync/outgoing/signals.py
@@ -20,11 +20,16 @@ def sync_outgoing_inhibit_dispatch():
     """
     Prevent direct and m2m tasks from being dispatched when User/Group/membership change
     """
-    _CTX_INHIBIT_DISPATCH.set(True)
+    token = _CTX_INHIBIT_DISPATCH.set(True)
     try:
         yield
     finally:
-        _CTX_INHIBIT_DISPATCH.set(False)
+        _CTX_INHIBIT_DISPATCH.reset(token)
+
+
+def sync_outgoing_dispatch_inhibited() -> bool:
+    """Check if outgoing sync signal dispatch is currently inhibited."""
+    return _CTX_INHIBIT_DISPATCH.get()
 
 
 def register_signals(
@@ -48,7 +53,7 @@ def register_signals(
         # This primarily happens during user login
         if sender == User and update_fields == {"last_login"}:
             return
-        if _CTX_INHIBIT_DISPATCH.get():
+        if sync_outgoing_dispatch_inhibited():
             return
         if not provider_type.objects.exists():
             return
@@ -62,7 +67,7 @@ def register_signals(
 
     def model_pre_delete(sender: type[Model], instance: User | Group, **_):
         """Pre-delete handler"""
-        if _CTX_INHIBIT_DISPATCH.get():
+        if sync_outgoing_dispatch_inhibited():
             return
         mappings = provider_type.get_object_mappings(instance)
         if not mappings:
@@ -81,7 +86,7 @@ def register_signals(
         """Sync group membership"""
         if action not in ["post_add", "post_remove"]:
             return
-        if _CTX_INHIBIT_DISPATCH.get():
+        if sync_outgoing_dispatch_inhibited():
             return
         if not provider_type.objects.exists():
             return

--- a/authentik/providers/scim/signals.py
+++ b/authentik/providers/scim/signals.py
@@ -1,8 +1,12 @@
 """SCIM provider signals"""
 
-from authentik.lib.sync.outgoing.signals import register_signals
+from django.db.models.signals import m2m_changed
+
+from authentik.core.models import Group, User
+from authentik.lib.sync.outgoing.signals import register_signals, sync_outgoing_dispatch_inhibited
 from authentik.providers.scim.models import SCIMProvider
 from authentik.providers.scim.tasks import (
+    scim_sync,
     scim_sync_delete_dispatch,
     scim_sync_direct_dispatch,
     scim_sync_m2m_dispatch,
@@ -13,4 +17,50 @@ register_signals(
     task_sync_direct_dispatch=scim_sync_direct_dispatch,
     task_sync_delete_dispatch=scim_sync_delete_dispatch,
     task_sync_m2m_dispatch=scim_sync_m2m_dispatch,
+)
+
+
+def scim_application_policy_membership_changed(
+    sender: type,
+    instance: User | Group,
+    action: str,
+    pk_set: set,
+    reverse: bool,
+    **_,
+):
+    """Sync SCIM providers when a group-bound application policy changes user scope."""
+    if action not in ["post_add", "post_remove"]:
+        return
+    if sync_outgoing_dispatch_inhibited():
+        return
+
+    if reverse:
+        group_pks = [instance.pk]
+    else:
+        group_pks = pk_set
+    if not group_pks:
+        return
+
+    groups = Group.objects.filter(pk__in=group_pks).with_ancestors()
+    providers = SCIMProvider.objects.filter(
+        backchannel_application__bindings__enabled=True,
+        backchannel_application__bindings__group__in=groups,
+    ).distinct()
+    for provider in providers:
+        scim_sync.send_with_options(
+            args=(provider.pk,),
+            rel_obj=provider,
+            uid=(
+                f"{provider.name}:application-policy-groups:{action}:"
+                f"{sorted(str(group_pk) for group_pk in group_pks)}"
+            ),
+            time_limit=provider.get_sync_time_limit_ms(),
+        )
+
+
+m2m_changed.connect(
+    scim_application_policy_membership_changed,
+    sender=User.groups.through,
+    dispatch_uid="authentik.providers.scim.signals.application_policy_membership",
+    weak=False,
 )

--- a/authentik/providers/scim/tests/test_application_policies.py
+++ b/authentik/providers/scim/tests/test_application_policies.py
@@ -1,10 +1,13 @@
 """SCIM Application Policies tests"""
 
+from unittest.mock import patch
+
 from django.test import TestCase
 
 from authentik.blueprints.tests import apply_blueprint
 from authentik.core.models import Application, Group, User
 from authentik.lib.generators import generate_id
+from authentik.lib.sync.outgoing.signals import sync_outgoing_inhibit_dispatch
 from authentik.policies.models import PolicyBinding
 from authentik.providers.scim.models import SCIMMapping, SCIMProvider
 from authentik.tenants.models import Tenant
@@ -88,3 +91,44 @@ class SCIMApplicationPoliciesTests(TestCase):
             set([self.users[1].pk, self.users[2].pk, self.users[4].pk]),
             set(user_qs.values_list("pk", flat=True)),
         )
+
+    def test_group_policy_member_add_dispatches_sync(self):
+        """Adding a user to a policy-bound group triggers a full SCIM sync"""
+        PolicyBinding.objects.create(target=self.app, group=self.group1, order=0)
+
+        with patch("authentik.providers.scim.signals.scim_sync.send_with_options") as sync:
+            self.users[3].groups.add(self.group1)
+
+        sync.assert_called_once()
+        self.assertEqual(sync.call_args.kwargs["args"], (self.provider.pk,))
+
+    def test_group_policy_member_remove_dispatches_sync(self):
+        """Removing a user from a policy-bound group triggers SCIM cleanup"""
+        PolicyBinding.objects.create(target=self.app, group=self.group1, order=0)
+
+        with patch("authentik.providers.scim.signals.scim_sync.send_with_options") as sync:
+            self.group1.users.remove(self.users[1])
+
+        sync.assert_called_once()
+        self.assertEqual(sync.call_args.kwargs["args"], (self.provider.pk,))
+
+    def test_unbound_group_member_change_does_not_dispatch_sync(self):
+        """Changing a group outside application policy bindings does not sync"""
+        PolicyBinding.objects.create(target=self.app, group=self.group1, order=0)
+
+        with patch("authentik.providers.scim.signals.scim_sync.send_with_options") as sync:
+            self.users[3].groups.add(self.group3)
+
+        sync.assert_not_called()
+
+    def test_inhibited_member_change_does_not_dispatch_sync(self):
+        """Bulk sync contexts can inhibit application-policy sync dispatch"""
+        PolicyBinding.objects.create(target=self.app, group=self.group1, order=0)
+
+        with (
+            sync_outgoing_inhibit_dispatch(),
+            patch("authentik.providers.scim.signals.scim_sync.send_with_options") as sync,
+        ):
+            self.users[3].groups.add(self.group1)
+
+        sync.assert_not_called()


### PR DESCRIPTION
- Queue a full SCIM sync when membership changes touch a group bound to a SCIM backchannel application's policy bindings.
- Reuse outgoing-sync dispatch inhibition for this new policy-scope dispatch path.
- Fix nested outgoing-sync inhibition so inner contexts restore the previous state instead of unconditionally clearing it.

SCIM direct and membership signal handling only covered object changes and SCIM group membership updates. After SCIM user filtering moved to application policy bindings, changing membership of a policy-bound group changes which users are in scope for the SCIM provider. A direct user sync can skip out-of-scope users, and stale-user cleanup only runs during a full provider sync, so removals were not automatically deprovisioned until a manual sync ran.

closes https://github.com/goauthentik/authentik/issues/21754

Closes #25291
