### PR TITLE
events: group application usage by ID

### DIFF
--- a/authentik/events/api/events.py
+++ b/authentik/events/api/events.py
@@ -257,7 +257,7 @@ class EventViewSet(
             .annotate(application=KeyTransform("authorized_application", "context"))
             .annotate(user_pk=KeyTextTransform("pk", "user"))
             .values("application_pk")
-            .annotate(counted_events=Count("event_uuid"))
+            .annotate(counted_events=Count("pk"))
             .annotate(unique_users=Count("user_pk", distinct=True))
             .annotate(applications=ArrayAgg("application", order_by=("-created", "-event_uuid")))
             .values("unique_users", "applications", "counted_events")

--- a/authentik/events/api/events.py
+++ b/authentik/events/api/events.py
@@ -15,7 +15,7 @@ from django.utils.timezone import now
 from djangoql.schema import DateTimeField as QLDateTimeFIeld
 from djangoql.schema import IntField, StrField
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_field
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from guardian.shortcuts import get_objects_for_user
 from rest_framework.decorators import action
 from rest_framework.fields import (
@@ -25,7 +25,6 @@ from rest_framework.fields import (
     DictField,
     IntegerField,
     ListField,
-    SerializerMethodField,
 )
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -78,14 +77,14 @@ class EventSerializer(ModelSerializer):
 class EventTopPerUserSerializer(PassiveSerializer):
     """Response object of Event's top_per_user"""
 
-    application = SerializerMethodField()
+    application = DictField()
     counted_events = IntegerField()
     unique_users = IntegerField()
 
-    @extend_schema_field(OpenApiTypes.OBJECT)
-    def get_application(self, instance: dict) -> dict:
-        """Return the latest stored application payload for this group."""
-        return instance["applications"][0]
+    def to_representation(self, instance: dict) -> dict:
+        """Return the latest stored application payload as the application."""
+        instance = {**instance, "application": instance["applications"][0]}
+        return super().to_representation(instance)
 
 
 class EventsFilter(django_filters.FilterSet):

--- a/authentik/events/api/events.py
+++ b/authentik/events/api/events.py
@@ -15,7 +15,7 @@ from django.utils.timezone import now
 from djangoql.schema import DateTimeField as QLDateTimeFIeld
 from djangoql.schema import IntField, StrField
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import OpenApiParameter, extend_schema
+from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_field
 from guardian.shortcuts import get_objects_for_user
 from rest_framework.decorators import action
 from rest_framework.fields import (
@@ -25,6 +25,7 @@ from rest_framework.fields import (
     DictField,
     IntegerField,
     ListField,
+    SerializerMethodField,
 )
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -77,9 +78,14 @@ class EventSerializer(ModelSerializer):
 class EventTopPerUserSerializer(PassiveSerializer):
     """Response object of Event's top_per_user"""
 
-    application = DictField()
+    application = SerializerMethodField()
     counted_events = IntegerField()
     unique_users = IntegerField()
+
+    @extend_schema_field(OpenApiTypes.OBJECT)
+    def get_application(self, instance: dict) -> dict:
+        """Return the latest stored application payload for this group."""
+        return instance["applications"][0]
 
 
 class EventsFilter(django_filters.FilterSet):
@@ -244,7 +250,7 @@ class EventViewSet(
         filtered_action = request.query_params.get("action", EventAction.LOGIN)
         top_n = int(request.query_params.get("top_n", "15"))
         application_pk = KeyTextTransform("pk", KeyTransform("authorized_application", "context"))
-        events = list(
+        events = (
             get_objects_for_user(request.user, "authentik_events.view_event")
             .filter(action=filtered_action)
             .exclude(context__authorized_application=None)
@@ -258,8 +264,6 @@ class EventViewSet(
             .values("unique_users", "applications", "counted_events")
             .order_by("-counted_events")[:top_n]
         )
-        for event in events:
-            event["application"] = event.pop("applications")[0]
         return Response(EventTopPerUserSerializer(instance=events, many=True).data)
 
     @extend_schema(

--- a/authentik/events/api/events.py
+++ b/authentik/events/api/events.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from datetime import timedelta
 
 import django_filters
+from django.contrib.postgres.aggregates import ArrayAgg
 from django.db.models import Count, ExpressionWrapper, F, QuerySet
 from django.db.models import DateTimeField as DjangoDateTimeField
 from django.db.models.fields.json import KeyTextTransform, KeyTransform
@@ -242,18 +243,23 @@ class EventViewSet(
         """Get the top_n events grouped by user count"""
         filtered_action = request.query_params.get("action", EventAction.LOGIN)
         top_n = int(request.query_params.get("top_n", "15"))
-        events = (
+        application_pk = KeyTextTransform("pk", KeyTransform("authorized_application", "context"))
+        events = list(
             get_objects_for_user(request.user, "authentik_events.view_event")
             .filter(action=filtered_action)
             .exclude(context__authorized_application=None)
+            .annotate(application_pk=application_pk)
             .annotate(application=KeyTransform("authorized_application", "context"))
             .annotate(user_pk=KeyTextTransform("pk", "user"))
-            .values("application")
-            .annotate(counted_events=Count("application"))
+            .values("application_pk")
+            .annotate(counted_events=Count("event_uuid"))
             .annotate(unique_users=Count("user_pk", distinct=True))
-            .values("unique_users", "application", "counted_events")
+            .annotate(applications=ArrayAgg("application", order_by=("-created", "-event_uuid")))
+            .values("unique_users", "applications", "counted_events")
             .order_by("-counted_events")[:top_n]
         )
+        for event in events:
+            event["application"] = event.pop("applications")[0]
         return Response(EventTopPerUserSerializer(instance=events, many=True).data)
 
     @extend_schema(

--- a/authentik/events/tests/test_api.py
+++ b/authentik/events/tests/test_api.py
@@ -58,6 +58,41 @@ class TestEventsAPI(APITestCase):
         )
         self.assertEqual(response.status_code, 200)
 
+    def test_top_n_groups_renamed_applications_by_pk(self):
+        """Test top_per_user groups application events by application ID"""
+        app_pk = 1
+        Event.new(
+            EventAction.AUTHORIZE_APPLICATION,
+            authorized_application={
+                "app": "authentik_core",
+                "model_name": "application",
+                "pk": app_pk,
+                "name": "Previous name",
+            },
+        ).set_user(self.user).save()
+        Event.new(
+            EventAction.AUTHORIZE_APPLICATION,
+            authorized_application={
+                "app": "authentik_core",
+                "model_name": "application",
+                "pk": app_pk,
+                "name": "Renamed application",
+            },
+        ).set_user(self.user).save()
+
+        response = self.client.get(
+            reverse("authentik_api:event-top-per-user"),
+            data={"action": EventAction.AUTHORIZE_APPLICATION},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        body = loads(response.content)
+        self.assertEqual(len(body), 1)
+        self.assertEqual(body[0]["application"]["pk"], app_pk)
+        self.assertEqual(body[0]["application"]["name"], "Renamed application")
+        self.assertEqual(body[0]["counted_events"], 2)
+        self.assertEqual(body[0]["unique_users"], 1)
+
     def test_actions(self):
         """Test actions"""
         response = self.client.get(


### PR DESCRIPTION
This fixes “Apps with most usage” aggregation so applications are grouped by the stable serialized application `pk` instead of the full serialized application payload.

Before, renaming an application could cause the same application to appear as multiple rows in the usage response. The stored event context includes serialized application details, including `authorized_application.name`, so a rename changed the grouped value even though the underlying application was the same.

Closes #21782
Closes #25278