### PR TITLE
website/docs: document email magic link login example

### DIFF
--- a/blueprints/example/flows-login-email-magic-link.yaml
+++ b/blueprints/example/flows-login-email-magic-link.yaml
@@ -1,0 +1,55 @@
+version: 1
+metadata:
+  labels:
+    blueprints.goauthentik.io/instantiate: "false"
+  name: Example - Login with email magic link
+entries:
+  - identifiers:
+      slug: default-authentication-flow
+    model: authentik_flows.flow
+    id: flow
+    attrs:
+      name: Default Authentication Flow
+      title: Welcome to authentik!
+      designation: authentication
+      authentication: require_unauthenticated
+  - identifiers:
+      name: default-authentication-identification
+    id: default-authentication-identification
+    model: authentik_stages_identification.identificationstage
+    attrs:
+      user_fields:
+        - email
+        - username
+      template: stages/identification/login.html
+  - identifiers:
+      name: default-authentication-email-magic-link
+    id: default-authentication-email-magic-link
+    model: authentik_stages_email.emailstage
+    attrs:
+      use_global_settings: true
+      token_expiry: minutes=30
+      subject: authentik sign-in link
+      template: email/account_confirmation.html
+      activate_user_on_success: false
+      recovery_max_attempts: 5
+      recovery_cache_timeout: minutes=5
+  - identifiers:
+      name: default-authentication-login
+    id: default-authentication-login
+    model: authentik_stages_user_login.userloginstage
+  - identifiers:
+      target: !KeyOf flow
+      stage: !KeyOf default-authentication-identification
+      order: 10
+    model: authentik_flows.flowstagebinding
+  - identifiers:
+      target: !KeyOf flow
+      stage: !KeyOf default-authentication-email-magic-link
+      order: 20
+    model: authentik_flows.flowstagebinding
+  - identifiers:
+      target: !KeyOf flow
+      stage: !KeyOf default-authentication-login
+      order: 100
+    model: authentik_flows.flowstagebinding

--- a/website/docs/add-secure-apps/flows-stages/flow/examples/flows.md
+++ b/website/docs/add-secure-apps/flows-stages/flow/examples/flows.md
@@ -50,7 +50,7 @@ Passwordless login flow that lets users sign in from a link sent to their email 
 
 Before importing this flow, make sure that global email settings are configured and that users have valid email addresses. Use this flow only when access to the user's email inbox is an acceptable sign-in factor for your environment.
 
-After import, review the Email stage. The example uses the built-in account confirmation template, so you can replace it with a custom sign-in email template if you want the email text to match the magic-link login experience.
+After import, review the Email stage binding in the flow. The example uses the built-in account confirmation email template. You can replace it with a [custom email template](../../stages/email/#custom-templates) if you want the email text to match the magic-link login experience.
 
 ## Log in with conditional CAPTCHA
 

--- a/website/docs/add-secure-apps/flows-stages/flow/examples/flows.md
+++ b/website/docs/add-secure-apps/flows-stages/flow/examples/flows.md
@@ -50,7 +50,7 @@ Passwordless login flow that lets users sign in from a link sent to their email 
 
 Before importing this flow, make sure that global email settings are configured and that users have valid email addresses. Use this flow only when access to the user's email inbox is an acceptable sign-in factor for your environment.
 
-After import, review the Email stage binding in the flow. The example uses the built-in account confirmation email template. You can replace it with a [custom email template](../../stages/email/#custom-templates) if you want the email text to match the magic-link login experience.
+After import, review the Email stage binding in the flow. The example uses the built-in account confirmation email template. You can replace it with a [custom email template](../../stages/email/index.md#custom-templates) if you want the email text to match the magic-link login experience.
 
 ## Log in with conditional CAPTCHA
 

--- a/website/docs/add-secure-apps/flows-stages/flow/examples/flows.md
+++ b/website/docs/add-secure-apps/flows-stages/flow/examples/flows.md
@@ -40,6 +40,18 @@ Login flow that follows the default pattern (username/email, then password), but
 
 You can force two-factor authentication by editing the _Not configured action_ in the Authenticator Validation Stage.
 
+## Log in with an email magic link
+
+Blueprint path: `example/flows-login-email-magic-link.yaml`
+
+Flow: right-click <DownloadLink to="/blueprints/example/flows-login-email-magic-link.yaml">here</DownloadLink> and save the file.
+
+Passwordless login flow that lets users sign in from a link sent to their email address. Users enter their email address or username, authentik sends them a confirmation link, and they are signed in after they open the link.
+
+Before importing this flow, make sure that global email settings are configured and that users have valid email addresses. Use this flow only when access to the user's email inbox is an acceptable sign-in factor for your environment.
+
+After import, review the Email stage. The example uses the built-in account confirmation template, so you can replace it with a custom sign-in email template if you want the email text to match the magic-link login experience.
+
 ## Log in with conditional CAPTCHA
 
 Blueprint path: `example/flows-login-conditional-captcha.yaml`


### PR DESCRIPTION
## Summary

- Add a bundled example flow for passwordless login with an email magic link.
- Add the flow to the example flows documentation with admin-facing setup notes.
- Call out email prerequisites and where to customize the email template after import.

## Validation
- `uv run coverage run manage.py test --keepdb authentik/blueprints/tests/test_packaged.py`
- `corepack npm --prefix website exec prettier -- --check website/docs/add-secure-apps/flows-stages/flow/examples/flows.md blueprints/example/flows-login-email-magic-link.yaml`
- `corepack npm exec cspell -- --config cspell.config.jsonc website/docs/add-secure-apps/flows-stages/flow/examples/flows.md blueprints/example/flows-login-email-magic-link.yaml`

Closes: #5012
