### PR TITLE
website/integrations: Gitea: add organizational mapping example

### DIFF
--- a/website/integrations/development/gitea/index.md
+++ b/website/integrations/development/gitea/index.md
@@ -134,10 +134,12 @@ For this to function, the Gitea `ENABLE_AUTO_REGISTRATION: true` variable must b
 3. Set the following configurations:
     - **Additional Scopes**: `email profile gitea`
     - **Required Claim Name**: `gitea`
-    - **Claim name providing group names for this source.** (Optional): `gitea`
-    - **Group Claim value for administrator users.** (Optional - requires claim name to be set): `admin`
-    - **Group Claim value for restricted users.** (Optional - requires claim name to be set): `restricted`
-4. Click **Update Authentication Source**.
+    - **Claim name providing group names for this source. (Optional)**: `gitea`
+    - **Group Claim value for administrator users. (Optional - requires claim name to be set)**: `admin`
+    - **Group Claim value for restricted users. (Optional - requires claim name to be set)**: `restricted`
+4. (Optional) It is possible to assign users to Organizational teams based upon their group. For example, members of the group `admin` could be made owners of the `Acme` group in this way:
+    - **Map claimed groups to Organization teams.**: `{"admin":{"Acme":["Owners"]}}`
+5. Click **Update Authentication Source**.
 
 :::info
 Users who are assigned none of the defined entitlements will be denied login access.


### PR DESCRIPTION
<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?
Integration documentation

### Why is this change needed?
1. Added step about org teams.
2. Formatting change. All those "(Optional)" texts are actually part of the fields in Gitea, which is why I'm extending the bold markdown to encompass them.

### How was this tested?
I implemented this integration. I did not do a `make docs`, as I have no experience doing that.

### Linked issues
None
<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
