### PR TITLE
website/docs: Set maxResponseBodySize to 4 MiB for Traefik Documentation

### DIFF
--- a/website/docs/add-secure-apps/providers/proxy/_traefik_standalone.md
+++ b/website/docs/add-secure-apps/providers/proxy/_traefik_standalone.md
@@ -5,7 +5,7 @@ http:
             forwardAuth:
                 address: http://outpost.company:9000/outpost.goauthentik.io/auth/traefik
                 trustForwardHeader: true
-                maxResponseBodySize: 4194304  # 4 MiB is a safe, generous cap.
+                maxResponseBodySize: 4194304
                 authResponseHeaders:
                     - X-authentik-username
                     - X-authentik-groups

--- a/website/docs/add-secure-apps/providers/proxy/_traefik_standalone.md
+++ b/website/docs/add-secure-apps/providers/proxy/_traefik_standalone.md
@@ -5,6 +5,7 @@ http:
             forwardAuth:
                 address: http://outpost.company:9000/outpost.goauthentik.io/auth/traefik
                 trustForwardHeader: true
+                maxResponseBodySize: 4194304  # 4 MiB is a safe, generous cap.
                 authResponseHeaders:
                     - X-authentik-username
                     - X-authentik-groups


### PR DESCRIPTION
Increase max response body size to 4 MiB for authentik.

<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?

### Why is this change needed?

### How was this tested?

### Linked issues

<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
