### PR TITLE
root: bump requests & fix double slash

### DIFF
--- a/authentik/enterprise/endpoints/connectors/fleet/controller.py
+++ b/authentik/enterprise/endpoints/connectors/fleet/controller.py
@@ -30,6 +30,10 @@ from authentik.policies.utils import delete_none_values
 class FleetController(BaseController[DBC]):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        base_url = self.connector.url
+        if base_url.endswith("/"):
+            base_url = base_url[:-1]
+        self._base_url = base_url
         self._session = get_http_session()
         self._session.headers["Authorization"] = f"Bearer {self.connector.token}"
         if self.connector.headers_mapping:
@@ -51,7 +55,7 @@ class FleetController(BaseController[DBC]):
         return [Capabilities.STAGE_ENDPOINTS, Capabilities.ENROLL_AUTOMATIC_API]
 
     def _url(self, path: str) -> str:
-        return f"{self.connector.url}{path}"
+        return f"{self._base_url}{path}"
 
     def _paginate_hosts(self):
         try:

--- a/tests/openid_conformance/base.py
+++ b/tests/openid_conformance/base.py
@@ -65,7 +65,7 @@ class TestOpenIDConformance(SSLLiveMixin, SeleniumTestCase):
     def run_test(
         self, test_name: str, test_plan_config: dict[str, Any], test_variant: dict[str, Any]
     ):
-        self.conformance = Conformance(f"https://{self.host}:8443/", None, verify_ssl=False)
+        self.conformance = Conformance(f"https://{self.host}:8443", None, verify_ssl=False)
 
         test_plan = self.conformance.create_test_plan(
             test_name,

--- a/uv.lock
+++ b/uv.lock
@@ -3234,7 +3234,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.33.1"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -3242,9 +3242,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?

This PR bumps the request dependency to 2.34.2. This brings a change where [double slashes inside of urls are preserved](https://github.com/psf/requests/pull/7315)

This PR also cleans up locations where we accidentally create // inside of a url

### Why is this change needed?

Without this change, our fleet calls and oidc testing calls will not work

### How was this tested?

Through CI/CD pipeline tests. Fleet was not tested but seems clear

### Linked issues

<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
