### PR TITLE
web/flows: fix untranslated user field labels in identification stage

### DIFF
--- a/web/src/flow/components/ak-flow-card.ts
+++ b/web/src/flow/components/ak-flow-card.ts
@@ -27,10 +27,10 @@ export class FlowCard extends AKElement {
     role = "presentation";
 
     @property({ type: Object })
-    challenge?: Pick<FormStaticChallenge, "flowInfo">;
+    public challenge: Pick<FormStaticChallenge, "flowInfo"> | null = null;
 
     @property({ type: Boolean })
-    loading = false;
+    public loading = false;
 
     static styles: CSSResult[] = [PFLogin, PFTitle, Styles];
 

--- a/web/src/flow/stages/identification/IdentificationStage.ts
+++ b/web/src/flow/stages/identification/IdentificationStage.ts
@@ -15,6 +15,11 @@ import CaptchaDisplayController from "#flow/stages/identification/controllers/Ca
 import RememberMeController from "#flow/stages/identification/controllers/RememberMeController";
 import WebauthnController from "#flow/stages/identification/controllers/WebauthnController";
 import Styles from "#flow/stages/identification/styles.css";
+import {
+    compareLoginSource,
+    formatUIFieldLabel,
+    OR_LIST_FORMATTERS,
+} from "#flow/stages/identification/utils";
 
 import {
     FlowDesignationEnum,
@@ -26,7 +31,6 @@ import {
 } from "@goauthentik/api";
 
 import { kebabCase } from "change-case";
-import { match } from "ts-pattern";
 
 import { msg, str } from "@lit/localize";
 import { html, nothing, PropertyValues, ReactiveControllerHost } from "lit";
@@ -50,23 +54,6 @@ export const PasswordManagerPrefill: {
     password?: string;
     totp?: string;
 } = {};
-
-export const OR_LIST_FORMATTERS: Intl.ListFormat = new Intl.ListFormat("default", {
-    style: "short",
-    type: "disjunction",
-});
-
-const uiFieldLabels = (): { [key: string]: string } => ({
-    [UserFieldsEnum.Username]: msg("Username"),
-    [UserFieldsEnum.Email]: msg("Email"),
-    [UserFieldsEnum.Upn]: msg("UPN"),
-});
-
-const sortLoginSources = (a: LoginSource, b: LoginSource) =>
-    match([!!a.promoted, !!b.promoted])
-        .with([true, false], () => -1)
-        .with([false, true], () => 1)
-        .otherwise(() => 0);
 
 @customElement("ak-stage-identification")
 export class IdentificationStage extends BaseStage<
@@ -293,7 +280,7 @@ export class IdentificationStage extends BaseStage<
 
     protected renderUidField(
         id: string,
-        type: string,
+        type: "email" | "text",
         label: string,
         initialUserIdentification: string | null,
         passwordFields?: boolean,
@@ -341,6 +328,7 @@ export class IdentificationStage extends BaseStage<
             challenge;
 
         const fields = (userFields || []).sort();
+
         if (fields.length === 0) {
             return html`<p>${msg("Select one of the options below to continue.")}</p>`;
         }
@@ -353,8 +341,8 @@ export class IdentificationStage extends BaseStage<
 
         const offerRecovery = flowDesignation === FlowDesignationEnum.Recovery;
         const type = fields.length === 1 && fields[0] === UserFieldsEnum.Email ? "email" : "text";
-        const uiFields = uiFieldLabels();
-        const label = OR_LIST_FORMATTERS.format(fields.map((f) => uiFields[f]));
+
+        const label = OR_LIST_FORMATTERS.format(fields.map((field) => formatUIFieldLabel(field)));
 
         // prettier-ignore
         return html`${offerRecovery ? this.renderRecoveryMessage() : nothing}
@@ -441,7 +429,7 @@ export class IdentificationStage extends BaseStage<
         >
             <legend class="sr-only">${msg("Login sources")}</legend>
             ${repeat(
-                [...sources].sort(sortLoginSources),
+                [...sources].sort(compareLoginSource),
                 (source, idx) => source.name + idx,
                 (source) => this.renderLoginSource(source, showLabels),
             )}

--- a/web/src/flow/stages/identification/IdentificationStage.ts
+++ b/web/src/flow/stages/identification/IdentificationStage.ts
@@ -56,11 +56,11 @@ export const OR_LIST_FORMATTERS: Intl.ListFormat = new Intl.ListFormat("default"
     type: "disjunction",
 });
 
-const UI_FIELDS: { [key: string]: string } = {
+const uiFieldLabels = (): { [key: string]: string } => ({
     [UserFieldsEnum.Username]: msg("Username"),
     [UserFieldsEnum.Email]: msg("Email"),
     [UserFieldsEnum.Upn]: msg("UPN"),
-};
+});
 
 const sortLoginSources = (a: LoginSource, b: LoginSource) =>
     match([!!a.promoted, !!b.promoted])
@@ -353,7 +353,8 @@ export class IdentificationStage extends BaseStage<
 
         const offerRecovery = flowDesignation === FlowDesignationEnum.Recovery;
         const type = fields.length === 1 && fields[0] === UserFieldsEnum.Email ? "email" : "text";
-        const label = OR_LIST_FORMATTERS.format(fields.map((f) => UI_FIELDS[f]));
+        const uiFields = uiFieldLabels();
+        const label = OR_LIST_FORMATTERS.format(fields.map((f) => uiFields[f]));
 
         // prettier-ignore
         return html`${offerRecovery ? this.renderRecoveryMessage() : nothing}

--- a/web/src/flow/stages/identification/utils.ts
+++ b/web/src/flow/stages/identification/utils.ts
@@ -1,0 +1,35 @@
+import { LoginSource, UserFieldsEnum } from "@goauthentik/api";
+
+import { match } from "ts-pattern";
+
+import { msg, str } from "@lit/localize";
+
+export const OR_LIST_FORMATTERS: Intl.ListFormat = new Intl.ListFormat("default", {
+    style: "short",
+    type: "disjunction",
+});
+
+export const UIFieldLabels: Record<UserFieldsEnum, () => string> = {
+    [UserFieldsEnum.Username]: () => msg("Username"),
+    [UserFieldsEnum.Email]: () => msg("Email"),
+    [UserFieldsEnum.Upn]: () => msg("UPN"),
+    [UserFieldsEnum.UnknownDefaultOpenApi]: () => msg("Unknown Field"),
+};
+
+/**
+ * Given a UserFieldsEnum or string, returns a human-readable label for the field.
+ */
+export function formatUIFieldLabel(fieldLike: UserFieldsEnum | string): string {
+    if (Object.hasOwn(UIFieldLabels, fieldLike)) {
+        return UIFieldLabels[fieldLike as UserFieldsEnum]();
+    }
+
+    return msg(str`Unknown Field ${fieldLike}`);
+}
+
+export function compareLoginSource(a: LoginSource, b: LoginSource) {
+    return match([!!a.promoted, !!b.promoted])
+        .with([true, false], () => -1)
+        .with([false, true], () => 1)
+        .otherwise(() => 0);
+}

--- a/web/src/flow/stages/identification/utils.ts
+++ b/web/src/flow/stages/identification/utils.ts
@@ -1,3 +1,5 @@
+import { MessageFormatter } from "#common/ui/locale/format";
+
 import { LoginSource, UserFieldsEnum } from "@goauthentik/api";
 
 import { match } from "ts-pattern";
@@ -9,7 +11,7 @@ export const OR_LIST_FORMATTERS: Intl.ListFormat = new Intl.ListFormat("default"
     type: "disjunction",
 });
 
-export const UIFieldLabels: Record<UserFieldsEnum, () => string> = {
+export const UIFieldLabels: Record<UserFieldsEnum, MessageFormatter<string>> = {
     [UserFieldsEnum.Username]: () => msg("Username"),
     [UserFieldsEnum.Email]: () => msg("Email"),
     [UserFieldsEnum.Upn]: () => msg("UPN"),


### PR DESCRIPTION
## Details

### What does this PR change?

Fixes the Identification Stage so that the identifier field's label and placeholder ("Username", "Email", "UPN", or a combined variant like "Username or Email") are translated into the active UI locale.

The labels were built from a module-level `UI_FIELDS` constant whose `msg()` calls were evaluated once at import time. This constant is replaced with a `uiFieldLabels()` function that is invoked inside `renderInput()`, so the strings are resolved and rendered with the active locale.

### Why is this change needed?

Authentik's web UI uses `@lit/localize` in runtime mode, where only `msg()` calls made during render pick up the active locale and re-render when it changes. Because `UI_FIELDS` ran its `msg()` calls at module-import time - before the locale is applied — the field labels were frozen at the source locale (English) for every non-English UI. The translations already existed in the catalogs; they were simply never applied at runtime. As a result, the Identification Stage on the default authentication flow always showed an English field label even when the rest of the page was translated.

### How was this tested?

- Manually: Open `default-authentication-flow`  and change the locale to a non-English locale (German). Before the change the field label/placeholder rendered in English; after the change, it's renders localized (e.g.  "Anmeldename") and updates when the locale changes.
- Verified no other references to the removed `UI_FIELDS` constant remain.
- `make all` (lint, build, test).
### Linked issues

closes #23517

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
