### PR TITLE
tasks/schedules: fix paused schedules getting unpaused on startup

### DIFF
--- a/authentik/tasks/schedules/common.py
+++ b/authentik/tasks/schedules/common.py
@@ -46,18 +46,23 @@ class ScheduleSpec:
 
         from authentik.tasks.schedules.models import Schedule
 
+        paused = self.paused
         update_values = {
             "_uid": self.uid,
-            "paused": self.paused,
             "args": self.get_args(),
             "kwargs": self.get_kwargs(),
             "options": self.get_options(),
         }
+        # If the schedule should be paused, then pause it when updating.
+        # Otherwise, leave the previous value.
+        if paused:
+            update_values["paused"] = paused
         if self.rel_obj is not None:
             update_values["rel_obj_content_type"] = ContentType.objects.get_for_model(self.rel_obj)
             update_values["rel_obj_id"] = str(self.rel_obj.pk)
         create_values = {
             **update_values,
+            "paused": paused,
             "crontab": self.crontab,
         }
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?

Fixes the schedules getting unpaused on instance restart when they were paused by the user.

### Why is this change needed?

### How was this tested?

### Linked issues

<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
