### PR TITLE
core/api: add PrivilegedFieldsSerializerMixin

### DIFF
--- a/authentik/core/api/utils.py
+++ b/authentik/core/api/utils.py
@@ -81,6 +81,27 @@ class ModelSerializer(BaseModelSerializer):
         return instance
 
 
+class PrivilegedFieldsSerializerMixin:
+    """Serializer mixin that empties credential-bearing fields for callers who can
+    only use the object, not manage it."""
+
+    privileged_fields: list[str] = []
+
+    def to_representation(self, instance: Model) -> dict:
+        data = super().to_representation(instance)
+        request = self.context.get("request")
+        if not request or not self.privileged_fields:
+            return data
+        meta = instance._meta
+        permission = f"{meta.app_label}.view_{meta.model_name}"
+        if request.user.has_perm(permission, instance) or request.user.has_perm(permission):
+            return data
+        for field in self.privileged_fields:
+            if field in data:
+                data[field] = {}
+        return data
+
+
 class PassiveSerializer(Serializer):
     """Base serializer class which doesn't implement create/update methods"""
 

--- a/authentik/core/api/utils.py
+++ b/authentik/core/api/utils.py
@@ -94,7 +94,7 @@ class PrivilegedFieldsSerializerMixin:
             return data
         meta = instance._meta
         permission = f"{meta.app_label}.view_{meta.model_name}"
-        if request.user.has_perm(permission, instance) or request.user.has_perm(permission):
+        if request.user.has_perm(permission, instance):
             return data
         for field in self.privileged_fields:
             if field in data:

--- a/authentik/core/api/utils.py
+++ b/authentik/core/api/utils.py
@@ -82,21 +82,24 @@ class ModelSerializer(BaseModelSerializer):
 
 
 class PrivilegedFieldsSerializerMixin:
-    """Serializer mixin that empties credential-bearing fields for callers who can
-    only use the object, not manage it."""
+    """Empties credential-bearing fields for callers who can only use the object, not view it."""
 
     privileged_fields: list[str] = []
+
+    def get_privileged_fields(self) -> list[str]:
+        return self.privileged_fields
 
     def to_representation(self, instance: Model) -> dict:
         data = super().to_representation(instance)
         request = self.context.get("request")
-        if not request or not self.privileged_fields:
+        privileged_fields = self.get_privileged_fields()
+        if not request or not privileged_fields:
             return data
         meta = instance._meta
         permission = f"{meta.app_label}.view_{meta.model_name}"
         if request.user.has_perm(permission, instance):
             return data
-        for field in self.privileged_fields:
+        for field in privileged_fields:
             if field in data:
                 data[field] = {}
         return data

--- a/authentik/core/tests/test_api_utils.py
+++ b/authentik/core/tests/test_api_utils.py
@@ -7,15 +7,11 @@ from rest_framework.serializers import (
 from rest_framework.serializers import (
     ModelSerializer as BaseModelSerializer,
 )
-from rest_framework.test import APIRequestFactory, APITestCase
+from rest_framework.test import APITestCase
 
 from authentik.core.api.utils import ModelSerializer as CustomModelSerializer
-from authentik.core.api.utils import PrivilegedFieldsSerializerMixin, is_dict
-from authentik.core.models import Group
-from authentik.core.tests.utils import create_test_admin_user, create_test_user
-from authentik.lib.generators import generate_id
+from authentik.core.api.utils import is_dict
 from authentik.lib.utils.reflection import all_subclasses
-from authentik.rbac.models import Role
 
 
 class TestAPIUtils(APITestCase):
@@ -37,52 +33,3 @@ class TestAPIUtils(APITestCase):
         )
 
         self.assertEqual(expected, actual)
-
-
-class GroupPrivilegedSerializer(PrivilegedFieldsSerializerMixin, CustomModelSerializer):
-    """Serializer that treats `attributes` as privileged, for testing the mixin"""
-
-    privileged_fields = ["attributes"]
-
-    class Meta:
-        model = Group
-        fields = ["name", "attributes"]
-
-
-class TestPrivilegedFieldsSerializerMixin(APITestCase):
-    """Test PrivilegedFieldsSerializerMixin"""
-
-    def setUp(self):
-        self.group = Group.objects.create(name=generate_id(), attributes={"private": generate_id()})
-
-    def test_hidden_without_permission(self):
-        """A caller without the object's view permission gets the field emptied"""
-        request = APIRequestFactory().get("/")
-        request.user = create_test_user()
-        data = GroupPrivilegedSerializer(self.group, context={"request": request}).data
-        self.assertEqual(data["attributes"], {})
-
-    def test_visible_with_permission(self):
-        """A caller granted the model's view permission sees the stored value"""
-        user = create_test_user()
-        role = Role.objects.create(name=generate_id())
-        role.assign_perms("authentik_core.view_group")
-        access_group = Group.objects.create(name=generate_id())
-        access_group.roles.add(role)
-        access_group.users.add(user)
-        request = APIRequestFactory().get("/")
-        request.user = user
-        data = GroupPrivilegedSerializer(self.group, context={"request": request}).data
-        self.assertEqual(data["attributes"], self.group.attributes)
-
-    def test_visible_for_superuser(self):
-        """A superuser sees the stored value"""
-        request = APIRequestFactory().get("/")
-        request.user = create_test_admin_user()
-        data = GroupPrivilegedSerializer(self.group, context={"request": request}).data
-        self.assertEqual(data["attributes"], self.group.attributes)
-
-    def test_no_request_returns_field(self):
-        """Without a request in context the mixin leaves the field untouched"""
-        data = GroupPrivilegedSerializer(self.group).data
-        self.assertEqual(data["attributes"], self.group.attributes)

--- a/authentik/core/tests/test_api_utils.py
+++ b/authentik/core/tests/test_api_utils.py
@@ -7,11 +7,15 @@ from rest_framework.serializers import (
 from rest_framework.serializers import (
     ModelSerializer as BaseModelSerializer,
 )
-from rest_framework.test import APITestCase
+from rest_framework.test import APIRequestFactory, APITestCase
 
 from authentik.core.api.utils import ModelSerializer as CustomModelSerializer
-from authentik.core.api.utils import is_dict
+from authentik.core.api.utils import PrivilegedFieldsSerializerMixin, is_dict
+from authentik.core.models import Group
+from authentik.core.tests.utils import create_test_admin_user, create_test_user
+from authentik.lib.generators import generate_id
 from authentik.lib.utils.reflection import all_subclasses
+from authentik.rbac.models import Role
 
 
 class TestAPIUtils(APITestCase):
@@ -33,3 +37,52 @@ class TestAPIUtils(APITestCase):
         )
 
         self.assertEqual(expected, actual)
+
+
+class GroupPrivilegedSerializer(PrivilegedFieldsSerializerMixin, CustomModelSerializer):
+    """Serializer that treats `attributes` as privileged, for testing the mixin"""
+
+    privileged_fields = ["attributes"]
+
+    class Meta:
+        model = Group
+        fields = ["name", "attributes"]
+
+
+class TestPrivilegedFieldsSerializerMixin(APITestCase):
+    """Test PrivilegedFieldsSerializerMixin"""
+
+    def setUp(self):
+        self.group = Group.objects.create(name=generate_id(), attributes={"private": generate_id()})
+
+    def test_hidden_without_permission(self):
+        """A caller without the object's view permission gets the field emptied"""
+        request = APIRequestFactory().get("/")
+        request.user = create_test_user()
+        data = GroupPrivilegedSerializer(self.group, context={"request": request}).data
+        self.assertEqual(data["attributes"], {})
+
+    def test_visible_with_permission(self):
+        """A caller granted the model's view permission sees the stored value"""
+        user = create_test_user()
+        role = Role.objects.create(name=generate_id())
+        role.assign_perms("authentik_core.view_group")
+        access_group = Group.objects.create(name=generate_id())
+        access_group.roles.add(role)
+        access_group.users.add(user)
+        request = APIRequestFactory().get("/")
+        request.user = user
+        data = GroupPrivilegedSerializer(self.group, context={"request": request}).data
+        self.assertEqual(data["attributes"], self.group.attributes)
+
+    def test_visible_for_superuser(self):
+        """A superuser sees the stored value"""
+        request = APIRequestFactory().get("/")
+        request.user = create_test_admin_user()
+        data = GroupPrivilegedSerializer(self.group, context={"request": request}).data
+        self.assertEqual(data["attributes"], self.group.attributes)
+
+    def test_no_request_returns_field(self):
+        """Without a request in context the mixin leaves the field untouched"""
+        data = GroupPrivilegedSerializer(self.group).data
+        self.assertEqual(data["attributes"], self.group.attributes)

--- a/authentik/core/tests/test_privileged_fields.py
+++ b/authentik/core/tests/test_privileged_fields.py
@@ -1,0 +1,69 @@
+"""Test PrivilegedFieldsSerializerMixin"""
+
+from unittest.mock import patch
+
+from rest_framework.test import APIRequestFactory, APITestCase
+
+from authentik.core.api.utils import ModelSerializer as CustomModelSerializer
+from authentik.core.api.utils import PrivilegedFieldsSerializerMixin
+from authentik.core.models import Group
+from authentik.core.tests.utils import create_test_admin_user, create_test_user
+from authentik.lib.generators import generate_id
+from authentik.rbac.models import Role
+
+
+class GroupPrivilegedSerializer(PrivilegedFieldsSerializerMixin, CustomModelSerializer):
+    """Serializer that treats `attributes` as privileged, for testing the mixin"""
+
+    privileged_fields = ["attributes"]
+
+    class Meta:
+        model = Group
+        fields = ["name", "attributes"]
+
+
+class TestPrivilegedFieldsSerializerMixin(APITestCase):
+    """Test PrivilegedFieldsSerializerMixin"""
+
+    def setUp(self):
+        self.group = Group.objects.create(name=generate_id(), attributes={"private": generate_id()})
+
+    def test_hidden_without_permission(self):
+        """A caller without the object's view permission gets the field emptied"""
+        request = APIRequestFactory().get("/")
+        request.user = create_test_user()
+        data = GroupPrivilegedSerializer(self.group, context={"request": request}).data
+        self.assertEqual(data["attributes"], {})
+
+    def test_visible_with_permission(self):
+        """A caller granted the model's view permission sees the stored value"""
+        user = create_test_user()
+        role = Role.objects.create(name=generate_id())
+        role.assign_perms("authentik_core.view_group")
+        access_group = Group.objects.create(name=generate_id())
+        access_group.roles.add(role)
+        access_group.users.add(user)
+        request = APIRequestFactory().get("/")
+        request.user = user
+        data = GroupPrivilegedSerializer(self.group, context={"request": request}).data
+        self.assertEqual(data["attributes"], self.group.attributes)
+
+    def test_visible_for_superuser(self):
+        """A superuser sees the stored value"""
+        request = APIRequestFactory().get("/")
+        request.user = create_test_admin_user()
+        data = GroupPrivilegedSerializer(self.group, context={"request": request}).data
+        self.assertEqual(data["attributes"], self.group.attributes)
+
+    def test_no_request_returns_field(self):
+        """Without a request in context the mixin leaves the field untouched"""
+        data = GroupPrivilegedSerializer(self.group).data
+        self.assertEqual(data["attributes"], self.group.attributes)
+
+    def test_get_privileged_fields_override(self):
+        """to_representation consults get_privileged_fields(), not the attribute directly"""
+        request = APIRequestFactory().get("/")
+        request.user = create_test_user()
+        with patch.object(GroupPrivilegedSerializer, "get_privileged_fields", return_value=[]):
+            data = GroupPrivilegedSerializer(self.group, context={"request": request}).data
+        self.assertEqual(data["attributes"], self.group.attributes)


### PR DESCRIPTION
This is meant for free-form `JSONField` settings-style fields that can hold sensitive values, where marking the whole field `write_only` would be too coarse (it would also hide the value from the user who legitimately manages the object). 