### PR TITLE
root: fix "make gen" failing with "the input device is not a TTY"

### DIFF
--- a/packages/client-go/Makefile
+++ b/packages/client-go/Makefile
@@ -6,7 +6,7 @@ GID = $(shell id -g)
 build:
 	rm -rf "${PWD}"/*.go
 	"${PWD}/../../scripts/api_filter_schema.py" "${PWD}/../../schema.yml" "${PWD}/schema.yml" "${PWD}/operation_ids"
-	docker compose run --rm --user "${UID}:${GID}" gen \
+	docker compose run --rm -T --user "${UID}:${GID}" gen \
 		generate \
 		-i /local/schema.yml \
 		-g go \

--- a/packages/client-rust/Makefile
+++ b/packages/client-rust/Makefile
@@ -16,7 +16,7 @@ ifndef version
 endif
 	rm -rf "${PWD}/src"
 	"${PWD}/../../scripts/api_filter_schema.py" "${PWD}/../../schema.yml" "${PWD}/schema.yml" "${PWD}/operation_ids"
-	docker compose run --rm --user "${UID}:${GID}" gen \
+	docker compose run --rm -T --user "${UID}:${GID}" gen \
 		generate \
 		-i /local/schema.yml \
 		-g rust \

--- a/packages/client-ts/Makefile
+++ b/packages/client-ts/Makefile
@@ -5,7 +5,7 @@ GID = $(shell id -g)
 
 build:
 	rm -rf src
-	docker compose run --rm --user "${UID}:${GID}" gen \
+	docker compose run --rm -T --user "${UID}:${GID}" gen \
 		generate \
 		-i /schema.yml \
 		-g typescript-fetch \


### PR DESCRIPTION
## Details

`make gen` currently fails with "the input device is not a TTY" on Linux (at least Debian 13) when executed in a terminal. The reason is that when running with `-j` option (from ` $(MAKE) _gen-clients -j`) Make gives gives all but  one parallel job a non-terminal stdin. Those jobs then have a terminal stdout and a non-terminal stdin, so Docker aborts.

### What does this PR change?

The change just adds a "-T" options to `docker compose` invocation when generating API clients, preventing docker from trying to create a pseudo-TTY. 

### Why is this change needed?

This allows `make gen` to be ran interactively on Linux which is essential for development.

### How was this tested?

Tested by running `make gen`.

---

## Checklist

-   [x] The project has been linted, built, and tested (`make all`)
