### PR TITLE
providers/scim: fix enum warning when de-serializing

### DIFF
--- a/authentik/providers/scim/clients/schema.py
+++ b/authentik/providers/scim/clients/schema.py
@@ -218,6 +218,7 @@ class PatchRequest(BasePatchRequest):
     """PatchRequest which correctly sets schemas"""
 
     schemas: tuple[str] = ("urn:ietf:params:scim:api:messages:2.0:PatchOp",)
+    Operations: list[PatchOperation]
 
 
 class PatchOperation(BasePatchOperation):


### PR DESCRIPTION
fixes a very small warning that happens during scim requests