### PR TITLE
web/flows: fix race condition in continuous login and support source stages in authentication flows (cherry-pick #23049 to version-2026.2)

### DIFF
--- a/authentik/core/views/apps.py
+++ b/authentik/core/views/apps.py
@@ -76,6 +76,7 @@ class RedirectToAppStage(ChallengeStageView):
         return RedirectChallenge(
             instance={
                 "to": launch,
+                "final_redirect": True,
             }
         )
 

--- a/authentik/enterprise/stages/source/tests.py
+++ b/authentik/enterprise/stages/source/tests.py
@@ -76,9 +76,12 @@ class TestSourceStage(FlowTestCase):
             follow=True,
         )
         self.assertEqual(response.status_code, 200)
-        self.assertStageRedirects(
+        self.assertStageResponse(
             response,
-            reverse("authentik_sources_saml:login", kwargs={"source_slug": self.source.slug}),
+            flow,
+            component="xak-flow-redirect",
+            to=reverse("authentik_sources_saml:login", kwargs={"source_slug": self.source.slug}),
+            final_redirect=False,
         )
 
         # Hijack flow plan so we don't have to emulate the source

--- a/authentik/flows/challenge.py
+++ b/authentik/flows/challenge.py
@@ -68,6 +68,10 @@ class RedirectChallenge(Challenge):
     """Challenge type to redirect the client"""
 
     to = CharField()
+    # True only for the terminal redirect out of a completed flow. Intermediate redirects (e.g.
+    # source-stage hops to an external IdP) stay False so the web client doesn't resume other
+    # continuous-login tabs prematurely. See web/src/flow/tabs/orchestrator.ts.
+    final_redirect = BooleanField(default=False)
     component = CharField(default="xak-flow-redirect")
 
 

--- a/authentik/flows/tests/test_executor.py
+++ b/authentik/flows/tests/test_executor.py
@@ -42,7 +42,7 @@ POLICY_RETURN_FALSE = PropertyMock(return_value=PolicyResult(False, "foo"))
 POLICY_RETURN_TRUE = MagicMock(return_value=PolicyResult(True))
 
 
-def to_stage_response(request: HttpRequest, source: HttpResponse):
+def to_stage_response(request: HttpRequest, source: HttpResponse, final_redirect: bool = False):
     """Mock for to_stage_response that returns the original response, so we can check
     inheritance and member attributes"""
     return source
@@ -178,6 +178,22 @@ class TestFlowExecutor(FlowTestCase):
         response = self.client.get(url + f"?{QS_QUERY}={urlencode({NEXT_ARG_NAME: dest})}")
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, "/unique-string")
+
+    def test_flow_done_redirect_challenge_is_final(self):
+        """Test redirects generated when a flow is done are marked as final."""
+        flow = create_test_flow()
+
+        dest = "/unique-string"
+        url = reverse("authentik_api:flow-executor", kwargs={"flow_slug": flow.slug})
+
+        response = self.client.get(url + f"?{QS_QUERY}={urlencode({NEXT_ARG_NAME: dest})}")
+
+        self.assertStageResponse(
+            response,
+            component="xak-flow-redirect",
+            to=dest,
+            final_redirect=True,
+        )
 
     @patch(
         "authentik.flows.views.executor.to_stage_response",

--- a/authentik/flows/views/executor.py
+++ b/authentik/flows/views/executor.py
@@ -391,14 +391,18 @@ class FlowExecutorView(APIView):
             # check if its an absolute URL or a relative one
             self.cancel()
             return to_stage_response(
-                self.request, redirect(self.plan.context.get(PLAN_CONTEXT_REDIRECT))
+                self.request,
+                redirect(self.plan.context.get(PLAN_CONTEXT_REDIRECT)),
+                final_redirect=True,
             )
         next_param = self.request.session.get(SESSION_KEY_GET, {}).get(
             NEXT_ARG_NAME, "authentik_core:root-redirect"
         )
         self.cancel()
         if next_param and not is_url_absolute(next_param):
-            return to_stage_response(self.request, redirect_with_qs(next_param))
+            return to_stage_response(
+                self.request, redirect_with_qs(next_param), final_redirect=True
+            )
         return to_stage_response(
             self.request, self.stage_invalid(error_message=_("Invalid next URL"))
         )
@@ -540,7 +544,9 @@ class ToDefaultFlow(View):
         return redirect_with_qs("authentik_core:if-flow", request.GET, flow_slug=flow.slug)
 
 
-def to_stage_response(request: HttpRequest, source: HttpResponse) -> HttpResponse:
+def to_stage_response(
+    request: HttpRequest, source: HttpResponse, final_redirect: bool = False
+) -> HttpResponse:
     """Convert normal HttpResponse into JSON Response"""
     if (
         isinstance(source, HttpResponseRedirect)
@@ -559,6 +565,7 @@ def to_stage_response(request: HttpRequest, source: HttpResponse) -> HttpRespons
             RedirectChallenge(
                 {
                     "to": str(redirect_url),
+                    "final_redirect": final_redirect,
                 }
             )
         )

--- a/authentik/providers/oauth2/tests/test_device_init.py
+++ b/authentik/providers/oauth2/tests/test_device_init.py
@@ -118,6 +118,7 @@ class TesOAuth2DeviceInit(OAuthTestCase):
             res.content,
             {
                 "component": "xak-flow-redirect",
+                "final_redirect": False,
                 "to": reverse(
                     "authentik_core:if-flow",
                     kwargs={

--- a/authentik/providers/saml/tests/test_auth_n_request.py
+++ b/authentik/providers/saml/tests/test_auth_n_request.py
@@ -1,10 +1,13 @@
 """Test AuthN Request generator and parser"""
 
 from base64 import b64encode
+from json import loads
+from urllib.parse import parse_qs, urlparse
 
 from defusedxml.lxml import fromstring
 from django.http.request import QueryDict
 from django.test import TestCase
+from django.urls import reverse
 from guardian.utils import get_anonymous_user
 from lxml import etree  # nosec
 
@@ -15,6 +18,7 @@ from authentik.common.saml.constants import (
     SAML_NAME_ID_FORMAT_EMAIL,
     SAML_NAME_ID_FORMAT_UNSPECIFIED,
 )
+from authentik.core.models import Application
 from authentik.core.tests.utils import (
     RequestFactory,
     create_test_admin_user,
@@ -23,15 +27,19 @@ from authentik.core.tests.utils import (
 )
 from authentik.crypto.models import CertificateKeyPair
 from authentik.events.models import Event, EventAction
+from authentik.flows.apps import ContinuousLogin
+from authentik.flows.models import FlowStageBinding
 from authentik.lib.generators import generate_id
 from authentik.lib.xml import lxml_from_string
-from authentik.providers.saml.models import SAMLPropertyMapping, SAMLProvider
+from authentik.providers.saml.models import SAMLBindings, SAMLPropertyMapping, SAMLProvider
 from authentik.providers.saml.processors.assertion import AssertionProcessor
 from authentik.providers.saml.processors.authn_request_parser import AuthNRequestParser
 from authentik.sources.saml.exceptions import MismatchedRequestID
 from authentik.sources.saml.models import SAMLBindingTypes, SAMLSource
 from authentik.sources.saml.processors.request import SESSION_KEY_REQUEST_ID, RequestProcessor
 from authentik.sources.saml.processors.response import ResponseProcessor
+from authentik.stages.dummy.models import DummyStage
+from authentik.tenants.flags import patch_flag
 
 POST_REQUEST = (
     "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c2FtbDJwOkF1dGhuUmVxdWVzdCB4bWxuczpzYW1sMn"
@@ -97,6 +105,11 @@ class TestAuthNRequest(TestCase):
         )
         self.provider.property_mappings.set(SAMLPropertyMapping.objects.all())
         self.provider.save()
+        Application.objects.create(
+            name="test-app",
+            slug="test-app",
+            provider=self.provider,
+        )
         self.source = SAMLSource.objects.create(
             slug="provider",
             issuer="authentik",
@@ -123,6 +136,69 @@ class TestAuthNRequest(TestCase):
         )
         self.assertEqual(parsed_request.id, request_proc.request_id)
         self.assertEqual(parsed_request.relay_state, "test_state")
+
+    def test_redirect_binding_flow_redirect_includes_resume_url(self):
+        """Test SP-initiated Redirect binding keeps the original SAML URL as next."""
+        app = Application.objects.get(slug="test-app")
+        FlowStageBinding.objects.create(
+            target=self.provider.authorization_flow,
+            stage=DummyStage.objects.create(name=generate_id()),
+            order=0,
+        )
+        http_request = self.request_factory.get("/")
+        params = RequestProcessor(self.source, http_request, "test_state").build_auth_n_detached()
+        self.client.force_login(create_test_admin_user())
+        url = reverse(
+            "authentik_providers_saml:sso-redirect",
+            kwargs={"application_slug": app.slug},
+        )
+
+        response = self.client.get(url, params)
+
+        self.assertEqual(response.status_code, 302)
+        redirect_query = parse_qs(urlparse(response["Location"]).query)
+        self.assertIn("next", redirect_query)
+
+        next_url = urlparse(redirect_query["next"][0])
+        self.assertEqual(next_url.path, url)
+        next_query = parse_qs(next_url.query)
+        for key, value in params.items():
+            self.assertEqual(next_query[key], [value])
+
+    @patch_flag(ContinuousLogin, True)
+    def test_redirect_binding_continuous_login_final_redirect(self):
+        """Test SP-initiated Redirect binding returns a final redirect challenge under
+        continuous login, instead of an un-validated-serializer error."""
+        self.provider.sp_binding = SAMLBindings.REDIRECT
+        self.provider.save()
+        app = Application.objects.get(slug="test-app")
+        http_request = self.request_factory.get("/")
+        params = RequestProcessor(self.source, http_request, "test_state").build_auth_n_detached()
+        self.client.force_login(create_test_admin_user())
+
+        # Initiate the SP-initiated request, which plans the flow and redirects into the executor.
+        initiate = self.client.get(
+            reverse(
+                "authentik_providers_saml:sso-redirect",
+                kwargs={"application_slug": app.slug},
+            ),
+            params,
+        )
+        self.assertEqual(initiate.status_code, 302)
+
+        # Drive the flow executor to completion, reaching SAMLFlowFinalView.
+        response = self.client.get(
+            reverse(
+                "authentik_api:flow-executor",
+                kwargs={"flow_slug": self.provider.authorization_flow.slug},
+            )
+        )
+
+        self.assertEqual(response.status_code, 200)
+        body = loads(response.content.decode())
+        self.assertEqual(body["component"], "xak-flow-redirect")
+        self.assertTrue(body["final_redirect"])
+        self.assertTrue(body["to"].startswith(self.provider.acs_url))
 
     def test_request_encrypt(self):
         """Test full SAML Request/Response flow, fully encrypted"""

--- a/authentik/providers/saml/views/flows.py
+++ b/authentik/providers/saml/views/flows.py
@@ -12,12 +12,15 @@ from structlog.stdlib import get_logger
 
 from authentik.core.models import Application, AuthenticatedSession
 from authentik.events.models import Event, EventAction
+from authentik.flows.apps import ContinuousLogin
 from authentik.flows.challenge import (
     PLAN_CONTEXT_TITLE,
     AutosubmitChallenge,
     AutoSubmitChallengeResponse,
     Challenge,
     ChallengeResponse,
+    HttpChallengeResponse,
+    RedirectChallenge,
 )
 from authentik.flows.planner import PLAN_CONTEXT_APPLICATION
 from authentik.flows.stage import ChallengeStageView
@@ -142,6 +145,15 @@ class SAMLFlowFinalView(ChallengeStageView):
             if auth_n_request.relay_state:
                 url_args[REQUEST_KEY_RELAY_STATE] = auth_n_request.relay_state
             querystring = urlencode(url_args)
+            if ContinuousLogin.get():
+                return HttpChallengeResponse(
+                    RedirectChallenge(
+                        instance={
+                            "to": f"{provider.acs_url}?{querystring}",
+                            "final_redirect": True,
+                        }
+                    )
+                )
             return redirect(f"{provider.acs_url}?{querystring}")
         return bad_request_message(request, "Invalid sp_binding specified")
 

--- a/authentik/providers/saml/views/sso.py
+++ b/authentik/providers/saml/views/sso.py
@@ -10,6 +10,7 @@ from structlog.stdlib import get_logger
 
 from authentik.core.models import Application
 from authentik.events.models import Event, EventAction
+from authentik.flows.apps import ContinuousLogin
 from authentik.flows.exceptions import FlowNonApplicableException
 from authentik.flows.models import in_memory_stage
 from authentik.flows.planner import PLAN_CONTEXT_APPLICATION, PLAN_CONTEXT_SSO, FlowPlanner
@@ -53,6 +54,10 @@ class SAMLSSOView(BufferedPolicyAccessView):
         """Handler to verify the SAML Request. Must be implemented by a subclass"""
         raise NotImplementedError
 
+    def get_resume_url(self) -> str | None:
+        """URL to re-enter this SAML request after another tab authenticated."""
+        return None
+
     def get(self, request: HttpRequest, application_slug: str) -> HttpResponse:
         """Verify the SAML Request, and if valid initiate the FlowPlanner for the application"""
         # Call the method handler, which checks the SAML
@@ -81,8 +86,11 @@ class SAMLSSOView(BufferedPolicyAccessView):
         return plan.to_redirect(
             request,
             self.provider.authorization_flow,
+            next=self.get_resume_url(),
             allowed_silent_types=(
-                [SAMLFlowFinalView] if self.provider.sp_binding in [SAMLBindings.REDIRECT] else []
+                [SAMLFlowFinalView]
+                if self.provider.sp_binding in [SAMLBindings.REDIRECT] and not ContinuousLogin.get()
+                else []
             ),
         )
 
@@ -94,6 +102,9 @@ class SAMLSSOView(BufferedPolicyAccessView):
 
 class SAMLSSOBindingRedirectView(SAMLSSOView):
     """SAML Handler for SSO/Redirect bindings, which are sent via GET"""
+
+    def get_resume_url(self) -> str | None:
+        return self.request.get_full_path()
 
     def check_saml_request(self) -> HttpRequest | None:
         """Handle REDIRECT bindings"""

--- a/authentik/stages/identification/tests.py
+++ b/authentik/stages/identification/tests.py
@@ -205,6 +205,7 @@ class TestIdentificationStage(FlowTestCase):
                     "challenge": {
                         "component": "xak-flow-redirect",
                         "to": f"/source/oauth/login/{self.source.slug}/",
+                        "final_redirect": False,
                     },
                     "icon_url": "/static/authentik/sources/default.svg",
                     "name": self.source.name,
@@ -241,6 +242,7 @@ class TestIdentificationStage(FlowTestCase):
                     "challenge": {
                         "component": "xak-flow-redirect",
                         "to": f"/source/oauth/login/{self.source.slug}/",
+                        "final_redirect": False,
                     },
                     "icon_url": "/static/authentik/sources/default.svg",
                     "name": self.source.name,
@@ -316,6 +318,7 @@ class TestIdentificationStage(FlowTestCase):
                     "challenge": {
                         "component": "xak-flow-redirect",
                         "to": f"/source/oauth/login/{self.source.slug}/",
+                        "final_redirect": False,
                     },
                     "icon_url": "/static/authentik/sources/default.svg",
                     "name": self.source.name,
@@ -372,6 +375,7 @@ class TestIdentificationStage(FlowTestCase):
                     "challenge": {
                         "component": "xak-flow-redirect",
                         "to": f"/source/oauth/login/{self.source.slug}/",
+                        "final_redirect": False,
                     },
                     "icon_url": "/static/authentik/sources/default.svg",
                     "name": self.source.name,
@@ -435,6 +439,7 @@ class TestIdentificationStage(FlowTestCase):
                     "challenge": {
                         "component": "xak-flow-redirect",
                         "to": f"/source/oauth/login/{self.source.slug}/",
+                        "final_redirect": False,
                     },
                     "icon_url": "/static/authentik/sources/default.svg",
                     "name": self.source.name,
@@ -486,6 +491,7 @@ class TestIdentificationStage(FlowTestCase):
                     "challenge": {
                         "component": "xak-flow-redirect",
                         "to": f"/source/oauth/login/{self.source.slug}/",
+                        "final_redirect": False,
                     },
                     "promoted": False,
                 }
@@ -522,6 +528,7 @@ class TestIdentificationStage(FlowTestCase):
                     "challenge": {
                         "component": "xak-flow-redirect",
                         "to": f"/source/oauth/login/{self.source.slug}/",
+                        "final_redirect": False,
                     },
                     "icon_url": "/static/authentik/sources/default.svg",
                     "name": self.source.name,
@@ -550,6 +557,7 @@ class TestIdentificationStage(FlowTestCase):
                     "challenge": {
                         "component": "xak-flow-redirect",
                         "to": f"/source/oauth/login/{self.source.slug}/",
+                        "final_redirect": False,
                     },
                     "icon_url": "/static/authentik/sources/default.svg",
                     "name": self.source.name,

--- a/schema.yml
+++ b/schema.yml
@@ -52676,6 +52676,9 @@ components:
               $ref: '#/components/schemas/ErrorDetail'
         to:
           type: string
+        final_redirect:
+          type: boolean
+          default: false
       required:
       - to
     RedirectChallengeResponseRequest:

--- a/web/src/flow/FlowExecutor.ts
+++ b/web/src/flow/FlowExecutor.ts
@@ -32,7 +32,10 @@ import { ThemedImage } from "#elements/utils/images";
 
 import { AKFlowAdvanceEvent, AKFlowInspectorChangeEvent } from "#flow/events";
 import { BaseStage, StageHost, SubmitOptions } from "#flow/stages/base";
-import { multiTabOrchestrateLeave } from "#flow/tabs/orchestrator";
+import {
+    multiTabOrchestrateLeave,
+    suppressNextExitForSameOriginNavigation,
+} from "#flow/tabs/orchestrator";
 
 import { ConsoleLogger } from "#logger/browser";
 
@@ -195,24 +198,40 @@ export class FlowExecutor
         });
 
         window.addEventListener("ak-multitab-continue", () => {
-            document.title = "continued";
-            if (
-                this.challenge?.component === "ak-stage-identification" &&
-                this.challenge.applicationPreLaunch &&
-                this.challenge.applicationPreLaunch !== "blank://blank"
-            ) {
-                multiTabOrchestrateLeave();
-                window.location.assign(this.challenge.applicationPreLaunch);
+            const challenge = this.challenge;
+
+            if (!challenge) {
                 return;
             }
+
             const qs = new URLSearchParams(window.location.search);
             const next = qs.get("next");
+
             if (next) {
                 const url = new URL(next, window.location.origin);
-                if (!url.pathname.startsWith(`${globalAK().api.relBase}if/flow`)) {
+
+                // A same-origin `next` (e.g. the SP-initiated SAML resume re-entry) is an
+                // intermediate hop, so suppress our exit instead of signaling we left mid-flow.
+                if (url.origin === window.location.origin) {
+                    suppressNextExitForSameOriginNavigation();
+                } else {
                     multiTabOrchestrateLeave();
                 }
+
                 window.location.assign(url);
+
+                return;
+            }
+
+            // `blank://blank` is the 2026.2 mechanism for hiding an application; don't treat it
+            // as a launchable destination.
+            if (
+                challenge.component === "ak-stage-identification" &&
+                challenge.applicationPreLaunch &&
+                challenge.applicationPreLaunch !== "blank://blank"
+            ) {
+                multiTabOrchestrateLeave();
+                window.location.assign(challenge.applicationPreLaunch);
             }
         });
     }

--- a/web/src/flow/stages/RedirectStage.ts
+++ b/web/src/flow/stages/RedirectStage.ts
@@ -3,7 +3,11 @@ import "#flow/components/ak-flow-card";
 import { SlottedTemplateResult } from "#elements/types";
 
 import { BaseStage } from "#flow/stages/base";
-import { multiTabOrchestrateResume } from "#flow/tabs/orchestrator";
+import {
+    multiTabOrchestrateLeave,
+    multiTabOrchestrateResume,
+    suppressNextExitForSameOriginNavigation,
+} from "#flow/tabs/orchestrator";
 
 import { FlowChallengeResponseRequest, RedirectChallenge } from "@goauthentik/api";
 
@@ -59,24 +63,30 @@ export class RedirectStage extends BaseStage<RedirectChallenge, FlowChallengeRes
         this.redirect();
     }
 
-    isForeignURL() {
-        try {
-            const destination = new URL(this.challenge!.to, window.origin);
-            return destination.origin === window.origin;
-        } catch {
-            return true;
-        }
-    }
-
     async redirect() {
         console.debug(
             "authentik/stages/redirect: redirecting to url from server",
             this.challenge?.to,
         );
 
-        if (this.isForeignURL()) {
+        // `final_redirect` marks the terminal redirect out of a completed flow. Only then do we
+        // resume other continuous-login tabs; intermediate hops (source stages, the same-origin
+        // SAML resume re-entry) skip orchestration entirely.
+        const finalRedirect = this.challenge?.finalRedirect ?? false;
+        if (finalRedirect) {
             await multiTabOrchestrateResume();
         }
+
+        // A foreign final redirect means we're leaving authentik for good, so signal our exit.
+        // Same-origin navigation suppress it, otherwise we'd look like we left mid-flow.
+        const url = new URL(this.challenge!.to, window.location.origin);
+
+        if (finalRedirect && url.origin !== window.location.origin) {
+            multiTabOrchestrateLeave();
+        } else {
+            suppressNextExitForSameOriginNavigation();
+        }
+
         window.location.assign(this.challenge!.to);
         this.startedRedirect = true;
     }
@@ -119,8 +129,9 @@ export class RedirectStage extends BaseStage<RedirectChallenge, FlowChallengeRes
                         type="submit"
                         class="pf-c-button pf-m-primary pf-m-block"
                         href=${this.challenge.to}
-                        @click=${() => {
-                            this.startedRedirect = true;
+                        @click=${(ev: Event) => {
+                            ev.preventDefault();
+                            this.redirect();
                         }}
                     >
                         ${msg("Follow redirect")}

--- a/web/src/flow/tabs/TabID.ts
+++ b/web/src/flow/tabs/TabID.ts
@@ -1,21 +1,23 @@
 import { ascii_letters, digits, randomString } from "#common/utils";
 
-export const SESSION_STORAGE_TAB_ID = "authentik_tab_id";
-
 export class TabID {
-    static shared: TabID = new TabID();
+    public static readonly SessionStorageKey = "authentik_tab_id";
+    public static readonly shared: TabID = new TabID();
 
     #id: string;
 
     constructor() {
-        const id = sessionStorage.getItem(SESSION_STORAGE_TAB_ID);
-        const newId = randomString(32, ascii_letters + digits);
+        const id = sessionStorage.getItem(TabID.SessionStorageKey);
+        const newID = randomString(32, ascii_letters + digits);
+
         if (id) {
             this.#id = id;
             return;
         }
-        this.#id = newId;
-        sessionStorage.setItem(SESSION_STORAGE_TAB_ID, this.#id);
+
+        this.#id = newID;
+
+        sessionStorage.setItem(TabID.SessionStorageKey, this.#id);
     }
 
     get current() {
@@ -23,6 +25,6 @@ export class TabID {
     }
 
     clear() {
-        sessionStorage.removeItem(SESSION_STORAGE_TAB_ID);
+        sessionStorage.removeItem(TabID.SessionStorageKey);
     }
 }

--- a/web/src/flow/tabs/broadcast.ts
+++ b/web/src/flow/tabs/broadcast.ts
@@ -1,63 +1,32 @@
+import { AKMultiTabEvent, AKMultiTabExitEvent } from "#flow/tabs/events";
+import { BroadcastMessage, BroadcastMessageType } from "#flow/tabs/messages";
 import { TabID } from "#flow/tabs/TabID";
 
 import { ConsoleLogger, Logger } from "#logger/browser";
 
-export const BROADCAST_CHANNEL_NAME = "authentik";
-
-enum BroadcastMessageType {
-    discover = "discover",
-    continue = "continue",
-    exit = "exit",
-    discoverReply = "discoverReply",
-}
-
-export interface BroadcastMessage {
-    type: BroadcastMessageType;
-    sender: string;
-    [key: string]: unknown;
-}
+import { match } from "ts-pattern";
 
 export class Broadcast extends BroadcastChannel implements Disposable {
-    static shared = new Broadcast();
+    public static readonly ChannelName = "authentik";
+    public static readonly SessionStorageKey = "authentik_tab_resume_id";
+
+    public static readonly shared = new Broadcast();
 
     protected discoveredTabIDs = new Set<string>();
-    public exitedTabIDs: string[] = [];
+    protected shouldSuppressExit = false;
 
     protected logger: Logger;
+    protected storageKey: string;
 
-    protected messageListener = (ev: MessageEvent<BroadcastMessage>) => {
-        this.logger.debug("broadcast event", ev.data);
-        switch (ev.data.type) {
-            case BroadcastMessageType.discover:
-                if (ev.data.sender === TabID.shared.current) {
-                    return;
-                }
-                this.postMessage({
-                    type: BroadcastMessageType.discoverReply,
-                    sender: TabID.shared.current,
-                });
-                return;
-            case BroadcastMessageType.discoverReply:
-                this.discoveredTabIDs.add(ev.data.sender as string);
-                return;
-            case BroadcastMessageType.exit:
-                this.exitedTabIDs.push(ev.data.sender);
-                return;
-            case BroadcastMessageType.continue:
-                if (ev.data.target === TabID.shared.current) {
-                    this.logger.debug("Continuing upon event");
-                    window.dispatchEvent(new CustomEvent("ak-multitab-continue"));
-                }
-                return;
-        }
-    };
+    //#region Lifecycle
 
-    protected pageHideListener = () => {
-        this.akExitTab();
-    };
+    constructor(
+        channelName: string = Broadcast.ChannelName,
+        storageKey: string = Broadcast.SessionStorageKey,
+    ) {
+        super(channelName);
 
-    constructor() {
-        super(BROADCAST_CHANNEL_NAME);
+        this.storageKey = storageKey;
 
         this.addEventListener("message", this.messageListener);
         window.addEventListener("pagehide", this.pageHideListener);
@@ -65,15 +34,82 @@ export class Broadcast extends BroadcastChannel implements Disposable {
         this.logger = ConsoleLogger.prefix("mtab/broadcast");
     }
 
-    [Symbol.dispose]() {
+    public [Symbol.dispose]() {
         this.removeEventListener("message", this.messageListener);
+        window.removeEventListener("pagehide", this.pageHideListener);
     }
 
-    async akTabDiscover(): Promise<Set<string>> {
+    protected dispatchMessage(message: BroadcastMessage): void {
+        this.logger.debug("dispatching message", message);
+
+        this.postMessage(message);
+    }
+
+    //#endregion
+
+    //#region Event Listeners
+
+    protected messageListener = (event: MessageEvent<BroadcastMessage>): void => {
+        this.logger.debug("broadcast event", event.data);
+
+        match(event.data)
+            .with({ type: BroadcastMessageType.Discover }, () => {
+                if (event.data.sender === TabID.shared.current) {
+                    return;
+                }
+
+                this.dispatchMessage({
+                    type: BroadcastMessageType.DiscoverReply,
+                    sender: TabID.shared.current,
+                });
+            })
+            .with({ type: BroadcastMessageType.DiscoverReply }, ({ sender }) => {
+                this.discoveredTabIDs.add(sender);
+            })
+            .with({ type: BroadcastMessageType.Exit }, ({ sender, resumeID }) => {
+                window.dispatchEvent(new AKMultiTabExitEvent(sender, resumeID));
+            })
+            .with({ type: BroadcastMessageType.Continue }, ({ target, resumeID }) => {
+                if (target !== TabID.shared.current) {
+                    return;
+                }
+                if (typeof resumeID === "string") {
+                    sessionStorage.setItem(this.storageKey, resumeID);
+                }
+
+                this.logger.debug("Continuing upon event");
+
+                window.dispatchEvent(new AKMultiTabEvent());
+            })
+            .otherwise(() => {
+                this.logger.warn("Unknown broadcast message type", event.data);
+            });
+    };
+
+    protected pageHideListener = (): void => {
+        if (this.shouldSuppressExit) {
+            this.shouldSuppressExit = false;
+
+            return;
+        }
+
+        return this.dispatchExit();
+    };
+
+    //#endregion
+
+    //#region Public Methods
+
+    /**
+     * Sends a message to all other tabs to discover their tab IDs.
+     *
+     * @returns A promise that resolves with a set of discovered tab IDs.
+     */
+    public async discoverTabs(): Promise<Set<string>> {
         this.discoveredTabIDs.clear();
 
-        this.postMessage({
-            type: BroadcastMessageType.discover,
+        this.dispatchMessage({
+            type: BroadcastMessageType.Discover,
             sender: TabID.shared.current,
         });
 
@@ -84,18 +120,48 @@ export class Broadcast extends BroadcastChannel implements Disposable {
         return this.discoveredTabIDs;
     }
 
-    akResumeTab(tabId: string) {
-        this.postMessage({
-            type: BroadcastMessageType.continue,
+    /**
+     * Sends a message to a specific tab to resume its operation.
+     *
+     * @param tabID The ID of the tab to resume.
+     * @param resumeID The resume ID to send to the tab.
+     */
+    public resumeTab(tabID: string, resumeID: string): void {
+        this.dispatchMessage({
+            type: BroadcastMessageType.Continue,
             sender: TabID.shared.current,
-            target: tabId,
+            target: tabID,
+            resumeID,
         });
     }
 
-    akExitTab() {
-        this.postMessage({
-            type: BroadcastMessageType.exit,
+    /**
+     * Sends a message to all other tabs to notify them that this tab is exiting.
+     */
+    public dispatchExit(): void {
+        const resumeID = sessionStorage.getItem(this.storageKey);
+
+        this.dispatchMessage({
+            type: BroadcastMessageType.Exit,
             sender: TabID.shared.current,
+            resumeID,
         });
+
+        sessionStorage.removeItem(this.storageKey);
     }
+
+    /**
+     * Suppresses the next exit event that would be sent when the tab is closed or navigated away from.
+     *
+     * This is useful for cases where the tab is being programmatically closed or navigated away from,
+     * and we don't want to notify other tabs of the exit.
+     *
+     * This method should be called before the tab is closed or navigated away from,
+     * and it will prevent the exit event from being sent to other tabs.
+     */
+    public suppressNextExit(): void {
+        this.shouldSuppressExit = true;
+    }
+
+    //#endregion
 }

--- a/web/src/flow/tabs/events.ts
+++ b/web/src/flow/tabs/events.ts
@@ -1,0 +1,28 @@
+export class AKMultiTabEvent extends Event {
+    static readonly eventName = "ak-multitab-continue";
+
+    constructor() {
+        super(AKMultiTabEvent.eventName, { bubbles: true, composed: true });
+    }
+}
+
+export class AKMultiTabExitEvent extends Event {
+    static readonly eventName = "ak-multitab-exit";
+
+    public readonly tabID: string;
+    public readonly resumeID: string | null;
+
+    constructor(tabID: string, resumeID: string | null = null) {
+        super(AKMultiTabExitEvent.eventName, { bubbles: true, composed: true });
+
+        this.tabID = tabID;
+        this.resumeID = resumeID;
+    }
+}
+
+declare global {
+    interface WindowEventMap {
+        [AKMultiTabEvent.eventName]: AKMultiTabEvent;
+        [AKMultiTabExitEvent.eventName]: AKMultiTabExitEvent;
+    }
+}

--- a/web/src/flow/tabs/messages.ts
+++ b/web/src/flow/tabs/messages.ts
@@ -1,0 +1,56 @@
+export enum BroadcastMessageType {
+    Discover = "discover",
+    Continue = "continue",
+    Exit = "exit",
+    DiscoverReply = "discoverReply",
+}
+
+export interface BroadcastMessageDiscover {
+    type: BroadcastMessageType.Discover;
+    /**
+     * The tab ID of the sender. This is used to prevent responding to your own messages.
+     */
+    sender: string;
+}
+
+export interface BroadcastMessageDiscoverReply {
+    type: BroadcastMessageType.DiscoverReply;
+    /**
+     * The tab ID of the sender. This is used to prevent responding to your own messages.
+     */
+    sender: string;
+}
+
+export interface BroadcastMessageExit {
+    type: BroadcastMessageType.Exit;
+    /**
+     * The tab ID of the sender. This is used to prevent responding to your own messages.
+     */
+    sender: string;
+    /**
+     * The resume ID of the tab. This is used to continue the tab's operation.
+     */
+    resumeID: string | null;
+}
+
+export interface BroadcastMessageContinue {
+    type: BroadcastMessageType.Continue;
+    /**
+     * The tab ID of the sender. This is used to prevent responding to your own messages.
+     */
+    sender: string;
+    /**
+     * The tab ID of the target tab. This is used to direct the message to a specific tab.
+     */
+    target: string;
+    /**
+     * The resume ID of the tab. This is used to continue the tab's operation.
+     */
+    resumeID: string | null;
+}
+
+export type BroadcastMessage =
+    | BroadcastMessageDiscover
+    | BroadcastMessageDiscoverReply
+    | BroadcastMessageExit
+    | BroadcastMessageContinue;

--- a/web/src/flow/tabs/orchestrator.ts
+++ b/web/src/flow/tabs/orchestrator.ts
@@ -1,18 +1,120 @@
 import { globalAK } from "#common/global";
+import { ascii_letters, digits, randomString } from "#common/utils";
 
 import { Broadcast } from "#flow/tabs/broadcast";
+import { AKMultiTabExitEvent } from "#flow/tabs/events";
 import { TabID } from "#flow/tabs/TabID";
 
 import { ConsoleLogger } from "#logger/browser";
 
+/**
+ * Multi-tab continuous-login coordination.
+ *
+ * When several tabs sit in the same flow (e.g. multiple SP-initiated SAML logins), only one needs
+ * the user to authenticate. The tab that completes auth becomes the "leader" and walks every other
+ * ("follower") tab through its own resume, one at a time:
+ *
+ *  1. The leader takes a cross-tab lock ({@link lockKey} in localStorage) so a second finishing tab
+ *     won't also start resuming — it suppresses its own exit and bows out.
+ *  2. For each discovered follower the leader mints a one-shot `resumeID`, starts waiting for that
+ *     tab's exit, then tells it to continue ({@link Broadcast.resumeTab}).
+ *  3. The follower stores the `resumeID`, re-enters its flow, and only echoes it back in an exit
+ *     event once it reaches its OWN final redirect (see `final_redirect` / RedirectStage). The
+ *     leader matches tabID + resumeID, so stale or out-of-order exits from earlier rounds are
+ *     ignored.
+ *  4. {@link waitForTabExit} bounds the wait so one stuck follower can't deadlock the leader.
+ *
+ * Resume is only ever started from a `final_redirect` challenge — the terminal redirect out of a
+ * completed auth flow — never from intermediate hops (source stages, the same-origin SAML re-entry).
+ */
+
 const lockKey = "authentik-tab-locked";
 const logger = ConsoleLogger.prefix("mtab/orchestrate");
 
+// How often to poll for a follower that hasn't sent its exit event yet.
 const TAB_EXIT_TIMEOUT_MS = 3000;
+// Hard ceiling on waiting for a single follower, so one stuck tab can't block the leader forever.
+const TAB_EXIT_MAX_WAIT_MS = 15000;
+// Grace period after an exit event before resolving, to let the follower's navigation settle.
+const TAB_EXIT_SETTLE_MS = 100;
 
 export function multiTabOrchestrateLeave() {
-    Broadcast.shared.akExitTab();
+    Broadcast.shared.dispatchExit();
     TabID.shared.clear();
+}
+
+export function suppressNextExitForSameOriginNavigation() {
+    Broadcast.shared.suppressNextExit();
+}
+
+/**
+ * Wait for a tab to exit, with a timeout and fallback to checking if the tab is still present.
+ *
+ * @param tabID The tab ID to wait for.
+ * @param resumeID The resume ID to wait for.
+ *
+ * @returns A promise that resolves when the tab has exited or the timeout has been reached.
+ */
+function waitForTabExit(tabID: string, resumeID: string): Promise<void> {
+    const { resolve, promise } = Promise.withResolvers<void>();
+    const start = Date.now();
+
+    let timeout = -1;
+    let finished = false;
+    const abort = new AbortController();
+
+    const cleanup = (delay = 0) => {
+        if (finished) {
+            return;
+        }
+
+        finished = true;
+
+        self.clearTimeout(timeout);
+        abort.abort();
+
+        self.setTimeout(() => {
+            resolve();
+        }, delay);
+    };
+
+    const exitListener = ({ tabID: eventTabID, resumeID: eventResumeID }: AKMultiTabExitEvent) => {
+        if (eventTabID !== tabID || eventResumeID !== resumeID) {
+            return;
+        }
+
+        logger.debug("tab exited", tabID);
+
+        cleanup(TAB_EXIT_SETTLE_MS);
+    };
+
+    const timeoutCheck = async () => {
+        if (Date.now() - start >= TAB_EXIT_MAX_WAIT_MS) {
+            logger.warn("Timed out waiting for tab to complete, moving on", tabID);
+
+            cleanup();
+
+            return;
+        }
+
+        const tabs = await Broadcast.shared.discoverTabs();
+
+        if (!tabs.has(tabID)) {
+            logger.warn("Timed out waiting for tab exit event, tab is gone", tabID);
+            cleanup();
+            return;
+        }
+
+        logger.warn("Timed out waiting for tab to exit, tab still active", tabID);
+
+        timeout = self.setTimeout(timeoutCheck, TAB_EXIT_TIMEOUT_MS);
+    };
+
+    window.addEventListener(AKMultiTabExitEvent.eventName, exitListener, { signal: abort.signal });
+
+    timeout = self.setTimeout(timeoutCheck, TAB_EXIT_TIMEOUT_MS);
+
+    return promise;
 }
 
 export async function multiTabOrchestrateResume() {
@@ -21,13 +123,13 @@ export async function multiTabOrchestrateResume() {
     }
 
     const lockTabID = localStorage.getItem(lockKey);
-    const tabs = await Broadcast.shared.akTabDiscover();
+    const tabs = await Broadcast.shared.discoverTabs();
 
     logger.debug("Got list of tabs", tabs);
 
     if (lockTabID && tabs.has(lockTabID)) {
-        logger.debug("Tabs locked, leaving.");
-        multiTabOrchestrateLeave();
+        logger.debug("Tabs locked, suppressing same-origin exit.");
+        suppressNextExitForSameOriginNavigation();
         return;
     }
 
@@ -35,34 +137,13 @@ export async function multiTabOrchestrateResume() {
     localStorage.setItem(lockKey, TabID.shared.current);
 
     for (const tab of tabs) {
+        const resumeID = randomString(32, ascii_letters + digits);
+        const done = waitForTabExit(tab, resumeID);
+
         logger.debug("Telling tab to continue", tab);
-        Broadcast.shared.akResumeTab(tab);
+        Broadcast.shared.resumeTab(tab, resumeID);
 
-        const done = Promise.withResolvers<void>();
-
-        let timeout = -1;
-
-        const checker = requestAnimationFrame(() => {
-            if (Broadcast.shared.exitedTabIDs.includes(tab)) {
-                logger.debug("tab exited", tab);
-                self.clearTimeout(timeout);
-
-                self.setTimeout(() => {
-                    logger.debug("continue exited", tab);
-                    done.resolve();
-                }, 1000);
-
-                cancelAnimationFrame(checker);
-            }
-        });
-
-        timeout = self.setTimeout(() => {
-            logger.warn("Timed out waiting for tab to exit, moving on", tab);
-            cancelAnimationFrame(checker);
-            done.resolve();
-        }, TAB_EXIT_TIMEOUT_MS);
-
-        await done.promise;
+        await done;
 
         logger.debug("Tab done, continuing", tab);
     }


### PR DESCRIPTION
This PR is a backport of #23049 to `version-2026.2`, rebuilt from the merged commit on `main` (`42960643`) rather than the earlier PR revision the previous backport branch used in #23060

## Adaptations for version-2026.2
- `version-2026.2` lacks the flow controllers refactor (#20898), so `FlowMultitabController`'s logic is ported inline into `FlowExecutor`'s `ak-multitab-continue` listener. It uses the merged design's same-origin suppress/leave logic for `next` (the SP-initiated SAML resume fix) but keeps the `blank://blank` app-hiding guard, which 2026.2 still relies on (the dashboard-hide option only landed in 2026.5).
- The multi-tab files (`broadcast.ts`, `orchestrator.ts`, `TabID.ts`, new `events.ts`/`messages.ts`) are identical to `main`.
- `RedirectStage.ts` carries only the #23049 changes (`final_redirect` handling), without unrelated `main` drift.
- `test_auth_n_request.py` `setUp` creates the `test-app` Application (already present on `main`).
- Generated API clients (go/rust/ts) come from `schema.yml` at release time; 2026.2 tracks none of them, so only the schema contract is committed.
