### PR TITLE
website: upgrade postman dep to fix pipeline

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -175,91 +175,6 @@
                 "lightningcss-linux-x64-gnu": "1.32.0"
             }
         },
-        "api/node_modules/ajv": {
-            "version": "8.20.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-uri": "^3.0.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "api/node_modules/ajv-draft-04": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
-            "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
-            "license": "MIT",
-            "peerDependencies": {
-                "ajv": "^8.5.0"
-            },
-            "peerDependenciesMeta": {
-                "ajv": {
-                    "optional": true
-                }
-            }
-        },
-        "api/node_modules/commander": {
-            "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-            "license": "MIT"
-        },
-        "api/node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
-            }
-        },
-        "api/node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "license": "MIT"
-        },
-        "api/node_modules/openapi-to-postmanv2": {
-            "version": "5.8.0",
-            "resolved": "https://registry.npmjs.org/openapi-to-postmanv2/-/openapi-to-postmanv2-5.8.0.tgz",
-            "integrity": "sha512-7f02ypBlAx4G9z3bP/uDk8pBwRbYt97Eoso8XJLyclfyRvCC+CvERLUl0MD0x+GoumpkJYnQ0VGdib/kwtUdUw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "ajv": "^8.11.0",
-                "ajv-draft-04": "1.0.0",
-                "ajv-formats": "2.1.1",
-                "async": "3.2.6",
-                "commander": "2.20.3",
-                "graphlib": "2.1.8",
-                "js-yaml": "4.1.0",
-                "json-pointer": "0.6.2",
-                "json-schema-merge-allof": "0.8.1",
-                "lodash": "4.17.21",
-                "neotraverse": "0.6.15",
-                "oas-resolver-browser": "2.5.6",
-                "object-hash": "3.0.0",
-                "path-browserify": "1.0.1",
-                "postman-collection": "^5.0.0",
-                "swagger2openapi": "7.0.8",
-                "yaml": "1.10.2"
-            },
-            "bin": {
-                "openapi2postmanv2": "bin/openapi2postmanv2.js"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "docs": {
             "name": "@goauthentik/docs-topics",
             "version": "0.0.0",
@@ -18922,9 +18837,9 @@
             }
         },
         "node_modules/openapi-to-postmanv2": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/openapi-to-postmanv2/-/openapi-to-postmanv2-6.1.0.tgz",
-            "integrity": "sha512-qJ/SYQT0+oNxuOgd492cocXTNPowIgXV2EhifOUzlLt5STKWW3LSoddDqZUhSK9JsMLmdU3D7xbX/xRFqtho2w==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/openapi-to-postmanv2/-/openapi-to-postmanv2-6.2.0.tgz",
+            "integrity": "sha512-kKGHW5df7Fti9/tpFDNr9oX1ZGLJySuZane7YuehP/gzyVpp/q9tq86g4dRko+PyA7VBkyFN1prXcDoaWOiFNw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "ajv": "^8.11.0",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -175,6 +175,91 @@
                 "lightningcss-linux-x64-gnu": "1.32.0"
             }
         },
+        "api/node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "api/node_modules/ajv-draft-04": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+            "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "ajv": "^8.5.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
+        "api/node_modules/commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "license": "MIT"
+        },
+        "api/node_modules/js-yaml": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "api/node_modules/lodash": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "license": "MIT"
+        },
+        "api/node_modules/openapi-to-postmanv2": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/openapi-to-postmanv2/-/openapi-to-postmanv2-5.8.0.tgz",
+            "integrity": "sha512-7f02ypBlAx4G9z3bP/uDk8pBwRbYt97Eoso8XJLyclfyRvCC+CvERLUl0MD0x+GoumpkJYnQ0VGdib/kwtUdUw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "ajv": "^8.11.0",
+                "ajv-draft-04": "1.0.0",
+                "ajv-formats": "2.1.1",
+                "async": "3.2.6",
+                "commander": "2.20.3",
+                "graphlib": "2.1.8",
+                "js-yaml": "4.1.0",
+                "json-pointer": "0.6.2",
+                "json-schema-merge-allof": "0.8.1",
+                "lodash": "4.17.21",
+                "neotraverse": "0.6.15",
+                "oas-resolver-browser": "2.5.6",
+                "object-hash": "3.0.0",
+                "path-browserify": "1.0.1",
+                "postman-collection": "^5.0.0",
+                "swagger2openapi": "7.0.8",
+                "yaml": "1.10.2"
+            },
+            "bin": {
+                "openapi2postmanv2": "bin/openapi2postmanv2.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "docs": {
             "name": "@goauthentik/docs-topics",
             "version": "0.0.0",


### PR DESCRIPTION
<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

npm 11.11.0 and 11.16.0 will give a different output when running npm ci for what package version it expects for the openapi-to-postmanv2 dependency in the package-lock.json. We need to upgrade the package to pass the build

### What does this PR change?

### Why is this change needed?

### How was this tested?

### Linked issues

<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
