### PR TITLE
providers/scim: patch GitLab user active state

### DIFF
--- a/authentik/providers/scim/clients/users.py
+++ b/authentik/providers/scim/clients/users.py
@@ -14,9 +14,19 @@ from authentik.lib.sync.mapper import PropertyMappingManager
 from authentik.lib.sync.outgoing.exceptions import ObjectExistsSyncException, StopSync
 from authentik.policies.utils import delete_none_values
 from authentik.providers.scim.clients.base import SCIMClient
-from authentik.providers.scim.clients.schema import SCIM_USER_SCHEMA
+from authentik.providers.scim.clients.schema import (
+    SCIM_USER_SCHEMA,
+    PatchOp,
+    PatchOperation,
+    PatchRequest,
+)
 from authentik.providers.scim.clients.schema import User as SCIMUserSchema
-from authentik.providers.scim.models import SCIMMapping, SCIMProvider, SCIMProviderUser
+from authentik.providers.scim.models import (
+    SCIMCompatibilityMode,
+    SCIMMapping,
+    SCIMProvider,
+    SCIMProviderUser,
+)
 
 
 class SCIMUserClient(SCIMClient[User, SCIMProviderUser, SCIMUserSchema]):
@@ -109,6 +119,8 @@ class SCIMUserClient(SCIMClient[User, SCIMProviderUser, SCIMUserSchema]):
             mode="json",
             exclude_unset=True,
         )
+        if self.provider.compatibility_mode == SCIMCompatibilityMode.GITLAB:
+            return self._update_gitlab(payload, connection)
         if not self.diff(payload, connection):
             self.logger.debug("Skipping user write as data has not changed")
             return
@@ -118,6 +130,37 @@ class SCIMUserClient(SCIMClient[User, SCIMProviderUser, SCIMUserSchema]):
             json=payload,
         )
         connection.attributes = response
+        connection.save()
+
+    def _update_gitlab(self, payload: dict[str, Any], connection: SCIMProviderUser):
+        """Update a GitLab user via the subset of SCIM PATCH that GitLab supports."""
+        active = payload.get("active")
+        if active is None:
+            self.logger.debug("Skipping GitLab user write as active is not set")
+            return
+        if (connection.attributes or {}).get("active") == active:
+            self.logger.debug("Skipping GitLab user write as active has not changed")
+            return
+        response = self._request(
+            "PATCH",
+            f"/Users/{connection.scim_id}",
+            json=PatchRequest(
+                Operations=[
+                    PatchOperation(
+                        op=PatchOp.replace,
+                        path="active",
+                        value=active,
+                    )
+                ]
+            ).model_dump(
+                mode="json",
+            ),
+        )
+        attributes = {}
+        MERGE_LIST_UNIQUE.merge(attributes, connection.attributes or {})
+        MERGE_LIST_UNIQUE.merge(attributes, response)
+        attributes["active"] = active
+        connection.attributes = attributes
         connection.save()
 
     def discover(self):
@@ -133,7 +176,7 @@ class SCIMUserClient(SCIMClient[User, SCIMProviderUser, SCIMUserSchema]):
                 seen_items += 1
             if seen_items >= expected_items:
                 break
-            res = self._request("GET", f"/Users?startIndex={seen_items+1}")
+            res = self._request("GET", f"/Users?startIndex={seen_items + 1}")
 
     def _discover_user_single(self, user: dict):
         scim_user = SCIMUserSchema.model_validate(user)

--- a/authentik/providers/scim/tests/test_user.py
+++ b/authentik/providers/scim/tests/test_user.py
@@ -12,7 +12,12 @@ from authentik.core.models import Application, Group, User, UserTypes
 from authentik.lib.generators import generate_id
 from authentik.lib.sync.outgoing.base import SAFE_METHODS
 from authentik.lib.sync.outgoing.exceptions import TransientSyncException
-from authentik.providers.scim.models import SCIMMapping, SCIMProvider, SCIMProviderUser
+from authentik.providers.scim.models import (
+    SCIMCompatibilityMode,
+    SCIMMapping,
+    SCIMProvider,
+    SCIMProviderUser,
+)
 from authentik.providers.scim.tasks import scim_sync, scim_sync_objects, sync_tasks
 from authentik.tasks.models import Task
 from authentik.tenants.models import Tenant
@@ -283,6 +288,103 @@ class SCIMUserTests(TestCase):
         self.assertEqual(mock.request_history[0].method, "GET")
         self.assertEqual(mock.request_history[1].method, "POST")
         self.assertEqual(mock.request_history[2].method, "PUT")
+
+    @Mocker()
+    def test_user_update_gitlab_active_patch(self, mock: Mocker):
+        """Test GitLab user active updates use PATCH instead of PUT"""
+        self.provider.compatibility_mode = SCIMCompatibilityMode.GITLAB
+        self.provider.save()
+
+        scim_id = generate_id()
+        mock.post(
+            "https://localhost/Users",
+            json={
+                "id": scim_id,
+                "active": True,
+            },
+        )
+        mock.patch(f"https://localhost/Users/{scim_id}", status_code=204)
+
+        uid = generate_id()
+        user = User.objects.create(
+            username=uid,
+            name=f"{uid} {uid}",
+            email=f"{uid}@goauthentik.io",
+        )
+        self.assertEqual(mock.call_count, 1)
+        self.assertEqual(mock.request_history[0].method, "POST")
+
+        user.is_active = False
+        user.save()
+        self.assertEqual(mock.call_count, 2)
+        self.assertEqual(mock.request_history[1].method, "PATCH")
+        self.assertEqual(mock.request_history[1].url, f"https://localhost/Users/{scim_id}")
+        self.assertJSONEqual(
+            mock.request_history[1].body,
+            {
+                "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+                "Operations": [
+                    {
+                        "op": "replace",
+                        "path": "active",
+                        "value": False,
+                    }
+                ],
+            },
+        )
+
+        connection = SCIMProviderUser.objects.get(user=user, provider=self.provider)
+        self.assertFalse(connection.attributes["active"])
+
+        user.is_active = True
+        user.save()
+        self.assertEqual(mock.call_count, 3)
+        self.assertEqual(mock.request_history[2].method, "PATCH")
+        self.assertEqual(mock.request_history[2].url, f"https://localhost/Users/{scim_id}")
+        self.assertJSONEqual(
+            mock.request_history[2].body,
+            {
+                "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+                "Operations": [
+                    {
+                        "op": "replace",
+                        "path": "active",
+                        "value": True,
+                    }
+                ],
+            },
+        )
+
+        connection.refresh_from_db()
+        self.assertTrue(connection.attributes["active"])
+
+    @Mocker()
+    def test_user_update_gitlab_skips_profile_put(self, mock: Mocker):
+        """Test GitLab mode does not fall back to unsupported full user PUT"""
+        self.provider.compatibility_mode = SCIMCompatibilityMode.GITLAB
+        self.provider.save()
+
+        scim_id = generate_id()
+        mock.post(
+            "https://localhost/Users",
+            json={
+                "id": scim_id,
+                "active": True,
+            },
+        )
+
+        uid = generate_id()
+        user = User.objects.create(
+            username=uid,
+            name=f"{uid} {uid}",
+            email=f"{uid}@goauthentik.io",
+        )
+        self.assertEqual(mock.call_count, 1)
+        self.assertEqual(mock.request_history[0].method, "POST")
+
+        user.name = "Updated Name"
+        user.save()
+        self.assertEqual(mock.call_count, 1)
 
     @Mocker()
     def test_user_create_delete(self, mock: Mocker):


### PR DESCRIPTION
## Details

GitLab's SCIM API accepts user block/unblock changes through `PATCH /Users/:id` with the `active` attribute, but rejects full user `PUT` updates.

GitLab compatibility mode already skips `ServiceProviderConfig` probing, but user updates still went through the generic SCIM update path. This means changing `is_active` in authentik can fail against GitLab with a 405 response.

### What does this PR change?

When a SCIM provider is using GitLab compatibility mode, user updates now patch only the `active` attribute. Other providers keep using the existing full-user `PUT` behavior.

Profile-only changes in GitLab mode are skipped instead of sending an unsupported PUT request.

### How was this tested?

Added tests for GitLab mode to verify that block/unblock uses `PATCH` and that profile-only changes do not fall back to `PUT`.

Deployed the change against a GitLab SCIM setup and confirmed that disabling and re-enabling a user in authentik updates the GitLab user state correctly.