### PR TITLE
root, web, docs: Update pnpm to 11.9.0

### DIFF
--- a/lifecycle/aws/package.json
+++ b/lifecycle/aws/package.json
@@ -12,7 +12,7 @@
     },
     "engines": {
         "node": ">=24",
-        "pnpm": ">=11.5.1"
+        "pnpm": ">=11.9.0"
     },
     "devEngines": {
         "runtime": {
@@ -21,5 +21,5 @@
             "version": ">=24"
         }
     },
-    "packageManager": "pnpm@11.5.1+sha512.93f7b57422ea7068257235b4c16eb60762eb68e1dc23723199cc739043ea9be2c4143274a399d8c6defa2b1176226d9ca1c4b63482d6200c1a8fbaa78c1d1485"
+    "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b"
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     },
     "engines": {
         "node": ">=24",
-        "pnpm": ">=11.5.1"
+        "pnpm": ">=11.9.0"
     },
     "devEngines": {
         "runtime": {
@@ -39,6 +39,6 @@
             "version": ">=24"
         }
     },
-    "packageManager": "pnpm@11.5.1+sha512.93f7b57422ea7068257235b4c16eb60762eb68e1dc23723199cc739043ea9be2c4143274a399d8c6defa2b1176226d9ca1c4b63482d6200c1a8fbaa78c1d1485",
+    "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
     "prettier": "@goauthentik/prettier-config"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,11 +7,17 @@ packages:
   - "packages/tsconfig"
   - "lifecycle/aws"
 
+# Shared version references for the `catalog:` protocol. Keep these in sync with
+# the root package.json so overrides pin transitive deps to the versions we use.
+catalog:
+  eslint: "^9.39.3"
+  typescript: "^6.0.3"
+
 overrides:
-  "@typescript-eslint/eslint-plugin>typescript": "$typescript"
-  "@typescript-eslint/parser>typescript": "$typescript"
-  "format-imports>eslint": "$eslint"
-  "typescript-eslint>typescript": "$typescript"
+  "@typescript-eslint/eslint-plugin>typescript": "catalog:"
+  "@typescript-eslint/parser>typescript": "catalog:"
+  "format-imports>eslint": "catalog:"
+  "typescript-eslint>typescript": "catalog:"
 
 # Allow-list of dependencies whose install/postinstall scripts may run.
 # Everything else is blocked, replacing the prior `ignore-scripts=true` +

--- a/web/package.json
+++ b/web/package.json
@@ -291,7 +291,7 @@
     },
     "engines": {
         "node": ">=24",
-        "pnpm": ">=11.5.1"
+        "pnpm": ">=11.9.0"
     },
     "devEngines": {
         "runtime": {
@@ -300,6 +300,6 @@
             "version": ">=24"
         }
     },
-    "packageManager": "pnpm@11.5.1+sha512.93f7b57422ea7068257235b4c16eb60762eb68e1dc23723199cc739043ea9be2c4143274a399d8c6defa2b1176226d9ca1c4b63482d6200c1a8fbaa78c1d1485",
+    "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
     "prettier": "./prettier.config.mjs"
 }

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -14,23 +14,32 @@ packages:
 # npm's behavior.
 nodeLinker: hoisted
 
+# Shared version references for the `catalog:` protocol. Keep these in sync with
+# web/package.json so overrides pin transitive deps to the versions we use.
+catalog:
+    esbuild: "^0.28.1"
+    eslint: "^9.39.4"
+    prettier: "^3.8.3"
+    prettier-plugin-packagejson: "^3.0.2"
+    typescript: "^6.0.3"
+
 overrides:
-    "@goauthentik/esbuild-plugin-live-reload>esbuild": "$esbuild"
-    "@goauthentik/esbuild-plugin-live-reload>typescript": "$typescript"
-    "@goauthentik/eslint-config>typescript": "$typescript"
-    "@goauthentik/prettier-config>prettier": "$prettier"
-    "@goauthentik/prettier-config>prettier-plugin-packagejson": "$prettier-plugin-packagejson"
-    "@goauthentik/prettier-config>typescript": "$typescript"
-    "@mrmarble/djangoql-completion>lex": "$lex"
+    "@goauthentik/esbuild-plugin-live-reload>esbuild": "catalog:"
+    "@goauthentik/esbuild-plugin-live-reload>typescript": "catalog:"
+    "@goauthentik/eslint-config>typescript": "catalog:"
+    "@goauthentik/prettier-config>prettier": "catalog:"
+    "@goauthentik/prettier-config>prettier-plugin-packagejson": "catalog:"
+    "@goauthentik/prettier-config>typescript": "catalog:"
+    "@mrmarble/djangoql-completion>lex": "workspace:*"
     "@mrmarble/djangoql-completion>lodash": "^4.18.1"
-    "@typescript-eslint/eslint-plugin>typescript": "$typescript"
-    "@typescript-eslint/parser>typescript": "$typescript"
-    "@typescript-eslint/typescript-estree>typescript": "$typescript"
-    "@typescript-eslint/utils>typescript": "$typescript"
-    "format-imports>eslint": "$eslint"
-    "node-fetch-commonjs>node-domexception": "$node-domexception"
+    "@typescript-eslint/eslint-plugin>typescript": "catalog:"
+    "@typescript-eslint/parser>typescript": "catalog:"
+    "@typescript-eslint/typescript-estree>typescript": "catalog:"
+    "@typescript-eslint/utils>typescript": "catalog:"
+    "format-imports>eslint": "catalog:"
+    "node-fetch-commonjs>node-domexception": "workspace:*"
     "rapidoc>@apitools/openapi-parser": "0.0.37"
-    "typescript-eslint>typescript": "$typescript"
+    "typescript-eslint>typescript": "catalog:"
     "wireit>brace-expansion": "^1.1.14"
 
 # Allow-list of dependencies whose install/postinstall scripts may run.

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,6 +1,6 @@
 # Tag must track the root package.json `packageManager` version. ${BUILDPLATFORM}
 # keeps the binary's arch aligned with the builder stage on cross-arch builds.
-FROM --platform=${BUILDPLATFORM} ghcr.io/pnpm/pnpm:11.5.1@sha256:3cbdefab0d887dee497ddc8dfe6d871257317d69520fe30f9ccec0a84bde6e89 AS pnpm
+FROM --platform=${BUILDPLATFORM} ghcr.io/pnpm/pnpm:11.9.0@sha256:ea4a0c09e686d3a81e1f2b606d99cad200f4c5f9053c20599820e0fc812a1c67 AS pnpm
 
 FROM --platform=${BUILDPLATFORM} docker.io/library/node:26.4.0-trixie@sha256:b46a10d964ad15136ebdf9012142131481caa0697d7a4d4eafe4bbabd818f876 AS docs-builder
 

--- a/website/api/clients.mdx
+++ b/website/api/clients.mdx
@@ -38,7 +38,7 @@ import Tabs from "@theme/Tabs";
   </TabItem>
   <TabItem value="node" label="Node">
     ```shell
-    npm install @goauthentik/api
+    pnpm install @goauthentik/api
     ```
 
   </TabItem>

--- a/website/package.json
+++ b/website/package.json
@@ -51,7 +51,7 @@
     },
     "engines": {
         "node": ">=24",
-        "pnpm": ">=11.5.1"
+        "pnpm": ">=11.9.0"
     },
     "devEngines": {
         "runtime": {
@@ -60,6 +60,6 @@
             "version": ">=24"
         }
     },
-    "packageManager": "pnpm@11.5.1+sha512.93f7b57422ea7068257235b4c16eb60762eb68e1dc23723199cc739043ea9be2c4143274a399d8c6defa2b1176226d9ca1c4b63482d6200c1a8fbaa78c1d1485",
+    "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
     "prettier": "@goauthentik/prettier-config"
 }

--- a/website/specs/2026-06-24-code-mode-mcp-v1-plan.md
+++ b/website/specs/2026-06-24-code-mode-mcp-v1-plan.md
@@ -105,14 +105,14 @@ export const SERVER_VERSION = "0.1.0";
 
 - [ ] **Step 4: Install deps and run the test**
 
-Run: `npm install` (from repo root — installs the new workspace)
+Run: `pnpm install` (from repo root — installs the new workspace)
 Run: `node --test mcp-servers/code-mode/src/version.test.mjs`
 Expected: PASS (1 test).
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add mcp-servers/code-mode/package.json mcp-servers/code-mode/tsconfig.json mcp-servers/code-mode/src/version.mjs mcp-servers/code-mode/src/version.test.mjs package-lock.json
+git add mcp-servers/code-mode/package.json mcp-servers/code-mode/tsconfig.json mcp-servers/code-mode/src/version.mjs mcp-servers/code-mode/src/version.test.mjs pnpm-lock.yaml
 git commit -m "feat(code-mode): scaffold MCP server package"
 ```
 


### PR DESCRIPTION
## Details

A follow up to #22826, this PR updates pnpm to 11.9.0 which was released during the development of our migration branch.