### PR TITLE
stages/authenticator_duo: clarify duplicate Duo user enrollment

### DIFF
--- a/authentik/stages/authenticator_duo/stage.py
+++ b/authentik/stages/authenticator_duo/stage.py
@@ -2,6 +2,7 @@
 
 from django.http import HttpResponse
 from django.utils.timezone import now
+from django.utils.translation import gettext as _
 from rest_framework.fields import CharField
 
 from authentik.events.models import Event, EventAction
@@ -15,6 +16,17 @@ from authentik.flows.views.executor import InvalidStageError
 from authentik.stages.authenticator_duo.models import AuthenticatorDuoStage, DuoDevice
 
 PLAN_CONTEXT_DUO_ENROLL = "goauthentik.io/stages/authenticator_duo/enroll"
+DUO_USERNAME_EXISTS_ERROR = "username already exists"
+
+
+def duo_enrollment_error_message(exc: RuntimeError) -> str:
+    """Return a user-facing error message for Duo enrollment failures."""
+    if DUO_USERNAME_EXISTS_ERROR in str(exc).lower():
+        return _(
+            "A Duo user with this username already exists. Ask an administrator to import the "
+            "existing Duo authenticator or delete the Duo user before enrolling again."
+        )
+    return _("Failed to enroll with Duo. Please contact an administrator.")
 
 
 class AuthenticatorDuoChallenge(WithUserInfoChallenge):
@@ -49,7 +61,7 @@ class AuthenticatorDuoStageView(ChallengeStageView):
                 message=f"Failed to enroll user: {str(exc)}",
                 user=user,
             ).from_http(self.request, user)
-            raise InvalidStageError(str(exc)) from exc
+            raise InvalidStageError(duo_enrollment_error_message(exc)) from exc
         self.executor.plan.context[PLAN_CONTEXT_DUO_ENROLL] = enroll
         return enroll
 

--- a/authentik/stages/authenticator_duo/tests.py
+++ b/authentik/stages/authenticator_duo/tests.py
@@ -292,3 +292,50 @@ class AuthenticatorDuoStageTests(FlowTestCase):
                     reverse("authentik_api:flow-executor", kwargs={"flow_slug": flow.slug}), {}
                 )
                 self.assertStageRedirects(response, reverse("authentik_core:root-redirect"))
+
+    def test_stage_enroll_existing_duo_user(self):
+        """Test stage with a username that already exists in Duo"""
+        conf_stage = IdentificationStage.objects.create(
+            name=generate_id(),
+            user_fields=[
+                UserFields.USERNAME,
+            ],
+        )
+        stage = AuthenticatorDuoStage.objects.create(
+            name=generate_id(),
+            client_id=generate_id(),
+            client_secret=generate_id(),
+            api_hostname=generate_id(),
+        )
+        flow = create_test_flow()
+        FlowStageBinding.objects.create(target=flow, stage=conf_stage, order=0)
+        FlowStageBinding.objects.create(target=flow, stage=stage, order=1)
+
+        response = self.client.post(
+            reverse("authentik_api:flow-executor", kwargs={"flow_slug": flow.slug}),
+            {"uid_field": self.user.username},
+        )
+        self.assertEqual(response.status_code, 302)
+
+        with patch(
+            "duo_client.auth.Auth.enroll",
+            MagicMock(
+                side_effect=RuntimeError(
+                    "Received 400 Invalid request parameters (username already exists)"
+                )
+            ),
+        ):
+            response = self.client.get(
+                reverse("authentik_api:flow-executor", kwargs={"flow_slug": flow.slug}),
+                follow=True,
+            )
+            self.assertStageResponse(
+                response,
+                flow,
+                component="ak-stage-access-denied",
+                error_message=(
+                    "A Duo user with this username already exists. Ask an administrator to "
+                    "import the existing Duo authenticator or delete the Duo user before "
+                    "enrolling again."
+                ),
+            )


### PR DESCRIPTION
Duo enrollment fails with a raw API error when the Duo Auth API reports that the username already exists. This changes the flow-facing error to explain that the existing Duo authenticator must be imported by an administrator or the Duo user removed before enrollment, while preserving the detailed Duo response in the configuration error event for operators.

Closes: https://github.com/goauthentik/authentik/issues/22822
