### PR TITLE
website/docs: document Duo existing-user enrollment limit

### DIFF
--- a/website/docs/add-secure-apps/flows-stages/stages/authenticator_duo/index.md
+++ b/website/docs/add-secure-apps/flows-stages/stages/authenticator_duo/index.md
@@ -35,6 +35,8 @@ To require Duo during authentication, add an [Authenticator Validation stage](..
 Due to the way the Duo API works, authentik can only automatically import existing Duo users when a Duo MFA or higher license is active.
 :::
 
+The Duo Auth API enrollment flow creates a new Duo user. If a Duo user already exists with the same username, Duo rejects the enrollment request. To use that existing Duo user in authentik, configure the optional Duo Admin API credentials on the stage and import the authenticator instead of using the enrollment flow. If the Admin API is not available, delete or rename the existing Duo user before enrolling the authenticator.
+
 If you already have Duo users, you can import their authenticators into authentik from the admin UI. The Duo username can be found in the Duo Admin dashboard under **Users**. If needed, you can also use the Duo user ID shown in the Duo Admin URL for that user.
 
 For direct API use, the import endpoint accepts:


### PR DESCRIPTION
Duo enrollment has a limitation that is easy to miss: the Duo Auth API creates a new Duo user, so an existing Duo username causes enrollment to fail. This updates the Duo authenticator setup stage documentation to call out that limitation and directs administrators to use the optional Duo Admin API import flow for existing Duo users.

Closes https://github.com/goauthentik/authentik/issues/22822
