### PR TITLE
web: add additional context to event log messages

### DIFF
--- a/authentik/events/models.py
+++ b/authentik/events/models.py
@@ -144,9 +144,14 @@ class EventAction(models.TextChoices):
     CUSTOM_PREFIX = "custom_"
 
 
-def event_actions():
-    # Wrapper used in models to prevent migrations constantly changing when actions are added
-    return EventAction.choices
+class LoginFailedReason(models.TextChoices):
+    """All possible reasons a login failed, to be shown in event log"""
+
+    INCORRECT_PASSWORD = "incorrect_password"
+    ACCOUNT_INACTIVE = "account_inactive"
+    MFA_INVALID_OTP = "mfa_invalid_otp"
+    MFA_WEBAUTHN_FAILED = "mfa_webauthn_failed"
+    MFA_DUO_DENIED = "mfa_duo_denied"
 
 
 class Event(SerializerModel, ExpiringModel):

--- a/authentik/stages/authenticator_validate/challenge.py
+++ b/authentik/stages/authenticator_validate/challenge.py
@@ -24,7 +24,7 @@ from authentik.core.api.utils import JSONDictField, PassiveSerializer
 from authentik.core.models import Application, User
 from authentik.core.signals import login_failed
 from authentik.events.middleware import audit_ignore
-from authentik.events.models import Event, EventAction
+from authentik.events.models import Event, EventAction, LoginFailedReason
 from authentik.flows.planner import PLAN_CONTEXT_APPLICATION
 from authentik.flows.stage import StageView
 from authentik.lib.utils.email import mask_email
@@ -167,7 +167,8 @@ def validate_challenge_code(code: str, stage_view: StageView, user: User) -> Dev
             context={
                 PLAN_CONTEXT_METHOD_ARGS: {
                     "device_class": DeviceClasses.TOTP.value,
-                }
+                },
+                "reason": LoginFailedReason.MFA_INVALID_OTP,
             },
         )
         raise ValidationError(
@@ -246,6 +247,7 @@ def validate_challenge_webauthn(
                     "device_class": DeviceClasses.WEBAUTHN.value,
                     "device_type": device.device_type,
                 },
+                "reason": LoginFailedReason.MFA_WEBAUTHN_FAILED,
             },
         )
         raise ValidationError("Assertion failed") from exc
@@ -300,7 +302,8 @@ def validate_challenge_duo(device_pk: int, stage_view: StageView, user: User) ->
                     PLAN_CONTEXT_METHOD_ARGS: {
                         "device_class": DeviceClasses.DUO.value,
                         "duo_response": response,
-                    }
+                    },
+                    "reason": LoginFailedReason.MFA_DUO_DENIED,
                 },
             )
             raise ValidationError("Duo denied access", code="denied")

--- a/authentik/stages/authenticator_validate/tests/test_duo.py
+++ b/authentik/stages/authenticator_validate/tests/test_duo.py
@@ -8,7 +8,7 @@ from rest_framework.exceptions import ValidationError
 from authentik.brands.utils import get_brand_for_request
 from authentik.core.middleware import RESPONSE_HEADER_ID
 from authentik.core.tests.utils import RequestFactory, create_test_admin_user, create_test_flow
-from authentik.events.models import Event, EventAction
+from authentik.events.models import Event, EventAction, LoginFailedReason
 from authentik.flows.models import FlowDesignation, FlowStageBinding
 from authentik.flows.planner import PLAN_CONTEXT_PENDING_USER, FlowPlan
 from authentik.flows.stage import StageView
@@ -98,6 +98,9 @@ class AuthenticatorValidateStageDuoTests(FlowTestCase):
                     ),
                     self.user,
                 )
+        event = Event.objects.filter(action=EventAction.LOGIN_FAILED, user__pk=self.user.pk).first()
+        self.assertIsNotNone(event)
+        self.assertEqual(event.context["reason"], LoginFailedReason.MFA_DUO_DENIED.value)
 
     @patch(
         "authentik.stages.authenticator_duo.models.AuthenticatorDuoStage.auth_client",

--- a/authentik/stages/authenticator_validate/tests/test_email.py
+++ b/authentik/stages/authenticator_validate/tests/test_email.py
@@ -4,6 +4,7 @@ from django.test.client import RequestFactory
 from django.urls.base import reverse
 
 from authentik.core.tests.utils import create_test_admin_user, create_test_flow
+from authentik.events.models import Event, EventAction, LoginFailedReason
 from authentik.flows.models import FlowStageBinding, NotConfiguredAction
 from authentik.flows.tests import FlowTestCase
 from authentik.lib.generators import generate_id
@@ -181,3 +182,6 @@ class AuthenticatorValidateStageEmailTests(FlowTestCase):
                 ],
             },
         )
+        event = Event.objects.filter(action=EventAction.LOGIN_FAILED, user__pk=self.user.pk).first()
+        self.assertIsNotNone(event)
+        self.assertEqual(event.context["reason"], LoginFailedReason.MFA_INVALID_OTP.value)

--- a/authentik/stages/authenticator_validate/tests/test_totp.py
+++ b/authentik/stages/authenticator_validate/tests/test_totp.py
@@ -10,6 +10,7 @@ from jwt import encode
 from rest_framework.exceptions import ValidationError
 
 from authentik.core.tests.utils import create_test_admin_user, create_test_flow
+from authentik.events.models import Event, EventAction, LoginFailedReason
 from authentik.flows.models import FlowDesignation, FlowStageBinding, NotConfiguredAction
 from authentik.flows.stage import StageView
 from authentik.flows.tests import FlowTestCase
@@ -300,3 +301,6 @@ class AuthenticatorValidateStageTOTPTests(FlowTestCase):
             validate_challenge_code(
                 "1234", StageView(FlowExecutorView(current_stage=stage), request=request), self.user
             )
+        event = Event.objects.filter(action=EventAction.LOGIN_FAILED, user__pk=self.user.pk).first()
+        self.assertIsNotNone(event)
+        self.assertEqual(event.context["reason"], LoginFailedReason.MFA_INVALID_OTP.value)

--- a/authentik/stages/authenticator_validate/tests/test_webauthn.py
+++ b/authentik/stages/authenticator_validate/tests/test_webauthn.py
@@ -8,6 +8,7 @@ from webauthn.helpers.base64url_to_bytes import base64url_to_bytes
 from webauthn.helpers.bytes_to_base64url import bytes_to_base64url
 
 from authentik.core.tests.utils import RequestFactory, create_test_admin_user, create_test_flow
+from authentik.events.models import Event, EventAction, LoginFailedReason
 from authentik.flows.models import FlowStageBinding, NotConfiguredAction
 from authentik.flows.planner import PLAN_CONTEXT_PENDING_USER, FlowPlan
 from authentik.flows.stage import StageView
@@ -649,3 +650,6 @@ class AuthenticatorValidateStageWebAuthnTests(FlowTestCase):
                 stage_view,
                 self.user,
             )
+        event = Event.objects.filter(action=EventAction.LOGIN_FAILED, user__pk=self.user.pk).first()
+        self.assertIsNotNone(event)
+        self.assertEqual(event.context["reason"], LoginFailedReason.MFA_WEBAUTHN_FAILED.value)

--- a/authentik/stages/password/stage.py
+++ b/authentik/stages/password/stage.py
@@ -16,6 +16,7 @@ from structlog.stdlib import get_logger
 
 from authentik.core.models import User
 from authentik.core.signals import login_failed
+from authentik.events.models import LoginFailedReason
 from authentik.flows.challenge import (
     Challenge,
     ChallengeResponse,
@@ -68,6 +69,7 @@ def authenticate(
         credentials=_clean_credentials(credentials),
         request=request,
         stage=stage,
+        context={"reason": LoginFailedReason.INCORRECT_PASSWORD},
     )
 
 
@@ -115,6 +117,15 @@ class PasswordChallengeResponse(ChallengeResponse):
             del auth_kwargs["password"]
             # User was found, but permission was denied (i.e. user is not active)
             self.stage.logger.debug("Denied access", **auth_kwargs)
+            login_failed.send(
+                sender=__name__,
+                credentials={"username": auth_kwargs["username"]},
+                request=self.stage.request,
+                stage=self.stage.executor.current_stage,
+                context={
+                    "reason": LoginFailedReason.ACCOUNT_INACTIVE,
+                },
+            )
             raise StageInvalidException("Denied access") from exc
         except ValidationError as exc:
             del auth_kwargs["password"]

--- a/authentik/stages/password/tests.py
+++ b/authentik/stages/password/tests.py
@@ -6,6 +6,7 @@ from django.core.exceptions import PermissionDenied
 from django.urls import reverse
 
 from authentik.core.tests.utils import create_test_admin_user, create_test_brand, create_test_flow
+from authentik.events.models import Event, EventAction, LoginFailedReason
 from authentik.flows.markers import StageMarker
 from authentik.flows.models import FlowDesignation, FlowStageBinding
 from authentik.flows.planner import PLAN_CONTEXT_PENDING_USER, FlowPlan
@@ -111,6 +112,9 @@ class TestPasswordStage(FlowTestCase):
             self.flow,
             response_errors={"password": [{"string": "Invalid password", "code": "invalid"}]},
         )
+        event = Event.objects.filter(action=EventAction.LOGIN_FAILED, user__pk=self.user.pk).first()
+        self.assertIsNotNone(event)
+        self.assertEqual(event.context["reason"], LoginFailedReason.INCORRECT_PASSWORD.value)
 
     def test_invalid_password(self):
         """Test with a valid pending user and invalid password"""
@@ -126,6 +130,9 @@ class TestPasswordStage(FlowTestCase):
             {"password": self.user.username + "test"},
         )
         self.assertEqual(response.status_code, 200)
+        event = Event.objects.filter(action=EventAction.LOGIN_FAILED, user__pk=self.user.pk).first()
+        self.assertIsNotNone(event)
+        self.assertEqual(event.context["reason"], LoginFailedReason.INCORRECT_PASSWORD.value)
 
     def test_invalid_password_lockout(self):
         """Test with a valid pending user and invalid password (trigger logout counter)"""
@@ -197,3 +204,6 @@ class TestPasswordStage(FlowTestCase):
             component="ak-stage-access-denied",
             error_message="Unknown error",
         )
+        event = Event.objects.filter(action=EventAction.LOGIN_FAILED, user__pk=self.user.pk).first()
+        self.assertIsNotNone(event)
+        self.assertEqual(event.context["reason"], LoginFailedReason.ACCOUNT_INACTIVE.value)

--- a/web/src/admin/events/EventListPage.ts
+++ b/web/src/admin/events/EventListPage.ts
@@ -62,7 +62,7 @@ export class EventListPage extends WithLicenseSummary(TablePage<Event>) {
     ];
 
     protected override rowLabel(item: Event): string | null {
-        return actionToLabel(item.action);
+        return actionToLabel(item.action, item.context);
     }
 
     renderSectionBefore(): TemplateResult {

--- a/web/src/admin/events/EventListPage.ts
+++ b/web/src/admin/events/EventListPage.ts
@@ -101,7 +101,7 @@ export class EventListPage extends WithLicenseSummary(TablePage<Event>) {
 
     row(item: EventWithContext): SlottedTemplateResult[] {
         return [
-            html`<div>${actionToLabel(item.action)}</div>
+            html`<div>${actionToLabel(item.action, item.context)}</div>
                 <small>${item.app}</small>`,
             renderEventUser(item),
             Timestamp(item.created),

--- a/web/src/admin/events/EventViewPage.ts
+++ b/web/src/admin/events/EventViewPage.ts
@@ -65,7 +65,7 @@ export class EventViewPage extends AKElement {
                                 </dt>
                                 <dd class="pf-c-description-list__description">
                                     <div class="pf-c-description-list__text">
-                                        ${actionToLabel(this.event.action)}
+                                        ${actionToLabel(this.event.action, this.event.context)}
                                     </div>
                                 </dd>
                             </div>

--- a/web/src/admin/events/ObjectChangelog.ts
+++ b/web/src/admin/events/ObjectChangelog.ts
@@ -56,7 +56,7 @@ export class ObjectChangelog extends Table<Event> {
     }
 
     protected override rowLabel(item: Event): string {
-        return actionToLabel(item.action);
+        return actionToLabel(item.action, item.context);
     }
 
     protected columns: TableColumn[] = [

--- a/web/src/admin/events/ObjectChangelog.ts
+++ b/web/src/admin/events/ObjectChangelog.ts
@@ -74,7 +74,7 @@ export class ObjectChangelog extends Table<Event> {
 
     row(item: EventWithContext): SlottedTemplateResult[] {
         return [
-            html`${actionToLabel(item.action)}`,
+            html`${actionToLabel(item.action, item.context)}`,
             renderEventUser(item),
             Timestamp(item.created),
             html`<div>${item.clientIp || msg("-")}</div>

--- a/web/src/admin/events/SimpleEventTable.ts
+++ b/web/src/admin/events/SimpleEventTable.ts
@@ -46,7 +46,11 @@ export abstract class SimpleEventTable extends Table<Event> {
 
     row(item: EventWithContext): RowType[] {
         return [
-            html`<div><a href="${`#/events/log/${item.pk}`}">${actionToLabel(item.action)}</a></div>
+            html`<div>
+                    <a href="${`#/events/log/${item.pk}`}"
+                        >${actionToLabel(item.action, item.context)}</a
+                    >
+                </div>
                 <small>${item.app}</small>`,
             renderEventUser(item),
             [Timestamp(item.created), { style: "white-space: nowrap;" }],

--- a/web/src/admin/events/SimpleEventTable.ts
+++ b/web/src/admin/events/SimpleEventTable.ts
@@ -34,7 +34,7 @@ export abstract class SimpleEventTable extends Table<Event> {
     }
 
     protected override rowLabel(item: Event): string {
-        return actionToLabel(item.action);
+        return actionToLabel(item.action, item.context);
     }
 
     protected columns: TableColumn[] = [

--- a/web/src/admin/users/UserDevicesTable.ts
+++ b/web/src/admin/users/UserDevicesTable.ts
@@ -2,7 +2,7 @@ import "#elements/forms/DeleteBulkForm";
 
 import { aki } from "#common/api/client";
 import { createPaginatedResponse } from "#common/api/responses";
-import { deviceTypeName } from "#common/labels";
+import { formatDeviceTypeName } from "#common/labels";
 import { SentryIgnoredError } from "#common/sentry/index";
 
 import { PaginatedResponse, Table, TableColumn, Timestamp } from "#elements/table/Table";
@@ -96,7 +96,7 @@ export class UserDeviceTable extends Table<Device> {
         return [
             html`${item.name}`,
             html`<div>
-                    ${deviceTypeName(item)}
+                    ${formatDeviceTypeName(item)}
                     ${item.extraDescription ? ` - ${item.extraDescription}` : ""}
                 </div>
                 ${item.externalId ? html` <small>${item.externalId}</small> ` : nothing} `,

--- a/web/src/common/events.ts
+++ b/web/src/common/events.ts
@@ -67,7 +67,39 @@ export interface EventContext {
     device?: EventModel;
 }
 
+export enum LoginFailedReason {
+    IncorrectPassword = "incorrect_password",
+    AccountInactive = "account_inactive",
+    MFAInvalidOTP = "mfa_invalid_otp",
+    MFAWebAuthnFailed = "mfa_webauthn_failed",
+    MFADuoDenied = "mfa_duo_denied",
+}
+
+export interface EventContextWithReason extends EventContext {
+    reason: LoginFailedReason;
+}
+
+export function isEventContextWithReason(
+    context?: EventContext,
+): context is EventContextWithReason {
+    if (!context) return false;
+    if (!("reason" in context)) return false;
+
+    return !!(typeof context.reason === "string" && context.reason);
+}
+
 export interface EventWithContext extends EventSerializer {
     user: EventUser;
     context: EventContext;
+}
+
+export interface EventContextWithModel extends EventContext {
+    model: EventModel;
+}
+
+export function isContextWithModel(context?: EventContext): context is EventContextWithModel {
+    if (!context) return false;
+    if (!("model" in context)) return false;
+
+    return !!(typeof context.model === "object" && context.model);
 }

--- a/web/src/common/labels.ts
+++ b/web/src/common/labels.ts
@@ -35,7 +35,10 @@ export const EventActionLabelRecord: Record<
     MessageFormatter<string, [context?: EventContext]>
 > = {
     [EventActions.Login]: () => msg("Login"),
-    [EventActions.LoginFailed]: () => msg("Failed login"),
+    [EventActions.LoginFailed]: (context?: EventContext) =>
+            context && 'reason' in context
+                ? msg(str`Failed login (${loginFailedReasonToLabel(context.reason as LoginFailedReason)})`)
+                : msg("Failed login"),
     [EventActions.Logout]: () => msg("Logout"),
     [EventActions.UserWrite]: () => msg("User was written to"),
     [EventActions.UserOffboarded]: () => msg("User was offboarded"),
@@ -60,15 +63,15 @@ export const EventActionLabelRecord: Record<
     [EventActions.ConfigurationError]: () => msg("Configuration error"),
     [EventActions.ConfigurationWarning]: () => msg("Configuration warning"),
     [EventActions.ModelCreated]: (context?: EventContext) =>
-        context
+        context?.model
             ? msg(str`Model created (${(context.model as EventModel).model_name})`)
             : msg("Model created"),
     [EventActions.ModelUpdated]: (context?: EventContext) =>
-        context
+        context?.model
             ? msg(str`Model updated (${(context.model as EventModel).model_name})`)
             : msg("Model updated"),
     [EventActions.ModelDeleted]: (context?: EventContext) =>
-        context
+        context?.model
             ? msg(str`Model deleted (${(context.model as EventModel).model_name})`)
             : msg("Model deleted"),
     [EventActions.EmailSent]: () => msg("Email sent"),
@@ -159,4 +162,25 @@ export function userTypeToLabel(type?: UserTypeEnum): string {
     const formatter = type ? UserTypeLabelRecord[type] : null;
 
     return formatter?.() || "";
+}
+
+export enum LoginFailedReason {
+    IncorrectPassword = "incorrect_password",
+    AccountInactive = "account_inactive",
+    MFAInvalidOTP = "mfa_invalid_otp",
+    MFAWebAuthnFailed = "mfa_webauthn_failed",
+    MFADuoDenied = "mfa_duo_denied",
+}
+
+const LoginFailedReasonRecord: Record<LoginFailedReason, MessageFormatter<string>> = {
+    [LoginFailedReason.IncorrectPassword]: () => msg("incorrect password"),
+    [LoginFailedReason.AccountInactive]: () => msg("account inactive"),
+    [LoginFailedReason.MFAInvalidOTP]: () => msg("invalid OTP code"),
+    [LoginFailedReason.MFAWebAuthnFailed]: () => msg("WebAuthn assertion failed"),
+    [LoginFailedReason.MFADuoDenied]: () => msg("Duo denied access"),
+};
+
+export function loginFailedReasonToLabel(reason?: LoginFailedReason): string {
+    const formatter = reason ? LoginFailedReasonRecord[reason] : null;
+    return formatter?.() || msg("unknown");
 }

--- a/web/src/common/labels.ts
+++ b/web/src/common/labels.ts
@@ -2,6 +2,8 @@
  * @file Contains various label maps for API enums and other values that we want to display in the UI.
  */
 
+import { EventContext, EventModel } from "./events";
+
 import { MessageFormatter } from "#common/ui/locale/format";
 
 import {
@@ -28,7 +30,10 @@ export function formatIntentLabel(intent: IntentEnum = IntentEnum.Api): string {
     return IntentLabelRecord[intent]();
 }
 
-export const EventActionLabelRecord: Record<EventActions, MessageFormatter<string>> = {
+export const EventActionLabelRecord: Record<
+    EventActions,
+    MessageFormatter<string, [context?: EventContext]>
+> = {
     [EventActions.Login]: () => msg("Login"),
     [EventActions.LoginFailed]: () => msg("Failed login"),
     [EventActions.Logout]: () => msg("Logout"),
@@ -54,9 +59,18 @@ export const EventActionLabelRecord: Record<EventActions, MessageFormatter<strin
     [EventActions.SystemException]: () => msg("General system exception"),
     [EventActions.ConfigurationError]: () => msg("Configuration error"),
     [EventActions.ConfigurationWarning]: () => msg("Configuration warning"),
-    [EventActions.ModelCreated]: () => msg("Model created"),
-    [EventActions.ModelUpdated]: () => msg("Model updated"),
-    [EventActions.ModelDeleted]: () => msg("Model deleted"),
+    [EventActions.ModelCreated]: (context?: EventContext) =>
+        context
+            ? msg(str`Model created (${(context.model as EventModel).model_name})`)
+            : msg("Model created"),
+    [EventActions.ModelUpdated]: (context?: EventContext) =>
+        context
+            ? msg(str`Model updated (${(context.model as EventModel).model_name})`)
+            : msg("Model updated"),
+    [EventActions.ModelDeleted]: (context?: EventContext) =>
+        context
+            ? msg(str`Model deleted (${(context.model as EventModel).model_name})`)
+            : msg("Model deleted"),
     [EventActions.EmailSent]: () => msg("Email sent"),
     [EventActions.UpdateAvailable]: () => msg("Update available"),
     [EventActions.ExportReady]: () => msg("Data export ready"),
@@ -72,10 +86,10 @@ export const EventActionLabelRecord: Record<EventActions, MessageFormatter<strin
     [EventActions.Custom]: () => msg("Custom action"),
 };
 
-export function actionToLabel(action?: EventActions): string {
+export function actionToLabel(action?: EventActions, context?: EventContext): string {
     const formatter = action ? EventActionLabelRecord[action] : null;
 
-    return formatter?.() || "";
+    return formatter?.(context) || "";
 }
 
 const SeverityEnumLabelRecord: Record<SeverityEnum, MessageFormatter<string>> = {

--- a/web/src/common/labels.ts
+++ b/web/src/common/labels.ts
@@ -2,7 +2,12 @@
  * @file Contains various label maps for API enums and other values that we want to display in the UI.
  */
 
-import { EventContext, EventModel } from "./events";
+import {
+    EventContext,
+    isContextWithModel,
+    isEventContextWithReason,
+    LoginFailedReason,
+} from "./events";
 
 import { MessageFormatter } from "#common/ui/locale/format";
 
@@ -30,15 +35,30 @@ export function formatIntentLabel(intent: IntentEnum = IntentEnum.Api): string {
     return IntentLabelRecord[intent]();
 }
 
+const LoginFailedReasonRecord: Record<LoginFailedReason, MessageFormatter<string>> = {
+    [LoginFailedReason.IncorrectPassword]: () => msg("Incorrect password"),
+    [LoginFailedReason.AccountInactive]: () => msg("Account inactive"),
+    [LoginFailedReason.MFAInvalidOTP]: () => msg("Invalid OTP code"),
+    [LoginFailedReason.MFAWebAuthnFailed]: () => msg("WebAuthn assertion failed"),
+    [LoginFailedReason.MFADuoDenied]: () => msg("Duo denied access"),
+};
+
+export function formatEventContextReason(reason?: LoginFailedReason): string {
+    const formatter = reason ? LoginFailedReasonRecord[reason] : null;
+    return formatter?.() || msg("unknown");
+}
+
 export const EventActionLabelRecord: Record<
     EventActions,
     MessageFormatter<string, [context?: EventContext]>
 > = {
     [EventActions.Login]: () => msg("Login"),
-    [EventActions.LoginFailed]: (context?: EventContext) =>
-            context && 'reason' in context
-                ? msg(str`Failed login (${loginFailedReasonToLabel(context.reason as LoginFailedReason)})`)
-                : msg("Failed login"),
+    [EventActions.LoginFailed]: (context?: EventContext) => {
+        if (!isEventContextWithReason(context)) {
+            return msg("Failed login");
+        }
+        return msg(str`Failed login: (${formatEventContextReason(context.reason)})`);
+    },
     [EventActions.Logout]: () => msg("Logout"),
     [EventActions.UserWrite]: () => msg("User was written to"),
     [EventActions.UserOffboarded]: () => msg("User was offboarded"),
@@ -62,18 +82,27 @@ export const EventActionLabelRecord: Record<
     [EventActions.SystemException]: () => msg("General system exception"),
     [EventActions.ConfigurationError]: () => msg("Configuration error"),
     [EventActions.ConfigurationWarning]: () => msg("Configuration warning"),
-    [EventActions.ModelCreated]: (context?: EventContext) =>
-        context?.model
-            ? msg(str`Model created (${(context.model as EventModel).model_name})`)
-            : msg("Model created"),
-    [EventActions.ModelUpdated]: (context?: EventContext) =>
-        context?.model
-            ? msg(str`Model updated (${(context.model as EventModel).model_name})`)
-            : msg("Model updated"),
-    [EventActions.ModelDeleted]: (context?: EventContext) =>
-        context?.model
-            ? msg(str`Model deleted (${(context.model as EventModel).model_name})`)
-            : msg("Model deleted"),
+    [EventActions.ModelCreated]: (context?: EventContext) => {
+        if (!isContextWithModel(context)) {
+            return msg("Model created");
+        }
+
+        return msg(str`Model created (${context.model.model_name})`);
+    },
+    [EventActions.ModelUpdated]: (context?: EventContext) => {
+        if (!isContextWithModel(context)) {
+            return msg("Model updated");
+        }
+
+        return msg(str`Model updated (${context.model.model_name})`);
+    },
+    [EventActions.ModelDeleted]: (context?: EventContext) => {
+        if (!isContextWithModel(context)) {
+            return msg("Model deleted");
+        }
+
+        return msg(str`Model deleted (${context.model.model_name})`);
+    },
     [EventActions.EmailSent]: () => msg("Email sent"),
     [EventActions.UpdateAvailable]: () => msg("Update available"),
     [EventActions.ExportReady]: () => msg("Data export ready"),
@@ -122,13 +151,17 @@ export function severityToLevel(severity?: SeverityEnum | null): string {
  * @todo Add verbose_name field to now vendored OTP devices
  * @todo We seem to have these constants in the `ModelEnum` object in lowercase.
  */
-export const deviceTypeToLabel = new Map<string, string>([
-    ["authentik_stages_authenticator_static.StaticDevice", msg("Static tokens")],
-    ["authentik_stages_authenticator_totp.TOTPDevice", msg("TOTP Device")],
-]);
+export const deviceTypeToLabel: Record<
+    string,
+    MessageFormatter<string, [context?: EventContext]>
+> = {
+    ["authentik_stages_authenticator_static.StaticDevice"]: () => msg("Static tokens"),
+    ["authentik_stages_authenticator_totp.TOTPDevice"]: () => msg("TOTP Device"),
+};
 
-export const deviceTypeName = (device: Device) =>
-    deviceTypeToLabel.get(device.type) ?? device?.verboseName ?? "";
+export const formatDeviceTypeName = (device: Device) => {
+    return deviceTypeToLabel[device.type]?.() ?? device?.verboseName ?? "";
+};
 
 export function formatDeviceChallengeMessage(deviceChallenge?: DeviceChallenge | null): string {
     switch (deviceChallenge?.deviceClass) {
@@ -162,25 +195,4 @@ export function userTypeToLabel(type?: UserTypeEnum): string {
     const formatter = type ? UserTypeLabelRecord[type] : null;
 
     return formatter?.() || "";
-}
-
-export enum LoginFailedReason {
-    IncorrectPassword = "incorrect_password",
-    AccountInactive = "account_inactive",
-    MFAInvalidOTP = "mfa_invalid_otp",
-    MFAWebAuthnFailed = "mfa_webauthn_failed",
-    MFADuoDenied = "mfa_duo_denied",
-}
-
-const LoginFailedReasonRecord: Record<LoginFailedReason, MessageFormatter<string>> = {
-    [LoginFailedReason.IncorrectPassword]: () => msg("incorrect password"),
-    [LoginFailedReason.AccountInactive]: () => msg("account inactive"),
-    [LoginFailedReason.MFAInvalidOTP]: () => msg("invalid OTP code"),
-    [LoginFailedReason.MFAWebAuthnFailed]: () => msg("WebAuthn assertion failed"),
-    [LoginFailedReason.MFADuoDenied]: () => msg("Duo denied access"),
-};
-
-export function loginFailedReasonToLabel(reason?: LoginFailedReason): string {
-    const formatter = reason ? LoginFailedReasonRecord[reason] : null;
-    return formatter?.() || msg("unknown");
 }

--- a/web/src/common/labels.ts
+++ b/web/src/common/labels.ts
@@ -17,6 +17,7 @@ import {
     DeviceClassesEnum,
     EventActions,
     IntentEnum,
+    ModelEnum,
     SeverityEnum,
     UserTypeEnum,
 } from "@goauthentik/api";
@@ -151,17 +152,19 @@ export function severityToLevel(severity?: SeverityEnum | null): string {
  * @todo Add verbose_name field to now vendored OTP devices
  * @todo We seem to have these constants in the `ModelEnum` object in lowercase.
  */
-export const deviceTypeToLabel: Record<
-    string,
-    MessageFormatter<string, [context?: EventContext]>
-> = {
-    ["authentik_stages_authenticator_static.StaticDevice"]: () => msg("Static tokens"),
-    ["authentik_stages_authenticator_totp.TOTPDevice"]: () => msg("TOTP Device"),
+const DeviceTypeLabelRecord: Record<string, MessageFormatter<string, [context?: EventContext]>> = {
+    [ModelEnum.AuthentikStagesAuthenticatorStaticStaticdevice]: () => msg("Static Tokens"),
+    [ModelEnum.AuthentikStagesAuthenticatorTotpTotpdevice]: () => msg("TOTP Device"),
 };
 
-export const formatDeviceTypeName = (device: Device) => {
-    return deviceTypeToLabel[device.type]?.() ?? device?.verboseName ?? "";
-};
+export function formatDeviceTypeName(device: Device) {
+    const deviceType = device.type;
+    const normalizedKey = deviceType.toLowerCase();
+
+    const value = DeviceTypeLabelRecord[normalizedKey] || DeviceTypeLabelRecord[deviceType];
+
+    return value?.() ?? device?.verboseName ?? msg("Unknown device type");
+}
 
 export function formatDeviceChallengeMessage(deviceChallenge?: DeviceChallenge | null): string {
     switch (deviceChallenge?.deviceClass) {

--- a/web/src/components/notifications/NotificationDrawer.ts
+++ b/web/src/components/notifications/NotificationDrawer.ts
@@ -81,7 +81,7 @@ export class NotificationDrawer extends WithNotifications(WithSession(AKElement)
     }
 
     #renderItem = (item: Notification): TemplateResult => {
-        const label = actionToLabel(item.event?.action);
+        const label = actionToLabel(item.event?.action, item.event?.context);
         const level = severityToLevel(item.severity);
 
         // There's little information we can have to determine if the body

--- a/web/src/elements/controllers/NotificationsContextController.ts
+++ b/web/src/elements/controllers/NotificationsContextController.ts
@@ -119,7 +119,7 @@ export class NotificationsContextController extends ReactiveContextController<No
     #messageListener = ({ notification }: AKNotificationEvent) => {
         showMessage({
             level: MessageLevel.info,
-            message: actionToLabel(notification.event?.action) ?? notification.body,
+            message: actionToLabel(notification.event?.action, notification.event?.context) ?? notification.body,
             description: html`${notification.body}
             ${notification.hyperlink
                 ? html`<br /><a href=${notification.hyperlink}>${notification.hyperlinkLabel}</a>`

--- a/web/src/user/user-settings/mfa/MFADevicesPage.ts
+++ b/web/src/user/user-settings/mfa/MFADevicesPage.ts
@@ -10,7 +10,7 @@ import { aki } from "#common/api/client";
 import { AndNext } from "#common/api/config";
 import { createPaginatedResponse } from "#common/api/responses";
 import { globalAK } from "#common/global";
-import { deviceTypeName } from "#common/labels";
+import { formatDeviceTypeName } from "#common/labels";
 import { SentryIgnoredError } from "#common/sentry/index";
 
 import { PaginatedResponse, Table, TableColumn, Timestamp } from "#elements/table/Table";
@@ -145,7 +145,7 @@ export class MFADevicesPage extends Table<Device> {
     row(item: Device): SlottedTemplateResult[] {
         return [
             html`${item.name}`,
-            html`<div>${deviceTypeName(item)}</div>
+            html`<div>${formatDeviceTypeName(item)}</div>
                 ${item.extraDescription
                     ? html`
                           <pf-tooltip position="top" content=${item.externalId || ""}>


### PR DESCRIPTION
## Details

Updates event log messages to be more descriptive

<img width="302" height="184" alt="image" src="https://github.com/user-attachments/assets/ad8acbba-4961-4ffd-acf5-895917384d5b" />

### What does this PR change?

Adds context to event log messages
- Model created
- Model updated
- Model deleted
- Login failed

The Model messages just add the model type to the title. "Login failed" events add a new `context.reason` field in their API response containing the reason the login failed.

### Why is this change needed?

It's hard to tell what's being modified or the reason for login failures from a glance. This adds it front and center so it's easier for admins to see what was changed or why a login failed without expanding each logged event.

### How was this tested?

Updating existing tests to test new API fields.

### Linked issues

closes #23193  
---

## Checklist

-   [x] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
