### PR TITLE
packages/ak-common/config: coerce file:// and env:// values to their native type

### DIFF
--- a/packages/ak-common/src/config/mod.rs
+++ b/packages/ak-common/src/config/mod.rs
@@ -378,6 +378,42 @@ mod tests {
     }
 
     #[test]
+    fn expand_typed() {
+        let temp_dir = tempdir().expect("failed to create temp dir");
+
+        // A numeric value destined for an integer field (postgresql.port: u16) must be coerced
+        // from the string a file:// reference resolves to.
+        let port_path = temp_dir.path().join("port");
+        let mut port_file = File::create(&port_path).expect("failed to create file");
+        write!(port_file, "5432").expect("failed to write to file");
+        drop(port_file);
+
+        // A numeric-looking value destined for a string field (postgresql.password) must stay a
+        // string and never be coerced into a number.
+        let password_path = temp_dir.path().join("password");
+        let mut password_file = File::create(&password_path).expect("failed to create file");
+        write!(password_file, "12345").expect("failed to write to file");
+        drop(password_file);
+
+        let config_file_path = temp_dir.path().join("config");
+        let mut config_file = File::create(&config_file_path).expect("failed to create file");
+        writeln!(
+            config_file,
+            "postgresql:\n  port: file://{}\n  password: file://{}",
+            port_path.display(),
+            password_path.display()
+        )
+        .expect("failed to write to file");
+        drop(config_file);
+
+        let (config, _) =
+            super::Config::load(&[config_file_path], None).expect("failed to load config");
+
+        assert_eq!(config.postgresql.port, 5432);
+        assert_eq!(config.postgresql.password, "12345");
+    }
+
+    #[test]
     fn init() {
         super::init_with_paths(vec![]).expect("failed to init config");
     }

--- a/packages/ak-common/src/config/schema.rs
+++ b/packages/ak-common/src/config/schema.rs
@@ -36,12 +36,100 @@ where
     }
 }
 
+mod sealed {
+    use std::{fmt::Display, str::FromStr};
+
+    /// Numeric config types that may be provided either as a native number (YAML / environment
+    /// variables) or as a string (from `file://` / `env://` references, which resolve to strings).
+    ///
+    /// Sealed so [`super::deserialize_str_or_num`] can only be attached to numeric fields:
+    /// applying it to a `String` field would silently coerce values that must stay strings (e.g. an
+    /// all-digit password read from a file), which is a compile error instead.
+    pub(super) trait Numeric: FromStr<Err: Display> {}
+
+    impl Numeric for u16 {}
+    impl Numeric for u64 {}
+    impl Numeric for f32 {}
+    impl Numeric for std::num::NonZeroUsize {}
+}
+
+/// Deserialize a numeric field that may arrive as a number or as a string.
+///
+/// YAML numbers and environment variables (coerced by `config_rs`) arrive already typed; `file://`
+/// and `env://` references resolve to strings and are parsed here. Because this is opt-in per
+/// field, string-typed fields keep their raw value and are never coerced.
+fn deserialize_str_or_num<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de> + sealed::Numeric,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum NumOrStr<T> {
+        Num(T),
+        Str(String),
+    }
+
+    match NumOrStr::<T>::deserialize(deserializer)? {
+        NumOrStr::Num(n) => Ok(n),
+        NumOrStr::Str(s) => s.trim().parse().map_err(D::Error::custom),
+    }
+}
+
+/// Deserialize a boolean that may arrive as a native bool or as a string (`"true"`/`"false"`,
+/// case-insensitive), for the same `file://` / `env://` reason as [`deserialize_str_or_num`].
+fn deserialize_str_or_bool<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum BoolOrStr {
+        Bool(bool),
+        Str(String),
+    }
+
+    match BoolOrStr::deserialize(deserializer)? {
+        BoolOrStr::Bool(b) => Ok(b),
+        BoolOrStr::Str(s) => s
+            .trim()
+            .to_ascii_lowercase()
+            .parse()
+            .map_err(D::Error::custom),
+    }
+}
+
+/// Like [`deserialize_str_or_bool`] but for optional booleans.
+fn deserialize_optional_str_or_bool<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum BoolOrStr {
+        Bool(bool),
+        Str(String),
+    }
+
+    Ok(match Option::<BoolOrStr>::deserialize(deserializer)? {
+        None => None,
+        Some(BoolOrStr::Bool(b)) => Some(b),
+        Some(BoolOrStr::Str(s)) => Some(
+            s.trim()
+                .to_ascii_lowercase()
+                .parse()
+                .map_err(D::Error::custom)?,
+        ),
+    })
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     pub postgresql: PostgreSQLConfig,
 
     pub listen: ListenConfig,
 
+    #[serde(deserialize_with = "deserialize_str_or_bool")]
     pub debug: bool,
     #[serde(default)]
     pub secret_key: String,
@@ -60,12 +148,14 @@ pub struct Config {
     // Outpost specific fields
     pub host: Option<String>,
     pub token: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_optional_str_or_bool")]
     pub insecure: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PostgreSQLConfig {
     pub host: String,
+    #[serde(deserialize_with = "deserialize_str_or_num")]
     pub port: u16,
     pub user: String,
     pub password: String,
@@ -78,6 +168,7 @@ pub struct PostgreSQLConfig {
 
     #[serde(deserialize_with = "deserialize_optional_u64")]
     pub conn_max_age: Option<u64>,
+    #[serde(deserialize_with = "deserialize_str_or_bool")]
     pub conn_health_checks: bool,
 
     pub default_schema: String,
@@ -99,10 +190,13 @@ pub struct LogConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ErrorReportingConfig {
+    #[serde(deserialize_with = "deserialize_str_or_bool")]
     pub enabled: bool,
     pub sentry_dsn: Option<String>,
     pub environment: String,
+    #[serde(deserialize_with = "deserialize_str_or_bool")]
     pub send_pii: bool,
+    #[serde(deserialize_with = "deserialize_str_or_num")]
     pub sample_rate: f32,
 }
 
@@ -113,6 +207,7 @@ pub struct ComplianceConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ComplianceFipsConfig {
+    #[serde(deserialize_with = "deserialize_str_or_bool")]
     pub enabled: bool,
 }
 
@@ -127,5 +222,6 @@ pub struct WebConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkerConfig {
+    #[serde(deserialize_with = "deserialize_str_or_num")]
     pub processes: NonZeroUsize,
 }


### PR DESCRIPTION
<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?

Non-string config fields can now be supplied via `file://` and `env://`
references without crashing the worker at startup.

Each non-string scalar field gets a deserializer that accepts either a native
value (YAML / direct env var) or a string (what a `file://` / `env://` reference
resolves to).
String-typed fields are left untouched.

### Why is this change needed?

Setting e.g. `postgresql.port: file:///run/secrets/pg-port` crashed the worker:

```
Error:
   0: invalid type: string "5432", expected u16
```
A direct `AUTHENTIK_POSTGRESQL__PORT=5432` env var works because `config_rs`
coerces it to a number before it reaches the config tree. `file://` / `env://`
values are resolved later and arrive as strings, and `serde_json` won't coerce a
string into `u16`. This has been the case since the Rust config module was introduced, 
which replaced the Python loader's lenient handling with strict typed deserialization.

### How was this tested?

Added unit test `config::tests::expand_typed`: loads a config where
`postgresql.port` is set via `file://` and `postgresql.password` via a `file://`
whose contents are the digits `12345`, then asserts `port == 5432` (numeric field
coerced from the resolved string) and `password == "12345"` (numeric-looking
string field left untouched).

Local runs, all green:

- `cargo nextest run -p authentik-common` → **51/51 passed** (incl. `expand_typed`).
- `cargo +nightly fmt --all --check` (`ci-lint-rustfmt`) → clean.
- `cargo clippy -p authentik-common --all-targets -- -D warnings` (`ci-lint-clippy`) → clean.
- `cargo deny --locked --workspace check` (`ci-lint-cargo-deny`) → ok.
- `cargo machete` (`ci-lint-cargo-machete`) → ok.

End-to-end in a built image against the dev Postgres: `port` via `file://` boots
and runs migrations; a numeric-looking `password` via `file://` and `env://`
stays a string and connects.

### Linked issues

closes #22908

<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
