### PR TITLE
packages/ak-common/config: coerce file:// and env:// values to their native type (cherry-pick #23758 to version-2026.5)

### DIFF
--- a/packages/ak-common/src/config/mod.rs
+++ b/packages/ak-common/src/config/mod.rs
@@ -378,6 +378,42 @@ mod tests {
     }
 
     #[test]
+    fn expand_typed() {
+        let temp_dir = tempdir().expect("failed to create temp dir");
+
+        // A numeric value destined for an integer field (postgresql.port: u16) must be coerced
+        // from the string a file:// reference resolves to.
+        let port_path = temp_dir.path().join("port");
+        let mut port_file = File::create(&port_path).expect("failed to create file");
+        write!(port_file, "5432").expect("failed to write to file");
+        drop(port_file);
+
+        // A numeric-looking value destined for a string field (postgresql.password) must stay a
+        // string and never be coerced into a number.
+        let password_path = temp_dir.path().join("password");
+        let mut password_file = File::create(&password_path).expect("failed to create file");
+        write!(password_file, "12345").expect("failed to write to file");
+        drop(password_file);
+
+        let config_file_path = temp_dir.path().join("config");
+        let mut config_file = File::create(&config_file_path).expect("failed to create file");
+        writeln!(
+            config_file,
+            "postgresql:\n  port: file://{}\n  password: file://{}",
+            port_path.display(),
+            password_path.display()
+        )
+        .expect("failed to write to file");
+        drop(config_file);
+
+        let (config, _) =
+            super::Config::load(&[config_file_path], None).expect("failed to load config");
+
+        assert_eq!(config.postgresql.port, 5432);
+        assert_eq!(config.postgresql.password, "12345");
+    }
+
+    #[test]
     fn init() {
         super::init_with_paths(vec![]).expect("failed to init config");
     }

--- a/packages/ak-common/src/config/schema.rs
+++ b/packages/ak-common/src/config/schema.rs
@@ -36,12 +36,100 @@ where
     }
 }
 
+mod sealed {
+    use std::{fmt::Display, str::FromStr};
+
+    /// Numeric config types that may be provided either as a native number (YAML / environment
+    /// variables) or as a string (from `file://` / `env://` references, which resolve to strings).
+    ///
+    /// Sealed so [`super::deserialize_str_or_num`] can only be attached to numeric fields:
+    /// applying it to a `String` field would silently coerce values that must stay strings (e.g. an
+    /// all-digit password read from a file), which is a compile error instead.
+    pub(super) trait Numeric: FromStr<Err: Display> {}
+
+    impl Numeric for u16 {}
+    impl Numeric for u64 {}
+    impl Numeric for f32 {}
+    impl Numeric for std::num::NonZeroUsize {}
+}
+
+/// Deserialize a numeric field that may arrive as a number or as a string.
+///
+/// YAML numbers and environment variables (coerced by `config_rs`) arrive already typed; `file://`
+/// and `env://` references resolve to strings and are parsed here. Because this is opt-in per
+/// field, string-typed fields keep their raw value and are never coerced.
+fn deserialize_str_or_num<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de> + sealed::Numeric,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum NumOrStr<T> {
+        Num(T),
+        Str(String),
+    }
+
+    match NumOrStr::<T>::deserialize(deserializer)? {
+        NumOrStr::Num(n) => Ok(n),
+        NumOrStr::Str(s) => s.trim().parse().map_err(D::Error::custom),
+    }
+}
+
+/// Deserialize a boolean that may arrive as a native bool or as a string (`"true"`/`"false"`,
+/// case-insensitive), for the same `file://` / `env://` reason as [`deserialize_str_or_num`].
+fn deserialize_str_or_bool<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum BoolOrStr {
+        Bool(bool),
+        Str(String),
+    }
+
+    match BoolOrStr::deserialize(deserializer)? {
+        BoolOrStr::Bool(b) => Ok(b),
+        BoolOrStr::Str(s) => s
+            .trim()
+            .to_ascii_lowercase()
+            .parse()
+            .map_err(D::Error::custom),
+    }
+}
+
+/// Like [`deserialize_str_or_bool`] but for optional booleans.
+fn deserialize_optional_str_or_bool<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum BoolOrStr {
+        Bool(bool),
+        Str(String),
+    }
+
+    Ok(match Option::<BoolOrStr>::deserialize(deserializer)? {
+        None => None,
+        Some(BoolOrStr::Bool(b)) => Some(b),
+        Some(BoolOrStr::Str(s)) => Some(
+            s.trim()
+                .to_ascii_lowercase()
+                .parse()
+                .map_err(D::Error::custom)?,
+        ),
+    })
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     pub postgresql: PostgreSQLConfig,
 
     pub listen: ListenConfig,
 
+    #[serde(deserialize_with = "deserialize_str_or_bool")]
     pub debug: bool,
     #[serde(default)]
     pub secret_key: String,
@@ -60,12 +148,14 @@ pub struct Config {
     // Outpost specific fields
     pub host: Option<String>,
     pub token: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_optional_str_or_bool")]
     pub insecure: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PostgreSQLConfig {
     pub host: String,
+    #[serde(deserialize_with = "deserialize_str_or_num")]
     pub port: u16,
     pub user: String,
     pub password: String,
@@ -78,6 +168,7 @@ pub struct PostgreSQLConfig {
 
     #[serde(deserialize_with = "deserialize_optional_u64")]
     pub conn_max_age: Option<u64>,
+    #[serde(deserialize_with = "deserialize_str_or_bool")]
     pub conn_health_checks: bool,
 
     pub default_schema: String,
@@ -99,10 +190,13 @@ pub struct LogConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ErrorReportingConfig {
+    #[serde(deserialize_with = "deserialize_str_or_bool")]
     pub enabled: bool,
     pub sentry_dsn: Option<String>,
     pub environment: String,
+    #[serde(deserialize_with = "deserialize_str_or_bool")]
     pub send_pii: bool,
+    #[serde(deserialize_with = "deserialize_str_or_num")]
     pub sample_rate: f32,
 }
 
@@ -113,6 +207,7 @@ pub struct ComplianceConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ComplianceFipsConfig {
+    #[serde(deserialize_with = "deserialize_str_or_bool")]
     pub enabled: bool,
 }
 
@@ -127,5 +222,6 @@ pub struct WebConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkerConfig {
+    #[serde(deserialize_with = "deserialize_str_or_num")]
     pub processes: NonZeroUsize,
 }


### PR DESCRIPTION
## Details

### What does this PR change?

### Why is this change needed?

### How was this tested?

### Linked issues

<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
