### PR TITLE
providers/oauth2: enforce VSCHAR for client_id and client_secret

### DIFF
--- a/authentik/providers/oauth2/api/providers.py
+++ b/authentik/providers/oauth2/api/providers.py
@@ -30,6 +30,7 @@ from authentik.providers.oauth2.models import (
     RedirectURIType,
     ScopeMapping,
 )
+from authentik.providers.oauth2.utils import is_all_vschar
 from authentik.rbac.decorators import permission_required
 
 
@@ -47,6 +48,16 @@ class OAuth2ProviderSerializer(ProviderSerializer):
     """OAuth2Provider Serializer"""
 
     redirect_uris = RedirectURISerializer(many=True, source="_redirect_uris")
+
+    def validate_client_id(self, secret: str) -> str:
+        if not is_all_vschar(secret):
+            raise ValidationError("Client ID must consist of only ASCII characters.")
+        return secret
+
+    def validate_client_secret(self, secret: str) -> str:
+        if not is_all_vschar(secret):
+            raise ValidationError("Client secret must consist of only ASCII characters.")
+        return secret
 
     def validate_redirect_uris(self, data: list) -> list:
         for entry in data:

--- a/authentik/providers/oauth2/tests/test_api.py
+++ b/authentik/providers/oauth2/tests/test_api.py
@@ -66,6 +66,40 @@ class TestAPI(APITestCase):
         self.provider.refresh_from_db()
         self.assertIsNone(self.provider.launch_url)
 
+    def test_validate_client_id(self):
+        """Test redirect_uris API"""
+        response = self.client.post(
+            reverse("authentik_api:oauth2provider-list"),
+            data={
+                "name": generate_id(),
+                "authorization_flow": create_test_flow().pk,
+                "invalidation_flow": create_test_flow().pk,
+                "client_id": "ú",
+                "redirect_uris": [],
+            },
+        )
+        self.assertJSONEqual(
+            response.content,
+            {"client_id": ["Client ID must consist of only ASCII characters."]},
+        )
+
+    def test_validate_client_secret(self):
+        """Test redirect_uris API"""
+        response = self.client.post(
+            reverse("authentik_api:oauth2provider-list"),
+            data={
+                "name": generate_id(),
+                "authorization_flow": create_test_flow().pk,
+                "invalidation_flow": create_test_flow().pk,
+                "client_secret": "ú",
+                "redirect_uris": [],
+            },
+        )
+        self.assertJSONEqual(
+            response.content,
+            {"client_secret": ["Client secret must consist of only ASCII characters."]},
+        )
+
     def test_validate_redirect_uris(self):
         """Test redirect_uris API"""
         response = self.client.post(

--- a/authentik/providers/oauth2/tests/test_token.py
+++ b/authentik/providers/oauth2/tests/test_token.py
@@ -122,6 +122,31 @@ class TestToken(OAuthTestCase):
         with self.assertRaises(TokenError):
             TokenParams.parse(request, provider, provider.client_id, provider.client_secret)
 
+    def test_client_secret_non_ascii(self):
+        """test non-ascii client_secret"""
+        provider = OAuth2Provider.objects.create(
+            name=generate_id(),
+            authorization_flow=create_test_flow(),
+            grant_types=[GrantType.AUTHORIZATION_CODE],
+            redirect_uris=[RedirectURI(RedirectURIMatchingMode.STRICT, "http://testserver")],
+            signing_key=self.keypair,
+            client_secret="à",
+        )
+        header = b64encode(f"{provider.client_id}:{provider.client_secret}".encode()).decode()
+        request = self.factory.post(
+            "/",
+            data={
+                "grant_type": GRANT_TYPE_AUTHORIZATION_CODE,
+                "code": "foo",
+                "redirect_uri": "http://testserver",
+            },
+            HTTP_AUTHORIZATION=f"Basic {header}",
+        )
+        with self.assertRaises(TokenError) as cm:
+            TokenParams.parse(request, provider, provider.client_id, provider.client_secret)
+        self.assertEqual(cm.exception.error, "invalid_client")
+        self.assertEqual(cm.exception.cause, "invalid_secret")
+
     def test_request_refresh_token(self):
         """test request param"""
         provider = OAuth2Provider.objects.create(

--- a/authentik/providers/oauth2/utils.py
+++ b/authentik/providers/oauth2/utils.py
@@ -296,3 +296,13 @@ def build_frontchannel_logout_url(
 
     parsed_url = parsed_url._replace(query=urlencode(query_params))
     return urlunparse(parsed_url)
+
+
+VSCHAR_START = 0x20
+VSCHAR_END = 0x7E
+
+
+def is_all_vschar(s: str) -> bool:
+    """Ensure a string is fully VSCHAR, defined by the OAuth2 RFC
+    https://datatracker.ietf.org/doc/html/rfc6749#appendix-A"""
+    return all(VSCHAR_START <= ord(c) <= VSCHAR_END for c in s)

--- a/authentik/providers/oauth2/views/token.py
+++ b/authentik/providers/oauth2/views/token.py
@@ -69,6 +69,7 @@ from authentik.providers.oauth2.utils import (
     TokenResponse,
     cors_allow,
     extract_client_auth,
+    is_all_vschar,
     pkce_s256_challenge,
 )
 from authentik.providers.oauth2.views.authorize import FORBIDDEN_URI_SCHEMES
@@ -178,14 +179,15 @@ class TokenParams:
             GRANT_TYPE_REFRESH_TOKEN,
             GRANT_TYPE_DEVICE_CODE,
         ]:
-            if self.provider.client_type == ClientType.CONFIDENTIAL and not compare_digest(
-                self.provider.client_secret, self.client_secret
+            if self.provider.client_type == ClientType.CONFIDENTIAL and (
+                not is_all_vschar(self.client_secret)
+                or not compare_digest(self.provider.client_secret, self.client_secret)
             ):
                 LOGGER.warning(
                     "Invalid client secret",
                     client_id=self.provider.client_id,
                 )
-                raise TokenError("invalid_client")
+                raise TokenError("invalid_client").with_cause("invalid_secret")
         self.__check_scopes()
         if self.grant_type == GRANT_TYPE_AUTHORIZATION_CODE:
             with start_span(

--- a/locale/en/dictionaries/idp.txt
+++ b/locale/en/dictionaries/idp.txt
@@ -5,3 +5,4 @@ Yubikey
 Yubikeys
 mycorp
 mocksaml
+VSCHAR


### PR DESCRIPTION
closes https://github.com/goauthentik/authentik/issues/23681

we were already kinda requiring this by using compare_digest which only supports ASCII characters, however this adds full validation to the serializer & token endpoint