### PR TITLE
root: add a pnpm catalog drift lint + config cleanup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -159,11 +159,12 @@ updates:
 
   - package-ecosystem: npm
     directories:
-      - "/packages/esbuild-plugin-live-reload"
       - "/packages/prettier-config"
       - "/packages/tsconfig"
       - "/packages/docusaurus-config"
       - "/packages/eslint-config"
+      - "/packages/logger-js"
+      - "/packages/esbuild-plugin-live-reload"
     schedule:
       interval: daily
       time: "04:00"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -337,8 +337,9 @@ updates:
       - /packages/client-go
       - /packages/client-rust
       - /packages/client-ts
-      # - /scripts # Maybe
+      - /scripts
       - /tests/e2e
+      - /tests/openid_conformance
     schedule:
       interval: daily
       time: "04:00"

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -35,6 +35,8 @@ jobs:
             deps: python
           - job: spellcheck
             deps: node
+          - job: catalogs
+            deps: node
           - job: pending-migrations
             deps: python,runtime
           - job: ruff

--- a/.github/workflows/packages-npm-publish.yml
+++ b/.github/workflows/packages-npm-publish.yml
@@ -9,6 +9,7 @@ on:
       - packages/eslint-config/**
       - packages/prettier-config/**
       - packages/docusaurus-config/**
+      - packages/logger-js/**
       - packages/esbuild-plugin-live-reload/**
   workflow_dispatch:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,7 @@ make web-test          # Web UI tests (delegates to web/)
 make lint-fix          # Auto-fix: black + ruff (Python) and rustfmt (Rust)
 make lint              # Check: bandit, mypy --strict, golangci-lint, cargo deny/machete
 make lint-spellcheck   # cspell across the repo (shared dictionaries in locale/en/dictionaries/)
+make lint-catalogs     # pnpm catalog pins in sync across the root/web/website workspaces
 ```
 
 CI mirrors these as `ci-lint-*` / `ci-test` targets. Run the matching `make lint` / `make test` (plus `make web` / `make docs` for those subtrees) before pushing — CI runs the same checks.

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,9 @@ lint-fix: lint-fix-rust  ## Lint and automatically fix errors in the python sour
 lint-spellcheck:  ## Reports spelling errors.
 	npm run lint:spellcheck
 
+lint-catalogs:  ## Reports pnpm catalog pins that drifted between the root, web, and website workspaces.
+	node ./scripts/node/lint-catalogs.ts
+
 lint: ci-lint-bandit ci-lint-mypy ci-lint-cargo-deny ci-lint-cargo-machete  ## Lint the python and golang sources
 	golangci-lint run -v
 

--- a/Makefile
+++ b/Makefile
@@ -297,17 +297,17 @@ integrations-build:
 	pnpm --dir website run build:integrations
 
 integrations-watch:  ## Build and watch the Integrations documentation
-	pnpm --filter "./website/integrations" run start
+	pnpm --dir website/integrations run start
 
 docs-api-build:
 	pnpm --dir website run build:api
 
 docs-api-watch:  ## Build and watch the API documentation
-	pnpm --filter "./website/api" run generate
-	pnpm --filter "./website/api" run start
+	pnpm --dir website/api run generate
+	pnpm --dir website/api run start
 
 docs-api-clean:  ## Clean generated API documentation
-	pnpm --filter "./website/api" run clean
+	pnpm --dir website/api run clean
 
 #########################
 ## Docker
@@ -359,6 +359,9 @@ ci-lint-rustfmt: ci--meta-debug
 
 ci-lint-clippy: ci--meta-debug
 	$(CARGO) clippy --workspace -- -D warnings
+
+ci-lint-catalogs: ci--meta-debug
+	node ./scripts/node/lint-catalogs.ts
 
 ci-test: ci--meta-debug
 	$(UV) run coverage run manage.py test --keepdb --parallel auto authentik

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
     "version": "2026.8.0-rc1",
     "private": true,
     "scripts": {
-        "lint": "run-s lint:runtime lint:spellcheck",
+        "lint": "run-s lint:runtime lint:catalogs lint:spellcheck",
+        "lint:catalogs": "node ./scripts/node/lint-catalogs.ts",
         "lint:runtime": "node ./scripts/node/lint-runtime.mjs",
         "lint:spellcheck": "cspell . --config cspell.config.jsonc"
     },
@@ -26,7 +27,8 @@
         "prettier": "3.8.3",
         "prettier-plugin-packagejson": "^3.0.2",
         "typescript": "^6.0.3",
-        "typescript-eslint": "^8.62.1"
+        "typescript-eslint": "^8.62.1",
+        "yaml": "^2.9.0"
     },
     "engines": {
         "node": ">=24",

--- a/packages/esbuild-plugin-live-reload/package.json
+++ b/packages/esbuild-plugin-live-reload/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@goauthentik/esbuild-plugin-live-reload",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "description": "ESBuild + browser refresh. Build completes, page reloads.",
     "license": "MIT",
     "repository": {
@@ -44,14 +44,14 @@
         "find-free-ports": "^3.1.1"
     },
     "devDependencies": {
-        "@eslint/js": "^9.39.3",
+        "@eslint/js": "^9.39.4",
         "@goauthentik/eslint-config": "link:../eslint-config",
         "@goauthentik/logger-js": "link:../logger-js",
         "@goauthentik/prettier-config": "link:../prettier-config",
         "@goauthentik/tsconfig": "link:../tsconfig",
         "@types/node": "^25.9.4",
         "esbuild": "^0.28.1",
-        "eslint": "^9.39.3",
+        "eslint": "^9.39.4",
         "pino": "^10.3.1",
         "prettier": "3.8.3",
         "prettier-plugin-packagejson": "^3.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   '@typescript-eslint/eslint-plugin>typescript': ^6.0.3
   '@typescript-eslint/parser>typescript': ^6.0.3
-  format-imports>eslint: ^9.39.3
+  format-imports>eslint: ^9.39.4
   typescript-eslint>typescript: ^6.0.3
 
 importers:
@@ -59,6 +59,9 @@ importers:
       typescript-eslint:
         specifier: ^8.62.1
         version: 8.62.1(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
 
   lifecycle/aws:
     devDependencies:
@@ -141,7 +144,7 @@ importers:
         version: 3.1.1
     devDependencies:
       '@eslint/js':
-        specifier: ^9.39.3
+        specifier: ^9.39.4
         version: 9.39.4
       '@goauthentik/eslint-config':
         specifier: link:../eslint-config
@@ -162,7 +165,7 @@ importers:
         specifier: ^0.28.1
         version: 0.28.1
       eslint:
-        specifier: ^9.39.3
+        specifier: ^9.39.4
         version: 9.39.4(jiti@1.21.7)
       pino:
         specifier: ^10.3.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ packages:
 # Shared version references for the `catalog:` protocol. Keep these in sync with
 # the root package.json so overrides pin transitive deps to the versions we use.
 catalog:
-  eslint: "^9.39.3"
+  eslint: "^9.39.4"
   typescript: "^6.0.3"
 
 overrides:

--- a/scripts/node/lint-catalogs.ts
+++ b/scripts/node/lint-catalogs.ts
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * @file Lints the pnpm `catalog:` version pins across the repo's separate workspaces.
+ *
+ * The root, `web/`, and `website/` directories are each their own pnpm workspace
+ * (they diverge on `nodeLinker` — the root uses the strict isolated linker for its
+ * published packages, while `web` and `website` need `hoisted` for phantom deps).
+ * pnpm cannot share a catalog across workspace roots, so each file re-declares the
+ * same shared pins.
+ *
+ * This check fails when a package pinned in more than one workspace
+ * drifts out of sync — the manual "keep these in sync" comments already let eslint slip.
+ *
+ * Usage:
+ *   lint-catalogs
+ *
+ * Exit codes:
+ *   0  Catalogs agree
+ *   1  A shared package is pinned to differing versions
+ */
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { ConsoleLogger } from "../../packages/logger-js/lib/node.js";
+import { reportAndExit } from "./utils/commands.mjs";
+import { resolveRepoRoot } from "./utils/git.mjs";
+
+import { parse as parseYAML } from "yaml";
+
+const logger = ConsoleLogger.prefix("lint-catalogs");
+
+/**
+ * pnpm workspace roots, each with its own `pnpm-workspace.yaml` and lockfile.
+ */
+const WORKSPACES: Array<[name: string, filePath: string]> = [
+    ["root", "pnpm-workspace.yaml"],
+    ["web", "web/pnpm-workspace.yaml"],
+    ["website", "website/pnpm-workspace.yaml"],
+] as const;
+
+/**
+ * The subset of `pnpm-workspace.yaml` we care about: the default `catalog`
+ * and any named `catalogs`, both mapping a package name to a version range.
+ */
+interface PnpmWorkspace {
+    catalog?: Record<string, string>;
+    catalogs?: Record<string, Record<string, string>>;
+}
+
+/**
+ * A catalog pin keyed by `<catalog>::<package>` so entries from the default catalog
+ * and distinct named catalogs never collide when compared across workspaces.
+ */
+type Catalog = Map<string, string>;
+
+const DEFAULT_CATALOG = "default";
+
+/**
+ * Extracts every catalog pin from a parsed `pnpm-workspace.yaml`,
+ * covering both the default `catalog` and any named `catalogs`.
+ *
+ * @returns A map of `<catalog>::<package>` to version range.
+ */
+function collectCatalog(source: string): Catalog {
+    const workspace = (parseYAML(source) ?? {}) as PnpmWorkspace;
+    const catalog: Catalog = new Map();
+
+    const add = (catalogName: string, entries: Record<string, string> | undefined): void => {
+        for (const [name, range] of Object.entries(entries ?? {})) {
+            catalog.set(`${catalogName}::${name}`, String(range));
+        }
+    };
+
+    add(DEFAULT_CATALOG, workspace.catalog);
+
+    for (const [catalogName, entries] of Object.entries(workspace.catalogs ?? {})) {
+        add(catalogName, entries);
+    }
+
+    return catalog;
+}
+
+/**
+ * Renders a `<catalog>::<package>` key for humans, hiding the redundant default label.
+ */
+function formatKey(key: string): string {
+    const [catalogName, name] = key.split("::", 2);
+
+    return catalogName === DEFAULT_CATALOG ? name : `${name} (catalog: ${catalogName})`;
+}
+
+async function main(): Promise<void> {
+    const repoRoot = await resolveRepoRoot();
+
+    const catalogs = new Map<string, Catalog>();
+
+    for (const [name, filePath] of WORKSPACES) {
+        const source = await readFile(join(repoRoot, filePath), "utf-8");
+        catalogs.set(name, collectCatalog(source));
+    }
+
+    const keys = new Set<string>();
+
+    for (const catalog of catalogs.values()) {
+        for (const key of catalog.keys()) {
+            keys.add(key);
+        }
+    }
+
+    let failed = false;
+
+    for (const key of [...keys].sort()) {
+        const pins = new Map<string, string>();
+
+        for (const [workspaceName, catalog] of catalogs) {
+            const version = catalog.get(key);
+
+            if (version) {
+                pins.set(workspaceName, version);
+            }
+        }
+
+        // Only shared packages can drift; a package pinned in a single workspace is fine.
+        if (pins.size < 2) continue;
+
+        const distinct = new Set(pins.values());
+
+        // All workspaces agree on the same version, we're good.
+        if (distinct.size === 1) continue;
+
+        const detail = [...pins]
+            .map(([workspaceName, version]) => `${workspaceName}=${version}`)
+            .join(", ");
+
+        logger.error(`❌ ${formatKey(key)} pinned to differing versions: ${detail}`);
+        failed = true;
+    }
+
+    if (failed) {
+        throw new Error("Catalog pins are out of sync across workspaces. Reconcile them.");
+    }
+
+    logger.info("✅ Catalog pins are in sync across all workspaces.");
+}
+
+main()
+    .then(() => {
+        logger.info("✅ Catalog linting completed successfully.");
+        process.exit(0);
+    })
+    .catch((error) => reportAndExit(error, logger));

--- a/scripts/node/lint-catalogs.ts
+++ b/scripts/node/lint-catalogs.ts
@@ -145,8 +145,5 @@ async function main(): Promise<void> {
 }
 
 main()
-    .then(() => {
-        logger.info("✅ Catalog linting completed successfully.");
-        process.exit(0);
-    })
+    .then(() => process.exit(0))
     .catch((error) => reportAndExit(error, logger));

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   docusaurus-theme-openapi-docs>postman-code-generators: ^2.1.1
   docusaurus-theme-openapi-docs>detect-package-manager: workspace:*
   docusaurus-theme-openapi-docs>shelljs: 0.10.0
-  format-imports>eslint: ^9.39.3
+  format-imports>eslint: ^9.39.4
   lodash: ^4.18.1
   postman-code-generators>detect-package-manager: workspace:*
   postman-code-generators>shelljs: 0.10.0

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -12,7 +12,7 @@ packages:
 nodeLinker: hoisted
 
 catalog:
-  eslint: "^9.39.3"
+  eslint: "^9.39.4"
   typescript: "^6.0.3"
   prettier-plugin-packagejson: "^3.0.2"
 


### PR DESCRIPTION
Part 1 of 4 splitting the post-pnpm-migration cleanup (was #23781) into reviewable pieces.

Adds a lint that keeps the pnpm `catalog:` pins in sync across the root, `web/`, and `website/` workspaces, plus the small config fixes around it.

### Why

The three directories are separate pnpm workspaces (they need different `nodeLinker` settings), and pnpm cannot share a catalog across workspace roots, so each `pnpm-workspace.yaml` re-declares the same shared pins. The "keep these in sync" comments were the only guard, and eslint had already drifted (`^9.39.3` in one, `^9.39.4` in another).

### Changes

- `scripts/node/lint-catalogs.ts` + `make lint-catalogs` + CI `catalogs` job: fails when a package pinned in more than one workspace catalog diverges. Uses a real YAML parser, not a regex.
- Aligns all three catalogs at eslint `^9.39.4`.
- Makefile: `pnpm --filter "./website/api"` selectors matched nothing (`website/` is not part of the root workspace); replaced with `--dir`.
- dependabot: covers `packages/logger-js` (npm) plus `scripts/` and `tests/openid_conformance` (docker-compose); logger-js added to the npm publish path triggers.
- AGENTS.md documents `make lint-catalogs` so every `ci-lint-*` check keeps a local counterpart.

Follow-ups: #23784 migrates the duplicated pins to the `catalog:` protocol; the CI install and website type-portability fixes ship separately.
