### PR TITLE
website: make docusaurus theme config types portable

### DIFF
--- a/website/api/docusaurus.config.cjs
+++ b/website/api/docusaurus.config.cjs
@@ -1,1 +1,4 @@
+/**
+ * @type {import('@docusaurus/types').DocusaurusConfig}
+ */
 module.exports = import("./docusaurus.config.esm.mjs").then(($) => $.default);

--- a/website/api/docusaurus.config.esm.mjs
+++ b/website/api/docusaurus.config.esm.mjs
@@ -53,7 +53,7 @@ await Promise.all(
 /**
  * Documentation site configuration for Docusaurus.
  */
-export default createDocusaurusConfig({
+const config = createDocusaurusConfig({
     url: "https://api.goauthentik.io",
 
     staticDirectories: [
@@ -176,3 +176,5 @@ export default createDocusaurusConfig({
 });
 
 //#endregion
+
+export default config;

--- a/website/docs/docusaurus.config.cjs
+++ b/website/docs/docusaurus.config.cjs
@@ -1,1 +1,4 @@
+/**
+ * @type {import('@docusaurus/types').DocusaurusConfig}
+ */
 module.exports = import("./docusaurus.config.esm.mjs").then(($) => $.default);

--- a/website/integrations/docusaurus.config.cjs
+++ b/website/integrations/docusaurus.config.cjs
@@ -1,1 +1,4 @@
+/**
+ * @type {import('@docusaurus/types').DocusaurusConfig}
+ */
 module.exports = import("./docusaurus.config.esm.mjs").then(($) => $.default);


### PR DESCRIPTION
Part 4 of 4 of the post-pnpm-migration cleanup. Independent of the others.

`tsc -b` on the website failed with TS2883 in the generated docusaurus configs: an inferred type could not be named without a reference to `UserThemeConfigExtra` from `@goauthentik/docusaurus-config`. Adds the explicit type annotations so the theme config is portable and `check-types` passes.
