### PR TITLE
sources/oauth: prevent requests being made to disabled oauth social sources

### DIFF
--- a/authentik/sources/oauth/api/source.py
+++ b/authentik/sources/oauth/api/source.py
@@ -67,8 +67,9 @@ class OAuthSourceSerializer(SourceSerializer):
 
         well_known = attrs.get("oidc_well_known_url") or source_type.oidc_well_known_url
         inferred_oidc_jwks_url = None
+        enabled = attrs.get("enabled", self.instance.enabled if self.instance else True)
 
-        if well_known and well_known != "":
+        if enabled and well_known and well_known != "":
             try:
                 well_known_config = session.get(well_known)
                 well_known_config.raise_for_status()
@@ -105,7 +106,7 @@ class OAuthSourceSerializer(SourceSerializer):
 
         # Prefer user-entered URL to inferred URL to default URL
         jwks_url = attrs.get("oidc_jwks_url") or inferred_oidc_jwks_url or source_type.oidc_jwks_url
-        if jwks_url and jwks_url != "":
+        if enabled and jwks_url and jwks_url != "":
             attrs["oidc_jwks_url"] = jwks_url
             try:
                 jwks_config = session.get(jwks_url)

--- a/authentik/sources/oauth/tasks.py
+++ b/authentik/sources/oauth/tasks.py
@@ -22,7 +22,7 @@ LOGGER = get_logger()
 def update_well_known_jwks():
     self = CurrentTask.get_task()
     session = get_http_session()
-    for source in OAuthSource.objects.all().exclude(oidc_well_known_url=""):
+    for source in OAuthSource.objects.all().filter(enabled=True).exclude(oidc_well_known_url=""):
         try:
             well_known_config = session.get(source.oidc_well_known_url)
             well_known_config.raise_for_status()
@@ -60,7 +60,7 @@ def update_well_known_jwks():
             LOGGER.info("Updating sources' OpenID Configuration", source=source)
             source.save()
 
-    for source in OAuthSource.objects.all().exclude(oidc_jwks_url=""):
+    for source in OAuthSource.objects.all().filter(enabled=True).exclude(oidc_jwks_url=""):
         try:
             jwks_config = session.get(source.oidc_jwks_url)
             jwks_config.raise_for_status()

--- a/authentik/sources/oauth/tests/test_api.py
+++ b/authentik/sources/oauth/tests/test_api.py
@@ -1,4 +1,5 @@
 from django.urls import reverse
+from requests_mock import Mocker
 from rest_framework.test import APITestCase
 
 from authentik.core.tests.utils import create_test_admin_user
@@ -29,3 +30,25 @@ class TestOAuthSourceAPI(APITestCase):
             },
         )
         self.assertEqual(res.status_code, 200)
+
+    @Mocker()
+    def test_disable_source_invalid_well_known_url(self, mock: Mocker):
+        """Saving a disabled source should not make a request to the well-known url"""
+        self.client.force_login(self.user)
+
+        well_known_url = f"https://{generate_id()}/.well-known/openid-configuration"
+        mock.get(well_known_url, json={})
+
+        res = self.client.patch(
+            reverse("authentik_api:oauthsource-detail", kwargs={"slug": self.source.slug}),
+            {
+                "enabled": False,
+                "oidc_well_known_url": well_known_url,
+                "authorization_url": f"https://{generate_id()}",
+                "profile_url": f"https://{generate_id()}",
+                "access_token_url": f"https://{generate_id()}",
+            },
+            content_type="application/json",
+        )
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(mock.call_count, 0)


### PR DESCRIPTION

<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?

This makes it so no requests are made to disabled OAuth sources (e.g., when save button is pressed).

### Why is this change needed?

Sources are unable to be disabled when URLs are invalid, like if the source is unreachable or a certificate is expired. There is no reason for this request to be made when a source is being toggled from enabled to disabled.

### How was this tested?

Added a unit test ensuring no request is made when `enabled: false`

### Linked issues

closes #23487 

---

## Checklist

-   [x] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
