### PR TITLE
tests/openid_conformance: migrate to upstream images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -350,5 +350,10 @@ updates:
       - dependencies
     cooldown:
       default-days: 3
+    groups:
+      openid-conformance:
+        patterns:
+          - registry.gitlab.com/openid/conformance-suite
+          - registry.gitlab.com/openid/conformance-suite/nginx
 
   #endregion

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -334,7 +334,7 @@ jobs:
           docker compose -f tests/e2e/compose.yml up -d --quiet-pull
       - name: Setup conformance suite
         run: |
-          docker compose -f tests/openid_conformance/compose.yml up -d --quiet-pull
+          docker compose -f tests/openid_conformance/compose.yml up -d --quiet-pull --wait
       - id: cache-web
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4
         with:

--- a/tests/openid_conformance/compose.yml
+++ b/tests/openid_conformance/compose.yml
@@ -1,29 +1,30 @@
 services:
   mongodb:
-    image: mongo:6.0.13
+    image: docker.io/library/mongo:6.0.13
   nginx:
-    image: ghcr.io/beryju/oidc-conformance-suite-nginx:v5.1.43
+    image: registry.gitlab.com/openid/conformance-suite/nginx:release-v5.2.0
+    healthcheck:
+      test: ["CMD", "curl", "-fk", "https://localhost:8443"]
     ports:
       - "8443:8443"
-      - "8444:8444"
     depends_on:
       - server
   server:
-    image: ghcr.io/beryju/oidc-conformance-suite-server:v5.1.43
-    ports:
-      - "9999:9999"
+    image: registry.gitlab.com/openid/conformance-suite:release-v5.2.0
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    command: >
-      java
-      -Xdebug -Xrunjdwp:transport=dt_socket,address=*:9999,server=y,suspend=n
-      -jar /server/fapi-test-suite.jar
-      -Djdk.tls.maxHandshakeMessageSize=65536
-      --fintechlabs.base_url=https://localhost:8443
-      --fintechlabs.base_mtls_url=https://localhost:8444
-      --fintechlabs.devmode=true
-      --fintechlabs.startredir=true
-    links:
-      - mongodb:mongodb
+    healthcheck:
+      test: ["CMD", "curl", "-f", "--header", "X-Forwarded-Proto: https", "http://localhost:8080/api/ui/spec_links?public=true"]
+      start_period: 30s
+      interval: 30s
+      timeout: 15s
+    environment:
+      BASE_URL: https://localhost:8443
+      MONGODB_HOST: mongodb
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-dev}
+      OIDC_GOOGLE_CLIENTID: ${OIDC_GOOGLE_CLIENTID:-google-client}
+      OIDC_GOOGLE_SECRET: ${OIDC_GOOGLE_SECRET:-google-secret}
+      OIDC_GITLAB_CLIENTID: ${OIDC_GITLAB_CLIENTID:-gitlab-client}
+      OIDC_GITLAB_SECRET: ${OIDC_GITLAB_SECRET:-gitlab-secret}
     depends_on:
       - mongodb


### PR DESCRIPTION
Since https://gitlab.com/openid/conformance-suite/-/commit/c7e4d83b9482a7309ff7a1853c0d36dddef225fb there are now pre-built images for the OpenID Conformance test suite, so we can use those instead

small downside, they're linux/amd64 only

backporting so I can delete my forked repo and previous versions' CI still works