### PR TITLE
core: fix user_type check to correctly prevent internal_service_account

### DIFF
--- a/authentik/core/api/users.py
+++ b/authentik/core/api/users.py
@@ -287,14 +287,19 @@ class UserSerializer(ModelSerializer):
 
     def validate_type(self, user_type: str) -> str:
         """Validate user type, internal_service_account is an internal value"""
-        if (
-            self.instance
-            and self.instance.type == UserTypes.INTERNAL_SERVICE_ACCOUNT
-            and user_type != UserTypes.INTERNAL_SERVICE_ACCOUNT.value
-        ):
-            raise ValidationError(_("Can't change internal service account to other user type."))
-        if not self.instance and user_type == UserTypes.INTERNAL_SERVICE_ACCOUNT.value:
-            raise ValidationError(_("Setting a user to internal service account is not allowed."))
+        if not self.instance and user_type == UserTypes.INTERNAL_SERVICE_ACCOUNT:
+            raise ValidationError(_("Can't create internal service accounts"))
+        if self.instance:
+            if (
+                self.instance.type == UserTypes.INTERNAL_SERVICE_ACCOUNT
+                and user_type != UserTypes.INTERNAL_SERVICE_ACCOUNT.value
+            ) or (
+                self.instance.type != UserTypes.INTERNAL_SERVICE_ACCOUNT
+                and user_type == UserTypes.INTERNAL_SERVICE_ACCOUNT.value
+            ):
+                raise ValidationError(
+                    _("Can't change internal service account to other user type.")
+                )
         return user_type
 
     def validate_groups(self, groups: list) -> list:

--- a/authentik/core/tests/test_users_api.py
+++ b/authentik/core/tests/test_users_api.py
@@ -111,6 +111,19 @@ class TestUsersAPI(APITestCase):
         self.assertEqual(response.status_code, 400)
         self.assertJSONEqual(response.content, {"non_field_errors": "No recovery flow set."})
 
+    def test_set_type(self):
+        """Test type set"""
+        self.client.force_login(self.admin)
+        response = self.client.patch(
+            reverse("authentik_api:user-detail", kwargs={"pk": self.admin.pk}),
+            data={"type": UserTypes.INTERNAL_SERVICE_ACCOUNT},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertJSONEqual(
+            response.content,
+            {"type": ["Can't change internal service account to other user type."]},
+        )
+
     def test_set_password(self):
         """Test Direct password set"""
         self.client.force_login(self.admin)


### PR DESCRIPTION
https://github.com/goauthentik/authentik/issues/23769