### PR TITLE
Add configurable gunicorn worker timeout and graceful shutdown

### DIFF
--- a/lifecycle/gunicorn.conf.py
+++ b/lifecycle/gunicorn.conf.py
@@ -45,6 +45,8 @@ preload_app = True
 max_requests = CONFIG.get_int("web.max_requests", 1000)
 max_requests_jitter = CONFIG.get_int("web.max_requests_jitter", 50)
 
+timeout = CONFIG.get_int("gunicorn.timeout", 30)
+
 logconfig_dict = get_logger_config()
 
 workers = CONFIG.get_int("web.workers", 2)

--- a/lifecycle/worker.py
+++ b/lifecycle/worker.py
@@ -2,6 +2,8 @@
 
 from uvicorn.workers import UvicornWorker
 
+from authentik.lib.config import CONFIG
+
 
 class DjangoUvicornWorker(UvicornWorker):
     """Custom configured Uvicorn Worker without lifespan"""
@@ -11,6 +13,10 @@ class DjangoUvicornWorker(UvicornWorker):
         "http": "httptools",
         "lifespan": "off",
         "ws": "wsproto",
+        "timeout_graceful_shutdown": CONFIG.get_optional_int(
+            "gunicorn.timeout_graceful_shutdown",
+            10,
+        ),
     }
 
     _worker_id: int

--- a/website/docs/install-config/configuration/configuration.mdx
+++ b/website/docs/install-config/configuration/configuration.mdx
@@ -800,6 +800,20 @@ Defaults to `120s`
 
 ## Advanced settings
 
+##### `AUTHENTIK_GUNICORN__TIMEOUT`
+
+The number of seconds a gunicorn worker may go without notifying the gunicorn master before it is considered unresponsive, killed, and restarted. Maps to gunicorn's `timeout` setting.
+
+Defaults to `30`.
+
+##### `AUTHENTIK_GUNICORN__TIMEOUT_GRACEFUL_SHUTDOWN`
+
+The maximum number of seconds the gunicorn uvicorn worker waits for in-flight connections and background tasks to finish when shutting down (for example during worker recycling triggered by `AUTHENTIK_WEB__MAX_REQUESTS`) before remaining tasks are cancelled and the worker exits. Passed to uvicorn's `timeout_graceful_shutdown` option. Set to `0` or `null` to wait indefinitely.
+
+This value should be kept below `AUTHENTIK_GUNICORN__TIMEOUT` so that recycled workers exit cleanly instead of being forcibly aborted by gunicorn. For example, to allow longer graceful drains, raise both together (such as `AUTHENTIK_GUNICORN__TIMEOUT=45` with `AUTHENTIK_GUNICORN__TIMEOUT_GRACEFUL_SHUTDOWN=30`).
+
+Defaults to `10`.
+
 ##### `AUTHENTIK_SKIP_MIGRATIONS`
 
 Whether to skip running migrations on starting authentik. This is destined to advanced setups and not recommended in normal use.


### PR DESCRIPTION
### What does this PR change?
Adds two configurable web worker timeouts: `AUTHENTIK_WEB__GUNICORN_TIMEOUT` (Gunicorn worker silent timeout) and `AUTHENTIK_WEB__GRACEFUL_SHUTDOWN_TIMEOUT` (Uvicorn graceful shutdown timeout). Both default to sensible values (30s / 30s) via code fallbacks and are documented under Advanced settings.

### Why is this change needed?
When a worker hits Gunicorn's `max_requests`, Uvicorn begins shutdown. Its graceful shutdown wait was unbounded (`timeout_graceful_shutdown=None`), so a worker could stop heartbeating long enough for the arbiter to hit `WORKER TIMEOUT` and `SIGABRT` it. Bounding Uvicorn's shutdown (and exposing the paired Gunicorn worker timeout) prevents these avoidable `SIGABRT` worker aborts.

### How was this tested?
- Verified config resolution: defaults (`30`/`30`), env overrides (`45`/`30`), and `null` → `None` (restores prior unbounded behavior).
- Confirmed Gunicorn loads the module-level `timeout` from `-c ./lifecycle/gunicorn.conf.py` (same mechanism as `max_requests`).
- `ruff check` and `ruff format --check` pass on the changed lifecycle files.

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [X] The documentation has been updated and formatted (`make docs`)
