### PR TITLE
web: Fix Log Viewer Intersection Observer.

### DIFF
--- a/web/src/components/tasks/TaskList.ts
+++ b/web/src/components/tasks/TaskList.ts
@@ -220,9 +220,9 @@ export class TaskList extends Table<Task> {
     renderExpanded(item: Task): TemplateResult {
         return html`<div class="pf-c-content">
             <p class="pf-c-title pf-u-mb-md">${msg("Current execution logs")}</p>
-            <ak-log-viewer .items=${item.logs}></ak-log-viewer>
+            <ak-log-viewer display-box="contents" .items=${item.logs}></ak-log-viewer>
             <p class="pf-c-title pf-u-mt-xl pf-u-mb-md">${msg("Previous executions logs")}</p>
-            <ak-log-viewer .items=${item.previousLogs}></ak-log-viewer>
+            <ak-log-viewer display-box="contents" .items=${item.previousLogs}></ak-log-viewer>
         </div>`;
     }
 }


### PR DESCRIPTION
## Details

This PR fixes an issue which occurs when `<ak-log-viewer />` is rendered in a collapsable container, such as on the system tasks page. The fix is similar to other situations where intersection observers use an incorrect visibility check, such as when rendering a table in a sub-modal. 