### PR TITLE
lib/sync/outgoing: only run discover once per provider for outgoing syncs

### DIFF
--- a/authentik/enterprise/providers/google_workspace/tests/test_groups.py
+++ b/authentik/enterprise/providers/google_workspace/tests/test_groups.py
@@ -331,7 +331,8 @@ class GoogleWorkspaceGroupTests(TestCase):
                 ).exists()
             )
             self.assertFalse(Event.objects.filter(action=EventAction.SYSTEM_EXCEPTION).exists())
-            self.assertEqual(len(http.requests()), 7)
+            # Full sync creates separate clients for user and group discovery.
+            self.assertEqual(len(http.requests()), 9)
 
     def test_sync_discover_multiple(self):
         """Test group discovery"""
@@ -372,7 +373,8 @@ class GoogleWorkspaceGroupTests(TestCase):
                 ).exists()
             )
             self.assertFalse(Event.objects.filter(action=EventAction.SYSTEM_EXCEPTION).exists())
-            self.assertEqual(len(http.requests()), 7)
+            # Full sync creates separate clients for user and group discovery.
+            self.assertEqual(len(http.requests()), 9)
             # Change response to trigger update
             http.add_response(
                 f"https://admin.googleapis.com/admin/directory/v1/groups?customer=my_customer&maxResults=500&orderBy=email&key={self.api_key}&alt=json",

--- a/authentik/enterprise/providers/google_workspace/tests/test_users.py
+++ b/authentik/enterprise/providers/google_workspace/tests/test_users.py
@@ -309,7 +309,8 @@ class GoogleWorkspaceUserTests(TestCase):
                 ).exists()
             )
             self.assertFalse(Event.objects.filter(action=EventAction.SYSTEM_EXCEPTION).exists())
-            self.assertEqual(len(http.requests()), 7)
+            # Full sync creates separate clients for user and group discovery.
+            self.assertEqual(len(http.requests()), 9)
 
     def test_sync_discover_multiple(self):
         """Test user discovery, running multiple times"""
@@ -352,7 +353,8 @@ class GoogleWorkspaceUserTests(TestCase):
                 ).exists()
             )
             self.assertFalse(Event.objects.filter(action=EventAction.SYSTEM_EXCEPTION).exists())
-            self.assertEqual(len(http.requests()), 7)
+            # Full sync creates separate clients for user and group discovery.
+            self.assertEqual(len(http.requests()), 9)
             # Change response, which will trigger a discovery update
             http.add_response(
                 f"https://admin.googleapis.com/admin/directory/v1/users?customer=my_customer&maxResults=500&orderBy=email&key={self.api_key}&alt=json",

--- a/authentik/lib/sync/outgoing/tasks.py
+++ b/authentik/lib/sync/outgoing/tasks.py
@@ -39,7 +39,7 @@ class SyncTasks:
         self,
         current_task: Task,
         provider: OutgoingSyncProvider,
-        sync_objects: Actor[[str, int, int, bool], None],
+        sync_objects: Actor[[str, int, int, bool, bool], None],
         paginator: Paginator,
         object_type: type[User | Group],
         **options,
@@ -49,6 +49,7 @@ class SyncTasks:
         for page in paginator.page_range:
             page_sync = sync_objects.message_with_options(
                 args=(class_to_path(object_type), page, provider.pk),
+                kwargs={"discover": False},
                 time_limit=time_limit,
                 # Assign tasks to the same schedule as the current one
                 rel_obj=current_task.rel_obj,
@@ -61,7 +62,7 @@ class SyncTasks:
     def sync(
         self,
         provider_pk: int,
-        sync_objects: Actor[[str, int, int, bool], None],
+        sync_objects: Actor[[str, int, int, bool, bool], None],
     ):
         task = CurrentTask.get_task()
         self.logger = get_logger().bind(
@@ -101,7 +102,9 @@ class SyncTasks:
                         object_type=Group,
                     )
                 )
+                self._discover(provider, User)
                 users_tasks.run().wait(timeout=provider.get_object_sync_time_limit_ms(User))
+                self._discover(provider, Group)
                 group_tasks.run().wait(timeout=provider.get_object_sync_time_limit_ms(Group))
                 self._sync_cleanup(provider, task)
             except TransientSyncException as exc:
@@ -111,6 +114,13 @@ class SyncTasks:
             except StopSync as exc:
                 task.error(exc)
                 return
+
+    def _discover(self, provider: OutgoingSyncProvider, object_type: type[User | Group]):
+        client = provider.client_for_model(object_type)
+        if not client.can_discover:
+            return
+        self.logger.debug("starting discover", object_type=object_type._meta.model_name)
+        client.discover()
 
     def _sync_cleanup(self, provider: OutgoingSyncProvider, task: Task):
         """Delete remote objects that are no longer in scope"""
@@ -147,6 +157,7 @@ class SyncTasks:
         page: int,
         provider_pk: int,
         override_dry_run=False,
+        discover=True,
         **filter,
     ):
         task = CurrentTask.get_task()
@@ -175,7 +186,7 @@ class SyncTasks:
             provider.get_object_qs(_object_type, **filter),
             provider.sync_page_size,
         )
-        if client.can_discover:
+        if discover and client.can_discover:
             self.logger.debug("starting discover")
             client.discover()
         self.logger.debug("starting sync for page", page=page)

--- a/authentik/providers/scim/tests/test_client.py
+++ b/authentik/providers/scim/tests/test_client.py
@@ -1,13 +1,13 @@
 """SCIM Client tests"""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.core.cache import cache
 from django.test import TestCase
 from requests_mock import Mocker
 
 from authentik.blueprints.tests import apply_blueprint
-from authentik.core.models import Application
+from authentik.core.models import Application, Group, User
 from authentik.lib.generators import generate_id
 from authentik.providers.scim.clients.base import SCIMClient
 from authentik.providers.scim.models import SCIMMapping, SCIMProvider
@@ -106,6 +106,29 @@ class SCIMClientTests(TestCase):
     def test_scim_sync(self):
         """test scim_sync task"""
         scim_sync.send(self.provider.pk).get_result()
+
+    def test_full_sync_discovers_once_per_object_type(self):
+        """Full sync runs discovery once, not once per object page."""
+        SCIMProvider.objects.filter(pk=self.provider.pk).update(sync_page_size=1)
+        User.objects.bulk_create([User(username=generate_id()), User(username=generate_id())])
+        Group.objects.bulk_create([Group(name=generate_id()), Group(name=generate_id())])
+        user_client = MagicMock(can_discover=True)
+        group_client = MagicMock(can_discover=True)
+
+        def client_for_model(_provider, model):
+            if model is User:
+                return user_client
+            self.assertIs(model, Group)
+            return group_client
+
+        with patch.object(SCIMProvider, "client_for_model", autospec=True) as client_factory:
+            client_factory.side_effect = client_for_model
+            scim_sync.send(self.provider.pk).get_result()
+
+        self.assertGreater(user_client.write.call_count, 1)
+        self.assertGreater(group_client.write.call_count, 1)
+        user_client.discover.assert_called_once_with()
+        group_client.discover.assert_called_once_with()
 
     def test_config_caching(self):
         """Test that ServiceProviderConfig is cached after first successful fetch"""

--- a/authentik/providers/scim/tests/test_user.py
+++ b/authentik/providers/scim/tests/test_user.py
@@ -680,10 +680,13 @@ class SCIMUserTests(TestCase):
         TransientSyncException"""
         with Mocker() as mock:
             mock.get("https://localhost/ServiceProviderConfig", json={})
-            with patch.object(
-                SCIMProvider,
-                "client_for_model",
-                side_effect=TransientSyncException("connection failed"),
+            with (
+                patch.object(
+                    SCIMProvider,
+                    "client_for_model",
+                    side_effect=TransientSyncException("connection failed"),
+                ),
+                patch.object(sync_tasks, "_discover"),
             ):
                 scim_sync.send(self.provider.pk).get_result()
 


### PR DESCRIPTION
## Details
Move outgoing provider discovery out of individual page tasks so remote users and groups are each discovered only once per full sync. Manual single-object syncs retain discovery behavior.
This prevents large SCIM/Entra/GWS directories from being enumerated repeatedly for every local sync page.



---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
