### PR TITLE
core: honor expiry date for API tokens

### DIFF
--- a/authentik/core/api/tokens.py
+++ b/authentik/core/api/tokens.py
@@ -62,10 +62,12 @@ class TokenSerializer(ManagedSerializer, ModelSerializer):
         if attrs.get("intent") not in [TokenIntents.INTENT_API, TokenIntents.INTENT_APP_PASSWORD]:
             raise ValidationError({"intent": f"Invalid intent {attrs.get('intent')}"})
 
-        if attrs.get("intent") == TokenIntents.INTENT_APP_PASSWORD:
-            # user IS in attrs
-            user: User = attrs.get("user")
-            max_token_lifetime = user.group_attributes(request).get(
+        actor: User = request.user if request else attrs.get("user")
+        token_expiring = actor.attributes.get(USER_ATTRIBUTE_TOKEN_EXPIRING, True)
+        expires = attrs.get("expires")
+
+        if not actor.is_superuser and token_expiring:
+            max_token_lifetime = actor.attributes.get(
                 USER_ATTRIBUTE_TOKEN_MAXIMUM_LIFETIME,
             )
             max_token_lifetime_dt = default_token_duration()
@@ -75,7 +77,7 @@ class TokenSerializer(ManagedSerializer, ModelSerializer):
                 except ValueError:
                     pass
 
-            expires = attrs.get("expires")
+            # if expires is provided, ensure it does not exceed the maximum resolved token lifetime
             if expires is not None and expires > max_token_lifetime_dt:
                 raise ValidationError(
                     {
@@ -84,9 +86,10 @@ class TokenSerializer(ManagedSerializer, ModelSerializer):
                         )
                     }
                 )
-        elif attrs.get("intent") == TokenIntents.INTENT_API:
-            # For API tokens, expires cannot be overridden
-            attrs["expires"] = default_token_duration()
+
+            # if expires is None, set it to the allowed token lifetime
+            if expires is None:
+                attrs["expires"] = max_token_lifetime_dt
 
         return attrs
 

--- a/authentik/core/tests/test_token_api.py
+++ b/authentik/core/tests/test_token_api.py
@@ -13,6 +13,7 @@ from authentik.core.models import (
     USER_ATTRIBUTE_TOKEN_MAXIMUM_LIFETIME,
     Token,
     TokenIntents,
+    default_token_duration,
 )
 from authentik.core.tests.utils import create_test_admin_user, create_test_user
 from authentik.lib.generators import generate_id
@@ -151,7 +152,98 @@ class TestTokenAPI(APITestCase):
         self.assertEqual(token.user, self.user)
         self.assertEqual(token.intent, TokenIntents.INTENT_API)
         self.assertEqual(token.expiring, True)
-        self.assertNotEqual(token.expires.timestamp(), expires.timestamp())
+        self.assertEqual(token.expires.timestamp(), expires.timestamp())
+
+    def test_token_create_superuser_ignores_lifetime_limits(self):
+        """Test that superuser token creation is not subject to maximum lifetime constraints"""
+        self.client.force_login(self.admin)
+        self.admin.attributes[USER_ATTRIBUTE_TOKEN_EXPIRING] = True
+        self.admin.attributes[USER_ATTRIBUTE_TOKEN_MAXIMUM_LIFETIME] = "hours=2"
+        self.admin.save()
+        expires = datetime.now() + timedelta(days=365)
+        response = self.client.post(
+            reverse("authentik_api:token-list"),
+            {
+                "identifier": "test-token",
+                "expires": expires,
+                "intent": TokenIntents.INTENT_API,
+            },
+        )
+        self.assertEqual(response.status_code, 201)
+        token = Token.objects.get(identifier="test-token")
+        self.assertEqual(token.expires.timestamp(), expires.timestamp())
+
+    def test_token_create_api_exceeds_max_lifetime(self):
+        """Test that API token creation is rejected when expires exceeds the user's
+        maximum lifetime"""
+        self.user.attributes[USER_ATTRIBUTE_TOKEN_EXPIRING] = True
+        self.user.attributes[USER_ATTRIBUTE_TOKEN_MAXIMUM_LIFETIME] = "hours=2"
+        self.user.save()
+        expires = datetime.now() + timedelta(hours=2, minutes=1)
+        response = self.client.post(
+            reverse("authentik_api:token-list"),
+            {
+                "identifier": "test-token",
+                "expires": expires,
+                "intent": TokenIntents.INTENT_API,
+            },
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_token_create_no_expires_with_max_lifetime(self):
+        """Test that omitting expires falls back to the user attribute maximum lifetime"""
+        self.user.attributes[USER_ATTRIBUTE_TOKEN_EXPIRING] = True
+        self.user.attributes[USER_ATTRIBUTE_TOKEN_MAXIMUM_LIFETIME] = "hours=2"
+        self.user.save()
+        before = datetime.now() + timedelta(hours=2)
+        response = self.client.post(
+            reverse("authentik_api:token-list"),
+            {
+                "identifier": "test-token",
+                "intent": TokenIntents.INTENT_API,
+            },
+        )
+        after = datetime.now() + timedelta(hours=2)
+        self.assertEqual(response.status_code, 201)
+        token = Token.objects.get(identifier="test-token")
+        self.assertEqual(token.user, self.user)
+        self.assertEqual(token.intent, TokenIntents.INTENT_API)
+        self.assertIsNotNone(token.expires)
+        self.assertGreaterEqual(token.expires.timestamp(), before.timestamp())
+        self.assertLessEqual(token.expires.timestamp(), after.timestamp())
+
+    def test_token_create_no_expires_uses_system_default(self):
+        """Test that omitting expires with no user attribute falls back to the system default"""
+        before = default_token_duration()
+        response = self.client.post(
+            reverse("authentik_api:token-list"),
+            {
+                "identifier": "test-token",
+                "intent": TokenIntents.INTENT_API,
+            },
+        )
+        after = default_token_duration()
+        self.assertEqual(response.status_code, 201)
+        token = Token.objects.get(identifier="test-token")
+        self.assertIsNotNone(token.expires)
+        self.assertGreaterEqual(token.expires.timestamp(), before.timestamp())
+        self.assertLessEqual(token.expires.timestamp(), after.timestamp())
+
+    def test_token_create_non_expiring_ignores_max_lifetime(self):
+        """Max lifetime enforcement does not apply when token-expires is false"""
+        self.user.attributes[USER_ATTRIBUTE_TOKEN_EXPIRING] = False
+        self.user.attributes[USER_ATTRIBUTE_TOKEN_MAXIMUM_LIFETIME] = "hours=2"
+        self.user.save()
+        expires = datetime.now() + timedelta(days=365)
+        response = self.client.post(
+            reverse("authentik_api:token-list"),
+            {
+                "identifier": "test-token",
+                "expires": expires,
+                "intent": TokenIntents.INTENT_API,
+            },
+        )
+        self.assertEqual(response.status_code, 201)
 
     def test_token_change_user(self):
         """Test creating a token and then changing the user"""


### PR DESCRIPTION
<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

When creating or modifying an Tokens with  **Expiring** enabled, the
**Expires on** date was ignored. The token's expiry was overwritten
with the default duration regardless of the value submitted. 

From a superuser's perspective, these limitations also applied generating tokens with an expiry longer than the system default in the admin UI.

It feels a bit non-intuitive to treat the system token timeline as the authoritative max expiry but, it is called out in the docs as the behavior so I opted not to change that existing behavior https://docs.goauthentik.io/users-sources/user/user_ref/#goauthentikiousertoken-maximum-lifetime

### What does this PR change?

Expiry handling in `TokenSerializer.validate` is now uniform across token
intents and honors the submitted date within the acting user's limits:

- A submitted *expires* is honored as long as it does not exceed the acting user's
  maximum token lifetime (*token_maximum_lifetime* attribute, falling back to
  the system default if not specified).
- Superusers and users with *token_expiring* set to `false` are not subject to
  the limit, so expires greater than the system default or token_maximum_lifetime are allowed.
- The check reads the acting user's own attributes rather than group
attributes to align with existing check in `perform_create`


### Why is this change needed?

The **Expires on** field is presented as editable in the admin UI, so a user
who sets a future expiry reasonably expects it to be honored. Instead the value
was silently discarded and set to the system default, making longer-lived expiring API tokens impossible to create

### How was this tested?

Automated tests were added in `authentik/core/tests/test_token_api.py` covering:
- superuser allowed to create expiring token > system default
- API token creation is rejected when expires exceeds the user's maximum lifetime
- Omitting expires falls back to the user attribute maximum lifetime
- Omitting expires with no user attribute falls back to the system default

### Linked issues

closes #14093
closes #19045

closes #25282
---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
