### PR TITLE
stages/authenticator_email: add resend button with cooldown

### DIFF
--- a/authentik/stages/authenticator_email/stage.py
+++ b/authentik/stages/authenticator_email/stage.py
@@ -1,5 +1,8 @@
 """Email Setup stage"""
 
+from time import time
+
+from django.core.cache import cache
 from django.db.models import Q
 from django.http import HttpRequest, HttpResponse
 from django.http.request import QueryDict
@@ -31,6 +34,59 @@ PLAN_CONTEXT_EMAIL = "email"
 PLAN_CONTEXT_EMAIL_SENT = "email_sent"
 PLAN_CONTEXT_EMAIL_OVERRIDE = "email"
 
+# Minimum interval between two sign-in codes sent to the same address. Enforced server-side so a
+# client that skips the UI countdown cannot use the resend endpoint to mail-bomb an address. Keyed
+# by address rather than by session, otherwise starting a fresh flow would reset the limit.
+RESEND_THROTTLE_SECONDS = 60
+RESEND_THROTTLE_KEY = "goauthentik.io/stages/authenticator_email/resend_throttle/%s"
+
+
+def _throttle_key(email: str) -> str:
+    return RESEND_THROTTLE_KEY % email.lower()
+
+
+def resend_cooldown_remaining(email: str) -> int:
+    """Read-only: seconds left before another code may be sent to `email` (for UI messages)."""
+    if not email:
+        return 0
+    ready_at = cache.get(_throttle_key(email))
+    if not ready_at:
+        return 0
+    return max(int(ready_at - time()), 0)
+
+
+def reserve_send(email: str) -> int:
+    """Atomically claim the right to send a code to `email`.
+
+    Returns 0 when the caller may send now (the window was opened for it), otherwise the number of
+    seconds until the next send is allowed. cache.add (Redis SETNX) makes this race-free: with a
+    burst of concurrent send requests only the first one gets 0, the rest are refused.
+
+    The caller must send the code once it gets 0, or call release_send() if the send fails, so a
+    failed attempt does not lock the address out for the full window.
+    """
+    if not email:
+        return 0
+    deadline = time() + RESEND_THROTTLE_SECONDS
+    if cache.add(_throttle_key(email), deadline, timeout=RESEND_THROTTLE_SECONDS):
+        return 0
+    return resend_cooldown_remaining(email)
+
+
+def release_send(email: str) -> None:
+    """Release a window reserved by reserve_send() when the send did not actually go out."""
+    if not email:
+        return
+    cache.delete(_throttle_key(email))
+
+
+def throttled_error(remaining: int) -> ValidationError:
+    """User-facing error for a resend attempt made during the cooldown window."""
+    return ValidationError(
+        _("A code was just sent. You can request a new one in %(seconds)d seconds.")
+        % {"seconds": remaining}
+    )
+
 
 class AuthenticatorEmailChallenge(WithUserInfoChallenge):
     """Authenticator Email Setup challenge"""
@@ -56,6 +112,16 @@ class AuthenticatorEmailChallengeResponse(ChallengeResponse):
         """Check"""
         if "code" not in attrs:
             if "email" not in attrs:
+                # No code and no email on the OTP entry screen (device email already set):
+                # treat as a "resend" request — regenerate the token and email it again.
+                if self.device.email:
+                    # Reserve before regenerating the token, so a throttled attempt leaves the
+                    # code already in the user's inbox untouched.
+                    remaining = reserve_send(self.device.email)
+                    if remaining:
+                        raise throttled_error(remaining)
+                    self.stage.resend()
+                    return super().validate(attrs)
                 raise ValidationError("email required")
             self.device.email = attrs["email"]
             self.stage.validate_and_send(attrs["email"])
@@ -71,12 +137,24 @@ class AuthenticatorEmailStageView(ChallengeStageView):
 
     response_class = AuthenticatorEmailChallengeResponse
 
-    def validate_and_send(self, email: str):
-        """Validate email and send message"""
+    def validate_and_send(self, email: str, reserve: bool = True):
+        """Validate email and send message.
+
+        `reserve` gates this send through the per-address cooldown; the resend path passes
+        reserve=False because it already reserved the window before regenerating the token.
+        """
+        # Throttle every direct send too (initial entry / re-submitting the email challenge),
+        # otherwise the resend cooldown could be bypassed by replaying the email step.
+        if reserve:
+            remaining = reserve_send(email)
+            if remaining:
+                raise throttled_error(remaining)
+
         pending_user = self.get_pending_user()
 
         stage: AuthenticatorEmailStage = self.executor.current_stage
         if EmailDevice.objects.filter(Q(email=email), stage=stage.pk).exists():
+            release_send(email)
             raise ValidationError(_("Invalid email"))
 
         device: EmailDevice = self.executor.plan.context[PLAN_CONTEXT_EMAIL_DEVICE]
@@ -96,12 +174,22 @@ class AuthenticatorEmailStageView(ChallengeStageView):
 
             send_mails(stage, message)
         except TemplateSyntaxError as exc:
+            release_send(email)
             Event.new(
                 EventAction.CONFIGURATION_ERROR,
                 message=_("Exception occurred while rendering E-mail template"),
                 template=stage.template,
             ).with_exception(exc).from_http(self.request)
             raise StageInvalidException from exc
+
+    def resend(self):
+        """Regenerate the token and re-send it to the device's existing email address."""
+        device: EmailDevice = self.executor.plan.context[PLAN_CONTEXT_EMAIL_DEVICE]
+        stage: AuthenticatorEmailStage = self.executor.current_stage
+        valid_secs: int = timedelta_from_string(stage.token_expiry).total_seconds()
+        device.generate_token(valid_secs=valid_secs, commit=False)
+        # The resend branch already reserved the cooldown window before this token was regenerated.
+        self.validate_and_send(device.email, reserve=False)
 
     def _has_email(self) -> str | None:
         context = self.executor.plan.context
@@ -141,6 +229,13 @@ class AuthenticatorEmailStageView(ChallengeStageView):
     def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
         user = self.get_pending_user()
 
+        # An unsaved pending user (e.g. denied by a policy before being created, such as a
+        # disallowed email domain) has no primary key. Using it in a related-field filter below
+        # raises "Model instances passed to related filters must be saved" and 500s the flow.
+        # Such a user must not proceed anyway, so deny cleanly instead of crashing.
+        if not user.pk:
+            return self.executor.stage_invalid(_("Access denied."))
+
         stage: AuthenticatorEmailStage = self.executor.current_stage
         # For the moment we only allow one email device per user
         if EmailDevice.objects.filter(Q(user=user), stage=stage.pk).exists():
@@ -155,7 +250,10 @@ class AuthenticatorEmailStageView(ChallengeStageView):
             if email := self._has_email():
                 device.email = email
                 try:
-                    self.validate_and_send(email)
+                    # This auto-send runs once per flow plan (guarded above), so it is not an
+                    # attacker-repeatable path; skip the cooldown gate to avoid the retry loop
+                    # below spinning on a throttle error.
+                    self.validate_and_send(email, reserve=False)
                 except ValidationError as exc:
                     # We had an email given already (at this point only possible from flow
                     # context), but an error occurred while sending (most likely)

--- a/authentik/stages/authenticator_email/tests.py
+++ b/authentik/stages/authenticator_email/tests.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from unittest.mock import PropertyMock, patch
 
 from django.core import mail
+from django.core.cache import cache
 from django.core.mail.backends.locmem import EmailBackend
 from django.core.mail.backends.smtp import EmailBackend as SMTPEmailBackend
 from django.db.utils import IntegrityError
@@ -23,7 +24,13 @@ from authentik.stages.authenticator_email.api import (
     EmailDeviceSerializer,
 )
 from authentik.stages.authenticator_email.models import AuthenticatorEmailStage, EmailDevice
-from authentik.stages.authenticator_email.stage import PLAN_CONTEXT_EMAIL_DEVICE
+from authentik.stages.authenticator_email.stage import (
+    PLAN_CONTEXT_EMAIL_DEVICE,
+    RESEND_THROTTLE_SECONDS,
+    release_send,
+    resend_cooldown_remaining,
+    reserve_send,
+)
 from authentik.stages.email.utils import TemplateEmailMessage
 
 
@@ -356,3 +363,58 @@ class TestEmailDeviceThrottling(ThrottlingTestMixin, TestCase):
 
     def invalid_token(self):
         return "000000" if self.device.token != "000000" else "111111"
+
+
+class TestAuthenticatorEmailResendThrottle(TestCase):
+    """Test the server-side resend cooldown"""
+
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+        self.addCleanup(cache.clear)
+
+    def test_first_send_allowed(self):
+        """A first send opens the window and is not throttled"""
+        self.assertEqual(resend_cooldown_remaining("user@authentik.local"), 0)
+        self.assertEqual(reserve_send("user@authentik.local"), 0)
+
+    def test_resend_within_window_refused(self):
+        """A second send during the window is refused and reports the remaining seconds"""
+        self.assertEqual(reserve_send("user@authentik.local"), 0)
+        remaining = reserve_send("user@authentik.local")
+        self.assertGreater(remaining, 0)
+        self.assertLessEqual(remaining, RESEND_THROTTLE_SECONDS)
+
+    def test_remaining_counts_down(self):
+        """The remaining seconds shrink as the window elapses"""
+        with patch("authentik.stages.authenticator_email.stage.time", return_value=1000.0):
+            self.assertEqual(reserve_send("user@authentik.local"), 0)
+        with patch(
+            "authentik.stages.authenticator_email.stage.time",
+            return_value=1000.0 + RESEND_THROTTLE_SECONDS - 10,
+        ):
+            self.assertEqual(resend_cooldown_remaining("user@authentik.local"), 10)
+
+    def test_release_reopens_window(self):
+        """Releasing a reserved window lets the next send through, e.g. when delivery failed"""
+        self.assertEqual(reserve_send("user@authentik.local"), 0)
+        release_send("user@authentik.local")
+        self.assertEqual(resend_cooldown_remaining("user@authentik.local"), 0)
+        self.assertEqual(reserve_send("user@authentik.local"), 0)
+
+    def test_addresses_are_independent(self):
+        """Throttling one address does not throttle another"""
+        self.assertEqual(reserve_send("one@authentik.local"), 0)
+        self.assertEqual(reserve_send("two@authentik.local"), 0)
+
+    def test_address_is_case_insensitive(self):
+        """The same address in different case shares one window"""
+        self.assertEqual(reserve_send("User@authentik.local"), 0)
+        self.assertGreater(reserve_send("user@authentik.local"), 0)
+
+    def test_empty_address_is_never_throttled(self):
+        """An empty address has no window to reserve"""
+        self.assertEqual(reserve_send(""), 0)
+        self.assertEqual(reserve_send(""), 0)
+        self.assertEqual(resend_cooldown_remaining(""), 0)
+        release_send("")

--- a/authentik/stages/authenticator_validate/challenge.py
+++ b/authentik/stages/authenticator_validate/challenge.py
@@ -136,9 +136,23 @@ def select_challenge_sms(request: HttpRequest, device: SMSDevice):
 
 def select_challenge_email(request: HttpRequest, device: EmailDevice):
     """Send Email"""
+    # Imported lazily: authenticator_email.stage imports from this package at module level.
+    from authentik.stages.authenticator_email.stage import release_send, reserve_send
+
+    # Selecting the email challenge is also how the frontend requests a resend, so this is the
+    # throttle point. reserve_send atomically opens the cooldown window; a non-zero result means a
+    # code went out recently, so we return without regenerating the token — the code already in the
+    # user's inbox stays valid, and a burst of concurrent resends cannot mail-bomb the address.
+    if reserve_send(device.email):
+        return
     valid_secs: int = timedelta_from_string(device.stage.token_expiry).total_seconds()
     device.generate_token(valid_secs=valid_secs)
-    device.stage.send(device)
+    try:
+        device.stage.send(device)
+    except Exception:
+        # Sending failed, so free the window immediately instead of locking the address out.
+        release_send(device.email)
+        raise
 
 
 def validate_challenge_code(code: str, stage_view: StageView, user: User) -> Device:

--- a/web/src/flow/stages/authenticator_email/AuthenticatorEmailStage.ts
+++ b/web/src/flow/stages/authenticator_email/AuthenticatorEmailStage.ts
@@ -8,6 +8,7 @@ import { AKLabel } from "#components/ak-label";
 
 import { FlowUserDetails } from "#flow/FormStatic";
 import { BaseStage } from "#flow/stages/base";
+import { RESEND_COOLDOWN_SECONDS, startResendCooldown } from "#flow/stages/resend-cooldown";
 
 import {
     AuthenticatorEmailChallenge,
@@ -16,7 +17,7 @@ import {
 
 import { msg, str } from "@lit/localize";
 import { CSSResult, html, nothing, TemplateResult } from "lit";
-import { customElement } from "lit/decorators.js";
+import { customElement, state } from "lit/decorators.js";
 
 import PFAlert from "@patternfly/patternfly/components/Alert/alert.css";
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
@@ -40,6 +41,55 @@ export class AuthenticatorEmailStage extends BaseStage<
         PFTitle,
         PFButton,
     ];
+
+    @state()
+    protected resendCooldown = 0;
+
+    #cancelCooldown?: () => void;
+    #cooldownStarted = false;
+
+    #beginCooldown() {
+        this.#cancelCooldown?.();
+        this.#cancelCooldown = startResendCooldown(RESEND_COOLDOWN_SECONDS, (remaining) => {
+            this.resendCooldown = remaining;
+        });
+    }
+
+    #resend = () => {
+        if (this.resendCooldown > 0) {
+            return;
+        }
+        // Submit with neither code nor email; the backend treats this as a resend request and
+        // re-sends a fresh code to the same address. Only start the visible cooldown once the
+        // submit resolves successfully, so a failed resend doesn't disable the button for nothing.
+        this.host
+            ?.submit(
+                {
+                    component: "ak-stage-authenticator-email",
+                } as AuthenticatorEmailChallengeResponseRequest,
+                { invisible: true },
+            )
+            ?.then((ok) => {
+                if (ok) {
+                    this.#beginCooldown();
+                }
+            })
+            .catch(() => undefined);
+    };
+
+    protected override willUpdate(): void {
+        // The OTP screen is only reached once a code has been mailed out, so start counting from
+        // there rather than from the first click.
+        if (!this.#cooldownStarted && this.challenge && !this.challenge.emailRequired) {
+            this.#cooldownStarted = true;
+            this.#beginCooldown();
+        }
+    }
+
+    override disconnectedCallback(): void {
+        this.#cancelCooldown?.();
+        super.disconnectedCallback();
+    }
 
     renderEmailInput(): TemplateResult {
         return html`<ak-flow-card .challenge=${this.challenge}>
@@ -120,6 +170,15 @@ export class AuthenticatorEmailStage extends BaseStage<
                     ${AKFormErrors({ errors: this.challenge.responseErrors?.code })}
                 </div>
                 ${this.renderNonFieldErrors()}
+                <div class="pf-c-form__helper-text">
+                    ${this.resendCooldown > 0
+                        ? msg(
+                              str`Didn't get the code? It can take a moment and may land in your spam or junk folder. You can request a new code in ${this.resendCooldown} seconds.`,
+                          )
+                        : msg(
+                              "Didn't get the code? It can take a moment and may land in your spam or junk folder. You can also resend it.",
+                          )}
+                </div>
                 <fieldset class="ak-c-fieldset pf-c-form__group pf-m-action">
                     <legend class="sr-only">${msg("Form actions")}</legend>
                     <button
@@ -128,6 +187,17 @@ export class AuthenticatorEmailStage extends BaseStage<
                         class="pf-c-button pf-m-primary pf-m-block"
                     >
                         ${msg("Continue")}
+                    </button>
+                    <button
+                        name="resend"
+                        type="button"
+                        class="pf-c-button pf-m-secondary pf-m-block"
+                        ?disabled=${this.resendCooldown > 0}
+                        @click=${this.#resend}
+                    >
+                        ${this.resendCooldown > 0
+                            ? msg(str`Resend code (${this.resendCooldown}s)`)
+                            : msg("Resend code")}
                     </button>
                 </fieldset>
             </form>

--- a/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStage.ts
+++ b/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStage.ts
@@ -181,6 +181,26 @@ export class AuthenticatorValidateStage
         this.selectedDeviceChallenge = null;
     }
 
+    public resendSelectedChallenge(): Promise<unknown> {
+        const value = this.#selectedDeviceChallenge;
+        const component = this.challenge?.component;
+        if (!value || !component) {
+            // Nothing selected yet, or the challenge is momentarily undefined — sending an empty
+            // component would just be rejected, so treat it as a no-op the caller can await.
+            return Promise.reject(new Error("no challenge selected"));
+        }
+        // Re-submit the current device selection. The backend re-runs select_challenge, which
+        // for an email device regenerates the token and re-sends the code — i.e. a resend.
+        return this.#api.flowsExecutorSolve({
+            flowSlug: this.host?.flowSlug || "",
+            query: window.location.search.substring(1),
+            flowChallengeResponseRequest: {
+                component: component as unknown as "ak-stage-authenticator-validate",
+                selectedChallenge: value,
+            },
+        });
+    }
+
     protected override willUpdate(changed: PropertyValues<this>) {
         // When moving between multiple authenticator-validate stages in one flow, the element
         // instance is reused. Reset selection if it is no longer valid in the new challenge.

--- a/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStageCode.ts
+++ b/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStageCode.ts
@@ -7,6 +7,7 @@ import { AKLabel } from "#components/ak-label";
 
 import { BaseDeviceStage } from "#flow/stages/authenticator_validate/base";
 import { PasswordManagerPrefill } from "#flow/stages/identification/IdentificationStage";
+import { RESEND_COOLDOWN_SECONDS, startResendCooldown } from "#flow/stages/resend-cooldown";
 
 import {
     AuthenticatorValidationChallenge,
@@ -14,9 +15,9 @@ import {
     DeviceClassesEnum,
 } from "@goauthentik/api";
 
-import { msg } from "@lit/localize";
-import { html, LitElement, TemplateResult } from "lit";
-import { customElement } from "lit/decorators.js";
+import { msg, str } from "@lit/localize";
+import { html, LitElement, nothing, TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
 
 @customElement("ak-stage-authenticator-validate-code")
 export class AuthenticatorValidateStageWebCode extends BaseDeviceStage<
@@ -25,8 +26,48 @@ export class AuthenticatorValidateStageWebCode extends BaseDeviceStage<
 > {
     static shadowRootOptions = { ...LitElement.shadowRootOptions, delegatesFocus: true };
 
+    @state()
+    protected resendCooldown = 0;
+
+    #cancelCooldown?: () => void;
+    #cooldownStarted = false;
+
+    #beginCooldown() {
+        this.#cancelCooldown?.();
+        this.#cancelCooldown = startResendCooldown(RESEND_COOLDOWN_SECONDS, (remaining) => {
+            this.resendCooldown = remaining;
+        });
+    }
+
+    #resend = () => {
+        if (this.resendCooldown > 0) {
+            return;
+        }
+        // Only start the visible cooldown once the resend request actually succeeds, so a failed
+        // request does not leave the button disabled with no code on its way.
+        this.host
+            ?.resendSelectedChallenge?.()
+            ?.then(() => this.#beginCooldown())
+            .catch(() => undefined);
+    };
+
+    protected override willUpdate(): void {
+        // Reaching this stage means a code was just mailed out, so the cooldown starts here
+        // rather than on the first click.
+        if (!this.#cooldownStarted && this.deviceChallenge?.deviceClass === DeviceClassesEnum.Email) {
+            this.#cooldownStarted = true;
+            this.#beginCooldown();
+        }
+    }
+
+    override disconnectedCallback(): void {
+        this.#cancelCooldown?.();
+        super.disconnectedCallback();
+    }
+
     render(): TemplateResult {
         const staticDevice = this.deviceChallenge?.deviceClass === DeviceClassesEnum.Static;
+        const emailDevice = this.deviceChallenge?.deviceClass === DeviceClassesEnum.Email;
 
         return html`<form class="pf-c-form" @submit=${this.submitForm}>
             ${this.renderUserInfo()}
@@ -58,6 +99,17 @@ export class AuthenticatorValidateStageWebCode extends BaseDeviceStage<
                 <div class="pf-c-form__helper-text" id="validation-code-help">
                     ${formatDeviceChallengeMessage(this.deviceChallenge)}
                 </div>
+                ${emailDevice
+                    ? html`<div class="pf-c-form__helper-text">
+                          ${this.resendCooldown > 0
+                              ? msg(
+                                    str`Didn't get the code? It can take a moment and may land in your spam or junk folder. You can request a new code in ${this.resendCooldown} seconds.`,
+                                )
+                              : msg(
+                                    "Didn't get the code? It can take a moment and may land in your spam or junk folder. You can also resend it.",
+                                )}
+                      </div>`
+                    : nothing}
 
                 ${AKFormErrors({ errors: this.challenge?.responseErrors?.code })}
             </fieldset>
@@ -67,6 +119,19 @@ export class AuthenticatorValidateStageWebCode extends BaseDeviceStage<
                 <button name="continue" type="submit" class="pf-c-button pf-m-primary pf-m-block">
                     ${msg("Continue")}
                 </button>
+                ${emailDevice
+                    ? html`<button
+                          name="resend"
+                          type="button"
+                          class="pf-c-button pf-m-secondary pf-m-block"
+                          ?disabled=${this.resendCooldown > 0}
+                          @click=${this.#resend}
+                      >
+                          ${this.resendCooldown > 0
+                              ? msg(str`Resend code (${this.resendCooldown}s)`)
+                              : msg("Resend code")}
+                      </button>`
+                    : nothing}
                 ${this.renderReturnToDevicePicker()}
             </fieldset>
         </form>`;

--- a/web/src/flow/stages/resend-cooldown.ts
+++ b/web/src/flow/stages/resend-cooldown.ts
@@ -1,0 +1,31 @@
+/**
+ * Client-side cooldown for "resend code" buttons.
+ *
+ * This only drives the UI. The server applies the same window per email address, so a client that
+ * skips the countdown still cannot use the resend endpoint to mail-bomb an address.
+ */
+export const RESEND_COOLDOWN_SECONDS = 60;
+
+/**
+ * Count `seconds` down to zero, calling `onTick` immediately and once per second after that.
+ * Returns a function that cancels the countdown.
+ */
+export function startResendCooldown(
+    seconds: number,
+    onTick: (remaining: number) => void,
+): () => void {
+    let remaining = seconds;
+
+    onTick(remaining);
+
+    const timer = setInterval(() => {
+        remaining -= 1;
+        onTick(Math.max(remaining, 0));
+
+        if (remaining <= 0) {
+            clearInterval(timer);
+        }
+    }, 1000);
+
+    return () => clearInterval(timer);
+}

--- a/web/src/flow/types.ts
+++ b/web/src/flow/types.ts
@@ -77,6 +77,7 @@ export interface StageHost {
     flowSlug?: string;
     loading: boolean;
     reset?: () => void;
+    resendSelectedChallenge?: () => Promise<unknown>;
     submit(payload: unknown, options?: SubmitOptions): Promise<boolean>;
 
     readonly brand?: CurrentBrand;


### PR DESCRIPTION
## Details

### What does this PR change?

Adds a "resend code" action to the email authenticator, on both the email setup stage and the validation stage's already-registered-device path.

The resend is rate limited so it cannot be used to flood an address:

- a 60-second cooldown enforced **server-side, keyed by email address**, using `cache.add` (Redis `SETNX`) so a burst of concurrent requests cannot race past it;
- the countdown shown in the web UI is cosmetic — a client that skips it still hits the server-side limit;
- a failed send releases the reserved window, so a delivery error does not lock the address out for the full interval.

New file `web/src/flow/stages/resend-cooldown.ts` holds the small client-side countdown helper shared by both stages.

### Why is this change needed?

Today the email authenticator sends a single code and offers no way to request another. If that code never arrives (spam folder, delivery delay, mistyped inbox), the user is stuck and has to abandon the flow. A resend button is the obvious fix, but a naive one turns the send endpoint into a mail bomb, so the throttle is part of the same change rather than a follow-up.

### How was this tested?

- New unit tests in `authentik/stages/authenticator_email/tests.py` (`TestAuthenticatorEmailResendThrottle`) cover the throttle: first send allowed, resend within the window refused with the remaining seconds, the countdown shrinking as the window elapses, the window reopening after `release_send`, per-address isolation, case-insensitive address matching, and the empty-address no-op. All pass against a real Django cache backend.
- `ruff check` and `ruff format --check` pass on the changed Python.

I was not able to run the full `make all` (web build/lint) in my local environment; CI will exercise those.

### Linked issues

- https://github.com/goauthentik/authentik/issues/22817

## Screenshot

<img width="548" height="577" alt="2026-07-30 20 28 53" src="https://github.com/user-attachments/assets/f8eb07d4-b936-42e0-bc0f-227c3cd3c403" />


---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [x] The documentation has been updated and formatted (`make docs`)
