### PR TITLE
providers/oauth2: fix iframe logout stage progression

### DIFF
--- a/authentik/providers/oauth2/tests/test_end_session.py
+++ b/authentik/providers/oauth2/tests/test_end_session.py
@@ -226,7 +226,7 @@ class TestEndSessionView(OAuthTestCase):
             HTTP_HOST=self.brand.domain,
         )
 
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(self.client.session[SESSION_KEY_PLAN].flow_pk, plan.flow_pk)
 
     def test_frontchannel_iframe_callback_preserves_injected_stages(self):

--- a/authentik/providers/oauth2/tests/test_end_session.py
+++ b/authentik/providers/oauth2/tests/test_end_session.py
@@ -2,11 +2,18 @@
 
 from django.test import RequestFactory
 from django.urls import reverse
+from django.utils.timezone import now
 
-from authentik.core.models import Application
+from authentik.core.models import Application, AuthenticatedSession, Session
 from authentik.core.tests.utils import create_test_admin_user, create_test_brand, create_test_flow
+from authentik.flows.models import FlowDesignation, FlowStageBinding, in_memory_stage
+from authentik.flows.planner import FlowPlan
+from authentik.flows.views.executor import SESSION_KEY_PLAN
 from authentik.lib.generators import generate_id
+from authentik.lib.utils.time import timedelta_from_string
 from authentik.providers.oauth2.models import (
+    AccessToken,
+    OAuth2LogoutMethod,
     OAuth2Provider,
     RedirectURI,
     RedirectURIMatchingMode,
@@ -14,6 +21,10 @@ from authentik.providers.oauth2.models import (
 )
 from authentik.providers.oauth2.tests.utils import OAuthTestCase
 from authentik.providers.oauth2.views.end_session import EndSessionView
+from authentik.stages.dummy.stage import DummyStageView
+from authentik.stages.user_login.models import UserLoginStage
+from authentik.stages.user_logout.models import UserLogoutStage
+from authentik.stages.user_logout.stage import flow_pre_user_logout
 
 
 class TestEndSessionView(OAuthTestCase):
@@ -178,6 +189,118 @@ class TestEndSessionView(OAuthTestCase):
             HTTP_HOST=self.brand.domain,
         )
         self.assertEqual(response.status_code, 302)
+
+    def _brand_authentication_flow(self) -> None:
+        """Give the brand a usable authentication flow.
+
+        Without one, `handle_no_permission` raises Http404 instead of planning a flow, which
+        would mask the regression these tests guard against.
+        """
+        authentication_flow = create_test_flow(FlowDesignation.AUTHENTICATION)
+        FlowStageBinding.objects.create(
+            target=authentication_flow,
+            stage=UserLoginStage.objects.create(name=generate_id()),
+            order=0,
+        )
+        self.brand.flow_authentication = authentication_flow
+        self.brand.save()
+
+    def test_active_flow_plan_returns_early(self):
+        """An end-session request during an active flow plan must not touch that plan.
+
+        Front-channel logout iframes reach this endpoint while the invalidation flow is
+        still running. Falling through to PolicyAccessView would plan an authentication
+        flow and overwrite SESSION_KEY_PLAN.
+        """
+        self._brand_authentication_flow()
+        plan = FlowPlan(flow_pk=self.invalidation_flow.pk.hex)
+        session = self.client.session
+        session[SESSION_KEY_PLAN] = plan
+        session.save()
+
+        response = self.client.get(
+            reverse(
+                "authentik_providers_oauth2:end-session",
+                kwargs={"application_slug": self.app.slug},
+            ),
+            HTTP_HOST=self.brand.domain,
+        )
+
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(self.client.session[SESSION_KEY_PLAN].flow_pk, plan.flow_pk)
+
+    def test_frontchannel_iframe_callback_preserves_injected_stages(self):
+        """Stages injected into the logout plan survive the iframe's end-session hit.
+
+        Regression test: the hidden logout iframe navigates to end-session after
+        UserLogoutStage has already logged the user out, so the request is anonymous.
+        Planning an authentication flow there replaces SESSION_KEY_PLAN, and the executor
+        then discards the invalidation plan and re-plans it from the flow's bindings. Stages
+        injected by `flow_pre_user_logout` receivers exist only in memory, so they are lost.
+        """
+        self._brand_authentication_flow()
+        logout_flow = create_test_flow(FlowDesignation.INVALIDATION)
+        FlowStageBinding.objects.create(
+            target=logout_flow,
+            stage=UserLogoutStage.objects.create(name=generate_id()),
+            order=0,
+        )
+        self.brand.flow_invalidation = logout_flow
+        self.brand.save()
+
+        self.provider.logout_method = OAuth2LogoutMethod.FRONTCHANNEL
+        self.provider.logout_uri = "https://rp.example.com/logout"
+        self.provider.invalidation_flow = logout_flow
+        self.provider.save()
+
+        # Mirror a provider signal injecting a front-channel logout stage after the iframe
+        # stage, the way the SAML native logout and SAML source SLO stages do.
+        def inject_stage(sender, executor, **_):
+            executor.plan.append_stage(
+                in_memory_stage(DummyStageView, name="injected", throw_error=False)
+            )
+
+        flow_pre_user_logout.connect(inject_stage, weak=False)
+        self.addCleanup(flow_pre_user_logout.disconnect, inject_stage)
+
+        self.client.force_login(self.user)
+        session = Session.objects.filter(session_key=self.client.session.session_key).first()
+        auth_session = AuthenticatedSession.objects.filter(session=session).first()
+        AccessToken.objects.create(
+            provider=self.provider,
+            user=self.user,
+            session=auth_session,
+            token=generate_id(),
+            _scope="openid",
+            auth_time=now(),
+            expires=now() + timedelta_from_string("days=1"),
+        )
+
+        executor = reverse("authentik_api:flow-executor", kwargs={"flow_slug": logout_flow.slug})
+        response = self.client.get(executor, follow=True)
+        self.assertEqual(response.json()["component"], "ak-provider-iframe-logout")
+
+        # The hidden logout iframe navigates back into authentik. The user is anonymous now.
+        self.client.get(
+            reverse(
+                "authentik_providers_oauth2:end-session",
+                kwargs={"application_slug": self.app.slug},
+            ),
+        )
+        self.assertEqual(
+            self.client.session[SESSION_KEY_PLAN].flow_pk,
+            logout_flow.pk.hex,
+            "end-session replaced the in-flight invalidation plan",
+        )
+
+        # The stage injected after the iframe logout stage must still run.
+        self.client.post(
+            executor,
+            data={"component": "ak-provider-iframe-logout"},
+            content_type="application/json",
+        )
+        response = self.client.get(executor)
+        self.assertEqual(response.json()["component"], "ak-stage-dummy")
 
 
 class TestEndSessionAPI(OAuthTestCase):

--- a/authentik/providers/oauth2/views/end_session.py
+++ b/authentik/providers/oauth2/views/end_session.py
@@ -121,7 +121,7 @@ class EndSessionView(PolicyAccessView):
         queued after the iframe logout stage.
         """
         if SESSION_KEY_PLAN in request.session:
-            return HttpResponse(status=204)
+            return HttpResponse(status=200)
         return super().dispatch(request, *args, **kwargs)
 
     def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:

--- a/authentik/providers/oauth2/views/end_session.py
+++ b/authentik/providers/oauth2/views/end_session.py
@@ -21,6 +21,7 @@ from authentik.flows.planner import (
     FlowPlanner,
 )
 from authentik.flows.stage import SessionEndStage
+from authentik.flows.views.executor import SESSION_KEY_PLAN
 from authentik.lib.views import bad_request_message
 from authentik.policies.views import PolicyAccessView
 from authentik.providers.iframe_logout import IframeLogoutStageView
@@ -109,6 +110,19 @@ class EndSessionView(PolicyAccessView):
             self.post_logout_redirect_uri = (
                 f"{self.post_logout_redirect_uri}{separator}state={quote(state, safe='')}"
             )
+
+    def dispatch(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        """Return early when a flow plan is already executing in this session.
+
+        Front-channel logout iframes navigate to this endpoint while the invalidation flow
+        is still running, and `UserLogoutStage` has already made the request anonymous.
+        Falling through to `PolicyAccessView` would plan an authentication flow and store it
+        in `SESSION_KEY_PLAN`, replacing the invalidation plan and discarding every stage
+        queued after the iframe logout stage.
+        """
+        if SESSION_KEY_PLAN in request.session:
+            return HttpResponse(status=204)
+        return super().dispatch(request, *args, **kwargs)
 
     def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
         """Dispatch the flow planner for the invalidation flow"""


### PR DESCRIPTION
<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?

This prevents responses on the iframe logout stage from wiping the memory of the next logout stages and breaking single logout

### Why is this change needed?

Without it, native logouts and saml source logouts will not work

### How was this tested?

Setting up a saml source, iframe provider, and native logout provider, logging them all in, then logging out

### Linked issues

<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
