### PR TITLE
lifecycle/container: remove curl and perl from the container image

### DIFF
--- a/lifecycle/container/Dockerfile
+++ b/lifecycle/container/Dockerfile
@@ -258,7 +258,10 @@ RUN apt-get update && \
     ln -s /media /data/media && \
     mkdir -p /authentik/.ssh && \
     mkdir -p /ak-root && \
-    chown authentik:authentik /certs /data /data/media /media /authentik/.ssh /ak-root
+    chown authentik:authentik /certs /data /data/media /media /authentik/.ssh /ak-root && \
+    # remove runtime-unused packages until we have separate build/run images
+    dpkg --purge --force-remove-essential --force-depends \
+      curl libcurl4t64 perl perl-base perl-modules-5.40 libperl5.40 sysuser-helper
 
 COPY ./authentik/ /authentik
 COPY ./pyproject.toml /


### PR DESCRIPTION
Reduces CRITICAL/HIGH vulnerabilities from 80 to 20:

### Before

```
 ✔ Scanned for vulnerabilities     [276 vulnerability matches]
   ├── by severity: 26 critical, 54 high, 60 medium, 5 low, 95 negligible (36 unknown)
   └── by status:   5 fixed, 271 not-fixed, 0 ignored
```

### After:

```
 ✔ Scanned for vulnerabilities     [194 vulnerability matches]
   ├── by severity: 2 critical, 18 high, 50 medium, 5 low, 83 negligible (36 unknown)
   └── by status:   5 fixed, 189 not-fixed, 0 ignored
```

### Details

Container image security scanners like `grype` or `trivy` report even CVEs which have no fixes, like these curl/perl ones:

```
curl                8.14.1-2+deb13u4                      (won't fix)  deb     CVE-2026-11856       Critical    1.1% (60th)   1.0
curl                8.14.1-2+deb13u4                      (won't fix)  deb     CVE-2026-9079        Critical    1.1% (60th)   1.0
libcurl4t64         8.14.1-2+deb13u4                      (won't fix)  deb     CVE-2026-11856       Critical    1.1% (60th)   1.0
libcurl4t64         8.14.1-2+deb13u4                      (won't fix)  deb     CVE-2026-9079        Critical    1.1% (60th)   1.0
curl                8.14.1-2+deb13u4                      (won't fix)  deb     CVE-2026-10536       Critical    0.9% (55th)   0.8
libcurl4t64         8.14.1-2+deb13u4                      (won't fix)  deb     CVE-2026-10536       Critical    0.9% (55th)   0.8
curl                8.14.1-2+deb13u4                      (won't fix)  deb     CVE-2026-8927        Critical    0.8% (50th)   0.7
libcurl4t64         8.14.1-2+deb13u4                      (won't fix)  deb     CVE-2026-8927        Critical    0.8% (50th)   0.7
curl                8.14.1-2+deb13u4                      (won't fix)  deb     CVE-2026-8924        Critical    0.6% (46th)   0.6
libcurl4t64         8.14.1-2+deb13u4                      (won't fix)  deb     CVE-2026-8924        Critical    0.6% (46th)   0.6
curl                8.14.1-2+deb13u4                      (won't fix)  deb     CVE-2026-8926        Critical    0.6% (45th)   0.6
libcurl4t64         8.14.1-2+deb13u4                      (won't fix)  deb     CVE-2026-8926        Critical    0.6% (45th)   0.6
curl                8.14.1-2+deb13u4                      (won't fix)  deb     CVE-2026-12064       High        0.6% (43rd)   0.4
libcurl4t64         8.14.1-2+deb13u4                      (won't fix)  deb     CVE-2026-12064       High        0.6% (43rd)   0.4
curl                8.14.1-2+deb13u4                      (won't fix)  deb     CVE-2026-8286        High        0.5% (40th)   0.4
libcurl4t64         8.14.1-2+deb13u4                      (won't fix)  deb     CVE-2026-8286        High        0.5% (40th)   0.4
libperl5.40         5.40.1-6                              (won't fix)  deb     CVE-2026-42496       Critical    0.4% (34th)   0.4
perl                5.40.1-6                              (won't fix)  deb     CVE-2026-42496       Critical    0.4% (34th)   0.4
perl-base           5.40.1-6                              (won't fix)  deb     CVE-2026-42496       Critical    0.4% (34th)   0.4
perl-modules-5.40   5.40.1-6                              (won't fix)  deb     CVE-2026-42496       Critical    0.4% (34th)   0.4
curl                8.14.1-2+deb13u4                      (won't fix)  deb     CVE-2026-9547        High        0.5% (39th)   0.4
libcurl4t64         8.14.1-2+deb13u4                      (won't fix)  deb     CVE-2026-9547        High        0.5% (39th)   0.4
libperl5.40         5.40.1-6                              (won't fix)  deb     CVE-2026-8376        Critical    0.4% (31st)   0.4
perl                5.40.1-6                              (won't fix)  deb     CVE-2026-8376        Critical    0.4% (31st)   0.4
perl-base           5.40.1-6                              (won't fix)  deb     CVE-2026-8376        Critical    0.4% (31st)   0.4
perl-modules-5.40   5.40.1-6                              (won't fix)  deb     CVE-2026-8376        Critical    0.4% (31st)   0.4
curl                8.14.1-2+deb13u4                      (won't fix)  deb     CVE-2026-9080        High        0.5% (38th)   0.4
libcurl4t64         8.14.1-2+deb13u4                      (won't fix)  deb     CVE-2026-9080        High        0.5% (38th)   0.4
libperl5.40         5.40.1-6                                           deb     CVE-2026-12087       Critical    0.4% (31st)   0.4
perl                5.40.1-6                                           deb     CVE-2026-12087       Critical    0.4% (31st)   0.4
perl-base           5.40.1-6                                           deb     CVE-2026-12087       Critical    0.4% (31st)   0.4
perl-modules-5.40   5.40.1-6                                           deb     CVE-2026-12087       Critical    0.4% (31st)   0.4
libperl5.40         5.40.1-6                              (won't fix)  deb     CVE-2026-9538        High        0.4% (35th)   0.3
perl                5.40.1-6                              (won't fix)  deb     CVE-2026-9538        High        0.4% (35th)   0.3
perl-base           5.40.1-6                              (won't fix)  deb     CVE-2026-9538        High        0.4% (35th)   0.3
perl-modules-5.40   5.40.1-6                              (won't fix)  deb     CVE-2026-9538        High        0.4% (35th)   0.3
libperl5.40         5.40.1-6                              (won't fix)  deb     CVE-2026-42497       High        0.4% (33rd)   0.3
perl                5.40.1-6                              (won't fix)  deb     CVE-2026-42497       High        0.4% (33rd)   0.3
perl-base           5.40.1-6                              (won't fix)  deb     CVE-2026-42497       High        0.4% (33rd)   0.3
perl-modules-5.40   5.40.1-6                              (won't fix)  deb     CVE-2026-42497       High        0.4% (33rd)   0.3
curl                8.14.1-2+deb13u4                      (won't fix)  deb     CVE-2026-8458        Medium      0.5% (41st)   0.3
libcurl4t64         8.14.1-2+deb13u4                      (won't fix)  deb     CVE-2026-8458        Medium      0.5% (41st)   0.3
curl                8.14.1-2+deb13u4                      (won't fix)  deb     CVE-2026-9545        High        0.4% (32nd)   0.3
libcurl4t64         8.14.1-2+deb13u4                      (won't fix)  deb     CVE-2026-9545        High        0.4% (32nd)   0.3
libperl5.40         5.40.1-6                                           deb     CVE-2026-48959       High        0.4% (29th)   0.3
perl                5.40.1-6                                           deb     CVE-2026-48959       High        0.4% (29th)   0.3
perl-base           5.40.1-6                                           deb     CVE-2026-48959       High        0.4% (29th)   0.3
perl-modules-5.40   5.40.1-6                                           deb     CVE-2026-48959       High        0.4% (29th)   0.3
curl                8.14.1-2+deb13u4                      (won't fix)  deb     CVE-2026-8932        High        0.4% (28th)   0.3
libcurl4t64         8.14.1-2+deb13u4                      (won't fix)  deb     CVE-2026-8932        High        0.4% (28th)   0.3
libperl5.40         5.40.1-6                                           deb     CVE-2026-48962       High        0.3% (21st)   0.2
perl                5.40.1-6                                           deb     CVE-2026-48962       High        0.3% (21st)   0.2
perl-base           5.40.1-6                                           deb     CVE-2026-48962       High        0.3% (21st)   0.2
perl-modules-5.40   5.40.1-6                                           deb     CVE-2026-48962       High        0.3% (21st)   0.2
libperl5.40         5.40.1-6                                           deb     CVE-2026-48961       High        0.3% (17th)   0.2
perl                5.40.1-6                                           deb     CVE-2026-48961       High        0.3% (17th)   0.2
perl-base           5.40.1-6                                           deb     CVE-2026-48961       High        0.3% (17th)   0.2
perl-modules-5.40   5.40.1-6                                           deb     CVE-2026-48961       High        0.3% (17th)   0.2
libperl5.40         5.40.1-6                                           deb     CVE-2026-7017        High        0.3% (17th)   0.2
perl                5.40.1-6                                           deb     CVE-2026-7017        High        0.3% (17th)   0.2
perl-base           5.40.1-6                                           deb     CVE-2026-7017        High        0.3% (17th)   0.2
perl-modules-5.40   5.40.1-6                                           deb     CVE-2026-7017        High        0.3% (17th)   0.2
libperl5.40         5.40.1-6                                           deb     CVE-2026-7010        Medium      0.2% (13th)   0.1
perl                5.40.1-6                                           deb     CVE-2026-7010        Medium      0.2% (13th)   0.1
perl-base           5.40.1-6                                           deb     CVE-2026-7010        Medium      0.2% (13th)   0.1
perl-modules-5.40   5.40.1-6                                           deb     CVE-2026-7010        Medium      0.2% (13th)   0.1
libperl5.40         5.40.1-6                                           deb     CVE-2025-15649       Medium      0.1% (2nd)    < 0.1
perl                5.40.1-6                                           deb     CVE-2025-15649       Medium      0.1% (2nd)    < 0.1
perl-base           5.40.1-6                                           deb     CVE-2025-15649       Medium      0.1% (2nd)    < 0.1
perl-modules-5.40   5.40.1-6                                           deb     CVE-2025-15649       Medium      0.1% (2nd)    < 0.1
libperl5.40         5.40.1-6                                           deb     CVE-2011-4116        Negligible  0.5% (40th)   < 0.1
perl                5.40.1-6                                           deb     CVE-2011-4116        Negligible  0.5% (40th)   < 0.1
perl-base           5.40.1-6                                           deb     CVE-2011-4116        Negligible  0.5% (40th)   < 0.1
perl-modules-5.40   5.40.1-6                                           deb     CVE-2011-4116        Negligible  0.5% (40th)   < 0.1
curl                8.14.1-2+deb13u4                                   deb     CVE-2025-15079       Negligible  0.5% (36th)   < 0.1
libcurl4t64         8.14.1-2+deb13u4                                   deb     CVE-2025-15079       Negligible  0.5% (36th)   < 0.1
curl                8.14.1-2+deb13u4                                   deb     CVE-2025-15224       Negligible  0.4% (33rd)   < 0.1
libcurl4t64         8.14.1-2+deb13u4                                   deb     CVE-2025-15224       Negligible  0.4% (33rd)   < 0.1
curl                8.14.1-2+deb13u4                                   deb     CVE-2025-10966       Negligible  0.4% (31st)   < 0.1
libcurl4t64         8.14.1-2+deb13u4                                   deb     CVE-2025-10966       Negligible  0.4% (31st)   < 0.1
curl                8.14.1-2+deb13u4                                   deb     CVE-2025-14017       Negligible  0.1% (1st)    < 0.1
libcurl4t64         8.14.1-2+deb13u4                                   deb     CVE-2025-14017       Negligible  0.1% (1st)    < 0.1
```

Since we only use these at build time, they should be removed from the runtime image (at least until we have separate build/runtime images), which also reduces the attack surface.

