### PR TITLE
providers/scim: improve error display when error doesn't conform to scim schema

### DIFF
--- a/authentik/providers/scim/clients/exceptions.py
+++ b/authentik/providers/scim/clients/exceptions.py
@@ -16,7 +16,7 @@ class SCIMRequestException(TransientSyncException):
     def __init__(self, response: Response | None = None, message: str | None = None) -> None:
         super().__init__(response)
         self._response = response
-        self._message = message
+        self._message = message or self.error_default
 
     def detail(self) -> str:
         """Get human readable details of this error"""

--- a/authentik/providers/scim/clients/exceptions.py
+++ b/authentik/providers/scim/clients/exceptions.py
@@ -27,9 +27,7 @@ class SCIMRequestException(TransientSyncException):
             return error.detail
         except ValidationError:
             pass
-        return self._message
+        return self._response.text
 
     def __str__(self):
-        if self._response:
-            return self._response.text
-        return super().__str__()
+        return self.detail()


### PR DESCRIPTION
currently this leads to some errors just being `''`