### PR TITLE
ci: Run and gate on unit tests in CI.

### DIFF
--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -104,4 +104,4 @@ jobs:
           pnpm --dir web install --frozen-lockfile
       - name: test
         working-directory: web/
-        run: pnpm run test || exit 0
+        run: pnpm exec vitest run --project "Unit Tests"

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -108,4 +108,4 @@ jobs:
           pnpm --dir web install --frozen-lockfile
       - name: test
         working-directory: web/
-        run: pnpm run test || exit 0
+        run: pnpm exec vitest run --project "Unit Tests"


### PR DESCRIPTION
## Details

### What does this PR change?

The CI test step ran bare `vitest` (every project, including Playwright-backed browser tests that can't run in that job) and discarded the result with `|| exit 0` — so unit test failures never failed CI. The step now runs only the Unit Tests project, and its exit code counts.

Stacked on #23991, which un-breaks co-located unit tests so there is a fully green suite to gate on.

### Why is this change needed?

Upcoming router PRs (#23990, #23988) rely on unit tests gating regressions. A test step that cannot fail gates nothing.

### How was this tested?

`pnpm exec vitest run --project "Unit Tests"` from `web/` (the exact command CI now runs): 4 files / 41 tests pass on this branch.

### Linked issues

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
