### PR TITLE
web: Add path-router primitives.

### DIFF
--- a/web/src/elements/router/core/Route.ts
+++ b/web/src/elements/router/core/Route.ts
@@ -1,0 +1,55 @@
+/**
+ * @file Route definition for path-based routing.
+ *
+ * A `Route` wraps a `URLPattern` constructed **once** at construction (never
+ * per match) and renders a template for the matched path parameters. The
+ * `name` is a stable identifier used for Sentry span naming and href
+ * generation.
+ */
+
+import { type RouteParameterRecord } from "#elements/router/core/parameters";
+
+import { type SlottedTemplateResult } from "#elements/types";
+
+import { html, nothing, TemplateResult } from "lit";
+import { until } from "lit/directives/until.js";
+
+export type RouteRenderCallback<P> = (
+    params: P,
+) => SlottedTemplateResult | Promise<SlottedTemplateResult>;
+
+export class Route<P extends RouteParameterRecord = RouteParameterRecord> {
+    /**
+     * The compiled pattern, built once at construction.
+     */
+    public readonly pattern: URLPattern;
+
+    /**
+     * Stable identifier for Sentry spans and href generation.
+     */
+    public readonly name: string;
+
+    #render: RouteRenderCallback<P>;
+
+    constructor(
+        patternInit: URLPatternInit | string,
+        render: RouteRenderCallback<P>,
+        name?: string,
+    ) {
+        const init: URLPatternInit =
+            typeof patternInit === "string" ? { pathname: patternInit } : patternInit;
+
+        this.pattern = new URLPattern(init);
+        this.name = name ?? init.pathname ?? "";
+        this.#render = render;
+    }
+
+    /**
+     * Render the route's template for the given path parameters.
+     *
+     * The pending state is `nothing`; loading UI is the outlet's concern.
+     */
+    render(params: P): TemplateResult {
+        return html`${until(this.#render(params), nothing)}`;
+    }
+}

--- a/web/src/elements/router/core/Route.ts
+++ b/web/src/elements/router/core/Route.ts
@@ -8,7 +8,6 @@
  */
 
 import { type RouteParameterRecord } from "#elements/router/core/parameters";
-
 import { type SlottedTemplateResult } from "#elements/types";
 
 import { html, nothing, TemplateResult } from "lit";

--- a/web/src/elements/router/core/Route.unit.test.ts
+++ b/web/src/elements/router/core/Route.unit.test.ts
@@ -1,7 +1,8 @@
 import { Route } from "./Route.js";
 
-import { html } from "lit";
 import { describe, expect, it, vi } from "vitest";
+
+import { html } from "lit";
 
 describe("Route", () => {
     it("compiles the pattern once at construction", () => {

--- a/web/src/elements/router/core/Route.unit.test.ts
+++ b/web/src/elements/router/core/Route.unit.test.ts
@@ -1,0 +1,42 @@
+import { Route } from "./Route.js";
+
+import { html } from "lit";
+import { describe, expect, it, vi } from "vitest";
+
+describe("Route", () => {
+    it("compiles the pattern once at construction", () => {
+        const route = new Route("/users/:id", () => html`ok`);
+
+        expect(route.pattern).toBeInstanceOf(URLPattern);
+        // The pattern is a stored instance, not rebuilt per access.
+        expect(route.pattern).toBe(route.pattern);
+        expect(route.pattern.exec({ pathname: "/users/42" })?.pathname.groups.id).toBe("42");
+    });
+
+    it("accepts a URLPatternInit object", () => {
+        const route = new Route({ pathname: "/groups/:id" }, () => html`ok`);
+
+        expect(route.pattern.exec({ pathname: "/groups/7" })?.pathname.groups.id).toBe("7");
+    });
+
+    it("derives a name from the pathname when none is given", () => {
+        const route = new Route("/users/:id", () => html`ok`);
+
+        expect(route.name).toBe("/users/:id");
+    });
+
+    it("uses an explicit name when provided", () => {
+        const route = new Route("/users/:id", () => html`ok`, "user-detail");
+
+        expect(route.name).toBe("user-detail");
+    });
+
+    it("invokes the render callback with the matched params", () => {
+        const render = vi.fn(() => html`ok`);
+        const route = new Route<{ id: string }>("/users/:id", render);
+
+        route.render({ id: "42" });
+
+        expect(render).toHaveBeenCalledWith({ id: "42" });
+    });
+});

--- a/web/src/elements/router/core/config.ts
+++ b/web/src/elements/router/core/config.ts
@@ -31,9 +31,12 @@ export function initRouter(config: RouterConfig): void {
 
 /**
  * Read the current router configuration.
+ *
+ * @returns A shallow copy — mutations of the returned object do not affect the
+ * stored config.
  */
 export function getRouterConfig(): RouterConfig {
-    return currentConfig;
+    return { ...currentConfig };
 }
 
 /**

--- a/web/src/elements/router/core/config.ts
+++ b/web/src/elements/router/core/config.ts
@@ -1,0 +1,46 @@
+/**
+ * @file Router configuration injected by each entrypoint at boot.
+ *
+ * The router core never reads globals. Each entrypoint calls {@linkcode initRouter}
+ * once at boot with the deployment base path (read from `window.authentik.api.relBase`
+ * **at the entrypoint**) and the interface name. The core only ever receives values.
+ */
+
+export interface RouterConfig {
+    /**
+     * Deployment base path, trailing-slashed. Examples: `/`, `/auth/`.
+     */
+    base: string;
+
+    /**
+     * Interface prefix segment. Examples: `admin`, `user`.
+     */
+    interfaceName: string;
+}
+
+const DEFAULT_CONFIG: RouterConfig = { base: "/", interfaceName: "unknown" };
+
+let currentConfig: RouterConfig = { ...DEFAULT_CONFIG };
+
+/**
+ * Configure the router core. Called once by each entrypoint at boot.
+ */
+export function initRouter(config: RouterConfig): void {
+    currentConfig = { ...config };
+}
+
+/**
+ * Read the current router configuration.
+ */
+export function getRouterConfig(): RouterConfig {
+    return currentConfig;
+}
+
+/**
+ * Reset the configuration to its defaults.
+ *
+ * @remarks Test-only. Not for production call sites.
+ */
+export function resetRouterConfig(): void {
+    currentConfig = { ...DEFAULT_CONFIG };
+}

--- a/web/src/elements/router/core/config.unit.test.ts
+++ b/web/src/elements/router/core/config.unit.test.ts
@@ -1,0 +1,24 @@
+import { getRouterConfig, initRouter, resetRouterConfig } from "./config.js";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+describe("router config", () => {
+    afterEach(() => resetRouterConfig());
+
+    it("defaults to a root base and unknown interface", () => {
+        expect(getRouterConfig()).toEqual({ base: "/", interfaceName: "unknown" });
+    });
+
+    it("stores injected configuration", () => {
+        initRouter({ base: "/auth/", interfaceName: "admin" });
+
+        expect(getRouterConfig()).toEqual({ base: "/auth/", interfaceName: "admin" });
+    });
+
+    it("resets back to defaults", () => {
+        initRouter({ base: "/auth/", interfaceName: "admin" });
+        resetRouterConfig();
+
+        expect(getRouterConfig()).toEqual({ base: "/", interfaceName: "unknown" });
+    });
+});

--- a/web/src/elements/router/core/config.unit.test.ts
+++ b/web/src/elements/router/core/config.unit.test.ts
@@ -21,4 +21,13 @@ describe("router config", () => {
 
         expect(getRouterConfig()).toEqual({ base: "/", interfaceName: "unknown" });
     });
+
+    it("returns a copy so mutations do not affect the stored config", () => {
+        initRouter({ base: "/auth/", interfaceName: "admin" });
+
+        const config = getRouterConfig();
+        config.base = "/mutated/";
+
+        expect(getRouterConfig().base).toBe("/auth/");
+    });
 });

--- a/web/src/elements/router/core/constants.ts
+++ b/web/src/elements/router/core/constants.ts
@@ -21,5 +21,4 @@ export const ID_PATTERN = "\\d+";
  * @todo Enforcing this format on the front-end may be too strict; revisit if a
  * non-canonical UUID needs to route.
  */
-export const UUID_PATTERN =
-    "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
+export const UUID_PATTERN = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";

--- a/web/src/elements/router/core/constants.ts
+++ b/web/src/elements/router/core/constants.ts
@@ -1,0 +1,25 @@
+/**
+ * @file Router pattern constants for path-based routing.
+ *
+ * Raw `URLPattern` pathname-group regex sources used to type path parameters.
+ * App-context-free.
+ */
+
+/**
+ * Slug pattern, matching alphanumeric characters, underscores, and hyphens.
+ */
+export const SLUG_PATTERN = "[a-zA-Z0-9_\\-]+";
+
+/**
+ * Numeric ID pattern, typically used for database IDs.
+ */
+export const ID_PATTERN = "\\d+";
+
+/**
+ * UUID pattern (hex groups).
+ *
+ * @todo Enforcing this format on the front-end may be too strict; revisit if a
+ * non-canonical UUID needs to route.
+ */
+export const UUID_PATTERN =
+    "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";

--- a/web/src/elements/router/core/constants.unit.test.ts
+++ b/web/src/elements/router/core/constants.unit.test.ts
@@ -1,0 +1,27 @@
+import { ID_PATTERN, SLUG_PATTERN, UUID_PATTERN } from "./constants.js";
+
+import { describe, expect, it } from "vitest";
+
+describe("router pattern constants", () => {
+    it("SLUG_PATTERN matches a slug and rejects a slash", () => {
+        const pattern = new URLPattern({ pathname: `/apps/:slug(${SLUG_PATTERN})` });
+
+        expect(pattern.exec({ pathname: "/apps/my-app_1" })?.pathname.groups.slug).toBe("my-app_1");
+        expect(pattern.exec({ pathname: "/apps/a/b" })).toBeNull();
+    });
+
+    it("ID_PATTERN matches digits only", () => {
+        const pattern = new URLPattern({ pathname: `/users/:id(${ID_PATTERN})` });
+
+        expect(pattern.exec({ pathname: "/users/42" })?.pathname.groups.id).toBe("42");
+        expect(pattern.exec({ pathname: "/users/abc" })).toBeNull();
+    });
+
+    it("UUID_PATTERN matches a uuid", () => {
+        const pattern = new URLPattern({ pathname: `/o/:uuid(${UUID_PATTERN})` });
+        const uuid = "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d";
+
+        expect(pattern.exec({ pathname: `/o/${uuid}` })?.pathname.groups.uuid).toBe(uuid);
+        expect(pattern.exec({ pathname: "/o/not-a-uuid" })).toBeNull();
+    });
+});

--- a/web/src/elements/router/core/matcher.ts
+++ b/web/src/elements/router/core/matcher.ts
@@ -22,8 +22,10 @@ export interface RouteMatch<R extends RoutePatternLike> {
 /**
  * Match a pathname against a route table, first-match-wins.
  *
- * @param pathname The pathname to match (already stripped of base + interface
- * prefix by the caller).
+ * @param pathname The interface-relative pathname, beginning with `/`.
+ * The interface root is `/`. Callers stripping the interface prefix from
+ * `location.pathname` must keep (or restore) the leading slash:
+ * `/if/admin/users/42` → `/users/42`, `/if/admin/` → `/`.
  * @param routes The route table, scanned in order.
  * @returns The first match, or `null` when nothing matches.
  */

--- a/web/src/elements/router/core/matcher.ts
+++ b/web/src/elements/router/core/matcher.ts
@@ -1,0 +1,49 @@
+/**
+ * @file Pure route matcher.
+ *
+ * First-match-wins linear scan over pre-compiled `URLPattern`s. No globals,
+ * no side effects. Depends only on the structural shape of a route (a compiled
+ * `pattern`), so it never imports `Route`.
+ */
+
+/**
+ * The minimal shape the matcher needs from a route: a compiled pattern.
+ */
+export interface RoutePatternLike {
+    readonly pattern: URLPattern;
+}
+
+export interface RouteMatch<R extends RoutePatternLike> {
+    readonly route: R;
+    readonly parameters: Record<string, string | undefined>;
+    readonly pathname: string;
+}
+
+/**
+ * Match a pathname against a route table, first-match-wins.
+ *
+ * @param pathname The pathname to match (already stripped of base + interface
+ * prefix by the caller).
+ * @param routes The route table, scanned in order.
+ * @returns The first match, or `null` when nothing matches.
+ */
+export function matchRoute<R extends RoutePatternLike>(
+    pathname: string,
+    routes: readonly R[],
+): RouteMatch<R> | null {
+    if (!pathname) return null;
+
+    for (const route of routes) {
+        const match = route.pattern.exec({ pathname });
+
+        if (!match) continue;
+
+        return {
+            route,
+            parameters: match.pathname.groups,
+            pathname,
+        };
+    }
+
+    return null;
+}

--- a/web/src/elements/router/core/matcher.unit.test.ts
+++ b/web/src/elements/router/core/matcher.unit.test.ts
@@ -1,0 +1,37 @@
+import { matchRoute, type RoutePatternLike } from "./matcher.js";
+
+import { describe, expect, it } from "vitest";
+
+function route(pathname: string): RoutePatternLike {
+    return { pattern: new URLPattern({ pathname }) };
+}
+
+describe("matchRoute", () => {
+    it("returns null for an empty pathname", () => {
+        expect(matchRoute("", [route("/users")])).toBeNull();
+    });
+
+    it("returns the first matching route with its params and pathname", () => {
+        const routes = [route("/users/:id"), route("/groups/:id")];
+
+        const match = matchRoute("/users/42", routes);
+
+        expect(match?.route).toBe(routes[0]);
+        expect(match?.parameters.id).toBe("42");
+        expect(match?.pathname).toBe("/users/42");
+    });
+
+    it("is first-match-wins when two patterns overlap", () => {
+        const first = route("/users/:id");
+        const second = route("/users/:slug");
+
+        const match = matchRoute("/users/42", [first, second]);
+
+        expect(match?.route).toBe(first);
+        expect(match?.parameters.id).toBe("42");
+    });
+
+    it("returns null when nothing matches", () => {
+        expect(matchRoute("/nope", [route("/users/:id")])).toBeNull();
+    });
+});

--- a/web/src/elements/router/core/parameters.ts
+++ b/web/src/elements/router/core/parameters.ts
@@ -72,7 +72,14 @@ export function recordToSearchParams(params: RouterParameterInit): URLSearchPara
 function deserialize(value: string): PrimitiveRouteParameter {
     if (value === "true") return true;
     if (value === "false") return false;
-    if (/^\d+$/.test(value)) return Number.parseInt(value, 10);
+
+    if (/^\d+$/.test(value)) {
+        const parsed = Number(value);
+
+        if (Number.isSafeInteger(parsed) && String(parsed) === value) {
+            return parsed;
+        }
+    }
 
     return value;
 }

--- a/web/src/elements/router/core/parameters.ts
+++ b/web/src/elements/router/core/parameters.ts
@@ -1,0 +1,104 @@
+/**
+ * @file Search-parameter serialization for path-based routing.
+ *
+ * Round-trips primitive route parameters (string, number, boolean, and arrays
+ * thereof) to and from `URLSearchParams`. App-context-free.
+ *
+ * Adapted from the `basepath-aware-routing` prototype's `parsing.ts`.
+ */
+
+export type PrimitiveRouteParameter = string | number | boolean | null | undefined;
+
+export type RouteParameterRecord = Record<
+    string,
+    PrimitiveRouteParameter | PrimitiveRouteParameter[]
+>;
+
+export type RouterParameterInit = RouteParameterRecord | URLSearchParams;
+
+/**
+ * Serialize a single primitive to a search-param string, or `null` to omit it.
+ *
+ * Empty, nullish, and `false` values are omitted; `true` becomes `"true"`.
+ */
+function serialize(value: PrimitiveRouteParameter): string | null {
+    if (value === null || value === undefined || value === "") return null;
+
+    if (typeof value === "boolean") {
+        return value ? "true" : null;
+    }
+
+    return value.toString();
+}
+
+/**
+ * Given a record of parameters, build a `URLSearchParams` object.
+ *
+ * A `URLSearchParams` input is returned as-is.
+ */
+export function recordToSearchParams(params: RouterParameterInit): URLSearchParams {
+    if (params instanceof URLSearchParams) {
+        return params;
+    }
+
+    const searchParams = new URLSearchParams();
+
+    for (const [key, value] of Object.entries(params)) {
+        if (Array.isArray(value)) {
+            for (const item of value) {
+                const serialized = serialize(item);
+
+                if (serialized === null) continue;
+
+                searchParams.append(key, serialized);
+            }
+
+            continue;
+        }
+
+        const serialized = serialize(value);
+
+        if (serialized === null) continue;
+
+        searchParams.set(key, serialized);
+    }
+
+    return searchParams;
+}
+
+/**
+ * Deserialize a single search-param string back to a primitive.
+ */
+function deserialize(value: string): PrimitiveRouteParameter {
+    if (value === "true") return true;
+    if (value === "false") return false;
+    if (/^\d+$/.test(value)) return Number.parseInt(value, 10);
+
+    return value;
+}
+
+/**
+ * Given a `URLSearchParams` object, build a record of parameters.
+ *
+ * Keys that appear multiple times are collected into an array of values.
+ */
+export function searchParamsToRecord<T extends RouteParameterRecord = RouteParameterRecord>(
+    searchParams: URLSearchParams,
+): T {
+    const params: Record<string, PrimitiveRouteParameter | PrimitiveRouteParameter[]> = {};
+
+    for (const [key, raw] of searchParams.entries()) {
+        const value = deserialize(raw);
+        const existing = params[key];
+
+        if (existing === undefined) {
+            params[key] = value;
+        } else if (Array.isArray(existing)) {
+            existing.push(value);
+        } else {
+            params[key] = [existing, value];
+        }
+    }
+
+    return params as T;
+}

--- a/web/src/elements/router/core/parameters.unit.test.ts
+++ b/web/src/elements/router/core/parameters.unit.test.ts
@@ -50,4 +50,18 @@ describe("searchParamsToRecord", () => {
 
         expect(restored).toEqual(original);
     });
+
+    it("keeps leading-zero digit strings as strings", () => {
+        expect(searchParamsToRecord(new URLSearchParams("code=007"))).toEqual({ code: "007" });
+    });
+
+    it("keeps digit strings that lose precision as strings", () => {
+        expect(searchParamsToRecord(new URLSearchParams("id=123456789012345678"))).toEqual({
+            id: "123456789012345678",
+        });
+    });
+
+    it("still coerces safe integers", () => {
+        expect(searchParamsToRecord(new URLSearchParams("page=42"))).toEqual({ page: 42 });
+    });
 });

--- a/web/src/elements/router/core/parameters.unit.test.ts
+++ b/web/src/elements/router/core/parameters.unit.test.ts
@@ -1,0 +1,53 @@
+import { recordToSearchParams, searchParamsToRecord } from "./parameters.js";
+
+import { describe, expect, it } from "vitest";
+
+describe("recordToSearchParams", () => {
+    it("serializes strings, numbers, and true booleans", () => {
+        const search = recordToSearchParams({ q: "abc", page: 2, active: true });
+
+        expect(search.toString()).toBe("q=abc&page=2&active=true");
+    });
+
+    it("omits null, undefined, empty-string, and false values", () => {
+        const search = recordToSearchParams({ a: null, b: undefined, c: "", d: false, e: "x" });
+
+        expect(search.toString()).toBe("e=x");
+    });
+
+    it("appends array members as repeated keys", () => {
+        const search = recordToSearchParams({ ids: [1, 2, 3] });
+
+        expect(search.toString()).toBe("ids=1&ids=2&ids=3");
+    });
+
+    it("returns a URLSearchParams input unchanged", () => {
+        const input = new URLSearchParams("x=1");
+
+        expect(recordToSearchParams(input)).toBe(input);
+    });
+});
+
+describe("searchParamsToRecord", () => {
+    it("deserializes numbers, true, and false", () => {
+        const record = searchParamsToRecord(
+            new URLSearchParams("page=2&active=true&archived=false&q=abc"),
+        );
+
+        expect(record).toEqual({ page: 2, active: true, archived: false, q: "abc" });
+    });
+
+    it("collects repeated keys into an array", () => {
+        const record = searchParamsToRecord(new URLSearchParams("ids=1&ids=2&ids=3"));
+
+        expect(record).toEqual({ ids: [1, 2, 3] });
+    });
+
+    it("round-trips a record through search params", () => {
+        const original = { q: "abc", page: 2, active: true, ids: [1, 2] };
+
+        const restored = searchParamsToRecord(recordToSearchParams(original));
+
+        expect(restored).toEqual(original);
+    });
+});


### PR DESCRIPTION
## Details

### What does this PR change?

Adds the dependency-free building blocks of the new path-based router under `web/src/elements/router/core/`, all new files with co-located unit tests:

- `constants.ts` — slug/ID/UUID pathname-group patterns
- `parameters.ts` — search-param serialization with typed round-trips
- `config.ts` — base path and interface name injected by entrypoints (`initRouter`), so the router core never reads globals
- `Route.ts` — `URLPattern`-backed route, pattern compiled once at construction
- `matcher.ts` — pure first-match-wins scan over pre-compiled patterns

Nothing is wired into an entrypoint; the hash router is untouched and remains active.

### Why is this change needed?

Part of moving the web UI from hash routing (`/if/admin/#/core/applications;{"page":2}`) to real paths and query strings (`/if/admin/core/applications?page=2`), staged interface by interface. Server-side catch-alls: #23987. Navigation layer (click interception, href builders, legacy-hash translator): #23988, stacked on this PR.

### How was this tested?

26 unit tests across the five modules (Unit Tests vitest project), plus the full project run and typecheck. Depends on the transform fix in #23991 and the CI gating in #23989 (the base chain of this PR).

### Linked issues

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
