### PR TITLE
web: Allow the vite oxc transform to compile co-located unit tests.

### DIFF
--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -40,6 +40,17 @@ export default defineConfig({
         ],
         projects: [
             {
+                // The root `tsconfig.json` excludes `src/**/*.test.ts`, so `vite:oxc`'s
+                // per-file tsconfig discovery bails with `[TSCONFIG_ERROR] Tsconfig not
+                // found` on co-located `src/**/*.unit.test.ts`. Disabling tsconfig
+                // discovery for this Node project lets oxc transform those files while
+                // leaving `lint:types` (`tsgo -p .`) and the root excludes untouched.
+                // `tsconfig` is forwarded to oxc's transform at runtime but is omitted
+                // from vite's `OxcOptions` type, so the assertion adds it back to keep
+                // `tsgo -p .` clean.
+                oxc: /** @type {import("vite").OxcOptions & { tsconfig: false }} */ ({
+                    tsconfig: false,
+                }),
                 test: {
                     include: ["./test/unit/**/*.{test,spec}.ts", "**/*.unit.{test,spec}.ts"],
                     name: "Unit Tests",


### PR DESCRIPTION
## Details

### What does this PR change?

One config change in the "Unit Tests" vitest project: `oxc: { tsconfig: false }`, disabling the per-file tsconfig discovery that Vite 8's built-in oxc transform performs when compiling TypeScript test files.

Today that discovery makes every co-located unit test under `web/src/` fail before running: the root `tsconfig.json` excludes `src/**/*.test.ts`, and the transform refuses excluded files with `[TSCONFIG_ERROR] Tsconfig not found`. The committed `src/polyfill/custom-elements-get-name.unit.test.ts` fails this way today (masked in CI, see #23989). Tests under `test/unit/` are unaffected; they have their own tsconfig.

This only touches how vitest compiles test files. `lint:types`, the build, ESLint, and Prettier are unchanged — this is the transform half of the oxc toolchain that ships inside Vite 8, not the Oxlint/Oxfmt adoption tracked in #23519, which stays deferred.

### Why is this change needed?

Upcoming router PRs (#23990, #23988) ship co-located unit tests under `web/src/`, and the existing polyfill test should run at all. Scoping the workaround to the vitest project keeps the root tsconfig excludes intact for typechecking; when the broader oxc story lands via #23519, this line is the marker for revisiting.

### How was this tested?

`pnpm exec vitest run --project "Unit Tests"` from `web/`: the polyfill test file compiles and passes (previously failed at transform); `test/unit/` unaffected (41 tests total). `pnpm run lint:types` output identical before and after.

### Linked issues

refs #23519

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
