### PR TITLE
lifecycle/container: drop curl and runit

### DIFF
--- a/lifecycle/ak
+++ b/lifecycle/ak
@@ -55,7 +55,6 @@ function check_if_root_and_run {
         return
     fi
     SOCKET="/var/run/docker.sock"
-    GROUP="authentik"
     if [[ -e "$SOCKET" ]]; then
         # Get group ID of the docker socket, so we can create a matching group and
         # add ourselves to it
@@ -63,15 +62,12 @@ function check_if_root_and_run {
         # Ensure group for the id exists
         getent group "${DOCKER_GID}" || groupadd -f -g "${DOCKER_GID}" docker
         usermod -a -G "${DOCKER_GID}" authentik
-        # since the name of the group might not be docker, we need to lookup the group id
-        GROUP_NAME=$(getent group "${DOCKER_GID}" | sed 's/:/\n/g' | head -1)
-        GROUP="authentik:${GROUP_NAME}"
     fi
     # Fix permissions of certs and media
     chown -R authentik:authentik /data /certs "${PROMETHEUS_MULTIPROC_DIR}"
     chmod ug+rwx /data
     chmod ug+rx /certs
-    exec chpst -u authentik:"${GROUP}" env HOME=/authentik $(run_authentik "$@")
+    exec setpriv --reuid authentik --regid authentik --init-groups -- env HOME=/authentik $(run_authentik "$@")
 }
 
 function prepare_debug {

--- a/lifecycle/container/Dockerfile
+++ b/lifecycle/container/Dockerfile
@@ -248,8 +248,7 @@ RUN apt-get update && \
     libpq5 libmaxminddb0 ca-certificates \
     libkadm5clnt-mit12 libkadm5clnt7t64-heimdal \
     libltdl7 libxslt1.1 && \
-    # Required for bootstrap & healtcheck
-    apt-get install -y --no-install-recommends runit && \
+    apt-get purge -y curl libcurl4t64 && \
     pip3 install --no-cache-dir --upgrade pip && \
     apt-get clean && \
     rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/ && \


### PR DESCRIPTION
Alternative to https://github.com/goauthentik/authentik/pull/23953

### Differences:

- it drops `runit` (by changing from `chpst` to `setpriv`), which no longer pulls in a lot of perl dependencies
- it leaves `perl-base` installed since it's marked as an "essential" package in debian
- since we are not breaking dpkg, we can just use `apt-get purge` to remove `curl`

The tradeoff is that we accept some `perl-base` CVEs (3 critical, 6 high), but leave dpkg/apt in a working state.


### Numbers

Before:

```
 ✔ Scanned for vulnerabilities     [276 vulnerability matches]
   ├── by severity: 26 critical, 54 high, 60 medium, 5 low, 95 negligible (36 unknown)
   └── by status:   5 fixed, 271 not-fixed, 0 ignored
```

After:

```
 ✔ Scanned for vulnerabilities     [209 vulnerability matches]
   ├── by severity: 5 critical, 24 high, 52 medium, 5 low, 84 negligible (39 unknown)
   └── by status:   5 fixed, 204 not-fixed, 0 ignored
```