### PR TITLE
providers/oauth2: add support for ed448

### DIFF
--- a/authentik/providers/oauth2/models.py
+++ b/authentik/providers/oauth2/models.py
@@ -15,6 +15,8 @@ from cryptography.hazmat.primitives.asymmetric.ec import (
     SECP521R1,
     EllipticCurvePrivateKey,
 )
+from cryptography.hazmat.primitives.asymmetric.ed448 import Ed448PrivateKey
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
 from cryptography.hazmat.primitives.asymmetric.types import PrivateKeyTypes
 from dacite import Config
@@ -159,6 +161,7 @@ class JWTAlgorithms(models.TextChoices):
     ES256 = "ES256", _("ES256 (Asymmetric Encryption)")
     ES384 = "ES384", _("ES384 (Asymmetric Encryption)")
     ES512 = "ES512", _("ES512 (Asymmetric Encryption)")
+    EDDSA = "EdDSA", _("EdDSA (Asymmetric Encryption)")
 
     @classmethod
     def from_private_key(cls, private_key: PrivateKeyTypes | None) -> str:
@@ -172,6 +175,10 @@ class JWTAlgorithms(models.TextChoices):
                 return cls.ES384
             if isinstance(curve, SECP521R1):
                 return cls.ES512
+        # Per RFC 8037 both Ed25519 and Ed448 use the single "EdDSA" algorithm identifier; the
+        # curve is carried in the JWK's `crv` parameter rather than in `alg`.
+        if isinstance(private_key, Ed25519PrivateKey | Ed448PrivateKey):
+            return cls.EDDSA
         raise ValueError(f"Invalid private key type: {type(private_key)}")
 
 

--- a/authentik/providers/oauth2/models.py
+++ b/authentik/providers/oauth2/models.py
@@ -175,8 +175,6 @@ class JWTAlgorithms(models.TextChoices):
                 return cls.ES384
             if isinstance(curve, SECP521R1):
                 return cls.ES512
-        # Per RFC 8037 both Ed25519 and Ed448 use the single "EdDSA" algorithm identifier; the
-        # curve is carried in the JWK's `crv` parameter rather than in `alg`.
         if isinstance(private_key, Ed25519PrivateKey | Ed448PrivateKey):
             return cls.EDDSA
         raise ValueError(f"Invalid private key type: {type(private_key)}")

--- a/authentik/providers/oauth2/tests/test_jwks.py
+++ b/authentik/providers/oauth2/tests/test_jwks.py
@@ -6,7 +6,7 @@ import json
 from cryptography.hazmat.backends import default_backend
 from cryptography.x509 import load_der_x509_certificate
 from django.urls.base import reverse
-from jwt import PyJWKSet
+from jwt import PyJWKSet, decode
 
 from authentik.core.models import Application
 from authentik.core.tests.utils import create_test_cert, create_test_flow
@@ -92,6 +92,61 @@ class TestJWKS(OAuthTestCase):
         body = json.loads(response.content.decode())
         self.assertEqual(len(body["keys"]), 1)
         PyJWKSet.from_dict(body)
+
+    def test_eddsa(self):
+        """Test JWKS request with EdDSA, for both Edwards curves"""
+        for alg, crv in [(PrivateKeyAlg.ED25519, "Ed25519"), (PrivateKeyAlg.ED448, "Ed448")]:
+            with self.subTest(crv):
+                slug = generate_id()
+                provider = OAuth2Provider.objects.create(
+                    name=generate_id(),
+                    client_id=generate_id(),
+                    authorization_flow=create_test_flow(),
+                    redirect_uris=[
+                        RedirectURI(RedirectURIMatchingMode.STRICT, "http://local.invalid")
+                    ],
+                    signing_key=create_test_cert(alg),
+                )
+                app = Application.objects.create(name=slug, slug=slug, provider=provider)
+                response = self.client.get(
+                    reverse(
+                        "authentik_providers_oauth2:jwks", kwargs={"application_slug": app.slug}
+                    )
+                )
+                body = json.loads(response.content.decode())
+                self.assertEqual(len(body["keys"]), 1)
+                key = body["keys"][0]
+                self.assertEqual(key["kty"], "OKP")
+                self.assertEqual(key["alg"], "EdDSA")
+                self.assertEqual(key["crv"], crv)
+                # PyJWKSet rejects a JWK that is missing key material, so this asserts the OKP
+                # key is actually usable by a relying party rather than merely well-shaped.
+                PyJWKSet.from_dict(body)
+
+    def test_eddsa_sign_verify(self):
+        """Test a token signed with EdDSA verifies against the published JWKS"""
+        provider = OAuth2Provider.objects.create(
+            name=generate_id(),
+            client_id=generate_id(),
+            authorization_flow=create_test_flow(),
+            redirect_uris=[RedirectURI(RedirectURIMatchingMode.STRICT, "http://local.invalid")],
+            signing_key=create_test_cert(PrivateKeyAlg.ED25519),
+        )
+        slug = generate_id()
+        app = Application.objects.create(name=slug, slug=slug, provider=provider)
+        token = provider.encode({"sub": "test"})
+
+        response = self.client.get(
+            reverse("authentik_providers_oauth2:jwks", kwargs={"application_slug": app.slug})
+        )
+        jwks = PyJWKSet.from_dict(json.loads(response.content.decode()))
+        decoded = decode(
+            token,
+            jwks.keys[0].key,
+            algorithms=["EdDSA"],
+            options={"verify_aud": False},
+        )
+        self.assertEqual(decoded["sub"], "test")
 
     def test_enc(self):
         """Test with JWE"""

--- a/authentik/providers/oauth2/views/jwks.py
+++ b/authentik/providers/oauth2/views/jwks.py
@@ -12,6 +12,8 @@ from cryptography.hazmat.primitives.asymmetric.ec import (
     EllipticCurvePrivateKey,
     EllipticCurvePublicKey,
 )
+from cryptography.hazmat.primitives.asymmetric.ed448 import Ed448PrivateKey, Ed448PublicKey
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, RSAPublicKey
 from cryptography.hazmat.primitives.serialization import Encoding
 from django.http import Http404, HttpRequest, HttpResponse, JsonResponse
@@ -99,6 +101,13 @@ class JWKSView(View):
             key_data["x"] = to_base64url_uint(public_numbers.x, min_length_map[curve_type]).decode()
             key_data["y"] = to_base64url_uint(public_numbers.y, min_length_map[curve_type]).decode()
             key_data["crv"] = ec_crv_map.get(curve_type, public_key.curve.name)
+        elif isinstance(private_key, Ed25519PrivateKey | Ed448PrivateKey):
+            public_key: Ed25519PublicKey | Ed448PublicKey = private_key.public_key()
+            key_data["kid"] = key.kid
+            key_data["kty"] = "OKP"
+            key_data["use"] = use
+            key_data["crv"] = "Ed25519" if isinstance(private_key, Ed25519PrivateKey) else "Ed448"
+            key_data["x"] = base64url_encode(public_key.public_bytes_raw()).decode()
         else:
             return key_data
         key_data["x5c"] = [b64encode(key.certificate.public_bytes(Encoding.DER)).decode("utf-8")]


### PR DESCRIPTION
<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?

This allows for setting ed448 certificates on oauth2 providers

### Why is this change needed?

Without this change, if you set an ed448 cert on an oauth2 provider, and it gets used (go to /application/o/providername/jwks/), we will 500 error

### How was this tested?

Generating an ed448, setting it on a provider, going to /application/o/providername/jwks/

### Linked issues

<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
