### PR TITLE
packages/django-dramatiq-postgres/broker: close unusable PostgreSQL connections

### DIFF
--- a/packages/django-dramatiq-postgres/django_dramatiq_postgres/broker.py
+++ b/packages/django-dramatiq-postgres/django_dramatiq_postgres/broker.py
@@ -279,6 +279,13 @@ class _PostgresConsumer(Consumer):
     def locks_connection(self) -> DatabaseWrapper:
         if self._locks_connection is not None and self._locks_connection.is_usable():
             return self._locks_connection
+
+        if self._locks_connection is not None:
+            try:
+                self._locks_connection.close()
+            except DATABASE_ERRORS as exc:
+                self.logger.warning("Failed to close old unusable locks connection", exc=exc)
+
         self._locks_connection = cast(DatabaseWrapper, connections.create_connection(self.db_alias))
         return self._locks_connection
 
@@ -286,6 +293,13 @@ class _PostgresConsumer(Consumer):
     def listen_connection(self) -> DatabaseWrapper:
         if self._listen_connection is not None and self._listen_connection.is_usable():
             return self._listen_connection
+
+        if self._listen_connection is not None:
+            try:
+                self._listen_connection.close()
+            except DATABASE_ERRORS as exc:
+                self.logger.warning("Failed to close old unusable listen connection", exc=exc)
+
         self._listen_connection = cast(
             DatabaseWrapper, connections.create_connection(self.db_alias)
         )


### PR DESCRIPTION


<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?
This PR modifies the locks_connection and listen_connection properties in _PostgresConsumer to explicitly call .close() on their previous, unusable connection wrappers before instantiating new connection instances via connections.create_connection(self.db_alias). It also updates exception handling in the properties to specifically catch DATABASE_ERRORS rather than using blind/broad Exception catching, complying with Python linting best practices.


### Why is this change needed?
In django-dramatiq-postgres, _PostgresConsumer instantiates dedicated connection wrappers for handling advisory locks and notifications via connections.create_connection(self.db_alias). Because these connection objects are created dynamically and are not managed in Django's central thread-local/context-local connection registry (connections._connections), they are invisible to standard lifecycle hooks and cleanup operations like connections.close_all().

When a connection fails the .is_usable() check:

The property getter re-instantiates a new connection and overwrites the instance reference.
The old connection wrapper is orphaned in memory without first being closed.
This leaks the client-side TCP sockets and database file descriptors until Python's garbage collection runs.
During database reconnect storms, failovers, or network partitioning, this leaks connections linearly, exhausting PostgreSQL connection limits (OperationalError: FATAL: remaining connection slots are reserved for non-replication superuser connections) and causing a Denial of Service (DoS) for the entire application.
In addition, orphaned connections keep their advisory locks active on the PostgreSQL server, blocking other healthy worker nodes from reclaiming/executing those tasks until TCP/GC timeout occurs.
Explicitly calling .close() on the discarded wrappers frees client-side socket/FD resources instantly and forces PostgreSQL to drop the session and release its locks immediately.

### How was this tested?
Validated via codebase review of connection registry mechanics.
Verified file formatting and linting rules pass using black and ruff (ensuring catching DATABASE_ERRORS satisfies BLE001).

### Linked issues
https://github.com/goauthentik/authentik/issues/24022

<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [x] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
