### PR TITLE
api/search: add number and boolean support in AKQL queries on JSON fields (#23418)

### DIFF
--- a/authentik/api/search/fields.py
+++ b/authentik/api/search/fields.py
@@ -2,6 +2,7 @@
 
 from collections import OrderedDict, defaultdict
 from collections.abc import Generator
+from decimal import Decimal
 
 from django.db import connection
 from django.db.models import Model, Q
@@ -14,6 +15,17 @@ class JSONSearchField(StrField):
     """JSON field for DjangoQL"""
 
     model: Model
+
+    value_types = [str, bool, int, float, Decimal]
+    value_types_description = "strings, booleans or numbers"
+
+    def get_lookup_value(self, value):
+        value = super().get_lookup_value(value)
+        if isinstance(value, list):
+            return [float(item) if isinstance(item, Decimal) else item for item in value]
+        if isinstance(value, Decimal):
+            return float(value)
+        return value
 
     def __init__(
         self,

--- a/authentik/api/tests/test_search.py
+++ b/authentik/api/tests/test_search.py
@@ -71,3 +71,28 @@ class QLTest(APITestCase):
         content = loads(res.content)
         self.assertEqual(content["pagination"]["count"], 1)
         self.assertEqual(content["results"][0]["username"], self.user.username)
+
+    def test_search_json_non_string(self):
+        """Test search queries against non-string JSON values"""
+        self.user.attributes = {"enabled": True, "count": 3, "speed": 1.5}
+        self.user.save()
+        self.client.force_login(self.user)
+        for query in (
+            "attributes.enabled = True",
+            "attributes.count = 3",
+            "attributes.speed = 1.5",
+            "attributes.count = 3.0",
+            "attributes.speed in (1.5, 2.5)",
+            "attributes.speed >= 1.0 and attributes.speed <= 2.0",
+        ):
+            with self.subTest(query=query):
+                res = self.client.get(
+                    reverse(
+                        "authentik_api:user-list",
+                    )
+                    + f"?{urlencode({"search": query})}"
+                )
+                self.assertEqual(res.status_code, 200)
+                content = loads(res.content)
+                self.assertEqual(content["pagination"]["count"], 1)
+                self.assertEqual(content["results"][0]["username"], self.user.username)


### PR DESCRIPTION
## Details

Right now AKQL queries on JSON fields only match string attributes, but not boolean, int or float (see #23418). This PR addresses that deficiency.

### What does this PR change?

A `value_types` declaration is added on `authentik.api.search.fields.JSONSearchField`  + some care to correctly handle float queries.

### How was this tested?

UI + test suite + new tests. 

### Linked issues

closes #23418

---

## Checklist

-   [x] The project has been linted, built, and tested (`make all`)
