### PR TITLE
web: Add the path-router outlet.

### DIFF
--- a/web/src/common/sentry/tracing.ts
+++ b/web/src/common/sentry/tracing.ts
@@ -1,0 +1,29 @@
+/**
+ * @file Whether the initialized Sentry client is reporting.
+ *
+ * Deliberately a leaf module: it imports the Sentry SDK and nothing else, so
+ * router outlets can read the reporting decision without pulling in the app
+ * context (`globalAK`, the API client) that Sentry initialization needs.
+ */
+
+import { getClient } from "@sentry/browser";
+import { type Client } from "@sentry/core";
+
+/**
+ * Whether Sentry was initialized and is reporting.
+ *
+ * The enable/disable policy lives with Sentry initialization, which decides once
+ * and leaves the result on the client. Callers read the decision back off the
+ * client rather than re-deriving it — a second copy of the policy drifts from
+ * the first.
+ *
+ * Mirrors the SDK's own `_isEnabled()`: `enabled` is optional, and an unset
+ * value means enabled. Testing it for truthiness instead would report every
+ * client as disabled whenever initialization decides up front and passes no
+ * `enabled` at all.
+ *
+ * @param client The client to inspect. Defaults to the current one.
+ */
+export function sentryReporting(client: Client | undefined = getClient()): boolean {
+    return !!client && client.getOptions().enabled !== false;
+}

--- a/web/src/elements/router/RouterOutlet.ts
+++ b/web/src/elements/router/RouterOutlet.ts
@@ -2,6 +2,7 @@ import "#elements/router/Router404";
 import "#elements/a11y/ak-skip-to-content";
 
 import { ROUTE_SEPARATOR } from "#common/constants";
+import { sentryReporting } from "#common/sentry/tracing";
 
 import { type AKSkipToContent, findMainContent } from "#elements/a11y/ak-skip-to-content";
 import { AKElement } from "#elements/Base";
@@ -103,7 +104,7 @@ export class RouterOutlet extends AKElement {
 
         window.addEventListener("hashchange", this.navigate);
 
-        if (process.env.NODE_ENV !== "production" && this.#sentryClient) {
+        if (this.#sentryClient && sentryReporting(this.#sentryClient)) {
             this.#pageLoadSpan =
                 startBrowserTracingPageLoadSpan(this.#sentryClient, {
                     name: window.location.pathname,
@@ -196,7 +197,7 @@ export class RouterOutlet extends AKElement {
 
     protected override updated(changedProperties: PropertyValues<this>): void {
         if (!changedProperties.has("current") || !this.current) return;
-        if (!this.#sentryClient) return;
+        if (!this.#sentryClient || !sentryReporting(this.#sentryClient)) return;
 
         // https://docs.sentry.io/platforms/javascript/tracing/instrumentation/automatic-instrumentation/#custom-routing
         if (this.#pageLoadSpan) {

--- a/web/src/elements/router/core/Route.ts
+++ b/web/src/elements/router/core/Route.ts
@@ -51,4 +51,16 @@ export class Route<P extends RouteParameterRecord = RouteParameterRecord> {
     render(params: P): TemplateResult {
         return html`${until(this.#render(params), nothing)}`;
     }
+
+    /**
+     * Resolve the route's template for the given path parameters as a promise.
+     *
+     * Unlike {@linkcode render}, this exposes the render callback's result —
+     * synchronous or asynchronous — as a promise and lets rejections
+     * propagate, so the outlet can own the loading and error states. A
+     * synchronous throw in the callback becomes a rejected promise.
+     */
+    async resolve(params: P): Promise<SlottedTemplateResult> {
+        return this.#render(params);
+    }
 }

--- a/web/src/elements/router/core/Route.unit.test.ts
+++ b/web/src/elements/router/core/Route.unit.test.ts
@@ -40,4 +40,30 @@ describe("Route", () => {
 
         expect(render).toHaveBeenCalledWith({ id: "42" });
     });
+
+    it("resolves a synchronous callback to a promise", async () => {
+        const route = new Route("/x", () => html`ok`);
+
+        await expect(route.resolve({})).resolves.toBeDefined();
+    });
+
+    it("resolves an asynchronous callback to its awaited value", async () => {
+        const route = new Route("/x", async () => html`async ok`);
+
+        await expect(route.resolve({})).resolves.toBeDefined();
+    });
+
+    it("propagates a rejection from an async callback", async () => {
+        const route = new Route("/x", () => Promise.reject(new Error("boom")));
+
+        await expect(route.resolve({})).rejects.toThrow("boom");
+    });
+
+    it("surfaces a synchronous throw as a rejection", async () => {
+        const route = new Route("/x", () => {
+            throw new Error("sync boom");
+        });
+
+        await expect(route.resolve({})).rejects.toThrow("sync boom");
+    });
 });

--- a/web/src/elements/router/core/RouterView.browser.test.ts
+++ b/web/src/elements/router/core/RouterView.browser.test.ts
@@ -1,0 +1,167 @@
+import { formatSpanName, RouterView } from "./RouterView.js";
+
+import { getRouterConfig, initRouter, resetRouterConfig } from "#elements/router/core/config";
+import { Route } from "#elements/router/core/Route";
+
+import { page } from "@vitest/browser/context";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { html } from "lit";
+
+const PREFIX = "/if/user/";
+
+function makeRoutes(): Route[] {
+    return [
+        new Route("/", () => html`<h1>User Home</h1>`, "home"),
+        new Route("/settings", () => html`<h1>Settings Page</h1>`, "settings"),
+        new Route("/x", () => html`<h1>X Page</h1>`, "x"),
+        new Route("/link", () => html`<a href="/if/user/settings">Go to settings</a>`, "link"),
+        new Route("/boom", () => Promise.reject(new Error("kaboom")), "boom"),
+    ];
+}
+
+interface MountInit {
+    url: string;
+    routes?: Route[];
+    prefix?: string;
+    defaultPath?: string;
+}
+
+const mountedContainers: HTMLElement[] = [];
+
+function mountView(init: MountInit): RouterView {
+    history.replaceState(null, "", init.url);
+
+    const container = document.createElement("div");
+    mountedContainers.push(container);
+    document.body.append(container);
+
+    // @ts-expect-error `renderLit` is added to `page` by test/lit/setup.js.
+    page.renderLit(
+        html`<ak-router-view
+            .routes=${init.routes ?? makeRoutes()}
+            .prefix=${init.prefix ?? PREFIX}
+            .defaultPath=${init.defaultPath ?? "/"}
+        ></ak-router-view>`,
+        container,
+    );
+
+    return container.querySelector<RouterView>("ak-router-view")!;
+}
+
+describe("ak-router-view", () => {
+    beforeEach(() => {
+        initRouter({ base: "/", interfaceName: "user" });
+    });
+
+    afterEach(() => {
+        // The shared `renderLit` helper does not track containers for cleanup, so
+        // remove them here. Detaching each container fires the outlet's
+        // `disconnectedCallback`, tearing down its global click/popstate/navigate
+        // listeners so a prior test's outlet cannot re-render into the next test.
+        while (mountedContainers.length) mountedContainers.pop()!.remove();
+
+        resetRouterConfig();
+        history.replaceState(null, "", "/");
+    });
+
+    test("registers the custom element", () => {
+        expect(customElements.get("ak-router-view")).toBe(RouterView);
+    });
+
+    test("renders the route matched from the pathname", async () => {
+        mountView({ url: "/if/user/settings" });
+
+        await expect.element(page.getByText("Settings Page")).toBeInTheDocument();
+    });
+
+    test("strips the prefix down to the interface root", async () => {
+        mountView({ url: "/if/user/" });
+
+        await expect.element(page.getByText("User Home")).toBeInTheDocument();
+    });
+
+    test("replace-redirects the interface root to a non-root defaultPath", async () => {
+        mountView({ url: "/if/user/", defaultPath: "/settings" });
+
+        await expect.element(page.getByText("Settings Page")).toBeInTheDocument();
+        expect(window.location.pathname).toBe("/if/user/settings");
+    });
+
+    test("falls back to the 404 element while preserving the URL", async () => {
+        mountView({ url: "/if/user/does-not-exist" });
+
+        await expect.element(page.getByText(/was not found/i)).toBeInTheDocument();
+        expect(window.location.pathname).toBe("/if/user/does-not-exist");
+    });
+
+    test("intercepts an in-prefix anchor click and re-renders via pushState", async () => {
+        mountView({ url: "/if/user/link" });
+
+        await expect.element(page.getByText("Go to settings")).toBeInTheDocument();
+        await page.getByText("Go to settings").click();
+
+        await expect.element(page.getByText("Settings Page")).toBeInTheDocument();
+        expect(window.location.pathname).toBe("/if/user/settings");
+    });
+
+    test("re-renders on popstate", async () => {
+        mountView({ url: "/if/user/settings" });
+        await expect.element(page.getByText("Settings Page")).toBeInTheDocument();
+
+        history.replaceState(null, "", "/if/user/");
+        window.dispatchEvent(new PopStateEvent("popstate"));
+
+        await expect.element(page.getByText("User Home")).toBeInTheDocument();
+    });
+
+    test("translates a legacy hash route at boot and renders the path", async () => {
+        mountView({ url: "/if/user/#/x;a=1" });
+
+        await expect.element(page.getByText("X Page")).toBeInTheDocument();
+        expect(window.location.pathname).toBe("/if/user/x");
+        expect(window.location.search).toBe("?a=1");
+    });
+
+    test("renders the error state when a route rejects, without an unhandled rejection", async () => {
+        const rejections: PromiseRejectionEvent[] = [];
+        const onRejection = (event: PromiseRejectionEvent) => rejections.push(event);
+        window.addEventListener("unhandledrejection", onRejection);
+
+        try {
+            mountView({ url: "/if/user/boom" });
+
+            await expect.element(page.getByText("kaboom")).toBeInTheDocument();
+            expect(rejections, "no unhandled rejection escaped the outlet").toHaveLength(0);
+        } finally {
+            window.removeEventListener("unhandledrejection", onRejection);
+        }
+    });
+
+    test("reads live config through the click-interceptor scope", () => {
+        // Guards the scope getter contract Plan 3b relies on.
+        expect(getRouterConfig()).toEqual({ base: "/", interfaceName: "user" });
+    });
+});
+
+describe("formatSpanName", () => {
+    test("joins a bare route name onto the prefix with a single slash", () => {
+        expect(formatSpanName("/if/user/", "library", "/ignored")).toBe("/if/user/library");
+    });
+
+    test("collapses a slash-carrying default route name", () => {
+        expect(formatSpanName("/if/user/", "/x", "/ignored")).toBe("/if/user/x");
+    });
+
+    test("passes the pathname through for the null (404) branch", () => {
+        expect(formatSpanName("/if/user/", null, "/if/user/does-not-exist")).toBe(
+            "/if/user/does-not-exist",
+        );
+    });
+
+    test("handles a non-root base prefix", () => {
+        expect(formatSpanName("/auth/if/user/", "settings", "/ignored")).toBe(
+            "/auth/if/user/settings",
+        );
+    });
+});

--- a/web/src/elements/router/core/RouterView.ts
+++ b/web/src/elements/router/core/RouterView.ts
@@ -1,0 +1,246 @@
+/**
+ * @file Path-router outlet for the new route table.
+ *
+ * Renders the route matched from `location.pathname` (with the interface
+ * `prefix` stripped per the matcher's leading-slash contract), owns the
+ * loading and error states, and claims in-interface anchor clicks. Ships
+ * inert: nothing imports it until the interface flip in Plan 3b.
+ *
+ * App-context-free: imports only the router core, the reused 404/empty-state
+ * elements, `AKElement`, lit, `@sentry/browser`, and `@lit/localize`.
+ */
+
+import "#elements/router/Router404";
+import "#elements/EmptyState";
+
+import { AKElement } from "#elements/Base";
+import { getRouterConfig } from "#elements/router/core/config";
+import { applyHashRedirect } from "#elements/router/core/hash-shim";
+import { matchRoute, type RouteMatch } from "#elements/router/core/matcher";
+import {
+    createClickInterceptor,
+    navigate,
+    RouterNavigateEvent,
+} from "#elements/router/core/navigation";
+import { Route } from "#elements/router/core/Route";
+import { type SlottedTemplateResult } from "#elements/types";
+
+import {
+    getClient,
+    SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+    type Span,
+    startBrowserTracingNavigationSpan,
+    startBrowserTracingPageLoadSpan,
+} from "@sentry/browser";
+
+import { msg } from "@lit/localize";
+import { html, type PropertyValues, type TemplateResult } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import { until } from "lit/directives/until.js";
+
+/**
+ * Build a Sentry span name by joining the interface `prefix` to the matched
+ * route `name` with exactly one slash — a bare name (`"library"`) and a
+ * default-route name that carries its own leading slash (`"/x"`) both yield a
+ * single separator. A `null` name (the 404 / unmatched branch) passes the raw
+ * `pathname` through unchanged.
+ */
+export function formatSpanName(prefix: string, routeName: string | null, pathname: string): string {
+    if (routeName === null) return pathname;
+
+    return `${prefix.replace(/\/+$/, "")}/${routeName.replace(/^\/+/, "")}`;
+}
+
+@customElement("ak-router-view")
+export class RouterView extends AKElement {
+    /**
+     * Render into the light DOM so PatternFly page styles cascade and the 404 /
+     * empty-state children resolve normally. Mirrors the legacy outlet.
+     */
+    protected override createRenderRoot() {
+        return this;
+    }
+
+    public override role = "presentation";
+
+    //#region Properties
+
+    @property({ attribute: false })
+    public routes: Route[] = [];
+
+    @property({ type: String })
+    public prefix = "";
+
+    @property({ type: String, attribute: "default-path" })
+    public defaultPath = "/";
+
+    @state()
+    private current: RouteMatch<Route> | null = null;
+
+    //#endregion
+
+    //#region Sentry
+
+    #sentryClient = getClient();
+    #pageLoadSpan: Span | null = null;
+
+    constructor() {
+        super();
+
+        if (process.env.NODE_ENV !== "production" && this.#sentryClient) {
+            this.#pageLoadSpan =
+                startBrowserTracingPageLoadSpan(this.#sentryClient, {
+                    name: window.location.pathname,
+                    attributes: {
+                        [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: "url",
+                    },
+                }) ?? null;
+        }
+    }
+
+    //#endregion
+
+    //#region Lifecycle
+
+    #clickHandler = createClickInterceptor(
+        () => {
+            const { base, interfaceName } = getRouterConfig();
+
+            return {
+                origin: window.location.origin,
+                base,
+                interfaceName,
+                currentPathname: window.location.pathname,
+                currentSearch: window.location.search,
+            };
+        },
+        (url) => navigate(url),
+    );
+
+    #onPopState = (): void => this.#syncRoute();
+    #onNavigate = (): void => this.#syncRoute();
+
+    public override connectedCallback(): void {
+        super.connectedCallback();
+
+        window.addEventListener("popstate", this.#onPopState);
+        window.addEventListener(RouterNavigateEvent.eventName, this.#onNavigate);
+        document.addEventListener("click", this.#clickHandler, { capture: true });
+
+        applyHashRedirect();
+        this.#syncRoute();
+    }
+
+    public override disconnectedCallback(): void {
+        window.removeEventListener("popstate", this.#onPopState);
+        window.removeEventListener(RouterNavigateEvent.eventName, this.#onNavigate);
+        document.removeEventListener("click", this.#clickHandler, { capture: true });
+
+        super.disconnectedCallback();
+    }
+
+    //#endregion
+
+    //#region Matching
+
+    /**
+     * Strip the interface prefix, preserving the leading slash the matcher
+     * requires: `/if/user/settings` → `/settings`, `/if/user/` → `/`. A
+     * pathname outside the prefix is returned unchanged so it falls through to
+     * the 404 branch.
+     */
+    #strip(pathname: string): string {
+        if (!pathname.startsWith(this.prefix)) return pathname;
+
+        return `/${pathname.slice(this.prefix.length).replace(/^\/+/, "")}`;
+    }
+
+    /**
+     * Join a route-relative path onto the prefix for navigation.
+     */
+    #join(path: string): string {
+        return `${this.prefix}${path.replace(/^\/+/, "")}`;
+    }
+
+    #syncRoute = (): void => {
+        let stripped = this.#strip(window.location.pathname);
+
+        if (stripped === "/" && this.defaultPath !== "/") {
+            // `navigate` applies `replaceState` synchronously, so re-reading the
+            // location yields the redirected path immediately.
+            navigate(this.#join(this.defaultPath), { mode: "replace" });
+            stripped = this.#strip(window.location.pathname);
+        }
+
+        this.current = matchRoute(stripped, this.routes);
+    };
+
+    //#endregion
+
+    //#region Rendering
+
+    async #resolve(match: RouteMatch<Route>): Promise<SlottedTemplateResult> {
+        try {
+            return await match.route.resolve(match.parameters);
+        } catch (error) {
+            return this.#renderError(error);
+        }
+    }
+
+    #renderError(error: unknown): SlottedTemplateResult {
+        const message = error instanceof Error ? error.message : String(error);
+
+        return html`<ak-empty-state icon="fa-times-circle">
+            <span>${msg("This page failed to load.", { id: "router.view.error.heading" })}</span>
+            <span slot="body">${message}</span>
+        </ak-empty-state>`;
+    }
+
+    #spanName(): string {
+        return formatSpanName(
+            this.prefix,
+            this.current?.route.name ?? null,
+            window.location.pathname,
+        );
+    }
+
+    protected override updated(changedProperties: PropertyValues): void {
+        if (!changedProperties.has("current")) return;
+        if (!this.#sentryClient) return;
+
+        const name = this.#spanName();
+
+        if (this.#pageLoadSpan) {
+            this.#pageLoadSpan.updateName(name);
+            this.#pageLoadSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, "route");
+            this.#pageLoadSpan = null;
+        } else {
+            startBrowserTracingNavigationSpan(this.#sentryClient, {
+                op: "navigation",
+                name,
+                attributes: {
+                    [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: "route",
+                },
+            });
+        }
+    }
+
+    render(): TemplateResult {
+        if (!this.current) {
+            return html`<ak-router-404 url=${window.location.pathname}></ak-router-404>`;
+        }
+
+        return html`${until(
+            this.#resolve(this.current),
+            html`<ak-empty-state loading></ak-empty-state>`,
+        )}`;
+    }
+
+    //#endregion
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "ak-router-view": RouterView;
+    }
+}

--- a/web/src/elements/router/core/RouterView.ts
+++ b/web/src/elements/router/core/RouterView.ts
@@ -7,11 +7,14 @@
  * inert: nothing imports it until the interface flip in Plan 3b.
  *
  * App-context-free: imports only the router core, the reused 404/empty-state
- * elements, `AKElement`, lit, `@sentry/browser`, and `@lit/localize`.
+ * elements, `AKElement`, lit, `@sentry/browser` (plus the leaf
+ * `sentry/tracing` predicate), and `@lit/localize`.
  */
 
 import "#elements/router/Router404";
 import "#elements/EmptyState";
+
+import { sentryReporting } from "#common/sentry/tracing";
 
 import { AKElement } from "#elements/Base";
 import { getRouterConfig } from "#elements/router/core/config";
@@ -87,7 +90,7 @@ export class RouterView extends AKElement {
     constructor() {
         super();
 
-        if (process.env.NODE_ENV !== "production" && this.#sentryClient) {
+        if (this.#sentryClient && sentryReporting(this.#sentryClient)) {
             this.#pageLoadSpan =
                 startBrowserTracingPageLoadSpan(this.#sentryClient, {
                     name: window.location.pathname,
@@ -206,7 +209,7 @@ export class RouterView extends AKElement {
 
     protected override updated(changedProperties: PropertyValues): void {
         if (!changedProperties.has("current")) return;
-        if (!this.#sentryClient) return;
+        if (!this.#sentryClient || !sentryReporting(this.#sentryClient)) return;
 
         const name = this.#spanName();
 

--- a/web/src/elements/router/core/navigation.ts
+++ b/web/src/elements/router/core/navigation.ts
@@ -39,6 +39,24 @@ declare global {
 }
 
 /**
+ * Resolve the effective navigation mode for a destination.
+ *
+ * A cross-origin destination cannot use the history API — `pushState` /
+ * `replaceState` throw `SecurityError` — so it is forced to a full-page
+ * `assign`. An explicit `assign` is always preserved.
+ */
+export function resolveNavigationMode(
+    mode: NavigationMode,
+    targetOrigin: string,
+    currentOrigin: string,
+): NavigationMode {
+    if (mode === "assign") return "assign";
+    if (targetOrigin !== currentOrigin) return "assign";
+
+    return mode;
+}
+
+/**
  * Navigate to a destination.
  *
  * @param to An absolute or relative URL. Relative URLs resolve against the
@@ -48,15 +66,16 @@ declare global {
  */
 export function navigate(to: string | URL, { mode = "push" }: NavigateOptions = {}): void {
     const url = to instanceof URL ? to : new URL(to, window.location.origin);
+    const effectiveMode = resolveNavigationMode(mode, url.origin, window.location.origin);
 
-    if (mode === "assign") {
+    if (effectiveMode === "assign") {
         window.location.assign(url.href);
         return;
     }
 
     if (url.href === window.location.href) return;
 
-    if (mode === "replace") {
+    if (effectiveMode === "replace") {
         history.replaceState(null, "", url.href);
     } else {
         history.pushState(null, "", url.href);

--- a/web/src/elements/router/core/navigation.unit.test.ts
+++ b/web/src/elements/router/core/navigation.unit.test.ts
@@ -1,4 +1,9 @@
-import { type AnchorClickContext, decideInterception, type InterceptScope } from "./navigation.js";
+import {
+    type AnchorClickContext,
+    decideInterception,
+    type InterceptScope,
+    resolveNavigationMode,
+} from "./navigation.js";
 
 import { describe, expect, it } from "vitest";
 
@@ -109,5 +114,27 @@ describe("decideInterception", () => {
             decideInterception(ctx({ href: "https://id.example.com/auth/if/admin/x" }), authScope)
                 ?.pathname,
         ).toBe("/auth/if/admin/x");
+    });
+});
+
+describe("resolveNavigationMode", () => {
+    const origin = "https://id.example.com";
+
+    it("keeps push for a same-origin destination", () => {
+        expect(resolveNavigationMode("push", origin, origin)).toBe("push");
+    });
+
+    it("keeps replace for a same-origin destination", () => {
+        expect(resolveNavigationMode("replace", origin, origin)).toBe("replace");
+    });
+
+    it("falls back to assign for a cross-origin destination", () => {
+        expect(resolveNavigationMode("push", "https://evil.example.com", origin)).toBe("assign");
+        expect(resolveNavigationMode("replace", "https://evil.example.com", origin)).toBe("assign");
+    });
+
+    it("passes an explicit assign through unchanged", () => {
+        expect(resolveNavigationMode("assign", origin, origin)).toBe("assign");
+        expect(resolveNavigationMode("assign", "https://evil.example.com", origin)).toBe("assign");
     });
 });

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -61,6 +61,7 @@ export default defineConfig({
                 },
             },
             {
+                plugins: [inlineCSSPlugin()],
                 test: {
                     setupFiles: ["./test/lit/setup.js"],
 


### PR DESCRIPTION
## Details

This PR adds `<ak-router-view>`, the outlet that renders the new path-based route table, plus the two core hooks it needs. It strips the interface prefix from `location.pathname`, matches through the router core, intercepts in-interface clicks, re-matches on popstate, redirects `/` to a configurable `default-path`, falls back to `<ak-router-404>` with the URL preserved, and owns the loading and error states, so a rejecting route renders an error state instead of escaping as an unhandled rejection. Sentry pageload and navigation spans mirror the legacy hash outlet.

Two supporting changes come with it: `Route.resolve()` exposes a route's render callback as a promise so the outlet can own the async states, and `navigate()` falls back to a full-page assign for cross-origin destinations instead of letting `pushState` throw.

Nothing mounts the element yet. The user-interface flip lands on top of this.
