### PR TITLE
Add example brute-force lockout blueprint

### DIFF
--- a/blueprints/example/flows-brute-force-lockout.yaml
+++ b/blueprints/example/flows-brute-force-lockout.yaml
@@ -1,0 +1,83 @@
+# Example blueprint for goauthentik/authentik — copy to:
+#   blueprints/example/flows-brute-force-lockout.yaml
+#
+# Workaround for brute-force lockout when using reputation policies:
+# https://github.com/goauthentik/authentik/issues/10196
+# https://github.com/goauthentik/authentik/issues/8685
+#
+# Password MUST be a separate stage (order 20), NOT embedded in identification.
+# Flow: identification (10) → deny if low reputation (11) → password (20) → …
+version: 1
+metadata:
+  labels:
+    blueprints.goauthentik.io/instantiate: "false"
+  name: Example - Brute force lockout (reputation + deny)
+entries:
+  - identifiers:
+      slug: default-authentication-flow
+    id: flow
+    model: authentik_flows.flow
+  - identifiers:
+      name: default-authentication-identification
+    id: default-authentication-identification
+    model: authentik_stages_identification.identificationstage
+    attrs:
+      password_stage: null
+      user_fields:
+        - email
+        - username
+  - identifiers:
+      name: default-authentication-password
+    id: default-authentication-password
+    model: authentik_stages_password.passwordstage
+    attrs:
+      failed_attempts_before_cancel: 5
+  - identifiers:
+      name: default-authentication-flow-brute-force-deny
+    id: default-authentication-flow-brute-force-deny
+    model: authentik_stages_deny.denystage
+    attrs:
+      deny_message: >-
+        Too many failed sign-in attempts. Please try again later.
+  - identifiers:
+      name: default-authentication-flow-brute-force-reputation
+    id: default-authentication-flow-brute-force-reputation
+    model: authentik_policies_reputation.reputationpolicy
+    attrs:
+      check_ip: true
+      check_username: true
+      threshold: -5
+  - identifiers:
+      target: !KeyOf flow
+      stage: !KeyOf default-authentication-identification
+      order: 10
+    model: authentik_flows.flowstagebinding
+    attrs:
+      evaluate_on_plan: false
+      re_evaluate_policies: true
+  - identifiers:
+      target: !KeyOf flow
+      stage: !KeyOf default-authentication-flow-brute-force-deny
+      order: 11
+    id: flow-binding-brute-force-deny
+    model: authentik_flows.flowstagebinding
+    attrs:
+      evaluate_on_plan: false
+      re_evaluate_policies: true
+  - identifiers:
+      target: !KeyOf flow
+      stage: !KeyOf default-authentication-password
+      order: 20
+    model: authentik_flows.flowstagebinding
+    attrs:
+      evaluate_on_plan: false
+      re_evaluate_policies: true
+  - identifiers:
+      policy: !KeyOf default-authentication-flow-brute-force-reputation
+      target: !KeyOf flow-binding-brute-force-deny
+      order: 0
+    model: authentik_policies.policybinding
+    attrs:
+      enabled: true
+      negate: false
+      failure_result: false


### PR DESCRIPTION
## Summary

Adds an example blueprint that configures brute-force lockout on the default authentication flow using a **Reputation policy** and a **Deny stage**.

This documents the production-tested workaround for [#10196](https://github.com/goauthentik/authentik/issues/10196) / [#8685](https://github.com/goauthentik/authentik/issues/8685): lockout and `failed_attempts_before_cancel` do not work reliably when the password prompt is embedded in the Identification stage. The password must be a **separate stage** bound after identification.

## Flow layout

| Order | Stage | Purpose |
|------:|-------|---------|
| 10 | Identification | Username/email only (`password_stage: null`) |
| 11 | Deny | Blocks sign-in when reputation score ≤ threshold |
| 20 | Password | `failed_attempts_before_cancel: 5` |

## Reputation policy

- Checks client IP and username
- Threshold: `-5` (five failed attempts decrease score by 1 each)
- Bound to the Deny stage binding with `re_evaluate_policies: true`

## Related issues

- #10196 — Failed attempts not working when password is in Identification stage
- #8685 — Same root cause
- #12248 — Reputation policy not applied with embedded password (duplicate)

## Note

This is a **configuration example**, not a code fix for embedded-password lockout. Tested on authentik **2026.5.4** in production.

Similar to the existing `flows-login-conditional-captcha.yaml` example, but uses Deny instead of Captcha for hard lockout.

## Test plan

- [ ] Import blueprint on a test instance (Customization → Blueprints → Import)
- [ ] Enter wrong password 5+ times for the same user/IP
- [ ] Expect `access denied` (Deny stage) or flow cancel after 5 attempts on Password stage
- [ ] Confirm identification shows username only, password on a second step
