### PR TITLE
packages/django-dramatiq-postgres/broker: use positive state filter for pending messages

### DIFF
--- a/authentik/tasks/tests/test_broker.py
+++ b/authentik/tasks/tests/test_broker.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock
 
 from django.test import SimpleTestCase
-from django_dramatiq_postgres.broker import PostgresBroker
+from django_dramatiq_postgres.broker import CONSUMABLE_TASK_STATES, PostgresBroker
 from django_dramatiq_postgres.models import TaskState
 from dramatiq.broker import MessageProxy
 from dramatiq.message import Message
@@ -93,3 +93,24 @@ class TestPostgresConsumer(SimpleTestCase):
             {first_message.message_id, second_message.message_id},
         )
         self.assertNotIn(first_message.message_id, consumer.in_processing)
+
+    def test_fetch_pending_messages_filters_consumable_states(self):
+        consumer = self._consumer()
+        consumer.queue_name = "default"
+        consumer.timeout = 30
+        query_set = consumer.query_set
+        queue_query = query_set.exclude.return_value.filter.return_value
+        pending_query = queue_query.filter.return_value
+        values_list = pending_query.exclude.return_value.order_by.return_value.values_list
+        values_list.return_value = ["00000000-0000-0000-0000-000000000001"]
+
+        pending = consumer._fetch_pending_messages()
+
+        query_set.exclude.assert_called_once_with(message_id__in=consumer.in_processing)
+        query_set.exclude.return_value.filter.assert_called_once_with(
+            queue_name=consumer.queue_name,
+        )
+        queue_query.filter.assert_called_once_with(
+            state__in=CONSUMABLE_TASK_STATES,
+        )
+        self.assertEqual(pending, {"00000000-0000-0000-0000-000000000001"})

--- a/packages/django-dramatiq-postgres/django_dramatiq_postgres/broker.py
+++ b/packages/django-dramatiq-postgres/django_dramatiq_postgres/broker.py
@@ -48,6 +48,12 @@ DATABASE_ERRORS = (
     OperationalError,
 )
 
+CONSUMABLE_TASK_STATES: set[TaskState] = set(TaskState) - {
+    TaskState.DONE,
+    TaskState.REJECTED,
+    TaskState.WAITING_FOR_DEPENDENCIES,
+}
+
 
 def channel_name(queue_name: str, identifier: ChannelIdentifier) -> str:
     return f"{CHANNEL_PREFIX}.{queue_name}.{identifier.value}"
@@ -375,13 +381,7 @@ class _PostgresConsumer(Consumer):
         pending = set(
             self.query_set.exclude(message_id__in=self.in_processing)
             .filter(queue_name=self.queue_name)
-            .exclude(
-                state__in=(
-                    TaskState.DONE,
-                    TaskState.REJECTED,
-                    TaskState.WAITING_FOR_DEPENDENCIES,
-                )
-            )
+            .filter(state__in=CONSUMABLE_TASK_STATES)
             .exclude(eta__gte=timezone.now() + timedelta(seconds=self.timeout))
             .order_by(F("eta").asc(nulls_first=True))
             .values_list("message_id", flat=True)
@@ -417,7 +417,7 @@ class _PostgresConsumer(Consumer):
                     WHERE
                         {table}.{message_id} = %(message_id)s
                         AND
-                        {table}.{state} != ALL(%(excluded_states)s)
+                        {table}.{state} = ANY(%(consumable_states)s)
                         AND
                         ({table}.{eta} < %(maximum_eta)s OR {table}.{eta} IS NULL)
                         AND
@@ -433,11 +433,7 @@ class _PostgresConsumer(Consumer):
                     "state": TaskState.CONSUMED.value,
                     "mtime": timezone.now(),
                     "message_id": message_id,
-                    "excluded_states": [
-                        TaskState.DONE.value,
-                        TaskState.REJECTED.value,
-                        TaskState.WAITING_FOR_DEPENDENCIES.value,
-                    ],
+                    "consumable_states": [state.value for state in CONSUMABLE_TASK_STATES],
                     "maximum_eta": timezone.now() + timedelta(seconds=self.timeout),
                     "lock_id": self._get_message_lock_id(message_id),
                 },


### PR DESCRIPTION
## Details
- Change the Postgres task consumer pending-message lookup from a negative terminal-state exclusion to a positive consumable-state filter.
- Let PostgreSQL use the existing `(queue_name, state, eta)` index for queue polling.
- Add a regression test that asserts the consumer applies the positive state filter.

### What does this PR change?
Changes query to be positive and thereby near instant

### Why is this change needed?
Seek over all rows in tasks, including completed tasks is slow.

### How was this tested?

- `git diff --check`
- Built and published a container image from this branch.
- Deployed the image to a Kubernetes Authentik worker/server pair.
- Verified the running worker contains `.filter(state__in=CONSUMABLE_TASK_STATES)`.
- Verified PostgreSQL plans the positive-state query with `authentik_t_queue_n_099d0d_idx`.

On a production-like task table with about 409k rows, mostly completed tasks, the old query shape planned as a parallel sequential scan:

```text
Parallel Seq Scan on authentik_tasks_task
cost ~= 253678
```

The new query shape uses the existing index:

```text
Index Scan using authentik_t_queue_n_099d0d_idx on authentik_tasks_task
cost ~= 346
```

### Linked issues

None opened

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
