### PR TITLE
internal: remove custom Vary header

### DIFF
--- a/internal/web/static.go
+++ b/internal/web/static.go
@@ -190,7 +190,6 @@ func (ws *WebServer) staticHeaderMiddleware(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "public, no-transform")
 		w.Header().Set("X-authentik-version", constants.VERSION())
-		w.Header().Set("Vary", "X-authentik-version, Etag")
 		etagHandler.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION


<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

The `Vary` response header is designed to take a list of request
headers influencing the response.
The values listed in the `Vary` header here however are not request but
but response headers which appear to not influence anything if included
in a request.

### What does this PR change?

Remove the custom `Vary` response header - instead, Gorilla's default `Vary` header will be served.

### Why is this change needed?

The current `Vary` header
- is confusing
- causes additional configuration work when using proxy software which
  only handles specific `Vary` values
- overwrote the `Vary: Accept-Encoding` header set by Gorilla's
  `CompressHandler()` - a `Vary` header that's actually useful

### How was this tested?

Service still operates, even throughout version changes.

### Linked issues

<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [x] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
