### PR TITLE
core: add endpoint for revoking all user sessions

### DIFF
--- a/authentik/core/api/authenticated_sessions.py
+++ b/authentik/core/api/authenticated_sessions.py
@@ -16,6 +16,7 @@ from rest_framework.serializers import (
     DateTimeField,
     IPAddressField,
     ListField,
+    PrimaryKeyRelatedField,
 )
 from rest_framework.viewsets import GenericViewSet
 from ua_parser import user_agent_parser
@@ -23,7 +24,7 @@ from ua_parser import user_agent_parser
 from authentik.api.validation import validate
 from authentik.core.api.used_by import UsedByMixin
 from authentik.core.api.utils import ModelSerializer, PassiveSerializer
-from authentik.core.models import AuthenticatedSession
+from authentik.core.models import AuthenticatedSession, User
 from authentik.events.context_processors.asn import ASN_CONTEXT_PROCESSOR, ASNDict
 from authentik.events.context_processors.geoip import GEOIP_CONTEXT_PROCESSOR, GeoIPDict
 from authentik.rbac.decorators import permission_required
@@ -69,7 +70,7 @@ class BulkDeleteSessionSerializer(PassiveSerializer):
     """Serializer for bulk deleting authenticated sessions"""
 
     user_pks = ListField(
-        child=serializers.IntegerField(),
+        child=PrimaryKeyRelatedField(queryset=User.objects.all()),
         help_text="List of user IDs to revoke all sessions for, or empty to revoke all sessions.",
         required=False,
         default=[],
@@ -164,7 +165,7 @@ class AuthenticatedSessionViewSet(
         include_current_session = query.validated_data.get("include_current_session", False)
         sessions = AuthenticatedSession.objects.all()
         if len(user_pks) != 0:
-            sessions = sessions.filter(user_id__in=user_pks)
+            sessions = sessions.filter(user__in=user_pks)
         if not include_current_session:
             sessions = sessions.exclude(session__session_key=request.session.session_key)
         _, deleted = sessions.delete()

--- a/authentik/core/api/authenticated_sessions.py
+++ b/authentik/core/api/authenticated_sessions.py
@@ -8,7 +8,7 @@ from drf_spectacular.utils import (
 )
 from rest_framework import mixins, serializers
 from rest_framework.decorators import action
-from rest_framework.fields import SerializerMethodField
+from rest_framework.fields import BooleanField, SerializerMethodField
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import (
@@ -66,10 +66,19 @@ class UserAgentDict(TypedDict):
 
 
 class BulkDeleteSessionSerializer(PassiveSerializer):
-    """Serializer for bulk deleting authenticated sessions by user"""
+    """Serializer for bulk deleting authenticated sessions"""
 
     user_pks = ListField(
-        child=serializers.IntegerField(), help_text="List of user IDs to revoke all sessions for"
+        child=serializers.IntegerField(),
+        help_text="List of user IDs to revoke all sessions for, or empty to revoke all sessions.",
+        required=False,
+        default=[],
+    )
+
+    include_current_session = BooleanField(
+        help_text="Whether or not the current session should be included in the revocation",
+        default=False,
+        required=False,
     )
 
 
@@ -152,6 +161,13 @@ class AuthenticatedSessionViewSet(
     def bulk_delete(self, request: Request, *, query: BulkDeleteSessionSerializer) -> Response:
         """Bulk revoke all sessions for multiple users"""
         user_pks = query.validated_data.get("user_pks", [])
-        deleted_count, _ = AuthenticatedSession.objects.filter(user_id__in=user_pks).delete()
+        include_current_session = query.validated_data.get("include_current_session", False)
+        sessions = AuthenticatedSession.objects.all()
+        if len(user_pks) != 0:
+            sessions = sessions.filter(user_id__in=user_pks)
+        if not include_current_session:
+            sessions = sessions.exclude(session__session_key=request.session.session_key)
+        _, deleted = sessions.delete()
+        deleted_count = deleted.get("authentik_core.AuthenticatedSession")
 
         return Response({"deleted": deleted_count}, status=200)

--- a/authentik/core/tests/test_authenticated_sessions_api.py
+++ b/authentik/core/tests/test_authenticated_sessions_api.py
@@ -7,6 +7,7 @@ from rest_framework.test import APITestCase
 
 from authentik.core.models import AuthenticatedSession, Session, User
 from authentik.core.tests.utils import create_test_admin_user
+from authentik.lib.generators import generate_id
 
 
 class TestAuthenticatedSessionsAPI(APITestCase):
@@ -16,6 +17,17 @@ class TestAuthenticatedSessionsAPI(APITestCase):
         super().setUp()
         self.user = create_test_admin_user()
         self.other_user = User.objects.create(username="normal-user")
+
+    def _create_user_session(self, user: User):
+        session = Session.objects.create(
+            session_key=generate_id(),
+            last_ip="127.0.0.1",
+        )
+        AuthenticatedSession.objects.create(
+            session=session,
+            user=user,
+        )
+        return session
 
     def test_list(self):
         """Test session list endpoint"""
@@ -43,5 +55,61 @@ class TestAuthenticatedSessionsAPI(APITestCase):
             )
         )
         self.assertEqual(response.status_code, 204)
+        self.assertEqual(AuthenticatedSession.objects.all().count(), 0)
+        self.assertEqual(Session.objects.all().count(), 0)
+
+    def test_bulk_delete(self):
+        """Test deletion for all users except the current user session"""
+        self.client.force_login(self.user)
+        self._create_user_session(self.user)
+        self._create_user_session(self.other_user)
+        self.assertEqual(AuthenticatedSession.objects.all().count(), 3)
+        self.assertEqual(Session.objects.all().count(), 3)
+        response = self.client.delete(
+            reverse(
+                "authentik_api:authenticatedsession-bulk-delete",
+                kwargs={},
+            )
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(AuthenticatedSession.objects.all().count(), 1)
+        self.assertEqual(Session.objects.all().count(), 1)
+
+    def test_bulk_delete_including_current(self):
+        """Test deletion for all users including the current user session"""
+        self.client.force_login(self.user)
+        self._create_user_session(self.user)
+        self._create_user_session(self.other_user)
+        self.assertEqual(AuthenticatedSession.objects.all().count(), 3)
+        self.assertEqual(Session.objects.all().count(), 3)
+        response = self.client.delete(
+            reverse(
+                "authentik_api:authenticatedsession-bulk-delete",
+                query={
+                    "include_current_session": True,
+                },
+            ),
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(AuthenticatedSession.objects.all().count(), 0)
+        self.assertEqual(Session.objects.all().count(), 0)
+
+    def test_bulk_delete_users(self):
+        """Test deletion for select users"""
+        self.client.force_login(self.user)
+        self._create_user_session(self.user)
+        self._create_user_session(self.other_user)
+        self.assertEqual(AuthenticatedSession.objects.all().count(), 3)
+        self.assertEqual(Session.objects.all().count(), 3)
+        response = self.client.delete(
+            reverse(
+                "authentik_api:authenticatedsession-bulk-delete",
+                query={
+                    "include_current_session": True,
+                    "user_pks": [self.user.pk, self.other_user.pk],
+                },
+            ),
+        )
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(AuthenticatedSession.objects.all().count(), 0)
         self.assertEqual(Session.objects.all().count(), 0)

--- a/packages/client-ts/src/apis/CoreApi.ts
+++ b/packages/client-ts/src/apis/CoreApi.ts
@@ -209,7 +209,8 @@ export interface CoreApplicationsUsedByListRequest {
 }
 
 export interface CoreAuthenticatedSessionsBulkDeleteDestroyRequest {
-    userPks: Array<number>;
+    includeCurrentSession?: boolean;
+    userPks?: Array<number>;
 }
 
 export interface CoreAuthenticatedSessionsDestroyRequest {
@@ -1627,14 +1628,11 @@ export class CoreApi extends runtime.BaseAPI {
     async coreAuthenticatedSessionsBulkDeleteDestroyRequestOpts(
         requestParameters: CoreAuthenticatedSessionsBulkDeleteDestroyRequest,
     ): Promise<runtime.RequestOpts> {
-        if (requestParameters["userPks"] == null) {
-            throw new runtime.RequiredError(
-                "userPks",
-                'Required parameter "userPks" was null or undefined when calling coreAuthenticatedSessionsBulkDeleteDestroy().',
-            );
-        }
-
         const queryParameters: any = {};
+
+        if (requestParameters["includeCurrentSession"] != null) {
+            queryParameters["include_current_session"] = requestParameters["includeCurrentSession"];
+        }
 
         if (requestParameters["userPks"] != null) {
             queryParameters["user_pks"] = requestParameters["userPks"];
@@ -1681,7 +1679,7 @@ export class CoreApi extends runtime.BaseAPI {
      * Bulk revoke all sessions for multiple users
      */
     async coreAuthenticatedSessionsBulkDeleteDestroy(
-        requestParameters: CoreAuthenticatedSessionsBulkDeleteDestroyRequest,
+        requestParameters: CoreAuthenticatedSessionsBulkDeleteDestroyRequest = {},
         initOverrides?: RequestInit | runtime.InitOverrideFunction,
     ): Promise<BulkDeleteSessionResponse> {
         const response = await this.coreAuthenticatedSessionsBulkDeleteDestroyRaw(

--- a/schema.yml
+++ b/schema.yml
@@ -3092,13 +3092,21 @@ paths:
       description: Bulk revoke all sessions for multiple users
       parameters:
       - in: query
+        name: include_current_session
+        schema:
+          type: boolean
+          default: false
+        description: Whether or not the current session should be included in the
+          revocation
+      - in: query
         name: user_pks
         schema:
           type: array
           items:
             type: integer
-        description: List of user IDs to revoke all sessions for
-        required: true
+          default: []
+        description: List of user IDs to revoke all sessions for, or empty to revoke
+          all sessions.
       tags:
       - core
       security:


### PR DESCRIPTION
<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details
### What does this PR change?

Adapts existing API endpoint for bulk revoking user sessions to revoke all sessions when a list of `user_pks` is not provided.

`DELETE /api/v3/core/authenticated_sessions/bulk_delete/`

### Why is this change needed?

Shortcut to calling the bulk delete endpoint with every user ID.

### How was this tested?

Unit tests.

## Checklist

-   [x] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)