### PR TITLE
ak: obscure password for hashing

### DIFF
--- a/authentik/core/management/commands/hash_password.py
+++ b/authentik/core/management/commands/hash_password.py
@@ -1,5 +1,8 @@
 """Hash password using Django's password hashers"""
 
+import sys
+from getpass import getpass
+
 from django.contrib.auth.hashers import make_password
 from django.core.management.base import BaseCommand, CommandError
 
@@ -9,20 +12,64 @@ class Command(BaseCommand):
 
     help = "Hash a password for use with AUTHENTIK_BOOTSTRAP_PASSWORD_HASH"
 
+    # Not "stdin": call_command() maps that name onto the --stdin flag's dest.
+    stealth_options = ("stdin_stream",)
+
     def add_arguments(self, parser):
         parser.add_argument(
             "password",
             type=str,
-            help="Password to hash",
+            nargs="?",
+            default=None,
+            help=(
+                "Password to hash. Exposed in the process list and shell history, "
+                "so prefer --stdin or the interactive prompt."
+            ),
+        )
+        parser.add_argument(
+            "--stdin",
+            action="store_true",
+            dest="from_stdin",
+            help="Read the password from stdin instead of an argument.",
         )
 
-    def handle(self, *args, **options):
-        password = options["password"]
+    def execute(self, *args, **options):
+        self.stdin = options.get("stdin_stream", sys.stdin)
+        return super().execute(*args, **options)
 
+    def handle(self, *args, **options):
+        password = self.get_password(options["password"], options["from_stdin"])
         if not password:
             raise CommandError("Password cannot be empty")
         try:
             hashed = make_password(password)
-            self.stdout.write(hashed)
         except ValueError as exc:
             raise CommandError(f"Error hashing password: {exc}") from exc
+        self.stdout.write(hashed)
+
+    def get_password(self, password: str | None, from_stdin: bool) -> str:
+        """Resolve the password from stdin, an argument, or an interactive prompt."""
+        if from_stdin:
+            if password is not None:
+                raise CommandError("Cannot use both --stdin and a password argument.")
+            return self.read_stdin()
+        if password is not None:
+            return password
+        return self.prompt()
+
+    def read_stdin(self) -> str:
+        """Read a single line, discarding the trailing newline a pipe usually carries."""
+        password = self.stdin.readline()
+        return password.removesuffix("\n").removesuffix("\r")
+
+    def prompt(self) -> str:
+        """Prompt twice, so a typo fails here instead of in a deployed hash."""
+        if not self.stdin.isatty():
+            raise CommandError(
+                "No password given. Pass the password as an argument, use --stdin to read "
+                "it from a pipe, or attach a TTY to be prompted."
+            )
+        password = getpass("Password: ")
+        if password != getpass("Password (again): "):
+            raise CommandError("Passwords do not match.")
+        return password

--- a/authentik/core/tests/test_hash_password_command.py
+++ b/authentik/core/tests/test_hash_password_command.py
@@ -26,3 +26,47 @@ class TestHashPasswordCommand(TestCase):
             call_command("hash_password", "")
 
         self.assertIn("Password cannot be empty", str(ctx.exception))
+
+    def test_hash_password_stdin(self):
+        """Test hashing a password read from stdin."""
+        out = StringIO()
+        call_command("hash_password", "--stdin", stdin_stream=StringIO("test123\n"), stdout=out)
+        hashed = out.getvalue().strip()
+
+        self.assertTrue(hashed.startswith("pbkdf2_sha256$"))
+        self.assertTrue(check_password("test123", hashed))
+
+    def test_hash_password_stdin_without_trailing_newline(self):
+        """Test that a password piped without a trailing newline is read intact."""
+        out = StringIO()
+        call_command("hash_password", "--stdin", stdin_stream=StringIO("test123"), stdout=out)
+
+        self.assertTrue(check_password("test123", out.getvalue().strip()))
+
+    def test_hash_password_stdin_preserves_inner_whitespace(self):
+        """Test that only the trailing newline is stripped from stdin."""
+        out = StringIO()
+        call_command("hash_password", "--stdin", stdin_stream=StringIO(" pass word \n"), stdout=out)
+
+        self.assertTrue(check_password(" pass word ", out.getvalue().strip()))
+
+    def test_hash_password_stdin_empty_fails(self):
+        """Test that an empty stdin raises error."""
+        with self.assertRaises(CommandError) as ctx:
+            call_command("hash_password", "--stdin", stdin_stream=StringIO("\n"))
+
+        self.assertIn("Password cannot be empty", str(ctx.exception))
+
+    def test_hash_password_stdin_with_argument_fails(self):
+        """Test that --stdin and a password argument are mutually exclusive."""
+        with self.assertRaises(CommandError) as ctx:
+            call_command("hash_password", "test123", "--stdin", stdin_stream=StringIO("test123\n"))
+
+        self.assertIn("Cannot use both --stdin and a password argument", str(ctx.exception))
+
+    def test_hash_password_no_password_without_tty_fails(self):
+        """Test that omitting the password without a TTY raises an actionable error."""
+        with self.assertRaises(CommandError) as ctx:
+            call_command("hash_password", stdin_stream=StringIO(""))
+
+        self.assertIn("No password given", str(ctx.exception))


### PR DESCRIPTION
<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?

Currently, getting a hashed password to use requires you to pass in the password plaintext as part of the command argument, exposing it in your bash history. This pr obfuscates the plaintext password.

It also asks you to verify the password, a good safety measure to make sure there are no mistakes in inputting the password.

### Why is this change needed?

Having your password in plaintext in the command argument keeps it in your bash history, which can compromise the password.

### How was this tested?

Running the command before and after implementation.

### Linked issues

<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
