### PR TITLE
core: error malformed hashed password hash on import

### DIFF
--- a/authentik/core/models.py
+++ b/authentik/core/models.py
@@ -563,7 +563,8 @@ class User(SerializerModel, AttributesMixin, AbstractUser):
     @staticmethod
     def validate_password_hash(password_hash: str):
         """Validate that the value is a recognized Django password hash."""
-        identify_hasher(password_hash)  # Raises ValueError if invalid
+        hasher = identify_hasher(password_hash)  # Raises ValueError if unrecognized
+        hasher.decode(password_hash)  # Raises ValueError if the body is malformed
 
     def set_password_from_hash(self, password_hash: str, signal=True, sender=None, request=None):
         """Set password directly from a pre-hashed value.

--- a/authentik/core/tests/test_users.py
+++ b/authentik/core/tests/test_users.py
@@ -13,6 +13,10 @@ from authentik.core.signals import password_changed, password_hash_changed
 from authentik.events.models import Event
 from authentik.lib.generators import generate_id
 
+# Recognized algorithm prefix, but the $-separated fields were eaten by an env var
+# interpolating the hash. Only decoding the body catches this.
+CORRUPT_PASSWORD_HASH = "pbkdf2_sha256$1000000/K4wGpWYKfJPSCcNM="
+
 
 class TestUsers(TestCase):
     """Test user"""
@@ -83,6 +87,36 @@ class TestUsers(TestCase):
         ldap_sources_filter.assert_not_called()
         kerberos_connections_select.assert_not_called()
 
+    def test_set_password_from_hash_rejects_corrupt_hash(self):
+        """Test a hash with a recognized prefix but a corrupt body is rejected."""
+        user = User.objects.create(username=generate_id())
+        original = make_password("original-password")  # nosec
+        user.set_password_from_hash(original)
+        user.save()
+
+        with self.assertRaises(ValueError):
+            user.set_password_from_hash(CORRUPT_PASSWORD_HASH)
+
+        user.refresh_from_db()
+        self.assertEqual(user.password, original)
+        self.assertTrue(user.check_password("original-password"))
+
+    def test_validate_password_hash_rejects_malformed_bodies(self):
+        """Test hashes are validated past their algorithm prefix."""
+        for password_hash in (
+            CORRUPT_PASSWORD_HASH,
+            "pbkdf2_sha256$whatever",
+            "pbkdf2_sha256$not-a-number$salt$hash",
+            "argon2$garbage",
+            "scrypt$1$2",
+        ):
+            with self.subTest(password_hash=password_hash), self.assertRaises(ValueError):
+                User.validate_password_hash(password_hash)
+
+    def test_validate_password_hash_accepts_valid_hash(self):
+        """Test a well-formed hash still validates."""
+        User.validate_password_hash(make_password(generate_id()))
+
 
 class TestUserSerializerPasswordHash(TestCase):
     """Test UserSerializer password_hash support in blueprint context."""
@@ -114,6 +148,23 @@ class TestUserSerializerPasswordHash(TestCase):
                 "username": generate_id(),
                 "name": "Test User",
                 "password_hash": "not-a-valid-hash",
+            },
+            context={SERIALIZER_CONTEXT_BLUEPRINT: True},
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        with self.assertRaises(ValidationError) as ctx:
+            serializer.save()
+
+        self.assertIn("Invalid password hash format", str(ctx.exception))
+
+    def test_password_hash_rejects_corrupt_body(self):
+        """Test a hash with a recognized prefix but a corrupt body is rejected."""
+        serializer = UserSerializer(
+            data={
+                "username": generate_id(),
+                "name": "Test User",
+                "password_hash": CORRUPT_PASSWORD_HASH,
             },
             context={SERIALIZER_CONTEXT_BLUEPRINT: True},
         )

--- a/authentik/core/tests/test_users_api.py
+++ b/authentik/core/tests/test_users_api.py
@@ -30,6 +30,9 @@ from authentik.rbac.models import Role
 from authentik.stages.email.models import EmailStage
 
 INVALID_PASSWORD_HASH = "not-a-valid-hash"
+# Recognized algorithm prefix, but the $-separated fields were eaten by an env var
+# interpolating the hash. Only decoding the body catches this.
+CORRUPT_PASSWORD_HASH = "pbkdf2_sha256$1000000/K4wGpWYKfJPSCcNM="
 INVALID_PASSWORD_HASH_ERROR = "Invalid password hash format. Must be a valid Django password hash."
 
 
@@ -165,6 +168,20 @@ class TestUsersAPI(APITestCase):
             response.content,
             {"password": [INVALID_PASSWORD_HASH_ERROR]},
         )
+
+    def test_set_password_hash_corrupt_body(self):
+        """Test a hash with a recognized prefix but a corrupt body is rejected."""
+        self.client.force_login(self.admin)
+        original_password = self.user.password
+        response = self._set_password_hash(self.user, CORRUPT_PASSWORD_HASH)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertJSONEqual(
+            response.content,
+            {"password": [INVALID_PASSWORD_HASH_ERROR]},
+        )
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.password, original_password)
 
     def test_recovery(self):
         """Test user recovery link"""


### PR DESCRIPTION
<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?

Currently, if you import a hashed password (via .env like `AUTHENTIK_BOOTSTRAP_PASSWORD_HASH: HASEDPASSWORDHERE`, we do not validate the password isn't malformed until after it's already been imported.

### Why is this change needed?

A user can put a malformed password hash, boot up authentik, and then their admin login flow can explode. The error message will not make it clear as to why. This makes it clear at server boot that the hashed password is malformed.

### How was this tested?

Setting `AUTHENTIK_BOOTSTRAP_PASSWORD_HASH: malformed` before and after the changes

### Linked issues

<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
