### PR TITLE
root: fix make gen-changelog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,11 +184,11 @@ gen-compose:
 
 gen-changelog:  ## (Release) generate the changelog based from the commits since the last version
 # These are best-effort guesses based on commit messages
-	$(eval last_version := $(shell git tag --list 'version/*' --sort 'version:refname' | grep -vE 'rc\d+$$' | tail -1))
+	$(eval last_version := $(shell git tag --list 'version/*' --sort 'version:refname' | grep -vE 'rc[0-9]+$$' | tail -1))
 	$(eval current_commit := $(shell git rev-parse HEAD))
 	git log --pretty=format:"- %s" $(shell git merge-base ${last_version} ${current_commit})...${current_commit} > merged_to_current
 	git log --pretty=format:"- %s" $(shell git merge-base ${last_version} ${current_commit})...${last_version} > merged_to_last
-	grep -Eo 'cherry-pick (#\d+)' merged_to_last | cut -d ' ' -f 2 | sed 's/.*/(&)$$/' > cherry_picked_to_last
+	{ grep -Eo 'cherry-pick (#[0-9]+)' merged_to_last || true; } | cut -d ' ' -f 2 | sed 's/.*/(&)$$/' > cherry_picked_to_last
 	grep -vf cherry_picked_to_last merged_to_current | grep -vE '^- (ci:|website)' | sort > changelog.md
 	rm merged_to_current
 	rm merged_to_last
@@ -196,7 +196,7 @@ gen-changelog:  ## (Release) generate the changelog based from the commits since
 	npx prettier --write changelog.md
 
 gen-diff:  ## (Release) generate the changelog diff between the current schema and the last version
-	$(eval last_version := $(shell git tag --list 'version/*' --sort 'version:refname' | grep -vE 'rc\d+$$' | tail -1))
+	$(eval last_version := $(shell git tag --list 'version/*' --sort 'version:refname' | grep -vE 'rc[0-9]+$$' | tail -1))
 	git show ${last_version}:schema.yml > schema-old.yml
 	docker compose -f scripts/compose.yml run --rm --user "${UID}:${GID}" diff \
 		--markdown \


### PR DESCRIPTION
Fixes this:

```
$ git checkout version-2026.5
$ make gen-changelog last_version=version/2026.5.4
grep: warning: stray \ before d
git log --pretty=format:"- %s" c2942671a5b98dfa596de7bf247accb48a5c71ee...8704a1b89d7bf46bcef0d3c434c821b937fdecc3 > merged_to_current
git log --pretty=format:"- %s" c2942671a5b98dfa596de7bf247accb48a5c71ee...version/2026.5.4 > merged_to_last
grep -Eo 'cherry-pick (#\d+)' merged_to_last | cut -d ' ' -f 2 | sed 's/.*/(&)$/' > cherry_picked_to_last
grep: warning: stray \ before d
make: *** [Makefile:187: gen-changelog] Error 1
```

### Changes

- use portable `[0-9]` instead of `\d`
- handle empty cherry-pick list (because of `pipefail`)