### PR TITLE
web/flows: fix remember-me username being cleared after every login

### DIFF
--- a/web/src/flow/stages/identification/controllers/RememberMeController.ts
+++ b/web/src/flow/stages/identification/controllers/RememberMeController.ts
@@ -1,5 +1,4 @@
 import { StorageAccessor } from "#common/storage";
-import { getCookie } from "#common/utils";
 
 import { ReactiveElementHost } from "#elements/types";
 
@@ -13,15 +12,9 @@ import { createRef, Ref } from "lit-html/directives/ref.js";
 
 export class RememberMeStorage {
     static readonly user = StorageAccessor.local("authentik-remember-me-user");
-    static readonly session = StorageAccessor.local("authentik-remember-me-session");
     static reset = () => {
         this.user.delete();
-        this.session.delete();
     };
-}
-
-function readSessionID() {
-    return (getCookie("authentik_csrf") ?? "").substring(0, 8);
 }
 
 export interface RememberMeControllerInit {
@@ -44,9 +37,8 @@ export interface RememberMeControllerInit {
  * phase. If not present: record the username as it is typed in, and store it when the user proceeds
  * to the next phase.
  *
- * Uses a "we've been here before during the current session" heuristic to determine if the user
- * came back to this view after reaching the identity proof phase, indicating they pressed the "not
- * you?" link, at which point it begins again to record the username as it is typed in.
+ * The stored username persists until the user presses the "not you?" link, which clears it via
+ * {@linkcode RememberMeStorage.reset}, or disables the toggle.
  */
 export class RememberMeController implements ReactiveController {
     static readonly styles = [
@@ -69,7 +61,6 @@ export class RememberMeController implements ReactiveController {
 
     protected logger = ConsoleLogger.prefix("controller/remember-me");
     protected autoSubmitAttempts = 0;
-    protected currentSessionID = readSessionID();
 
     constructor(
         protected host: ReactiveElementHost<IdentificationStage>,
@@ -82,13 +73,6 @@ export class RememberMeController implements ReactiveController {
         this.identificationFieldRef = identificationFieldRef;
         this.passwordFieldRef = passwordFieldRef || null;
         this.identificationFieldID = identificationFieldID;
-
-        const persistedSessionID = RememberMeStorage.session.read();
-
-        if (persistedSessionID && persistedSessionID !== this.currentSessionID) {
-            this.logger.debug("Session ID mismatch, clearing remembered username");
-            RememberMeStorage.user.delete();
-        }
 
         const persistedUserIdentifier = RememberMeStorage.user.read();
 
@@ -166,7 +150,6 @@ export class RememberMeController implements ReactiveController {
         this.logger.debug("Enabling remember me for user");
 
         RememberMeStorage.user.write(usernameField.value);
-        RememberMeStorage.session.write(this.currentSessionID);
 
         usernameField.addEventListener("input", this.inputListener, {
             passive: true,

--- a/web/test/browser/101-session-lifecycle.test.ts
+++ b/web/test/browser/101-session-lifecycle.test.ts
@@ -6,7 +6,6 @@ import { GOOD_USERNAME, SessionFixture } from "#e2e/fixtures/SessionFixture";
 import type { Page } from "@playwright/test";
 
 const REMEMBER_ME_USER_KEY = "authentik-remember-me-user";
-const REMEMBER_ME_SESSION_KEY = "authentik-remember-me-session";
 
 const IDENTIFICATION_STAGE_NAME = "default-authentication-identification";
 
@@ -48,13 +47,9 @@ test.describe("Session Lifecycle", () => {
     test.beforeEach(async ({ session, page }) => {
         await session.toLoginPage();
 
-        await page.evaluate(
-            ([userKey, sessionKey]) => {
-                localStorage.removeItem(userKey);
-                localStorage.removeItem(sessionKey);
-            },
-            [REMEMBER_ME_USER_KEY, REMEMBER_ME_SESSION_KEY],
-        );
+        await page.evaluate((userKey) => {
+            localStorage.removeItem(userKey);
+        }, REMEMBER_ME_USER_KEY);
 
         await page.reload();
         await session.$identificationStage.waitFor({ state: "visible" });
@@ -129,6 +124,60 @@ test.describe("Session Lifecycle", () => {
             const storedUserIdentifier = await readStoredUserIdentifier(page);
 
             expect(storedUserIdentifier, "Removed after clicking not you link").toBeNull();
+        });
+    });
+
+    test("Remember me persists username for a returning browser", async ({
+        navigator,
+        session,
+        page,
+    }) => {
+        const signOut = async () => {
+            const signOutLink = page.getByRole("link", { name: "Sign out" });
+
+            await expect(signOutLink, "Sign out link is visible").toBeVisible();
+
+            await signOutLink.click();
+
+            await navigator.waitForPathname("/if/flow/default-authentication-flow/?next=%2F");
+            await session.$identificationStage.waitFor({ state: "visible" });
+        };
+
+        // A browser that has never completed a login carries no CSRF cookie; the first
+        // successful login sets and rotates it. Complete one full login/sign-out cycle
+        // before enabling remember-me, so the toggle is exercised in the same state a
+        // returning user's browser is in.
+        await test.step("Prime the browser with a completed login", async () => {
+            await session.login({ to: "if/user/#/library" }, page);
+            await signOut();
+        });
+
+        await test.step("Identify with remember-me enabled", async () => {
+            await session.login(
+                {
+                    rememberMe: true,
+                    to: "if/user/#/library",
+                },
+                page,
+            );
+
+            const storedUserIdentifier = await readStoredUserIdentifier(page);
+
+            expect(
+                storedUserIdentifier,
+                "username persists to localStorage when remember-me is checked",
+            ).toBe(GOOD_USERNAME);
+        });
+
+        await test.step("Sign out and verify username is still remembered", async () => {
+            await signOut();
+
+            const storedUserIdentifier = await readStoredUserIdentifier(page);
+
+            expect(
+                storedUserIdentifier,
+                "username survives a login/sign-out cycle on a returning browser",
+            ).toBe(GOOD_USERNAME);
         });
     });
 });


### PR DESCRIPTION
## Details

### What does this PR change?

Removes the session-ID heuristic from `RememberMeController`. The controller no longer stores a snapshot of the `authentik_csrf` cookie (`authentik-remember-me-session`) next to the remembered username, and no longer deletes the username when that snapshot differs from the current cookie. The stored username now persists until the user presses "Not you?" (which clears it explicitly via `RememberMeStorage.reset`, added in #21647) or disables the toggle.

Also extends `101-session-lifecycle.test.ts` with a returning-browser test that reproduces the regression, and drops the now-unused session storage key from the test setup.

### Why is this change needed?

Since 2026.5, "Remember me on this device" never survives a login. The refactor in #20578 inverted the heuristic's comparison: the pre-refactor code cleared the stored username when the persisted CSRF snapshot **equaled** the current cookie (detecting a same-session return to the identification stage, i.e. "Not you?"), while the refactored code clears it when they **differ**:

```ts
if (persistedSessionID && persistedSessionID !== this.currentSessionID) {
    this.logger.debug("Session ID mismatch, clearing remembered username");
    RememberMeStorage.user.delete();
}
```

Django's `login()` calls `rotate_token()` on every successful login, so the cookie is guaranteed to differ by the user's next visit to the identification stage, and the remembered username is always deleted. The feature is effectively broken for every returning user.

Simply restoring the `===` comparison would not match the 2025.x behavior either: the refactored constructor no longer rewrites the snapshot on every page load like the old `AkRememberMeController` did, so with `===` a same-session reload of the login page would clear the username instead. Since #21647 handles "Not you?" explicitly, the heuristic has no remaining purpose and is removed entirely.

Note: the existing browser test passes on broken code because a fresh Playwright context has no `authentik_csrf` cookie until the first login sets it (nothing calls `get_token()` before that), so the persisted snapshot is empty and the `persistedSessionID &&` guard makes the clearing branch unreachable. Real users always have the cookie from a previous login, which is exactly the state the new test creates by priming the browser with a completed login/sign-out cycle before enabling remember-me.

### How was this tested?

- New browser test "Remember me persists username for a returning browser": primes the context with a full login/sign-out cycle (so the CSRF cookie exists and has rotated), then logs in with remember-me enabled, signs out, and asserts `authentik-remember-me-user` is still present. This test fails without the fix and passes with it.
- The existing "Remember me persists username" and "Not you?" coverage is unchanged and still passes, as `RememberMeStorage.reset()` keeps clearing the username.
- `pnpm run lint:types` (tsc), `eslint --max-warnings 0`, and `prettier --check` pass on the changed files.
- Manually reproduced on a 2026.5.4 deployment: with a pre-existing `authentik_csrf` cookie, enabling remember-me, logging in, and signing out logs `Session ID mismatch, clearing remembered username` and deletes the stored email; with this change the email persists and the identification stage auto-submits again as in 2025.x.

Users upgrading with this fix may retain a stale `authentik-remember-me-session` key in localStorage; it is no longer read anywhere and is harmless.

### Linked issues

closes #ISSUE_NUMBER

---

## Checklist

-   [x] The project has been linted, built, and tested (`make all`)
-   [x] The documentation has been updated and formatted (`make docs`)
