### PR TITLE
core: prompt securely when hashing passwords

### DIFF
--- a/authentik/core/management/commands/hash_password.py
+++ b/authentik/core/management/commands/hash_password.py
@@ -18,10 +18,7 @@ class Command(BaseCommand):
             "password",
             type=str,
             nargs="?",
-            help=_(
-                "Password to hash. Supplying this argument exposes it in shell history and "
-                "the process list; omit it to be prompted securely."
-            ),
+            help=_("Password to hash. If omitted, prompt for the password."),
         )
 
     def handle(self, *args, **options):

--- a/authentik/core/management/commands/hash_password.py
+++ b/authentik/core/management/commands/hash_password.py
@@ -17,23 +17,14 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         if sys.stdin.isatty():
-            try:
-                password = getpass("Password: ")
-                password_again = getpass("Password (again): ")
-            except (EOFError, KeyboardInterrupt) as exc:
-                raise CommandError("Aborted") from exc
+            password = getpass("Password: ")
+            password_again = getpass("Password (again): ")
             if password != password_again:
                 raise CommandError("Passwords do not match")
         else:
-            try:
-                password = input()
-            except EOFError as exc:
-                raise CommandError("Password cannot be empty") from exc
+            password = input()
 
         if not password:
             raise CommandError("Password cannot be empty")
-        try:
-            hashed = make_password(password)
-            self.stdout.write(hashed)
-        except ValueError as exc:
-            raise CommandError(f"Error hashing password: {exc}") from exc
+        hashed = make_password(password)
+        self.stdout.write(hashed)

--- a/authentik/core/management/commands/hash_password.py
+++ b/authentik/core/management/commands/hash_password.py
@@ -1,28 +1,47 @@
 """Hash password using Django's password hashers"""
 
+import sys
+from getpass import getpass
+
 from django.contrib.auth.hashers import make_password
 from django.core.management.base import BaseCommand, CommandError
+from django.utils.translation import gettext as _
 
 
 class Command(BaseCommand):
     """Hash a password using Django's password hashers"""
 
-    help = "Hash a password for use with AUTHENTIK_BOOTSTRAP_PASSWORD_HASH"
+    help = _("Hash a password for use with AUTHENTIK_BOOTSTRAP_PASSWORD_HASH")
 
     def add_arguments(self, parser):
         parser.add_argument(
             "password",
             type=str,
-            help="Password to hash",
+            nargs="?",
+            help=_(
+                "Password to hash. Supplying this argument exposes it in shell history and "
+                "the process list; omit it to be prompted securely."
+            ),
         )
 
     def handle(self, *args, **options):
         password = options["password"]
 
+        if password is None:
+            if not sys.stdin.isatty():
+                raise CommandError(_("Password prompting requires an interactive terminal"))
+            try:
+                password = getpass(_("Password: "))
+                password_again = getpass(_("Password (again): "))
+            except (EOFError, KeyboardInterrupt) as exc:
+                raise CommandError(_("Aborted")) from exc
+            if password != password_again:
+                raise CommandError(_("Passwords do not match"))
+
         if not password:
-            raise CommandError("Password cannot be empty")
+            raise CommandError(_("Password cannot be empty"))
         try:
             hashed = make_password(password)
             self.stdout.write(hashed)
         except ValueError as exc:
-            raise CommandError(f"Error hashing password: {exc}") from exc
+            raise CommandError(f"{_('Error hashing password')}: {exc}") from exc

--- a/authentik/core/management/commands/hash_password.py
+++ b/authentik/core/management/commands/hash_password.py
@@ -11,22 +11,13 @@ from django.utils.translation import gettext as _
 class Command(BaseCommand):
     """Hash a password using Django's password hashers"""
 
-    help = _("Hash a password for use with AUTHENTIK_BOOTSTRAP_PASSWORD_HASH")
-
-    def add_arguments(self, parser):
-        parser.add_argument(
-            "password",
-            type=str,
-            nargs="?",
-            help=_("Password to hash. If omitted, prompt for the password."),
-        )
+    help = _(
+        "Hash a password for use with AUTHENTIK_BOOTSTRAP_PASSWORD_HASH. Prompt when "
+        "interactive, or read the password from standard input."
+    )
 
     def handle(self, *args, **options):
-        password = options["password"]
-
-        if password is None:
-            if not sys.stdin.isatty():
-                raise CommandError(_("Password prompting requires an interactive terminal"))
+        if sys.stdin.isatty():
             try:
                 password = getpass(_("Password: "))
                 password_again = getpass(_("Password (again): "))
@@ -34,6 +25,8 @@ class Command(BaseCommand):
                 raise CommandError(_("Aborted")) from exc
             if password != password_again:
                 raise CommandError(_("Passwords do not match"))
+        else:
+            password = sys.stdin.readline().rstrip("\r\n")
 
         if not password:
             raise CommandError(_("Password cannot be empty"))

--- a/authentik/core/management/commands/hash_password.py
+++ b/authentik/core/management/commands/hash_password.py
@@ -5,13 +5,12 @@ from getpass import getpass
 
 from django.contrib.auth.hashers import make_password
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.translation import gettext as _
 
 
 class Command(BaseCommand):
     """Hash a password using Django's password hashers"""
 
-    help = _(
+    help = (
         "Hash a password for use with AUTHENTIK_BOOTSTRAP_PASSWORD_HASH. Prompt when "
         "interactive, or read the password from standard input."
     )
@@ -19,19 +18,22 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         if sys.stdin.isatty():
             try:
-                password = getpass(_("Password: "))
-                password_again = getpass(_("Password (again): "))
+                password = getpass("Password: ")
+                password_again = getpass("Password (again): ")
             except (EOFError, KeyboardInterrupt) as exc:
-                raise CommandError(_("Aborted")) from exc
+                raise CommandError("Aborted") from exc
             if password != password_again:
-                raise CommandError(_("Passwords do not match"))
+                raise CommandError("Passwords do not match")
         else:
-            password = sys.stdin.readline().rstrip("\r\n")
+            try:
+                password = input()
+            except EOFError as exc:
+                raise CommandError("Password cannot be empty") from exc
 
         if not password:
-            raise CommandError(_("Password cannot be empty"))
+            raise CommandError("Password cannot be empty")
         try:
             hashed = make_password(password)
             self.stdout.write(hashed)
         except ValueError as exc:
-            raise CommandError(f"{_('Error hashing password')}: {exc}") from exc
+            raise CommandError(f"Error hashing password: {exc}") from exc

--- a/authentik/core/tests/test_hash_password_command.py
+++ b/authentik/core/tests/test_hash_password_command.py
@@ -26,10 +26,14 @@ class TestHashPasswordCommand(TestCase):
         ):
             call_command("hash_password", **options)
 
-    def test_hash_password(self):
-        """Test hashing a password."""
+    def test_hash_password_stdin(self):
+        """Test hashing a password read from standard input."""
         out = StringIO()
-        call_command("hash_password", "test123", stdout=out, stderr=out)
+        with patch(
+            "authentik.core.management.commands.hash_password.sys.stdin",
+            StringIO("test123\n"),
+        ):
+            call_command("hash_password", stdout=out)
         hashed = out.getvalue().strip()
 
         self.assertTrue(hashed.startswith("pbkdf2_sha256$"))
@@ -44,20 +48,25 @@ class TestHashPasswordCommand(TestCase):
         self.assertTrue(hashed.startswith("pbkdf2_sha256$"))
         self.assertTrue(check_password("test123", hashed))
 
-    def test_hash_password_empty_fails(self):
-        """Test that empty password raises error."""
+    def test_hash_password_argument_fails(self):
+        """Test that passwords cannot be supplied as command arguments."""
         with self.assertRaises(CommandError) as ctx:
-            call_command("hash_password", "")
+            call_command("hash_password", "test123")
 
-        self.assertIn("Password cannot be empty", str(ctx.exception))
+        self.assertIn("unrecognized arguments", str(ctx.exception))
 
-    @patch("authentik.core.management.commands.hash_password.sys.stdin.isatty", return_value=False)
-    def test_hash_password_prompt_without_tty_fails(self, _isatty_mock):
-        """Test that prompting requires an interactive terminal."""
-        with self.assertRaises(CommandError) as ctx:
+    def test_hash_password_empty_stdin_fails(self):
+        """Test that empty standard input raises an error."""
+        with (
+            patch(
+                "authentik.core.management.commands.hash_password.sys.stdin",
+                StringIO(),
+            ),
+            self.assertRaises(CommandError) as ctx,
+        ):
             call_command("hash_password")
 
-        self.assertIn("requires an interactive terminal", str(ctx.exception))
+        self.assertIn("Password cannot be empty", str(ctx.exception))
 
     def test_hash_password_prompt_errors(self):
         """Test errors raised while prompting for a password."""

--- a/authentik/core/tests/test_hash_password_command.py
+++ b/authentik/core/tests/test_hash_password_command.py
@@ -45,11 +45,11 @@ class TestHashPasswordCommand(TestCase):
         self.assertTrue(check_password("test123", hashed))
 
     def test_hash_password_empty_stdin_fails(self):
-        """Test that empty standard input raises an error."""
+        """Test that an empty password read from standard input raises an error."""
         with (
             patch(
                 "authentik.core.management.commands.hash_password.sys.stdin",
-                StringIO(),
+                StringIO("\n"),
             ),
             self.assertRaises(CommandError) as ctx,
         ):

--- a/authentik/core/tests/test_hash_password_command.py
+++ b/authentik/core/tests/test_hash_password_command.py
@@ -1,6 +1,7 @@
 """Tests for hash_password management command."""
 
 from io import StringIO
+from unittest.mock import patch
 
 from django.contrib.auth.hashers import check_password
 from django.core.management import call_command
@@ -11,10 +12,33 @@ from django.test import TestCase
 class TestHashPasswordCommand(TestCase):
     """Test hash_password management command."""
 
+    def call_prompt(self, side_effect, **options):
+        """Call the command with an interactive password prompt."""
+        with (
+            patch(
+                "authentik.core.management.commands.hash_password.getpass",
+                side_effect=side_effect,
+            ),
+            patch(
+                "authentik.core.management.commands.hash_password.sys.stdin.isatty",
+                return_value=True,
+            ),
+        ):
+            call_command("hash_password", **options)
+
     def test_hash_password(self):
         """Test hashing a password."""
         out = StringIO()
-        call_command("hash_password", "test123", stdout=out)
+        call_command("hash_password", "test123", stdout=out, stderr=out)
+        hashed = out.getvalue().strip()
+
+        self.assertTrue(hashed.startswith("pbkdf2_sha256$"))
+        self.assertTrue(check_password("test123", hashed))
+
+    def test_hash_password_prompt(self):
+        """Test hashing a password entered through the hidden prompt."""
+        out = StringIO()
+        self.call_prompt(["test123", "test123"], stdout=out)
         hashed = out.getvalue().strip()
 
         self.assertTrue(hashed.startswith("pbkdf2_sha256$"))
@@ -26,3 +50,22 @@ class TestHashPasswordCommand(TestCase):
             call_command("hash_password", "")
 
         self.assertIn("Password cannot be empty", str(ctx.exception))
+
+    @patch("authentik.core.management.commands.hash_password.sys.stdin.isatty", return_value=False)
+    def test_hash_password_prompt_without_tty_fails(self, _isatty_mock):
+        """Test that prompting requires an interactive terminal."""
+        with self.assertRaises(CommandError) as ctx:
+            call_command("hash_password")
+
+        self.assertIn("requires an interactive terminal", str(ctx.exception))
+
+    def test_hash_password_prompt_errors(self):
+        """Test errors raised while prompting for a password."""
+        for side_effect, message in (
+            (["", ""], "Password cannot be empty"),
+            (["test123", "different"], "Passwords do not match"),
+            (KeyboardInterrupt, "Aborted"),
+        ):
+            with self.subTest(message=message), self.assertRaises(CommandError) as ctx:
+                self.call_prompt(side_effect)
+            self.assertIn(message, str(ctx.exception))

--- a/authentik/core/tests/test_hash_password_command.py
+++ b/authentik/core/tests/test_hash_password_command.py
@@ -12,20 +12,6 @@ from django.test import TestCase
 class TestHashPasswordCommand(TestCase):
     """Test hash_password management command."""
 
-    def call_prompt(self, side_effect, **options):
-        """Call the command with an interactive password prompt."""
-        with (
-            patch(
-                "authentik.core.management.commands.hash_password.getpass",
-                side_effect=side_effect,
-            ),
-            patch(
-                "authentik.core.management.commands.hash_password.sys.stdin.isatty",
-                return_value=True,
-            ),
-        ):
-            call_command("hash_password", **options)
-
     def test_hash_password_stdin(self):
         """Test hashing a password read from standard input."""
         out = StringIO()
@@ -42,18 +28,21 @@ class TestHashPasswordCommand(TestCase):
     def test_hash_password_prompt(self):
         """Test hashing a password entered through the hidden prompt."""
         out = StringIO()
-        self.call_prompt(["test123", "test123"], stdout=out)
+        with (
+            patch(
+                "authentik.core.management.commands.hash_password.getpass",
+                side_effect=["test123", "test123"],
+            ),
+            patch(
+                "authentik.core.management.commands.hash_password.sys.stdin.isatty",
+                return_value=True,
+            ),
+        ):
+            call_command("hash_password", stdout=out)
         hashed = out.getvalue().strip()
 
         self.assertTrue(hashed.startswith("pbkdf2_sha256$"))
         self.assertTrue(check_password("test123", hashed))
-
-    def test_hash_password_argument_fails(self):
-        """Test that passwords cannot be supplied as command arguments."""
-        with self.assertRaises(CommandError) as ctx:
-            call_command("hash_password", "test123")
-
-        self.assertIn("unrecognized arguments", str(ctx.exception))
 
     def test_hash_password_empty_stdin_fails(self):
         """Test that empty standard input raises an error."""
@@ -68,13 +57,36 @@ class TestHashPasswordCommand(TestCase):
 
         self.assertIn("Password cannot be empty", str(ctx.exception))
 
-    def test_hash_password_prompt_errors(self):
-        """Test errors raised while prompting for a password."""
-        for side_effect, message in (
-            (["", ""], "Password cannot be empty"),
-            (["test123", "different"], "Passwords do not match"),
-            (KeyboardInterrupt, "Aborted"),
+    def test_hash_password_empty_prompt_fails(self):
+        """Test that an empty prompted password raises an error."""
+        with (
+            patch(
+                "authentik.core.management.commands.hash_password.getpass",
+                side_effect=["", ""],
+            ),
+            patch(
+                "authentik.core.management.commands.hash_password.sys.stdin.isatty",
+                return_value=True,
+            ),
+            self.assertRaises(CommandError) as ctx,
         ):
-            with self.subTest(message=message), self.assertRaises(CommandError) as ctx:
-                self.call_prompt(side_effect)
-            self.assertIn(message, str(ctx.exception))
+            call_command("hash_password")
+
+        self.assertIn("Password cannot be empty", str(ctx.exception))
+
+    def test_hash_password_mismatched_prompt_fails(self):
+        """Test that mismatched prompted passwords raise an error."""
+        with (
+            patch(
+                "authentik.core.management.commands.hash_password.getpass",
+                side_effect=["test123", "different"],
+            ),
+            patch(
+                "authentik.core.management.commands.hash_password.sys.stdin.isatty",
+                return_value=True,
+            ),
+            self.assertRaises(CommandError) as ctx,
+        ):
+            call_command("hash_password")
+
+        self.assertIn("Passwords do not match", str(ctx.exception))

--- a/website/docs/customize/blueprints/v1/models.mdx
+++ b/website/docs/customize/blueprints/v1/models.mdx
@@ -55,10 +55,10 @@ Use `password_hash` when you need to import or bootstrap an existing hash withou
 docker compose run --rm server hash_password
 ```
 
-Passing the password as a command argument remains supported, but exposes it in your shell history and the process list:
+For automation, pipe the password through standard input. The `-T` option disables pseudo-TTY allocation so that the command reads from standard input:
 
 ```bash
-docker compose run --rm server hash_password '<password>'
+printf '%s\n' "$PASSWORD" | docker compose run --rm -T server hash_password
 ```
 
 For example:

--- a/website/docs/customize/blueprints/v1/models.mdx
+++ b/website/docs/customize/blueprints/v1/models.mdx
@@ -49,10 +49,16 @@ For example:
 
 In blueprints, a user's password can also be set using the `password_hash` field. The value must be a valid Django password hash, such as one generated with the `hash_password` management command.
 
-Use `password_hash` when you need to import or bootstrap an existing hash without exposing the raw password to authentik:
+Use `password_hash` when you need to import or bootstrap an existing hash without exposing the raw password to authentik. Generate the hash without exposing the password in your shell history by entering it when prompted:
 
 ```bash
-docker compose run --rm server hash_password 'your-password'
+docker compose run --rm server hash_password
+```
+
+Passing the password as a command argument remains supported, but exposes it in your shell history and the process list:
+
+```bash
+docker compose run --rm server hash_password '<password>'
 ```
 
 For example:

--- a/website/docs/customize/blueprints/v1/models.mdx
+++ b/website/docs/customize/blueprints/v1/models.mdx
@@ -49,13 +49,13 @@ For example:
 
 In blueprints, a user's password can also be set using the `password_hash` field. The value must be a valid Django password hash, such as one generated with the `hash_password` management command.
 
-Use `password_hash` when you need to import or bootstrap an existing hash without exposing the raw password to authentik. Generate the hash without exposing the password in your shell history by entering it when prompted:
+Use `password_hash` when you need to import or bootstrap an existing hash without exposing the raw password to authentik. Enter the password when prompted to generate the hash:
 
 ```bash
 docker compose run --rm server hash_password
 ```
 
-For automation, pipe the password through standard input. The `-T` option disables pseudo-TTY allocation so that the command reads from standard input:
+For automation, pass the password in the `PASSWORD` environment variable and pipe it through standard input to prevent exposing the password in your shell history. The `-T` option disables pseudo-TTY allocation so that the command reads from standard input:
 
 ```bash
 printf '%s\n' "$PASSWORD" | docker compose run --rm -T server hash_password

--- a/website/docs/customize/blueprints/v1/models.mdx
+++ b/website/docs/customize/blueprints/v1/models.mdx
@@ -55,10 +55,10 @@ Use `password_hash` when you need to import or bootstrap an existing hash withou
 docker compose run --rm server hash_password
 ```
 
-For automation, pass the password in the `PASSWORD` environment variable and pipe it through standard input to prevent exposing the password in your shell history. The `-T` option disables pseudo-TTY allocation so that the command reads from standard input:
+For automation, pass the password in the `PASSWORD` environment variable and pipe it through standard input to prevent exposing the password in your shell history:
 
 ```bash
-printf '%s\n' "$PASSWORD" | docker compose run --rm -T server hash_password
+echo "$PASSWORD" | docker compose run --rm server hash_password
 ```
 
 For example:

--- a/website/docs/install-config/automated-install.mdx
+++ b/website/docs/install-config/automated-install.mdx
@@ -20,10 +20,16 @@ To generate a hash, run this command before your initial deployment and enter th
 docker compose run --rm server hash_password
 ```
 
-For automation, pass the password in the `PASSWORD` environment variable and pipe it through standard input to prevent exposing the password in your shell history. The `-T` option disables pseudo-TTY allocation so that the command reads from standard input:
+For automation, pass the password in the `PASSWORD` environment variable and pipe it through standard input to prevent exposing the password in your shell history:
 
 ```bash
-printf '%s\n' "$PASSWORD" | docker compose run --rm -T server hash_password
+echo "$PASSWORD" | docker compose run --rm server hash_password
+```
+
+Alternatively, redirect a file that contains the password into the command:
+
+```bash
+docker compose run --rm server hash_password < password.txt
 ```
 
 The generated hash includes a random salt, so running the command multiple times for the same password produces different output. Use the complete output as the value of `AUTHENTIK_BOOTSTRAP_PASSWORD_HASH`.

--- a/website/docs/install-config/automated-install.mdx
+++ b/website/docs/install-config/automated-install.mdx
@@ -14,13 +14,13 @@ Configure the default password for the `akadmin` user using a pre-hashed Django 
 
 This stores the hash directly as authentik's local password verifier. Because authentik never sees the raw password, hashed-password imports do not propagate the password to LDAP or Kerberos integrations, even when password writeback is enabled.
 
-To generate a hash without exposing the password in your shell history, run this command before your initial deployment and enter the password when prompted:
+To generate a hash, run this command before your initial deployment and enter the password when prompted:
 
 ```bash
 docker compose run --rm server hash_password
 ```
 
-For automation, pipe the password through standard input. The `-T` option disables pseudo-TTY allocation so that the command reads from standard input:
+For automation, pass the password in the `PASSWORD` environment variable and pipe it through standard input to prevent exposing the password in your shell history. The `-T` option disables pseudo-TTY allocation so that the command reads from standard input:
 
 ```bash
 printf '%s\n' "$PASSWORD" | docker compose run --rm -T server hash_password

--- a/website/docs/install-config/automated-install.mdx
+++ b/website/docs/install-config/automated-install.mdx
@@ -20,10 +20,10 @@ To generate a hash without exposing the password in your shell history, run this
 docker compose run --rm server hash_password
 ```
 
-Passing the password as a command argument remains supported, but exposes it in your shell history and the process list:
+For automation, pipe the password through standard input. The `-T` option disables pseudo-TTY allocation so that the command reads from standard input:
 
 ```bash
-docker compose run --rm server hash_password '<password>'
+printf '%s\n' "$PASSWORD" | docker compose run --rm -T server hash_password
 ```
 
 The generated hash includes a random salt, so running the command multiple times for the same password produces different output. Use the complete output as the value of `AUTHENTIK_BOOTSTRAP_PASSWORD_HASH`.

--- a/website/docs/install-config/automated-install.mdx
+++ b/website/docs/install-config/automated-install.mdx
@@ -14,10 +14,16 @@ Configure the default password for the `akadmin` user using a pre-hashed Django 
 
 This stores the hash directly as authentik's local password verifier. Because authentik never sees the raw password, hashed-password imports do not propagate the password to LDAP or Kerberos integrations, even when password writeback is enabled.
 
-To generate a hash, run this command before your initial deployment:
+To generate a hash without exposing the password in your shell history, run this command before your initial deployment and enter the password when prompted:
 
 ```bash
-docker compose run --rm server hash_password 'your-password'
+docker compose run --rm server hash_password
+```
+
+Passing the password as a command argument remains supported, but exposes it in your shell history and the process list:
+
+```bash
+docker compose run --rm server hash_password '<password>'
 ```
 
 The generated hash includes a random salt, so running the command multiple times for the same password produces different output. Use the complete output as the value of `AUTHENTIK_BOOTSTRAP_PASSWORD_HASH`.

--- a/website/docs/releases/2026/v2026.8.md
+++ b/website/docs/releases/2026/v2026.8.md
@@ -17,7 +17,7 @@ docker compose run --rm server hash_password
 For automation, pipe the password through standard input:
 
 ```bash
-printf '%s\n' "$PASSWORD" | docker compose run --rm -T server hash_password
+echo "$PASSWORD" | docker compose run --rm server hash_password
 ```
 
 ## New features and improvements

--- a/website/docs/releases/2026/v2026.8.md
+++ b/website/docs/releases/2026/v2026.8.md
@@ -6,7 +6,19 @@ draft: true
 
 ## Highlights
 
-<!-- ## Breaking changes -->
+## Breaking changes
+
+The `hash_password` management command no longer accepts a password as a positional command-line argument. Run the command without arguments to enter the password at a hidden interactive prompt:
+
+```bash
+docker compose run --rm server hash_password
+```
+
+For automation, pipe the password through standard input:
+
+```bash
+printf '%s\n' "$PASSWORD" | docker compose run --rm -T server hash_password
+```
 
 ## New features and improvements
 


### PR DESCRIPTION
Generating a password hash currently requires placing the plaintext password on the command line, where it can be retained in shell history and exposed through process inspection. The command now prompts twice without echoing when standard input is a terminal, or reads one password from standard input for automation.

Follow up to: https://github.com/goauthentik/authentik/pull/24118
