### PR TITLE
core: validate imported password hashes at the API boundary

### DIFF
--- a/authentik/core/api/users.py
+++ b/authentik/core/api/users.py
@@ -287,12 +287,6 @@ class UserSerializer(AttributesMixinSerializer, ModelSerializer):
                 raise ValidationError(_("No empty segments in user path allowed."))
         return path
 
-    def validate_password_hash(self, password_hash: str | None) -> str | None:
-        """Validate a password hash supplied by a blueprint."""
-        if password_hash is None:
-            return None
-        return validate_imported_password_hash(password_hash)
-
     def validate_type(self, user_type: str) -> str:
         """Validate user type, internal_service_account is an internal value"""
         if not self.instance and user_type == UserTypes.INTERNAL_SERVICE_ACCOUNT:

--- a/authentik/core/api/users.py
+++ b/authentik/core/api/users.py
@@ -240,11 +240,6 @@ class UserSerializer(AttributesMixinSerializer, ModelSerializer):
         self._ensure_password_not_empty(instance)
         return instance
 
-    def _validate_password_inputs(self, password: str | None, password_hash: str | None):
-        """Validate mutually-exclusive password inputs before any model mutation."""
-        if password is not None and password_hash is not None:
-            raise ValidationError(_("Cannot set both password and password_hash. Use only one."))
-
     def _set_password(self, instance: User, password: str | None, password_hash: str | None = None):
         """Set password from plain text or hash."""
         if password_hash is not None:
@@ -321,8 +316,12 @@ class UserSerializer(AttributesMixinSerializer, ModelSerializer):
         return roles
 
     def validate(self, attrs: dict) -> dict:
-        if SERIALIZER_CONTEXT_BLUEPRINT in self.context:
-            self._validate_password_inputs(attrs.get("password"), attrs.get("password_hash"))
+        if (
+            SERIALIZER_CONTEXT_BLUEPRINT in self.context
+            and attrs.get("password") is not None
+            and attrs.get("password_hash") is not None
+        ):
+            raise ValidationError(_("Cannot set both password and password_hash. Use only one."))
         if self.instance and self.instance.type == UserTypes.INTERNAL_SERVICE_ACCOUNT:
             raise ValidationError(_("Can't modify internal service account users"))
         return super().validate(attrs)

--- a/authentik/core/api/users.py
+++ b/authentik/core/api/users.py
@@ -5,7 +5,6 @@ from json import loads
 from typing import Any
 
 from django.contrib.auth import update_session_auth_hash
-from django.contrib.auth.hashers import identify_hasher
 from django.contrib.auth.models import AnonymousUser, Permission
 from django.db.models import Exists, OuterRef, Prefetch, Q
 from django.db.transaction import atomic
@@ -98,6 +97,7 @@ from authentik.flows.views.executor import QS_KEY_TOKEN
 from authentik.lib.avatars import get_avatar
 from authentik.lib.utils.reflection import ConditionalInheritance
 from authentik.lib.utils.time import timedelta_from_string, timedelta_string_validator
+from authentik.lib.validators import validate_password_hash
 from authentik.rbac.api.roles import RoleSerializer
 from authentik.rbac.decorators import permission_required
 from authentik.rbac.models import Role, get_permission_choices
@@ -107,20 +107,6 @@ from authentik.stages.email.tasks import send_mails
 from authentik.stages.email.utils import TemplateEmailMessage
 
 LOGGER = get_logger()
-
-INVALID_PASSWORD_HASH_MESSAGE = _(
-    "Invalid password hash format. Must be a valid Django password hash."
-)
-
-
-def validate_imported_password_hash(password_hash: str) -> str:
-    """Validate the format of a password hash imported through the API."""
-    try:
-        hasher = identify_hasher(password_hash)
-        hasher.decode(password_hash)
-    except (AssertionError, TypeError, ValueError) as exc:
-        raise ValidationError(INVALID_PASSWORD_HASH_MESSAGE) from exc
-    return password_hash
 
 
 class ParamUserSerializer(PassiveSerializer):
@@ -478,11 +464,7 @@ class UserPasswordSetSerializer(PassiveSerializer):
 class UserPasswordHashSetSerializer(PassiveSerializer):
     """Payload to set a users' password hash directly"""
 
-    password = CharField(required=True)
-
-    def validate_password(self, password_hash: str) -> str:
-        """Validate a password hash supplied through the API."""
-        return validate_imported_password_hash(password_hash)
+    password = CharField(required=True, validators=[validate_password_hash])
 
 
 class UserServiceAccountSerializer(PassiveSerializer):

--- a/authentik/core/api/users.py
+++ b/authentik/core/api/users.py
@@ -5,6 +5,7 @@ from json import loads
 from typing import Any
 
 from django.contrib.auth import update_session_auth_hash
+from django.contrib.auth.hashers import identify_hasher
 from django.contrib.auth.models import AnonymousUser, Permission
 from django.db.models import Exists, OuterRef, Prefetch, Q
 from django.db.transaction import atomic
@@ -14,7 +15,6 @@ from django.utils.http import urlencode
 from django.utils.text import slugify
 from django.utils.timezone import now
 from django.utils.translation import gettext as _
-from django.utils.translation import gettext_lazy
 from django_filters.filters import (
     BooleanFilter,
     CharFilter,
@@ -108,9 +108,19 @@ from authentik.stages.email.utils import TemplateEmailMessage
 
 LOGGER = get_logger()
 
-INVALID_PASSWORD_HASH_MESSAGE = gettext_lazy(
+INVALID_PASSWORD_HASH_MESSAGE = _(
     "Invalid password hash format. Must be a valid Django password hash."
 )
+
+
+def validate_imported_password_hash(password_hash: str) -> str:
+    """Validate the format of a password hash imported through the API."""
+    try:
+        hasher = identify_hasher(password_hash)
+        hasher.decode(password_hash)
+    except (AssertionError, TypeError, ValueError) as exc:
+        raise ValidationError(INVALID_PASSWORD_HASH_MESSAGE) from exc
+    return password_hash
 
 
 class ParamUserSerializer(PassiveSerializer):
@@ -213,7 +223,6 @@ class UserSerializer(AttributesMixinSerializer, ModelSerializer):
             password = validated_data.pop("password", None)
             password_hash = validated_data.pop("password_hash", None)
             permissions = validated_data.pop("permissions", [])
-            self._validate_password_inputs(password, password_hash)
 
         instance: User = super().create(validated_data)
         if is_blueprint:
@@ -233,7 +242,6 @@ class UserSerializer(AttributesMixinSerializer, ModelSerializer):
             password = validated_data.pop("password", None)
             password_hash = validated_data.pop("password_hash", None)
             permissions = validated_data.pop("permissions", [])
-            self._validate_password_inputs(password, password_hash)
 
         instance = super().update(instance, validated_data)
         if is_blueprint:
@@ -250,13 +258,6 @@ class UserSerializer(AttributesMixinSerializer, ModelSerializer):
         """Validate mutually-exclusive password inputs before any model mutation."""
         if password is not None and password_hash is not None:
             raise ValidationError(_("Cannot set both password and password_hash. Use only one."))
-        if password_hash is None:
-            return
-        try:
-            User.validate_password_hash(password_hash)
-        except ValueError as exc:
-            LOGGER.warning("Failed to identify password hash format", exc_info=exc)
-            raise ValidationError(INVALID_PASSWORD_HASH_MESSAGE) from exc
 
     def _set_password(self, instance: User, password: str | None, password_hash: str | None = None):
         """Set password from plain text or hash."""
@@ -285,6 +286,12 @@ class UserSerializer(AttributesMixinSerializer, ModelSerializer):
             if segment == "":
                 raise ValidationError(_("No empty segments in user path allowed."))
         return path
+
+    def validate_password_hash(self, password_hash: str | None) -> str | None:
+        """Validate a password hash supplied by a blueprint."""
+        if password_hash is None:
+            return None
+        return validate_imported_password_hash(password_hash)
 
     def validate_type(self, user_type: str) -> str:
         """Validate user type, internal_service_account is an internal value"""
@@ -334,6 +341,8 @@ class UserSerializer(AttributesMixinSerializer, ModelSerializer):
         return roles
 
     def validate(self, attrs: dict) -> dict:
+        if SERIALIZER_CONTEXT_BLUEPRINT in self.context:
+            self._validate_password_inputs(attrs.get("password"), attrs.get("password_hash"))
         if self.instance and self.instance.type == UserTypes.INTERNAL_SERVICE_ACCOUNT:
             raise ValidationError(_("Can't modify internal service account users"))
         return super().validate(attrs)
@@ -476,6 +485,10 @@ class UserPasswordHashSetSerializer(PassiveSerializer):
     """Payload to set a users' password hash directly"""
 
     password = CharField(required=True)
+
+    def validate_password(self, password_hash: str) -> str:
+        """Validate a password hash supplied through the API."""
+        return validate_imported_password_hash(password_hash)
 
 
 class UserServiceAccountSerializer(PassiveSerializer):
@@ -884,9 +897,6 @@ class UserViewSet(
         try:
             user.set_password_from_hash(body.validated_data["password"], request=request)
             user.save()
-        except ValueError as exc:
-            LOGGER.debug("Failed to set password hash", exc=exc)
-            return Response(data={"password": [INVALID_PASSWORD_HASH_MESSAGE]}, status=400)
         except (ValidationError, IntegrityError) as exc:
             LOGGER.debug("Failed to set password hash", exc=exc)
             return Response(status=400)

--- a/authentik/core/models.py
+++ b/authentik/core/models.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 
 import pgtrigger
 from deepmerge import always_merger
-from django.contrib.auth.hashers import check_password, identify_hasher
+from django.contrib.auth.hashers import check_password
 from django.contrib.auth.models import AbstractUser, Permission
 from django.contrib.auth.models import UserManager as DjangoUserManager
 from django.contrib.contenttypes.models import ContentType
@@ -568,24 +568,15 @@ class User(SerializerModel, AttributesMixin, AbstractUser):
         self.password_change_date = now()
         return super().set_password(raw_password)
 
-    @staticmethod
-    def validate_password_hash(password_hash: str):
-        """Validate that the value is a recognized Django password hash."""
-        identify_hasher(password_hash)  # Raises ValueError if invalid
-
     def set_password_from_hash(self, password_hash: str, signal=True, sender=None, request=None):
         """Set password directly from a pre-hashed value.
 
         Unlike set_password(), this does not hash the input again. The provided value
-        must already be a valid Django password hash, and it is stored directly on the
-        user after validation.
+        must already be validated by the caller, and it is stored directly on the user.
 
         Because no raw password is available, downstream password sync integrations
         such as LDAP and Kerberos cannot be updated from this code path.
-
-        Raises ValueError if the hash format is not recognized.
         """
-        self.validate_password_hash(password_hash)
         if self.pk and signal:
             from authentik.core.signals import password_hash_changed
 

--- a/authentik/core/setup/signals.py
+++ b/authentik/core/setup/signals.py
@@ -6,6 +6,7 @@ from structlog.stdlib import get_logger
 from authentik.blueprints.models import BlueprintInstance
 from authentik.blueprints.v1.importer import Importer
 from authentik.core.apps import Setup
+from authentik.lib.validators import validate_password_hash
 from authentik.root.signals import post_startup
 from authentik.tenants.models import Tenant
 
@@ -32,6 +33,8 @@ def post_startup_setup_bootstrap(sender, **_):
             LOGGER.info("Tenant is already setup, skipping", tenant=tenant.schema_name)
             continue
         with tenant:
+            if password_hash := getenv("AUTHENTIK_BOOTSTRAP_PASSWORD_HASH"):
+                validate_password_hash(password_hash)
             importer = Importer.from_string(content)
             valid, logs = importer.validate()
             if not valid:

--- a/authentik/core/setup/signals.py
+++ b/authentik/core/setup/signals.py
@@ -38,5 +38,8 @@ def post_startup_setup_bootstrap(sender, **_):
                 LOGGER.warning("Blueprint invalid", tenant=tenant.schema_name)
                 for log in logs:
                     log.log()
-            importer.apply()
+                continue
+            if not importer.apply():
+                LOGGER.warning("Failed to apply bootstrap blueprint", tenant=tenant.schema_name)
+                continue
             Setup.set(True, tenant=tenant)

--- a/authentik/core/tests/test_setup.py
+++ b/authentik/core/tests/test_setup.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from django.contrib.auth.hashers import make_password
 from django.urls import reverse
+from rest_framework.exceptions import ValidationError
 
 from authentik.blueprints.tests import apply_blueprint
 from authentik.core.apps import Setup
@@ -222,12 +223,11 @@ class TestSetup(FlowTestCase):
         environ.pop("AUTHENTIK_BOOTSTRAP_PASSWORD", None)
         environ["AUTHENTIK_BOOTSTRAP_PASSWORD_HASH"] = "pbkdf2_sha256$1000000/K4wGpWYKfJPSCcNM="
         pre_startup.send(sender=self)
-        with patch("authentik.core.setup.signals.LOGGER.warning") as warning:
+        with self.assertRaises(ValidationError):
             post_startup.send(sender=self)
 
         self.assertFalse(Setup.get())
         self.assertFalse(User.objects.filter(username="akadmin").exists())
-        warning.assert_any_call("Blueprint invalid", tenant="public")
 
     def test_setup_bootstrap_env_apply_failure(self):
         """Test setup remains incomplete when the bootstrap blueprint fails to apply."""

--- a/authentik/core/tests/test_setup.py
+++ b/authentik/core/tests/test_setup.py
@@ -1,5 +1,6 @@
 from http import HTTPStatus
 from os import environ
+from unittest.mock import patch
 
 from django.contrib.auth.hashers import make_password
 from django.urls import reverse
@@ -182,6 +183,7 @@ class TestSetup(FlowTestCase):
         User.objects.filter(username="akadmin").delete()
         Setup.set(False)
 
+        environ.pop("AUTHENTIK_BOOTSTRAP_PASSWORD_HASH", None)
         environ["AUTHENTIK_BOOTSTRAP_PASSWORD"] = generate_id()
         environ["AUTHENTIK_BOOTSTRAP_TOKEN"] = generate_id()
         pre_startup.send(sender=self)
@@ -200,6 +202,7 @@ class TestSetup(FlowTestCase):
         User.objects.filter(username="akadmin").delete()
         Setup.set(False)
 
+        environ.pop("AUTHENTIK_BOOTSTRAP_PASSWORD", None)
         password = generate_id()
         password_hash = make_password(password)
         environ["AUTHENTIK_BOOTSTRAP_PASSWORD_HASH"] = password_hash
@@ -210,3 +213,33 @@ class TestSetup(FlowTestCase):
         user = User.objects.get(username="akadmin")
         self.assertEqual(user.password, password_hash)
         self.assertTrue(user.check_password(password))
+
+    def test_setup_bootstrap_env_malformed_password_hash(self):
+        """Test setup rejects a malformed password hash from the environment."""
+        User.objects.filter(username="akadmin").delete()
+        Setup.set(False)
+
+        environ.pop("AUTHENTIK_BOOTSTRAP_PASSWORD", None)
+        environ["AUTHENTIK_BOOTSTRAP_PASSWORD_HASH"] = "pbkdf2_sha256$1000000/K4wGpWYKfJPSCcNM="
+        pre_startup.send(sender=self)
+        with patch("authentik.core.setup.signals.LOGGER.warning") as warning:
+            post_startup.send(sender=self)
+
+        self.assertFalse(Setup.get())
+        self.assertFalse(User.objects.filter(username="akadmin").exists())
+        warning.assert_any_call("Blueprint invalid", tenant="public")
+
+    def test_setup_bootstrap_env_apply_failure(self):
+        """Test setup remains incomplete when the bootstrap blueprint fails to apply."""
+        Setup.set(False)
+        environ["AUTHENTIK_BOOTSTRAP_TOKEN"] = generate_id()
+        pre_startup.send(sender=self)
+
+        with (
+            patch("authentik.core.setup.signals.Importer.apply", return_value=False),
+            patch("authentik.core.setup.signals.LOGGER.warning") as warning,
+        ):
+            post_startup.send(sender=self)
+
+        self.assertFalse(Setup.get())
+        warning.assert_any_call("Failed to apply bootstrap blueprint", tenant="public")

--- a/authentik/core/tests/test_users.py
+++ b/authentik/core/tests/test_users.py
@@ -106,19 +106,22 @@ class TestUserSerializerPasswordHash(TestCase):
         self.assertTrue(user.check_password(password))
         self.assertIsNotNone(user.password_change_date)
 
-    def test_password_hash_rejects_invalid_format(self):
-        """Test invalid password hash values are rejected."""
+    def test_unrecognized_password_hash_is_stored_unchanged(self):
+        """Test blueprint password hashes are stored without validation."""
+        password_hash = "custom$password$hash"
         serializer = UserSerializer(
             data={
                 "username": generate_id(),
                 "name": "Test User",
-                "password_hash": "pbkdf2_sha256$1000000/K4wGpWYKfJPSCcNM=",
+                "password_hash": password_hash,
             },
             context={SERIALIZER_CONTEXT_BLUEPRINT: True},
         )
 
-        self.assertFalse(serializer.is_valid())
-        self.assertIn("Invalid password hash", str(serializer.errors))
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        user = serializer.save()
+
+        self.assertEqual(user.password, password_hash)
 
     def test_password_hash_ignored_outside_blueprint_context(self):
         """Test password_hash is not accepted by the regular serializer."""

--- a/authentik/core/tests/test_users.py
+++ b/authentik/core/tests/test_users.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 
 from django.contrib.auth.hashers import make_password
 from django.test.testcases import TestCase
-from rest_framework.exceptions import ValidationError
 
 from authentik.blueprints.v1.importer import SERIALIZER_CONTEXT_BLUEPRINT
 from authentik.core.api.users import UserSerializer
@@ -113,16 +112,13 @@ class TestUserSerializerPasswordHash(TestCase):
             data={
                 "username": generate_id(),
                 "name": "Test User",
-                "password_hash": "not-a-valid-hash",
+                "password_hash": "pbkdf2_sha256$1000000/K4wGpWYKfJPSCcNM=",
             },
             context={SERIALIZER_CONTEXT_BLUEPRINT: True},
         )
 
-        self.assertTrue(serializer.is_valid(), serializer.errors)
-        with self.assertRaises(ValidationError) as ctx:
-            serializer.save()
-
-        self.assertIn("Invalid password hash format", str(ctx.exception))
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("Invalid password hash", str(serializer.errors))
 
     def test_password_hash_ignored_outside_blueprint_context(self):
         """Test password_hash is not accepted by the regular serializer."""

--- a/authentik/core/tests/test_users_api.py
+++ b/authentik/core/tests/test_users_api.py
@@ -54,6 +54,17 @@ class TestUsersAPI(APITestCase):
         self.assertEqual(user.password, password_hash)
         self.assertTrue(user.check_password(password))
 
+    def _assert_password_hash_rejected(
+        self, user: User, original_password_hash: str, response
+    ) -> None:
+        self.assertEqual(response.status_code, 400)
+        self.assertJSONEqual(
+            response.content,
+            {"password": [INVALID_PASSWORD_HASH_ERROR]},
+        )
+        user.refresh_from_db()
+        self.assertEqual(user.password, original_password_hash)
+
     def test_filter_type(self):
         """Test API filtering by type"""
         self.client.force_login(self.admin)
@@ -158,13 +169,15 @@ class TestUsersAPI(APITestCase):
     def test_set_password_hash_invalid(self):
         """Test invalid password hashes are rejected."""
         self.client.force_login(self.admin)
-        response = self._set_password_hash(self.user, INVALID_PASSWORD_HASH)
+        original_password = self.user.password
+        for password_hash in (
+            INVALID_PASSWORD_HASH,
+            "pbkdf2_sha256$1000000/K4wGpWYKfJPSCcNM=",
+        ):
+            with self.subTest(password_hash=password_hash):
+                response = self._set_password_hash(self.user, password_hash)
 
-        self.assertEqual(response.status_code, 400)
-        self.assertJSONEqual(
-            response.content,
-            {"password": [INVALID_PASSWORD_HASH_ERROR]},
-        )
+                self._assert_password_hash_rejected(self.user, original_password, response)
 
     def test_recovery(self):
         """Test user recovery link"""

--- a/authentik/lib/validators.py
+++ b/authentik/lib/validators.py
@@ -1,9 +1,21 @@
 """Serializer validators"""
 
+from django.contrib.auth.hashers import identify_hasher
 from django.utils.translation import gettext_lazy as _
 from rest_framework.exceptions import ValidationError
 from rest_framework.serializers import Serializer
 from rest_framework.utils.representation import smart_repr
+
+
+def validate_password_hash(password_hash: str) -> None:
+    """Validate the format of an encoded Django password."""
+    try:
+        hasher = identify_hasher(password_hash)
+        hasher.decode(password_hash)
+    except (AssertionError, TypeError, ValueError) as exc:
+        raise ValidationError(
+            _("Invalid password hash format. Must be a valid Django password hash.")
+        ) from exc
 
 
 class RequiredTogetherValidator:

--- a/website/docs/install-config/automated-install.mdx
+++ b/website/docs/install-config/automated-install.mdx
@@ -12,7 +12,7 @@ These can't be defined using the file-based syntax (`file://`), so you can't pas
 
 Configure the default password for the `akadmin` user using a pre-hashed Django password value. Only read on the first startup.
 
-This stores the hash directly as authentik's local password verifier. Because authentik never sees the raw password, hashed-password imports do not propagate the password to LDAP or Kerberos integrations, even when password writeback is enabled.
+This stores the hash directly as authentik's local password verifier. Because authentik never sees the raw password, hashed-password imports do not propagate the password to LDAP or Kerberos integrations, even when password writeback is enabled. authentik validates imported hashes before storing them and rejects malformed values.
 
 To generate a hash, run this command before your initial deployment and enter the password when prompted:
 
@@ -69,7 +69,7 @@ Setting both `AUTHENTIK_BOOTSTRAP_PASSWORD` and `AUTHENTIK_BOOTSTRAP_PASSWORD_HA
 
 For post-install automation, hashed passwords can also be set via blueprints with the `password_hash` user attribute, or via the `/api/v3/core/users/<id>/set_password_hash/` API endpoint with the hash provided in the `password` field. The API endpoint requires the `authentik_core.reset_user_password` permission and can target regular users or service accounts.
 
-These paths share the same local-verifier-only behavior as `AUTHENTIK_BOOTSTRAP_PASSWORD_HASH`.
+These paths share the same validation and local-verifier-only behavior as `AUTHENTIK_BOOTSTRAP_PASSWORD_HASH`.
 
 ### `AUTHENTIK_BOOTSTRAP_TOKEN`
 


### PR DESCRIPTION
Malformed hashes submitted to the password-hash API previously reached the model before format validation. This moves structural validation into `authentik.lib.validators` and attaches it directly to the API serializer field, while leaving the user model as a storage primitive and user-authored blueprints unrestricted.

`AUTHENTIK_BOOTSTRAP_PASSWORD_HASH` is validated explicitly at its environment boundary because bootstrap is implemented through a system blueprint. Bootstrap apply failures leave setup incomplete. This PR is stacked on #24126. Validated with focused Django tests, `make gen`, `make lint-fix`, `make docs`, and `./manage.py makemigrations --check`.
