### PR TITLE
enterprise: fix enterprise_test skipping tests when used as class decorator

### DIFF
--- a/authentik/enterprise/tests/__init__.py
+++ b/authentik/enterprise/tests/__init__.py
@@ -31,6 +31,17 @@ def enterprise_test(
     """Install testing enterprise license"""
 
     def wrapper_outer(func: Callable):
+        # Mirror `unittest.mock.patch`'s class decoration: wrap each test method
+        # individually. Wrapping the class itself would replace it with a function,
+        # and pytest would silently collect no tests from it.
+        if isinstance(func, type):
+            for name in dir(func):
+                if not name.startswith("test"):
+                    continue
+                attr = getattr(func, name)
+                if callable(attr):
+                    setattr(func, name, wrapper_outer(attr))
+            return func
 
         @wraps(func)
         def wrapper(*args, **kwargs):


### PR DESCRIPTION


#18404 replaced `patch_license` with `enterprise_test()`, but the new decorator only handles functions. 

When applied to a class it replaces the class with a plain function, so pytest silently collects nothing from it.
The suites in enterprise/reports/tests and enterprise/lifecycle/tests/test_api.py currently run 0 tests on main.

This makes enterprise_test() handle classes the same way `mock.patch` does: wrap each test* method and return the class.

Before/after:
- enterprise/reports/tests/test_api.py: 0 -> 2 tests
- enterprise/lifecycle/tests/test_api.py: 0 -> 21 tests

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
