### PR TITLE
website/integrations: Gotify

### DIFF
--- a/website/integrations/monitoring/gotify/index.mdx
+++ b/website/integrations/monitoring/gotify/index.mdx
@@ -10,11 +10,9 @@ import Tabs from "@theme/Tabs";
 
 ## What is Gotify?
 
-> Gotify is a self-hosted server for sending and receiving push notifications in real time over WebSockets. It ships with a web UI, a REST API for delivering messages from scripts or applications, and mobile and desktop clients that subscribe to the message stream.
+> Gotify is a self-hosted server for sending and receiving messages in real time over WebSockets. It includes a web UI and REST API, with an Android app and command-line client.
 >
 > -- https://gotify.net/
-
-This guide was tested with Gotify 3.0 and authentik 2026.5.5.
 
 ## Preparation
 
@@ -33,7 +31,7 @@ This documentation lists only the settings that you need to change from their de
 
 To support the integration of Gotify with authentik, you need to create an application/provider pair in authentik.
 
-### Create an application and provider in authentik
+### Create an application and provider
 
 1. Log in to authentik as an administrator and open the authentik Admin interface.
 2. Navigate to **Applications** > **Applications** and click **New Application** to open the application wizard.
@@ -42,6 +40,7 @@ To support the integration of Gotify with authentik, you need to create an appli
     - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
         - Note the **Client ID** and **Client Secret** values because they will be required later.
         - Add a **Redirect URI** of type `Strict` `Authorization` as `https://gotify.company/auth/oidc/callback`.
+        - If users will log in from the Gotify Android app, add another **Redirect URI** of type `Strict` `Authorization` as `gotify://oidc/callback`.
         - Select any available signing key.
     - **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/bindings-overview/) (policy, group, or user) to manage the listing and access to applications on a user's **Application Dashboard** page.
 
@@ -49,63 +48,61 @@ To support the integration of Gotify with authentik, you need to create an appli
 
 ## Gotify configuration
 
-Gotify reads its configuration from a `config.yml` file or from environment variables (any value set as an environment variable overrides the corresponding value from `config.yml`). Choose whichever variant fits your deployment.
+Choose the configuration method that matches your Gotify deployment.
 
 <Tabs
-defaultValue="yaml"
+defaultValue="environment-file"
 values={[
-{ label: "Configuration file", value: "yaml" },
-{ label: "Environment variables", value: "env" },
+{ label: "Environment file", value: "environment-file" },
+{ label: "Container or service", value: "container-service" },
 ]}>
-<TabItem value="yaml">
+<TabItem value="environment-file">
 
-Add the following `oidc` block to your Gotify `config.yml`:
+Add the following settings to the Gotify environment file:
 
-```yaml title="config.yml"
-oidc:
-    enabled: true
-    issuer: https://authentik.company/application/o/<application_slug>/
-    clientid: <client_id>
-    clientsecret: <client_secret>
-    redirecturl: https://gotify.company/auth/oidc/callback
-    usernameclaim: preferred_username
-    autoregister: true
-    linkbyusername: false
-    scopes:
-        - openid
-        - profile
-        - email
-```
-
-</TabItem>
-<TabItem value="env">
-
-Set the following environment variables on the Gotify container or service:
-
-```env title="Gotify environment variables"
+```env title="gotify-server.env"
 GOTIFY_OIDC_ENABLED=true
 GOTIFY_OIDC_ISSUER=https://authentik.company/application/o/<application_slug>/
-GOTIFY_OIDC_CLIENTID=<client_id>
-GOTIFY_OIDC_CLIENTSECRET=<client_secret>
+GOTIFY_OIDC_CLIENTID=<Client ID from authentik>
+GOTIFY_OIDC_CLIENTSECRET=<Client Secret from authentik>
 GOTIFY_OIDC_REDIRECTURL=https://gotify.company/auth/oidc/callback
-GOTIFY_OIDC_USERNAMECLAIM=preferred_username
-GOTIFY_OIDC_AUTOREGISTER=true
-GOTIFY_OIDC_LINK_BY_USERNAME=false
-GOTIFY_OIDC_SCOPES=openid,profile,email
 ```
+
+Restart Gotify to apply the changes.
+
+</TabItem>
+<TabItem value="container-service">
+
+Set the following environment variables for the Gotify container or service:
+
+```env title=".env"
+GOTIFY_OIDC_ENABLED=true
+GOTIFY_OIDC_ISSUER=https://authentik.company/application/o/<application_slug>/
+GOTIFY_OIDC_CLIENTID=<Client ID from authentik>
+GOTIFY_OIDC_CLIENTSECRET=<Client Secret from authentik>
+GOTIFY_OIDC_REDIRECTURL=https://gotify.company/auth/oidc/callback
+```
+
+Restart the Gotify container or service to apply the changes.
 
 </TabItem>
 </Tabs>
 
-Replace `<application_slug>` with the slug of the authentik application, and `<client_id>` and `<client_secret>` with the values from the authentik provider. Restart Gotify to apply the changes.
+Use the same callback URL for the authentik **Redirect URI** and `GOTIFY_OIDC_REDIRECTURL`. If Gotify is served from a subpath, include the subpath before `/auth/oidc/callback` in both values.
 
-:::info User provisioning
-The `autoregister` and `linkbyusername` settings control how Gotify handles incoming OIDC logins for users that do not yet have a matching Gotify account:
+### Link existing users _(optional)_
 
-- **`autoregister`** (default `true`): if `true`, Gotify creates a new local user account on the first successful OIDC login. If `false`, only users that already have a local Gotify account matching the OIDC identity are allowed to log in; unknown users are rejected.
-- **`linkbyusername`** (default `false`): if `true`, an incoming OIDC login is linked to an existing local Gotify user whose username matches the `usernameclaim` value from authentik, instead of creating a separate account. This is useful when migrating existing local users to SSO. Leave `false` if all users should always be created and managed through OIDC.
+Gotify creates a local user when a new user logs in with OIDC. If a Gotify user with the same username already exists, Gotify rejects the login until you enable existing-user linking:
 
+```env title="gotify-server.env"
+GOTIFY_OIDC_LINK_BY_USERNAME=true
+```
+
+:::warning Existing-account linking
+Enable existing-user linking only if usernames in authentik correspond to the same people as the matching Gotify usernames.
 :::
+
+To permit only existing Gotify users to log in, also set `GOTIFY_OIDC_AUTOREGISTER=false`.
 
 ## Configuration verification
 
@@ -113,4 +110,5 @@ To confirm that authentik is properly configured with Gotify, log out of Gotify 
 
 ## Resources
 
-- [Gotify OIDC configuration reference](https://github.com/gotify/server/blob/master/config/config.go)
+- [Gotify documentation - OpenID Connect](https://gotify.net/docs/oidc)
+- [Gotify documentation - Configuration](https://gotify.net/docs/config)

--- a/website/integrations/monitoring/gotify/index.mdx
+++ b/website/integrations/monitoring/gotify/index.mdx
@@ -1,0 +1,116 @@
+---
+title: Integrate with Gotify
+sidebar_label: Gotify
+support_level: community
+---
+
+import RedirectURI20265Note from "../../_redirect-uri-2026-5-note.mdx";
+import TabItem from "@theme/TabItem";
+import Tabs from "@theme/Tabs";
+
+## What is Gotify?
+
+> Gotify is a self-hosted server for sending and receiving push notifications in real time over WebSockets. It ships with a web UI, a REST API for delivering messages from scripts or applications, and mobile and desktop clients that subscribe to the message stream.
+>
+> -- https://gotify.net/
+
+This guide was tested with Gotify 3.0 and authentik 2026.5.5.
+
+## Preparation
+
+The following placeholders are used in this guide:
+
+- `gotify.company` is the FQDN of the Gotify installation.
+- `authentik.company` is the FQDN of the authentik installation.
+
+:::info
+This documentation lists only the settings that you need to change from their default values. Be aware that any changes other than those explicitly mentioned in this guide could cause issues accessing your application.
+:::
+
+## authentik configuration
+
+<RedirectURI20265Note />
+
+To support the integration of Gotify with authentik, you need to create an application/provider pair in authentik.
+
+### Create an application and provider in authentik
+
+1. Log in to authentik as an administrator and open the authentik Admin interface.
+2. Navigate to **Applications** > **Applications** and click **New Application** to open the application wizard.
+    - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings. Note the **Slug** value because you will use it when configuring Gotify.
+    - **Choose a Provider type**: select **OAuth2/OpenID Connect** as the provider type.
+    - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
+        - Note the **Client ID** and **Client Secret** values because they will be required later.
+        - Add a **Redirect URI** of type `Strict` `Authorization` as `https://gotify.company/auth/oidc/callback`.
+        - Select any available signing key.
+    - **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/bindings-overview/) (policy, group, or user) to manage the listing and access to applications on a user's **Application Dashboard** page.
+
+3. Click **Submit** to save the new application and provider.
+
+## Gotify configuration
+
+Gotify reads its configuration from a `config.yml` file or from environment variables (any value set as an environment variable overrides the corresponding value from `config.yml`). Choose whichever variant fits your deployment.
+
+<Tabs
+defaultValue="yaml"
+values={[
+{ label: "Configuration file", value: "yaml" },
+{ label: "Environment variables", value: "env" },
+]}>
+<TabItem value="yaml">
+
+Add the following `oidc` block to your Gotify `config.yml`:
+
+```yaml title="config.yml"
+oidc:
+    enabled: true
+    issuer: https://authentik.company/application/o/<application_slug>/
+    clientid: <client_id>
+    clientsecret: <client_secret>
+    redirecturl: https://gotify.company/auth/oidc/callback
+    usernameclaim: preferred_username
+    autoregister: true
+    linkbyusername: false
+    scopes:
+        - openid
+        - profile
+        - email
+```
+
+</TabItem>
+<TabItem value="env">
+
+Set the following environment variables on the Gotify container or service:
+
+```env title="Gotify environment variables"
+GOTIFY_OIDC_ENABLED=true
+GOTIFY_OIDC_ISSUER=https://authentik.company/application/o/<application_slug>/
+GOTIFY_OIDC_CLIENTID=<client_id>
+GOTIFY_OIDC_CLIENTSECRET=<client_secret>
+GOTIFY_OIDC_REDIRECTURL=https://gotify.company/auth/oidc/callback
+GOTIFY_OIDC_USERNAMECLAIM=preferred_username
+GOTIFY_OIDC_AUTOREGISTER=true
+GOTIFY_OIDC_LINK_BY_USERNAME=false
+GOTIFY_OIDC_SCOPES=openid,profile,email
+```
+
+</TabItem>
+</Tabs>
+
+Replace `<application_slug>` with the slug of the authentik application, and `<client_id>` and `<client_secret>` with the values from the authentik provider. Restart Gotify to apply the changes.
+
+:::info User provisioning
+The `autoregister` and `linkbyusername` settings control how Gotify handles incoming OIDC logins for users that do not yet have a matching Gotify account:
+
+- **`autoregister`** (default `true`): if `true`, Gotify creates a new local user account on the first successful OIDC login. If `false`, only users that already have a local Gotify account matching the OIDC identity are allowed to log in; unknown users are rejected.
+- **`linkbyusername`** (default `false`): if `true`, an incoming OIDC login is linked to an existing local Gotify user whose username matches the `usernameclaim` value from authentik, instead of creating a separate account. This is useful when migrating existing local users to SSO. Leave `false` if all users should always be created and managed through OIDC.
+
+:::
+
+## Configuration verification
+
+To confirm that authentik is properly configured with Gotify, log out of Gotify and click the **Login with OIDC** button on the login page. You should be redirected to authentik to log in, then redirected back to the Gotify web UI.
+
+## Resources
+
+- [Gotify OIDC configuration reference](https://github.com/gotify/server/blob/master/config/config.go)


### PR DESCRIPTION
## Details

Adds a new integration guide for **Gotify** (https://gotify.net/), a self-hosted push notification server, with OIDC SSO against authentik. The guide covers:

- Creating an OAuth2/OpenID Connect application and provider in authentik with the Gotify-side callback URL `https://<gotify>/auth/oidc/callback`
- Configuring Gotify via **both** `config.yml` and the equivalent `GOTIFY_OIDC_*` environment variables, presented as tabs so the reader can pick the deployment style that matches their setup (Docker/Kubernetes vs. bare install)
- An explanation of the `autoregister` and `linkbyusername` flags so operators can choose between auto-provisioning new users on first login, restricting login to pre-existing accounts, or linking OIDC identities to existing local users during a migration to SSO

Tested with **Gotify 3.0** (which added native OIDC support) and **authentik 2026.5.5**.

## Category note

I placed the guide under `monitoring`, since Gotify is very often used as a notification target for monitoring / alerting stacks. It could arguably also fit under `chat-communication-collaboration` (it is at heart a messaging service), or `miscellaneous`. I am not 100% sure which fits the repo's conventions best, so please feel free to relocate it during review if a different category is preferred.

## Checklist

- [ ] Local tests pass (`ak test authentik/`)
- [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

- [ ] The API schema and clients have been updated (`make gen`)

If changes to the frontend have been made

- [ ] The code has been formatted (`make web`)

If applicable

- [x] The documentation has been updated
- [x] The documentation has been formatted (`make docs`)