### PR TITLE
internal/config: make storage file paths overwritable via env vars

### DIFF
--- a/internal/config/struct.go
+++ b/internal/config/struct.go
@@ -69,7 +69,7 @@ type StorageConfig struct {
 }
 
 type StorageFileConfig struct {
-	Path string `yaml:"path" env:"AUTHENTIK_STORAGE__FILE__PATH"`
+	Path string `yaml:"path" env:"AUTHENTIK_STORAGE__FILE__PATH, overwrite"`
 }
 
 type StorageMediaConfig struct {
@@ -78,7 +78,7 @@ type StorageMediaConfig struct {
 }
 
 type StorageMediaFileConfig struct {
-	Path string `yaml:"path" env:"AUTHENTIK_STORAGE__MEDIA__FILE__PATH"`
+	Path string `yaml:"path" env:"AUTHENTIK_STORAGE__MEDIA__FILE__PATH, overwrite"`
 }
 
 type StorageReportsConfig struct {
@@ -87,7 +87,7 @@ type StorageReportsConfig struct {
 }
 
 type StorageReportsFileConfig struct {
-	Path string `yaml:"path" env:"AUTHENTIK_STORAGE__REPORTS__FILE__PATH"`
+	Path string `yaml:"path" env:"AUTHENTIK_STORAGE__REPORTS__FILE__PATH, overwrite"`
 }
 
 type ErrorReportingConfig struct {


### PR DESCRIPTION
Now *__FILE__PATH environemnt variables have an effect and can overwrite values from default.yml. Without this change uploaded files can not be accessed if the folder is different from the default /data because the GoLang part assumes a /data prefix and e.g. ignores AUTHENTIK_STORAGE__FILE__PATH.

### How was this tested?

I have not tested this. I am on NixOS and `make all` does not work out-of-the-box due to dynamic linking. I presume that this minor change will not break anything.

### Linked issues

I have not created an issue, since I already (hopefully) have the solution.


P.S. AFAICS your [package list](https://docs.goauthentik.io/developer-docs/contributing/#authentiks-structure) does not include Go modules. Therefore, I was not able to chose a fitting prefix and came up with `config:`. Feel free to change if you need. I just want this to be fixed.