### PR TITLE
packages/ak-common/tracing: make console subscriber optional

### DIFF
--- a/authentik/lib/default.yml
+++ b/authentik/lib/default.yml
@@ -48,7 +48,7 @@ listen:
     - "[::]:9300"
   debug: 0.0.0.0:9900
   debug_py: 0.0.0.0:9901
-  debug_tokio: "[::]:6669"
+  # debug_tokio: "[::]:6669"
   trusted_proxy_cidrs:
     - 127.0.0.0/8
     - 10.0.0.0/8

--- a/packages/ak-common/src/config/schema.rs
+++ b/packages/ak-common/src/config/schema.rs
@@ -178,7 +178,7 @@ pub struct PostgreSQLConfig {
 pub struct ListenConfig {
     pub http: Vec<SocketAddr>,
     pub metrics: Vec<SocketAddr>,
-    pub debug_tokio: SocketAddr,
+    pub debug_tokio: Option<SocketAddr>,
     pub trusted_proxy_cidrs: Vec<IpNet>,
 }
 

--- a/packages/ak-common/src/tracing.rs
+++ b/packages/ak-common/src/tracing.rs
@@ -29,10 +29,13 @@ pub fn install() -> Result<()> {
         filter_layer = filter_layer.add_directive(format!("{k}={v}").parse()?);
     }
 
+    let console_layer = config.listen.debug_tokio.map(|listen| {
+        console_subscriber::ConsoleLayer::builder()
+            .server_addr(listen)
+            .spawn()
+    });
+
     if config.debug {
-        let console_layer = console_subscriber::ConsoleLayer::builder()
-            .server_addr(config.listen.debug_tokio)
-            .spawn();
         tracing_subscriber::registry()
             .with(ErrorLayer::default())
             .with(console_layer)
@@ -55,6 +58,7 @@ pub fn install() -> Result<()> {
     } else {
         tracing_subscriber::registry()
             .with(ErrorLayer::default())
+            .with(console_layer)
             .with(json::layer().with_filter(filter_layer))
             .with(::sentry::integrations::tracing::layer())
             .init();


### PR DESCRIPTION
<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?

Make listening on debug_tokio optional.

### Why is this change needed?

Currently we always try to listen there and fail when the port is already occupied, for example if another authentik process is running. So running both the server and proxy outpost (for example) in dev would crash the second process that starts.

### How was this tested?

### Linked issues

<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
