### PR TITLE
website/docs: document the hexworld event map

### DIFF
--- a/website/docs/install-config/air-gapped.mdx
+++ b/website/docs/install-config/air-gapped.mdx
@@ -13,7 +13,8 @@ By default, authentik creates outbound connections to the following URLs:
 - https://goauthentik.io: Anonymous analytics on startup
 - https://secure.gravatar.com: Avatars for users
 - https://authentik.error-reporting.a7k.io: Error reporting
-- https://tile.openstreetmap.org: Map tiles for event logs :ak-enterprise
+
+The [events map](../sys-mgmt/events/index.md#event-map) ships with a bundled basemap and makes no outbound connections. If a custom basemap is configured under **System** > **Brands** (**Map tiles**), the browser loads tiles from the configured URL — in an air-gapped environment, point it at an internally reachable tile source or leave it empty to keep the bundled default.
 
 ## Configuration
 

--- a/website/docs/sys-mgmt/events/index.md
+++ b/website/docs/sys-mgmt/events/index.md
@@ -23,3 +23,15 @@ The event retention setting is configured in the **System > Settings** area of t
 If you want to forward these events to another application, forward the log output of all authentik containers. Every event creation is logged with the log level "info". For this configuration, it is also recommended to set the internal retention time period to a short time frame (for example, `days=1`).
 
 If you want to forward authentik events to another system, see [Log forwarding](./log-forwarding.mdx).
+
+## Event map :ak-enterprise {#event-map}
+
+The events overview renders login and audit event locations on a built-in map. By default authentik uses a bundled "hexworld" basemap: land drawn as a hexagonal grid at three zoom bands, with country, region, and locality labels layered on top. The archive ships as part of the web bundle, so the map draws with no tile server, no external service, and no online request, and it works in air-gapped deployments.
+
+Event locations come from GeoIP and are city-accurate at best. The hex bands are sized to match: about 1000 km at world view, 400 km mid-range, and 130 km at closest zoom. Events raise their hex cell into a column — the fuller a cell, the taller the column — on a tilted globe. When a cell contains more than one kind of event, the column splits into pie wedges colored by kind: logins (green), failed logins (red), logouts (blue), application authorizations (purple), and everything else (gray). Clicking a column filters the event list below to that cell's events. Custom basemaps configured under **System** > **Brands** show the same event columns over the configured tiles.
+
+Label data is derived from [OpenStreetMap](https://openstreetmap.org/copyright) (© OpenStreetMap contributors, ODbL). Land shapes are from Natural Earth (public domain).
+
+### Using a conventional basemap instead
+
+To replace the hexworld default with a conventional vector basemap, set a tile URL template on the brand under **System** > **Brands** — the **Map tiles** field takes either a `pmtiles://` archive URL or an XYZ endpoint like `/tiles/{z}/{x}/{y}.mvt`. Any non-empty value overrides the bundled default; leave it blank to keep hexworld.


### PR DESCRIPTION
## Details

### What does this PR change?

Documents the bundled event map — what the columns and colors mean, how clicking filters the list, and how to point a brand at a self-hosted basemap via the **Map tiles** field. The section is marked `:ak-enterprise`, matching the license gate on the map in the events view, and carries an explicit `{#event-map}` anchor so the air-gapped page can link straight to it.

Also removes the OSM tile server from the air-gapped outbound-connections list, since the bundled basemap makes no outbound requests, and replaces it with a note on what a custom basemap implies for an air-gapped deployment.

### Why is this change needed?

Keeps the events and air-gapped documentation in step with the map swap (refs #21849). The old outbound-connections entry told air-gapped operators to expect a call to `tile.openstreetmap.org` that no longer happens.

### How was this tested?

`make docs` builds clean and spellcheck passes. Verified in the built output that the heading renders `id=event-map` (so the air-gapped cross-link resolves) and that the enterprise badge is emitted.

### Linked issues

refs #21849

🤖 Generated with [Claude Code](https://claude.com/claude-code)
