### PR TITLE
web: Handle interactive Turnstile failures

### DIFF
--- a/web/src/flow/stages/captcha/controllers/turnstile.ts
+++ b/web/src/flow/stages/captcha/controllers/turnstile.ts
@@ -6,6 +6,8 @@ import { TurnstileObject } from "turnstile-types";
 
 import { html } from "lit";
 
+const TURNSTILE_INITIALIZATION_TIMEOUT_MS = 15_000;
+
 declare global {
     interface Window {
         turnstile: TurnstileObject;
@@ -57,15 +59,43 @@ export class TurnstileController extends CaptchaController {
 
         return html`<div id="ak-container"></div>
             <script>
-                function onTurnstileReady() {
-                    turnstile.render("#ak-container", {
-                        sitekey: "${siteKey}",
-                        theme: "${theme}",
-                        language: "${language}",
-                        size: "flexible",
-                        callback,
+                function reportTurnstileError(error) {
+                    self.parent.postMessage({
+                        message: "error",
+                        source: "goauthentik.io",
+                        context: "flow-executor",
+                        error,
                     });
-                    loadListener();
+                }
+
+                // Avoid leaving the flow on an indefinite loading state if the API never becomes ready.
+                let initializationFailed = false;
+                const initializationTimeout = self.setTimeout(() => {
+                    initializationFailed = true;
+                    reportTurnstileError("Turnstile failed to initialize.");
+                }, ${TURNSTILE_INITIALIZATION_TIMEOUT_MS});
+
+                function onTurnstileReady() {
+                    self.clearTimeout(initializationTimeout);
+                    if (initializationFailed) return;
+
+                    try {
+                        turnstile.render("#ak-container", {
+                            "sitekey": "${siteKey}",
+                            "theme": "${theme}",
+                            "language": "${language}",
+                            "size": "flexible",
+                            callback,
+                            "error-callback": (errorCode) => {
+                                reportTurnstileError("Turnstile error: " + errorCode);
+                            },
+                        });
+                        loadListener();
+                    } catch (error) {
+                        const detail =
+                            error instanceof Error ? error.message : "Turnstile failed to render.";
+                        reportTurnstileError(detail);
+                    }
                 }
             </script>`;
     };

--- a/web/test/unit/turnstile-controller.test.ts
+++ b/web/test/unit/turnstile-controller.test.ts
@@ -1,0 +1,53 @@
+import type { CaptchaHandlerHost } from "#flow/stages/captcha/controllers/CaptchaController";
+import { TurnstileController } from "#flow/stages/captcha/controllers/turnstile";
+
+import type { CaptchaChallenge } from "@goauthentik/api";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { createRef } from "lit/directives/ref.js";
+
+const createHost = (): CaptchaHandlerHost =>
+    ({
+        activeLanguageTag: "EN",
+        activeTheme: "light",
+        addController: vi.fn(),
+        captchaDocumentContainer: {} as HTMLElement,
+        challenge: {
+            interactive: true,
+            jsUrl: "https://challenges.cloudflare.com/turnstile/v0/api.js",
+            siteKey: "1x00000000000000000000AA",
+        } as CaptchaChallenge,
+        error: null,
+        iframeRef: createRef<HTMLIFrameElement>(),
+        onTokenChange: vi.fn(),
+        removeController: vi.fn(),
+        requestUpdate: vi.fn(),
+        updateComplete: Promise.resolve(true),
+    }) satisfies CaptchaHandlerHost;
+
+describe("TurnstileController", () => {
+    it("reports interactive widget failures to the host frame", () => {
+        const controller = new TurnstileController(createHost());
+
+        const template = controller.interactive();
+        const source = template.strings.join("");
+
+        expect(source).toContain("self.parent.postMessage");
+        expect(source).toContain('message: "error"');
+        expect(source).toContain('"error-callback"');
+        expect(source).toContain('reportTurnstileError("Turnstile error: " + errorCode)');
+        expect(source).toContain("catch (error)");
+    });
+
+    it("reports an error when Turnstile does not initialize", () => {
+        const controller = new TurnstileController(createHost());
+
+        const template = controller.interactive();
+        const source = template.strings.join("");
+
+        expect(source).toContain('reportTurnstileError("Turnstile failed to initialize.")');
+        expect(source).toContain("if (initializationFailed) return");
+        expect(template.values).toContain(15_000);
+    });
+});


### PR DESCRIPTION
  ## Details

  ### What does this PR change?

  - Forward interactive Turnstile errors through the CAPTCHA iframe’s existing error channel.
  - Catch synchronous `turnstile.render()` failures.
  - Report an initialization failure after 15 seconds instead of displaying an indefinite loading state.

  ### Why is this change needed?

  The non-interactive Turnstile path already handles client errors, but the interactive explicit-render path only registers its success callback. If Turnstile reports an error such as
  `300030`/`300031`, or never invokes `onTurnstileReady`, the containing flow receives no failure signal and remains on a spinner indefinitely.

  This preserves Turnstile’s existing retry and lifecycle behavior; it only makes terminal initialization and render failures visible to authentik.

  ### How was this tested?

  - Vitest unit suite: 38 tests passed
  - ESLint
  - Prettier
  - TypeScript type-check
  - Production WebUI build

  ### Linked issues

  Refs #12058

  ### Backport note

  `version-2026.2` also needs the iframe error-message handler currently present on `main`; otherwise the posted error will be ignored.