### PR TITLE
web/admin: drop misleading delete consequences from user activation review

### DIFF
--- a/web/src/admin/users/UserActiveForm.ts
+++ b/web/src/admin/users/UserActiveForm.ts
@@ -9,7 +9,7 @@ import { DestructiveModelForm } from "#elements/forms/DestructiveModelForm";
 import { WithLocale } from "#elements/mixins/locale";
 import { SlottedTemplateResult } from "#elements/types";
 
-import { CoreApi, User } from "@goauthentik/api";
+import { CoreApi, UsedBy, User } from "@goauthentik/api";
 
 import { str } from "@lit/localize";
 import { msg } from "@lit/localize/init/install";
@@ -68,11 +68,16 @@ export class UserActivationToggleForm extends WithLocale(DestructiveModelForm<Us
             : msg(str`Review ${this.verboseName} Activation`, { id: "form.headline.activation" });
     }
 
-    // Toggling active state never deletes associated objects, so we skip the used-by
-    // consequence list the destructive form would otherwise render (#23778).
-    protected override renderForm(): SlottedTemplateResult {
-        return html``;
-    }
+    // Toggling active state deletes nothing (#23778).
+    protected override showConsequences = false;
+
+    public override usedBy = (): Promise<UsedBy[]> => {
+        if (!this.instance) {
+            return Promise.resolve([]);
+        }
+
+        return this.coreAPI.coreUsersUsedByList({ id: this.instance.pk });
+    };
 }
 
 declare global {

--- a/web/src/admin/users/UserActiveForm.ts
+++ b/web/src/admin/users/UserActiveForm.ts
@@ -9,7 +9,7 @@ import { DestructiveModelForm } from "#elements/forms/DestructiveModelForm";
 import { WithLocale } from "#elements/mixins/locale";
 import { SlottedTemplateResult } from "#elements/types";
 
-import { CoreApi, UsedBy, User } from "@goauthentik/api";
+import { CoreApi, User } from "@goauthentik/api";
 
 import { str } from "@lit/localize";
 import { msg } from "@lit/localize/init/install";
@@ -68,13 +68,11 @@ export class UserActivationToggleForm extends WithLocale(DestructiveModelForm<Us
             : msg(str`Review ${this.verboseName} Activation`, { id: "form.headline.activation" });
     }
 
-    public override usedBy = (): Promise<UsedBy[]> => {
-        if (!this.instance) {
-            return Promise.resolve([]);
-        }
-
-        return this.coreAPI.coreUsersUsedByList({ id: this.instance.pk });
-    };
+    // Toggling active state never deletes associated objects, so we skip the used-by
+    // consequence list the destructive form would otherwise render (#23778).
+    protected override renderForm(): SlottedTemplateResult {
+        return html``;
+    }
 }
 
 declare global {

--- a/web/src/admin/users/UserActiveForm.ts
+++ b/web/src/admin/users/UserActiveForm.ts
@@ -1,6 +1,7 @@
 import "#elements/buttons/SpinnerButton/index";
 
 import { aki } from "#common/api/client";
+import { PFSize } from "#common/enums";
 import { formatDisambiguatedUserDisplayName } from "#common/users";
 
 import { modalInvoker } from "#elements/dialogs";
@@ -22,6 +23,8 @@ import { customElement } from "lit/decorators.js";
 export class UserActivationToggleForm extends WithLocale(DestructiveModelForm<User>) {
     public static override verboseName = msg("User");
     public static override verboseNamePlural = msg("Users");
+
+    public override size = PFSize.Small;
 
     protected coreAPI = aki(CoreApi);
 
@@ -72,10 +75,10 @@ export class UserActivationToggleForm extends WithLocale(DestructiveModelForm<Us
 
         return html`<p class="pf-c-form__helper-text">
             ${this.instance?.isActive
-                ? msg(str`Are you sure you want to deactivate ${displayName}?`, {
+                ? msg(html`Are you sure you want to deactivate <code>${displayName}</code>?`, {
                       id: "user.activation.confirm.deactivate",
                   })
-                : msg(str`Are you sure you want to activate ${displayName}?`, {
+                : msg(html`Are you sure you want to activate <code>${displayName}</code>?`, {
                       id: "user.activation.confirm.activate",
                   })}
         </p>`;

--- a/web/src/admin/users/UserActiveForm.ts
+++ b/web/src/admin/users/UserActiveForm.ts
@@ -1,5 +1,4 @@
 import "#elements/buttons/SpinnerButton/index";
-import "#elements/forms/FormGroup";
 
 import { aki } from "#common/api/client";
 import { formatDisambiguatedUserDisplayName } from "#common/users";
@@ -9,7 +8,7 @@ import { DestructiveModelForm } from "#elements/forms/DestructiveModelForm";
 import { WithLocale } from "#elements/mixins/locale";
 import { SlottedTemplateResult } from "#elements/types";
 
-import { CoreApi, UsedBy, User } from "@goauthentik/api";
+import { CoreApi, User } from "@goauthentik/api";
 
 import { str } from "@lit/localize";
 import { msg } from "@lit/localize/init/install";
@@ -68,16 +67,19 @@ export class UserActivationToggleForm extends WithLocale(DestructiveModelForm<Us
             : msg(str`Review ${this.verboseName} Activation`, { id: "form.headline.activation" });
     }
 
-    // Toggling active state deletes nothing (#23778).
-    protected override showConsequences = false;
+    protected override renderForm(): SlottedTemplateResult {
+        const displayName = this.formatDisplayName();
 
-    public override usedBy = (): Promise<UsedBy[]> => {
-        if (!this.instance) {
-            return Promise.resolve([]);
-        }
-
-        return this.coreAPI.coreUsersUsedByList({ id: this.instance.pk });
-    };
+        return html`<p class="pf-c-form__helper-text">
+            ${this.instance?.isActive
+                ? msg(str`Are you sure you want to deactivate ${displayName}?`, {
+                      id: "user.activation.confirm.deactivate",
+                  })
+                : msg(str`Are you sure you want to activate ${displayName}?`, {
+                      id: "user.activation.confirm.activate",
+                  })}
+        </p>`;
+    }
 }
 
 declare global {

--- a/web/src/elements/forms/DestructiveModelForm.ts
+++ b/web/src/elements/forms/DestructiveModelForm.ts
@@ -43,6 +43,9 @@ export class DestructiveModelForm<T extends object = object> extends ModelForm<T
     @state()
     protected usedByList: UsedBy[] = [];
 
+    /** Render the "Consequence" column (e.g. "will be deleted"). */
+    protected showConsequences = true;
+
     /**
      * Get the display name for the object being deleted/updated.
      */
@@ -75,7 +78,7 @@ export class DestructiveModelForm<T extends object = object> extends ModelForm<T
     protected renderUsedBySection(): SlottedTemplateResult {
         const { usedByList, verboseName } = this;
 
-        return guard([usedByList, verboseName], () => {
+        return guard([usedByList, verboseName, this.showConsequences], () => {
             const displayName = this.formatDisplayName();
 
             const objectUsageMessage = plural(usedByList.length, {
@@ -110,13 +113,16 @@ export class DestructiveModelForm<T extends object = object> extends ModelForm<T
                     ${displayName}
                 </div>
                 <ak-simple-table
-                    .columns=${[msg("Object Name"), msg("Consequence"), msg("ID")]}
+                    .columns=${this.showConsequences
+                        ? [msg("Object Name"), msg("Consequence"), msg("ID")]
+                        : [msg("Object Name"), msg("ID")]}
                     .content=${usedByList.map((ub): RawContent[] => {
-                        return [
-                            pluckEntityName(ub) || msg("Unnamed"),
-                            formatUsedByConsequence(ub),
-                            html`<code>${ub.pk}</code>`,
-                        ];
+                        const name = pluckEntityName(ub) || msg("Unnamed");
+                        const id = html`<code>${ub.pk}</code>`;
+
+                        return this.showConsequences
+                            ? [name, formatUsedByConsequence(ub), id]
+                            : [name, id];
                     })}
                 ></ak-simple-table>
             </ak-form-group>`;

--- a/web/src/elements/forms/DestructiveModelForm.ts
+++ b/web/src/elements/forms/DestructiveModelForm.ts
@@ -43,9 +43,6 @@ export class DestructiveModelForm<T extends object = object> extends ModelForm<T
     @state()
     protected usedByList: UsedBy[] = [];
 
-    /** Render the "Consequence" column (e.g. "will be deleted"). */
-    protected showConsequences = true;
-
     /**
      * Get the display name for the object being deleted/updated.
      */
@@ -78,7 +75,7 @@ export class DestructiveModelForm<T extends object = object> extends ModelForm<T
     protected renderUsedBySection(): SlottedTemplateResult {
         const { usedByList, verboseName } = this;
 
-        return guard([usedByList, verboseName, this.showConsequences], () => {
+        return guard([usedByList, verboseName], () => {
             const displayName = this.formatDisplayName();
 
             const objectUsageMessage = plural(usedByList.length, {
@@ -113,16 +110,13 @@ export class DestructiveModelForm<T extends object = object> extends ModelForm<T
                     ${displayName}
                 </div>
                 <ak-simple-table
-                    .columns=${this.showConsequences
-                        ? [msg("Object Name"), msg("Consequence"), msg("ID")]
-                        : [msg("Object Name"), msg("ID")]}
+                    .columns=${[msg("Object Name"), msg("Consequence"), msg("ID")]}
                     .content=${usedByList.map((ub): RawContent[] => {
-                        const name = pluckEntityName(ub) || msg("Unnamed");
-                        const id = html`<code>${ub.pk}</code>`;
-
-                        return this.showConsequences
-                            ? [name, formatUsedByConsequence(ub), id]
-                            : [name, id];
+                        return [
+                            pluckEntityName(ub) || msg("Unnamed"),
+                            formatUsedByConsequence(ub),
+                            html`<code>${ub.pk}</code>`,
+                        ];
                     })}
                 ></ak-simple-table>
             </ak-form-group>`;


### PR DESCRIPTION
<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

The activate/deactivate review reused the destructive form's used-by table, whose "Consequence" column claims associated objects "will be deleted". Toggling `is_active` deletes nothing, so that column was false.

~Add a `showConsequences` opt-out to the shared form and set it on the user activation toggle, so the review still lists the user's associations but without the deletion framing.~

now just shows the user to be activated/deactivated

Before:
<img width="758" height="371" alt="image" src="https://github.com/user-attachments/assets/3a286d63-9ce1-46c4-b705-d79b8dd4cf1f" />

poposal:
<img width="762" height="381" alt="image" src="https://github.com/user-attachments/assets/d9c7028b-9e57-493e-925c-f38964bf9685" />

final:
<img width="784" height="251" alt="image" src="https://github.com/user-attachments/assets/f669f004-87d4-4dd5-914a-ffbfcbd70b50" />



Closes #23778
Closes #23777


---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
