### PR TITLE
web: show manual fallback in RedirectStage after a delay

### DIFF
--- a/web/src/flow/stages/RedirectStage.ts
+++ b/web/src/flow/stages/RedirectStage.ts
@@ -38,7 +38,7 @@ export class RedirectStage extends BaseStage<RedirectChallenge, FlowChallengeRes
      * Revealed when the automatic redirect appears to have been blocked by the
      * environment. Some embedded WebViews (notably Google's account-setup
      * "MinuteMaid" WebView, gh#23660) veto script-initiated, gesture-less
-     * top-level navigations, so `window.location.assign` silently does nothing
+     * top-level navigation, so `window.location.assign` silently does nothing
      * and the flow hangs on the spinner. Exposing an anchor the user activates
      * makes the navigation carry  user gesture, which such WebViews honor.
      */

--- a/web/src/flow/stages/RedirectStage.ts
+++ b/web/src/flow/stages/RedirectStage.ts
@@ -21,10 +21,36 @@ import PFFormControl from "@patternfly/patternfly/components/FormControl/form-co
 import PFLogin from "@patternfly/patternfly/components/Login/login.css";
 import PFTitle from "@patternfly/patternfly/components/Title/title.css";
 
+/**
+ * How long to wait after starting the automatic redirect before revealing the
+ * manual fallback. In a normal browser the navigation commits and this component
+ * is torn down long before this fires; if we're still alive afterwards the
+ * automatic navigation was most likely blocked.
+ */
+const MANUAL_FALLBACK_DELAY_MS = 2000;
+
 @customElement("ak-stage-redirect")
 export class RedirectStage extends BaseStage<RedirectChallenge, FlowChallengeResponseRequest> {
     @state()
     startedRedirect = false;
+
+    /**
+     * Revealed when the automatic redirect appears to have been blocked by the
+     * environment. Some embedded WebViews (notably Google's account-setup
+     * "MinuteMaid" WebView, gh#23660) veto script-initiated, gesture-less
+     * top-level navigations, so `window.location.assign` silently does nothing
+     * and the flow hangs on the spinner. Exposing an anchor the user activates
+     * makes the navigation carry  user gesture, which such WebViews honor.
+     */
+    @state()
+    showManualFallback = false;
+
+    #fallbackTimer?: ReturnType<typeof setTimeout>;
+
+    disconnectedCallback(): void {
+        super.disconnectedCallback();
+        clearTimeout(this.#fallbackTimer);
+    }
 
     static styles: CSSResult[] = [
         PFLogin,
@@ -94,6 +120,16 @@ export class RedirectStage extends BaseStage<RedirectChallenge, FlowChallengeRes
 
         window.location.assign(this.challenge!.to);
         this.startedRedirect = true;
+
+        // If the automatic navigation was silently blocked, this component is still
+        // alive after the delay -> reveal the manual fallback so the user can complete
+        // the redirect with a gesture-carrying activation
+        // Custom-scheme targets keep their own "you may close this" message.
+        if (url.protocol.startsWith("http")) {
+            this.#fallbackTimer = setTimeout(() => {
+                this.showManualFallback = true;
+            }, MANUAL_FALLBACK_DELAY_MS);
+        }
     }
 
     renderLoading(): TemplateResult {
@@ -113,12 +149,17 @@ export class RedirectStage extends BaseStage<RedirectChallenge, FlowChallengeRes
     }
 
     protected render(): SlottedTemplateResult {
-        if (this.startedRedirect || !this.promptUser) {
-            return this.renderLoading();
-        }
-
         if (!this.challenge) {
             return nothing;
+        }
+
+        // Show the manual "Follow redirect" when the flow inspector is open
+        // (promptUser) or when the automatic redirect appears to have been blocked
+        // (showManualFallback). Otherwise keep showing the loading spinner while the
+        // automatic redirect proceeds.
+        const showManual = (this.promptUser && !this.startedRedirect) || this.showManualFallback;
+        if (!showManual) {
+            return this.renderLoading();
         }
 
         return html`<ak-flow-card .challenge=${this.challenge}>


### PR DESCRIPTION
Testing the hypothesis that MinuteMaid (Google's embedded account-setup WebView) is blocking scripted/gesture-less navigation

Ref https://github.com/goauthentik/authentik/issues/23660

_DO NOT MERGE, just a PoC for now_



