### PR TITLE
web: add build start/end log to build script

### DIFF
--- a/web/scripts/build-web.mjs
+++ b/web/scripts/build-web.mjs
@@ -70,9 +70,11 @@ const BASE_ESBUILD_PLUGINS = [
             });
             build.onEnd((r) => {
                 const end = new Date();
-                const dur = (end.getTime() - start.getTime());
-                logger.info(`Build finished (took ${dur} ms, ${r.errors.length} error(s), ${r.warnings.length} warning(s))`);
-            })
+                const dur = end.getTime() - start.getTime();
+                logger.info(
+                    `Build finished (took ${dur} ms, ${r.errors.length} error(s), ${r.warnings.length} warning(s))`,
+                );
+            });
         },
     },
 

--- a/web/scripts/build-web.mjs
+++ b/web/scripts/build-web.mjs
@@ -60,6 +60,21 @@ const BASE_ESBUILD_PLUGINS = [
             });
         },
     },
+    {
+        name: "log",
+        setup(build) {
+            let start = new Date(0);
+            build.onStart(() => {
+                start = new Date();
+                logger.info("Build started");
+            });
+            build.onEnd((r) => {
+                const end = new Date();
+                const dur = (end.getTime() - start.getTime());
+                logger.info(`Build finished (took ${dur} ms, ${r.errors.length} error(s), ${r.warnings.length} warning(s))`);
+            })
+        },
+    },
 
     mdxPlugin({
         root: MonoRepoRoot,


### PR DESCRIPTION
was a slight bit annoying previously, not knowing whether a rebuild had kicked in or not

also logs build duration, error and warning count