### PR TITLE
web: exclude dependabot-materialized link deps from workspace glob

### DIFF
--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -36,9 +36,6 @@ catalogs:
     typescript:
       specifier: ^6.0.3
       version: 6.0.3
-    typescript-eslint:
-      specifier: ^8.64.0
-      version: 8.64.0
 
 overrides:
   '@goauthentik/esbuild-plugin-live-reload>esbuild': ^0.28.1
@@ -441,37 +438,6 @@ importers:
 
   packages/node-domexception: {}
 
-  packages/prettier-config:
-    dependencies:
-      format-imports:
-        specifier: ^4.0.8
-        version: 4.0.8(jiti@2.7.0)
-    devDependencies:
-      '@eslint/js':
-        specifier: 'catalog:'
-        version: 9.39.5
-      '@goauthentik/tsconfig':
-        specifier: link:../tsconfig
-        version: link:../tsconfig
-      '@types/node':
-        specifier: 'catalog:'
-        version: 26.1.1
-      eslint:
-        specifier: 'catalog:'
-        version: 9.39.5(jiti@2.7.0)
-      prettier:
-        specifier: 'catalog:'
-        version: 3.8.3
-      prettier-plugin-packagejson:
-        specifier: ^3.0.2
-        version: 3.0.2(prettier@3.8.3)
-      typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
-      typescript-eslint:
-        specifier: 'catalog:'
-        version: 8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3)
-
   packages/sfe:
     dependencies:
       '@goauthentik/api':
@@ -553,8 +519,6 @@ importers:
       '@swc/core-win32-x64-msvc':
         specifier: ^1.15.40
         version: 1.15.43
-
-  packages/tsconfig: {}
 
 packages:
 

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -5,6 +5,14 @@ packages:
     # it cannot represent in this lockfile. Link it as an external local package
     # instead (see web + sfe package.json).
     - "!packages/client-ts"
+    # Dependabot resolves the `link:../packages/prettier-config` dev dependency
+    # (see web/package.json) by materializing the target — and its own linked
+    # `tsconfig` — under web/packages/ when it regenerates this workspace's
+    # lockfile. Without these exclusions the `packages/*` glob then swallows
+    # them as workspace importers, committing phantom entries that every local
+    # `pnpm install` prunes right back out.
+    - "!packages/prettier-config"
+    - "!packages/tsconfig"
 
 # pnpm's default isolated linker exposes packages strictly — only declared
 # dependencies are visible. The web bundle relies on a handful of phantom


### PR DESCRIPTION
## Details

### What does this PR change?

Adds `!packages/prettier-config` and `!packages/tsconfig` negations to the `packages:` glob in `web/pnpm-workspace.yaml` (same pattern as the existing `!packages/client-ts` exclusion), and prunes the two phantom importer blocks — plus the `typescript-eslint` catalogs entry only they referenced — from `web/pnpm-lock.yaml`.

### Why is this change needed?

Every local `pnpm install` in `web/` produced a 36-line lockfile diff, reintroduced by each dependabot PR that regenerated the web lockfile (most recently #24152).

Root cause: `web/package.json` declares `"@goauthentik/prettier-config-dev": "link:../packages/prettier-config"`, which points outside the web workspace. When dependabot regenerates the lockfile, it materializes the link target — and its own `link:../tsconfig` — inside its reconstructed project tree at `web/packages/`. The `packages/*` workspace glob then swallows both as workspace members, so pnpm records them as importers. Locally those directories don't exist, so `pnpm install` pruned them right back out — recurring churn in both directions.

With the negations in place, the entries are excluded even when the directories are present, so dependabot's environment and local checkouts now agree on the lockfile.

The `website/` workspace has the same out-of-root `link:` dependencies but enumerates its workspace members explicitly (no `packages/*` glob), so it is not affected.

### How was this tested?

Reproduced dependabot's environment by copying the two link targets' `package.json` files into `web/packages/` and running `pnpm install --lockfile-only`: this regenerated the committed phantom entries byte-for-byte, confirming the mechanism. With the negations applied and the simulated directories still present, the same command prunes the entries. Removed the simulation and verified repeated `pnpm install` runs leave the lockfile untouched.

### Linked issues

—

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
