### PR TITLE
events: show account changes in user event history

### DIFF
--- a/authentik/events/api/events.py
+++ b/authentik/events/api/events.py
@@ -31,6 +31,7 @@ from authentik.api.search.fields import ChoiceSearchField, JSONSearchField
 from authentik.api.validation import validate
 from authentik.core.api.object_types import TypeCreateSerializer
 from authentik.core.api.utils import ModelSerializer, PassiveSerializer
+from authentik.core.models import User
 from authentik.events.models import Event, EventAction
 from authentik.lib.utils.reflection import ConditionalInheritance
 from authentik.lib.utils.time import timedelta_from_string, timedelta_string_validator
@@ -124,7 +125,15 @@ class EventsFilter(django_filters.FilterSet):
     )
 
     def filter_username(self, queryset, name, value):
-        return queryset.filter(Q(user__username=value) | Q(context__username=value))
+        query = Q(user__username=value) | Q(context__username=value)
+        user_pk = User.objects.filter(username=value).values_list("pk", flat=True).first()
+        if user_pk is not None:
+            query |= Q(
+                context__model__app=User._meta.app_label,
+                context__model__model_name=User._meta.model_name,
+                context__model__pk=user_pk,
+            )
+        return queryset.filter(query)
 
     def filter_context_model_pk(self, queryset, name, value):
         """Because we store the PK as UUID.hex,

--- a/authentik/events/tests/test_api.py
+++ b/authentik/events/tests/test_api.py
@@ -9,7 +9,7 @@ from django.utils.http import urlencode
 from django.utils.timezone import now
 from rest_framework.test import APITestCase
 
-from authentik.core.tests.utils import create_test_admin_user
+from authentik.core.tests.utils import create_test_admin_user, create_test_user
 from authentik.events.models import (
     Event,
     EventAction,
@@ -47,6 +47,47 @@ class TestEventsAPI(APITestCase):
         self.assertEqual(response.status_code, 200)
         body = loads(response.content)
         self.assertEqual(body["pagination"]["count"], 1)
+
+    def test_filter_username_includes_user_model_events(self):
+        """User event filtering includes changes made to the user model."""
+        target_user = create_test_user()
+
+        for is_active in (False, True):
+            with self.subTest(is_active=is_active):
+                Event.objects.all().delete()
+                response = self.client.patch(
+                    reverse("authentik_api:user-detail", kwargs={"pk": target_user.pk}),
+                    data={"is_active": is_active},
+                )
+                self.assertEqual(response.status_code, 200)
+
+                for model in (
+                    {
+                        "app": "other_app",
+                        "model_name": target_user._meta.model_name,
+                        "pk": target_user.pk,
+                        "name": "unrelated",
+                    },
+                    {
+                        "app": target_user._meta.app_label,
+                        "model_name": "other_model",
+                        "pk": target_user.pk,
+                        "name": "unrelated",
+                    },
+                ):
+                    Event.new(EventAction.MODEL_UPDATED, model=model).save()
+
+                response = self.client.get(
+                    reverse("authentik_api:event-list"),
+                    data={
+                        "username": target_user.username,
+                        "action": EventAction.MODEL_UPDATED,
+                    },
+                )
+                self.assertEqual(response.status_code, 200)
+                body = loads(response.content)
+                self.assertEqual(body["pagination"]["count"], 1)
+                self.assertEqual(body["results"][0]["context"]["model"]["pk"], target_user.pk)
 
     def test_top_n(self):
         """Test top_per_user"""


### PR DESCRIPTION
User model updates are recorded with the affected user in the event's model context, while the User events tab currently filters only by actor or top-level username.

As a result, administrator actions such as activating or deactivating an account appear in Events > Logs but not in that account’s event history.

Extend the existing username filter to recognize User model context by its complete app, model, and PK identity.

Closes #24315

\