### PR TITLE
web/elements: key the message list so stacked toasts don't share state

### DIFF
--- a/web/src/elements/messages/MessageContainer.ts
+++ b/web/src/elements/messages/MessageContainer.ts
@@ -16,6 +16,7 @@ import { instanceOfValidationError } from "@goauthentik/api";
 import { msg } from "@lit/localize";
 import { CSSResult, html, PropertyValues } from "lit";
 import { customElement, property } from "lit/decorators.js";
+import { repeat } from "lit/directives/repeat.js";
 
 import PFAlertGroup from "@patternfly/patternfly/components/AlertGroup/alert-group.css";
 
@@ -205,19 +206,26 @@ export class MessageContainer extends AKElement {
             class="pf-c-alert-group pf-m-toast"
             data-alignment=${this.alignment}
         >
-            ${this.messages.toReversed().map((message, idx) => {
-                const { message: title, description, level, icon } = message;
+            ${repeat(
+                this.messages.toReversed(),
+                // Key on the message itself so each toast keeps its own <ak-message>.
+                // Without a stable key, Lit reuses elements across messages and their
+                // per-element state (resolved icon, one-shot dismiss timer) bleeds over.
+                (message) => message,
+                (message, idx) => {
+                    const { message: title, description, level, icon } = message;
 
-                return html`<ak-message
-                    ?live=${idx === 0}
-                    icon=${ifPresent(icon)}
-                    level=${level}
-                    .description=${description}
-                    .onDismiss=${() => this.#removeMessage(message)}
-                >
-                    ${title}
-                </ak-message>`;
-            })}
+                    return html`<ak-message
+                        ?live=${idx === 0}
+                        icon=${ifPresent(icon)}
+                        level=${level}
+                        .description=${description}
+                        .onDismiss=${() => this.#removeMessage(message)}
+                    >
+                        ${title}
+                    </ak-message>`;
+                },
+            )}
         </ul>`;
     }
 }


### PR DESCRIPTION
The toast container renders messages with an unkeyed `.map`, so Lit reuses `<ak-message>` elements across messages. Stateful bits then bleed: the newer toast loses its level icon (e.g. the success checkmark), and the auto-dismiss timer set in `firstUpdated` sticks to whichever message rendered first.

Render with `repeat()` keyed on the message so each toast keeps its own element.

before:
<img width="660" height="132" alt="image" src="https://github.com/user-attachments/assets/cc8e4a95-47cf-46ea-883c-7790a7485bb8" />

after:
<img width="412" height="120" alt="image" src="https://github.com/user-attachments/assets/f71f3b81-5552-4983-bb25-deb50c8fbd16" />

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
