### PR TITLE
web/elements: upgrade ak-button to Patternfly 5, make API and AKElement independent

### DIFF
--- a/web/src/elements/Button.ts
+++ b/web/src/elements/Button.ts
@@ -1,0 +1,22 @@
+/**
+ * @file Barrel file and default registry ('ak-button') for the Button component
+ */
+
+import {
+    Button,
+    type ButtonSeverity,
+    type ButtonSize,
+    type ButtonType,
+    type ButtonVariant,
+} from "./Button_impl/Button";
+import { akButton, type ButtonProps } from "./Button_impl/Button.builder";
+
+export { akButton, Button, ButtonProps, ButtonSeverity, ButtonSize, ButtonType, ButtonVariant };
+
+window.customElements.define("ak-button", Button);
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "ak-button": Button;
+    }
+}

--- a/web/src/elements/Button_impl/Button.builder.ts
+++ b/web/src/elements/Button_impl/Button.builder.ts
@@ -1,0 +1,73 @@
+import { Button, ButtonSeverity, ButtonSize } from "./Button";
+
+import type { ElementRest } from "#elements/types";
+
+import { spread } from "@open-wc/lit-helpers";
+
+import { html, nothing, TemplateResult } from "lit";
+import { ifDefined } from "lit/directives/if-defined.js";
+
+/**
+ * Configuration options for the akButton helper function
+ */
+export type ButtonProps = ElementRest &
+    Partial<Pick<Button, "type" | "variant" | "label" | "value" | "href" | "target" | "name">> & {
+        content?: string | TemplateResult | TemplateResult[] | typeof nothing;
+        disabled?: boolean;
+        severity?: ButtonSeverity;
+        size?: ButtonSize;
+        block?: boolean;
+        inline?: boolean;
+        active?: boolean;
+        expanded?: boolean;
+    };
+
+/**
+ * @summary Helper function to create a Button component programmatically
+ *
+ * @returns {TemplateResult} A Lit template result containing the configured ak-button element
+ *
+ * @see {@link Button} - The underlying web component
+ */
+export function akButton(options: ButtonProps = {}) {
+    const {
+        type,
+        variant,
+        severity,
+        size,
+        label,
+        value,
+        href,
+        target,
+        name,
+        disabled,
+        block,
+        inline,
+        active,
+        expanded,
+        content = nothing,
+        ...rest
+    } = options;
+
+    return html`
+        <ak-button
+            ${spread(rest)}
+            type=${ifDefined(type)}
+            variant=${ifDefined(variant)}
+            severity=${ifDefined(severity)}
+            size=${ifDefined(size)}
+            label=${ifDefined(label)}
+            value=${ifDefined(value)}
+            href=${ifDefined(href)}
+            target=${ifDefined(target)}
+            name=${ifDefined(name)}
+            ?disabled=${!!disabled}
+            ?block=${!!block}
+            ?inline=${!!inline}
+            ?active=${!!active}
+            ?expanded=${!!expanded}
+        >
+            ${content || nothing}
+        </ak-button>
+    `;
+}

--- a/web/src/elements/Button_impl/Button.root.css
+++ b/web/src/elements/Button_impl/Button.root.css
@@ -1,0 +1,246 @@
+:root {
+    --ak-c-button--PaddingTop: var(--pf-global--spacer--form-element);
+    --ak-c-button--PaddingRight: var(--pf-global--spacer--md);
+    --ak-c-button--PaddingBottom: var(--pf-global--spacer--form-element);
+    --ak-c-button--PaddingLeft: var(--pf-global--spacer--md);
+    --ak-c-button--LineHeight: var(--pf-global--LineHeight--md);
+    --ak-c-button--FontWeight: var(--pf-global--FontWeight--normal);
+    --ak-c-button--FontSize: var(--pf-global--FontSize--md);
+    --ak-c-button--BackgroundColor: transparent;
+    --ak-c-button--BorderRadius: var(--pf-global--BorderRadius--sm);
+    --ak-c-button--after--BorderRadius: var(--pf-global--BorderRadius--sm);
+    --ak-c-button--after--BorderColor: transparent;
+    --ak-c-button--after--BorderWidth: var(--pf-global--BorderWidth--sm);
+    --ak-c-button--hover--after--BorderWidth: var(--pf-global--BorderWidth--md);
+    --ak-c-button--focus--after--BorderWidth: var(--pf-global--BorderWidth--md);
+    --ak-c-button--active--after--BorderWidth: var(--pf-global--BorderWidth--md);
+    --ak-c-button--disabled--Color: var(--pf-global--disabled-color--100);
+    --ak-c-button--disabled--BackgroundColor: var(--pf-global--disabled-color--200);
+    --ak-c-button--disabled--after--BorderColor: transparent;
+    --ak-c-button--m-primary--BackgroundColor: var(--pf-global--primary-color--100);
+    --ak-c-button--m-primary--Color: var(--pf-global--Color--light-100);
+    --ak-c-button--m-primary--hover--BackgroundColor: var(--pf-global--primary-color--200);
+    --ak-c-button--m-primary--hover--Color: var(--pf-global--Color--light-100);
+    --ak-c-button--m-primary--focus--BackgroundColor: var(--pf-global--primary-color--200);
+    --ak-c-button--m-primary--focus--Color: var(--pf-global--Color--light-100);
+    --ak-c-button--m-primary--active--BackgroundColor: var(--pf-global--primary-color--200);
+    --ak-c-button--m-primary--active--Color: var(--pf-global--Color--light-100);
+    --ak-c-button--m-secondary--BackgroundColor: transparent;
+    --ak-c-button--m-secondary--after--BorderColor: var(--pf-global--primary-color--100);
+    --ak-c-button--m-secondary--Color: var(--pf-global--primary-color--100);
+    --ak-c-button--m-secondary--hover--BackgroundColor: transparent;
+    --ak-c-button--m-secondary--hover--after--BorderColor: var(--pf-global--primary-color--100);
+    --ak-c-button--m-secondary--hover--Color: var(--pf-global--primary-color--100);
+    --ak-c-button--m-secondary--focus--BackgroundColor: transparent;
+    --ak-c-button--m-secondary--focus--after--BorderColor: var(--pf-global--primary-color--100);
+    --ak-c-button--m-secondary--focus--Color: var(--pf-global--primary-color--100);
+    --ak-c-button--m-secondary--active--BackgroundColor: transparent;
+    --ak-c-button--m-secondary--active--after--BorderColor: var(--pf-global--primary-color--100);
+    --ak-c-button--m-secondary--active--Color: var(--pf-global--primary-color--100);
+    --ak-c-button--m-secondary--m-danger--BackgroundColor: transparent;
+    --ak-c-button--m-secondary--m-danger--Color: var(--pf-global--danger-color--100);
+    --ak-c-button--m-secondary--m-danger--after--BorderColor: var(--pf-global--danger-color--100);
+    --ak-c-button--m-secondary--m-danger--hover--BackgroundColor: transparent;
+    --ak-c-button--m-secondary--m-danger--hover--Color: var(--pf-global--danger-color--200);
+    --ak-c-button--m-secondary--m-danger--hover--after--BorderColor: var(
+        --pf-global--danger-color--100
+    );
+    --ak-c-button--m-secondary--m-danger--focus--BackgroundColor: transparent;
+    --ak-c-button--m-secondary--m-danger--focus--Color: var(--pf-global--danger-color--200);
+    --ak-c-button--m-secondary--m-danger--focus--after--BorderColor: var(
+        --pf-global--danger-color--100
+    );
+    --ak-c-button--m-secondary--m-danger--active--BackgroundColor: transparent;
+    --ak-c-button--m-secondary--m-danger--active--Color: var(--pf-global--danger-color--200);
+    --ak-c-button--m-secondary--m-danger--active--after--BorderColor: var(
+        --pf-global--danger-color--100
+    );
+    --ak-c-button--m-tertiary--BackgroundColor: transparent;
+    --ak-c-button--m-tertiary--after--BorderColor: var(--pf-global--Color--100);
+    --ak-c-button--m-tertiary--Color: var(--pf-global--Color--100);
+    --ak-c-button--m-tertiary--hover--BackgroundColor: transparent;
+    --ak-c-button--m-tertiary--hover--after--BorderColor: var(--pf-global--Color--100);
+    --ak-c-button--m-tertiary--hover--Color: var(--pf-global--Color--100);
+    --ak-c-button--m-tertiary--focus--BackgroundColor: transparent;
+    --ak-c-button--m-tertiary--focus--after--BorderColor: var(--pf-global--Color--100);
+    --ak-c-button--m-tertiary--focus--Color: var(--pf-global--Color--100);
+    --ak-c-button--m-tertiary--active--BackgroundColor: transparent;
+    --ak-c-button--m-tertiary--active--after--BorderColor: var(--pf-global--Color--100);
+    --ak-c-button--m-tertiary--active--Color: var(--pf-global--Color--100);
+    --ak-c-button--m-warning--BackgroundColor: var(--pf-global--warning-color--100);
+    --ak-c-button--m-warning--Color: var(--pf-global--Color--dark-100);
+    --ak-c-button--m-warning--hover--BackgroundColor: var(--pf-global--palette--gold-500);
+    --ak-c-button--m-warning--hover--Color: var(--pf-global--Color--dark-100);
+    --ak-c-button--m-warning--focus--BackgroundColor: var(--pf-global--palette--gold-500);
+    --ak-c-button--m-warning--focus--Color: var(--pf-global--Color--dark-100);
+    --ak-c-button--m-warning--active--BackgroundColor: var(--pf-global--palette--gold-500);
+    --ak-c-button--m-warning--active--Color: var(--pf-global--Color--dark-100);
+    --ak-c-button--m-danger--BackgroundColor: var(--pf-global--danger-color--100);
+    --ak-c-button--m-danger--Color: var(--pf-global--Color--light-100);
+    --ak-c-button--m-danger--hover--BackgroundColor: var(--pf-global--danger-color--200);
+    --ak-c-button--m-danger--hover--Color: var(--pf-global--Color--light-100);
+    --ak-c-button--m-danger--focus--BackgroundColor: var(--pf-global--danger-color--200);
+    --ak-c-button--m-danger--focus--Color: var(--pf-global--Color--light-100);
+    --ak-c-button--m-danger--active--BackgroundColor: var(--pf-global--danger-color--200);
+    --ak-c-button--m-danger--active--Color: var(--pf-global--Color--light-100);
+    --ak-c-button--m-link--BackgroundColor: transparent;
+    --ak-c-button--m-link--Color: var(--pf-global--link--Color);
+    --ak-c-button--m-link--hover--BackgroundColor: transparent;
+    --ak-c-button--m-link--hover--Color: var(--pf-global--link--Color--hover);
+    --ak-c-button--m-link--focus--BackgroundColor: transparent;
+    --ak-c-button--m-link--focus--Color: var(--pf-global--link--Color--hover);
+    --ak-c-button--m-link--active--BackgroundColor: transparent;
+    --ak-c-button--m-link--active--Color: var(--pf-global--link--Color--hover);
+    --ak-c-button--m-link--disabled--BackgroundColor: transparent;
+    --ak-c-button--m-link--disabled--Color: var(--pf-global--disabled-color--100);
+    --ak-c-button--m-link--m-inline--FontSize: inherit;
+    --ak-c-button--m-link--m-inline--hover--TextDecoration: var(
+        --pf-global--link--TextDecoration--hover
+    );
+    --ak-c-button--m-link--m-inline--hover--Color: var(--pf-global--link--Color--hover);
+    --ak-c-button--m-link--m-inline--PaddingTop: 0;
+    --ak-c-button--m-link--m-inline--PaddingRight: 0;
+    --ak-c-button--m-link--m-inline--PaddingBottom: 0;
+    --ak-c-button--m-link--m-inline--PaddingLeft: 0;
+    --ak-c-button--m-link--m-inline__progress--Left: var(--pf-global--spacer--xs);
+    --ak-c-button--m-link--m-inline--m-in-progress--PaddingLeft: calc(
+        var(--ak-c-button--m-link--m-inline__progress--Left) + var(--pf-global--spacer--sm) + 1rem
+    );
+    --ak-c-button--m-link--m-danger--BackgroundColor: transparent;
+    --ak-c-button--m-link--m-danger--Color: var(--pf-global--danger-color--100);
+    --ak-c-button--m-link--m-danger--hover--BackgroundColor: transparent;
+    --ak-c-button--m-link--m-danger--hover--Color: var(--pf-global--danger-color--200);
+    --ak-c-button--m-link--m-danger--focus--BackgroundColor: transparent;
+    --ak-c-button--m-link--m-danger--focus--Color: var(--pf-global--danger-color--200);
+    --ak-c-button--m-link--m-danger--active--BackgroundColor: transparent;
+    --ak-c-button--m-link--m-danger--active--Color: var(--pf-global--danger-color--200);
+    --ak-c-button--m-plain--BackgroundColor: transparent;
+    --ak-c-button--m-plain--Color: var(--pf-global--Color--200);
+    --ak-c-button--m-plain--hover--BackgroundColor: transparent;
+    --ak-c-button--m-plain--hover--Color: var(--pf-global--Color--100);
+    --ak-c-button--m-plain--focus--BackgroundColor: transparent;
+    --ak-c-button--m-plain--focus--Color: var(--pf-global--Color--100);
+    --ak-c-button--m-plain--active--BackgroundColor: transparent;
+    --ak-c-button--m-plain--active--Color: var(--pf-global--Color--100);
+    --ak-c-button--m-plain--disabled--Color: var(--pf-global--disabled-color--200);
+    --ak-c-button--m-plain--disabled--BackgroundColor: transparent;
+    --ak-c-button--m-control--BackgroundColor: var(--pf-global--BackgroundColor--100);
+    --ak-c-button--m-control--Color: var(--pf-global--Color--100);
+    --ak-c-button--m-control--BorderRadius: 0;
+    --ak-c-button--m-control--after--BorderWidth: var(--pf-global--BorderWidth--sm);
+    --ak-c-button--m-control--after--BorderTopColor: var(--pf-global--BorderColor--300);
+    --ak-c-button--m-control--after--BorderRightColor: var(--pf-global--BorderColor--300);
+    --ak-c-button--m-control--after--BorderBottomColor: var(--pf-global--BorderColor--200);
+    --ak-c-button--m-control--after--BorderLeftColor: var(--pf-global--BorderColor--300);
+    --ak-c-button--m-control--disabled--BackgroundColor: var(--pf-global--disabled-color--300);
+    --ak-c-button--m-control--hover--BackgroundColor: var(--pf-global--BackgroundColor--100);
+    --ak-c-button--m-control--hover--Color: var(--pf-global--Color--100);
+    --ak-c-button--m-control--hover--after--BorderBottomWidth: var(--pf-global--BorderWidth--md);
+    --ak-c-button--m-control--hover--after--BorderBottomColor: var(--pf-global--active-color--100);
+    --ak-c-button--m-control--active--BackgroundColor: var(--pf-global--BackgroundColor--100);
+    --ak-c-button--m-control--active--Color: var(--pf-global--Color--100);
+    --ak-c-button--m-control--active--after--BorderBottomWidth: var(--pf-global--BorderWidth--md);
+    --ak-c-button--m-control--active--after--BorderBottomColor: var(--pf-global--active-color--100);
+    --ak-c-button--m-control--focus--BackgroundColor: var(--pf-global--BackgroundColor--100);
+    --ak-c-button--m-control--focus--Color: var(--pf-global--Color--100);
+    --ak-c-button--m-control--focus--after--BorderBottomWidth: var(--pf-global--BorderWidth--md);
+    --ak-c-button--m-control--focus--after--BorderBottomColor: var(--pf-global--active-color--100);
+    --ak-c-button--m-control--m-expanded--BackgroundColor: var(--pf-global--BackgroundColor--100);
+    --ak-c-button--m-control--m-expanded--Color: var(--pf-global--Color--100);
+    --ak-c-button--m-control--m-expanded--after--BorderBottomWidth: var(
+        --pf-global--BorderWidth--md
+    );
+    --ak-c-button--m-control--m-expanded--after--BorderBottomColor: var(
+        --pf-global--active-color--100
+    );
+    --ak-c-button--m-small--FontSize: var(--pf-global--FontSize--sm);
+    --ak-c-button--m-display-lg--PaddingTop: var(--pf-global--spacer--md);
+    --ak-c-button--m-display-lg--PaddingRight: var(--pf-global--spacer--xl);
+    --ak-c-button--m-display-lg--PaddingBottom: var(--pf-global--spacer--md);
+    --ak-c-button--m-display-lg--PaddingLeft: var(--pf-global--spacer--xl);
+    --ak-c-button--m-display-lg--FontWeight: var(--pf-global--FontWeight--bold);
+    --ak-c-button--m-link--m-display-lg--FontSize: var(--pf-global--FontSize--lg);
+    --ak-c-button__icon--m-start--MarginRight: var(--pf-global--spacer--xs);
+    --ak-c-button__icon--m-end--MarginLeft: var(--pf-global--spacer--xs);
+    --ak-c-button__progress--width: calc(
+        var(--pf-global--icon--FontSize--md) + var(--pf-global--spacer--sm)
+    );
+    --ak-c-button__progress--Opacity: 0;
+    --ak-c-button__progress--TranslateY: -50%;
+    --ak-c-button__progress--TranslateX: 0;
+    --ak-c-button__progress--Top: 50%;
+    --ak-c-button__progress--Left: var(--pf-global--spacer--md);
+    --ak-c-button--m-progress--TransitionProperty: padding;
+    --ak-c-button--m-progress--TransitionDuration: var(--pf-global--TransitionDuration);
+    --ak-c-button--m-progress--PaddingRight: calc(
+        var(--pf-global--spacer--md) + calc(var(--ak-c-button__progress--width) / 2)
+    );
+
+    --ak-c-button--m-progress--PaddingLeft: calc(
+        var(--pf-global--spacer--md) + calc(var(--ak-c-button__progress--width) / 2)
+    );
+    --ak-c-button--m-in-progress--PaddingRight: var(--pf-global--spacer--md);
+    --ak-c-button--m-in-progress--PaddingLeft: calc(
+        var(--pf-global--spacer--md) + var(--ak-c-button__progress--width)
+    );
+    --ak-c-button--m-in-progress--m-plain--Color: var(--pf-global--primary-color--100);
+    --ak-c-button--m-in-progress--m-plain__progress--Left: 50%;
+    --ak-c-button--m-in-progress--m-plain__progress--TranslateX: -50%;
+    --ak-c-button__count--MarginLeft: var(--pf-global--spacer--sm);
+    --ak-c-button--disabled__c-badge--Color: var(--pf-global--Color--dark-100);
+    --ak-c-button--disabled__c-badge--BackgroundColor: var(--pf-global--BackgroundColor--200);
+    --ak-c-button--m-primary__c-badge--BorderColor: var(--pf-global--BorderColor--300);
+    --ak-c-button--m-primary__c-badge--BorderWidth: var(--pf-global--BorderWidth--sm);
+
+    --ak-c-button--m-narrow--PaddingTop: var(--pf-global--spacer--form-element);
+    --ak-c-button--m-narrow--PaddingRight: var(--pf-global--spacer--sm);
+    --ak-c-button--m-narrow--PaddingBottom: var(--pf-global--spacer--form-element);
+    --ak-c-button--m-narrow--PaddingLeft: var(--pf-global--spacer--sm);
+}
+
+.pf-theme-dark,
+html[theme="dark"],
+html[data-theme="dark"] {
+    --ak-c-button--disabled--Color: var(--pf-global--disabled-color--300);
+    --ak-c-button--m-primary--BackgroundColor: var(--pf-global--primary-color--300);
+    --ak-c-button--m-primary--Color: var(--pf-global--primary-color--400);
+    --ak-c-button--m-tertiary--after--BorderColor: var(--pf-global--BorderColor--100);
+    --ak-c-button--m-tertiary--Color: var(--pf-global--palette--black-100);
+    --ak-c-button--m-tertiary--hover--after--BorderColor: var(--pf-global--BorderColor--100);
+    --ak-c-button--m-tertiary--hover--Color: var(--pf-global--palette--black-100);
+    --ak-c-button--m-tertiary--focus--after--BorderColor: var(--pf-global--BorderColor--100);
+    --ak-c-button--m-tertiary--focus--Color: var(--pf-global--palette--black-100);
+    --ak-c-button--m-tertiary--active--after--BorderColor: var(--pf-global--BorderColor--100);
+    --ak-c-button--m-tertiary--active--Color: var(--pf-global--palette--black-100);
+    --ak-c-button--m-warning--Color: var(--pf-global--palette--black-900);
+    --ak-c-button--m-warning--hover--Color: var(--pf-global--palette--black-900);
+    --ak-c-button--m-warning--focus--Color: var(--pf-global--palette--black-900);
+    --ak-c-button--m-warning--active--Color: var(--pf-global--palette--black-900);
+    --ak-c-button--m-warning--hover--BackgroundColor: var(--pf-global--warning-color--200);
+    --ak-c-button--m-warning--focus--BackgroundColor: var(--pf-global--warning-color--200);
+    --ak-c-button--m-warning--active--BackgroundColor: var(--pf-global--warning-color--200);
+    --ak-c-button--m-danger--Color: var(--pf-global--palette--black-900);
+    --ak-c-button--m-danger--hover--Color: var(--pf-global--palette--black-900);
+    --ak-c-button--m-danger--focus--Color: var(--pf-global--palette--black-900);
+    --ak-c-button--m-danger--active--Color: var(--pf-global--palette--black-900);
+    --ak-c-button--m-link--disabled--Color: var(--pf-global--disabled-color--100);
+    --ak-c-button--m-control--BackgroundColor: var(--pf-global--BackgroundColor--400);
+    --ak-c-button--m-control--hover--BackgroundColor: var(--pf-global--BackgroundColor--400);
+    --ak-c-button--m-control--active--BackgroundColor: var(--pf-global--BackgroundColor--400);
+    --ak-c-button--m-control--focus--BackgroundColor: var(--pf-global--BackgroundColor--400);
+    --ak-c-button--m-control--m-expanded--BackgroundColor: var(--pf-global--BackgroundColor--400);
+    --ak-c-button--m-control--after--BorderTopColor: transparent;
+    --ak-c-button--m-control--after--BorderRightColor: transparent;
+    --ak-c-button--m-control--after--BorderBottomColor: var(--pf-global--BorderColor--400);
+    --ak-c-button--m-control--after--BorderLeftColor: transparent;
+    --ak-c-button--m-control--hover--after--BorderBottomColor: var(--pf-global--primary-color--100);
+    --ak-c-button--m-control--active--after--BorderBottomColor: var(
+        --pf-global--primary-color--100
+    );
+    --ak-c-button--m-control--focus--after--BorderBottomColor: var(--pf-global--primary-color--100);
+    --ak-c-button--m-control--m-expanded--after--BorderBottomColor: var(
+        --pf-global--primary-color--100
+    );
+    --ak-c-button--m-control--disabled--BackgroundColor: var(--pf-global--disabled-color--200);
+    --ak-c-button--m-primary__c-badge--BorderColor: var(--pf-global--Color--100);
+}

--- a/web/src/elements/Button_impl/Button.stories.ts
+++ b/web/src/elements/Button_impl/Button.stories.ts
@@ -1,0 +1,441 @@
+import "../Button";
+
+import { type ButtonProps } from "../Button";
+
+import type { Meta, StoryObj } from "@storybook/web-components";
+
+import { html, TemplateResult } from "lit";
+import { ifDefined } from "lit/directives/if-defined.js";
+
+type Renderable = string | TemplateResult;
+
+type StoryArgs = ButtonProps & { content: Renderable };
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
+const metadata: Meta<StoryArgs> = {
+    title: "Elements / Button",
+    // This component will be used to render the component in the Stories
+    component: "ak-button",
+    // Define component tagName - this is optional, but helpful for auto-generation
+    // The tag name will be used to generate the component's displayName
+    tags: ["autodocs"],
+    // More on argTypes: https://storybook.js.org/docs/api/argtypes
+    argTypes: {
+        variant: {
+            control: "select",
+            options: ["primary", "secondary", "tertiary", "control", "plain", "link"],
+            description: "Button styling variant",
+        },
+        severity: {
+            control: "select",
+            options: [undefined, "danger", "warning"],
+            description: "Button severity level (danger = red, warning = yellow)",
+        },
+        size: {
+            control: "select",
+            options: [undefined, "sm", "lg"],
+            description: "Button size",
+        },
+        disabled: {
+            control: "boolean",
+            description: "Disables the button",
+        },
+        block: {
+            control: "boolean",
+            description: "Makes the button full width",
+        },
+        inline: {
+            control: "boolean",
+            description: "Renders button inline with text (link variant only)",
+        },
+        active: {
+            control: "boolean",
+            description: "Sets button to active state",
+        },
+        expanded: {
+            control: "boolean",
+            description: "Sets control variant button to expanded state",
+        },
+        type: {
+            control: "select",
+            options: ["button", "submit", "reset"],
+            description: "Button type (for form interactions)",
+        },
+        href: {
+            control: "text",
+            description: "URL for link buttons (renders as <a>)",
+        },
+        target: {
+            control: "text",
+            description: "Target attribute for link buttons",
+        },
+        label: {
+            control: "text",
+            description: "Accessible label for screen readers",
+        },
+    },
+    args: {
+        content: "Do you feel lucky... punk?",
+    },
+    // https://storybook.js.org/docs/parameters
+    parameters: {
+        // https://storybook.js.org/docs/writing-docs/docs-page
+        docs: {
+            description: {
+                component: `
+# Button 
+
+A button component based on PatternFly 5 design system.
+`,
+            },
+        },
+        // How to position stories: https://storybook.js.org/docs/configure/story-layout
+        layout: "centered",
+    },
+};
+
+export default metadata;
+
+type Story = StoryObj<StoryArgs>;
+
+const template = {
+    render: (args: StoryArgs) => html`
+        <ak-button
+            variant=${ifDefined(args.variant)}
+            ?disabled=${!!args.disabled}
+            ?block=${!!args.block}
+            ?active=${!!args.active}
+            size=${ifDefined(args.size || undefined)}
+            severity=${ifDefined(args.severity || undefined)}
+            type=${ifDefined(args.type || undefined)}
+            href=${ifDefined(args.href || undefined)}
+            target=${ifDefined(args.target || undefined)}
+            label=${ifDefined(args.label || undefined)}
+        >
+            ${args.content ?? "Button"}
+        </ak-button>
+    `,
+};
+
+// More on component templates: https://storybook.js.org/docs/writing-stories/introduction#using-args
+export const Primary: Story = {
+    ...template,
+    args: {
+        variant: "primary",
+        content: "Primary",
+    },
+};
+
+export const Secondary: Story = {
+    ...template,
+    args: {
+        variant: "secondary",
+        content: "Secondary",
+    },
+};
+
+export const Tertiary: Story = {
+    ...template,
+    args: {
+        variant: "tertiary",
+        content: "Tertiary",
+    },
+};
+
+export const Danger: Story = {
+    ...template,
+    args: {
+        variant: "primary",
+        severity: "danger",
+        content: "Danger!",
+    },
+};
+
+export const Warning: Story = {
+    ...template,
+    args: {
+        variant: "primary",
+        severity: "warning",
+        content: "Warning",
+    },
+};
+
+export const Small: Story = {
+    ...template,
+    args: {
+        size: "sm",
+        content: "Small Button",
+    },
+};
+
+export const Large: Story = {
+    ...template,
+    args: {
+        size: "lg",
+        content: "Large Button",
+    },
+};
+
+export const Disabled: Story = {
+    ...template,
+    args: {
+        disabled: true,
+        content: "Disabled Button",
+    },
+};
+
+export const Block: Story = {
+    ...template,
+    args: {
+        block: true,
+        content: "You paid for the whole block, use the whole block",
+    },
+};
+
+export const Link: Story = {
+    ...template,
+    args: {
+        variant: "link",
+        href: "https://goauthentik.io",
+        target: "_blank",
+        content: "Zeldaaaaa!",
+    },
+};
+
+export const DisabledLink: Story = {
+    ...template,
+    args: {
+        variant: "link",
+        href: "https://goauthentik.io",
+        target: "_blank",
+        disabled: true,
+        content: "Gerudo!",
+    },
+};
+
+export const InlineLink: Story = {
+    args: {
+        variant: "link",
+        href: "https://goauthentik.io",
+        target: "_blank",
+        inline: true,
+    },
+    render: (args) => html`
+        <div>
+            This is a paragraph with an
+            <ak-button
+                variant=${ifDefined(args.variant)}
+                target=${ifDefined(args.target)}
+                ?inline=${args.inline}
+                ?disabled=${args.disabled}
+                href=${ifDefined(args.href || undefined)}
+            >
+                inline link button
+            </ak-button>
+            in the middle of the text.
+        </div>
+    `,
+};
+
+export const Plain: Story = {
+    ...template,
+    args: {
+        variant: "plain",
+        content: html`<svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+        >
+            <circle cx="12" cy="12" r="10"></circle>
+            <line x1="12" y1="8" x2="12" y2="16"></line>
+            <line x1="8" y1="12" x2="16" y2="12"></line>
+        </svg>`,
+    },
+};
+
+export const Control: Story = {
+    ...template,
+    args: {
+        variant: "control",
+        content: "Control Button",
+    },
+};
+
+export const ControlExpanded: Story = {
+    ...template,
+    args: {
+        variant: "control",
+        expanded: true,
+        content: "Expanded Control",
+    },
+};
+
+export const Active: Story = {
+    ...template,
+    args: {
+        active: true,
+        content: "Activated",
+    },
+};
+
+export const FormSubmit: Story = {
+    args: {
+        type: "submit",
+    },
+    render: (args) => html`
+        <form
+            @submit=${(e: Event) => {
+                e.preventDefault();
+                // eslint-disable-next-line no-alert
+                alert("Form submitted!");
+            }}
+        >
+            <ak-button
+                variant=${args.variant || "primary"}
+                type=${ifDefined(args.type)}
+                ?disabled=${!!args.disabled}
+            >
+                Submit Form
+            </ak-button>
+        </form>
+    `,
+};
+
+export const FormReset: Story = {
+    args: {
+        type: "reset",
+        variant: "secondary",
+    },
+    render: (args) => html`
+        <form
+            @reset=${() => {
+                // eslint-disable-next-line no-alert
+                alert("Form reset!");
+            }}
+        >
+            <ak-button
+                variant=${ifDefined(args.variant)}
+                type=${ifDefined(args.type)}
+                ?disabled=${!!args.disabled}
+            >
+                Reset Form
+            </ak-button>
+        </form>
+    `,
+};
+
+export const AllVariants: Story = {
+    render: () => html`
+        <div style="display: flex; flex-direction: column; gap: 1rem; align-items: flex-start;">
+            <ak-button variant="primary">Primary</ak-button>
+            <ak-button variant="secondary">Secondary</ak-button>
+            <ak-button variant="tertiary">Tertiary</ak-button>
+            <ak-button variant="link">Link</ak-button>
+            <ak-button variant="plain">
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                >
+                    <circle cx="12" cy="12" r="10"></circle>
+                    <line x1="12" y1="8" x2="12" y2="16"></line>
+                    <line x1="8" y1="12" x2="16" y2="12"></line>
+                </svg>
+            </ak-button>
+            <ak-button variant="control">Control</ak-button>
+        </div>
+    `,
+};
+
+export const AllSeverities: Story = {
+    render: () => html`
+        <div style="display: flex; flex-direction: column; gap: 1rem; align-items: flex-start;">
+            <div style="display: flex; gap: 1rem;">
+                <ak-button variant="primary">Default</ak-button>
+                <ak-button variant="primary" severity="danger">Danger</ak-button>
+                <ak-button variant="primary" severity="warning">Warning</ak-button>
+            </div>
+            <div style="display: flex; gap: 1rem;">
+                <ak-button variant="secondary">Default</ak-button>
+                <ak-button variant="secondary" severity="danger">Danger</ak-button>
+            </div>
+            <div style="display: flex; gap: 1rem;">
+                <ak-button variant="link">Default</ak-button>
+                <ak-button variant="link" severity="danger">Danger</ak-button>
+            </div>
+        </div>
+    `,
+};
+
+export const AllSizes: Story = {
+    render: () => html`
+        <div style="display: flex; flex-direction: column; gap: 1rem; align-items: flex-start;">
+            <div style="display: flex; gap: 1rem; align-items: center;">
+                <ak-button variant="primary" size="sm">Small</ak-button>
+                <ak-button variant="primary">Default</ak-button>
+                <ak-button variant="primary" size="lg">Large</ak-button>
+            </div>
+            <div style="display: flex; gap: 1rem; align-items: center;">
+                <ak-button variant="secondary" size="sm">Small</ak-button>
+                <ak-button variant="secondary">Default</ak-button>
+                <ak-button variant="secondary" size="lg">Large</ak-button>
+            </div>
+        </div>
+    `,
+};
+
+export const NarrowSizes: Story = {
+    render: () => html`
+        <p style="margin-bottom: 1rem">
+            Narrow buttons have very small padding around the label, while the label text still
+            responds to t-shirt sizes.
+        </p>
+        <div style="display: flex; flex-direction: column; gap: 1rem; align-items: flex-start;">
+            <div style="display: flex; gap: 1rem; align-items: center;">
+                <ak-button narrow variant="primary" size="sm">Small</ak-button>
+                <ak-button narrow variant="primary">Default</ak-button>
+                <ak-button narrow variant="primary" size="lg">Large</ak-button>
+            </div>
+            <div style="display: flex; gap: 1rem; align-items: center;">
+                <ak-button narrow variant="secondary" size="sm">Small</ak-button>
+                <ak-button narrow variant="secondary">Default</ak-button>
+                <ak-button narrow variant="secondary" size="lg">Large</ak-button>
+            </div>
+        </div>
+    `,
+};
+
+export const States: Story = {
+    render: () => html`
+        <div style="display: flex; flex-direction: column; gap: 1rem; align-items: flex-start;">
+            <div style="display: flex; gap: 1rem;">
+                <ak-button variant="primary">Normal</ak-button>
+                <ak-button variant="primary" active>Active</ak-button>
+                <ak-button variant="primary" disabled>Disabled</ak-button>
+            </div>
+            <div style="display: flex; gap: 1rem;">
+                <ak-button variant="secondary">Normal</ak-button>
+                <ak-button variant="secondary" active>Active</ak-button>
+                <ak-button variant="secondary" disabled>Disabled</ak-button>
+            </div>
+            <div style="display: flex; gap: 1rem;">
+                <ak-button variant="control">Normal</ak-button>
+                <ak-button variant="control" active>Active</ak-button>
+                <ak-button variant="control" expanded>Expanded</ak-button>
+                <ak-button variant="control" disabled>Disabled</ak-button>
+            </div>
+        </div>
+    `,
+};

--- a/web/src/elements/Button_impl/Button.styles.ts
+++ b/web/src/elements/Button_impl/Button.styles.ts
@@ -1,0 +1,506 @@
+import { css } from "lit";
+
+export const styles = css`
+    :host {
+        position: relative;
+        display: inline-block;
+        --ak-c-button-_FontFamily--fallback: redhattext, helvetica, arial, sans-serif;
+        --ak-c-button--FontFamily: var(
+            --ak-c-button--FontFamily,
+            var(--ak-c-button-_FontFamily--fallback)
+        );
+    }
+
+    [part="button"] {
+        padding-block-start: var(--ak-c-button--PaddingTop);
+        padding-block-end: var(--ak-c-button--PaddingBottom);
+        padding-inline-start: var(--ak-c-button--PaddingLeft);
+        padding-inline-end: var(--ak-c-button--PaddingRight);
+        font-size: var(--ak-c-button--FontSize);
+        font-weight: var(--ak-c-button--FontWeight);
+        line-height: var(--ak-c-button--LineHeight);
+        text-align: center;
+        white-space: nowrap;
+        user-select: none;
+        border: 0;
+        border-radius: var(--ak-c-button--BorderRadius);
+        position: relative;
+        font-family: var(--ak-c-button--FontFamily);
+    }
+
+    [part="button"]::after {
+        position: absolute;
+        inset-block-start: 0;
+        inset-block-end: 0;
+        inset-inline-start: 0;
+        inset-inline-end: 0;
+        pointer-events: none;
+        content: "";
+        border: var(--ak-c-button--after--BorderWidth) solid;
+        border-color: var(--ak-c-button--after--BorderColor);
+        border-radius: var(--ak-c-button--after--BorderRadius);
+    }
+
+    [part="anchor"] {
+        padding-block-start: var(--ak-c-button--PaddingTop);
+        padding-block-end: var(--ak-c-button--PaddingBottom);
+        padding-inline-start: var(--ak-c-button--PaddingLeft);
+        padding-inline-end: var(--ak-c-button--PaddingRight);
+        font-size: var(--ak-c-button--FontSize);
+        font-weight: var(--ak-c-button--FontWeight);
+        line-height: var(--ak-c-button--LineHeight);
+        text-align: center;
+        white-space: nowrap;
+        user-select: none;
+        border: 0;
+        border-radius: var(--ak-c-button--BorderRadius);
+    }
+
+    [part="anchor"]::after {
+        position: absolute;
+        inset-block-start: 0;
+        inset-block-end: 0;
+        inset-inline-start: 0;
+        inset-inline-end: 0;
+        pointer-events: none;
+        content: "";
+        border: var(--ak-c-button--after--BorderWidth) solid;
+        border-color: var(--ak-c-button--after--BorderColor);
+        border-radius: var(--ak-c-button--after--BorderRadius);
+    }
+
+    :host(:hover) {
+        --ak-c-button--after--BorderWidth: var(--ak-c-button--hover--after--BorderWidth);
+        text-decoration: none;
+    }
+
+    :host(:focus-within) {
+        --ak-c-button--after--BorderWidth: var(--ak-c-button--focus--after--BorderWidth);
+    }
+
+    :host(:active) {
+        --ak-c-button--after--BorderWidth: var(--ak-c-button--active--after--BorderWidth);
+    }
+
+    :host([block]) {
+        display: block;
+        width: 100%;
+    }
+
+    :host([block]) #main {
+        width: 100%;
+    }
+
+    :host([small]) {
+        --ak-c-button--FontSize: var(--ak-c-button--m-small--FontSize);
+    }
+
+    :host([size="sm"]) {
+        --ak-c-button--FontSize: var(--ak-c-button--m-small--FontSize);
+    }
+
+    :host([size="lg"]) {
+        --ak-c-button--PaddingTop: var(--ak-c-button--m-display-lg--PaddingTop);
+        --ak-c-button--PaddingRight: var(--ak-c-button--m-display-lg--PaddingRight);
+        --ak-c-button--PaddingBottom: var(--ak-c-button--m-display-lg--PaddingBottom);
+        --ak-c-button--PaddingLeft: var(--ak-c-button--m-display-lg--PaddingLeft);
+        --ak-c-button--FontWeight: var(--ak-c-button--m-display-lg--FontWeight);
+        --ak-c-button--FontSize: var(--ak-c-button--m-link--m-display-lg--FontSize);
+    }
+
+    :host([narrow]) {
+        --ak-c-button--PaddingTop: var(--ak-c-button--m-narrow--PaddingTop);
+        --ak-c-button--PaddingRight: var(--ak-c-button--m-narrow--PaddingRight);
+        --ak-c-button--PaddingBottom: var(--ak-c-button--m-narrow--PaddingBottom);
+        --ak-c-button--PaddingLeft: var(--ak-c-button--m-narrow--PaddingLeft);
+    }
+
+    :host([variant="primary"]) #main {
+        color: var(--ak-c-button--m-primary--Color);
+        background-color: var(--ak-c-button--m-primary--BackgroundColor);
+    }
+
+    :host([variant="secondary"]) #main {
+        --ak-c-button--after--BorderColor: var(--ak-c-button--m-secondary--after--BorderColor);
+        color: var(--ak-c-button--m-secondary--Color);
+        background-color: var(--ak-c-button--m-secondary--BackgroundColor);
+    }
+
+    :host([variant="tertiary"]) #main {
+        --ak-c-button--after--BorderColor: var(--ak-c-button--m-tertiary--after--BorderColor);
+        color: var(--ak-c-button--m-tertiary--Color);
+        background-color: var(--ak-c-button--m-tertiary--BackgroundColor);
+    }
+
+    :host([variant="link"]) #main {
+        --ak-c-button--disabled--BackgroundColor: var(
+            --ak-c-button--m-link--disabled--BackgroundColor
+        );
+        --ak-c-button--disabled--Color: var(--ak-c-button--m-link--disabled--Color);
+        color: var(--ak-c-button--m-link--Color);
+        background-color: var(--ak-c-button--m-link--BackgroundColor);
+    }
+
+    :host([variant="plain"]) #main {
+        --ak-c-button--disabled--Color: var(--ak-c-button--m-plain--disabled--Color);
+        --ak-c-button--disabled--BackgroundColor: var(
+            --ak-c-button--m-plain--disabled--BackgroundColor
+        );
+        color: var(--ak-c-button--m-plain--Color);
+        background-color: var(--ak-c-button--m-plain--BackgroundColor);
+    }
+
+    :host([variant="control"]) #main {
+        --ak-c-button--BorderRadius: var(--ak-c-button--m-control--BorderRadius);
+        --ak-c-button--disabled--BackgroundColor: var(
+            --ak-c-button--m-control--disabled--BackgroundColor
+        );
+        --ak-c-button--after--BorderWidth: var(--ak-c-button--m-control--after--BorderWidth);
+        color: var(--ak-c-button--m-control--Color);
+        background-color: var(--ak-c-button--m-control--BackgroundColor);
+        --ak-c-button--after--BorderColor: var(--ak-c-button--m-control--after--BorderTopColor)
+            var(--ak-c-button--m-control--after--BorderRightColor)
+            var(--ak-c-button--m-control--after--BorderBottomColor)
+            var(--ak-c-button--m-control--after--BorderLeftColor);
+    }
+
+    :host([variant="primary"]:hover) #main {
+        --ak-c-button--m-primary--Color: var(--ak-c-button--m-primary--hover--Color);
+        --ak-c-button--m-primary--BackgroundColor: var(
+            --ak-c-button--m-primary--hover--BackgroundColor
+        );
+    }
+
+    :host([variant="primary"]:focus-visible) #main {
+        --ak-c-button--m-primary--Color: var(--ak-c-button--m-primary--focus--Color);
+        --ak-c-button--m-primary--BackgroundColor: var(
+            --ak-c-button--m-primary--focus--BackgroundColor
+        );
+    }
+
+    :host([variant="primary"]:active) #main {
+        --ak-c-button--m-primary--Color: var(--ak-c-button--m-primary--active--Color);
+        --ak-c-button--m-primary--BackgroundColor: var(
+            --ak-c-button--m-primary--active--BackgroundColor
+        );
+    }
+
+    :host([variant="secondary"]:hover) #main {
+        --ak-c-button--m-secondary--Color: var(--ak-c-button--m-secondary--hover--Color);
+        --ak-c-button--m-secondary--BackgroundColor: var(
+            --ak-c-button--m-secondary--hover--BackgroundColor
+        );
+        --ak-c-button--after--BorderColor: var(
+            --ak-c-button--m-secondary--hover--after--BorderColor
+        );
+    }
+
+    :host([variant="secondary"]:focus-visible) #main {
+        --ak-c-button--m-secondary--Color: var(--ak-c-button--m-secondary--focus--Color);
+        --ak-c-button--m-secondary--BackgroundColor: var(
+            --ak-c-button--m-secondary--focus--BackgroundColor
+        );
+        --ak-c-button--after--BorderColor: var(
+            --ak-c-button--m-secondary--focus--after--BorderColor
+        );
+    }
+
+    :host([variant="tertiary"]:hover) #main {
+        --ak-c-button--m-tertiary--Color: var(--ak-c-button--m-tertiary--hover--Color);
+        --ak-c-button--m-tertiary--BackgroundColor: var(
+            --ak-c-button--m-tertiary--hover--BackgroundColor
+        );
+        --ak-c-button--after--BorderColor: var(
+            --ak-c-button--m-tertiary--hover--after--BorderColor
+        );
+    }
+
+    :host([variant="tertiary"]:focus-visible) #main {
+        --ak-c-button--m-tertiary--Color: var(--ak-c-button--m-tertiary--focus--Color);
+        --ak-c-button--m-tertiary--BackgroundColor: var(
+            --ak-c-button--m-tertiary--focus--BackgroundColor
+        );
+        --ak-c-button--after--BorderColor: var(
+            --ak-c-button--m-tertiary--focus--after--BorderColor
+        );
+    }
+
+    :host([variant="tertiary"]:active) #main {
+        --ak-c-button--m-tertiary--Color: var(--ak-c-button--m-tertiary--active--Color);
+        --ak-c-button--m-tertiary--BackgroundColor: var(
+            --ak-c-button--m-tertiary--active--BackgroundColor
+        );
+        --ak-c-button--after--BorderColor: var(
+            --ak-c-button--m-tertiary--active--after--BorderColor
+        );
+    }
+
+    :host([variant="control"]:hover) #main {
+        --ak-c-button--m-control--Color: var(--ak-c-button--m-control--hover--Color);
+        --ak-c-button--m-control--BackgroundColor: var(
+            --ak-c-button--m-control--hover--BackgroundColor
+        );
+        --ak-c-button--m-control--after--BorderBottomColor: var(
+            --ak-c-button--m-control--hover--after--BorderBottomColor
+        );
+    }
+
+    :host([variant="control"]:active) #main {
+        --ak-c-button--m-control--Color: var(--ak-c-button--m-control--active--Color);
+        --ak-c-button--m-control--BackgroundColor: var(
+            --ak-c-button--m-control--active--BackgroundColor
+        );
+        --ak-c-button--m-control--after--BorderBottomColor: var(
+            --ak-c-button--m-control--active--after--BorderBottomColor
+        );
+    }
+
+    :host([variant="control"]:focus-visible) #main {
+        --ak-c-button--m-control--Color: var(--ak-c-button--m-control--focus--Color);
+        --ak-c-button--m-control--BackgroundColor: var(
+            --ak-c-button--m-control--focus--BackgroundColor
+        );
+        --ak-c-button--m-control--after--BorderBottomColor: var(
+            --ak-c-button--m-control--focus--after--BorderBottomColor
+        );
+    }
+
+    :host([variant="plain"]:hover) #main {
+        --ak-c-button--m-plain--Color: var(--ak-c-button--m-plain--hover--Color);
+        --ak-c-button--m-plain--BackgroundColor: var(
+            --ak-c-button--m-plain--hover--BackgroundColor
+        );
+    }
+
+    :host([variant="plain"]:active) #main {
+        --ak-c-button--m-plain--Color: var(--ak-c-button--m-plain--active--Color);
+        --ak-c-button--m-plain--BackgroundColor: var(
+            --ak-c-button--m-plain--active--BackgroundColor
+        );
+    }
+
+    :host([variant="plain"]:focus-visible) #main {
+        --ak-c-button--m-plain--Color: var(--ak-c-button--m-plain--focus--Color);
+        --ak-c-button--m-plain--BackgroundColor: var(
+            --ak-c-button--m-plain--focus--BackgroundColor
+        );
+    }
+
+    :host([variant="secondary"][active]) #main {
+        --ak-c-button--m-secondary--Color: var(--ak-c-button--m-secondary--active--Color);
+        --ak-c-button--m-secondary--BackgroundColor: var(
+            --ak-c-button--m-secondary--active--BackgroundColor
+        );
+        --ak-c-button--after--BorderColor: var(
+            --ak-c-button--m-secondary--active--after--BorderColor
+        );
+    }
+
+    :host([severity="danger"]) #main {
+        color: var(--ak-c-button--m-danger--Color);
+        background-color: var(--ak-c-button--m-danger--BackgroundColor);
+    }
+
+    :host([severity="warning"]) #main {
+        color: var(--ak-c-button--m-warning--Color);
+        background-color: var(--ak-c-button--m-warning--BackgroundColor);
+    }
+
+    :host([severity="danger"]:hover) #main {
+        --ak-c-button--m-danger--Color: var(--ak-c-button--m-danger--hover--Color);
+        --ak-c-button--m-danger--BackgroundColor: var(
+            --ak-c-button--m-danger--hover--BackgroundColor
+        );
+    }
+
+    :host([severity="danger"]:focus-visible) #main {
+        --ak-c-button--m-danger--Color: var(--ak-c-button--m-danger--focus--Color);
+        --ak-c-button--m-danger--BackgroundColor: var(
+            --ak-c-button--m-danger--focus--BackgroundColor
+        );
+    }
+
+    :host([severity="danger"]:active) #main {
+        --ak-c-button--m-danger--Color: var(--ak-c-button--m-danger--active--Color);
+        --ak-c-button--m-danger--BackgroundColor: var(
+            --ak-c-button--m-danger--active--BackgroundColor
+        );
+    }
+
+    :host([severity="warning"]:hover) #main {
+        --ak-c-button--m-warning--Color: var(--ak-c-button--m-warning--hover--Color);
+        --ak-c-button--m-warning--BackgroundColor: var(
+            --ak-c-button--m-warning--hover--BackgroundColor
+        );
+    }
+
+    :host([severity="warning"]:focus-visible) #main {
+        --ak-c-button--m-warning--Color: var(--ak-c-button--m-warning--focus--Color);
+        --ak-c-button--m-warning--BackgroundColor: var(
+            --ak-c-button--m-warning--focus--BackgroundColor
+        );
+    }
+
+    :host([severity="warning"]:active) #main {
+        --ak-c-button--m-warning--Color: var(--ak-c-button--m-warning--active--Color);
+        --ak-c-button--m-warning--BackgroundColor: var(
+            --ak-c-button--m-warning--active--BackgroundColor
+        );
+    }
+
+    :host([variant="secondary"][severity="danger"]):hover #main {
+        --ak-c-button--m-secondary--m-danger--Color: var(
+            --ak-c-button--m-secondary--m-danger--hover--Color
+        );
+        --ak-c-button--m-secondary--m-danger--BackgroundColor: var(
+            --ak-c-button--m-secondary--m-danger--hover--BackgroundColor
+        );
+        --ak-c-button--after--BorderColor: var(
+            --ak-c-button--m-secondary--m-danger--hover--after--BorderColor
+        );
+    }
+
+    :host([variant="secondary"][severity="danger"]):focus-visible #main {
+        --ak-c-button--m-secondary--m-danger--Color: var(
+            --ak-c-button--m-secondary--m-danger--focus--Color
+        );
+        --ak-c-button--m-secondary--m-danger--BackgroundColor: var(
+            --ak-c-button--m-secondary--m-danger--focus--BackgroundColor
+        );
+        --ak-c-button--after--BorderColor: var(
+            --ak-c-button--m-secondary--m-danger--focus--after--BorderColor
+        );
+    }
+
+    :host([variant="secondary"][severity="danger"]):active #main {
+        --ak-c-button--m-secondary--m-danger--Color: var(
+            --ak-c-button--m-secondary--m-danger--active--Color
+        );
+        --ak-c-button--m-secondary--m-danger--BackgroundColor: var(
+            --ak-c-button--m-secondary--m-danger--active--BackgroundColor
+        );
+        --ak-c-button--after--BorderColor: var(
+            --ak-c-button--m-secondary--m-danger--active--after--BorderColor
+        );
+    }
+
+    :host([variant="link"][severity="danger"]):hover #main {
+        --ak-c-button--m-link--m-danger--Color: var(--ak-c-button--m-link--m-danger--hover--Color);
+        --ak-c-button--m-link--m-danger--BackgroundColor: var(
+            --ak-c-button--m-link--m-danger--hover--BackgroundColor
+        );
+    }
+
+    :host([variant="link"][severity="danger"]):focus-visible #main {
+        --ak-c-button--m-link--m-danger--Color: var(--ak-c-button--m-link--m-danger--focus--Color);
+        --ak-c-button--m-link--m-danger--BackgroundColor: var(
+            --ak-c-button--m-link--m-danger--focus--BackgroundColor
+        );
+    }
+
+    :host([variant="link"][severity="danger"]):active #main {
+        --ak-c-button--m-link--m-danger--Color: var(--ak-c-button--m-link--m-danger--active--Color);
+        --ak-c-button--m-link--m-danger--BackgroundColor: var(
+            --ak-c-button--m-link--m-danger--active--BackgroundColor
+        );
+    }
+
+    :host([variant="control"]) #main::after {
+        border-radius: initial;
+        --ak-c-button--after--BorderColor: var(--ak-c-button--m-control--after--BorderTopColor)
+            var(--ak-c-button--m-control--after--BorderRightColor)
+            var(--ak-c-button--m-control--after--BorderBottomColor)
+            var(--ak-c-button--m-control--after--BorderLeftColor);
+    }
+
+    :host([variant="control"]):hover #main::after {
+        border-block-end-width: var(--ak-c-button--m-control--hover--after--BorderBottomWidth);
+    }
+
+    :host([variant="control"]):active #main::after {
+        border-block-end-width: var(--ak-c-button--m-control--active--after--BorderBottomWidth);
+    }
+
+    :host([variant="control"]):focus-visible #main::after {
+        border-block-end-width: var(--ak-c-button--m-control--focus--after--BorderBottomWidth);
+    }
+
+    :host([variant="control"][expanded]) #main {
+        --ak-c-button--m-control--Color: var(--ak-c-button--m-control--m-expanded--Color);
+        --ak-c-button--m-control--BackgroundColor: var(
+            --ak-c-button--m-control--m-expanded--BackgroundColor
+        );
+        --ak-c-button--m-control--after--BorderBottomColor: var(
+            --ak-c-button--m-control--m-expanded--after--BorderBottomColor
+        );
+    }
+
+    :host([variant="control"][expanded]) #main::after {
+        border-block-end-width: var(--ak-c-button--m-control--m-expanded--after--BorderBottomWidth);
+    }
+
+    :host([icon-position="start"]) #main {
+        margin-inline-end: var(--ak-c-button__icon--m-start--MarginRight);
+    }
+
+    :host([icon-position="end"]) #main {
+        margin-inline-start: var(--ak-c-button__icon--m-end--MarginLeft);
+    }
+
+    :host:disabled,
+    :host([disabled]) {
+        color: var(--ak-c-button--disabled--Color);
+        background-color: var(--ak-c-button--disabled--BackgroundColor);
+    }
+
+    :host:disabled #main,
+    :host([disabled]) #main {
+        pointer-events: none;
+    }
+
+    :host:disabled #main::after,
+    :host([disabled]) #main::after {
+        border-color: var(--ak-c-button--disabled--after--BorderColor);
+    }
+
+    :host([variant="link"]:not([inline])):hover #main {
+        --ak-c-button--m-link--Color: var(--ak-c-button--m-link--hover--Color);
+        --ak-c-button--m-link--BackgroundColor: var(--ak-c-button--m-link--hover--BackgroundColor);
+    }
+
+    :host([variant="link"]:not([inline])):focus-visible #main {
+        --ak-c-button--m-link--Color: var(--ak-c-button--m-link--focus--Color);
+        --ak-c-button--m-link--BackgroundColor: var(--ak-c-button--m-link--focus--BackgroundColor);
+    }
+
+    :host([variant="link"]:not([inline])):active #main {
+        --ak-c-button--m-link--Color: var(--ak-c-button--m-link--active--Color);
+        --ak-c-button--m-link--BackgroundColor: var(--ak-c-button--m-link--active--BackgroundColor);
+    }
+
+    :host([variant="link"][size="lg"]) {
+        --ak-c-button--FontSize: var(--ak-c-button--m-link--m-display-lg--FontSize);
+    }
+
+    :host([variant="link"][inline]) #main {
+        --ak-c-button--FontSize: var(--ak-c-button--m-link--m-inline--FontSize);
+        --ak-c-button__progress--Left: var(--ak-c-button--m-link--m-inline__progress--Left);
+        display: inline;
+        padding-block-start: var(--ak-c-button--m-link--m-inline--PaddingTop);
+        padding-block-end: var(--ak-c-button--m-link--m-inline--PaddingBottom);
+        padding-inline-start: var(--ak-c-button--m-link--m-inline--PaddingLeft);
+        padding-inline-end: var(--ak-c-button--m-link--m-inline--PaddingRight);
+        text-align: start;
+        white-space: normal;
+        cursor: pointer;
+    }
+
+    :host([variant="link"][severity="danger"]) #main {
+        --ak-c-button--m-danger--Color: var(--ak-c-button--m-link--m-danger--Color);
+        --ak-c-button--m-danger--BackgroundColor: var(
+            --ak-c-button--m-link--m-danger--BackgroundColor
+        );
+    }
+`;
+
+export default styles;

--- a/web/src/elements/Button_impl/Button.template.ts
+++ b/web/src/elements/Button_impl/Button.template.ts
@@ -1,0 +1,64 @@
+import { ifPresent } from "#elements/utils/attributes";
+
+import { html } from "lit";
+
+interface ButtonButtonProps {
+    disabled: boolean;
+    type?: string;
+    name?: string;
+    value?: string;
+    onClick: (ev: MouseEvent) => void;
+}
+
+type ButtonLinkProps = Pick<ButtonButtonProps, "disabled" | "onClick"> & {
+    href: string;
+    target?: string;
+    rel?: string;
+    download?: string;
+};
+
+/**
+ * @remarks
+ * The ARIA rules for disabled links specifies that "to communicate a link as ‘disabled,’ remove
+ * the `href` attribute and style accordingly." Hence the `href=${ifDefined(...)}`.
+ *
+ * @see {@link https://www.w3.org/TR/html-aria/#example-communicate-a-disabled-link-with-aria | ARIA Disabled Link Rules}
+ */
+
+/**
+ * @remarks
+ *
+ * The distinction here is not just functional; by having distinct `[part]` definitions, we allow
+ * customizers to target links *or* buttons, if they so choose.
+ */
+
+export function linkTemplate(props: ButtonLinkProps) {
+    const { href, target, disabled, download, rel, onClick } = props;
+    return html`<a
+        id="main"
+        href=${ifPresent(disabled ? null : href)}
+        part="anchor"
+        target="${ifPresent(target)}"
+        ?disabled=${disabled}
+        download=${ifPresent(download)}
+        rel=${ifPresent(rel)}
+        tabindex=${disabled ? -1 : 0}
+        @click=${onClick}
+        ><slot></slot
+    ></a>`;
+}
+
+export function buttonTemplate(props: ButtonButtonProps) {
+    const { disabled, type, name, value, onClick } = props;
+    return html`<button
+        id="main"
+        part="button"
+        ?disabled=${disabled}
+        type=${ifPresent(type)}
+        name=${ifPresent(name)}
+        value=${ifPresent(value)}
+        @click=${onClick}
+    >
+        <slot></slot>
+    </button>`;
+}

--- a/web/src/elements/Button_impl/Button.ts
+++ b/web/src/elements/Button_impl/Button.ts
@@ -1,0 +1,171 @@
+import styles from "./Button.styles";
+import { buttonTemplate, linkTemplate } from "./Button.template";
+
+import { InternalsController } from "@patternfly/pfe-core/controllers/internals-controller.js";
+import { match, P } from "ts-pattern";
+
+import { LitElement, PropertyValues } from "lit";
+import { property, query } from "lit/decorators.js";
+
+/**
+ * Variant types
+ */
+export const buttonVariant = [
+    "primary",
+    "secondary",
+    "tertiary",
+    "control",
+    "plain",
+    "link",
+] as const;
+export type ButtonVariant = (typeof buttonVariant)[number];
+
+/**
+ * Severity levels.
+ */
+export const buttonSeverity = ["danger", "warning"] as const;
+export type ButtonSeverity = (typeof buttonSeverity)[number];
+
+/**
+ * Optional button sizes
+ */
+export const buttonSize = ["sm", "md", "lg"] as const;
+export type ButtonSize = (typeof buttonSize)[number];
+
+/**
+ * Button behaviors.
+ */
+export const buttonType = ["button", "submit", "reset"] as const;
+export type ButtonType = (typeof buttonType)[number];
+
+/**
+ * @element ak-button
+ *
+ * @summary A button component with multiple variants, sizes, and form integration capabilities
+ *
+ * @attr {ButtonType} type - Button behavior: "button" (default), "submit", "reset"
+ * @attr {ButtonVariant} variant - Visual variant
+ *   - "primary": Filled button with strong emphasis
+ *   - "secondary": Outlined button with medium emphasis
+ *   - "tertiary": Subtle button with low emphasis
+ *   - "control": Button used in form controls
+ *   - "plain": Icon button without background/border
+ *   - "link": Looks like a hyperlink
+ * @attr {ButtonSeverity} severity - Severity level: "danger", "warning"
+ *   - "danger": Red styling for destructive actions
+ *   - "warning": Yellow styling for cautionary actions
+ * @attr {ButtonSize} size - Button size: "sm", "lg"
+ *   - "sm": Smaller than default. Used for compact settings.
+ *   - "md": Medium (the default)
+ *   - "lg": Larger than default. Used for CTAs.
+ * @attr {string} name - Name attribute for the button
+ * @attr {string} value - Value attribute when button is part of a form
+ * @attr {string} label - Aria-accessible label for the button
+ * @attr {string} href - URL to navigate to (for link variant)
+ * @attr {string} target - Target attribute for link variant (e.g., "_blank")
+ * @attr {boolean} disabled - Whether the button is disabled
+ * @attr {boolean} block - Whether button occupies full width of container
+ * @attr {boolean} inline - Whether button flows inline with text (removes host padding)
+ * @attr {boolean} active - Whether button is in active state
+ * @attr {boolean} expanded - Whether control variant button is in expanded state
+ *
+ * @fires click - Fired when button is clicked (unless disabled)
+ *
+ * @slot - Default slot for button content (text, icons, etc.)
+ *
+ * @csspart button - The button element (when not using href)
+ * @csspart anchor - The anchor element (when href is provided)
+ *
+ */
+export class Button extends LitElement {
+    static override shadowRootOptions = { ...LitElement.shadowRootOptions, delegatesFocus: true };
+
+    static readonly styles = [styles];
+
+    static readonly formAssociated = true;
+
+    // While it's unlikely that client code will modify these by manipulating `type` and `variant`
+    // fields directly, it's still possible. Their presence triggers corresponding CSS effects, so
+    // they must be monitored and reflected.
+    @property({ reflect: true })
+    public type?: ButtonType = "button";
+
+    @property({ reflect: true })
+    public variant: ButtonVariant = "primary";
+
+    @property()
+    public label?: string;
+
+    @property()
+    public name?: string;
+
+    @property()
+    public value?: string;
+
+    @property()
+    public href?: string;
+
+    @property()
+    public target?: string;
+
+    @property()
+    public rel?: string;
+
+    @property()
+    public download?: string;
+
+    #internals = InternalsController.of(this);
+
+    @property({ reflect: true, type: Boolean })
+    public disabled = false;
+
+    @query("#main")
+    theButton?: HTMLButtonElement;
+
+    get #disabled() {
+        return this.matches(":disabled") || this.disabled;
+    }
+
+    private onClick = (event: MouseEvent) => {
+        // Using `requestSubmit()` rather than `submit()`.  See:
+        // https://github.com/WICG/webcomponents/issues/814
+
+        // prettier-ignore
+        match([this.disabled, this.type])
+            .with([true, P._], () => { event.preventDefault(); })
+            .with([false, "reset"], () => { this.#internals.form?.reset(); })
+            .with([false, "submit"], () => { this.#internals.form?.requestSubmit(this.theButton); })
+            .otherwise(() => { /* no-op */ });
+    };
+
+    formDisabledCallback(disabled: boolean) {
+        if (disabled) {
+            this.theButton?.setAttribute("disabled", "");
+            this.setAttribute("disabled", "");
+        } else {
+            // Logic for when the element becomes enabled
+            this.theButton?.removeAttribute("disabled");
+            this.removeAttribute("disabled");
+        }
+    }
+
+    constructor() {
+        super();
+        this.addEventListener("click", this.onClick);
+    }
+
+    public willUpdate(changed: PropertyValues<this>): void {
+        super.willUpdate(changed);
+        this.#internals.ariaLabel = this.label || null;
+        this.#internals.ariaDisabled = String(!!this.#disabled);
+    }
+
+    public override render() {
+        const { href, type, target, name, value, rel, download, onClick } = this;
+        const disabled = this.#disabled;
+
+        return this.variant === "link" && typeof href === "string"
+            ? linkTemplate({ href, target, disabled, rel, download, onClick })
+            : buttonTemplate({ disabled, type, name, value, onClick });
+    }
+}

--- a/web/src/elements/Button_impl/holder.css
+++ b/web/src/elements/Button_impl/holder.css
@@ -1,0 +1,60 @@
+/*
+ * TODO: These have been set aside because we're not quite sure what to do with them yet.
+ */
+
+.pf-m-primary .pf-v5-c-badge.pf-m-unread {
+    border: var(--pf-v5-c-button--m-primary__c-badge--BorderWidth) solid
+        var(--pf-v5-c-button--m-primary__c-badge--BorderColor);
+}
+
+:disabled .pf-v5-c-badge,
+.pf-m-disabled .pf-v5-c-badge,
+.pf-m-aria-disabled .pf-v5-c-badge {
+    --pf-v5-c-badge--m-unread--Color: var(--pf-v5-c-button--disabled__c-badge--Color);
+    --pf-v5-c-badge--m-unread--BackgroundColor: var(
+        --pf-v5-c-button--disabled__c-badge--BackgroundColor
+    );
+    --pf-v5-c-button--m-primary__c-badge--BorderWidth: 0;
+}
+
+.pf-m-aria-disabled {
+    --pf-v5-c-button--after--BorderWidth: 0;
+    --pf-v5-c-button--m-link--m-inline--hover--TextDecoration: none;
+
+    cursor: default;
+}
+
+.pf-m-progress {
+    --pf-v5-c-button--PaddingRight: var(--pf-v5-c-button--m-progress--PaddingRight);
+    --pf-v5-c-button--PaddingLeft: var(--pf-v5-c-button--m-progress--PaddingLeft);
+
+    transition: var(--pf-v5-c-button--m-progress--TransitionProperty)
+        var(--pf-v5-c-button--m-progress--TransitionDuration);
+}
+
+.pf-m-in-progress {
+    --pf-v5-c-button--m-link--m-inline--PaddingLeft: var(
+        --pf-v5-c-button--m-link--m-inline--m-in-progress--PaddingLeft
+    );
+}
+
+.pf-m-in-progress:not(.pf-m-plain) {
+    --pf-v5-c-button--PaddingRight: var(--pf-v5-c-button--m-in-progress--PaddingRight);
+    --pf-v5-c-button--PaddingLeft: var(--pf-v5-c-button--m-in-progress--PaddingLeft);
+}
+
+.pf-m-in-progress.pf-m-plain {
+    --pf-v5-c-button--m-plain--Color: var(--pf-v5-c-button--m-in-progress--m-plain--Color);
+    --pf-v5-c-button__progress--Left: var(--pf-v5-c-button--m-in-progress--m-plain__progress--Left);
+    --pf-v5-c-button__progress--TranslateX: var(
+        --pf-v5-c-button--m-in-progress--m-plain__progress--TranslateX
+    );
+}
+
+.pf-m-in-progress.pf-m-plain > :not(.pf-v5-c-button__progress) {
+    opacity: 0;
+}
+
+.pf-c-v5-button__progress .pf-v5-c-spinner {
+    --pf-v5-c-spinner--Color: currentcolor;
+}

--- a/web/src/styles/flows.global.css
+++ b/web/src/styles/flows.global.css
@@ -29,6 +29,7 @@
 @import "#styles/authentik/components/Placeholder/placeholder.css" layer(components);
 @import "#elements/ak-drawer/ak-drawer.root.css" layer(components);
 @import "#elements/Divider_impl/Divider.root.css" layer(components);
+@import "#elements/Button_impl/Button.root.css" layer(components);
 @import "#styles/global/locales/ja/globals.css" layer(components);
 @import "#styles/global/locales/ko/globals.css" layer(components);
 @import "#styles/global/locales/zh/globals.css" layer(components);

--- a/web/src/styles/interface.global.css
+++ b/web/src/styles/interface.global.css
@@ -33,6 +33,7 @@
 @import "#elements/ToggleGroup_impl/ToggleGroup.root.css" layer(components);
 @import "#elements/Divider_impl/Divider.root.css" layer(components);
 @import "#elements/Label_impl/Label.root.css" layer(components);
+@import "#elements/Button_impl/Button.root.css" layer(components);
 @import "#elements/Progress_impl/Progress.root.css" layer(components);
 @import "#styles/global/locales/ja/globals.css" layer(components);
 @import "#styles/global/locales/ko/globals.css" layer(components);


### PR DESCRIPTION
web/maint: upgrade ak-button

## What

This commit upgrades the base ak-button with the following improvements:

- **Works correctly without AkElement**
- Upgrades our code to use the **Patternfly 5** CSS with our changes

I have provided a comprehensive Storybook story.

<img width="833" height="796" alt="image" src="https://github.com/user-attachments/assets/23b670ef-4961-4300-94bb-eb22139081ca" />---

## Checklist

-   [🚧] The project has been linted, built, and tested (`make all`)
-   [🚧] The documentation has been updated and formatted (`make docs`)
