### PR TITLE
stages/email: allow plain text email templates

### DIFF
--- a/authentik/stages/email/models.py
+++ b/authentik/stages/email/models.py
@@ -58,9 +58,14 @@ def get_template_choices():
 
         # when .html and .txt files are both present, only show .html
         html_files = list(template_dir.glob("**/*.html"))
+        html_files_set = set(html_files)
         template_files = [
             *html_files,
-            *[t for t in template_dir.glob("**/*.txt") if t.with_suffix(".html") not in html_files],
+            *[
+                t
+                for t in template_dir.glob("**/*.txt")
+                if t.with_suffix(".html") not in html_files_set
+            ],
         ]
         for template in template_files:
             path = str(template)

--- a/authentik/stages/email/models.py
+++ b/authentik/stages/email/models.py
@@ -55,7 +55,14 @@ def get_template_choices():
     for template_dir in dirs:
         if not template_dir.exists() or not template_dir.is_dir():
             continue
-        for template in template_dir.glob("**/*.html"):
+
+        # when .html and .txt files are both present, only show .html
+        html_files = list(template_dir.glob("**/*.html"))
+        template_files = [
+            *html_files,
+            *[t for t in template_dir.glob("**/*.txt") if t.with_suffix(".html") not in html_files],
+        ]
+        for template in template_files:
             path = str(template)
             if not access(path, R_OK):
                 LOGGER.warning("Custom template file is not readable, check permissions", path=path)

--- a/authentik/stages/email/tests/test_templates.py
+++ b/authentik/stages/email/tests/test_templates.py
@@ -58,6 +58,19 @@ class TestEmailStageTemplates(FlowTestCase):
             unlink(file)
             unlink(file2)
 
+    def test_custom_template_multipart(self):
+        """Test with multipart templates"""
+        with self.settings(TEMPLATES=get_templates_setting(self.dir)):
+            txt_file = self.dir / "multipart.txt"
+            txt_file.write_text("")
+            choices = get_template_choices()
+            self.assertEqual(len(choices), 6)
+
+            html_file = self.dir / "multipart.html"
+            html_file.write_text("")
+            choices = get_template_choices()
+            self.assertEqual(len(choices), 6)
+
     def test_custom_template_invalid_syntax(self):
         """Test with custom template"""
         with open(self.dir / Path("invalid.html"), "w+", encoding="utf-8") as _invalid:

--- a/authentik/stages/email/utils.py
+++ b/authentik/stages/email/utils.py
@@ -56,14 +56,19 @@ class TemplateEmailMessage(EmailMultiAlternatives):
         super().__init__(to=sanitized_to, cc=sanitized_cc, bcc=sanitized_bcc, **kwargs)
         if not template_name:
             return
-        with translation.override(language):
-            html_content = render_to_string(template_name, template_context)
-            try:
-                text_content = render_to_string(
-                    template_name.replace("html", "txt"), template_context
-                )
-                self.body = text_content
-            except TemplateDoesNotExist:
-                pass
-        self.mixed_subtype = "related"
-        self.attach_alternative(html_content, "text/html")
+
+        content = render_to_string(template_name, template_context)
+        if template_name.endswith(".html"):
+            with translation.override(language):
+                try:
+                    text_content = render_to_string(
+                        template_name.replace("html", "txt"), template_context
+                    )
+                    self.body = text_content
+                except TemplateDoesNotExist:
+                    pass
+
+            self.mixed_subtype = "related"
+            self.attach_alternative(content, "text/html")
+        else:
+            self.body = content

--- a/authentik/stages/email/utils.py
+++ b/authentik/stages/email/utils.py
@@ -45,7 +45,7 @@ class TemplateEmailMessage(EmailMultiAlternatives):
         to: list[tuple[str, str]],
         cc: list[tuple[str, str]] | None = None,
         bcc: list[tuple[str, str]] | None = None,
-        template_name=None,
+        template_name: str | None = None,
         template_context=None,
         language="",
         **kwargs,
@@ -58,17 +58,17 @@ class TemplateEmailMessage(EmailMultiAlternatives):
             return
 
         content = render_to_string(template_name, template_context)
-        if template_name.endswith(".html"):
-            with translation.override(language):
+        with translation.override(language):
+            if template_name.endswith(".html"):
                 try:
                     text_content = render_to_string(
-                        template_name.replace("html", "txt"), template_context
+                        template_name.removesuffix(".html") + ".txt", template_context
                     )
                     self.body = text_content
                 except TemplateDoesNotExist:
                     pass
 
-            self.mixed_subtype = "related"
-            self.attach_alternative(content, "text/html")
-        else:
-            self.body = content
+                self.mixed_subtype = "related"
+                self.attach_alternative(content, "text/html")
+            else:
+                self.body = content

--- a/website/docs/add-secure-apps/flows-stages/stages/email/index.md
+++ b/website/docs/add-secure-apps/flows-stages/stages/email/index.md
@@ -61,7 +61,7 @@ The recovery rate-limiting fields only affect recovery-style email sends. They l
 
 ### Custom templates
 
-You can provide custom email templates.
+You can provide custom email templates. Email templates must be either `.html` or `.txt` files.
 
 :::info
 You can also add a matching `.txt` file next to the `.html` file to send multipart text and HTML emails.


### PR DESCRIPTION
<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?

Allows non-HTML plaintext custom email templates from .txt files.

### Why is this change needed?

So non-HTML emails can be sent.

### How was this tested?

Manual testing.

### Linked issues

closes #23914 

---

## Checklist

-   [x] The project has been linted, built, and tested (`make all`)
-   [x] The documentation has been updated and formatted (`make docs`)
