### PR TITLE
website/docs: recovery flow: add note about skipping email stage

### DIFF
--- a/website/docs/add-secure-apps/flows-stages/flow/examples/flows.md
+++ b/website/docs/add-secure-apps/flows-stages/flow/examples/flows.md
@@ -72,6 +72,12 @@ With this recovery flow, the user is sent an email after they've identified them
 
 There's also <DownloadLink to="/blueprints/example/flows-recovery-email-verification.yaml">a version</DownloadLink> of this flow available without MFA validation at `example/flows-recovery-email-verification.yaml`, which is not recommended.
 
+:::note Skip the email stage
+To skip the email stage in the flow, bind the same `default-recovery-skip-if-restored` policy used by the identification stage to the email stage.
+
+Users who meet the policy criteria will then proceed directly to the MFA validation stage.
+:::
+
 ## User deletion
 
 Blueprint path: `example/flows-unenrollment.yaml`


### PR DESCRIPTION
## Details

### What does this PR change?

Adds note about skipping email stage to the recovery flow documentation

### Why is this change needed?

Some users want the email stage to be skipped

### How was this tested?

n/a

### Linked issues

Closes https://github.com/goauthentik/authentik/issues/9781

---

## Checklist

-   [x] The project has been linted, built, and tested (`make all`)
-   [x] The documentation has been updated and formatted (`make docs`)
