### PR TITLE
core: bump library/golang from 1.26.2-trixie to 1.26.5-trixie in /lifecycle/container

### DIFF
--- a/lifecycle/container/Dockerfile
+++ b/lifecycle/container/Dockerfile
@@ -29,7 +29,7 @@ RUN npm run build && \
     npm run build:sfe
 
 # Stage: Build go proxy
-FROM --platform=${BUILDPLATFORM} docker.io/library/golang:1.26.2-trixie@sha256:4a7137ea573f79c86ae451ff05817ed762ef5597fcf732259e97abeb3108d873 AS go-builder
+FROM --platform=${BUILDPLATFORM} docker.io/library/golang:1.26.5-trixie@sha256:4ee9ffa999b4583ce281939cdff828763083610292f252279a0cee77473bd9a7 AS go-builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/lifecycle/container/ldap.Dockerfile
+++ b/lifecycle/container/ldap.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Stage 1: Build
-FROM --platform=${BUILDPLATFORM} docker.io/library/golang:1.26.2-trixie@sha256:4a7137ea573f79c86ae451ff05817ed762ef5597fcf732259e97abeb3108d873 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/library/golang:1.26.5-trixie@sha256:4ee9ffa999b4583ce281939cdff828763083610292f252279a0cee77473bd9a7 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/lifecycle/container/proxy.Dockerfile
+++ b/lifecycle/container/proxy.Dockerfile
@@ -21,7 +21,7 @@ COPY web .
 RUN npm run build-proxy
 
 # Stage 2: Build
-FROM --platform=${BUILDPLATFORM} docker.io/library/golang:1.26.2-trixie@sha256:4a7137ea573f79c86ae451ff05817ed762ef5597fcf732259e97abeb3108d873 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/library/golang:1.26.5-trixie@sha256:4ee9ffa999b4583ce281939cdff828763083610292f252279a0cee77473bd9a7 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/lifecycle/container/rac.Dockerfile
+++ b/lifecycle/container/rac.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Stage 1: Build
-FROM --platform=${BUILDPLATFORM} docker.io/library/golang:1.26.2-trixie@sha256:4a7137ea573f79c86ae451ff05817ed762ef5597fcf732259e97abeb3108d873 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/library/golang:1.26.5-trixie@sha256:4ee9ffa999b4583ce281939cdff828763083610292f252279a0cee77473bd9a7 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/lifecycle/container/radius.Dockerfile
+++ b/lifecycle/container/radius.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Stage 1: Build
-FROM --platform=${BUILDPLATFORM} docker.io/library/golang:1.26.2-trixie@sha256:4a7137ea573f79c86ae451ff05817ed762ef5597fcf732259e97abeb3108d873 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/library/golang:1.26.5-trixie@sha256:4ee9ffa999b4583ce281939cdff828763083610292f252279a0cee77473bd9a7 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
Only for `2026.5` since the main branch is already covered.

Fixes the following CVEs:

```
NAME                      INSTALLED                             FIXED IN                       TYPE        VULNERABILITY        SEVERITY    EPSS          RISK
stdlib                    go1.26.2                              1.25.10, *1.26.3               go-module   CVE-2026-33811       High        0.8% (53rd)   0.6    
stdlib                    go1.26.2                              1.25.10, *1.26.3               go-module   GO-2026-4981         High        0.8% (53rd)   0.6    
stdlib                    go1.26.2                              1.25.10, *1.26.3               go-module   CVE-2026-42499       High        0.8% (52nd)   0.6    
stdlib                    go1.26.2                              1.25.10, *1.26.3               go-module   GO-2026-4977         High        0.8% (52nd)   0.6    
stdlib                    go1.26.2                              1.25.10, *1.26.3               go-module   CVE-2026-39820       High        0.8% (52nd)   0.6    
stdlib                    go1.26.2                              1.25.10, *1.26.3               go-module   GO-2026-4986         High        0.8% (52nd)   0.6    
stdlib                    go1.26.2                              1.25.10, *1.26.3               go-module   CVE-2026-33814       High        0.8% (52nd)   0.6    
stdlib                    go1.26.2                              1.25.10, *1.26.3               go-module   GO-2026-4918         High        0.8% (52nd)   0.6    
stdlib                    go1.26.2                              1.25.11, *1.26.4               go-module   GO-2026-5037         High        0.6% (44th)   0.4    
stdlib                    go1.26.2                              1.25.10, *1.26.3               go-module   CVE-2026-39836       High        0.6% (44th)   0.4    
stdlib                    go1.26.2                              1.25.10, *1.26.3               go-module   GO-2026-4971         High        0.6% (44th)   0.4    
stdlib                    go1.26.2                              1.25.11, *1.26.4               go-module   CVE-2026-27145       High        0.6% (44th)   0.4    
stdlib                    go1.26.2                              1.25.11, *1.26.4               go-module   CVE-2026-42504       High        0.6% (43rd)   0.4    
stdlib                    go1.26.2                              1.25.11, *1.26.4               go-module   GO-2026-5038         High        0.6% (43rd)   0.4    
stdlib                    go1.26.2                              1.25.10, *1.26.3               go-module   CVE-2026-39826       Medium      0.4% (29th)   0.2    
stdlib                    go1.26.2                              1.25.10, *1.26.3               go-module   GO-2026-4980         Medium      0.4% (29th)   0.2    
stdlib                    go1.26.2                              1.25.10, *1.26.3               go-module   CVE-2026-39825       Medium      0.4% (31st)   0.2    
stdlib                    go1.26.2                              1.25.10, *1.26.3               go-module   GO-2026-4976         Medium      0.4% (31st)   0.2    
stdlib                    go1.26.2                              1.25.11, *1.26.4               go-module   CVE-2026-42507       Medium      0.4% (29th)   0.2    
stdlib                    go1.26.2                              1.25.11, *1.26.4               go-module   GO-2026-5039         Medium      0.4% (29th)   0.2    
stdlib                    go1.26.2                              1.25.12, *1.26.5, 1.27.0-rc.2  go-module   CVE-2026-39822       High        0.2% (14th)   0.2    
stdlib                    go1.26.2                              1.25.12, *1.26.5, 1.27.0-rc.2  go-module   GO-2026-4970         High        0.2% (14th)   0.2    
stdlib                    go1.26.2                              1.25.10, *1.26.3               go-module   CVE-2026-39823       Medium      0.3% (23rd)   0.2    
stdlib                    go1.26.2                              1.25.10, *1.26.3               go-module   GO-2026-4982         Medium      0.3% (23rd)   0.2    
stdlib                    go1.26.2                              1.25.10, *1.26.3               go-module   CVE-2026-42501       High        0.2% (14th)   0.2    
stdlib                    go1.26.2                              1.25.12, *1.26.5, 1.27.0-rc.2  go-module   CVE-2026-42505       Medium      0.3% (16th)   0.1    
stdlib                    go1.26.2                              1.25.12, *1.26.5, 1.27.0-rc.2  go-module   GO-2026-5856         Medium      0.3% (16th)   0.1    
stdlib                    go1.26.2                              1.25.10, *1.26.3               go-module   CVE-2026-39817       Medium      0.2% (6th)    < 0.1  
stdlib                    go1.26.2                              1.25.10, *1.26.3               go-module   CVE-2026-39819       Medium      0.2% (7th)    < 0.1  
```