### PR TITLE
web/elements: Add location to sessions

### DIFF
--- a/web/src/elements/user/SessionList.ts
+++ b/web/src/elements/user/SessionList.ts
@@ -2,6 +2,7 @@ import "#elements/forms/DeleteBulkForm";
 
 import { aki } from "#common/api/client";
 
+import { WithLocale } from "#elements/mixins/locale";
 import { PaginatedResponse, Table, TableColumn, Timestamp } from "#elements/table/Table";
 import { SlottedTemplateResult } from "#elements/types";
 
@@ -13,26 +14,8 @@ import { msg } from "@lit/localize";
 import { html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
-function formatLocation(geoIp?: AuthenticatedSessionGeoIp | null): string | null {
-    if (!geoIp) return null;
-
-    let country: string | null = geoIp.country;
-
-    if (country) {
-        try {
-            country = new Intl.DisplayNames(undefined, { type: "region" }).of(country) ?? country;
-        } catch {
-            // Not a region code the runtime knows about, fall back to the raw value.
-        }
-    }
-
-    const parts = [geoIp.city, country].filter(Boolean);
-
-    return parts.length ? parts.join(", ") : null;
-}
-
 @customElement("ak-user-session-list")
-export class AuthenticatedSessionList extends Table<AuthenticatedSession> {
+export class AuthenticatedSessionList extends WithLocale(Table<AuthenticatedSession>) {
     public static override verboseName = msg("Session");
     public static override verboseNamePlural = msg("Sessions");
 
@@ -52,6 +35,26 @@ export class AuthenticatedSessionList extends Table<AuthenticatedSession> {
 
     protected override rowLabel(item: AuthenticatedSession): string | null {
         return item.lastIp ?? null;
+    }
+
+    protected formatLocation(geoIp?: AuthenticatedSessionGeoIp | null): string | null {
+        if (!geoIp) return null;
+
+        let country: string | null = geoIp.country;
+
+        if (country) {
+            try {
+                country =
+                    new Intl.DisplayNames(this.activeLanguageTag, { type: "region" }).of(country) ??
+                    country;
+            } catch {
+                // Not a region code the runtime knows about, fall back to the raw value.
+            }
+        }
+
+        const parts = [geoIp.city, country].filter(Boolean);
+
+        return parts.length ? parts.join(", ") : null;
     }
 
     protected columns: TableColumn[] = [
@@ -89,7 +92,7 @@ export class AuthenticatedSessionList extends Table<AuthenticatedSession> {
     }
 
     row(item: AuthenticatedSession): SlottedTemplateResult[] {
-        const location = formatLocation(item.geoIp);
+        const location = this.formatLocation(item.geoIp);
         const device = [item.userAgent.userAgent?.family, item.userAgent.os?.family]
             .filter(Boolean)
             .join(", ");

--- a/web/src/elements/user/SessionList.ts
+++ b/web/src/elements/user/SessionList.ts
@@ -5,13 +5,37 @@ import { aki } from "#common/api/client";
 import { PaginatedResponse, Table, TableColumn, Timestamp } from "#elements/table/Table";
 import { SlottedTemplateResult } from "#elements/types";
 
-import { AuthenticatedSession, CoreApi } from "@goauthentik/api";
+import { AuthenticatedSession, AuthenticatedSessionGeoIp, CoreApi } from "@goauthentik/api";
 
 import getUnicodeFlagIcon from "country-flag-icons/unicode";
 
 import { msg } from "@lit/localize";
 import { html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
+
+/**
+ * Format the GeoIP data of a session as a human-readable location, i.e. "Toronto, Canada".
+ *
+ * Either part may be missing from the GeoIP database, in which case only the
+ * available one is used. Returns null when nothing can be resolved.
+ */
+function formatLocation(geoIp?: AuthenticatedSessionGeoIp | null): string | null {
+    if (!geoIp) return null;
+
+    let country: string | null = geoIp.country;
+
+    if (country) {
+        try {
+            country = new Intl.DisplayNames(undefined, { type: "region" }).of(country) ?? country;
+        } catch {
+            // Not a region code the runtime knows about, fall back to the raw value.
+        }
+    }
+
+    const parts = [geoIp.city, country].filter(Boolean);
+
+    return parts.length ? parts.join(", ") : null;
+}
 
 @customElement("ak-user-session-list")
 export class AuthenticatedSessionList extends Table<AuthenticatedSession> {
@@ -71,6 +95,11 @@ export class AuthenticatedSessionList extends Table<AuthenticatedSession> {
     }
 
     row(item: AuthenticatedSession): SlottedTemplateResult[] {
+        const location = formatLocation(item.geoIp);
+        const device = [item.userAgent.userAgent?.family, item.userAgent.os?.family]
+            .filter(Boolean)
+            .join(", ");
+
         return [
             html`<div>
                     ${item.geoIp?.country
@@ -79,7 +108,7 @@ export class AuthenticatedSessionList extends Table<AuthenticatedSession> {
                     ${item.current ? html`${msg("(Current session)")}&nbsp;` : nothing}
                     ${item.lastIp}
                 </div>
-                <small>${item.userAgent.userAgent?.family}, ${item.userAgent.os?.family}</small>`,
+                <small>${[location, device].filter(Boolean).join(" — ")}</small>`,
             Timestamp(item.lastUsed),
             Timestamp(item.expires ?? new Date()),
         ];

--- a/web/src/elements/user/SessionList.ts
+++ b/web/src/elements/user/SessionList.ts
@@ -13,12 +13,6 @@ import { msg } from "@lit/localize";
 import { html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
-/**
- * Format the GeoIP data of a session as a human-readable location, i.e. "Toronto, Canada".
- *
- * Either part may be missing from the GeoIP database, in which case only the
- * available one is used. Returns null when nothing can be resolved.
- */
 function formatLocation(geoIp?: AuthenticatedSessionGeoIp | null): string | null {
     if (!geoIp) return null;
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?

Currently, the list of sessions shows a flag to denote location, but doesn't show city or anything else. This adds a city name next to the device information.

### Why is this change needed?

Just a flag doesn't always help show that a session is one that you don't know. I may see a second session in the US and assume it's me on a different device, but if I see it's in a city I've never been to, it helps me identity a bad session faster.

### How was this tested?

Built and ran locally

### Linked issues

<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
