### PR TITLE
core: add admin_authenticated_session_deleted signal for admin deleted session

### DIFF
--- a/authentik/core/api/authenticated_sessions.py
+++ b/authentik/core/api/authenticated_sessions.py
@@ -6,7 +6,7 @@ from drf_spectacular.utils import (
     extend_schema,
     inline_serializer,
 )
-from rest_framework import mixins, serializers
+from rest_framework import mixins, serializers, status
 from rest_framework.decorators import action
 from rest_framework.fields import SerializerMethodField
 from rest_framework.request import Request
@@ -24,8 +24,10 @@ from authentik.api.validation import validate
 from authentik.core.api.used_by import UsedByMixin
 from authentik.core.api.utils import ModelSerializer, PassiveSerializer
 from authentik.core.models import AuthenticatedSession
+from authentik.core.signals import admin_authenticated_session_deleted
 from authentik.events.context_processors.asn import ASN_CONTEXT_PROCESSOR, ASNDict
 from authentik.events.context_processors.geoip import GEOIP_CONTEXT_PROCESSOR, GeoIPDict
+from authentik.lib.utils.db import chunked_queryset
 from authentik.rbac.decorators import permission_required
 
 
@@ -152,6 +154,16 @@ class AuthenticatedSessionViewSet(
     def bulk_delete(self, request: Request, *, query: BulkDeleteSessionSerializer) -> Response:
         """Bulk revoke all sessions for multiple users"""
         user_pks = query.validated_data.get("user_pks", [])
-        deleted_count, _ = AuthenticatedSession.objects.filter(user_id__in=user_pks).delete()
+        count = 0
+        for session in chunked_queryset(AuthenticatedSession.objects.filter(user_id__in=user_pks)):
+            admin_authenticated_session_deleted.send(self, session=session, request=request)
+            session.delete()
+            count += 1
 
-        return Response({"deleted": deleted_count}, status=200)
+        return Response({"deleted": count}, status=200)
+
+    def destroy(self, request, *args, **kwargs):
+        instance = self.get_object()
+        admin_authenticated_session_deleted.send(self, session=instance, request=request)
+        self.perform_destroy(instance)
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/authentik/core/api/authenticated_sessions.py
+++ b/authentik/core/api/authenticated_sessions.py
@@ -164,6 +164,6 @@ class AuthenticatedSessionViewSet(
 
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()
-        admin_authenticated_session_deleted.send(self, session=instance, request=request)
+        admin_authenticated_session_deleted.send(self, instance=instance, request=request)
         self.perform_destroy(instance)
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/authentik/core/signals.py
+++ b/authentik/core/signals.py
@@ -21,13 +21,15 @@ from authentik.flows.apps import RefreshOtherFlowsAfterAuthentication
 from authentik.lib.models import ExpiringModel
 from authentik.root.ws.consumer import build_device_group
 
-# Arguments: user: User, password: str
 password_changed = Signal()
-# Arguments: user: User, request: HttpRequest | None
+"""Arguments: user: User, password: str"""
 password_hash_changed = Signal()
-# Arguments: credentials: dict[str, any], request: HttpRequest,
-#            stage: Stage, context: dict[str, any]
+"""Arguments: user: User, request: HttpRequest | None"""
 login_failed = Signal()
+"""Arguments: credentials: dict[str, any], request: HttpRequest,
+stage: Stage, context: dict[str, any]"""
+admin_authenticated_session_deleted = Signal()
+"""Arguments: instance: AuthenticatedSession, request: HttpRequest"""
 
 LOGGER = get_logger()
 

--- a/authentik/enterprise/providers/ssf/signals.py
+++ b/authentik/enterprise/providers/ssf/signals.py
@@ -1,8 +1,9 @@
 from hashlib import sha256
 
 from django.db.models import Model
-from django.db.models.signals import post_delete, post_save, pre_delete
+from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
+from django.http import HttpRequest
 
 from authentik.core.models import (
     USER_PATH_SYSTEM_PREFIX,
@@ -12,7 +13,11 @@ from authentik.core.models import (
     User,
     UserTypes,
 )
-from authentik.core.signals import password_changed, password_hash_changed
+from authentik.core.signals import (
+    admin_authenticated_session_deleted,
+    password_changed,
+    password_hash_changed,
+)
 from authentik.enterprise.providers.ssf.models import (
     EventTypes,
     SSFProvider,
@@ -59,8 +64,10 @@ def ssf_providers_post_save(sender: type[Model], instance: SSFProvider, created:
             instance.save()
 
 
-@receiver(pre_delete, sender=AuthenticatedSession)
-def ssf_user_session_delete_session_revoked(sender, instance: AuthenticatedSession, **_):
+@receiver(admin_authenticated_session_deleted)
+def ssf_user_session_delete_session_revoked(
+    sender, instance: AuthenticatedSession, request: HttpRequest, **_
+):
     """Session revoked trigger (users' session has been deleted)
 
     As this signal is also triggered with a regular logout, we can't be sure
@@ -70,6 +77,7 @@ def ssf_user_session_delete_session_revoked(sender, instance: AuthenticatedSessi
         {
             "initiating_entity": "user",
         },
+        request=request,
         sub_id={
             "format": "complex",
             "session": {

--- a/authentik/enterprise/providers/ssf/tests/test_signals.py
+++ b/authentik/enterprise/providers/ssf/tests/test_signals.py
@@ -4,7 +4,8 @@ from django.contrib.auth.hashers import make_password
 from django.urls import reverse
 from rest_framework.test import APITestCase
 
-from authentik.core.models import Application, Group
+from authentik.core.models import Application, AuthenticatedSession, Group
+from authentik.core.signals import admin_authenticated_session_deleted
 from authentik.core.tests.utils import (
     create_test_cert,
     create_test_user,
@@ -70,9 +71,11 @@ class TestSignals(APITestCase):
 
     def test_signal_logout(self):
         """Test user logout"""
+        AuthenticatedSession.objects.all().delete()
         user = create_test_user()
         self.client.force_login(user)
-        self.client.logout()
+        session = AuthenticatedSession.objects.first()
+        admin_authenticated_session_deleted.send(self, instance=session, request=None)
 
         stream = Stream.objects.filter(provider=self.provider).first()
         self.assertIsNotNone(stream)


### PR DESCRIPTION
currently ssf listens on pre_delete of AuthenticatedSession, which also fires if a user logs out manually, which then propagates and causes ssf to log out out of everything even if it still has refresh tokens