### PR TITLE
website/integrations: termix: fix broken link

### DIFF
--- a/website/integrations/infrastructure/termix/index.mdx
+++ b/website/integrations/infrastructure/termix/index.mdx
@@ -62,4 +62,4 @@ To verify that authentik is correctly integrated with Termix, first log out of y
 
 ## Resources
 
-- [Termix Docs - OIDC (OpenID Connect) Setup Guide](https://docs.termix.site/oidc)
+- [Termix Docs - OIDC (OpenID Connect) Setup Guide](https://docs.termix.site/features/authentication/oidc)


### PR DESCRIPTION
Prior link returned a "Page Not Found" error. Updated URL for current Termix OIDC documentation page.

## Details
'Termix Docs - OIDC (OpenID Connect) Setup Guide' link in `website/integrations/infrastructure/termix/index.mdx` returns "Page Not Found" error.

### What does this PR change?
Updates the URL to the current Termix Authentication OIDC documentation page.

### Why is this change needed?
Broken URL link.

### How was this tested?
Verified the updated URL opens the correct Termix documentation page when clicked.

### Linked issues

closes #24462 

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
