### PR TITLE
packages/ak-axum: Correctly canonicalize IP when checking for trusted reverse proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,6 +363,7 @@ dependencies = [
  "durstr",
  "eyre",
  "futures",
+ "ipnet",
  "pin-project-lite",
  "tokio",
  "tokio-rustls",

--- a/packages/ak-axum/Cargo.toml
+++ b/packages/ak-axum/Cargo.toml
@@ -17,6 +17,7 @@ client-ip.workspace = true
 durstr.workspace = true
 eyre.workspace = true
 futures.workspace = true
+ipnet.workspace = true
 pin-project-lite.workspace = true
 tokio-rustls.workspace = true
 tokio.workspace = true

--- a/packages/ak-axum/src/extract/trusted_proxy.rs
+++ b/packages/ak-axum/src/extract/trusted_proxy.rs
@@ -1,6 +1,6 @@
 //! axum extractor and middleware to check if a request comes from a trusted proxy.
 
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 
 use ak_common::config;
 use axum::{
@@ -10,6 +10,7 @@ use axum::{
     middleware::Next,
     response::Response,
 };
+use ipnet::IpNet;
 use tracing::{instrument, trace};
 
 /// Whether the request comes from a trusted proxy.
@@ -32,22 +33,28 @@ where
     }
 }
 
+fn ip_addr_trusted(ip: &IpAddr) -> Option<IpNet> {
+    let trusted_proxy_cidrs = &config::get().listen.trusted_proxy_cidrs;
+    for net in trusted_proxy_cidrs {
+        if net.contains(&ip.to_canonical()) {
+            return Some(*net);
+        }
+    }
+    None
+}
+
 /// Check whether the request comes from a trusted proxy.
 #[instrument(skip_all)]
 async fn extract_trusted_proxy(parts: &mut Parts) -> bool {
-    if let Ok(ConnectInfo(addr)) = parts.extract::<ConnectInfo<SocketAddr>>().await {
-        let trusted_proxy_cidrs = &config::get().listen.trusted_proxy_cidrs;
-
-        for trusted_net in trusted_proxy_cidrs {
-            if trusted_net.contains(&addr.ip()) {
-                trace!(
-                    ?addr,
-                    ?trusted_net,
-                    "connection is now considered coming from a trusted proxy"
-                );
-                return true;
-            }
-        }
+    if let Ok(ConnectInfo(addr)) = parts.extract::<ConnectInfo<SocketAddr>>().await
+        && let Some(trusted_net) = ip_addr_trusted(&addr.ip())
+    {
+        trace!(
+            ?addr,
+            ?trusted_net,
+            "connection is now considered coming from a trusted proxy"
+        );
+        return true;
     }
     false
 }
@@ -68,4 +75,24 @@ pub async fn trusted_proxy_middleware(request: Request, next: Next) -> Response 
     let request = Request::from_parts(parts, body);
 
     next.run(request).await
+}
+
+#[cfg(test)]
+mod test {
+    use std::net::IpAddr;
+
+    use ak_common::config;
+
+    use crate::extract::trusted_proxy::ip_addr_trusted;
+
+    #[test]
+    fn ipv4_mapped_ipv6_matches_ipv4_cidr() {
+        config::init().unwrap();
+        // IPv4-mapped IPv6 address within the IPv4 CIDR matches.
+        let ip: IpAddr = "::ffff:10.2.0.229".parse().expect("valid IP");
+        assert!(ip_addr_trusted(&ip).is_some());
+        // An IPv4-mapped address outside the CIDR does not.
+        let ip: IpAddr = "::ffff:11.0.0.1".parse().expect("valid IP");
+        assert!(ip_addr_trusted(&ip).is_none());
+    }
 }


### PR DESCRIPTION
at least in istio client IPs show up as `::ffff:10.2.0.229`