### PR TITLE
ci: add rust proxy binary build to release CI

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -29,30 +29,36 @@ permissions:
 
 jobs:
   build-outpost-test:
-    runs-on: ubuntu-latest
+    # aws-lc-sys/aws-lc-fips-sys compile C via cc/cmake, so every target needs a matching
+    # native toolchain. Build each one on a runner of the same OS/arch instead of cross-compiling.
+    runs-on: "${{ matrix.target.runs-on }}"
     strategy:
       fail-fast: false
       matrix:
         type:
           - proxy
         target:
-          - x86_64-unknown-linux-gnu
-          - aarch64-unknown-linux-gnu
-          - x86_64-apple-darwin
-          - aarch64-apple-darwin
+          - triple: x86_64-unknown-linux-gnu
+            runs-on: ubuntu-latest
+          - triple: aarch64-unknown-linux-gnu
+            runs-on: ubuntu-24.04-arm
+          - triple: x86_64-apple-darwin
+            runs-on: macos-15-intel
+          - triple: aarch64-apple-darwin
+            runs-on: macos-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
       - name: Setup rust
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           rustflags: ""
-          target: "${{ matrix.target }}"
+          target: "${{ matrix.target.triple }}"
       - name: Build outpost
         run: |
           set -x
           mkdir -p build/binaries/
-          cargo build --package authentik --no-default-features --features "${{ matrix.type }}" --locked --release --target "${{ matrix.target }}"
-          cp ./target/release/authentik "build/binaries/authentik-outpost-${{ matrix.type }}-${{ matrix.target }}"
+          cargo build --package authentik --no-default-features --features "${{ matrix.type }}" --locked --release --target "${{ matrix.target.triple }}"
+          cp "./target/${{ matrix.target.triple }}/release/authentik" "build/binaries/authentik-outpost-${{ matrix.type }}-${{ matrix.target.triple }}"
   build-compute-tags:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -28,43 +28,6 @@ permissions:
   id-token: write
 
 jobs:
-  build-outpost-test:
-    # aws-lc-sys/aws-lc-fips-sys compile C via cc/cmake, so every target needs a matching
-    # native toolchain. Build each one on a runner of the same OS/arch instead of cross-compiling.
-    runs-on: "${{ matrix.target.runs-on }}"
-    strategy:
-      fail-fast: false
-      matrix:
-        type:
-          - proxy
-        target:
-          - triple: x86_64-unknown-linux-gnu
-            runs-on: ubuntu-latest
-          - triple: aarch64-unknown-linux-gnu
-            runs-on: ubuntu-24.04-arm
-          - triple: x86_64-apple-darwin
-            runs-on: macos-15-intel
-          - triple: aarch64-apple-darwin
-            runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
-      - name: Setup rust
-        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
-        with:
-          rustflags: ""
-          target: "${{ matrix.target.triple }}"
-      # aws-lc-fips-sys needs Go and Perl to generate its FIPS sources.
-      - name: Setup go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: "go.mod"
-          cache: false
-      - name: Build outpost
-        run: |
-          set -x
-          mkdir -p build/binaries/
-          cargo build --package authentik --no-default-features --features "${{ matrix.type }}" --locked --release --target "${{ matrix.target.triple }}"
-          cp "./target/${{ matrix.target.triple }}/release/authentik" "build/binaries/authentik-outpost-${{ matrix.type }}-${{ matrix.target.triple }}"
   build-compute-tags:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -28,6 +28,31 @@ permissions:
   id-token: write
 
 jobs:
+  build-outpost-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        type:
+          - proxy
+        target:
+          - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
+          - x86_64-apple-darwin
+          - aarch64-apple-darwin
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+      - name: Setup rust
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          rustflags: ""
+          target: "${{ matrix.target }}"
+      - name: Build outpost
+        run: |
+          set -x
+          mkdir -p build/binaries/
+          cargo build --package authentik --no-default-features --features "${{ matrix.type }}" --locked --release --target "${{ matrix.target }}"
+          cp ./target/release/authentik "build/binaries/authentik-outpost-${{ matrix.type }}-${{ matrix.target }}"
   build-compute-tags:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -53,8 +53,12 @@ jobs:
         with:
           rustflags: ""
           target: "${{ matrix.target.triple }}"
+      # aws-lc-fips-sys needs Go and Perl to generate its FIPS sources.
       - name: Setup go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v5
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: "go.mod"
+          cache: false
       - name: Build outpost
         run: |
           set -x

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -53,6 +53,8 @@ jobs:
         with:
           rustflags: ""
           target: "${{ matrix.target.triple }}"
+      - name: Setup go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v5
       - name: Build outpost
         run: |
           set -x

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -174,9 +174,6 @@ jobs:
     needs:
       - bump-version
     timeout-minutes: 120
-    # aws-lc-sys/aws-lc-fips-sys compile C via cc/cmake, so every target needs a matching
-    # native toolchain. Build each one on a runner of the same OS/arch instead of cross-compiling.
-    runs-on: "${{ matrix.target.runs-on }}"
     permissions:
       # Needed for checkout
       contents: read
@@ -194,6 +191,7 @@ jobs:
             runs-on: macos-15-intel
           - triple: aarch64-apple-darwin
             runs-on: macos-latest
+    runs-on: "${{ matrix.target.runs-on }}"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
         with:
@@ -203,7 +201,6 @@ jobs:
         with:
           rustflags: ""
           target: "${{ matrix.target.triple }}"
-      # aws-lc-fips-sys needs Go and Perl to generate its FIPS sources.
       - name: Setup go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -125,7 +125,7 @@ jobs:
       image-dockerfile: "lifecycle/container/${{ matrix.dockerfile }}"
       image-build-args: |
         VERSION=${{ needs.check-inputs.outputs.version }}
-  build-binaries:
+  build-go-binaries:
     needs:
       - bump-version
     timeout-minutes: 120
@@ -137,7 +137,6 @@ jobs:
       fail-fast: false
       matrix:
         type:
-          - proxy
           - ldap
           - radius
         goos: [linux, darwin]
@@ -171,6 +170,46 @@ jobs:
           if-no-files-found: error
           retention-days: 2
           include-hidden-files: true
+  build-rust-binaries:
+    needs:
+      - bump-version
+    timeout-minutes: 120
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed for checkout
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        type:
+          - proxy
+        target:
+          - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
+          - x86_64-apple-darwin
+          - aarch64-apple-darwin
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+        with:
+          ref: "${{ needs.bump-version.outputs.release-commit }}"
+      - name: Setup rust
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          rustflags: ""
+          target: "${{ matrix.target }}"
+      - name: Build outpost
+        run: |
+          set -x
+          mkdir -p build/binaries/
+          cargo build --package authentik --no-default-features --features "${{ matrix.type }}" --locked --release --target "${{ matrix.target }}"
+          cp ./target/release/authentik "build/binaries/authentik-outpost-${{ matrix.type }}-${{ matrix.target }}"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: "binaries-build-${{ matrix.type }}-${{ matrix.target }}"
+          path: build/
+          if-no-files-found: error
+          retention-days: 2
+          include-hidden-files: true
   test:
     name: Pre-release test
     runs-on: ubuntu-latest
@@ -200,7 +239,8 @@ jobs:
       - check-inputs
       - bump-version
       - build-container
-      - build-binaries
+      - build-go-binaries
+      - build-rust-binaries
       - test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -203,6 +203,8 @@ jobs:
         with:
           rustflags: ""
           target: "${{ matrix.target.triple }}"
+      - name: Setup go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v5
       - name: Build outpost
         run: |
           set -x

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -174,7 +174,9 @@ jobs:
     needs:
       - bump-version
     timeout-minutes: 120
-    runs-on: ubuntu-latest
+    # aws-lc-sys/aws-lc-fips-sys compile C via cc/cmake, so every target needs a matching
+    # native toolchain. Build each one on a runner of the same OS/arch instead of cross-compiling.
+    runs-on: "${{ matrix.target.runs-on }}"
     permissions:
       # Needed for checkout
       contents: read
@@ -184,10 +186,14 @@ jobs:
         type:
           - proxy
         target:
-          - x86_64-unknown-linux-gnu
-          - aarch64-unknown-linux-gnu
-          - x86_64-apple-darwin
-          - aarch64-apple-darwin
+          - triple: x86_64-unknown-linux-gnu
+            runs-on: ubuntu-latest
+          - triple: aarch64-unknown-linux-gnu
+            runs-on: ubuntu-24.04-arm
+          - triple: x86_64-apple-darwin
+            runs-on: macos-15-intel
+          - triple: aarch64-apple-darwin
+            runs-on: macos-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
         with:
@@ -196,16 +202,16 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           rustflags: ""
-          target: "${{ matrix.target }}"
+          target: "${{ matrix.target.triple }}"
       - name: Build outpost
         run: |
           set -x
           mkdir -p build/binaries/
-          cargo build --package authentik --no-default-features --features "${{ matrix.type }}" --locked --release --target "${{ matrix.target }}"
-          cp ./target/release/authentik "build/binaries/authentik-outpost-${{ matrix.type }}-${{ matrix.target }}"
+          cargo build --package authentik --no-default-features --features "${{ matrix.type }}" --locked --release --target "${{ matrix.target.triple }}"
+          cp "./target/${{ matrix.target.triple }}/release/authentik" "build/binaries/authentik-outpost-${{ matrix.type }}-${{ matrix.target.triple }}"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
-          name: "binaries-build-${{ matrix.type }}-${{ matrix.target }}"
+          name: "binaries-build-${{ matrix.type }}-${{ matrix.target.triple }}"
           path: build/
           if-no-files-found: error
           retention-days: 2

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -203,8 +203,12 @@ jobs:
         with:
           rustflags: ""
           target: "${{ matrix.target.triple }}"
+      # aws-lc-fips-sys needs Go and Perl to generate its FIPS sources.
       - name: Setup go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v5
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: "go.mod"
+          cache: false
       - name: Build outpost
         run: |
           set -x


### PR DESCRIPTION
This is a breaking change in the way outpost binaries are named, but I think it's fine.

Tested by hijacking the CI on main: https://github.com/goauthentik/authentik/actions/runs/30542610801/job/90870892705?pr=24480