### PR TITLE
website/docs: release notes: draft for 2026.11

### DIFF
--- a/website/docs/releases/2026/v2026.11.md
+++ b/website/docs/releases/2026/v2026.11.md
@@ -1,0 +1,49 @@
+---
+title: Release 2026.11
+slug: "/releases/2026.11"
+draft: true
+---
+
+## Highlights
+
+<!-- ## Breaking changes -->
+
+## New features and improvements
+
+## Upgrading
+
+This release does not introduce any new requirements. You can follow the upgrade instructions below; for more detailed information about upgrading authentik, refer to our [Upgrade documentation](../install-config/upgrade.mdx).
+
+:::warning Upgrade in order and upgrade all components
+Upgrades MUST be performed sequentially by major version. If you are two or more major releases behind, you must first upgrade to each intermediate major release before upgrading to this one. Refer to our [Upgrade documentation](../../install-config/upgrade.mdx) for more information on upgrade sequence.
+
+The version of the authentik instance and of any outposts must be the same. We recommend that you always upgrade any outposts at the same time you upgrade your authentik instance.
+:::
+
+### Docker Compose
+
+To upgrade, download the new compose file and update the Docker stack with the new version, using these commands:
+
+```shell
+wget -O compose.yml https://goauthentik.io/version/xxxx.x/lifecycle/container/compose.yml
+docker compose up -d
+```
+
+The `-O` flag retains the downloaded file's name, overwriting any existing local file with the same name.
+
+### Kubernetes
+
+Upgrade the Helm Chart to the new version, using the following commands:
+
+```shell
+helm repo update
+helm upgrade authentik authentik/authentik -f values.yaml --version ^xxxx.x
+```
+
+## Minor changes/fixes
+
+<!-- _Insert the output of `make gen-changelog` here_ -->
+
+## API Changes
+
+<!-- _Insert output of `make gen-diff` here_ -->


### PR DESCRIPTION
Provide the 2026.11 release notes template in `draft` mode.