### PR TITLE
outpost/proxy: send X-Forwarded-Proto with the backchannel Host override so the token issuer matches

### DIFF
--- a/src/outpost/proxy/application/handlers/mod.rs
+++ b/src/outpost/proxy/application/handlers/mod.rs
@@ -262,7 +262,7 @@ pub(super) async fn handle_auth_callback(
         let access_token = backchannel::exchange_code(
             &app.api_config.client,
             &app.endpoint.token_url,
-            app.token_host.as_deref(),
+            app.token_host.as_ref(),
             &code,
             &redirect_uri,
             client_id,

--- a/src/outpost/proxy/application/mod.rs
+++ b/src/outpost/proxy/application/mod.rs
@@ -15,6 +15,7 @@ use url::Url;
 
 use crate::outpost::proxy::{
     ProxyOutpost, allowlist,
+    backchannel::TokenHost,
     claims::Claims,
     cookie::SessionCookie,
     endpoint::OidcEndpoint,
@@ -36,8 +37,8 @@ pub(crate) struct Application {
     pub(super) session_cookie: SessionCookie,
     /// Authenticated API client configuration (backchannel calls + events API).
     pub(super) api_config: Configuration,
-    /// `Host` header for backchannel token requests (browser host), if rewriting applies.
-    pub(super) token_host: Option<String>,
+    /// Host and scheme to claim on backchannel token requests, if rewriting applies.
+    pub(super) token_host: Option<TokenHost>,
     /// Short-lived cache of claims keyed by the `Authorization` header.
     pub(super) auth_cache: Cache<String, Claims>,
     /// Outpost name, sent upstream as `X-authentik-meta-outpost`.
@@ -95,7 +96,7 @@ impl Application {
         let token_host = host_browser
             .as_ref()
             .or(authentik_host.as_ref())
-            .map(|url| url.authority().to_owned());
+            .and_then(TokenHost::new);
 
         // Embedded outposts persist sessions in PostgreSQL; others use the filesystem.
         #[cfg(feature = "core")]

--- a/src/outpost/proxy/auth.rs
+++ b/src/outpost/proxy/auth.rs
@@ -105,7 +105,7 @@ impl Application {
         backchannel::introspect_token(
             &self.api_config.client,
             &self.endpoint.token_introspection,
-            self.token_host.as_deref(),
+            self.token_host.as_ref(),
             client_id,
             client_secret,
             token,
@@ -184,7 +184,7 @@ impl Application {
         let id_token = backchannel::client_credentials_token(
             &self.api_config.client,
             &self.endpoint.token_url,
-            self.token_host.as_deref(),
+            self.token_host.as_ref(),
             client_id,
             username,
             password,

--- a/src/outpost/proxy/backchannel.rs
+++ b/src/outpost/proxy/backchannel.rs
@@ -2,11 +2,46 @@
 
 use eyre::Result;
 use jsonwebtoken::jwk::JwkSet;
-use reqwest::header::HOST;
-use reqwest_middleware::ClientWithMiddleware;
+use reqwest::header::{HOST, HeaderName};
+use reqwest_middleware::{ClientWithMiddleware, RequestBuilder};
 use serde::Deserialize;
+use url::Url;
 
 use crate::outpost::proxy::claims::Claims;
+
+const X_FORWARDED_PROTO: HeaderName = HeaderName::from_static("x-forwarded-proto");
+
+/// The host and scheme to claim on backchannel requests.
+///
+/// The core derives a provider's issuer from the request host and forwarded
+/// scheme, so a request sent to the internal host has to present the
+/// browser-facing one for the resulting token to verify against
+/// [`OidcEndpoint::issuer`](crate::outpost::proxy::endpoint::OidcEndpoint).
+#[derive(Debug, Clone)]
+pub(crate) struct TokenHost {
+    host: String,
+    scheme: String,
+}
+
+impl TokenHost {
+    /// Build the override from a browser-facing URL, or `None` if it has no host.
+    pub(crate) fn new(url: &Url) -> Option<Self> {
+        let host = url.host_str()?;
+        Some(Self {
+            host: match url.port() {
+                Some(port) => format!("{host}:{port}"),
+                None => host.to_owned(),
+            },
+            scheme: url.scheme().to_owned(),
+        })
+    }
+
+    fn apply(&self, request: RequestBuilder) -> RequestBuilder {
+        request
+            .header(HOST, self.host.as_str())
+            .header(X_FORWARDED_PROTO, self.scheme.as_str())
+    }
+}
 
 #[derive(Deserialize)]
 struct TokenResponse {
@@ -26,12 +61,13 @@ struct IntrospectionResponse {
 
 /// Exchange an authorization code for an access token (used as the ID token).
 ///
-/// `token_host`, when set, overrides the `Host` header so the issuer matches the
-/// browser-facing host even though the request is sent over the backchannel.
+/// `token_host`, when set, makes the request claim the browser-facing host and
+/// scheme so the issuer matches even though the request goes over the
+/// backchannel.
 pub(crate) async fn exchange_code(
     client: &ClientWithMiddleware,
     token_url: &str,
-    token_host: Option<&str>,
+    token_host: Option<&TokenHost>,
     code: &str,
     redirect_uri: &str,
     client_id: &str,
@@ -45,7 +81,7 @@ pub(crate) async fn exchange_code(
         ("client_secret", client_secret),
     ]);
     if let Some(host) = token_host {
-        request = request.header(HOST, host);
+        request = host.apply(request);
     }
     let response = request.send().await?.error_for_status()?;
     Ok(response.json::<TokenResponse>().await?.access_token)
@@ -61,7 +97,7 @@ pub(crate) async fn fetch_jwks(client: &ClientWithMiddleware, jwks_uri: &str) ->
 pub(crate) async fn client_credentials_token(
     client: &ClientWithMiddleware,
     token_url: &str,
-    token_host: Option<&str>,
+    token_host: Option<&TokenHost>,
     client_id: &str,
     username: &str,
     password: &str,
@@ -75,7 +111,7 @@ pub(crate) async fn client_credentials_token(
         ("scope", scope),
     ]);
     if let Some(host) = token_host {
-        request = request.header(HOST, host);
+        request = host.apply(request);
     }
     let response = request.send().await?;
     if !response.status().is_success() {
@@ -88,7 +124,7 @@ pub(crate) async fn client_credentials_token(
 pub(crate) async fn introspect_token(
     client: &ClientWithMiddleware,
     introspection_url: &str,
-    token_host: Option<&str>,
+    token_host: Option<&TokenHost>,
     client_id: &str,
     client_secret: &str,
     token: &str,
@@ -99,7 +135,7 @@ pub(crate) async fn introspect_token(
         ("token", token),
     ]);
     if let Some(host) = token_host {
-        request = request.header(HOST, host);
+        request = host.apply(request);
     }
     let response = request.send().await?;
     if !response.status().is_success() {
@@ -112,4 +148,61 @@ pub(crate) async fn introspect_token(
     let mut claims = introspection.claims;
     token.clone_into(&mut claims.raw_token);
     Ok(Some(claims))
+}
+
+#[cfg(test)]
+mod tests {
+    use reqwest::header::HOST;
+    use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
+    use url::Url;
+
+    use super::{TokenHost, X_FORWARDED_PROTO};
+
+    fn client() -> ClientWithMiddleware {
+        ClientBuilder::new(reqwest::Client::new()).build()
+    }
+
+    fn token_host(raw: &str) -> TokenHost {
+        TokenHost::new(&Url::parse(raw).expect("valid url")).expect("url has a host")
+    }
+
+    #[test]
+    fn overrides_host_and_forwarded_scheme() {
+        // A request to the internal token endpoint must claim the browser-facing host and scheme,
+        // otherwise the core mints a token whose issuer is `http://...` and verification against
+        // the `https://` issuer fails.
+        let request = token_host("https://authentik.test.goauthentik.io/")
+            .apply(client().post("http://localhost:8000/application/o/token/"))
+            .build()
+            .expect("failed to build request");
+
+        assert_eq!(
+            request.headers().get(HOST).expect("host header"),
+            "authentik.test.goauthentik.io"
+        );
+        assert_eq!(
+            request
+                .headers()
+                .get(X_FORWARDED_PROTO)
+                .expect("forwarded proto header"),
+            "https"
+        );
+    }
+
+    #[test]
+    fn keeps_non_default_port() {
+        let host = token_host("http://authentik.test.goauthentik.io:9000/");
+        assert_eq!(host.host, "authentik.test.goauthentik.io:9000");
+        assert_eq!(host.scheme, "http");
+
+        assert_eq!(
+            token_host("https://authentik.test.goauthentik.io:443/").host,
+            "authentik.test.goauthentik.io"
+        );
+    }
+
+    #[test]
+    fn rejects_url_without_host() {
+        assert!(TokenHost::new(&Url::parse("file:///tmp/authentik").expect("valid url")).is_none());
+    }
 }


### PR DESCRIPTION
<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?

### Why is this change needed?

### How was this tested?

### Linked issues

<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
