### PR TITLE
web/elements: compile ak-mdx content from the API as CommonMark

### DIFF
--- a/web/src/elements/ak-mdx/ak-mdx.tsx
+++ b/web/src/elements/ak-mdx/ak-mdx.tsx
@@ -55,6 +55,17 @@ const highlightThemeOptions: HighlightOptions = {
  */
 export type Replacer = (input: string) => string;
 
+/**
+ * The syntax a source is compiled as.
+ *
+ * - `mdx` additionally parses JSX, expressions (`{...}`) and ESM
+ *   imports/exports, all of which are evaluated when the compiled module runs.
+ * - `md` is CommonMark only, i.e. no part of the source is evaluated.
+ *
+ * @see {@linkcode https://mdxjs.com/packages/mdx/#optionsformat}
+ */
+type ContentFormat = "md" | "mdx";
+
 @customElement("ak-mdx")
 export class AKMDX extends AKElement {
     // HACK: Fixes Lit Analyzer's parsing of TSX files with decorators.
@@ -97,16 +108,26 @@ export class AKMDX extends AKElement {
                 this.url.slice(this.url.indexOf("/assets"));
 
             nextMDXModule = await fetchMDXModule(pathname);
-        } else {
-            nextMDXModule = {
-                content: `${BrandedHTMLPolicy.createHTML(this.content || "")}`,
-            };
+
+            // Documentation is authored in-tree and bundled with the web
+            // interface, so it may use the full MDX syntax.
+            return this.delegateRender(nextMDXModule, "mdx");
         }
 
-        return this.delegateRender(nextMDXModule);
+        nextMDXModule = {
+            content: `${BrandedHTMLPolicy.createHTML(this.content || "")}`,
+        };
+
+        // `content` is supplied through the API — user and group notes, and
+        // blueprint descriptions — and is therefore compiled as CommonMark, so
+        // that no part of it is evaluated at runtime.
+        return this.delegateRender(nextMDXModule, "md");
     }
 
-    protected async delegateRender(mdxModule: MDXModule): Promise<void> {
+    protected async delegateRender(
+        mdxModule: MDXModule,
+        format: ContentFormat = "mdx",
+    ): Promise<void> {
         if (!this.#reactRoot) return;
 
         const normalized = this.replacers.reduce(
@@ -117,6 +138,7 @@ export class AKMDX extends AKElement {
         const { activeTheme } = this;
 
         const mdx = await compileMDX(normalized, {
+            format,
             outputFormat: "function-body",
             remarkPlugins: [
                 remarkParse,

--- a/web/src/elements/ak-mdx/content-format.unit.test.ts
+++ b/web/src/elements/ak-mdx/content-format.unit.test.ts
@@ -1,0 +1,86 @@
+import { compile, run } from "@mdx-js/mdx";
+import { renderToStaticMarkup } from "react-dom/server";
+import * as runtime from "react/jsx-runtime";
+import { describe, expect, it } from "vitest";
+
+/**
+ * `<ak-mdx>` renders sources of two different kinds:
+ *
+ * - documentation bundled with the web interface, referenced by `url`, which is
+ *   authored in-tree and compiled as MDX,
+ * - content returned by the API, passed as `content` — user and group notes,
+ *   and blueprint descriptions — which is compiled as CommonMark.
+ *
+ * The distinction matters because MDX evaluates expressions and ESM
+ * imports/exports of a source when the compiled module runs, while CommonMark
+ * has no evaluated syntax at all. These tests cover that the format the
+ * element passes to the compiler decides whether a source is evaluated.
+ */
+async function renderWithFormat(source: string, format: "md" | "mdx"): Promise<string> {
+    const compiled = await compile(source, { format, outputFormat: "function-body" });
+    const { default: Content } = await run(compiled, { ...runtime, baseUrl: import.meta.url });
+
+    return renderToStaticMarkup(Content({}));
+}
+
+/**
+ * A source can only report back that it was evaluated by reaching outside of
+ * itself, so the compiled sources below call into this global.
+ */
+const probeGlobal = globalThis as typeof globalThis & {
+    __akMDXFormatProbe?: string[];
+};
+
+function withProbe<T>(body: (calls: string[]) => Promise<T>): Promise<T> {
+    const calls: string[] = [];
+
+    probeGlobal.__akMDXFormatProbe = calls;
+
+    return body(calls).finally(() => {
+        delete probeGlobal.__akMDXFormatProbe;
+    });
+}
+
+const EXPRESSION_SOURCE = `Release notes {globalThis.__akMDXFormatProbe?.push("expression")}`;
+const ESM_SOURCE = `export const note = globalThis.__akMDXFormatProbe?.push("esm");\n\nRelease notes`;
+
+describe("ak-mdx content format", () => {
+    it("evaluates expressions and ESM when compiled as MDX", async () => {
+        await withProbe(async (calls) => {
+            await renderWithFormat(EXPRESSION_SOURCE, "mdx");
+            await renderWithFormat(ESM_SOURCE, "mdx");
+
+            expect(calls).toEqual(["expression", "esm"]);
+        });
+    });
+
+    it("does not evaluate expressions when compiled as CommonMark", async () => {
+        await withProbe(async (calls) => {
+            const markup = await renderWithFormat(EXPRESSION_SOURCE, "md");
+
+            expect(calls).toEqual([]);
+            expect(markup).toContain("__akMDXFormatProbe");
+        });
+    });
+
+    it("does not evaluate ESM when compiled as CommonMark", async () => {
+        await withProbe(async (calls) => {
+            const markup = await renderWithFormat(ESM_SOURCE, "md");
+
+            expect(calls).toEqual([]);
+            expect(markup).toContain("export const note");
+        });
+    });
+
+    it("still renders CommonMark features", async () => {
+        const markup = await renderWithFormat(
+            "## Heading\n\n**bold** and _italic_\n\n- one\n- two\n",
+            "md",
+        );
+
+        expect(markup).toContain("<h2>Heading</h2>");
+        expect(markup).toContain("<strong>bold</strong>");
+        expect(markup).toContain("<em>italic</em>");
+        expect(markup).toContain("<li>one</li>");
+    });
+});


### PR DESCRIPTION
## What

`<ak-mdx>` renders two kinds of source:

- documentation authored in-tree and bundled with the web interface, passed as `url`,
- content that comes back from the API, passed as `content` — `user.attributes.notes` (`UserNotesCard.ts`), `group.attributes.notes` (`GroupViewPage.ts`) and blueprint descriptions (`BlueprintListPage.ts`).

Both were compiled with the same `compile()` call, i.e. as MDX. MDX parses expressions (`{...}`), JSX and ESM `import`/`export` in addition to Markdown, and those are evaluated when the compiled module is run by `run()` in `delegateRender()`. So a source that came from the API was evaluated as code in the admin interface.

The `BrandedHTMLPolicy` DOMPurify pass in front of the compiler does not cover this: it operates on HTML, and neither `{...}` nor an `export` statement is HTML — both reach `compile()` unchanged.

Reported privately as GHSA-5vfm-49hj-h95w.

## Change

Thread the compile format through `delegateRender()`:

- `url` (bundled documentation) keeps `format: "mdx"` — unchanged behaviour,
- `content` (from the API) gets `format: "md"`, i.e. CommonMark, so nothing in it is evaluated.

This is a parser-level distinction rather than a filter, so it does not depend on enumerating constructs. The DOMPurify pass stays where it is.

## Behaviour

Measured against the pinned versions (`@mdx-js/mdx` 3.1.1, `dompurify` 3.4.12, `react` 19.2.8), rendering through the same `compile()`/`run()` pipeline the element uses:

| Source in `content` | before | after |
| --- | --- | --- |
| `{...}` expression | evaluated | rendered as text |
| `export const … = …` | evaluated | rendered as text |
| `import "data:text/javascript,…"` | evaluated | rendered as text |
| `<div>{…}</div>` | evaluated | rendered as text |
| headings, bold/italic, lists, GFM tables, fenced code with highlighting, links | rendered | rendered, unchanged |

One intentional difference: raw HTML in `content` (for example `<strong>hi</strong>` in a note) now renders as text instead of as an element. Markdown syntax is unaffected.

## Tests

`web/src/elements/ak-mdx/content-format.unit.test.ts` covers that a source is evaluated under `mdx` and inert under `md`, and that CommonMark still renders.

A note on running them locally: `web/vite.config.js` points the `Unit Tests` project at `./tsconfig.unit.json`, which is not in the tree, so `vitest --project "Unit Tests"` fails during transform before any test runs — including for the existing `custom-elements-get-name.unit.test.ts`. I therefore ran the assertions of the new test as a plain node script against `web/node_modules` (all four pass) rather than through vitest. Happy to look at the missing tsconfig in a separate PR if that is useful.