### PR TITLE
server: avoid looping indefinitely on embedded outpost start

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -363,9 +363,14 @@ pub(crate) async fn start(_cli: Cli, tasks: &mut Tasks) -> Result<Arc<Server>> {
         }
 
         info!("starting embedded outpost");
-        server.proxy_outpost.store(Some(
-            outpost::start::<ProxyOutpost>(outpost::proxy::Cli::default(), tasks, None).await?,
-        ));
+        let proxy_outpost = tokio::select! {
+            res = outpost::start::<ProxyOutpost>(outpost::proxy::Cli::default(), tasks, None) => res?,
+            () = arbiter.shutdown() => {
+                warn!("we were told to shutdown before starting the embedded outpost");
+                return Ok(server);
+            },
+        };
+        server.proxy_outpost.store(Some(proxy_outpost));
     }
 
     Ok(server)


### PR DESCRIPTION
if you ctrl+c at the exact moment between when gunicorn sent a SIGUSR1 to the rust server and when the proxy outpost starts making requests to the backend, the server will loop forever on the outpost_instances_list call, and will need to be `kill -9`'ed. This fixes that.