### PR TITLE
stages/authenticator_validate: unskip flaky test

### DIFF
--- a/authentik/stages/authenticator_validate/tests/test_throttling.py
+++ b/authentik/stages/authenticator_validate/tests/test_throttling.py
@@ -1,5 +1,3 @@
-from unittest import skip
-
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.urls.base import reverse
@@ -210,7 +208,6 @@ class ValidateStageThrottlingFlowTests(FlowTestCase):
             },
         )
 
-    @skip("Flaky test")
     def test_bad_code_then_correct_code_is_still_blocked(self):
         """After a bad code over HTTP, a subsequent correct code is still rejected
         because the lockout persists in the database."""


### PR DESCRIPTION
Reverts goauthentik/authentik#24554

merge with a fix for the test, otherwise, don't