### PR TITLE
root: Ignore local cached TypeScript build info.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ media
 # Node
 
 node_modules
+tsconfig.tsbuildinfo
 
 .cspellcache
 cspell-report.*


### PR DESCRIPTION
## Details

Small fix, preventing TypeScript's `tsconfig.tsbuildinfo` cache files from being committed. These are used by TypeScript to improve build performance and have no use outside of local development.