### PR TITLE
ci: release tag: fix test docker compose project name

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -233,6 +233,7 @@ jobs:
           ref: "${{ needs.bump-version.outputs.release-commit }}"
       - name: Run test in Docker
         env:
+          COMPOSE_PROJECT_NAME: authentik-release-test
           AUTHENTIK_IMAGE: authentik.invalid/goauthentik/server
           AUTHENTIK_TAG: "${{ needs.check-inputs.outputs.version }}"
         run: ./scripts/test_docker.sh

--- a/scripts/test_docker.sh
+++ b/scripts/test_docker.sh
@@ -12,7 +12,7 @@ fi
 
 echo PG_PASS="$(openssl rand -base64 36 | tr -d '\n')" >lifecycle/container/.env
 echo AUTHENTIK_SECRET_KEY="$(openssl rand -base64 60 | tr -d '\n')" >>lifecycle/container/.env
-export COMPOSE_PROJECT_NAME="authentik-test-${AUTHENTIK_TAG}"
+export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-authentik-test-${AUTHENTIK_TAG}}"
 
 if [[ -v BUILD ]]; then
     echo AUTHENTIK_IMAGE="${AUTHENTIK_IMAGE}" >>lifecycle/container/.env


### PR DESCRIPTION
currently fails with
```
invalid project name "authentik-test-2026.8.0-rc1": must consist only of lowercase alphanumeric characters, hyphens, and underscores as well as start with a letter or number
```