### PR TITLE
endpoints/agent: fix Secure Enclave key dropped on first Platform SSO user registration

### DIFF
--- a/authentik/enterprise/endpoints/connectors/agent/tests/test_apple_register.py
+++ b/authentik/enterprise/endpoints/connectors/agent/tests/test_apple_register.py
@@ -8,6 +8,7 @@ from authentik.core.tests.utils import create_test_user
 from authentik.endpoints.connectors.agent.models import (
     AgentConnector,
     AgentDeviceConnection,
+    AgentDeviceUserBinding,
     DeviceAuthenticationToken,
     DeviceToken,
     EnrollmentToken,
@@ -69,15 +70,40 @@ class TestAppleRegister(APITestCase):
             user=self.user,
             token=generate_id(),
         )
+        enclave_key = generate_id()
+        enclave_key_id = generate_id()
         response = self.client.post(
             reverse("authentik_api:psso-register-user"),
             data={
                 "user_auth": device_auth.token,
-                "user_secure_enclave_key": generate_id(),
-                "enclave_key_id": generate_id(),
+                "user_secure_enclave_key": enclave_key,
+                "enclave_key_id": enclave_key_id,
             },
             HTTP_AUTHORIZATION=f"Bearer+agent {self.device_token.key}",
         )
         self.assertEqual(response.status_code, 200)
         body = loads(response.content)
         self.assertEqual(body["username"], self.user.username)
+        # The binding is created here for the first time, so the enclave key must be
+        # persisted by the create branch of update_or_create()
+        binding = AgentDeviceUserBinding.objects.get(target=self.device, user=self.user)
+        self.assertEqual(binding.apple_secure_enclave_key, enclave_key)
+        self.assertEqual(binding.apple_enclave_key_id, enclave_key_id)
+        self.assertTrue(binding.is_primary)
+
+        # Re-registering an existing binding must replace the enclave key
+        new_enclave_key = generate_id()
+        new_enclave_key_id = generate_id()
+        response = self.client.post(
+            reverse("authentik_api:psso-register-user"),
+            data={
+                "user_auth": device_auth.token,
+                "user_secure_enclave_key": new_enclave_key,
+                "enclave_key_id": new_enclave_key_id,
+            },
+            HTTP_AUTHORIZATION=f"Bearer+agent {self.device_token.key}",
+        )
+        self.assertEqual(response.status_code, 200)
+        binding.refresh_from_db()
+        self.assertEqual(binding.apple_secure_enclave_key, new_enclave_key)
+        self.assertEqual(binding.apple_enclave_key_id, new_enclave_key_id)

--- a/authentik/enterprise/endpoints/connectors/agent/views/apple_register.py
+++ b/authentik/enterprise/endpoints/connectors/agent/views/apple_register.py
@@ -113,6 +113,12 @@ class RegisterUserView(APIView):
         ).first()
         if not user_token:
             raise ValidationError("Invalid user authentication")
+        # These fields must be set on create as well as update; update_or_create() returns
+        # immediately when it creates, so anything only in `defaults` is never applied.
+        enclave_keys = {
+            "apple_secure_enclave_key": body.validated_data["user_secure_enclave_key"],
+            "apple_enclave_key_id": body.validated_data["enclave_key_id"],
+        }
         AgentDeviceUserBinding.objects.update_or_create(
             target=conn.device,
             user=user_token.user,
@@ -120,11 +126,9 @@ class RegisterUserView(APIView):
             create_defaults={
                 "is_primary": True,
                 "order": 0,
+                **enclave_keys,
             },
-            defaults={
-                "apple_secure_enclave_key": body.validated_data["user_secure_enclave_key"],
-                "apple_enclave_key_id": body.validated_data["enclave_key_id"],
-            },
+            defaults=enclave_keys,
         )
         return Response(
             UserSelfSerializer(instance=user_token.user, context={"request": request}).data


### PR DESCRIPTION
<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?

`RegisterUserView` passed the Secure Enclave fields to `update_or_create()` in `defaults`
only, with `create_defaults` holding just `is_primary` and `order`. Django's
`update_or_create()` returns immediately when it creates the object, so `defaults` is never
applied on the create path — the enclave key and key ID were silently discarded the first
time a user registered, and the endpoint still returned 200.

The fields are now passed in both `create_defaults` and `defaults`.

`test_register_user` previously asserted only the response status and username, which is why
this went unnoticed. It now asserts that the enclave key and key ID are persisted on create,
and that re-registering replaces them.

### Why is this change needed?

Platform SSO is unusable after a first-time registration. The binding is written with an
empty `apple_enclave_key_id`, so `validate_embedded_assertion()` in `apple_token.py` cannot
match the assertion to a binding or an independent enclave, and the token exchange fails.

The bug only bites on the create path — a second registration takes the update branch, where
`defaults` does apply and the key is written correctly. That makes it easy to miss in manual
testing and is likely why it survived review.

### How was this tested?

Reproduced end to end against a live macOS 26.6 device with authentik Agent 0.50.5, before
applying the fix:

- `POST /api/v3/endpoints/agents/psso/register/user/` → 200
- the resulting binding had `apple_enclave_key_id = ''` and a zero-length
  `apple_secure_enclave_key`
- the next `POST /endpoints/agent/psso/token/` failed, logging
  `Could not find device user binding or independent enclave for user`

### Linked issues

<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
