### PR TITLE
endpoints/agent: return 400 instead of 500 for invalid Platform SSO token requests

### DIFF
--- a/authentik/enterprise/endpoints/connectors/agent/tests/test_apple_token.py
+++ b/authentik/enterprise/endpoints/connectors/agent/tests/test_apple_token.py
@@ -116,6 +116,77 @@ class TestAppleToken(TestCase):
         self.assertEqual(event.context["device"]["name"], self.device.name)
 
     @reconcile_app("authentik_crypto")
+    def test_token_unknown_kid(self):
+        """An assertion signed by a key ID we don't know must be rejected with a 400"""
+        assertion = encode(
+            {
+                "iss": str(self.connector.pk),
+                "aud": "http://testserver/endpoints/agent/psso/token/",
+                "request_nonce": generate_id(),
+            },
+            self.apple_sign_key.private_key,
+            headers={
+                "kid": generate_id(),
+            },
+            algorithm=JWTAlgorithms.from_private_key(self.apple_sign_key.private_key),
+        )
+        res = self.client.post(
+            reverse("authentik_enterprise_endpoints_connectors_agent:psso-token"),
+            data={
+                "assertion": assertion,
+                "platform_sso_version": "1.0",
+                "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+            },
+        )
+        self.assertEqual(res.status_code, 400)
+
+    @reconcile_app("authentik_crypto")
+    def test_token_unregistered_enclave(self):
+        """A device with no Secure Enclave key registered must be rejected with a 400"""
+        AgentDeviceUserBinding.objects.all().update(apple_enclave_key_id="")
+        nonce = generate_id()
+        AppleNonce.objects.create(
+            device_token=self.device_token,
+            nonce=nonce,
+        )
+        embedded = encode(
+            {"iss": str(self.connector.pk), "aud": str(self.device.pk), "request_nonce": nonce},
+            self.apple_sign_key.private_key,
+            headers={
+                "kid": self.apple_sign_key.kid,
+            },
+            algorithm=JWTAlgorithms.from_private_key(self.apple_sign_key.private_key),
+        )
+        assertion = encode(
+            {
+                "iss": str(self.connector.pk),
+                "aud": "http://testserver/endpoints/agent/psso/token/",
+                "request_nonce": nonce,
+                "assertion": embedded,
+                "jwe_crypto": {
+                    "apv": (
+                        "AAAABUFwcGxlAAAAQQTFgZOospN6KbkhXhx1lfa-AKYxjEfJhTJrkpdEY_srMmkPzS7VN0Bzt2AtNBEXE"
+                        "aphDONiP2Mq6Oxytv5JKOxHAAAAJDgyOThERkY5LTVFMUUtNEUwMS04OEUwLUI3QkQzOUM4QjA3Qw"
+                    )
+                },
+            },
+            self.apple_sign_key.private_key,
+            headers={
+                "kid": self.apple_sign_key.kid,
+            },
+            algorithm=JWTAlgorithms.from_private_key(self.apple_sign_key.private_key),
+        )
+        res = self.client.post(
+            reverse("authentik_enterprise_endpoints_connectors_agent:psso-token"),
+            data={
+                "assertion": assertion,
+                "platform_sso_version": "1.0",
+                "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+            },
+        )
+        self.assertEqual(res.status_code, 400)
+
+    @reconcile_app("authentik_crypto")
     def test_token_independent(self):
         nonce = generate_id()
 

--- a/authentik/enterprise/endpoints/connectors/agent/views/apple_token.py
+++ b/authentik/enterprise/endpoints/connectors/agent/views/apple_token.py
@@ -41,6 +41,15 @@ class TokenView(View):
     device_connection: AgentDeviceConnection
     connector: AgentConnector
 
+    def dispatch(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        # This is a plain Django View, so DRF's exception handler never runs and a
+        # ValidationError raised below would surface as a 500 instead of a 400.
+        try:
+            return super().dispatch(request, *args, **kwargs)
+        except ValidationError as exc:
+            LOGGER.warning("Invalid Platform SSO token request", exc=exc)
+            return HttpResponse(status=400)
+
     def post(self, request: HttpRequest) -> HttpResponse:
         assertion = request.POST.get("assertion", request.POST.get("request"))
         if not assertion:
@@ -51,6 +60,8 @@ class TokenView(View):
         except PyJWTError as exc:
             LOGGER.warning("failed to parse JWT", exc=exc)
             raise ValidationError("Invalid request") from None
+        if self.jwt_request is None:
+            return HttpResponse(status=400)
         version = request.POST.get("platform_sso_version")
         grant_type = request.POST.get("grant_type")
         handler_func = (
@@ -66,7 +77,7 @@ class TokenView(View):
         LOGGER.debug("sending to handler", handler=handler_func)
         return handler()
 
-    def validate_request_token(self, assertion: str) -> dict[str, Any]:
+    def validate_request_token(self, assertion: str) -> dict[str, Any] | None:
         # Decode without validation to get header
         header = get_unverified_header(assertion)
         LOGGER.debug("token header", header=header)
@@ -77,6 +88,9 @@ class TokenView(View):
             .select_related("device")
             .first()
         )
+        if not self.device_connection:
+            LOGGER.warning("No device connection found for key ID", kid=expected_kid)
+            return None
         self.connector = AgentConnector.objects.get(pk=self.device_connection.connector.pk)
         LOGGER.debug("got device", device=self.device_connection.device)
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?

Two error-handling fixes in the Platform SSO token endpoint:

- `validate_request_token()` used the result of a `.first()` lookup without checking it. An
  assertion whose `kid` matches no `AgentDeviceConnection` raised
  `AttributeError: 'NoneType' object has no attribute 'connector'`. It now logs the
  unmatched key ID and returns `None`, and `post()` turns that into a 400.
- `TokenView` is a plain Django `View`, so DRF's exception handler never runs and the
  `ValidationError`s raised throughout the class escaped as HTTP 500. A `dispatch()`
  override now catches them and returns 400.

### Why is this change needed?

Both cases are client errors — an unknown key ID, a device with no Secure Enclave key
registered, a replayed nonce — but they surfaced as 500s. That points debugging at the
server rather than at the device's registration state, and it makes them indistinguishable
from genuine faults in logs and monitoring.

### How was this tested?

Observed against a live macOS 26.6 device with authentik Agent 0.50.5: a device whose
binding carried no enclave key produced
`POST /endpoints/agent/psso/token/ -> 500` with `ValidationError('Invalid request')`, from
`Could not find device user binding or independent enclave for user`.

Two regression tests were added to `TestAppleToken`: one for an assertion signed with an
unknown `kid`, one for a device with no enclave key registered. Both assert 400.

### Linked issues

<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
