### PR TITLE
fix pipeline for version 2026.5

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -18922,9 +18922,9 @@
             }
         },
         "node_modules/openapi-to-postmanv2": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/openapi-to-postmanv2/-/openapi-to-postmanv2-6.3.0.tgz",
-            "integrity": "sha512-Gx047TkS+GlAVzNlUIz2Kfgk9GquxAvO2P2uQgF/qRPkaF0SGQZ9fVlev3xKaboweXZly1QSnhJOo+yNEFnM6A==",
+            "version": "6.3.2",
+            "resolved": "https://registry.npmjs.org/openapi-to-postmanv2/-/openapi-to-postmanv2-6.3.2.tgz",
+            "integrity": "sha512-5F8l6OIFlBvhpFwq7tqo2LAkY1t0kx34/I8foTVcmglmI3cd4065va/FTKjlJiRa+y80V79sCeCKdLdrXZ3e3g==",
             "license": "Apache-2.0",
             "dependencies": {
                 "ajv": "^8.11.0",


### PR DESCRIPTION
<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?

There is a funky state that keeps happening where running ci doesn't give back the same package version number as npm install gives back. Just patching this until we don't support this version branch anymore

### Why is this change needed?

### How was this tested?

### Linked issues

<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
