### PR TITLE
website/docs: correct authentik Agent CLI reference and macOS logging paths

### DIFF
--- a/website/docs/endpoint-devices/authentik-agent/agent-deployment/macos.md
+++ b/website/docs/endpoint-devices/authentik-agent/agent-deployment/macos.md
@@ -88,7 +88,17 @@ ak version
 
 ## Logging
 
-The authentik Agent uses macOS's native logging abilities. To retrieve the logs, open the Console application and then filter for authentik-related processes such as `authentik-agent` or `authentik-sysd`.
+The system agent writes its output to a log file:
+
+```sh
+sudo tail -f /Library/Logs/io.goauthentik/sysd.log
+```
+
+The user agent uses macOS's native logging abilities. To retrieve its logs, open the Console application and filter for the `ak-agent-desktop` process, or run:
+
+```sh
+log show --last 30m --predicate 'process == "ak-agent-desktop"' --info --debug
+```
 
 ## Reporting issues
 

--- a/website/docs/endpoint-devices/authentik-agent/authentik-cli.mdx
+++ b/website/docs/endpoint-devices/authentik-agent/authentik-cli.mdx
@@ -13,6 +13,16 @@ Use the `-h`/`--help` flag to access help information.
 
 ## authentik-cli commands
 
+### api
+
+Directly interact with the authentik API, authenticated as the active profile's user.
+
+```bash
+ak api <command>
+```
+
+The subcommands are generated from the authentik API schema. Run `ak api --help` to list the ones available in your version.
+
 ### auth
 
 Commands for authenticating with different CLI applications.
@@ -24,7 +34,7 @@ ak auth <command>
 - `aws` - Authenticate to AWS with the authentik profile.
 - `kubectl` - Authenticate to a Kubernetes Cluster with the authentik profile.
 - `raw` - Authenticate to arbitrary API calls.
-- `vault` - Generate a JWT for authenticating to HashiCorp Vault.
+- `vault` - Generate a JWT for authenticating to HashiCorp Vault. Available up to authentik Agent 0.43.2; removed in 0.44.0.
 
 ### completion
 
@@ -60,9 +70,19 @@ ak help <command>
 
 Where `<command>` is any authentik CLI command you want help with, for example: `ak help whoami`
 
+### switch-profile
+
+Switch to a different active profile. Can be shortened to `ak s`.
+
+```bash
+ak switch-profile <profile>
+```
+
+Where `<profile>` is the name of a profile reported by `ak config list-profiles`.
+
 ### system
 
-Commands for interacting with authentik sessions.
+Commands for interacting with authentik sessions. Available up to authentik Agent 0.43.2; removed in 0.44.0.
 
 ```bash
 ak system <command>


### PR DESCRIPTION
<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?

Adds some missing commands, notes some removed commands, and updates logging information for mac

### Why is this change needed?

### How was this tested?

### Linked issues

<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
