### PR TITLE
ci: release tag: fix attestation permissions

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -254,6 +254,10 @@ jobs:
       - build-rust-binaries
       - test
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     steps:
       - id: app-token
         name: Generate app token
@@ -300,7 +304,6 @@ jobs:
             container/radius.oci.tar
             container/rac.oci.tar
             binaries/authentik-outpost-*
-          github-token: "${{ steps.app-token.outputs.token }}"
       - name: Create Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:


### PR DESCRIPTION
The Create release job failed in actions/attest before it could create the draft release because the job-scoped GITHUB_TOKEN could not mint the OIDC token used to request a Sigstore signing certificate.

Scope the new permissions to create-release so build and test jobs do not gain release credentials:

- id-token: write allows actions/attest to mint the short-lived OIDC token required for Sigstore signing. This directly fixes the reported failure.
- attestations: write allows the signed provenance to be persisted in the repository's attestation store.
- artifact-metadata: write allows actions/attest to create the artifact storage metadata required by the pinned action version.

Remove the github-token override from actions/attest so it uses the explicitly permissioned job-scoped GITHUB_TOKEN. The authentik Automation App does not have attestation permissions, so its token would fail when the action tried to persist the provenance after obtaining the OIDC token. Continue using the App token for checkout, tag creation, and draft release creation, where its repository write permissions are required.

Failed run: https://github.com/goauthentik/authentik/actions/runs/30651490530/job/91240818711

<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?

### Why is this change needed?

### How was this tested?

### Linked issues

<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
