### PR TITLE
web: improve user header at intermediate widths

### DIFF
--- a/web/src/user/ak-interface-user.css
+++ b/web/src/user/ak-interface-user.css
@@ -15,6 +15,16 @@
     }
 }
 
+@media screen and (992px <= width < 1200px) {
+    .pf-c-page__header-nav {
+        --pf-c-page__header-nav--PaddingRight: var(--pf-global--spacer--lg);
+        --pf-c-page__header-nav--PaddingLeft: var(--pf-global--spacer--lg);
+
+        grid-column: 2 / 3;
+        grid-row: 1 / 2;
+    }
+}
+
 .pf-c-brand {
     min-height: 2rem;
     height: 2rem;


### PR DESCRIPTION
Before:

<img width="2980" height="280" alt="image" src="https://github.com/user-attachments/assets/7eadb082-31cd-411c-bb06-d05af865085c" />

After:

<img width="2050" height="166" alt="image" src="https://github.com/user-attachments/assets/3d7a2281-800c-4986-beb2-dfcd128c1c9f" />
