### PR TITLE
web: fix file search input interactions

### DIFF
--- a/web/src/admin/files/FileListPage.ts
+++ b/web/src/admin/files/FileListPage.ts
@@ -8,6 +8,7 @@ import { aki } from "#common/api/client";
 import { createPaginatedResponse } from "#common/api/responses";
 import { docLink } from "#common/global";
 
+import { ModalInvokerButton } from "#elements/dialogs";
 import { WithCapabilitiesConfig } from "#elements/mixins/capabilities";
 import { getURLParam } from "#elements/router/RouteMatch";
 import { PaginatedResponse, TableColumn } from "#elements/table/Table";
@@ -16,22 +17,18 @@ import { SlottedTemplateResult } from "#elements/types";
 
 import { FileUploadForm } from "#admin/files/FileUploadForm";
 
-import { AdminApi, CapabilitiesEnum, UsageEnum } from "@goauthentik/api";
+import { AdminApi, CapabilitiesEnum, FileList, UsageEnum } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { html, nothing, PropertyValues, TemplateResult } from "lit";
+import { html, PropertyValues, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
-export interface FileItem {
-    name: string;
-    url: string;
-    mimeType: string;
-}
+export type FileListItem = Pick<FileList, "name" | "url" | "mimeType">;
 
 export type FileListOrderKey = "name" | "mimeType";
 
 @customElement("ak-files-list")
-export class FileListPage extends WithCapabilitiesConfig(TablePage<FileItem>) {
+export class FileListPage extends WithCapabilitiesConfig(TablePage<FileListItem>) {
     public override checkbox = true;
     public override clearOnRefresh = true;
 
@@ -47,24 +44,18 @@ export class FileListPage extends WithCapabilitiesConfig(TablePage<FileItem>) {
     public override firstUpdated(changed: PropertyValues<this>): void {
         super.firstUpdated(changed);
 
-        if (!getURLParam("upload", false) || !this.can(CapabilitiesEnum.CanSaveMedia)) {
-            return;
+        if (getURLParam("upload", false) && this.can(CapabilitiesEnum.CanSaveMedia)) {
+            FileUploadForm.showModal();
         }
-
-        const uploadForm = new FileUploadForm();
-        uploadForm.headline = msg("Upload File");
-        uploadForm.submitLabel = msg("Upload");
-        uploadForm.showModal().then(() => this.fetch());
     }
 
-    async apiEndpoint(): Promise<PaginatedResponse<FileItem>> {
+    async apiEndpoint(): Promise<PaginatedResponse<FileListItem>> {
         const api = aki(AdminApi);
-        // Cast necessary: API returns File objects but we only use name, url, and mimeType properties
-        const items = (await api.adminFileList({
+        const items = await api.adminFileList({
             usage: UsageEnum.Media,
             manageableOnly: true,
             ...(this.search ? { search: this.search } : {}),
-        })) as unknown as FileItem[];
+        });
 
         // Wrap array response in paginated response structure
         return createPaginatedResponse(items);
@@ -76,27 +67,29 @@ export class FileListPage extends WithCapabilitiesConfig(TablePage<FileItem>) {
         [msg("Actions"), null, msg("Row Actions")],
     ];
 
-    renderToolbarSelected() {
+    protected override renderToolbarSelected() {
         if (!this.can(CapabilitiesEnum.CanSaveMedia)) {
-            return nothing;
+            return null;
         }
+
         const disabled = !this.selectedElements.length;
         const count = this.selectedElements.length;
+
         return html`<ak-forms-delete-bulk
             object-label=${count === 1 ? msg("file") : msg("files")}
             .objects=${this.selectedElements}
-            .metadata=${(item: FileItem) => {
+            .metadata=${(item: FileListItem) => {
                 return [
                     { key: msg("Name"), value: item.name },
                     { key: msg("Type"), value: item.mimeType },
                 ];
             }}
-            .usedBy=${(item: FileItem) => {
+            .usedBy=${(item: FileListItem) => {
                 return aki(AdminApi).adminFileUsedByList({
                     name: item.name,
                 });
             }}
-            .delete=${(item: FileItem) => {
+            .delete=${(item: FileListItem) => {
                 return aki(AdminApi).adminFileDestroy({
                     name: item.name,
                     usage: UsageEnum.Media,
@@ -109,10 +102,10 @@ export class FileListPage extends WithCapabilitiesConfig(TablePage<FileItem>) {
         </ak-forms-delete-bulk>`;
     }
 
-    row(item: FileItem): SlottedTemplateResult[] {
+    row(item: FileListItem): SlottedTemplateResult[] {
         return [
-            html`<div>${item.name}</div>`,
-            html`<div>${item.mimeType || msg("-")}</div>`,
+            item.name,
+            item.mimeType || msg("-"),
             html`<div>
                 <a
                     class="pf-c-button pf-m-plain"
@@ -150,20 +143,8 @@ export class FileListPage extends WithCapabilitiesConfig(TablePage<FileItem>) {
         );
     }
 
-    protected renderObjectCreate() {
-        if (!this.can(CapabilitiesEnum.CanSaveMedia)) {
-            return nothing;
-        }
-        return html`
-            <ak-forms-modal>
-                <span slot="submit">${msg("Upload")}</span>
-                <span slot="header">${msg("Upload File")}</span>
-                <ak-file-upload-form slot="form"> </ak-file-upload-form>
-                <button slot="trigger" class="pf-c-button pf-m-primary">
-                    ${msg("Upload File")}
-                </button>
-            </ak-forms-modal>
-        `;
+    protected override renderObjectCreate(): SlottedTemplateResult {
+        return ModalInvokerButton(FileUploadForm);
     }
 }
 

--- a/web/src/admin/files/FileListPage.ts
+++ b/web/src/admin/files/FileListPage.ts
@@ -1,4 +1,3 @@
-import "#admin/files/FileUploadForm";
 import "#elements/buttons/SpinnerButton/index";
 import "#elements/forms/DeleteBulkForm";
 import "#elements/forms/ModalForm";
@@ -10,14 +9,17 @@ import { createPaginatedResponse } from "#common/api/responses";
 import { docLink } from "#common/global";
 
 import { WithCapabilitiesConfig } from "#elements/mixins/capabilities";
+import { getURLParam } from "#elements/router/RouteMatch";
 import { PaginatedResponse, TableColumn } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
 import { SlottedTemplateResult } from "#elements/types";
 
+import { FileUploadForm } from "#admin/files/FileUploadForm";
+
 import { AdminApi, CapabilitiesEnum, UsageEnum } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { html, nothing, TemplateResult } from "lit";
+import { html, nothing, PropertyValues, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 export interface FileItem {
@@ -41,6 +43,19 @@ export class FileListPage extends WithCapabilitiesConfig(TablePage<FileItem>) {
 
     @property({ type: String, useDefault: true })
     public order: FileListOrderKey = "name";
+
+    public override firstUpdated(changed: PropertyValues<this>): void {
+        super.firstUpdated(changed);
+
+        if (!getURLParam("upload", false) || !this.can(CapabilitiesEnum.CanSaveMedia)) {
+            return;
+        }
+
+        const uploadForm = new FileUploadForm();
+        uploadForm.headline = msg("Upload File");
+        uploadForm.submitLabel = msg("Upload");
+        uploadForm.showModal().then(() => this.fetch());
+    }
 
     async apiEndpoint(): Promise<PaginatedResponse<FileItem>> {
         const api = aki(AdminApi);

--- a/web/src/admin/files/FileUploadForm.ts
+++ b/web/src/admin/files/FileUploadForm.ts
@@ -1,144 +1,111 @@
 import "#elements/forms/HorizontalFormElement";
+import "#components/ak-text-input";
 
 import { aki } from "#common/api/client";
+import { PFSize } from "#common/enums";
 import { docLink } from "#common/global";
-import { MessageLevel } from "#common/messages";
 
 import { Form } from "#elements/forms/Form";
 import { PreventFormSubmit } from "#elements/forms/helpers";
-import { showMessage } from "#elements/messages/MessageContainer";
+import { SlottedTemplateResult } from "#elements/types";
+import {
+    assertValidFileName,
+    FileNamePattern,
+    formatValidationMessage,
+    getFileExtension,
+} from "#elements/utils/files";
 
-import { AdminApi, UsageEnum } from "@goauthentik/api";
+import { AKLabel } from "#components/ak-label";
+
+import { AdminApi, AdminFileCreateRequest, UsageEnum } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
 import { html } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
-import { createRef, ref } from "lit/directives/ref.js";
+import { customElement, property } from "lit/decorators.js";
 
-// Theme variable placeholder for theme-specific files like logo-%(theme)s.png
-const THEME_VARIABLE = "%(theme)s";
-
-// Same regex is used in the backend as well (after replacing %(theme)s)
-const VALID_FILE_NAME_PATTERN = /^[a-zA-Z0-9._/-]+$/;
-
-// Note: browsers compile `pattern` using the new `v` RegExp flag (Unicode sets). Under `/v`,
-// both `/` and `-` must be escaped inside character classes.
-// This pattern allows %(theme)s by including %, (, and ) characters
-const VALID_FILE_NAME_PATTERN_STRING = "^[a-zA-Z0-9._\\/\\-%()+]+$";
-
-function assertValidFileName(fileName: string): void {
-    // Allow %(theme)s placeholder for theme-specific files
-    // Replace with placeholder for validation, then check the result
-    const nameForValidation = fileName.replaceAll(THEME_VARIABLE, "theme");
-    if (!VALID_FILE_NAME_PATTERN.test(nameForValidation)) {
-        throw new Error(
-            msg(
-                "Filename can only contain letters, numbers, dots, hyphens, underscores, slashes, and the placeholder %(theme)s",
-            ),
-        );
-    }
-}
-
-function getFileExtension(fileName: string): string {
-    const lastDot = fileName.lastIndexOf(".");
-    if (lastDot <= 0) return "";
-    return fileName.slice(lastDot);
+interface FileUploadFormData {
+    /**
+     * Fake path provided by the browser for the selected file.
+     */
+    file: string;
+    /**
+     * Custom name for the file, without an extension.
+     */
+    name: string;
 }
 
 @customElement("ak-file-upload-form")
-export class FileUploadForm extends Form<Record<string, unknown>> {
+export class FileUploadForm extends Form<FileUploadFormData> {
+    public static override verboseName = msg("File");
+    public static override verboseNamePlural = msg("Files");
+    public static override submitVerb = msg("Upload");
+    public static override createLabel = msg("Upload");
+    public override headline = msg("Select File");
+
+    public override size = PFSize.Medium;
+
     @property({ type: String, useDefault: true })
     public usage: UsageEnum = UsageEnum.Media;
 
-    @state()
-    protected selectedFile: File | null = null;
+    public override async send(data: FileUploadFormData): Promise<AdminFileCreateRequest> {
+        const file = this.files<keyof FileUploadFormData>().get("file");
 
-    #formRef = createRef<HTMLFormElement>();
-
-    public override reset(): void {
-        super.reset();
-
-        this.selectedFile = null;
-    }
-
-    #fileChangeListener = (e: Event) => {
-        const input = e.target as HTMLInputElement;
-        if (input.files?.length) {
-            this.selectedFile = input.files[0];
-        } else {
-            this.selectedFile = null;
-        }
-    };
-
-    protected clearFileInput() {
-        this.selectedFile = null;
-        this.#formRef.value?.reset();
-    }
-
-    public override async send(data: Record<string, unknown>): Promise<void> {
-        if (!this.selectedFile) {
+        if (!file) {
             throw new PreventFormSubmit("Selected file not provided", this);
         }
 
-        const api = aki(AdminApi);
         const customName = typeof data.name === "string" ? data.name.trim() : "";
 
         // If custom name provided, append original file extension; otherwise use original filename
-        const finalName = customName
-            ? `${customName}${getFileExtension(this.selectedFile.name)}`
-            : this.selectedFile.name;
+        const finalName = customName ? `${customName}${getFileExtension(file.name)}` : file.name;
 
         assertValidFileName(finalName);
 
-        await api.adminFileCreate({
-            file: this.selectedFile,
+        const payload: AdminFileCreateRequest = {
+            file,
             name: finalName,
             usage: this.usage,
-        });
+        };
 
-        showMessage({
-            level: MessageLevel.success,
-            message: msg("File uploaded successfully"),
-        });
-
-        this.reset();
-        this.clearFileInput();
+        return aki(AdminApi)
+            .adminFileCreate(payload)
+            .then(() => payload);
     }
 
-    renderForm() {
-        return html`
-            <form ${ref(this.#formRef)} class="pf-c-form pf-m-horizontal">
-                <ak-form-element-horizontal label=${msg("File")} required>
-                    <input
-                        type="file"
-                        class="pf-c-form-control"
-                        id="file-input"
-                        required
-                        @change=${this.#fileChangeListener}
-                    />
-                </ak-form-element-horizontal>
-                <ak-form-element-horizontal label=${msg("File Name")} name="name">
-                    <input
-                        type="text"
-                        class="pf-c-form-control"
-                        pattern=${VALID_FILE_NAME_PATTERN_STRING}
-                        placeholder=${msg("Type an optional custom file name...")}
-                    />
-                    <p class="pf-c-form__helper-text">
-                        ${msg(
-                            "Optionally rename the file (without extension). Leave empty to keep the original filename.",
-                        )}
-                        <a
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            href=${docLink("/customize/file-picker/")}
-                        >
-                            ${msg("See documentation for path rules and theme-aware names.")}
-                        </a>
-                    </p>
-                </ak-form-element-horizontal>
-            </form>
-        `;
+    protected override renderForm(): SlottedTemplateResult {
+        const validationMessage = formatValidationMessage();
+
+        return html`<ak-form-element-horizontal required name="file">
+                ${AKLabel(
+                    {
+                        slot: "label",
+                        className: "pf-c-form__group-label",
+                        htmlFor: "file-input",
+                        required: true,
+                    },
+                    msg("File"),
+                )}
+                <input type="file" class="pf-c-form-control" id="file-input" required />
+            </ak-form-element-horizontal>
+            <ak-text-input
+                name="name"
+                autocomplete="off"
+                control-title=${validationMessage}
+                pattern=${FileNamePattern.DOM}
+                placeholder=${msg("Type an optional file name without an extension...")}
+                label=${msg("Custom Name")}
+                .bighelp=${html`<p class="pf-c-form__helper-text">
+                    ${msg("Leave empty to keep the original filename.")} ${validationMessage}
+                    <a
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        href=${docLink("/customize/file-picker/")}
+                    >
+                        <br />
+                        ${msg("See documentation for path rules and theme-aware names.")}
+                    </a>
+                </p>`}
+            ></ak-text-input>`;
     }
 }
 

--- a/web/src/components/ak-file-search-input.css
+++ b/web/src/components/ak-file-search-input.css
@@ -1,0 +1,9 @@
+.ak-file-search-input__actions {
+    display: inline-flex;
+    gap: var(--pf-global--spacer--xs);
+    margin-inline-start: var(--pf-global--spacer--sm);
+}
+
+.ak-file-search-input__separator {
+    color: var(--pf-global--Color--200);
+}

--- a/web/src/components/ak-file-search-input.css
+++ b/web/src/components/ak-file-search-input.css
@@ -1,9 +1,8 @@
-.ak-file-search-input__actions {
-    display: inline-flex;
-    gap: var(--pf-global--spacer--xs);
-    margin-inline-start: var(--pf-global--spacer--sm);
+.ak-file-search-input__select {
+    flex: 1;
+    min-width: 0;
 }
 
-.ak-file-search-input__separator {
-    color: var(--pf-global--Color--200);
+.ak-file-search-input__documentation {
+    margin-inline-start: var(--pf-global--spacer--sm);
 }

--- a/web/src/components/ak-file-search-input.ts
+++ b/web/src/components/ak-file-search-input.ts
@@ -4,20 +4,29 @@ import "#elements/forms/SearchSelect/index";
 import HostStyles from "./ak-file-search-input.css";
 
 import { aki } from "#common/api/client";
-import { docLink, globalAK } from "#common/global";
+import { PFSize } from "#common/enums";
+import { docLink } from "#common/global";
 
 import { AKElement } from "#elements/Base";
-import { paramURL } from "#elements/router/RouterOutlet";
+import { renderModal } from "#elements/dialogs";
+import { AKFormSubmittedEvent } from "#elements/forms/events";
+import SearchSelect from "#elements/forms/SearchSelect/index";
+import { SlottedTemplateResult } from "#elements/types";
+import { ifPresent } from "#elements/utils/attributes";
 
 import { AKLabel } from "#components/ak-label";
 
-import { AdminApi, FileList, UsageEnum } from "@goauthentik/api";
+import { FileUploadForm } from "#admin/files/FileUploadForm";
+
+import { ConsoleLogger } from "#logger/browser";
+
+import { AdminApi, AdminFileCreateRequest, FileList, UsageEnum } from "@goauthentik/api";
 import { IDGenerator } from "@goauthentik/core/id";
 
 import { msg } from "@lit/localize";
 import { html } from "lit";
 import { customElement, property } from "lit/decorators.js";
-import { ifDefined } from "lit/directives/if-defined.js";
+import { createRef, ref } from "lit/directives/ref.js";
 
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFInputGroup from "@patternfly/patternfly/components/InputGroup/input-group.css";
@@ -39,6 +48,8 @@ export class AKFileSearchInput extends AKElement {
     protected createRenderRoot() {
         return this;
     }
+
+    protected logger = ConsoleLogger.prefix(`model-form/${this.localName}`);
 
     @property({ type: String })
     public name: string | null = null;
@@ -64,15 +75,65 @@ export class AKFileSearchInput extends AKElement {
     @property({ type: String, reflect: false })
     public fieldID?: string = IDGenerator.elementID().toString();
 
+    protected fileSearchRef = createRef<SearchSelect>();
+
+    protected openFileUploadModal = (invocationEvent?: Event) => {
+        invocationEvent?.stopPropagation();
+
+        const fileUploadForm = new FileUploadForm();
+
+        let createdFile: AdminFileCreateRequest | null = null;
+
+        fileUploadForm.addEventListener(AKFormSubmittedEvent.eventName, (event) => {
+            createdFile = (event as AKFormSubmittedEvent<AdminFileCreateRequest>).response;
+        });
+
+        return renderModal(fileUploadForm, {
+            invokerElement:
+                invocationEvent?.target instanceof HTMLElement ? invocationEvent.target : this,
+            size: PFSize.Medium,
+            onDispose: (disposeEvent) => {
+                const { target } = disposeEvent || {};
+
+                if (!(target instanceof HTMLDialogElement) || target.returnValue !== "submitted") {
+                    return;
+                }
+
+                const fileSearch = this.fileSearchRef.value;
+
+                if (!fileSearch) {
+                    this.logger.error(
+                        "Failed to refresh file search after creating new file. No file search found.",
+                    );
+
+                    return;
+                }
+
+                // Refresh the file search and select the newly created file.
+                if (!createdFile) {
+                    this.logger.error(
+                        "File upload form closed as submitted, but no created file was captured.",
+                    );
+
+                    return;
+                }
+
+                this.value = createdFile.name ?? "";
+
+                return fileSearch.updateData();
+            },
+        });
+    };
+
     #selected = (item: FileList) => {
         return this.value === item.name;
     };
 
-    #changeListener(event: CustomEvent<{ value: FileList | null }>) {
+    protected changeListener = (event: CustomEvent<{ value: FileList | null }>) => {
         this.value = event.detail.value?.name ?? "";
-    }
+    };
 
-    async #fetch(query?: string): Promise<FileList[]> {
+    protected refresh = async (query?: string): Promise<FileList[]> => {
         const results = await aki(AdminApi).adminFileList({
             usage: this.usage,
             ...(query ? { search: query.toLocaleLowerCase() } : {}),
@@ -92,12 +153,12 @@ export class AKFileSearchInput extends AKElement {
         }
 
         return results;
-    }
+    };
 
-    render() {
+    protected override render(): SlottedTemplateResult {
         const uploadLabel = msg("Upload file", { id: "file-picker.upload-link.label" });
 
-        return html` <ak-form-element-horizontal name=${ifDefined(this.name ?? undefined)}>
+        return html`<ak-form-element-horizontal name=${ifPresent(this.name)}>
             ${AKLabel(
                 {
                     slot: "label",
@@ -110,9 +171,10 @@ export class AKFileSearchInput extends AKElement {
 
             <div class="pf-c-input-group">
                 <ak-search-select
+                    ${ref(this.fileSearchRef)}
                     class="ak-file-search-input__select"
                     .fieldID=${this.fieldID}
-                    .fetchObjects=${this.#fetch.bind(this)}
+                    .fetchObjects=${this.refresh.bind(this)}
                     .renderElement=${renderElement}
                     .value=${renderValue}
                     .selected=${this.#selected}
@@ -121,19 +183,19 @@ export class AKFileSearchInput extends AKElement {
                     })}
                     ?blankable=${this.blankable}
                     creatable
-                    @ak-change=${this.#changeListener}
-                >
-                </ak-search-select>
-                <a
+                    @ak-change=${this.changeListener}
+                    action-label=${msg("Upload a file", { id: "file-picker.upload-link.label" })}
+                    @ak-search-select-action=${this.openFileUploadModal}
+                ></ak-search-select>
+                <button
+                    @click=${this.openFileUploadModal}
+                    type="button"
                     class="pf-c-button pf-m-control"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    href=${`${globalAK().api.base}if/admin/${paramURL("/files", { upload: true })}`}
                     aria-label=${uploadLabel}
                     title=${uploadLabel}
                 >
                     <i class="fas fa-upload" aria-hidden="true"></i>
-                </a>
+                </button>
             </div>
             <p class="pf-c-form__helper-text">
                 ${this.help

--- a/web/src/components/ak-file-search-input.ts
+++ b/web/src/components/ak-file-search-input.ts
@@ -184,7 +184,7 @@ export class AKFileSearchInput extends AKElement {
                     ?blankable=${this.blankable}
                     creatable
                     @ak-change=${this.changeListener}
-                    action-label=${msg("Upload a file", { id: "file-picker.upload-link.label" })}
+                    action-label=${uploadLabel}
                     @ak-search-select-action=${this.openFileUploadModal}
                 ></ak-search-select>
                 <button

--- a/web/src/components/ak-file-search-input.ts
+++ b/web/src/components/ak-file-search-input.ts
@@ -2,14 +2,13 @@ import "#elements/forms/HorizontalFormElement";
 import "#elements/forms/SearchSelect/index";
 
 import { aki } from "#common/api/client";
-import { parseAPIResponseError, pluckErrorDetail } from "#common/errors/network";
 import { docLink } from "#common/global";
 
 import { AKElement } from "#elements/Base";
 
 import { AKLabel } from "#components/ak-label";
 
-import { AdminApi, UsageEnum } from "@goauthentik/api";
+import { AdminApi, FileList, UsageEnum } from "@goauthentik/api";
 import { IDGenerator } from "@goauthentik/core/id";
 
 import { msg } from "@lit/localize";
@@ -17,16 +16,8 @@ import { html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
-interface FileItem {
-    name: string;
-    url: string;
-    mime_type: string;
-    size: number;
-    usage: string;
-}
-
-const renderElement = (item: FileItem) => item.name;
-const renderValue = (item?: FileItem | null) => item?.name;
+const renderElement = (item: FileList) => item.name;
+const renderValue = (item?: FileList | null) => item?.name;
 
 /**
  * File Search Input Component
@@ -65,60 +56,34 @@ export class AKFileSearchInput extends AKElement {
     @property({ type: String, reflect: false })
     public fieldID?: string = IDGenerator.elementID().toString();
 
-    #selected = (item: FileItem) => {
+    #selected = (item: FileList) => {
         return this.value === item.name;
     };
 
-    public override firstUpdated() {
-        // If we have a value but it's not in the fetched results (like fa:// or custom URL),
-        // the search-select won't show it. We need to add it to the initial fetch.
-        if (this.value) {
-            // Search-select will call #fetch and then try to select using #selected
-            // And then if the value isn't found in results, creatable mode will handle it
-        }
+    #changeListener(event: CustomEvent<{ value: FileList | null }>) {
+        this.value = event.detail.value?.name ?? "";
     }
 
-    async #fetch(query?: string): Promise<FileItem[]> {
-        const api = aki(AdminApi);
-        return api
-            .adminFileList({
-                usage: this.usage as UsageEnum,
-                ...(query ? { search: query } : {}),
-            })
-            .then((response) => {
-                // Cast necessary: API returns File objects but we only use name, url, mime_type, size, and usage properties
-                const fileResponse = response as unknown as FileItem[];
+    async #fetch(query?: string): Promise<FileList[]> {
+        const results = await aki(AdminApi).adminFileList({
+            usage: this.usage,
+            ...(query ? { search: query.toLocaleLowerCase() } : {}),
+        });
 
-                if (!fileResponse || !Array.isArray(fileResponse)) {
-                    console.error("Invalid response format from files API", fileResponse);
-                    return [];
-                }
+        // Custom URLs and Font Awesome icons are valid values, but are not returned by the files
+        // API. Include the current value on the initial load so the control can select it.
+        if (!query && this.value && !results.some((item) => item.name === this.value)) {
+            return [
+                {
+                    name: this.value,
+                    url: this.value,
+                    mimeType: "",
+                },
+                ...results,
+            ];
+        }
 
-                let results = fileResponse;
-
-                // Only add synthetic item on initial load (no query), not during search.
-                // This prevents stale values from appearing in search results.
-                // The synthetic item is needed for fa:// URLs or custom URLs that aren't in the API.
-                if (!query && this.value && !results.find((item) => item.name === this.value)) {
-                    results = [
-                        {
-                            name: this.value,
-                            url: this.value,
-                            mime_type: "",
-                            size: 0,
-                            usage: this.usage,
-                        },
-                        ...results,
-                    ];
-                }
-
-                return results;
-            })
-            .catch(async (error) => {
-                const parsedError = await parseAPIResponseError(error);
-                console.error(msg("Failed to fetch files"), pluckErrorDetail(parsedError));
-                return [];
-            });
+        return results;
     }
 
     render() {
@@ -140,16 +105,23 @@ export class AKFileSearchInput extends AKElement {
                 .renderElement=${renderElement}
                 .value=${renderValue}
                 .selected=${this.#selected}
+                placeholder=${msg("Select a file or enter a value...", {
+                    id: "file-picker.value.placeholder",
+                })}
                 ?blankable=${this.blankable}
                 creatable
+                @ak-change=${this.#changeListener}
             >
             </ak-search-select>
             <p class="pf-c-form__helper-text">
                 ${this.help
                     ? this.help
-                    : msg(
-                          "You can also enter a URL (https://...), Font Awesome icon (fa://fa-icon-name), or upload a new file.",
-                      )}
+                    : msg("Choose an existing file, or enter a URL or Font Awesome icon.", {
+                          id: "file-picker.value.description",
+                      })}
+                <a target="_blank" rel="noopener noreferrer" href="#/files">
+                    ${msg("Upload a file.", { id: "file-picker.upload-link.label" })}
+                </a>
                 <a
                     target="_blank"
                     rel="noopener noreferrer"

--- a/web/src/components/ak-file-search-input.ts
+++ b/web/src/components/ak-file-search-input.ts
@@ -1,8 +1,10 @@
 import "#elements/forms/HorizontalFormElement";
 import "#elements/forms/SearchSelect/index";
 
+import HostStyles from "./ak-file-search-input.css";
+
 import { aki } from "#common/api/client";
-import { docLink } from "#common/global";
+import { docLink, globalAK } from "#common/global";
 
 import { AKElement } from "#elements/Base";
 
@@ -27,6 +29,8 @@ const renderValue = (item?: FileList | null) => item?.name;
  */
 @customElement("ak-file-search-input")
 export class AKFileSearchInput extends AKElement {
+    public static hostStyles = [HostStyles];
+
     // Render into the lightDOM
     protected createRenderRoot() {
         return this;
@@ -119,16 +123,25 @@ export class AKFileSearchInput extends AKElement {
                     : msg("Choose an existing file, or enter a URL or Font Awesome icon.", {
                           id: "file-picker.value.description",
                       })}
-                <a target="_blank" rel="noopener noreferrer" href="#/files">
-                    ${msg("Upload a file.", { id: "file-picker.upload-link.label" })}
-                </a>
-                <a
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    href=${docLink("/customize/file-picker/")}
-                >
-                    ${msg("See documentation for supported values.")}
-                </a>
+                <span class="ak-file-search-input__actions">
+                    <a
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        href=${`${globalAK().api.base}if/admin/#/files`}
+                    >
+                        ${msg("Upload file", { id: "file-picker.upload-link.label" })}
+                    </a>
+                    <span class="ak-file-search-input__separator" aria-hidden="true">·</span>
+                    <a
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        href=${docLink("/customize/file-picker/")}
+                    >
+                        ${msg("Supported values", {
+                            id: "file-picker.documentation-link.label",
+                        })}
+                    </a>
+                </span>
             </p>
         </ak-form-element-horizontal>`;
     }

--- a/web/src/components/ak-file-search-input.ts
+++ b/web/src/components/ak-file-search-input.ts
@@ -18,6 +18,9 @@ import { html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
+import PFButton from "@patternfly/patternfly/components/Button/button.css";
+import PFInputGroup from "@patternfly/patternfly/components/InputGroup/input-group.css";
+
 const renderElement = (item: FileList) => item.name;
 const renderValue = (item?: FileList | null) => item?.name;
 
@@ -29,7 +32,7 @@ const renderValue = (item?: FileList | null) => item?.name;
  */
 @customElement("ak-file-search-input")
 export class AKFileSearchInput extends AKElement {
-    public static hostStyles = [HostStyles];
+    public static hostStyles = [PFButton, PFInputGroup, HostStyles];
 
     // Render into the lightDOM
     protected createRenderRoot() {
@@ -91,6 +94,8 @@ export class AKFileSearchInput extends AKElement {
     }
 
     render() {
+        const uploadLabel = msg("Upload file", { id: "file-picker.upload-link.label" });
+
         return html` <ak-form-element-horizontal name=${ifDefined(this.name ?? undefined)}>
             ${AKLabel(
                 {
@@ -102,46 +107,49 @@ export class AKFileSearchInput extends AKElement {
                 this.label,
             )}
 
-            <ak-search-select
-                style="width: 100%;"
-                .fieldID=${this.fieldID}
-                .fetchObjects=${this.#fetch.bind(this)}
-                .renderElement=${renderElement}
-                .value=${renderValue}
-                .selected=${this.#selected}
-                placeholder=${msg("Select a file or enter a value...", {
-                    id: "file-picker.value.placeholder",
-                })}
-                ?blankable=${this.blankable}
-                creatable
-                @ak-change=${this.#changeListener}
-            >
-            </ak-search-select>
+            <div class="pf-c-input-group">
+                <ak-search-select
+                    class="ak-file-search-input__select"
+                    .fieldID=${this.fieldID}
+                    .fetchObjects=${this.#fetch.bind(this)}
+                    .renderElement=${renderElement}
+                    .value=${renderValue}
+                    .selected=${this.#selected}
+                    placeholder=${msg("Select a file or enter a value...", {
+                        id: "file-picker.value.placeholder",
+                    })}
+                    ?blankable=${this.blankable}
+                    creatable
+                    @ak-change=${this.#changeListener}
+                >
+                </ak-search-select>
+                <a
+                    class="pf-c-button pf-m-control"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href=${`${globalAK().api.base}if/admin/#/files`}
+                    aria-label=${uploadLabel}
+                    title=${uploadLabel}
+                >
+                    <i class="fas fa-upload" aria-hidden="true"></i>
+                </a>
+            </div>
             <p class="pf-c-form__helper-text">
                 ${this.help
                     ? this.help
                     : msg("Choose an existing file, or enter a URL or Font Awesome icon.", {
                           id: "file-picker.value.description",
                       })}
-                <span class="ak-file-search-input__actions">
-                    <a
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        href=${`${globalAK().api.base}if/admin/#/files`}
-                    >
-                        ${msg("Upload file", { id: "file-picker.upload-link.label" })}
-                    </a>
-                    <span class="ak-file-search-input__separator" aria-hidden="true">·</span>
-                    <a
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        href=${docLink("/customize/file-picker/")}
-                    >
-                        ${msg("Supported values", {
-                            id: "file-picker.documentation-link.label",
-                        })}
-                    </a>
-                </span>
+                <a
+                    class="ak-file-search-input__documentation"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href=${docLink("/customize/file-picker/")}
+                >
+                    ${msg("Supported values", {
+                        id: "file-picker.documentation-link.label",
+                    })}
+                </a>
             </p>
         </ak-form-element-horizontal>`;
     }

--- a/web/src/components/ak-file-search-input.ts
+++ b/web/src/components/ak-file-search-input.ts
@@ -7,6 +7,7 @@ import { aki } from "#common/api/client";
 import { docLink, globalAK } from "#common/global";
 
 import { AKElement } from "#elements/Base";
+import { paramURL } from "#elements/router/RouterOutlet";
 
 import { AKLabel } from "#components/ak-label";
 
@@ -127,7 +128,7 @@ export class AKFileSearchInput extends AKElement {
                     class="pf-c-button pf-m-control"
                     target="_blank"
                     rel="noopener noreferrer"
-                    href=${`${globalAK().api.base}if/admin/#/files`}
+                    href=${`${globalAK().api.base}if/admin/${paramURL("/files", { upload: true })}`}
                     aria-label=${uploadLabel}
                     title=${uploadLabel}
                 >

--- a/web/src/components/ak-text-input.ts
+++ b/web/src/components/ak-text-input.ts
@@ -29,10 +29,16 @@ export class AkTextInput extends HorizontalLightComponent<string> {
     public readOnly: boolean = false;
 
     @property({ type: String, attribute: "inputmode", useDefault: true })
-    inputMode: string = "text";
+    public inputMode: string = "text";
+
+    @property({ type: String, attribute: "control-title", useDefault: true })
+    public controlTitle: string = "";
 
     @property({ type: String })
     public type: "text" | "email" | "url" = "text";
+
+    @property({ type: String, useDefault: true })
+    public pattern: string = "";
 
     #inputListener(ev: InputEvent) {
         this.value = (ev.target as HTMLInputElement).value;
@@ -71,8 +77,10 @@ export class AkTextInput extends HorizontalLightComponent<string> {
             autocomplete=${ifPresent(code ? "off" : this.autocomplete)}
             spellcheck=${ifPresent(code ? "false" : this.spellcheck)}
             aria-describedby=${this.helpID}
+            pattern=${ifPresent(this.pattern)}
             placeholder=${ifPresent(this.#formatPlaceholder())}
             inputmode=${this.inputMode}
+            title=${ifPresent(this.controlTitle)}
             ?required=${this.required}
             ?readonly=${this.readOnly}
             ?autofocus=${this.autofocus}

--- a/web/src/elements/forms/SearchSelect/SearchSelect.ts
+++ b/web/src/elements/forms/SearchSelect/SearchSelect.ts
@@ -181,6 +181,7 @@ export abstract class SearchSelectBase<T>
     //#region State
 
     #loading = false;
+    #updateRequestID = 0;
 
     @state()
     protected error?: APIError;
@@ -234,15 +235,16 @@ export abstract class SearchSelectBase<T>
     }
 
     public async updateData() {
-        if (this.#loading) {
-            return Promise.resolve();
-        }
-
+        const requestID = ++this.#updateRequestID;
         this.#loading = true;
         this.dispatchEvent(new Event("loading"));
 
         return this.fetchObjects(this.query)
             .then((nextObjects) => {
+                if (requestID !== this.#updateRequestID) {
+                    return;
+                }
+
                 const selectedObject = nextObjects.find((obj) => this.selected?.(obj, nextObjects));
 
                 if (selectedObject) {
@@ -251,14 +253,18 @@ export abstract class SearchSelectBase<T>
                 }
 
                 this.objects = nextObjects;
+                this.error = undefined;
                 this.#loading = false;
             })
             .catch(async (error: unknown) => {
-                this.#loading = false;
-                this.objects = undefined;
-
                 const parsedError = await parseAPIResponseError(error);
 
+                if (requestID !== this.#updateRequestID) {
+                    return;
+                }
+
+                this.#loading = false;
+                this.objects = undefined;
                 this.error = parsedError;
             });
     }
@@ -277,37 +283,46 @@ export abstract class SearchSelectBase<T>
         this.removeEventListener(EVENT_REFRESH, this.updateData);
     }
 
-    #searchListener = (event: InputEvent) => {
+    #searchListener = async (event: InputEvent) => {
         if (this.readOnly) return;
 
-        const value = (event.target as SearchSelectView).rawValue;
+        const view = event.target as SearchSelectView;
+        const value = view.rawValue;
+        const requestID = this.#updateRequestID + 1;
 
         if (!value) {
+            view.open = false;
             this.selectedObject = null;
             this.query = undefined;
-            this.updateData();
+            this.dispatchChangeEvent(null);
+            await this.updateData();
             return;
         }
 
         this.query = value;
-        this.updateData()?.then(() => {
-            // If creatable, check if selectedObject's value matches the typed value exactly
-            if (this.creatable) {
-                const selectedValue = this.selectedObject ? this.value(this.selectedObject) : null;
-                if (selectedValue !== value) {
-                    // No exact match so create a synthetic object with the raw value
-                    // "synthetic" isn't an official term or anything, it's just called like that here
-                    this.selectedObject = { name: value } as T;
-                }
+        this.objects = [];
+        await this.updateData();
+
+        if (requestID !== this.#updateRequestID) {
+            return;
+        }
+
+        // If creatable, check if selectedObject's value matches the typed value exactly
+        if (this.creatable) {
+            const selectedValue = this.selectedObject ? this.value(this.selectedObject) : null;
+            if (selectedValue !== value) {
+                // No exact match so create a synthetic object with the raw value
+                // "synthetic" isn't an official term or anything, it's just called like that here
+                this.selectedObject = { name: value } as T;
             }
-            this.dispatchChangeEvent(this.selectedObject);
-        });
+        }
+        this.dispatchChangeEvent(this.selectedObject);
     };
 
-    private onSelect(event: InputEvent) {
+    private onSelect(event: Event) {
         if (this.readOnly) return;
 
-        const value = (event.target as SearchSelectView).value;
+        const value = (event.currentTarget as SearchSelectView).value;
 
         if (!value) {
             this.selectedObject = null;

--- a/web/src/elements/forms/SearchSelect/SearchSelectMenuController.ts
+++ b/web/src/elements/forms/SearchSelect/SearchSelectMenuController.ts
@@ -1,0 +1,254 @@
+import type { ListSelect } from "#elements/ak-list-select/ak-list-select";
+import { AnchorPositionSupported, AnchorSizeSupported } from "#elements/dialogs/positioning";
+
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+
+const DEFAULT_REFOCUS_DELAY = 250;
+
+/**
+ * Firefox reports support for anchor positioning but mis-renders anchored elements inside
+ * dialogs, so use the shared capability checks rather than CSS.supports directly.
+ */
+const CSSAnchorPositioningSupported = AnchorPositionSupported && AnchorSizeSupported;
+
+interface SearchSelectMenuHost extends ReactiveControllerHost, HTMLElement {
+    open: boolean;
+    readOnly: boolean;
+}
+
+type ElementGetter<T extends HTMLElement> = () => T | undefined;
+
+/** Owns popover visibility, positioning, and scroll behavior for a search-select menu. */
+export class SearchSelectMenuController implements ReactiveController {
+    #anchorObserver?: IntersectionObserver;
+    /** Timestamp of the last browser-driven popover close (see reopen guard). */
+    #lastLightDismiss = -Infinity;
+    #reflowFrame?: number;
+
+    constructor(
+        private readonly host: SearchSelectMenuHost,
+        private readonly getInput: ElementGetter<HTMLInputElement>,
+        private readonly getMenu: ElementGetter<ListSelect>,
+    ) {
+        host.addController(this);
+    }
+
+    public hostConnected() {
+        // Styling hook: opt this instance into the CSS anchor-positioning block.
+        this.host.toggleAttribute("data-anchor-css", CSSAnchorPositioningSupported);
+    }
+
+    /**
+     * Reconcile the popover's actual open state with the host's `open` state.
+     * Called after the host updates so the menu has rendered.
+     */
+    public hostUpdated() {
+        const menu = this.getMenu();
+
+        if (!menu) {
+            this.#stopTracking();
+            return;
+        }
+
+        const popoverOpen = menu.matches(":popover-open");
+
+        if (this.host.open && !this.host.readOnly && !popoverOpen) {
+            menu.showPopover();
+            // Start tracking synchronously (not via the async `toggle` event) so the
+            // fallback places the menu in the same frame it becomes visible — no flash
+            // at the UA default position.
+            this.#startTracking();
+        } else if ((!this.host.open || this.host.readOnly) && popoverOpen) {
+            menu.hidePopover();
+        }
+    }
+
+    public hostDisconnected() {
+        this.#stopTracking();
+    }
+
+    public readonly handleInputClick = (event: Event) => {
+        if (this.host.readOnly) return;
+
+        const configuredDelay = getComputedStyle(this.host).getPropertyValue(
+            "--ak-search-select--RefocusDelay",
+        );
+        const refocusDelay = parseInt(configuredDelay, 10) || DEFAULT_REFOCUS_DELAY;
+        const dismissedByThisClick = event.timeStamp - this.#lastLightDismiss < refocusDelay;
+
+        this.host.open = dismissedByThisClick ? false : !this.host.open;
+        this.getInput()?.focus();
+    };
+
+    public readonly handleMenuToggle = (event: ToggleEvent) => {
+        // Opening is handled synchronously in hostUpdated; here we only react to closes
+        // (including browser-driven light dismiss / Esc).
+        if (event.newState === "open") return;
+
+        this.#stopTracking();
+
+        // Record when the browser closes the popover so a click on the input that
+        // caused the dismiss doesn't immediately reopen it.
+        this.#lastLightDismiss = event.timeStamp;
+
+        if (this.host.open) {
+            this.host.open = false;
+        }
+    };
+
+    /**
+     * Forward wheel scrolling to the input's nearest scrollable ancestor once the
+     * menu itself can't scroll any further in that direction. The menu is a
+     * top-layer, fixed-position popover, so the browser chains its overscroll to the
+     * viewport rather than to the (e.g. modal dialog) container behind it — meaning
+     * scrolling over the menu would otherwise appear stuck.
+     */
+    public readonly handleMenuWheel = (event: WheelEvent) => {
+        const menu = this.getMenu();
+        if (!menu) return;
+
+        const goingDown = event.deltaY > 0;
+        const menuCanScroll = goingDown
+            ? Math.ceil(menu.scrollTop + menu.clientHeight) < menu.scrollHeight
+            : menu.scrollTop > 0;
+
+        if (menuCanScroll) return;
+
+        const scroller = this.#findScrollableAncestor();
+        if (!scroller) return;
+
+        const deltaY = (() => {
+            switch (event.deltaMode) {
+                case WheelEvent.DOM_DELTA_LINE: {
+                    const lineHeight = parseFloat(getComputedStyle(scroller).lineHeight);
+                    return event.deltaY * (Number.isFinite(lineHeight) ? lineHeight : 16);
+                }
+                case WheelEvent.DOM_DELTA_PAGE:
+                    return event.deltaY * scroller.clientHeight;
+                default:
+                    return event.deltaY;
+            }
+        })();
+
+        scroller.scrollTop += deltaY;
+        event.preventDefault();
+    };
+
+    /**
+     * Walk the flattened (composed) tree upward from the host — crossing shadow
+     * boundaries and slots — to the nearest vertically scrollable ancestor.
+     */
+    #findScrollableAncestor(): HTMLElement | null {
+        const composedParent = (node: Node): Node | null => {
+            const slot = (node as Element).assignedSlot;
+            if (slot) return slot;
+
+            const parent = node.parentNode;
+            return parent instanceof ShadowRoot ? parent.host : parent;
+        };
+
+        for (let node = composedParent(this.host); node; node = composedParent(node)) {
+            if (!(node instanceof HTMLElement)) continue;
+
+            const { overflowY } = getComputedStyle(node);
+            const scrollable =
+                overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay";
+
+            if (scrollable && node.scrollHeight > node.clientHeight) {
+                return node;
+            }
+        }
+
+        return null;
+    }
+
+    #startTracking() {
+        const input = this.getInput();
+        const menu = this.getMenu();
+        if (!input || !menu) return;
+
+        // Close the menu when its anchor input is no longer visible — scrolled out
+        // of the viewport, clipped away by a scroll container, or hidden. This works
+        // in every browser regardless of anchor-positioning support.
+        this.#anchorObserver?.disconnect();
+        this.#anchorObserver = new IntersectionObserver(
+            (entries) => {
+                if (entries.some((entry) => !entry.isIntersecting)) {
+                    this.host.open = false;
+                }
+            },
+            { threshold: 0 },
+        );
+        this.#anchorObserver.observe(input);
+
+        // Native CSS anchor positioning handles placement and tracks scrolling on its
+        // own — nothing else to do.
+        if (CSSAnchorPositioningSupported) return;
+
+        // Otherwise position the menu imperatively and keep it in sync. We can't rely
+        // on a global scroll listener: `scroll` events are `composed: false`, so
+        // scrolling inside a shadow-rendered container (e.g. a modal dialog body)
+        // never reaches `window`. Instead we re-place the menu each animation frame
+        // while open, which also covers nested scrollers, layout shifts, and resizes.
+        let lastGeometry = "";
+        const reflow = () => {
+            const rect = this.getInput()?.getBoundingClientRect();
+
+            if (rect) {
+                const geometry = `${rect.left},${rect.top},${rect.bottom},${rect.width},${window.innerHeight}`;
+
+                if (geometry !== lastGeometry) {
+                    lastGeometry = geometry;
+                    this.#positionMenu();
+                }
+            }
+
+            this.#reflowFrame = requestAnimationFrame(reflow);
+        };
+
+        this.#positionMenu();
+        this.#reflowFrame = requestAnimationFrame(reflow);
+    }
+
+    #stopTracking() {
+        this.#anchorObserver?.disconnect();
+        this.#anchorObserver = undefined;
+
+        if (this.#reflowFrame !== undefined) {
+            cancelAnimationFrame(this.#reflowFrame);
+            this.#reflowFrame = undefined;
+        }
+    }
+
+    /**
+     * Position the menu against the input imperatively, matching the CSS
+     * anchor-positioning behavior (below by default, flip above when there's no
+     * room, width matched to the input, capped height). Only used where CSS anchor
+     * positioning is unavailable.
+     */
+    #positionMenu() {
+        const input = this.getInput();
+        const menu = this.getMenu();
+        if (!input || !menu) return;
+
+        const rect = input.getBoundingClientRect();
+        const viewportHeight = window.innerHeight;
+        const maxHeight = Math.round(viewportHeight * 0.4);
+        const menuHeight = Math.min(menu.offsetHeight || maxHeight, maxHeight);
+        const spaceBelow = viewportHeight - rect.bottom;
+        const flipUp = spaceBelow < menuHeight && rect.top > spaceBelow;
+
+        menu.style.position = "fixed";
+        menu.style.left = `${Math.round(rect.left)}px`;
+        menu.style.width = `${Math.round(rect.width)}px`;
+        menu.style.maxHeight = `${maxHeight}px`;
+
+        if (flipUp) {
+            menu.style.top = "auto";
+            menu.style.bottom = `${Math.round(viewportHeight - rect.top)}px`;
+        } else {
+            menu.style.bottom = "auto";
+            menu.style.top = `${Math.round(rect.bottom)}px`;
+        }
+    }
+}

--- a/web/src/elements/forms/SearchSelect/ak-search-select-view.ts
+++ b/web/src/elements/forms/SearchSelect/ak-search-select-view.ts
@@ -1,17 +1,17 @@
 import "#elements/ak-list-select/ak-list-select";
 
+import { SearchSelectMenuController } from "./SearchSelectMenuController.js";
 import { findFlatOptions, findOptionsSubset, groupOptions, optionsToFlat } from "./utils.js";
 
 import { ListSelect } from "#elements/ak-list-select/ak-list-select";
 import { AKElement } from "#elements/Base";
-import { AnchorPositionSupported, AnchorSizeSupported } from "#elements/dialogs/positioning";
 import Styles from "#elements/forms/SearchSelect/ak-search-select-view.css";
 import type { GroupedOptions, SelectOption, SelectOptions } from "#elements/types";
 import { ifPresent } from "#elements/utils/attributes";
 import { randomId } from "#elements/utils/randomId";
 
 import { msg } from "@lit/localize";
-import { CSSResult, html, PropertyValues } from "lit";
+import { CSSResult, html, nothing, PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { createRef, ref, Ref } from "lit/directives/ref.js";
@@ -19,17 +19,6 @@ import { createRef, ref, Ref } from "lit/directives/ref.js";
 import PFForm from "@patternfly/patternfly/components/Form/form.css";
 import PFFormControl from "@patternfly/patternfly/components/FormControl/form-control.css";
 import PFSelect from "@patternfly/patternfly/components/Select/select.css";
-
-const DEFAULT_REFOCUS_DELAY = 250;
-
-/**
- * Whether this browser can position *and* size the menu against its anchor purely
- * in CSS. When true the menu uses native anchor positioning (which tracks scrolling
- * for free); otherwise it is placed imperatively. `AnchorSizeSupported` already
- * excludes Firefox, whose anchor positioning mis-renders inside a `<dialog>` despite
- * reporting support — see {@link "#elements/dialogs/positioning"}.
- */
-const CSSAnchorPositioningSupported = AnchorPositionSupported && AnchorSizeSupported;
 
 export interface ISearchSelectView {
     options: SelectOptions;
@@ -237,6 +226,12 @@ export class SearchSelectView extends AKElement implements ISearchSelectView {
      */
     #inputRef: Ref<HTMLInputElement> = createRef();
 
+    #menuController = new SearchSelectMenuController(
+        this,
+        () => this.#inputRef.value,
+        () => this.#menuRef.value,
+    );
+
     /**
      * Maps a value from the portal to labels to be put into the <input> field>
      */
@@ -247,42 +242,13 @@ export class SearchSelectView extends AKElement implements ISearchSelectView {
     //#region Lifecycle
 
     public override updated() {
-        this.#syncMenuVisibility();
         this.setAttribute("data-ouia-component-safe", "true");
-    }
-
-    /**
-     * Reconcile the popover's actual open state with `this.open`.
-     * Called from `updated()` so it runs after the menu has rendered.
-     */
-    #syncMenuVisibility() {
-        const menu = this.#menuRef.value;
-        if (!menu) return;
-
-        const popoverOpen = menu.matches(":popover-open");
-
-        if (this.open && !this.readOnly && !popoverOpen) {
-            menu.showPopover();
-            // Start tracking synchronously (not via the async `toggle` event) so the
-            // fallback places the menu in the same frame it becomes visible — no flash
-            // at the UA default position.
-            this.#startAnchorTracking();
-        } else if ((!this.open || this.readOnly) && popoverOpen) {
-            menu.hidePopover();
-        }
     }
 
     connectedCallback() {
         super.connectedCallback();
         this.setAttribute("data-ouia-component-type", "ak-search-select-view");
         this.setAttribute("data-ouia-component-id", this.getAttribute("id") || randomId());
-        // Styling hook: opt this instance into the CSS anchor-positioning block.
-        this.toggleAttribute("data-anchor-css", CSSAnchorPositioningSupported);
-    }
-
-    disconnectedCallback() {
-        this.#stopAnchorTracking();
-        super.disconnectedCallback();
     }
 
     // TODO: Reconcile value <-> display value, Reconcile option changes to value <-> displayValue
@@ -296,210 +262,6 @@ export class SearchSelectView extends AKElement implements ISearchSelectView {
     //#endregion
 
     //#region Event Listeners
-
-    /** Timestamp of the last browser-driven popover close (see reopen guard). */
-    #lastLightDismiss = -Infinity;
-
-    #clickListener = (event: Event) => {
-        if (this.readOnly) return;
-
-        const computedRefocusDelay = getComputedStyle(this)?.getPropertyValue(
-            "--ak-search-select--RefocusDelay",
-        );
-
-        const refocusDelay = parseInt(computedRefocusDelay, 10) || DEFAULT_REFOCUS_DELAY;
-
-        // If this same click just light-dismissed the open popover, treat it as a
-        // close: leave `open` false instead of toggling it back on.
-        const dismissedByThisClick = event.timeStamp - this.#lastLightDismiss < refocusDelay;
-
-        this.open = dismissedByThisClick ? false : !this.open;
-        this.#inputRef.value?.focus();
-    };
-
-    /**
-     * Reflect browser-driven popover state changes (light dismiss, Esc) back
-     * into `this.open`, keeping component state authoritative.
-     */
-    #menuToggleListener = (event: ToggleEvent) => {
-        // Opening is handled synchronously in #syncMenuVisibility; here we only
-        // react to closes (including browser-driven light dismiss / Esc).
-        if (event.newState === "open") return;
-
-        this.#stopAnchorTracking();
-
-        // Record when the browser closes the popover so a click on the input
-        // that *caused* the dismiss doesn't immediately reopen it.
-        this.#lastLightDismiss = event.timeStamp;
-
-        if (this.open) {
-            this.open = false;
-        }
-    };
-
-    /**
-     * Forward wheel scrolling to the input's nearest scrollable ancestor once the
-     * menu itself can't scroll any further in that direction. The menu is a
-     * top-layer, fixed-position popover, so the browser chains its overscroll to the
-     * viewport rather than to the (e.g. modal dialog) container behind it — meaning
-     * scrolling over the menu would otherwise appear stuck.
-     */
-    #menuWheelListener = (event: WheelEvent) => {
-        const menu = this.#menuRef.value;
-        if (!menu) return;
-
-        const goingDown = event.deltaY > 0;
-        const menuCanScroll = goingDown
-            ? Math.ceil(menu.scrollTop + menu.clientHeight) < menu.scrollHeight
-            : menu.scrollTop > 0;
-
-        if (menuCanScroll) return;
-
-        const scroller = this.#findScrollableAncestor();
-        if (!scroller) return;
-
-        const deltaY = (() => {
-            switch (event.deltaMode) {
-                case WheelEvent.DOM_DELTA_LINE: {
-                    const lh = parseFloat(getComputedStyle(scroller).lineHeight);
-                    return event.deltaY * (Number.isFinite(lh) ? lh : 16);
-                }
-                case WheelEvent.DOM_DELTA_PAGE:
-                    return event.deltaY * scroller.clientHeight;
-                default:
-                    return event.deltaY;
-            }
-        })();
-
-        scroller.scrollTop += deltaY;
-        event.preventDefault();
-    };
-
-    /**
-     * Walk the flattened (composed) tree upward from this element — crossing shadow
-     * boundaries and slots — to the nearest vertically scrollable ancestor.
-     */
-    #findScrollableAncestor(): HTMLElement | null {
-        const composedParent = (node: Node): Node | null => {
-            const slot = (node as Element).assignedSlot;
-            if (slot) return slot;
-
-            const parent = node.parentNode;
-            return parent instanceof ShadowRoot ? parent.host : parent;
-        };
-
-        for (let node = composedParent(this); node; node = composedParent(node)) {
-            if (!(node instanceof HTMLElement)) continue;
-
-            const { overflowY } = getComputedStyle(node);
-            const scrollable =
-                overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay";
-
-            if (scrollable && node.scrollHeight > node.clientHeight) {
-                return node;
-            }
-        }
-
-        return null;
-    }
-
-    #anchorObserver?: IntersectionObserver;
-
-    #startAnchorTracking() {
-        const input = this.#inputRef.value;
-        const menu = this.#menuRef.value;
-
-        if (!input || !menu) return;
-
-        // Close the menu when its anchor input is no longer visible — scrolled out
-        // of the viewport, clipped away by a scroll container, or hidden. This works
-        // in every browser regardless of anchor-positioning support.
-        this.#anchorObserver?.disconnect();
-        this.#anchorObserver = new IntersectionObserver(
-            (entries) => {
-                if (entries.some((entry) => !entry.isIntersecting)) {
-                    this.open = false;
-                }
-            },
-            { threshold: 0 },
-        );
-        this.#anchorObserver.observe(input);
-
-        // Native CSS anchor positioning handles placement and tracks scrolling on its
-        // own — nothing else to do.
-        if (CSSAnchorPositioningSupported) return;
-
-        // Otherwise position the menu imperatively and keep it in sync. We can't rely
-        // on a global scroll listener: `scroll` events are `composed: false`, so
-        // scrolling inside a shadow-rendered container (e.g. a modal dialog body)
-        // never reaches `window`. Instead we re-place the menu each animation frame
-        // while open, which also covers nested scrollers, layout shifts, and resizes.
-        let lastGeometry = "";
-
-        const reflow = () => {
-            const rect = this.#inputRef.value?.getBoundingClientRect();
-
-            if (rect) {
-                const geometry = `${rect.left},${rect.top},${rect.bottom},${rect.width},${window.innerHeight}`;
-
-                if (geometry !== lastGeometry) {
-                    lastGeometry = geometry;
-                    this.#positionMenu();
-                }
-            }
-
-            this.#reflowFrame = requestAnimationFrame(reflow);
-        };
-
-        this.#positionMenu();
-        this.#reflowFrame = requestAnimationFrame(reflow);
-    }
-
-    #reflowFrame?: number;
-
-    #stopAnchorTracking() {
-        this.#anchorObserver?.disconnect();
-        this.#anchorObserver = undefined;
-
-        if (this.#reflowFrame !== undefined) {
-            cancelAnimationFrame(this.#reflowFrame);
-            this.#reflowFrame = undefined;
-        }
-    }
-
-    /**
-     * Position the menu against the input imperatively, matching the CSS
-     * anchor-positioning behavior (below by default, flip above when there's no
-     * room, width matched to the input, capped height). Only used where CSS anchor
-     * positioning is unavailable.
-     */
-    #positionMenu() {
-        const input = this.#inputRef.value;
-        const menu = this.#menuRef.value;
-
-        if (!input || !menu) return;
-
-        const rect = input.getBoundingClientRect();
-        const viewportHeight = window.innerHeight;
-        const maxHeight = Math.round(viewportHeight * 0.4);
-        const menuHeight = Math.min(menu.offsetHeight || maxHeight, maxHeight);
-
-        const spaceBelow = viewportHeight - rect.bottom;
-        const flipUp = spaceBelow < menuHeight && rect.top > spaceBelow;
-
-        menu.style.position = "fixed";
-        menu.style.left = `${Math.round(rect.left)}px`;
-        menu.style.width = `${Math.round(rect.width)}px`;
-        menu.style.maxHeight = `${maxHeight}px`;
-
-        if (flipUp) {
-            menu.style.top = "auto";
-            menu.style.bottom = `${Math.round(viewportHeight - rect.top)}px`;
-        } else {
-            menu.style.bottom = "auto";
-            menu.style.top = `${Math.round(rect.bottom)}px`;
-        }
-    }
 
     setFromMatchList(value?: string) {
         if (!value) return;
@@ -630,17 +392,19 @@ export class SearchSelectView extends AKElement implements ISearchSelectView {
         );
     };
 
-    #changeListener = (event: InputEvent) => {
+    #changeListener = (event: Event) => {
         if (this.readOnly) return;
 
-        if (!event.target) {
-            return;
-        }
-        const value = (event.target as HTMLInputElement).value;
+        // Translate the list's change into a single view-level change event. Without stopping the
+        // original event, the managed search receives both events and reconciles the same
+        // selection twice.
+        event.stopPropagation();
+
+        const value = (event.currentTarget as ListSelect).value ?? undefined;
         if (value) {
             const newDisplayValue = this.findDisplayForValue(value);
             if (this.#inputRef.value) {
-                this.#inputRef.value.value = newDisplayValue ?? "";
+                this.#inputRef.value.value = newDisplayValue ?? value;
             }
         } else if (this.#inputRef.value) {
             this.#inputRef.value.value = "";
@@ -662,13 +426,17 @@ export class SearchSelectView extends AKElement implements ISearchSelectView {
     }
 
     public override willUpdate(changed: PropertyValues<this>) {
-        if (changed.has("value") && this.value) {
-            const newDisplayValue = this.findDisplayForValue(this.value);
-            if (newDisplayValue) {
-                this.displayValue = newDisplayValue;
+        if (changed.has("value")) {
+            if (this.value) {
+                const newDisplayValue = this.findDisplayForValue(this.value);
+                if (newDisplayValue) {
+                    this.displayValue = newDisplayValue;
+                } else {
+                    // If no display value found (e.g., custom creatable value), use the value itself
+                    this.displayValue = this.value;
+                }
             } else {
-                // If no display value found (e.g., custom creatable value), use the value itself
-                this.displayValue = this.value;
+                this.displayValue = "";
             }
         } else if (this.value && this.displayValue === this.value) {
             // The display label may not have been available when the value was set,
@@ -698,6 +466,8 @@ export class SearchSelectView extends AKElement implements ISearchSelectView {
         const emptyOption = this.blankable
             ? this.emptyOption || this.placeholder || msg("Select an option...")
             : null;
+        const hasMenuContent =
+            this.#flatOptions.length > 0 || Boolean(emptyOption) || Boolean(this.actionLabel);
 
         return html`<div class="pf-c-select" part="ak-search-select">
                 <div class="pf-c-select__toggle pf-m-typeahead" part="ak-search-select-toggle">
@@ -715,7 +485,7 @@ export class SearchSelectView extends AKElement implements ISearchSelectView {
                             name=${ifDefined(this.name)}
                             spellcheck="false"
                             @input=${this.#inputListener}
-                            @click=${this.#clickListener}
+                            @click=${this.#menuController.handleInputClick}
                             @blur=${this.#blurListener}
                             @keyup=${this.#searchKeyupListener}
                             @keydown=${this.#searchKeydownListener}
@@ -725,22 +495,24 @@ export class SearchSelectView extends AKElement implements ISearchSelectView {
                     </div>
                 </div>
             </div>
-            <ak-list-select
-                popover="auto"
-                id="menu-${this.getAttribute("data-ouia-component-id")}"
-                ${ref(this.#menuRef)}
-                .options=${this.managedOptions}
-                value=${ifDefined(this.value)}
-                @change=${this.#changeListener}
-                @blur=${this.#blurListener}
-                @toggle=${this.#menuToggleListener}
-                @wheel=${this.#menuWheelListener}
-                emptyOption=${ifPresent(emptyOption)}
-                actionLabel=${ifPresent(this.actionLabel)}
-                @ak-select-action=${this.#actionListener}
-                @keydown=${this.#listKeydownListener}
-                @keyup=${this.#listKeyupListener}
-            ></ak-list-select>`;
+            ${hasMenuContent
+                ? html`<ak-list-select
+                      popover="auto"
+                      id="menu-${this.getAttribute("data-ouia-component-id")}"
+                      ${ref(this.#menuRef)}
+                      .options=${this.managedOptions}
+                      value=${ifDefined(this.value)}
+                      @change=${this.#changeListener}
+                      @blur=${this.#blurListener}
+                      @toggle=${this.#menuController.handleMenuToggle}
+                      @wheel=${this.#menuController.handleMenuWheel}
+                      emptyOption=${ifPresent(emptyOption)}
+                      actionLabel=${ifPresent(this.actionLabel)}
+                      @ak-select-action=${this.#actionListener}
+                      @keydown=${this.#listKeydownListener}
+                      @keyup=${this.#listKeyupListener}
+                  ></ak-list-select>`
+                : nothing}`;
     }
 
     //#endregion

--- a/web/src/elements/forms/SearchSelect/ak-search-select.ts
+++ b/web/src/elements/forms/SearchSelect/ak-search-select.ts
@@ -53,7 +53,7 @@ export interface ISearchSelect<T> extends ISearchSelectBase<T> {
  */
 @customElement("ak-search-select")
 export class SearchSelect<
-    TFetch extends (query?: string) => Promise<never[]>,
+    TFetch extends (query?: string) => Promise<never[]> = (query?: string) => Promise<never[]>,
     T = AsyncReturnArrayElement<TFetch>,
 > extends SearchSelectBase<T> {
     @property({ attribute: false })

--- a/web/src/elements/utils/files.ts
+++ b/web/src/elements/utils/files.ts
@@ -1,0 +1,82 @@
+import { msg, str } from "@lit/localize";
+import { html, TemplateResult } from "lit-html";
+import { unsafeHTML } from "lit-html/directives/unsafe-html.js";
+
+const FILE_NAME_REPLACEMENTS = ["theme"] as const;
+
+const FILE_NAME_CHARS = "a-zA-Z0-9._/-";
+const PLACEHOLDER_PATTERN = FILE_NAME_REPLACEMENTS.join("|");
+
+export const FileNamePattern = {
+    /**
+     * Used by the {@linkcode assertValidFileName} function to validate file names at runtime. This pattern is stricter than the one used in the HTML pattern attribute, as it does not allow for unescaped parentheses or hyphens.
+     */
+    Runtime: new RegExp(`^(?:%\\((?:${PLACEHOLDER_PATTERN})\\)s|[${FILE_NAME_CHARS}])+$`),
+
+    /**
+     * Used by the HTML pattern attribute. Browsers compile with the `/v` flag,
+     * so -, (, and ) must be escaped inside the character class.
+     */
+    DOM: `^(?:%\\((?:${PLACEHOLDER_PATTERN})\\)s|[a-zA-Z0-9._\\/\\-])+$`,
+} as const;
+
+function createListFormatter(localeOrFormatter?: Intl.ListFormat | Intl.LocalesArgument) {
+    return localeOrFormatter instanceof Intl.ListFormat
+        ? localeOrFormatter
+        : new Intl.ListFormat(localeOrFormatter, {
+              style: "narrow",
+              type: "disjunction",
+          });
+}
+
+export function formatValidationMessage(
+    localeOrFormatter?: Intl.ListFormat | Intl.LocalesArgument,
+): string {
+    const listFormatter = createListFormatter(localeOrFormatter);
+
+    const replacements = listFormatter.format(
+        FILE_NAME_REPLACEMENTS.map((value) => `%(${value})s`),
+    );
+
+    return msg(
+        str`Valid file names can contain letters, numbers, dots, hyphens, underscores, slashes, and
+        placeholders such as ${replacements}.`,
+        {
+            id: "file.name.validation.plaintext",
+            desc: "Validation message for file name input. The placeholders are displayed as plain text.",
+        },
+    );
+}
+
+export function formatHTMLValidationMessage(
+    localeOrFormatter?: Intl.ListFormat | Intl.LocalesArgument,
+): TemplateResult {
+    const listFormatter = createListFormatter(localeOrFormatter);
+
+    const replacements = listFormatter.format(
+        FILE_NAME_REPLACEMENTS.map((value) => `<code>%(${value})s</code>`),
+    );
+
+    return msg(
+        html`Valid file names can contain letters, numbers, dots, hyphens, underscores, slashes, and
+        placeholders such as ${unsafeHTML(replacements)}.`,
+        {
+            id: "file.name.validation.html",
+            desc: "Validation message for file name input. The placeholders are displayed as code elements.",
+        },
+    );
+}
+
+export function assertValidFileName(fileName: string): void {
+    if (!FileNamePattern.Runtime.test(fileName)) {
+        throw new Error(`Invalid file name: ${fileName}. ${formatValidationMessage()}`);
+    }
+}
+
+export function getFileExtension(fileName: string): string {
+    const lastDot = fileName.lastIndexOf(".");
+
+    if (lastDot === -1) return "";
+
+    return fileName.slice(lastDot);
+}


### PR DESCRIPTION
This fixes several bugs in the file search input. To name a few:
* Clearing the field no longer restores the previous value,
* unmatched searches no longer display stale or empty results, 
* and selecting a suggestion keeps the selected filename visible. 

It also adds a link to the existing Files page for uploading new files and closes a few miscellaneous tasks such as adding id's to translated strings 

The menu positioning and scrolling logic was extracted into SearchSelectMenuController because the bugs crossed input state, selection, popover visibility, positioning, and scrolling.

After:

<img width="899" height="263" alt="image" src="https://github.com/user-attachments/assets/83ac667d-0cd0-4971-af65-b6e5631476c2" />

