### PR TITLE
ci: add names to release-tag input steps for readability

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -29,14 +29,16 @@ jobs:
     name: Check inputs validity
     runs-on: ubuntu-latest
     steps:
-      - id: check
+      - name: Validate release version input
+        id: check
         env:
           VERSION: "${{ inputs.version }}"
         run: |
           echo "${VERSION}" | grep -E '^[0-9]{4}\.(0?[1-9]|1[0-2])\.[0-9]+(-rc[0-9]+)?$'
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "major-version=${VERSION}" | grep -oE "^major-version=[0-9]{4}\.[0-9]{1,2}" >> "$GITHUB_OUTPUT"
-      - id: changelog-url
+      - name: Resolve changelog URL
+        id: changelog-url
         run: |
           if [ "${{ inputs.release_reason }}" = "feature" ]; then
             changelog_url="https://docs.goauthentik.io/docs/releases/${{ steps.check.outputs.major-version }}"


### PR DESCRIPTION
## Problem

In `.github/workflows/release-tag.yml`, the `check` and `changelog-url` steps are unnamed long `run` blocks, so the Actions UI shows generic labels while validating the release version and resolving the changelog URL.

## Changes

Semantics are unchanged: same step `id`s, same `GITHUB_OUTPUT` keys, and the same job/step output wiring.

- Add `name: Validate release version input` to `id: check`
- Add `name: Resolve changelog URL` to `id: changelog-url`

## Test plan
- [ ] Confirm `check-inputs.outputs.version` / `major-version` / `changelog-url` still resolve from the same step ids
- [ ] Confirm the version regex and changelog URL logic are unchanged
