### PR TITLE
web/flow: fix untranslated password visibility labels

### DIFF
--- a/web/src/flow/components/ak-flow-password-input.ts
+++ b/web/src/flow/components/ak-flow-password-input.ts
@@ -1,3 +1,5 @@
+import { MessageFormatter } from "#common/ui/locale/format";
+
 import { AKElement } from "#elements/Base";
 import { bound } from "#elements/decorators/bound";
 import { isActiveElement } from "#elements/utils/focus";
@@ -21,7 +23,7 @@ import PFInputGroup from "@patternfly/patternfly/components/InputGroup/input-gro
  */
 interface VisibilityProps {
     icon: string;
-    label: string;
+    label: MessageFormatter<string>;
 }
 
 /**
@@ -30,11 +32,11 @@ interface VisibilityProps {
 const Visibility = {
     Reveal: {
         icon: "fa-eye",
-        label: msg("Show password"),
+        label: () => msg("Show password"),
     },
     Mask: {
         icon: "fa-eye-slash",
-        label: msg("Hide password"),
+        label: () => msg("Hide password"),
     },
 } as const satisfies Record<string, VisibilityProps>;
 
@@ -265,7 +267,7 @@ export class InputPassword extends AKElement {
 
         toggleElement.setAttribute(
             "aria-label",
-            masked ? Visibility.Reveal.label : Visibility.Mask.label,
+            masked ? Visibility.Reveal.label() : Visibility.Mask.label(),
         );
 
         const iconElement = toggleElement.querySelector("i")!;
@@ -281,7 +283,7 @@ export class InputPassword extends AKElement {
 
         return html`<button
             ${ref(this.toggleVisibilityRef)}
-            aria-label=${label}
+            aria-label=${label()}
             @click=${this.togglePasswordVisibility}
             class="pf-c-button pf-m-control"
             type="button"


### PR DESCRIPTION
## Details

### What does this PR change?

The `aria-label` of the password visibility toggle (`Show password` / `Hide password`) is always
rendered in the source language, even when a translation exists and the locale is correctly set.
This makes the two labels lazy, so they are formatted at render time under the active locale.

### Why is this change needed?

`Visibility` is a module-scope constant, so `msg()` is evaluated once at module load — before
`setLocale()` has run. In `@lit/localize` runtime mode, `msg()` only re-evaluates when it is called
from inside a function; at module scope the returned string is frozen at the source language and
`render()` merely reads the already-frozen object.

```ts
const Visibility = {
    Reveal: { icon: "fa-eye", label: msg("Show password") },   // evaluated once, at import time
    Mask:   { icon: "fa-eye-slash", label: msg("Hide password") },
} as const satisfies Record<string, VisibilityProps>;
```

This is the same class of bug fixed in #23518 for `UI_FIELDS` in the identification stage, and the
same one the `@todo` in `web/src/common/labels.ts` refers to. `ak-flow-password-input.ts` was not
covered by that change.

Both strings are already translated in the shipped catalogues — e.g. `pt-BR.xlf` has
`Show password → Mostrar senha` and `Hide password → Esconder senha` — so no translation work is
needed; the strings simply never reach the DOM.

Because these are `aria-label`s, the impact falls entirely on screen reader users, for whom the
control is announced in English regardless of the interface language.

The fix follows #23518 exactly: lazy labels typed as `MessageFormatter<string>`, called at the two
use sites.

### How was this tested?

Set a non-English locale, open a flow with a password field, and inspect the toggle button's
`aria-label` — before the change it reads `Show password`; after, it follows the active locale.
Toggling visibility updates it in the same language (`syncVisibilityToggle`).

### Linked issues

refs #23518, refs #23517

---

## Checklist

-   [x] The project has been linted, built, and tested — see the note below for exactly what was run
-   [ ] The documentation has been updated and formatted (`make docs`) — not applicable, no `website/` change

### What was run locally

The `web` targets, on this branch, all passing:

| Target | Command | Result |
| --- | --- | --- |
| `web-lint-fix` | `pnpm --dir web run prettier` | pass — no files changed |
| `web-lint` | `pnpm --dir web run lint` | pass |
| `web-lint` | `pnpm --dir web run lit-analyse` | pass |
| `web-check-compile` | `pnpm --dir web run tsc` | pass |
| `web-test` | `pnpm --dir web run test` | pass — 9/9 files, 67/67 tests |

I did not run the Python, Go, or Rust targets of `make all`, nor `make gen` (it needs a populated
database): this change touches a single `.ts` file under `web/`, and I don't have a full backend
development environment set up. Happy to run anything else you'd like to see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
