### PR TITLE
web: hide plain action icons while loading

### DIFF
--- a/web/src/elements/buttons/SpinnerButton/BaseTaskButton.ts
+++ b/web/src/elements/buttons/SpinnerButton/BaseTaskButton.ts
@@ -26,6 +26,9 @@ const buttonStyles = [
         #spinner-button.working {
             pointer-events: none;
         }
+        #spinner-button.pf-m-in-progress.pf-m-plain slot::slotted(*) {
+            visibility: hidden;
+        }
 
         .pf-c-button {
             &.pf-m-primary.pf-m-success {


### PR DESCRIPTION
Closes: #22907

Hides plain action-button icons while loading so the SCIM sync play icon no longer overlaps the spinner.