### PR TITLE
providers/scim: recognize primary application assignments

### DIFF
--- a/authentik/providers/scim/api/providers.py
+++ b/authentik/providers/scim/api/providers.py
@@ -30,6 +30,8 @@ class SCIMProviderSerializer(
             "property_mappings",
             "property_mappings_group",
             "component",
+            "assigned_application_slug",
+            "assigned_application_name",
             "assigned_backchannel_application_slug",
             "assigned_backchannel_application_name",
             "verbose_name",

--- a/packages/client-ts/src/models/SCIMProvider.ts
+++ b/packages/client-ts/src/models/SCIMProvider.ts
@@ -64,6 +64,18 @@ export interface SCIMProvider {
      * @type {string}
      * @memberof SCIMProvider
      */
+    readonly assignedApplicationSlug: string | null;
+    /**
+     * Application's display Name.
+     * @type {string}
+     * @memberof SCIMProvider
+     */
+    readonly assignedApplicationName: string | null;
+    /**
+     * Internal application name, used in URLs.
+     * @type {string}
+     * @memberof SCIMProvider
+     */
     readonly assignedBackchannelApplicationSlug: string | null;
     /**
      * Application's display Name.
@@ -201,6 +213,20 @@ export function instanceOfSCIMProvider(value: object): value is SCIMProvider {
     if (!("name" in value) || value["name"] === undefined) return false;
     if (!("component" in value) || value["component"] === undefined) return false;
     if (
+        (!("assignedApplicationSlug" in (value as Record<string, any>)) &&
+            !("assigned_application_slug" in (value as Record<string, any>))) ||
+        ((value as Record<string, any>)["assignedApplicationSlug"] === undefined &&
+            (value as Record<string, any>)["assigned_application_slug"] === undefined)
+    )
+        return false;
+    if (
+        (!("assignedApplicationName" in (value as Record<string, any>)) &&
+            !("assigned_application_name" in (value as Record<string, any>))) ||
+        ((value as Record<string, any>)["assignedApplicationName"] === undefined &&
+            (value as Record<string, any>)["assigned_application_name"] === undefined)
+    )
+        return false;
+    if (
         (!("assignedBackchannelApplicationSlug" in (value as Record<string, any>)) &&
             !("assigned_backchannel_application_slug" in (value as Record<string, any>))) ||
         ((value as Record<string, any>)["assignedBackchannelApplicationSlug"] === undefined &&
@@ -282,6 +308,8 @@ export function SCIMProviderFromJSONTyped(json: any, ignoreDiscriminator: boolea
         propertyMappingsGroup:
             json["property_mappings_group"] == null ? undefined : json["property_mappings_group"],
         component: json["component"],
+        assignedApplicationSlug: json["assigned_application_slug"],
+        assignedApplicationName: json["assigned_application_name"],
         assignedBackchannelApplicationSlug: json["assigned_backchannel_application_slug"],
         assignedBackchannelApplicationName: json["assigned_backchannel_application_name"],
         verboseName: json["verbose_name"],
@@ -340,6 +368,8 @@ export function SCIMProviderToJSONTyped(
         SCIMProvider,
         | "pk"
         | "component"
+        | "assignedApplicationSlug"
+        | "assignedApplicationName"
         | "assignedBackchannelApplicationSlug"
         | "assignedBackchannelApplicationName"
         | "verboseName"

--- a/schema.yml
+++ b/schema.yml
@@ -57302,6 +57302,16 @@ components:
           type: string
           description: Get object component so that we know how to edit the object
           readOnly: true
+        assigned_application_slug:
+          type: string
+          description: Internal application name, used in URLs.
+          readOnly: true
+          nullable: true
+        assigned_application_name:
+          type: string
+          description: Application's display Name.
+          readOnly: true
+          nullable: true
         assigned_backchannel_application_slug:
           type: string
           description: Internal application name, used in URLs.
@@ -57391,6 +57401,8 @@ components:
           description: When enabled, provider will not modify or create objects in
             the remote system.
       required:
+      - assigned_application_name
+      - assigned_application_slug
       - assigned_backchannel_application_name
       - assigned_backchannel_application_slug
       - auth_oauth_token_expires

--- a/web/src/admin/providers/RelatedApplicationButton.ts
+++ b/web/src/admin/providers/RelatedApplicationButton.ts
@@ -22,16 +22,13 @@ export class RelatedApplicationButton extends AKElement {
     @property({ attribute: false })
     public provider?: Provider | null = null;
 
-    @property({ type: String })
-    public mode: "primary" | "backchannel" = "primary";
-
     protected override render(): SlottedTemplateResult {
-        if (this.mode === "primary" && this.provider?.assignedApplicationSlug) {
+        if (this.provider?.assignedApplicationSlug) {
             return html`<a href="#/core/applications/${this.provider.assignedApplicationSlug}">
                 ${this.provider.assignedApplicationName}
             </a>`;
         }
-        if (this.mode === "backchannel" && this.provider?.assignedBackchannelApplicationSlug) {
+        if (this.provider?.assignedBackchannelApplicationSlug) {
             return html`<a
                 href="#/core/applications/${this.provider.assignedBackchannelApplicationSlug}"
             >

--- a/web/src/admin/providers/scim/SCIMProviderViewPage.ts
+++ b/web/src/admin/providers/scim/SCIMProviderViewPage.ts
@@ -214,7 +214,7 @@ export class SCIMProviderViewPage extends AKElement {
             !this.provider.assignedBackchannelApplicationName
                 ? html`<div slot="header" class="pf-c-banner pf-m-warning">
                       ${msg(
-                          "Warning: Provider is not assigned to an application as backchannel provider.",
+                          "Warning: Provider is not assigned to an application.",
                       )}
                   </div>`
                 : nothing}

--- a/web/src/admin/providers/scim/SCIMProviderViewPage.ts
+++ b/web/src/admin/providers/scim/SCIMProviderViewPage.ts
@@ -210,7 +210,8 @@ export class SCIMProviderViewPage extends AKElement {
             return nothing;
         }
 
-        return html` ${!this.provider?.assignedBackchannelApplicationName
+        return html` ${!this.provider.assignedApplicationName &&
+            !this.provider.assignedBackchannelApplicationName
                 ? html`<div slot="header" class="pf-c-banner pf-m-warning">
                       ${msg(
                           "Warning: Provider is not assigned to an application as backchannel provider.",
@@ -228,7 +229,6 @@ export class SCIMProviderViewPage extends AKElement {
                             [
                                 msg("Assigned to application"),
                                 html`<ak-provider-related-application
-                                    mode="backchannel"
                                     .provider=${this.provider}
                                 ></ak-provider-related-application>`,
                             ],


### PR DESCRIPTION
authentik explicitly supports SCIM providers as either primary or backchannel providers, but the SCIM detail endpoint and UI only considered backchannel assignments.

This caused valid primary assignments to appear unassigned and exposed an action that could only fail because the application already existed.