### PR TITLE
web: scale small application icons

### DIFF
--- a/web/src/elements/AppIcon.css
+++ b/web/src/elements/AppIcon.css
@@ -44,5 +44,10 @@
     max-height: calc(var(--icon-height) + var(--icon-border) + var(--icon-border));
     line-height: 1;
     filter: drop-shadow(-0.5px 0px 0px var(--app-icon-shadow-blend-color));
-    max-height: calc(var(--icon-height) + var(--icon-border) + var(--icon-border));
+}
+
+img.icon {
+    height: var(--icon-height);
+    width: var(--icon-height);
+    object-fit: contain;
 }


### PR DESCRIPTION
Scale raster application icons to their configured display size while preserving their aspect ratio, preventing small source images from rendering at their natural dimensions.

Closes: #21348

Before:

<img width="754" height="608" alt="image" src="https://github.com/user-attachments/assets/76e2d96f-9ad2-4896-a9bd-b3f11f4bebc1" />

After:

<img width="642" height="534" alt="image" src="https://github.com/user-attachments/assets/b495d280-91cb-4230-90c8-b257daf4508e" />