### PR TITLE
web: contain long text in tables and application cards

### DIFF
--- a/web/src/styles/authentik/components/Table/table.css
+++ b/web/src/styles/authentik/components/Table/table.css
@@ -1,6 +1,11 @@
 .pf-c-table {
     --pf-c-table__sort__button__text--Color: var(--pf-global--Color--100);
     --pf-c-table__button--hover--Color: var(--pf-global--link--Color--hover);
+
+    tbody > tr > * {
+        overflow-wrap: anywhere;
+        word-break: break-all;
+    }
 }
 
 .pf-c-toolbar {

--- a/web/src/user/LibraryPage/ApplicationList.css
+++ b/web/src/user/LibraryPage/ApplicationList.css
@@ -75,6 +75,7 @@
 [part="card-title"] {
     padding: 0 !important;
     z-index: 1;
+    min-width: 0;
     text-stroke-width: 0.15em;
     text-stroke-color: var(--pf-c-card--BackgroundColor);
 
@@ -98,6 +99,7 @@
         box-orient: vertical;
         -webkit-box-orient: vertical;
         overflow: hidden;
+        overflow-wrap: anywhere;
         text-align: center;
         text-wrap: balance;
         line-height: 1.2;


### PR DESCRIPTION
Allow unbroken values to wrap inside shared table cells and application card titles so user-controlled names cannot expand their containers or overlap neighboring content.

Before:

<img width="3514" height="170" alt="image" src="https://github.com/user-attachments/assets/ae371f13-286e-4b6a-a949-0a6854d1d171" />

<img width="3788" height="700" alt="image" src="https://github.com/user-attachments/assets/ab8df0ef-6539-4b56-8dca-1cc714dc3191" />

<img width="3508" height="436" alt="image" src="https://github.com/user-attachments/assets/56595fce-912d-4950-b768-1ad546c2787f" />

After:

(ignore the downscaled icon; it's fixed in a pr I opened a few minutes ago)

<img width="744" height="610" alt="image" src="https://github.com/user-attachments/assets/e0486233-d2db-4711-bd33-9c862453ba6c" />

<img width="2648" height="684" alt="image" src="https://github.com/user-attachments/assets/6170d526-948c-44e5-be45-0998338c85f7" />

<img width="3520" height="654" alt="image" src="https://github.com/user-attachments/assets/1d4baa08-48d3-425a-8703-0969b66781a1" />

Closes: #22788