### PR TITLE
web: ensure native select popup contrast

### DIFF
--- a/web/src/styles/authentik/components/Form/form.css
+++ b/web/src/styles/authentik/components/Form/form.css
@@ -84,6 +84,20 @@
     /* #endregion */
 }
 
+/* #region Native select popup */
+
+/*
+ * Chromium uses the select's computed colors for its native popup. Keep the pair
+ * opaque and contrasting; flat selectors also cover Lit shadow roots.
+ */
+[data-theme="dark"] select.pf-c-form-control:not(:disabled),
+:host([theme="dark"]) select.pf-c-form-control:not(:disabled) {
+    background-color: var(--pf-global--BackgroundColor--dark-100);
+    color: var(--pf-global--Color--light-100);
+}
+
+/* #endregion */
+
 .pf-c-form__helper-text {
     text-wrap: pretty;
 }


### PR DESCRIPTION
This bug does not affect MacOS.

This took way too long to resolve.

Chromium derives the base colors for native select popups from the computed foreground and background colors of the select element. authentik overrides the PatternFly form-control background with a transparent value, which can produce dark text on a dark popup background in dark mode.

Give enabled native selects an explicit opaque dark background and light foreground. Use separate selectors for document and Lit shadow root themes so the rule applies consistently throughout the web UI. Disabled selects retain their existing PatternFly styling.

Before:

<img width="1082" height="220" alt="image" src="https://github.com/user-attachments/assets/84e40311-4af3-4f1d-a979-acc5ece6837f" />

After:

<img width="1110" height="243" alt="image" src="https://github.com/user-attachments/assets/1f5d2f66-81f2-4d3e-8e73-e722783f2602" />

Closes: #22609