### PR TITLE
outpost/proxyv2: fix session mismatch after sign-out

### DIFF
--- a/internal/outpost/proxyv2/application/auth.go
+++ b/internal/outpost/proxyv2/application/auth.go
@@ -55,12 +55,7 @@ func (a *Application) getClaimsFromSession(rw http.ResponseWriter, r *http.Reque
 	if err != nil {
 		// err == user has no session/session is not valid
 		// Delete the stale session cookie if it exists
-		if rw != nil {
-			s.Options.MaxAge = -1
-			if saveErr := s.Save(r, rw); saveErr != nil {
-				a.log.WithError(saveErr).Warning("failed to delete stale session cookie")
-			}
-		}
+		a.discardSession(rw, r, s)
 		return nil
 	}
 	claims, ok := s.Values[constants.SessionClaims]

--- a/internal/outpost/proxyv2/application/oauth.go
+++ b/internal/outpost/proxyv2/application/oauth.go
@@ -1,7 +1,6 @@
 package application
 
 import (
-	"context"
 	"net/http"
 	"net/url"
 	"strings"
@@ -17,44 +16,14 @@ const (
 )
 
 func (a *Application) handleAuthStart(rw http.ResponseWriter, r *http.Request, fwd string) {
+	// A client presenting a cookie whose session is gone (sign-out, or an
+	// outpost restart with sessions in a tmpfs) is not an error here:
+	// createState discards the dead session and starts a new one.
 	state, err := a.createState(r, rw, fwd)
 	if err != nil {
 		a.log.WithError(err).Warning("failed to create state")
-		if !strings.HasPrefix(err.Error(), "failed to get session") {
-			rw.WriteHeader(400)
-			return
-		}
-
-		// Client has a cookie but we're unable to load the session from
-		// storage (TMPDIR=/dev/shm). This can happen if the session file
-		// was deleted due to container restart or session invalidation
-		// (e.g., logout on auth server).
-		//
-		// Re-save an empty session and try again.
-
-		session, err := a.sessions.Get(r, a.SessionName())
-		if err != nil && !strings.HasSuffix(err.Error(), "no such file or directory") {
-			a.log.WithError(err).Warning("failed to get session")
-			rw.WriteHeader(400)
-			return
-		}
-		err = a.sessions.Save(r, rw, session)
-		if err != nil {
-			a.log.WithError(err).Warning("failed to save session")
-			rw.WriteHeader(400)
-			return
-		}
-
-		// The registry caches the previous attempt to open the session so it
-		// needs to be cleared in order to get the session in createState().
-		*r = *r.WithContext(context.Background())
-
-		state, err = a.createState(r, rw, fwd)
-		if err != nil {
-			a.log.WithError(err).Warning("failed to create state on retry")
-			rw.WriteHeader(400)
-			return
-		}
+		rw.WriteHeader(400)
+		return
 	}
 	http.Redirect(rw, r, a.oauthConfig.AuthCodeURL(state), http.StatusFound)
 }

--- a/internal/outpost/proxyv2/application/oauth_state.go
+++ b/internal/outpost/proxyv2/application/oauth_state.go
@@ -71,15 +71,21 @@ func (a *Application) checkRedirectParam(r *http.Request) (string, bool) {
 func (a *Application) createState(r *http.Request, w http.ResponseWriter, fwd string) (string, error) {
 	s, err := a.sessions.Get(r, a.SessionName())
 	if err != nil {
-		// Session file may not exist (e.g., after outpost restart or logout)
-		// Delete the stale session cookie and continue with the new empty session
-		a.log.WithError(err).Debug("failed to get session, clearing stale cookie")
-		s.Options.MaxAge = -1
-		if saveErr := s.Save(r, w); saveErr != nil {
-			a.log.WithError(saveErr).Warning("failed to delete stale session cookie")
-		}
-		// Get a fresh session after clearing the stale cookie
-		s, _ = a.sessions.Get(r, a.SessionName())
+		// The client presented a session cookie but the backing session could not
+		// be loaded: it was erased on sign-out, or lost because the outpost
+		// restarted while storing sessions in a tmpfs (TMPDIR=/dev/shm).
+		//
+		// Reset the stale session in place and continue with a new one.
+		// a.sessions.Get() memoises both the session and the error in the
+		// request-scoped registry, so re-fetching would only hand back this very
+		// same object with the dead ID still set, skipping the regeneration below
+		// and minting a state JWT for a session that is never written to the
+		// store. Options is left alone: it is shared with every other Get() in
+		// this request and Save() below depends on its MaxAge.
+		a.log.WithError(err).Debug("discarding stale session")
+		s.ID = ""
+		s.IsNew = true
+		s.Values = map[any]any{}
 	}
 	if s.ID == "" {
 		// Ensure session has an ID
@@ -136,12 +142,7 @@ func (a *Application) stateFromRequest(rw http.ResponseWriter, r *http.Request) 
 	if err != nil {
 		a.log.WithError(err).Warning("failed to get session")
 		// Delete the stale session cookie if it exists
-		if rw != nil {
-			s.Options.MaxAge = -1
-			if saveErr := s.Save(r, rw); saveErr != nil {
-				a.log.WithError(saveErr).Warning("failed to delete stale session cookie")
-			}
-		}
+		a.discardSession(rw, r, s)
 		return nil
 	}
 	if claims.SessionID != s.ID {

--- a/internal/outpost/proxyv2/application/session.go
+++ b/internal/outpost/proxyv2/application/session.go
@@ -81,6 +81,32 @@ func (a *Application) SessionName() string {
 	return a.sessionName
 }
 
+// discardSession erases a session that could not be loaded from the store and
+// tells the client to drop its session cookie.
+//
+// It deliberately works on a copy of the session. gorilla's registry memoises
+// the *sessions.Session per request, so every a.sessions.Get() within a single
+// request hands back the same object — Options included. Setting
+// Options.MaxAge = -1 on the shared object makes every later Save() in that
+// request take the store's "MaxAge <= 0" branch and erase the session instead
+// of persisting it. That is how signing out and logging back in used to fail:
+// checkAuth expired the cookie of the session that sign-out had already
+// deleted, and createState then "saved" a new session that was never written,
+// leaving the state JWT pointing at a session ID the callback could not find
+// ("mismatched session ID ... should=").
+func (a *Application) discardSession(rw http.ResponseWriter, r *http.Request, s *sessions.Session) {
+	if rw == nil {
+		return
+	}
+	expired := *s
+	opts := *s.Options
+	opts.MaxAge = -1
+	expired.Options = &opts
+	if err := a.sessions.Save(r, rw, &expired); err != nil {
+		a.log.WithError(err).Warning("failed to delete stale session cookie")
+	}
+}
+
 func (a *Application) getAllCodecs() []securecookie.Codec {
 	apps := a.srv.Apps()
 	cs := []securecookie.Codec{}

--- a/internal/outpost/proxyv2/application/session_test.go
+++ b/internal/outpost/proxyv2/application/session_test.go
@@ -8,11 +8,63 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/assert"
 	"goauthentik.io/internal/outpost/proxyv2/constants"
+	"goauthentik.io/internal/outpost/proxyv2/filesystemstore"
 	"goauthentik.io/internal/outpost/proxyv2/types"
 )
+
+func sessionPath(id string) string {
+	return filepath.Join(os.TempDir(), "session_"+id)
+}
+
+// withStoreMaxAge gives the session store a real lifetime for the duration of a
+// test. newTestApplication builds a provider without AccessTokenValidity, which
+// leaves the store's MaxAge at 0 — and a store whose MaxAge is <= 0 erases on
+// every Save() instead of persisting, so no session ever round-trips.
+func withStoreMaxAge(t *testing.T, a *Application, maxAge int) {
+	t.Helper()
+	store, ok := a.sessions.(*filesystemstore.Store)
+	if !ok {
+		t.Fatalf("expected a filesystem store, got %T", a.sessions)
+	}
+	previous := store.Options.MaxAge
+	store.Options.MaxAge = maxAge
+	t.Cleanup(func() { store.Options.MaxAge = previous })
+}
+
+// lastSessionCookie returns the final Set-Cookie carrying the session name.
+// A response may set it more than once; clients apply them in order, so the
+// last one is what actually ends up in the cookie jar.
+func lastSessionCookie(t *testing.T, a *Application, rr *httptest.ResponseRecorder) *http.Cookie {
+	t.Helper()
+	var found *http.Cookie
+	for _, cookie := range rr.Result().Cookies() {
+		if cookie.Name == a.SessionName() {
+			found = cookie
+		}
+	}
+	if found == nil {
+		t.Fatal("no session cookie was set")
+	}
+	return found
+}
+
+// parseState decodes a state JWT without checking it against a session, so
+// tests can inspect the session ID it references.
+func parseState(t *testing.T, a *Application, state string) *OAuthState {
+	t.Helper()
+	token, err := jwt.Parse(state, func(token *jwt.Token) (any, error) {
+		return []byte(a.proxyConfig.GetCookieSecret()), nil
+	})
+	assert.NoError(t, err)
+	claims := &OAuthState{}
+	assert.NoError(t, mapstructure.Decode(token.Claims, claims))
+	return claims
+}
 
 func TestLogout(t *testing.T) {
 	a := newTestApplication()
@@ -158,6 +210,7 @@ func TestStateFromRequestDeletesStaleCookie(t *testing.T) {
 func TestCreateStateWithStaleCookie(t *testing.T) {
 	a := newTestApplication()
 	_ = a.configureProxy()
+	withStoreMaxAge(t, a, 86400)
 
 	// Create a request with a stale session cookie (simulates outpost restart or user change)
 	req, _ := http.NewRequest("GET", "https://ext.t.goauthentik.io/outpost.goauthentik.io/start", nil)
@@ -179,14 +232,60 @@ func TestCreateStateWithStaleCookie(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, state)
 
-	// Verify the response includes a Set-Cookie header to delete the stale cookie
-	cookies := rr.Result().Cookies()
-	var foundDeleteCookie bool
-	for _, cookie := range cookies {
-		if cookie.Name == a.SessionName() && cookie.MaxAge < 0 {
-			foundDeleteCookie = true
-			break
-		}
-	}
-	assert.True(t, foundDeleteCookie, "Expected stale session cookie to be deleted")
+	// The state must reference a session that was actually written to the store,
+	// otherwise the callback rejects it with "mismatched session ID".
+	parsed := parseState(t, a, state)
+	assert.NotEqual(t, nonExistentSessionID, parsed.SessionID)
+	assert.FileExists(t, sessionPath(parsed.SessionID))
+
+	// The client has to be left holding that session, so the cookie must be a
+	// persisting one rather than a deletion.
+	cookie := lastSessionCookie(t, a, rr)
+	assert.Greater(t, cookie.MaxAge, 0, "Expected a persisting session cookie, not a deletion")
+}
+
+// TestCreateStateAfterSignOut reproduces the forward-auth sequence that runs
+// after signing out: the session file is gone but the client still presents its
+// cookie, so checkAuth fails and hands off to the auth start.
+//
+// Both halves run inside one request and therefore share a single gorilla
+// session registry, which memoises the *sessions.Session — Options included.
+// Expiring the stale cookie by setting MaxAge = -1 on that shared object used to
+// leak into createState's Save(), which then erased the new session instead of
+// persisting it and minted a state JWT for a session that existed nowhere.
+func TestCreateStateAfterSignOut(t *testing.T) {
+	a := newTestApplication()
+	_ = a.configureProxy()
+	withStoreMaxAge(t, a, 86400)
+
+	// Log in, capturing the cookie the client keeps.
+	loginReq, _ := http.NewRequest("GET", "https://ext.t.goauthentik.io/foo", nil)
+	loginRR := httptest.NewRecorder()
+	s, _ := a.sessions.Get(loginReq, a.SessionName())
+	s.Values[constants.SessionClaims] = types.Claims{Sub: "foo"}
+	assert.NoError(t, a.sessions.Save(loginReq, loginRR, s))
+	assert.FileExists(t, sessionPath(s.ID))
+	staleCookie := lastSessionCookie(t, a, loginRR)
+
+	// Signing out deletes the session but leaves the client's cookie behind.
+	assert.NoError(t, os.Remove(sessionPath(s.ID)))
+
+	req, _ := http.NewRequest("GET", "https://ext.t.goauthentik.io/foo", nil)
+	req.AddCookie(&http.Cookie{Name: staleCookie.Name, Value: staleCookie.Value})
+	rr := httptest.NewRecorder()
+
+	// checkAuth runs first and finds nothing, then the auth start mints a state.
+	assert.Nil(t, a.getClaimsFromSession(rr, req))
+	state, err := a.createState(req, rr, "/redirect")
+	assert.NoError(t, err)
+
+	parsed := parseState(t, a, state)
+	assert.NotEqual(t, s.ID, parsed.SessionID, "state must not reference the signed-out session")
+	assert.FileExists(t, sessionPath(parsed.SessionID))
+
+	// Set-Cookie headers are applied in order, so the last one is what the
+	// client keeps into the callback.
+	cookie := lastSessionCookie(t, a, rr)
+	assert.Greater(t, cookie.MaxAge, 0, "Expected a persisting session cookie, not a deletion")
+	assert.NotEmpty(t, cookie.Value)
 }


### PR DESCRIPTION
<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?

Fixes a 400 `mismatched session ID` at `/outpost.goauthentik.io/callback` on the first login after `sign_out`.

gorilla's `Registry.Get` memoises `{session, error}` per request, so every `a.sessions.Get()` within one request returns the same `*sessions.Session` — **`Options` included**. `getClaimsFromSession` expired a stale session's cookie by setting `s.Options.MaxAge = -1` on that shared object and never restored it. Later in the same request, `createState` saved through those options, and both the filesystem and PostgreSQL stores treat `MaxAge <= 0` as *delete* — so `Save()` erased the new session instead of persisting it, and returned `nil`. The state JWT was minted against a session ID that was never written to the store, and the callback had nothing to load.

Two commits:

1. **`outpost/proxyv2: fix session mismatch after sign-out`**
   - Adds `discardSession()`, which expires a stale cookie via a *copy* of the session so the shared `Options` is never mutated. Used by both `getClaimsFromSession` and `stateFromRequest`.
   - `createState` now resets the dead session in place instead of re-fetching it from the memoised registry, which previously returned the same object with the dead ID still set — skipping the regenerate-and-save block entirely.
   - Adds `TestCreateStateAfterSignOut`, and corrects `TestCreateStateWithStaleCookie`, which asserted the buggy behaviour (that `createState` emits a *deletion* cookie).

2. **`outpost/proxyv2: drop unreachable session retry in handleAuthStart`**
   - Removes a retry gated on `createState` returning an error prefixed `"failed to get session"`. `createState` stopped returning that string when stale-session handling moved inside it, so the branch has been unreachable since before 2026.5.6. It also did `*r = *r.WithContext(context.Background())`, replacing the whole request context — discarding cancellation, deadlines, and tracing — to work around the same memoisation.

### Why is this change needed?

Signing out and logging back in fails on the first attempt, every time, on outposts using the filesystem session backend. The second attempt succeeds — because the deletion cookies from the failed attempt mean the next request presents no cookie, so the error branch never runs and nothing gets poisoned — so it presents as a consistent alternating failure rather than a hard outage.

`handleSignOut` deletes the session but leaves the client holding its cookie, which is the precondition that puts every subsequent request onto the broken path.

The `MaxAge <= 0` → delete branch is identical in `PostgresStore.Save`, so this is not inherently filesystem-only; whether the Postgres store's `New()` errors on a missing session is unverified.

### How was this tested?

`TestCreateStateAfterSignOut` drives the real forward-auth sequence — `getClaimsFromSession` then `createState` within a single request, so both share one session registry — against a session that was persisted and then deleted while its cookie survives.

It fails on unpatched code with exactly the reported production symptom:

```
unable to find file ".../session_DC3MMHBZ..."     ← no session written
"-1" is not greater than "0"                      ← deletion cookie, not a persisting one
```

and passes with the fix. Verified by reverting only the `auth.go` change and re-running.

Both commits build, vet, and pass the proxyv2 suite independently, so the branch stays bisectable. Also verified against tag `version/2026.5.6` and confirmed on a live external outpost.

Note: `TestCreateStateWithStaleCookie` passed before this PR only because the test provider sets no `AccessTokenValidity`, leaving the store's `MaxAge` at `0` — under which nothing ever persists. The new `withStoreMaxAge` helper gives the store a real lifetime so tests exercise the same save path as production.

### Linked issues

closes #24624
