### PR TITLE
root: don't include debug info for rust release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -275,7 +275,7 @@ verbose_file_reads = "warn"
 opt-level = 3
 
 [profile.release]
-debug = 0
+debug = false
 lto = "fat"
 strip = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -275,7 +275,6 @@ verbose_file_reads = "warn"
 opt-level = 3
 
 [profile.release]
-debug = false
 lto = "fat"
 strip = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -275,7 +275,7 @@ verbose_file_reads = "warn"
 opt-level = 3
 
 [profile.release]
-debug = 2
+debug = 0
 lto = "fat"
 strip = true
 


### PR DESCRIPTION
Because:
- `debug = 2` tells the compiler to make full debug info
- `strip = true` then removes that info from the binary

It seems pointless to keep the debug info, as builders with less RAM have trouble building it in the link optimizer step due the amount of data:
- `debug = 2`: 0.83 GiB
- `debug = 0`: 0.58 GiB

---

`lto = "thin"` might also be something worth exploring, but that can be later on.