### PR TITLE
root: limit request body size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,7 @@ tower = "= 0.5.3"
 tower-http = { version = "= 0.7.0", features = [
   "compression-full",
   "fs",
+  "limit",
   "timeout",
 ] }
 tracing = "= 0.1.44"

--- a/packages/ak-axum/src/router.rs
+++ b/packages/ak-axum/src/router.rs
@@ -9,7 +9,7 @@ use axum::{
     response::Response,
 };
 use tower::ServiceBuilder;
-use tower_http::timeout::TimeoutLayer;
+use tower_http::{limit::RequestBodyLimitLayer, timeout::TimeoutLayer};
 
 use crate::{
     extract::{
@@ -56,4 +56,11 @@ pub fn wrap_router(router: Router, with_tracing: bool) -> Router {
     } else {
         router.layer(service_builder)
     }
+}
+
+#[inline]
+pub fn make_request_body_limit_layer() -> RequestBodyLimitLayer {
+    const MAX_BODY_SIZE_BYTES: usize = 32 * 1024 * 1024;
+
+    RequestBodyLimitLayer::new(MAX_BODY_SIZE_BYTES)
 }

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -1,6 +1,9 @@
 use std::{env::temp_dir, os::unix, path::PathBuf, sync::Arc};
 
-use ak_axum::{router::wrap_router, server};
+use ak_axum::{
+    router::{make_request_body_limit_layer, wrap_router},
+    server,
+};
 use ak_common::{
     arbiter::{Arbiter, Tasks},
     config,
@@ -71,6 +74,7 @@ fn build_router(state: Arc<Metrics>) -> Router {
             .with_state(state),
         true,
     )
+    .layer(make_request_body_limit_layer())
 }
 
 pub(crate) fn start(tasks: &mut Tasks) -> Result<Arc<Metrics>> {

--- a/src/outpost/proxy/mod.rs
+++ b/src/outpost/proxy/mod.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
-use ak_axum::router::wrap_router;
+use ak_axum::router::{make_request_body_limit_layer, wrap_router};
 use ak_client::{apis::outposts_api::outposts_proxy_list, models::ProxyMode};
 use ak_common::{
     Tasks,
@@ -283,4 +283,5 @@ fn build_router(outpost: Arc<ProxyOutpost>) -> Router {
             .with_state(outpost),
         true,
     )
+    .layer(make_request_body_limit_layer())
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -9,9 +9,12 @@ use std::{
     },
 };
 
-use ak_axum::extract::{
-    host::{Host, host_middleware},
-    trusted_proxy::trusted_proxy_middleware,
+use ak_axum::{
+    extract::{
+        host::{Host, host_middleware},
+        trusted_proxy::trusted_proxy_middleware,
+    },
+    router::make_request_body_limit_layer,
 };
 use ak_common::{Arbiter, Event, Tasks, config, tls::self_signed};
 use arc_swap::ArcSwapOption;
@@ -306,7 +309,8 @@ fn build_router(server: &Arc<Server>) -> Result<Router> {
         .fallback(any(route_core_and_outpost))
         .with_state((core_router, proxy_router, Arc::clone(&server.proxy_outpost)))
         .layer(from_fn(host_middleware))
-        .layer(from_fn(trusted_proxy_middleware)))
+        .layer(from_fn(trusted_proxy_middleware))
+        .layer(make_request_body_limit_layer()))
 }
 
 pub(crate) async fn start(_cli: Cli, tasks: &mut Tasks) -> Result<Arc<Server>> {

--- a/src/worker/healthcheck.rs
+++ b/src/worker/healthcheck.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
-use ak_axum::{error::Result, router::wrap_router};
+use ak_axum::{
+    error::Result,
+    router::{make_request_body_limit_layer, wrap_router},
+};
 use ak_common::db;
 use axum::{Router, extract::State, http::StatusCode, routing::any};
 use tracing::{instrument, warn};
@@ -69,4 +72,5 @@ pub(super) fn build_router(workers: Arc<Workers>) -> Router {
             .with_state(workers),
         true,
     )
+    .layer(make_request_body_limit_layer())
 }


### PR DESCRIPTION
Missing from the go rewrite.

We can't rely on `wrap_router` here since that isn't always applied to "top-level" routers.