### PR TITLE
website/docs: Mark the release notes for 2026.8 as 'beta'

### DIFF
--- a/website/docs/releases/2026/v2026.8.md
+++ b/website/docs/releases/2026/v2026.8.md
@@ -1,7 +1,7 @@
 ---
 title: Release 2026.8
 slug: "/releases/2026.8"
-draft: true
+beta: true
 ---
 
 ## Highlights

--- a/website/docs/releases/2026/v2026.8.md
+++ b/website/docs/releases/2026/v2026.8.md
@@ -41,7 +41,7 @@ Users can now request access to applications and application entitlements from t
 
 Administrators define request rules that control who can request and approve access. Rules support approval by individual users, groups, or policies, minimum reviewer counts, request and grant expiration limits, reviewer notifications, and custom flows that collect request details. Reviewers can approve or deny pending requests and revoke active grants. Each action is recorded in the event log.
 
-For more details, refer to the [privileged access management documentation](TODO).
+For more details, refer to the privileged access management documentation.
 
 ### User switching
 
@@ -108,8 +108,6 @@ authentik now supports using a transaction-mode PostgreSQL connection pooler alo
 As part of our ongoing project to improve the performance and resource consumption of authentik, the authentik server (only the entrypoint for requests, the core remains Django) and proxy outpost, previously written in Golang, have been rewritten in Rust. We aimed this rewrite to be a 1-to-1 match with the previous code.
 
 This currently does not bring any improvements, but is a stepping stone for us to couple the Django core and the proxying Rust closer together, to avoid wasting resources. Stay tuned for more in following releases!
-
-### Agent Skills (@GirlBossRush TODO)
 
 ### Small general improvements
 


### PR DESCRIPTION
Mark the release notes for 2026.8 as 'beta'
