### PR TITLE
ci: release: rename major release to release family

### DIFF
--- a/.github/workflows/release-branch-off.yml
+++ b/.github/workflows/release-branch-off.yml
@@ -46,10 +46,10 @@ jobs:
         env:
           GH_TOKEN: "${{ steps.app-token.outputs.token }}"
         run: |
-          current_major_version="$(uv version --short | grep -oE "^[0-9]{4}\.[0-9]{1,2}")"
-          git checkout -b "version-${current_major_version}"
-          git push origin "version-${current_major_version}"
-          gh label create "backport/version-${current_major_version}" --description "Add this label to PRs to backport changes to version-${current_major_version}" --color "fbca04"
+          current_version_family="$(uv version --short | grep -oE "^[0-9]{4}\.[0-9]{1,2}")"
+          git checkout -b "version-${current_version_family}"
+          git push origin "version-${current_version_family}"
+          gh label create "backport/version-${current_version_family}" --description "Add this label to PRs to backport changes to version-${current_version_family}" --color "fbca04"
   bump-version-pr:
     name: Open version bump PR
     needs:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -11,7 +11,7 @@ jobs:
     outputs:
       tag-name: "${{ steps.metadata.outputs.tag-name }}"
       version: "${{ steps.metadata.outputs.version }}"
-      major-version: "${{ steps.metadata.outputs.major-version }}"
+      version-family: "${{ steps.metadata.outputs.version-family }}"
       release-reason: "${{ steps.metadata.outputs.release-reason }}"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
@@ -23,7 +23,7 @@ jobs:
           gh release download "$tag_name" --pattern metadata.json
           gh attestation verify metadata.json --owner goauthentik
           echo "version=$(jq -r '.version')" >> "$GITHUB_OUTPUT"
-          echo "major-version=$(jq -r '.major_version')" >> "$GITHUB_OUTPUT"
+          echo "version-family=$(jq -r '.version_family')" >> "$GITHUB_OUTPUT"
           echo "release-reason=$(jq -r '.release_reason')" >> "$GITHUB_OUTPUT"
           echo "changelog-url=$(jq -r '.changelog_url')" >> "$GITHUB_OUTPUT"
   publish-containers:
@@ -65,9 +65,9 @@ jobs:
           regctl image import "ocidir://${{ matrix.name }}:${{ needs.metadata.outputs.version }}" "${{ matrix.name }}.oci.tar"
           echo "digest=$(regctl image digest "ocidir://${{ matrix.name }}:${{ needs.metadata.outputs.version }}")" >> "$GITHUB_OUTPUT"
           regctl image import "ghcr.io/goauthentik/${{ matrix.name }}:${{ needs.metadata.outputs.version }}" "${{ matrix.name }}.oci.tar"
-          regctl image import "ghcr.io/goauthentik/${{ matrix.name }}:${{ needs.metadata.outputs.major-version }}" "${{ matrix.name }}.oci.tar"
+          regctl image import "ghcr.io/goauthentik/${{ matrix.name }}:${{ needs.metadata.outputs.version-family }}" "${{ matrix.name }}.oci.tar"
           regctl image import "docker.io/authentik/${{ matrix.name }}:${{ needs.metadata.outputs.version }}" "${{ matrix.name }}.oci.tar"
-          regctl image import "docker.io/authentik/${{ matrix.name }}:${{ needs.metadata.outputs.major-version }}" "${{ matrix.name }}.oci.tar"
+          regctl image import "docker.io/authentik/${{ matrix.name }}:${{ needs.metadata.outputs.version-family }}" "${{ matrix.name }}.oci.tar"
       - uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d
         with:
           subject-name: "ghcr.io/goauthentik/${{ matrix.name }}"
@@ -103,7 +103,7 @@ jobs:
         with:
           tags: |
             ghcr.io/goauthentik/docs:${{ needs.metadata.outputs.version }}
-            ghcr.io/goauthentik/docs:${{ needs.metadata.outputs.major-version }}
+            ghcr.io/goauthentik/docs:${{ needs.metadata.outputs.version-family }}
           file: website/Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -35,20 +35,20 @@ jobs:
         run: |
           echo "${VERSION}" | grep -E '^[0-9]{4}\.(0?[1-9]|1[0-2])\.[0-9]+(-rc[0-9]+)?$'
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "major-version=${VERSION}" | grep -oE "^major-version=[0-9]{4}\.[0-9]{1,2}" >> "$GITHUB_OUTPUT"
+          echo "version-family=${VERSION}" | grep -oE "^version-family=[0-9]{4}\.[0-9]{1,2}" >> "$GITHUB_OUTPUT"
       - id: changelog-url
         run: |
           if [ "${{ inputs.release_reason }}" = "feature" ]; then
-            changelog_url="https://docs.goauthentik.io/docs/releases/${{ steps.check.outputs.major-version }}"
+            changelog_url="https://docs.goauthentik.io/docs/releases/${{ steps.check.outputs.version-family }}"
           elif [ "${{ inputs.release_reason }}" = "prerelease" ]; then
-            changelog_url="https://next.goauthentik.io/docs/releases/${{ steps.check.outputs.major-version }}"
+            changelog_url="https://next.goauthentik.io/docs/releases/${{ steps.check.outputs.version-family }}"
           else
-            changelog_url="https://docs.goauthentik.io/docs/releases/${{ steps.check.outputs.major-version }}#fixed-in-$(echo -n "${{ steps.check.outputs.version }}" | sed 's/\.//g')"}
+            changelog_url="https://docs.goauthentik.io/docs/releases/${{ steps.check.outputs.version-family }}#fixed-in-$(echo -n "${{ steps.check.outputs.version }}" | sed 's/\.//g')"}
           fi
           echo "changelog-url=${changelog_url}" >> "$GITHUB_OUTPUT"
     outputs:
       version: "${{ steps.check.outputs.version }}"
-      major-version: "${{ steps.check.outputs.major-version }}"
+      version-family: "${{ steps.check.outputs.version-family }}"
       changelog-url: "${{ steps.changelog-url.outputs.changelog-url }}"
   bump-version:
     name: Bump authentik version
@@ -71,7 +71,7 @@ jobs:
           GH_TOKEN: "${{ steps.app-token.outputs.token }}"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
         with:
-          ref: "version-${{ needs.check-inputs.outputs.major-version }}"
+          ref: "version-${{ needs.check-inputs.outputs.version-family }}"
           token: "${{ steps.app-token.outputs.token }}"
       - name: Setup authentik env
         uses: ./.github/actions/setup
@@ -276,7 +276,7 @@ jobs:
           git push --tags
       - name: Create metadata file
         run: |
-          echo '{"version": "${{ needs.check-inputs.outputs.version }}", "major_version": "${{ needs.check-inputs.outputs.major-version }}", "release_reason": "${{ inputs.release_reason }}", "changelog_url": "${{ needs.check-inputs.outputs.changelog-url }}"}' > metadata.json
+          echo '{"version": "${{ needs.check-inputs.outputs.version }}", "version_family": "${{ needs.check-inputs.outputs.version-family }}", "release_reason": "${{ inputs.release_reason }}", "changelog_url": "${{ needs.check-inputs.outputs.changelog-url }}"}' > metadata.json
       - name: Fetch container images
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v5
         with:

--- a/website/integrations/docusaurus.config.esm.mjs
+++ b/website/integrations/docusaurus.config.esm.mjs
@@ -109,7 +109,7 @@ export default createDocusaurusConfig(
         }),
 
         // TODO: This can be removed after https://github.com/goauthentik/authentik/pull/24687
-        // is merged and the docusuaurs config dependency has been bumped
+        // is merged and the docusaurus config dependency has been bumped
         headTags: [
             {
                 tagName: "script",


### PR DESCRIPTION
breaking change if the workflow is used by other repositories (for instance for security releases), so let's make it while we can