### PR TITLE
core/sources: reuse group property mapping manager across groups

### DIFF
--- a/authentik/core/sources/flow_manager.py
+++ b/authentik/core/sources/flow_manager.py
@@ -109,9 +109,15 @@ class SourceFlowManager:
         self.user_properties = self.mapper.build_object_properties(
             object_type=User, request=request, user=None, **self.user_info
         )
+        # Build the group property mapping manager once and reuse it for every group.
+        # Letting build_object_properties() create it per group re-evaluates the mapping
+        # queryset (including select_subclasses()) and recompiles every expression for
+        # each group, which makes group sync scale poorly for users with many groups.
+        groups_manager = self.mapper.get_manager(Group, ["group_id", *self.user_info.keys()])
         self.groups_properties = {
             group_id: self.mapper.build_object_properties(
                 object_type=Group,
+                manager=groups_manager,
                 request=request,
                 user=None,
                 group_id=group_id,

--- a/authentik/core/sources/flow_manager.py
+++ b/authentik/core/sources/flow_manager.py
@@ -109,10 +109,6 @@ class SourceFlowManager:
         self.user_properties = self.mapper.build_object_properties(
             object_type=User, request=request, user=None, **self.user_info
         )
-        # Build the group property mapping manager once and reuse it for every group.
-        # Letting build_object_properties() create it per group re-evaluates the mapping
-        # queryset (including select_subclasses()) and recompiles every expression for
-        # each group, which makes group sync scale poorly for users with many groups.
         groups_manager = self.mapper.get_manager(Group, ["group_id", *self.user_info.keys()])
         self.groups_properties = {
             group_id: self.mapper.build_object_properties(

--- a/authentik/core/tests/test_source_flow_manager.py
+++ b/authentik/core/tests/test_source_flow_manager.py
@@ -1,7 +1,9 @@
 """Test Source flow_manager"""
 
 from django.contrib.auth.models import AnonymousUser
+from django.db import connection
 from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from guardian.shortcuts import get_anonymous_user
 
@@ -15,7 +17,11 @@ from authentik.lib.generators import generate_id
 from authentik.policies.denied import AccessDeniedResponse
 from authentik.policies.expression.models import ExpressionPolicy
 from authentik.policies.models import PolicyBinding
-from authentik.sources.oauth.models import OAuthSource, UserOAuthSourceConnection
+from authentik.sources.oauth.models import (
+    OAuthSource,
+    OAuthSourcePropertyMapping,
+    UserOAuthSourceConnection,
+)
 from authentik.sources.oauth.views.callback import OAuthSourceFlowManager
 
 
@@ -255,3 +261,38 @@ class TestSourceFlowManager(TestCase):
         self.assertIsInstance(response, AccessDeniedResponse)
 
         self.assertEqual(response.error_message, "foo")
+
+    def build_group_properties(self, group_count: int) -> int:
+        """Build group properties for `group_count` groups, check them, and return the
+        number of queries it took"""
+        group_ids = [f"group-{index}" for index in range(group_count)]
+        with CaptureQueriesContext(connection) as queries:
+            flow_manager = OAuthSourceFlowManager(
+                self.source,
+                self.request_factory.get("/", user=AnonymousUser()),
+                self.identifier,
+                {"info": {"groups": group_ids}},
+                {},
+            )
+        self.assertEqual(len(flow_manager.groups_properties), group_count)
+        for group_id in group_ids:
+            # Each group must get its own properties, from both the base properties and
+            # the property mapping
+            self.assertEqual(
+                flow_manager.groups_properties[group_id],
+                {"name": group_id, "attributes": {"group_id": group_id}},
+            )
+        return len(queries.captured_queries)
+
+    def test_group_properties_reuse_mapping_manager(self):
+        """Test that building group properties doesn't re-fetch and re-compile the
+        source's group property mappings for every single group"""
+        self.source.group_property_mappings.add(
+            OAuthSourcePropertyMapping.objects.create(
+                name=generate_id(),
+                expression="""return {"attributes": {"group_id": group_id}}""",
+            )
+        )
+        # The property mappings are fetched and compiled once per flow manager, so the
+        # query count must not grow with the number of groups
+        self.assertEqual(self.build_group_properties(1), self.build_group_properties(20))

--- a/authentik/core/tests/test_source_flow_manager.py
+++ b/authentik/core/tests/test_source_flow_manager.py
@@ -262,7 +262,7 @@ class TestSourceFlowManager(TestCase):
 
         self.assertEqual(response.error_message, "foo")
 
-    def build_group_properties(self, group_count: int) -> int:
+    def calculate_group_property_mapping_queries(self, group_count: int) -> int:
         """Build group properties for `group_count` groups, check them, and return the
         number of queries it took"""
         group_ids = [f"group-{index}" for index in range(group_count)]
@@ -293,6 +293,5 @@ class TestSourceFlowManager(TestCase):
                 expression="""return {"attributes": {"group_id": group_id}}""",
             )
         )
-        # The property mappings are fetched and compiled once per flow manager, so the
-        # query count must not grow with the number of groups
-        self.assertEqual(self.build_group_properties(1), self.build_group_properties(20))
+        # Building N groups must take fewer than N queries
+        self.assertLess(self.calculate_group_property_mapping_queries(100), 100)


### PR DESCRIPTION
Closes #24694.

`SourceFlowManager.__init__` builds group properties in a loop without passing the `manager` argument that `SourceMapper.build_object_properties()` already accepts, so every group re-creates the `PropertyMappingManager` — re-evaluating `group_property_mappings.all().select_subclasses()` and recompiling every expression once per group.

`PropertyMappingManager` is explicitly built for reuse ("Pre-compile and cache property mappings when an identical set is used multiple times", and it guards compilation behind `__has_compiled`), so this hoists the instance out of the loop. The `context_keys` are identical on every iteration (`["group_id"] + user_info keys`) and the mapping queryset does not change mid-login, so one manager serves the whole loop.

### Measurements

**⚠️ The numbers in #24694 understated this by roughly 30×.** I filed it having measured with *zero* group property mappings attached, where `compile()` walks an empty queryset. Once **even one** group property mapping exists — the normal case for anyone using them — the per-group cost jumps from ~24 ms to ~615 ms.

`SourceFlowManager.__init__` with **69 groups and 1 group property mapping**, stock 2026.5.5 server image, 5 runs after a warm-up:

| | min | median | max |
|---|---|---|---|
| before | 46,259 ms | **46,868 ms** | 47,423 ms |
| after | 671 ms | **714 ms** | 1,146 ms |

Queries for the same constructor: **28 → 9** for 20 groups (9 for 1 group in both cases, i.e. constant after the change).

Where the per-group cost goes — `select_subclasses()`, not expression compilation:

| Measured, per call | 0 mappings | 1 mapping | 2 mappings |
|---|---|---|---|
| `get_manager()` + `compile()` | 21.02 ms | **615.69 ms** | 612.01 ms |
| `group_property_mappings.all().select_subclasses()` | 19.95 ms | **712.21 ms** | 729.05 ms |
| same queryset without `select_subclasses()` | 1.11 ms | 2.61 ms | 2.88 ms |
| `PropertyMappingEvaluator(...)` construction | — | 0.08 ms | — |
| construction + `.compile()` | — | 0.27 ms | — |

Two things worth noting from that table:

- Constructing and compiling the evaluator is **0.27 ms** — the cost is not expression compilation. It is iterating the `select_subclasses()` queryset.
- The cost is **fixed once the result set is non-empty** rather than per-row (1 mapping ≈ 2 mappings), which is why a single property mapping is enough to trigger it.

That ~710 ms for a one-row `select_subclasses()` looks worth a separate look on its own merits; this PR only stops the login path from paying it once per group.

With zero group property mappings the same change takes 69 groups from ~24.5 ms/group (~1.7 s) to ~0.01 ms/call.

### Test

`test_group_properties_reuse_mapping_manager` asserts the query count for 1 group equals the count for 20, and that every group still receives its own properties from both the base properties and the property mapping. Comparing counts rather than asserting an absolute number keeps it robust against unrelated query changes.

Verified it discriminates: on unpatched code the two counts are 9 vs 28 and the assertion fails; with the change they are both 9 and it passes.

I also confirmed reuse is semantically safe before writing this — a mapping whose output derives from `group_id` returns per-group-correct, byte-identical results across 8 groups with a shared manager (`iter_eval()` re-runs `set_context()` per call, so nothing is captured at compile time). That was the main correctness risk, since a stale context would have returned the first group's values for every group.
