### PR TITLE
ci: work around pnpm hang-after-install in CI and container builds

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -91,9 +91,18 @@ runs:
       if: ${{ contains(inputs.dependencies, 'node') }}
       shell: bash
       working-directory: ${{ inputs.working-directory }}
+      # pnpm 11 can intermittently finish an install and then never exit (its
+      # worker-pool shutdown waits forever; pnpm/pnpm#13617), which stalls the
+      # job until the workflow timeout. The hang happens after the store and
+      # node_modules are fully written, so each attempt is bounded and retried
+      # once — the retry validates the completed work in seconds.
       run: |
-        pnpm install --frozen-lockfile
-        pnpm --dir web install --frozen-lockfile
+        pnpm_install() {
+          timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile \
+            || timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile
+        }
+        pnpm_install
+        pnpm_install --dir web
     - name: Setup go
       if: ${{ contains(inputs.dependencies, 'go') }}
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v5
@@ -120,7 +129,10 @@ runs:
       if: ${{ contains(inputs.dependencies, 'runtime') && contains(inputs.dependencies, 'node') }}
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: pnpm --dir web install --frozen-lockfile
+      # Bounded + retried for the same pnpm hang-after-install as above.
+      run: |
+        timeout --kill-after=15 420 pnpm --dir web install --frozen-lockfile \
+          || timeout --kill-after=15 420 pnpm --dir web install --frozen-lockfile
     - name: Generate config
       if: ${{ contains(inputs.dependencies, 'python') }}
       shell: uv run python {0}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -91,18 +91,10 @@ runs:
       if: ${{ contains(inputs.dependencies, 'node') }}
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      # pnpm 11 can intermittently finish an install and then never exit (its
-      # worker-pool shutdown waits forever; pnpm/pnpm#13617), which stalls the
-      # job until the workflow timeout. The hang happens after the store and
-      # node_modules are fully written, so each attempt is bounded and retried
-      # once — the retry validates the completed work in seconds.
+      # pnpm can hang after installing (pnpm/pnpm#13617); bounded by the calling job's timeout-minutes.
       run: |
-        pnpm_install() {
-          timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile \
-            || timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile
-        }
-        pnpm_install
-        pnpm_install --dir web
+        pnpm install --frozen-lockfile
+        pnpm --dir web install --frozen-lockfile
     - name: Setup go
       if: ${{ contains(inputs.dependencies, 'go') }}
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v5
@@ -129,10 +121,8 @@ runs:
       if: ${{ contains(inputs.dependencies, 'runtime') && contains(inputs.dependencies, 'node') }}
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      # Bounded + retried for the same pnpm hang-after-install as above.
-      run: |
-        timeout --kill-after=15 420 pnpm --dir web install --frozen-lockfile \
-          || timeout --kill-after=15 420 pnpm --dir web install --frozen-lockfile
+      # Same pnpm hang-after-install caveat as above (pnpm/pnpm#13617).
+      run: pnpm --dir web install --frozen-lockfile
     - name: Generate config
       if: ${{ contains(inputs.dependencies, 'python') }}
       shell: uv run python {0}

--- a/.github/workflows/_reusable-container-build-single.yml
+++ b/.github/workflows/_reusable-container-build-single.yml
@@ -49,6 +49,8 @@ jobs:
       contents: read
     name: "Build ${{ inputs.image-name }} on ${{ inputs.image-arch }}"
     runs-on: "${{ inputs.runs-on }}"
+    # Bounds a pnpm hang-after-install (pnpm/pnpm#13617) inside `docker build`.
+    timeout-minutes: 120
     outputs:
       image-digest: "${{ steps.build.outputs.digest }}"
       artifact-id: "${{ steps.upload.outputs.artifact-id }}"

--- a/.github/workflows/ci-api-docs.yml
+++ b/.github/workflows/ci-api-docs.yml
@@ -39,15 +39,11 @@ jobs:
             pnpm-lock.yaml
             website/pnpm-lock.yaml
       - name: Install dependencies
+        # Capped: pnpm can hang after an install completes (pnpm/pnpm#13617).
+        timeout-minutes: 10
         run: |
-          pnpm_install() {
-            # Bounded + retried once: pnpm can hang after an install completes
-            # (pnpm/pnpm#13617); the retry validates the finished work in seconds.
-            timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile \
-              || timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile
-          }
-          pnpm_install
-          pnpm_install --dir website
+          pnpm install --frozen-lockfile
+          pnpm --dir website install --frozen-lockfile
       - name: Lint
         run: pnpm --dir website run ${{ matrix.command }}
   build:
@@ -68,15 +64,11 @@ jobs:
             pnpm-lock.yaml
             website/pnpm-lock.yaml
       - name: Install dependencies
+        # Capped: pnpm can hang after an install completes (pnpm/pnpm#13617).
+        timeout-minutes: 10
         run: |
-          pnpm_install() {
-            # Bounded + retried once: pnpm can hang after an install completes
-            # (pnpm/pnpm#13617); the retry validates the finished work in seconds.
-            timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile \
-              || timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile
-          }
-          pnpm_install
-          pnpm_install --dir website
+          pnpm install --frozen-lockfile
+          pnpm --dir website install --frozen-lockfile
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4
         with:
           path: |
@@ -120,15 +112,11 @@ jobs:
             pnpm-lock.yaml
             website/pnpm-lock.yaml
       - name: Install dependencies
+        # Capped: pnpm can hang after an install completes (pnpm/pnpm#13617).
+        timeout-minutes: 10
         run: |
-          pnpm_install() {
-            # Bounded + retried once: pnpm can hang after an install completes
-            # (pnpm/pnpm#13617); the retry validates the finished work in seconds.
-            timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile \
-              || timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile
-          }
-          pnpm_install
-          pnpm_install --dir website
+          pnpm install --frozen-lockfile
+          pnpm --dir website install --frozen-lockfile
       - name: Deploy Netlify (Production)
         working-directory: website/api
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/ci-api-docs.yml
+++ b/.github/workflows/ci-api-docs.yml
@@ -40,8 +40,14 @@ jobs:
             website/pnpm-lock.yaml
       - name: Install dependencies
         run: |
-          pnpm install --frozen-lockfile
-          pnpm --dir website install --frozen-lockfile
+          pnpm_install() {
+            # Bounded + retried once: pnpm can hang after an install completes
+            # (pnpm/pnpm#13617); the retry validates the finished work in seconds.
+            timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile \
+              || timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile
+          }
+          pnpm_install
+          pnpm_install --dir website
       - name: Lint
         run: pnpm --dir website run ${{ matrix.command }}
   build:
@@ -63,8 +69,14 @@ jobs:
             website/pnpm-lock.yaml
       - name: Install dependencies
         run: |
-          pnpm install --frozen-lockfile
-          pnpm --dir website install --frozen-lockfile
+          pnpm_install() {
+            # Bounded + retried once: pnpm can hang after an install completes
+            # (pnpm/pnpm#13617); the retry validates the finished work in seconds.
+            timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile \
+              || timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile
+          }
+          pnpm_install
+          pnpm_install --dir website
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4
         with:
           path: |
@@ -109,8 +121,14 @@ jobs:
             website/pnpm-lock.yaml
       - name: Install dependencies
         run: |
-          pnpm install --frozen-lockfile
-          pnpm --dir website install --frozen-lockfile
+          pnpm_install() {
+            # Bounded + retried once: pnpm can hang after an install completes
+            # (pnpm/pnpm#13617); the retry validates the finished work in seconds.
+            timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile \
+              || timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile
+          }
+          pnpm_install
+          pnpm_install --dir website
       - name: Deploy Netlify (Production)
         working-directory: website/api
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/ci-aws-cfn.yml
+++ b/.github/workflows/ci-aws-cfn.yml
@@ -39,7 +39,11 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: |
+          # Bounded + retried once: pnpm can hang after an install completes
+          # (pnpm/pnpm#13617); the retry validates the finished work in seconds.
+          timeout --kill-after=15 420 pnpm install --frozen-lockfile \
+            || timeout --kill-after=15 420 pnpm install --frozen-lockfile
       - name: Check changes have been applied
         run: |
           uv run make aws-cfn

--- a/.github/workflows/ci-aws-cfn.yml
+++ b/.github/workflows/ci-aws-cfn.yml
@@ -24,6 +24,7 @@ env:
 jobs:
   check-changes-applied:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
       - name: Setup authentik env
@@ -39,11 +40,9 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
       - name: Install dependencies
-        run: |
-          # Bounded + retried once: pnpm can hang after an install completes
-          # (pnpm/pnpm#13617); the retry validates the finished work in seconds.
-          timeout --kill-after=15 420 pnpm install --frozen-lockfile \
-            || timeout --kill-after=15 420 pnpm install --frozen-lockfile
+        # Capped: pnpm can hang after an install completes (pnpm/pnpm#13617).
+        timeout-minutes: 10
+        run: pnpm install --frozen-lockfile
       - name: Check changes have been applied
         run: |
           uv run make aws-cfn

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -42,8 +42,14 @@ jobs:
             website/pnpm-lock.yaml
       - name: Install dependencies
         run: |
-          pnpm install --frozen-lockfile
-          pnpm --dir website install --frozen-lockfile
+          pnpm_install() {
+            # Bounded + retried once: pnpm can hang after an install completes
+            # (pnpm/pnpm#13617); the retry validates the finished work in seconds.
+            timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile \
+              || timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile
+          }
+          pnpm_install
+          pnpm_install --dir website
       - name: Lint
         run: pnpm --dir website run ${{ matrix.command }}
   build-docs:
@@ -67,8 +73,14 @@ jobs:
             website/pnpm-lock.yaml
       - name: Install dependencies
         run: |
-          pnpm install --frozen-lockfile
-          pnpm --dir website install --frozen-lockfile
+          pnpm_install() {
+            # Bounded + retried once: pnpm can hang after an install completes
+            # (pnpm/pnpm#13617); the retry validates the finished work in seconds.
+            timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile \
+              || timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile
+          }
+          pnpm_install
+          pnpm_install --dir website
       - name: Build Documentation via Docusaurus
         run: pnpm --dir website run build
   build-integrations:
@@ -91,8 +103,14 @@ jobs:
             website/pnpm-lock.yaml
       - name: Install dependencies
         run: |
-          pnpm install --frozen-lockfile
-          pnpm --dir website install --frozen-lockfile
+          pnpm_install() {
+            # Bounded + retried once: pnpm can hang after an install completes
+            # (pnpm/pnpm#13617); the retry validates the finished work in seconds.
+            timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile \
+              || timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile
+          }
+          pnpm_install
+          pnpm_install --dir website
       - name: Build Integrations via Docusaurus
         run: pnpm --dir website run build:integrations
   build-container:

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -41,15 +41,11 @@ jobs:
             pnpm-lock.yaml
             website/pnpm-lock.yaml
       - name: Install dependencies
+        # Capped: pnpm can hang after an install completes (pnpm/pnpm#13617).
+        timeout-minutes: 10
         run: |
-          pnpm_install() {
-            # Bounded + retried once: pnpm can hang after an install completes
-            # (pnpm/pnpm#13617); the retry validates the finished work in seconds.
-            timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile \
-              || timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile
-          }
-          pnpm_install
-          pnpm_install --dir website
+          pnpm install --frozen-lockfile
+          pnpm --dir website install --frozen-lockfile
       - name: Lint
         run: pnpm --dir website run ${{ matrix.command }}
   build-docs:
@@ -72,15 +68,11 @@ jobs:
             pnpm-lock.yaml
             website/pnpm-lock.yaml
       - name: Install dependencies
+        # Capped: pnpm can hang after an install completes (pnpm/pnpm#13617).
+        timeout-minutes: 10
         run: |
-          pnpm_install() {
-            # Bounded + retried once: pnpm can hang after an install completes
-            # (pnpm/pnpm#13617); the retry validates the finished work in seconds.
-            timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile \
-              || timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile
-          }
-          pnpm_install
-          pnpm_install --dir website
+          pnpm install --frozen-lockfile
+          pnpm --dir website install --frozen-lockfile
       - name: Build Documentation via Docusaurus
         run: pnpm --dir website run build
   build-integrations:
@@ -102,19 +94,17 @@ jobs:
             pnpm-lock.yaml
             website/pnpm-lock.yaml
       - name: Install dependencies
+        # Capped: pnpm can hang after an install completes (pnpm/pnpm#13617).
+        timeout-minutes: 10
         run: |
-          pnpm_install() {
-            # Bounded + retried once: pnpm can hang after an install completes
-            # (pnpm/pnpm#13617); the retry validates the finished work in seconds.
-            timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile \
-              || timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile
-          }
-          pnpm_install
-          pnpm_install --dir website
+          pnpm install --frozen-lockfile
+          pnpm --dir website install --frozen-lockfile
       - name: Build Integrations via Docusaurus
         run: pnpm --dir website run build:integrations
   build-container:
     runs-on: ubuntu-latest
+    # Bounds a pnpm hang-after-install (pnpm/pnpm#13617) inside `docker build`.
+    timeout-minutes: 60
     permissions:
       # Needed to upload container images to ghcr.io
       packages: write

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -72,6 +72,7 @@ jobs:
       should-cache: "${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}"
       cache-suffix: "-${{ needs.build-compute-tags.outputs.safe-branch-name }}"
   lint:
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -115,6 +116,7 @@ jobs:
         run: make ci-lint-${{ matrix.job }}
   test-gen:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
         with:
@@ -131,6 +133,7 @@ jobs:
         run: git diff --exit-code -- schema.yml blueprints/schema.json packages/client-go packages/client-rust packages/client-ts
   test-migrations:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
       - name: Setup authentik env
@@ -347,11 +350,9 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
       - name: Install dependencies
-        run: |
-          # Bounded + retried once: pnpm can hang after an install completes
-          # (pnpm/pnpm#13617); the retry validates the finished work in seconds.
-          timeout --kill-after=15 420 pnpm install --frozen-lockfile \
-            || timeout --kill-after=15 420 pnpm install --frozen-lockfile
+        # Capped: pnpm can hang after an install completes (pnpm/pnpm#13617).
+        timeout-minutes: 10
+        run: pnpm install --frozen-lockfile
       - id: cache-web
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4
         if: contains(matrix.job.profiles, 'selenium')
@@ -363,11 +364,10 @@ jobs:
         working-directory: web
         env:
           NODE_ENV: "production"
+        # Capped: pnpm can hang after an install completes (pnpm/pnpm#13617).
+        timeout-minutes: 15
         run: |
-          # Bounded + retried once: pnpm can hang after an install completes
-          # (pnpm/pnpm#13617); the retry validates the finished work in seconds.
-          timeout --kill-after=15 420 pnpm install --frozen-lockfile \
-            || timeout --kill-after=15 420 pnpm install --frozen-lockfile
+          pnpm install --frozen-lockfile
           pnpm run build
           pnpm run build:sfe
       - name: run e2e
@@ -422,11 +422,10 @@ jobs:
         if: steps.cache-web.outputs.cache-hit != 'true'
         env:
           NODE_ENV: "production"
+        # Capped: pnpm can hang after an install completes (pnpm/pnpm#13617).
+        timeout-minutes: 15
         run: |
-          # Bounded + retried once: pnpm can hang after an install completes
-          # (pnpm/pnpm#13617); the retry validates the finished work in seconds.
-          timeout --kill-after=15 420 pnpm --dir web install --frozen-lockfile \
-            || timeout --kill-after=15 420 pnpm --dir web install --frozen-lockfile
+          pnpm --dir web install --frozen-lockfile
           pnpm --dir web run build
           pnpm --dir web run build:sfe
       - name: run conformance

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -347,7 +347,11 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: |
+          # Bounded + retried once: pnpm can hang after an install completes
+          # (pnpm/pnpm#13617); the retry validates the finished work in seconds.
+          timeout --kill-after=15 420 pnpm install --frozen-lockfile \
+            || timeout --kill-after=15 420 pnpm install --frozen-lockfile
       - id: cache-web
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4
         if: contains(matrix.job.profiles, 'selenium')
@@ -360,7 +364,10 @@ jobs:
         env:
           NODE_ENV: "production"
         run: |
-          pnpm install --frozen-lockfile
+          # Bounded + retried once: pnpm can hang after an install completes
+          # (pnpm/pnpm#13617); the retry validates the finished work in seconds.
+          timeout --kill-after=15 420 pnpm install --frozen-lockfile \
+            || timeout --kill-after=15 420 pnpm install --frozen-lockfile
           pnpm run build
           pnpm run build:sfe
       - name: run e2e
@@ -416,7 +423,10 @@ jobs:
         env:
           NODE_ENV: "production"
         run: |
-          pnpm --dir web install --frozen-lockfile
+          # Bounded + retried once: pnpm can hang after an install completes
+          # (pnpm/pnpm#13617); the retry validates the finished work in seconds.
+          timeout --kill-after=15 420 pnpm --dir web install --frozen-lockfile \
+            || timeout --kill-after=15 420 pnpm --dir web install --frozen-lockfile
           pnpm --dir web run build
           pnpm --dir web run build:sfe
       - name: run conformance

--- a/.github/workflows/ci-outpost.yml
+++ b/.github/workflows/ci-outpost.yml
@@ -43,6 +43,7 @@ jobs:
           skip-cache: true
   test-unittest:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -101,15 +102,11 @@ jobs:
             pnpm-lock.yaml
             web/pnpm-lock.yaml
       - name: Install dependencies
+        # Capped: pnpm can hang after an install completes (pnpm/pnpm#13617).
+        timeout-minutes: 10
         run: |
-          pnpm_install() {
-            # Bounded + retried once: pnpm can hang after an install completes
-            # (pnpm/pnpm#13617); the retry validates the finished work in seconds.
-            timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile \
-              || timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile
-          }
-          pnpm_install
-          pnpm_install --dir web
+          pnpm install --frozen-lockfile
+          pnpm --dir web install --frozen-lockfile
       - name: Build web
         run: pnpm --dir web run build-proxy
       - name: Build outpost

--- a/.github/workflows/ci-outpost.yml
+++ b/.github/workflows/ci-outpost.yml
@@ -102,8 +102,14 @@ jobs:
             web/pnpm-lock.yaml
       - name: Install dependencies
         run: |
-          pnpm install --frozen-lockfile
-          pnpm --dir web install --frozen-lockfile
+          pnpm_install() {
+            # Bounded + retried once: pnpm can hang after an install completes
+            # (pnpm/pnpm#13617); the retry validates the finished work in seconds.
+            timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile \
+              || timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile
+          }
+          pnpm_install
+          pnpm_install --dir web
       - name: Build web
         run: pnpm --dir web run build-proxy
       - name: Build outpost

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -35,15 +35,11 @@ jobs:
             pnpm-lock.yaml
             web/pnpm-lock.yaml
       - name: Install dependencies
+        # Capped: pnpm can hang after an install completes (pnpm/pnpm#13617).
+        timeout-minutes: 10
         run: |
-          pnpm_install() {
-            # Bounded + retried once: pnpm can hang after an install completes
-            # (pnpm/pnpm#13617); the retry validates the finished work in seconds.
-            timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile \
-              || timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile
-          }
-          pnpm_install
-          pnpm_install --dir web
+          pnpm install --frozen-lockfile
+          pnpm --dir web install --frozen-lockfile
       - name: Lint
         run: pnpm --dir web run lint-check
       - name: Check types
@@ -71,15 +67,11 @@ jobs:
             pnpm-lock.yaml
             web/pnpm-lock.yaml
       - name: Install dependencies
+        # Capped: pnpm can hang after an install completes (pnpm/pnpm#13617).
+        timeout-minutes: 10
         run: |
-          pnpm_install() {
-            # Bounded + retried once: pnpm can hang after an install completes
-            # (pnpm/pnpm#13617); the retry validates the finished work in seconds.
-            timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile \
-              || timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile
-          }
-          pnpm_install
-          pnpm_install --dir web
+          pnpm install --frozen-lockfile
+          pnpm --dir web install --frozen-lockfile
       - name: build
         env:
           NODE_ENV: "production"
@@ -115,15 +107,11 @@ jobs:
             pnpm-lock.yaml
             web/pnpm-lock.yaml
       - name: Install dependencies
+        # Capped: pnpm can hang after an install completes (pnpm/pnpm#13617).
+        timeout-minutes: 10
         run: |
-          pnpm_install() {
-            # Bounded + retried once: pnpm can hang after an install completes
-            # (pnpm/pnpm#13617); the retry validates the finished work in seconds.
-            timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile \
-              || timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile
-          }
-          pnpm_install
-          pnpm_install --dir web
+          pnpm install --frozen-lockfile
+          pnpm --dir web install --frozen-lockfile
       - name: test
         working-directory: web/
         run: pnpm run test || exit 0

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -36,8 +36,14 @@ jobs:
             web/pnpm-lock.yaml
       - name: Install dependencies
         run: |
-          pnpm install --frozen-lockfile
-          pnpm --dir web install --frozen-lockfile
+          pnpm_install() {
+            # Bounded + retried once: pnpm can hang after an install completes
+            # (pnpm/pnpm#13617); the retry validates the finished work in seconds.
+            timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile \
+              || timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile
+          }
+          pnpm_install
+          pnpm_install --dir web
       - name: Lint
         run: pnpm --dir web run lint-check
       - name: Check types
@@ -66,8 +72,14 @@ jobs:
             web/pnpm-lock.yaml
       - name: Install dependencies
         run: |
-          pnpm install --frozen-lockfile
-          pnpm --dir web install --frozen-lockfile
+          pnpm_install() {
+            # Bounded + retried once: pnpm can hang after an install completes
+            # (pnpm/pnpm#13617); the retry validates the finished work in seconds.
+            timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile \
+              || timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile
+          }
+          pnpm_install
+          pnpm_install --dir web
       - name: build
         env:
           NODE_ENV: "production"
@@ -104,8 +116,14 @@ jobs:
             web/pnpm-lock.yaml
       - name: Install dependencies
         run: |
-          pnpm install --frozen-lockfile
-          pnpm --dir web install --frozen-lockfile
+          pnpm_install() {
+            # Bounded + retried once: pnpm can hang after an install completes
+            # (pnpm/pnpm#13617); the retry validates the finished work in seconds.
+            timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile \
+              || timeout --kill-after=15 420 pnpm "$@" install --frozen-lockfile
+          }
+          pnpm_install
+          pnpm_install --dir web
       - name: test
         working-directory: web/
         run: pnpm run test || exit 0

--- a/.github/workflows/gen-update-webauthn-mds.yml
+++ b/.github/workflows/gen-update-webauthn-mds.yml
@@ -14,6 +14,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - id: generate_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v2

--- a/.github/workflows/packages-npm-publish.yml
+++ b/.github/workflows/packages-npm-publish.yml
@@ -48,7 +48,11 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: |
+          # Bounded + retried once: pnpm can hang after an install completes
+          # (pnpm/pnpm#13617); the retry validates the finished work in seconds.
+          timeout --kill-after=15 420 pnpm install --frozen-lockfile \
+            || timeout --kill-after=15 420 pnpm install --frozen-lockfile
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # 24d32ffd492484c1d75e0c0b894501ddb9d30d62

--- a/.github/workflows/packages-npm-publish.yml
+++ b/.github/workflows/packages-npm-publish.yml
@@ -48,11 +48,9 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
       - name: Install dependencies
-        run: |
-          # Bounded + retried once: pnpm can hang after an install completes
-          # (pnpm/pnpm#13617); the retry validates the finished work in seconds.
-          timeout --kill-after=15 420 pnpm install --frozen-lockfile \
-            || timeout --kill-after=15 420 pnpm install --frozen-lockfile
+        # Capped: pnpm can hang after an install completes (pnpm/pnpm#13617).
+        timeout-minutes: 10
+        run: pnpm install --frozen-lockfile
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # 24d32ffd492484c1d75e0c0b894501ddb9d30d62

--- a/.github/workflows/qa-codeql.yml
+++ b/.github/workflows/qa-codeql.yml
@@ -13,6 +13,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/release-branch-off.yml
+++ b/.github/workflows/release-branch-off.yml
@@ -55,6 +55,7 @@ jobs:
     needs:
       - branch-off
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - id: generate_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v2

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -64,6 +64,7 @@ jobs:
     needs:
       - check-inputs
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     outputs:
       release-commit: "${{ steps.commit.outputs.release-commit }}"
     steps:

--- a/.github/workflows/translation-extract-compile.yml
+++ b/.github/workflows/translation-extract-compile.yml
@@ -18,6 +18,7 @@ env:
 jobs:
   compile:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - id: generate_token
         if: ${{ github.event_name != 'pull_request' }}

--- a/lifecycle/container/Dockerfile
+++ b/lifecycle/container/Dockerfile
@@ -42,8 +42,7 @@ RUN --mount=type=bind,target=/work/.npmrc,src=./.npmrc \
     --mount=type=bind,target=/work/web/packages/sfe/package.json,src=./web/packages/sfe/package.json \
     --mount=type=bind,target=/work/web/scripts,src=./web/scripts \
     --mount=type=cache,id=pnpm-ak,sharing=shared,target=/root/.local/share/pnpm/store \
-    timeout --kill-after=20 420 pnpm install --frozen-lockfile \
-    || timeout --kill-after=20 420 pnpm install --frozen-lockfile
+    pnpm install --frozen-lockfile
 
 COPY ./package.json /work
 COPY ./web /work/web/

--- a/lifecycle/container/Dockerfile
+++ b/lifecycle/container/Dockerfile
@@ -16,6 +16,12 @@ WORKDIR /work
 COPY --from=pnpm /opt/pnpm /opt/pnpm
 ENV PATH="/opt/pnpm:${PATH}"
 
+# `pnpm run` would otherwise spawn a nested `pnpm install` to re-verify
+# node_modules against the lockfile. The install layer below already
+# guarantees that, and the nested install is the spot where pnpm's
+# hang-after-install (pnpm/pnpm#13617) stalls image builds.
+ENV npm_config_verify_deps_before_run=false
+
 RUN --mount=type=bind,target=/work/package.json,src=./package.json \
     --mount=type=bind,target=/work/web/package.json,src=./web/package.json \
     --mount=type=bind,target=/work/web/pnpm-lock.yaml,src=./web/pnpm-lock.yaml \
@@ -36,7 +42,8 @@ RUN --mount=type=bind,target=/work/.npmrc,src=./.npmrc \
     --mount=type=bind,target=/work/web/packages/sfe/package.json,src=./web/packages/sfe/package.json \
     --mount=type=bind,target=/work/web/scripts,src=./web/scripts \
     --mount=type=cache,id=pnpm-ak,sharing=shared,target=/root/.local/share/pnpm/store \
-    pnpm install --frozen-lockfile
+    timeout --kill-after=20 420 pnpm install --frozen-lockfile \
+    || timeout --kill-after=20 420 pnpm install --frozen-lockfile
 
 COPY ./package.json /work
 COPY ./web /work/web/

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -11,6 +11,13 @@ WORKDIR /work
 COPY --from=pnpm /opt/pnpm /opt/pnpm
 ENV PATH="/opt/pnpm:${PATH}"
 
+# `pnpm run` would otherwise spawn a nested `pnpm install` to re-verify
+# node_modules against the lockfile. The install layers below already
+# guarantee that, the re-verify mis-prunes workspace packages whose manifests
+# are bind-mounted only in the install layers, and the nested install is the
+# spot where pnpm's hang-after-install (pnpm/pnpm#13617) stalls image builds.
+ENV npm_config_verify_deps_before_run=false
+
 RUN --mount=type=bind,target=/work/package.json,src=./package.json \
     --mount=type=bind,target=/work/scripts/node/,src=./scripts/node/ \
     --mount=type=bind,target=/work/packages/logger-js/,src=./packages/logger-js/ \
@@ -18,6 +25,10 @@ RUN --mount=type=bind,target=/work/package.json,src=./package.json \
     --mount=type=bind,target=/work/website/pnpm-lock.yaml,src=./website/pnpm-lock.yaml \
     node ./scripts/node/lint-runtime.mjs ./website
 
+# Install attempts are bounded and retried once: pnpm can hang after an
+# install completes (pnpm/pnpm#13617); the retry validates the already-written
+# store and node_modules in seconds.
+#
 # Hoisted root install so `@goauthentik/docusaurus-config` resolves its own deps
 # (e.g. `deepmerge-ts`) from /work/node_modules during the docs build; its source
 # is bind-mounted read-only, so a per-package node_modules can't be written.
@@ -33,7 +44,9 @@ RUN --mount=type=bind,target=/work/.npmrc,src=./.npmrc \
     --mount=type=bind,target=/work/packages/tsconfig/package.json,src=./packages/tsconfig/package.json \
     --mount=type=bind,target=/work/lifecycle/aws/package.json,src=./lifecycle/aws/package.json \
     --mount=type=cache,id=pnpm-root,sharing=shared,target=/root/.local/share/pnpm/store \
-    pnpm install --frozen-lockfile --config.node-linker=hoisted \
+    timeout --kill-after=20 420 pnpm install --frozen-lockfile --config.node-linker=hoisted \
+    --filter "@goauthentik/docusaurus-config" \
+    || timeout --kill-after=20 420 pnpm install --frozen-lockfile --config.node-linker=hoisted \
     --filter "@goauthentik/docusaurus-config"
 
 RUN --mount=type=bind,target=/work/.npmrc,src=./.npmrc \
@@ -47,7 +60,8 @@ RUN --mount=type=bind,target=/work/.npmrc,src=./.npmrc \
     --mount=type=bind,target=/work/website/integrations/package.json,src=./website/integrations/package.json \
     --mount=type=bind,target=/work/website/docs/package.json,src=./website/docs/package.json \
     --mount=type=cache,id=pnpm-website,sharing=shared,target=/root/.local/share/pnpm/store \
-    pnpm --dir website install --frozen-lockfile
+    timeout --kill-after=20 420 pnpm --dir website install --frozen-lockfile \
+    || timeout --kill-after=20 420 pnpm --dir website install --frozen-lockfile
 
 WORKDIR /work/website
 

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -25,9 +25,8 @@ RUN --mount=type=bind,target=/work/package.json,src=./package.json \
     --mount=type=bind,target=/work/website/pnpm-lock.yaml,src=./website/pnpm-lock.yaml \
     node ./scripts/node/lint-runtime.mjs ./website
 
-# Install attempts are bounded and retried once: pnpm can hang after an
-# install completes (pnpm/pnpm#13617); the retry validates the already-written
-# store and node_modules in seconds.
+# pnpm can intermittently hang after an install completes (pnpm/pnpm#13617);
+# a stalled build here is bounded by the CI job's timeout-minutes.
 #
 # Hoisted root install so `@goauthentik/docusaurus-config` resolves its own deps
 # (e.g. `deepmerge-ts`) from /work/node_modules during the docs build; its source
@@ -44,9 +43,7 @@ RUN --mount=type=bind,target=/work/.npmrc,src=./.npmrc \
     --mount=type=bind,target=/work/packages/tsconfig/package.json,src=./packages/tsconfig/package.json \
     --mount=type=bind,target=/work/lifecycle/aws/package.json,src=./lifecycle/aws/package.json \
     --mount=type=cache,id=pnpm-root,sharing=shared,target=/root/.local/share/pnpm/store \
-    timeout --kill-after=20 420 pnpm install --frozen-lockfile --config.node-linker=hoisted \
-    --filter "@goauthentik/docusaurus-config" \
-    || timeout --kill-after=20 420 pnpm install --frozen-lockfile --config.node-linker=hoisted \
+    pnpm install --frozen-lockfile --config.node-linker=hoisted \
     --filter "@goauthentik/docusaurus-config"
 
 RUN --mount=type=bind,target=/work/.npmrc,src=./.npmrc \
@@ -60,8 +57,7 @@ RUN --mount=type=bind,target=/work/.npmrc,src=./.npmrc \
     --mount=type=bind,target=/work/website/integrations/package.json,src=./website/integrations/package.json \
     --mount=type=bind,target=/work/website/docs/package.json,src=./website/docs/package.json \
     --mount=type=cache,id=pnpm-website,sharing=shared,target=/root/.local/share/pnpm/store \
-    timeout --kill-after=20 420 pnpm --dir website install --frozen-lockfile \
-    || timeout --kill-after=20 420 pnpm --dir website install --frozen-lockfile
+    pnpm --dir website install --frozen-lockfile
 
 WORKDIR /work/website
 


### PR DESCRIPTION
## Details

Our intermittent CI timeouts (and the occasional local "install finished but never came back") turned out to be an upstream pnpm 11 bug: the install completes all of its work, prints `Done in Xs`, and the process never exits. Reported upstream with details in pnpm/pnpm#13617; a captured example is [this 72-minute `build-container` job](https://github.com/goauthentik/authentik/actions/runs/30828500630/job/91736191294) that hung 4 seconds into a `pnpm install` that had already finished.

Until it's fixed upstream, two small guards:

- **Cap installs with GitHub Actions timeouts.** Inline workflow install steps get `timeout-minutes: 10` (15 where the step also builds the web UI). Installs that run inside the setup composite action or `docker build` can't take a step-level timeout, so those jobs carry a job-level `timeout-minutes` instead — several previously had none and would have idled for the 6-hour default. A hang now surfaces as a fast, retryable failure instead of a stalled job.
- **Disable `verify-deps-before-run` in the image builds.** The install layer right before already guarantees `node_modules` matches the lockfile; the nested install `pnpm run build` spawns was both the observed hang site and quietly mis-pruning workspace packages whose manifests are only bind-mounted in the install layers.

The pnpm version alignment that was previously part of this branch now lives in #24789.

## Verification

- All touched workflows/action parse (js-yaml) and pass Prettier; both Dockerfiles pass `docker build --check`.
