### PR TITLE
web/admin: add user app entitelments screen

### DIFF
--- a/authentik/core/api/application_entitlements.py
+++ b/authentik/core/api/application_entitlements.py
@@ -1,8 +1,15 @@
 """Application Roles API Viewset"""
 
+from django.db.models import QuerySet
 from django.http import HttpRequest
 from django.utils.translation import gettext_lazy as _
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+from guardian.shortcuts import get_objects_for_user
 from rest_framework.exceptions import ValidationError
+from rest_framework.fields import ReadOnlyField
+from rest_framework.request import Request
+from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
 from authentik.blueprints.v1.importer import SERIALIZER_CONTEXT_BLUEPRINT
@@ -12,12 +19,16 @@ from authentik.core.api.utils import ModelSerializer
 from authentik.core.models import (
     Application,
     ApplicationEntitlement,
+    User,
 )
 from authentik.lib.utils.reflection import ConditionalInheritance
 
 
 class ApplicationEntitlementSerializer(AttributesMixinSerializer, ModelSerializer):
     """ApplicationEntitlement Serializer"""
+
+    app_name = ReadOnlyField(source="app.name")
+    app_slug = ReadOnlyField(source="app.slug")
 
     def validate_app(self, app: Application) -> Application:
         """Ensure user has permission to view"""
@@ -37,6 +48,8 @@ class ApplicationEntitlementSerializer(AttributesMixinSerializer, ModelSerialize
             "pbm_uuid",
             "name",
             "app",
+            "app_name",
+            "app_slug",
             "attributes",
         ]
 
@@ -50,7 +63,7 @@ class ApplicationEntitlementViewSet(
 ):
     """ApplicationEntitlement Viewset"""
 
-    queryset = ApplicationEntitlement.objects.all()
+    queryset = ApplicationEntitlement.objects.select_related("app").all()
     serializer_class = ApplicationEntitlementSerializer
     search_fields = [
         "pbm_uuid",
@@ -64,4 +77,38 @@ class ApplicationEntitlementViewSet(
         "name",
         "app",
     ]
-    ordering = ["name"]
+    ordering = ["app__name", "name"]
+    ordering_fields = ["name", "app__name"]
+
+    def filter_queryset(self, queryset: QuerySet) -> QuerySet:
+        queryset = super().filter_queryset(queryset)
+        for_user_pk = self.request.query_params.get("for_user")
+        if for_user_pk is None:
+            return queryset
+        try:
+            for_user_pk = int(for_user_pk)
+        except ValueError:
+            raise ValidationError({"for_user": "for_user must be numerical"}) from None
+        for_user: User | None = (
+            get_objects_for_user(self.request.user, "authentik_core.view_user_applications")
+            .filter(pk=for_user_pk)
+            .first()
+        )
+        if not for_user:
+            raise ValidationError({"for_user": "User not found"})
+        return queryset.filter(
+            pbm_uuid__in=for_user.all_app_entitlements().values_list("pbm_uuid", flat=True)
+        )
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="for_user",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.INT,
+            )
+        ]
+    )
+    def list(self, request: Request, *args, **kwargs) -> Response:
+        """List application entitlements, optionally scoped to a user via `for_user`."""
+        return super().list(request, *args, **kwargs)

--- a/authentik/core/models.py
+++ b/authentik/core/models.py
@@ -483,21 +483,28 @@ class User(SerializerModel, AttributesMixin, AbstractUser):
     def app_entitlements(self, app: Application | None) -> QuerySet[ApplicationEntitlement]:
         """Get all entitlements this user has for `app`."""
         if not app:
-            return []
+            return ApplicationEntitlement.objects.none()
+        return self.all_app_entitlements().filter(app=app)
+
+    def all_app_entitlements(self) -> QuerySet[ApplicationEntitlement]:
+        """Get all entitlements this user has, across all applications."""
         all_groups = self.all_groups()
-        qs = app.applicationentitlement_set.filter(
-            Q(
-                Q(bindings__user=self) | Q(bindings__group__in=all_groups),
-                bindings__negate=False,
+        return (
+            ApplicationEntitlement.objects.filter(
+                Q(
+                    Q(bindings__user=self) | Q(bindings__group__in=all_groups),
+                    bindings__negate=False,
+                )
+                | Q(
+                    Q(~Q(bindings__user=self), bindings__user__isnull=False)
+                    | Q(~Q(bindings__group__in=all_groups), bindings__group__isnull=False),
+                    bindings__negate=True,
+                ),
+                bindings__enabled=True,
             )
-            | Q(
-                Q(~Q(bindings__user=self), bindings__user__isnull=False)
-                | Q(~Q(bindings__group__in=all_groups), bindings__group__isnull=False),
-                bindings__negate=True,
-            ),
-            bindings__enabled=True,
-        ).order_by("name")
-        return qs
+            .order_by("name")
+            .distinct()
+        )
 
     def app_entitlements_attributes(self, app: Application | None) -> dict:
         """Get a dictionary containing all merged attributes from app entitlements for `app`."""

--- a/authentik/core/models.py
+++ b/authentik/core/models.py
@@ -484,21 +484,28 @@ class User(SerializerModel, AttributesMixin, AbstractUser):
     def app_entitlements(self, app: Application | None) -> QuerySet[ApplicationEntitlement]:
         """Get all entitlements this user has for `app`."""
         if not app:
-            return []
+            return ApplicationEntitlement.objects.none()
+        return self.all_app_entitlements().filter(app=app)
+
+    def all_app_entitlements(self) -> QuerySet[ApplicationEntitlement]:
+        """Get all entitlements this user has, across all applications."""
         all_groups = self.all_groups()
-        qs = app.applicationentitlement_set.filter(
-            Q(
-                Q(bindings__user=self) | Q(bindings__group__in=all_groups),
-                bindings__negate=False,
+        return (
+            ApplicationEntitlement.objects.filter(
+                Q(
+                    Q(bindings__user=self) | Q(bindings__group__in=all_groups),
+                    bindings__negate=False,
+                )
+                | Q(
+                    Q(~Q(bindings__user=self), bindings__user__isnull=False)
+                    | Q(~Q(bindings__group__in=all_groups), bindings__group__isnull=False),
+                    bindings__negate=True,
+                ),
+                bindings__enabled=True,
             )
-            | Q(
-                Q(~Q(bindings__user=self), bindings__user__isnull=False)
-                | Q(~Q(bindings__group__in=all_groups), bindings__group__isnull=False),
-                bindings__negate=True,
-            ),
-            bindings__enabled=True,
-        ).order_by("name")
-        return qs
+            .order_by("name")
+            .distinct()
+        )
 
     def app_entitlements_attributes(self, app: Application | None) -> dict:
         """Get a dictionary containing all merged attributes from app entitlements for `app`."""

--- a/authentik/core/models.py
+++ b/authentik/core/models.py
@@ -485,27 +485,22 @@ class User(SerializerModel, AttributesMixin, AbstractUser):
         """Get all entitlements this user has for `app`."""
         if not app:
             return ApplicationEntitlement.objects.none()
-        return self.all_app_entitlements().filter(app=app)
+        return self._app_entitlements_for(ApplicationEntitlement.objects.filter(app=app))
 
     def all_app_entitlements(self) -> QuerySet[ApplicationEntitlement]:
         """Get all entitlements this user has, across all applications."""
-        all_groups = self.all_groups()
-        return (
-            ApplicationEntitlement.objects.filter(
-                Q(
-                    Q(bindings__user=self) | Q(bindings__group__in=all_groups),
-                    bindings__negate=False,
-                )
-                | Q(
-                    Q(~Q(bindings__user=self), bindings__user__isnull=False)
-                    | Q(~Q(bindings__group__in=all_groups), bindings__group__isnull=False),
-                    bindings__negate=True,
-                ),
-                bindings__enabled=True,
-            )
-            .order_by("name")
-            .distinct()
-        )
+        return self._app_entitlements_for(ApplicationEntitlement.objects.all())
+
+    def _app_entitlements_for(
+        self, queryset: QuerySet[ApplicationEntitlement]
+    ) -> QuerySet[ApplicationEntitlement]:
+        from authentik.policies.engine import ListPolicyEngine
+
+        engine = ListPolicyEngine(queryset, self)
+        # An entitlement with no bindings is granted to no one
+        engine.empty_result = False
+        engine.build()
+        return engine.result.order_by("name")
 
     def app_entitlements_attributes(self, app: Application | None) -> dict:
         """Get a dictionary containing all merged attributes from app entitlements for `app`."""

--- a/authentik/core/tests/test_application_entitlements.py
+++ b/authentik/core/tests/test_application_entitlements.py
@@ -135,6 +135,112 @@ class TestApplicationEntitlements(APITestCase):
             {"non_field_errors": ["One of 'group', 'user' must be set."]},
         )
 
+    def test_api_for_user(self):
+        """Test listing all entitlements a user has via for_user"""
+        other_app = Application.objects.create(name=generate_id(), slug=generate_id())
+        ent_direct = ApplicationEntitlement.objects.create(app=self.app, name=generate_id())
+        PolicyBinding.objects.create(target=ent_direct, user=self.user, order=0)
+        group = Group.objects.create(name=generate_id())
+        self.user.groups.add(group)
+        ent_group = ApplicationEntitlement.objects.create(app=other_app, name=generate_id())
+        PolicyBinding.objects.create(target=ent_group, group=group, order=0)
+        # Entitlement the user does not have
+        ApplicationEntitlement.objects.create(app=self.app, name=generate_id())
+        self.client.force_login(create_test_admin_user())
+        res = self.client.get(
+            reverse("authentik_api:applicationentitlement-list"),
+            {"for_user": self.user.pk},
+        )
+        self.assertEqual(res.status_code, 200)
+        body = res.json()
+        self.assertEqual(body["pagination"]["count"], 2)
+        self.assertCountEqual(
+            [ent["name"] for ent in body["results"]],
+            [ent_direct.name, ent_group.name],
+        )
+        self.assertCountEqual(
+            [ent["app_name"] for ent in body["results"]],
+            [self.app.name, other_app.name],
+        )
+
+    def test_api_for_user_ordering(self):
+        """Test that for_user results can be ordered by application name"""
+        app_a = Application.objects.create(name=f"aaa-{generate_id()}", slug=generate_id())
+        app_b = Application.objects.create(name=f"bbb-{generate_id()}", slug=generate_id())
+        ent_a = ApplicationEntitlement.objects.create(app=app_a, name=generate_id())
+        ent_b = ApplicationEntitlement.objects.create(app=app_b, name=generate_id())
+        PolicyBinding.objects.create(target=ent_a, user=self.user, order=0)
+        PolicyBinding.objects.create(target=ent_b, user=self.user, order=0)
+        self.client.force_login(create_test_admin_user())
+        for ordering, expected in [
+            ("app__name", [ent_a.name, ent_b.name]),
+            ("-app__name", [ent_b.name, ent_a.name]),
+        ]:
+            with self.subTest(ordering=ordering):
+                res = self.client.get(
+                    reverse("authentik_api:applicationentitlement-list"),
+                    {"for_user": self.user.pk, "ordering": ordering, "search": ""},
+                )
+                self.assertEqual(res.status_code, 200)
+                self.assertEqual(
+                    [ent["name"] for ent in res.json()["results"]],
+                    expected,
+                )
+
+    def test_api_for_user_deduplicated(self):
+        """Test that an entitlement matched by multiple bindings is only returned once"""
+        ent = ApplicationEntitlement.objects.create(app=self.app, name=generate_id())
+        PolicyBinding.objects.create(target=ent, user=self.user, order=0)
+        group = Group.objects.create(name=generate_id())
+        self.user.groups.add(group)
+        PolicyBinding.objects.create(target=ent, group=group, order=1)
+        self.client.force_login(create_test_admin_user())
+        res = self.client.get(
+            reverse("authentik_api:applicationentitlement-list"),
+            {"for_user": self.user.pk},
+        )
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json()["pagination"]["count"], 1)
+
+    def test_api_for_user_with_permission(self):
+        """Test for_user with explicitly granted permissions (non-superuser)"""
+        ent = ApplicationEntitlement.objects.create(app=self.app, name=generate_id())
+        PolicyBinding.objects.create(target=ent, user=self.user, order=0)
+        self.other_user.assign_perms_to_managed_role("authentik_core.view_applicationentitlement")
+        self.other_user.assign_perms_to_managed_role("authentik_core.view_user_applications")
+        self.client.force_login(self.other_user)
+        res = self.client.get(
+            reverse("authentik_api:applicationentitlement-list"),
+            {"for_user": self.user.pk},
+        )
+        self.assertEqual(res.status_code, 200)
+        body = res.json()
+        self.assertEqual(body["pagination"]["count"], 1)
+        self.assertEqual(body["results"][0]["name"], ent.name)
+
+    def test_api_for_user_denied(self):
+        """Test that for_user requires view_user_applications on the target user"""
+        ent = ApplicationEntitlement.objects.create(app=self.app, name=generate_id())
+        PolicyBinding.objects.create(target=ent, user=self.user, order=0)
+        self.other_user.assign_perms_to_managed_role("authentik_core.view_applicationentitlement")
+        self.client.force_login(self.other_user)
+        res = self.client.get(
+            reverse("authentik_api:applicationentitlement-list"),
+            {"for_user": self.user.pk},
+        )
+        self.assertEqual(res.status_code, 400)
+        self.assertJSONEqual(res.content, {"for_user": "User not found"})
+
+    def test_api_for_user_invalid(self):
+        """Test for_user with a non-numerical value"""
+        self.client.force_login(create_test_admin_user())
+        res = self.client.get(
+            reverse("authentik_api:applicationentitlement-list"),
+            {"for_user": "foo"},
+        )
+        self.assertEqual(res.status_code, 400)
+        self.assertJSONEqual(res.content, {"for_user": "for_user must be numerical"})
+
     def test_api_bindings_group(self):
         """Test that API doesn't allow policies to be bound to this"""
         ent = ApplicationEntitlement.objects.create(app=self.app, name=generate_id())

--- a/packages/client-ts/src/apis/CoreApi.ts
+++ b/packages/client-ts/src/apis/CoreApi.ts
@@ -154,6 +154,7 @@ export interface CoreApplicationEntitlementsDestroyRequest {
 
 export interface CoreApplicationEntitlementsListRequest {
     app?: string;
+    forUser?: number;
     name?: string;
     ordering?: string;
     page?: number;
@@ -770,6 +771,10 @@ export class CoreApi extends runtime.BaseAPI {
             queryParameters["app"] = requestParameters["app"];
         }
 
+        if (requestParameters["forUser"] != null) {
+            queryParameters["for_user"] = requestParameters["forUser"];
+        }
+
         if (requestParameters["name"] != null) {
             queryParameters["name"] = requestParameters["name"];
         }
@@ -816,7 +821,7 @@ export class CoreApi extends runtime.BaseAPI {
     }
 
     /**
-     * ApplicationEntitlement Viewset
+     * List application entitlements, optionally scoped to a user via `for_user`.
      */
     async coreApplicationEntitlementsListRaw(
         requestParameters: CoreApplicationEntitlementsListRequest,
@@ -832,7 +837,7 @@ export class CoreApi extends runtime.BaseAPI {
     }
 
     /**
-     * ApplicationEntitlement Viewset
+     * List application entitlements, optionally scoped to a user via `for_user`.
      */
     async coreApplicationEntitlementsList(
         requestParameters: CoreApplicationEntitlementsListRequest = {},

--- a/packages/client-ts/src/models/ApplicationEntitlement.ts
+++ b/packages/client-ts/src/models/ApplicationEntitlement.ts
@@ -37,6 +37,18 @@ export interface ApplicationEntitlement {
      */
     app: string;
     /**
+     * Application's display Name.
+     * @type {string}
+     * @memberof ApplicationEntitlement
+     */
+    readonly appName: string;
+    /**
+     * Internal application name, used in URLs.
+     * @type {string}
+     * @memberof ApplicationEntitlement
+     */
+    readonly appSlug: string;
+    /**
      *
      * @type {{ [key: string]: any; }}
      * @memberof ApplicationEntitlement
@@ -57,6 +69,20 @@ export function instanceOfApplicationEntitlement(value: object): value is Applic
         return false;
     if (!("name" in value) || value["name"] === undefined) return false;
     if (!("app" in value) || value["app"] === undefined) return false;
+    if (
+        (!("appName" in (value as Record<string, any>)) &&
+            !("app_name" in (value as Record<string, any>))) ||
+        ((value as Record<string, any>)["appName"] === undefined &&
+            (value as Record<string, any>)["app_name"] === undefined)
+    )
+        return false;
+    if (
+        (!("appSlug" in (value as Record<string, any>)) &&
+            !("app_slug" in (value as Record<string, any>))) ||
+        ((value as Record<string, any>)["appSlug"] === undefined &&
+            (value as Record<string, any>)["app_slug"] === undefined)
+    )
+        return false;
     return true;
 }
 
@@ -75,6 +101,8 @@ export function ApplicationEntitlementFromJSONTyped(
         pbmUuid: json["pbm_uuid"],
         name: json["name"],
         app: json["app"],
+        appName: json["app_name"],
+        appSlug: json["app_slug"],
         attributes: json["attributes"] == null ? undefined : json["attributes"],
     };
 }
@@ -84,7 +112,7 @@ export function ApplicationEntitlementToJSON(json: any): ApplicationEntitlement 
 }
 
 export function ApplicationEntitlementToJSONTyped(
-    value?: Omit<ApplicationEntitlement, "pbmUuid"> | null,
+    value?: Omit<ApplicationEntitlement, "pbmUuid" | "appName" | "appSlug"> | null,
     ignoreDiscriminator: boolean = false,
 ): any {
     if (value == null) {

--- a/schema.yml
+++ b/schema.yml
@@ -2714,13 +2714,18 @@ paths:
   /core/application_entitlements/:
     get:
       operationId: core_application_entitlements_list
-      description: ApplicationEntitlement Viewset
+      description: List application entitlements, optionally scoped to a user via
+        `for_user`.
       parameters:
       - in: query
         name: app
         schema:
           type: string
           format: uuid
+      - in: query
+        name: for_user
+        schema:
+          type: integer
       - $ref: '#/components/parameters/QueryName'
       - $ref: '#/components/parameters/QueryPaginationOrdering'
       - $ref: '#/components/parameters/QueryPaginationPage'
@@ -36394,11 +36399,21 @@ components:
         app:
           type: string
           format: uuid
+        app_name:
+          type: string
+          description: Application's display Name.
+          readOnly: true
+        app_slug:
+          type: string
+          description: Internal application name, used in URLs.
+          readOnly: true
         attributes:
           type: object
           additionalProperties: {}
       required:
       - app
+      - app_name
+      - app_slug
       - name
       - pbm_uuid
     ApplicationEntitlementRequest:

--- a/schema.yml
+++ b/schema.yml
@@ -2537,13 +2537,18 @@ paths:
   /core/application_entitlements/:
     get:
       operationId: core_application_entitlements_list
-      description: ApplicationEntitlement Viewset
+      description: List application entitlements, optionally scoped to a user via
+        `for_user`.
       parameters:
       - in: query
         name: app
         schema:
           type: string
           format: uuid
+      - in: query
+        name: for_user
+        schema:
+          type: integer
       - $ref: '#/components/parameters/QueryName'
       - $ref: '#/components/parameters/QueryPaginationOrdering'
       - $ref: '#/components/parameters/QueryPaginationPage'
@@ -35992,11 +35997,21 @@ components:
         app:
           type: string
           format: uuid
+        app_name:
+          type: string
+          description: Application's display Name.
+          readOnly: true
+        app_slug:
+          type: string
+          description: Internal application name, used in URLs.
+          readOnly: true
         attributes:
           type: object
           additionalProperties: {}
       required:
       - app
+      - app_name
+      - app_slug
       - name
       - pbm_uuid
     ApplicationEntitlementRequest:

--- a/web/src/admin/users/UserApplicationEntitlementTable.ts
+++ b/web/src/admin/users/UserApplicationEntitlementTable.ts
@@ -1,0 +1,69 @@
+import { aki } from "#common/api/client";
+
+import { paramURL } from "#elements/router/RouterOutlet";
+import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
+import { SlottedTemplateResult } from "#elements/types";
+
+import { ApplicationEntitlement, CoreApi, User } from "@goauthentik/api";
+
+import { msg } from "@lit/localize";
+import { html } from "lit";
+import { customElement, property } from "lit/decorators.js";
+
+@customElement("ak-user-application-entitlement-table")
+export class UserApplicationEntitlementTable extends Table<ApplicationEntitlement> {
+    @property({ attribute: false })
+    user?: User;
+
+    protected override searchEnabled = true;
+
+    public override order = "app__name";
+
+    async apiEndpoint(): Promise<PaginatedResponse<ApplicationEntitlement>> {
+        return aki(CoreApi).coreApplicationEntitlementsList({
+            ...(await this.defaultEndpointConfig()),
+            forUser: this.user?.pk,
+        });
+    }
+
+    protected columns: TableColumn[] = [
+        [msg("Application"), "app__name"],
+        [msg("Name"), "name"],
+    ];
+
+    row(item: ApplicationEntitlement): SlottedTemplateResult[] {
+        return [
+            html`<a
+                href=${paramURL(`/core/applications/${item.appSlug}`, {
+                    page: "page-app-entitlements",
+                })}
+            >
+                ${item.appName}
+            </a>`,
+            html`${item.name}`,
+        ];
+    }
+
+    protected override renderEmpty(): SlottedTemplateResult {
+        return super.renderEmpty(
+            html`<ak-empty-state icon="pf-icon-module">
+                <span>
+                    ${msg("No application entitlements.", {
+                        id: "user.entitlements.empty.label",
+                    })}
+                </span>
+                <div slot="body">
+                    ${msg("This user has not been granted any application entitlements.", {
+                        id: "user.entitlements.empty.description",
+                    })}
+                </div>
+            </ak-empty-state>`,
+        );
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "ak-user-application-entitlement-table": UserApplicationEntitlementTable;
+    }
+}

--- a/web/src/admin/users/UserApplicationsTab.ts
+++ b/web/src/admin/users/UserApplicationsTab.ts
@@ -1,29 +1,69 @@
+import "#admin/users/UserApplicationEntitlementTable";
 import "#admin/users/UserApplicationTable";
+import "#elements/Tabs";
 
 import { AKElement } from "#elements/Base";
+import { WithLazyTabs } from "#elements/mixins/lazy-tabs";
 
 import { User } from "@goauthentik/api";
 
+import { msg } from "@lit/localize";
 import { html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import PFCard from "@patternfly/patternfly/components/Card/card.css";
+import PFPage from "@patternfly/patternfly/components/Page/page.css";
 
 @customElement("ak-user-applications-tab")
-export class UserApplicationsTab extends AKElement {
+export class UserApplicationsTab extends WithLazyTabs(AKElement) {
     @property({ attribute: false })
     public user?: User;
 
-    static styles = [PFCard];
+    public override activatedTabs = new Set<string>(["page-applications"]);
+
+    static styles = [PFPage, PFCard];
 
     protected override render() {
         if (!this.user) {
             return nothing;
         }
 
-        return html`<div class="pf-c-card">
-            <ak-user-application-table .user=${this.user}></ak-user-application-table>
-        </div>`;
+        return html`<ak-tabs pageIdentifier="userApplications" vertical>
+            <div
+                role="tabpanel"
+                tabindex="0"
+                slot="page-applications"
+                id="page-applications"
+                aria-label=${msg("Applications")}
+                class="pf-c-page__main-section pf-m-no-padding-mobile"
+                @activate=${() => this.activateTab("page-applications")}
+            >
+                ${this.renderWhenActive(
+                    "page-applications",
+                    html`<div class="pf-c-card">
+                        <ak-user-application-table .user=${this.user}></ak-user-application-table>
+                    </div>`,
+                )}
+            </div>
+            <div
+                role="tabpanel"
+                tabindex="0"
+                slot="page-entitlements"
+                id="page-entitlements"
+                aria-label=${msg("Application entitlements")}
+                class="pf-c-page__main-section pf-m-no-padding-mobile"
+                @activate=${() => this.activateTab("page-entitlements")}
+            >
+                ${this.renderWhenActive(
+                    "page-entitlements",
+                    html`<div class="pf-c-card">
+                        <ak-user-application-entitlement-table
+                            .user=${this.user}
+                        ></ak-user-application-entitlement-table>
+                    </div>`,
+                )}
+            </div>
+        </ak-tabs>`;
     }
 }
 

--- a/web/src/admin/users/UserViewPage.ts
+++ b/web/src/admin/users/UserViewPage.ts
@@ -179,7 +179,6 @@ export class UserViewPage extends WithLazyTabs(
                     slot="page-applications"
                     id="page-applications"
                     aria-label=${msg("Applications")}
-                    class="pf-c-page__main-section pf-m-no-padding-mobile"
                     @activate=${() => this.activateTab("page-applications")}
                 >
                     ${this.renderWhenActive(


### PR DESCRIPTION
## Details

### What does this PR change?

This adds a "user application entitlements" screen in the admin UI where a single user's entitlements can be observed across all applications. The "Applications" tab in the user view is now split into two "subtabs" - "Applications" and "Application entitlements", the former preserving the old Applications view and the latter showing entitlements. 

The entitlements API endpoint now accepts `for_user` query parameter that allows filtering by individual user.

### Why is this change needed?

To simplify reviewing a user's entitlements, see #23194

### How was this tested?

Manual test + a few new tests in the suite for the new API endpoint.

### Linked issues

closes #23194
---

## Checklist

-   [x] The project has been linted, built, and tested (`make all`)
-   [x] The documentation has been updated and formatted (`make docs`)
