### PR TITLE
providers/rac: fix endpoint list for users with model-level RAC permissions

### DIFF
--- a/authentik/providers/rac/api/endpoints.py
+++ b/authentik/providers/rac/api/endpoints.py
@@ -89,25 +89,55 @@ class EndpointViewSet(UsedByMixin, ModelViewSet):
             queryset = backend().filter_queryset(self.request, queryset, self)
         return queryset
 
+    def _has_model_level_rbac_perm(self, user, endpoint: Endpoint) -> bool:
+        """Check if user has a model-level (non-guardian) RAC permission.
+
+        When a user has explicit model-level permissions, they should
+        be able to list endpoints for management even without application-level
+        access. Sensitive fields (e.g. settings) are already redacted by
+        EndpointSerializer.to_representation().
+        """
+        if user.has_perm("authentik_providers_rac.view_endpoint"):
+            return True
+        if user.has_perm("authentik_providers_rac.change_endpoint"):
+            return True
+        if user.has_perm("authentik_providers_rac.delete_endpoint"):
+            return True
+        if user.has_perm("authentik_providers_rac.add_endpoint"):
+            return True
+        return False
+
     def _get_allowed_endpoints(self, queryset: QuerySet) -> list[Endpoint]:
         endpoints = []
-        # An endpoint is only reachable through its provider's application, so it must
-        # not be listed to a user who has no access to that application - this mirrors
-        # the launch flow (PolicyAccessView.user_has_access). Endpoints have no policy
-        # bindings by default, so the per-endpoint check alone would let any caller see
-        # every endpoint.
-        application_access: dict[str, bool] = {}
         for endpoint in queryset:
+            # If the user has a model-level RBAC permission for RAC endpoints,
+            # include it in the list regardless of application access.
+            # The serializer's to_representation() will redact sensitive
+            # fields (e.g. connection credentials in "settings") for users
+            # without the per-instance view_endpoint permission.
+            # This keeps behavior consistent with the detail endpoint, which
+            # returns the full object (with redacted settings) regardless of
+            # application access.
+            if self._has_model_level_rbac_perm(self.request.user, endpoint):
+                endpoints.append(endpoint)
+                continue
+
+            # For users without model-level permissions (e.g. end-users), only
+            # show endpoints reachable through their application access. This
+            # mirrors the launch flow (PolicyAccessView.user_has_access).
+            # Endpoints have no policy bindings by default, so the per-endpoint
+            # check alone would let any caller see every endpoint.
             try:
                 application = endpoint.provider.application
             except Provider.application.RelatedObjectDoesNotExist:
                 continue
+            application_access: dict[str, bool] = {}
             if application.pk not in application_access:
                 app_engine = PolicyEngine(application, self.request.user, self.request)
                 app_engine.empty_result = AppAccessWithoutBindings.get()
                 app_engine.build()
                 application_access[application.pk] = app_engine.passing
-            if not application_access[application.pk]:
+            if not application_access.get(application.pk, False):
                 continue
             engine = PolicyEngine(endpoint, self.request.user, self.request)
             engine.build()

--- a/authentik/providers/rac/tests/test_endpoints_api.py
+++ b/authentik/providers/rac/tests/test_endpoints_api.py
@@ -264,3 +264,162 @@ class TestEndpointsAPI(APITestCase):
         self.assertEqual(response.status_code, 200)
         pks = [result["pk"] for result in response.json()["results"]]
         self.assertIn(str(endpoint.pk), pks)
+
+    def test_list_user_with_model_permissions_sees_endpoints(self):
+        """A user with model-level RAC permissions (e.g. view_endpoint)
+        must see all endpoints in the list, even those for applications they have
+        no access to. This fixes the regression introduced by the security backport
+        that filtered the entire list by application access, which broke users
+        who only had model-level permissions but no application-level
+        access.
+
+        Sensitive fields (settings) are still redacted for users without the
+        per-instance view_endpoint permission, preserving the security fix."""
+        # Gate the application so the user has no application access.
+        PolicyBinding.objects.create(
+            target=self.app,
+            policy=DummyPolicy.objects.create(
+                name=f"deny-{generate_id()}", result=False, wait_min=1, wait_max=2
+            ),
+            order=0,
+        )
+
+        # Create a user with model-level view permission but no
+        # application access (the denied policy above blocks it).
+        user = create_test_user()
+        from django.contrib.auth.models import Permission
+
+        perm = Permission.objects.get(
+            content_type__app_label="authentik_providers_rac",
+            codename="view_endpoint",
+        )
+        user.user_permissions.add(perm)
+
+        self.assertFalse(
+            user.has_perm("authentik_providers_rac.view_application", self.app)
+        )
+        self.client.force_login(user)
+
+        response = self.client.get(reverse("authentik_api:endpoint-list"))
+        self.assertEqual(response.status_code, 200)
+        pks = [r["pk"] for r in response.json()["results"]]
+        # The user MUST see the endpoint despite having no app access.
+        self.assertIn(str(self.allowed.pk), pks)
+        # And also the denied endpoint, because it has model-level permission.
+        self.assertIn(str(self.denied.pk), pks)
+
+    def test_list_user_with_model_permissions_settings_redacted(self):
+        """A user with model-level view_endpoint permission must
+        receive the settings only for endpoints where it also has the
+        per-instance view_permission.
+
+        This ensures the security fix (redacting sensitive settings) is
+        preserved for users that manage endpoints globally
+        but should not see credentials for all of them."""
+        endpoint_secret = generate_id()
+        endpoint = Endpoint.objects.create(
+            name=f"c-{generate_id()}",
+            host=generate_id(),
+            protocol=Protocols.RDP,
+            auth_mode="static",
+            settings={"username": "user", "password": endpoint_secret},
+            provider=self.provider,
+        )
+
+        # Create a user with model-level view permission.
+        user = create_test_user()
+        from django.contrib.auth.models import Permission
+
+        perm = Permission.objects.get(
+            content_type__app_label="authentik_providers_rac",
+            codename="view_endpoint",
+        )
+        user.user_permissions.add(perm)
+
+        # user has model-level permission but NOT per-instance permission
+        # for the endpoint (no guardian grant).
+        self.assertFalse(
+            user.has_perm("authentik_providers_rac.view_endpoint", endpoint)
+        )
+
+        self.client.force_login(user)
+
+        response = self.client.get(reverse("authentik_api:endpoint-list"))
+        self.assertEqual(response.status_code, 200)
+        result = next(
+            r for r in response.json()["results"] if r["pk"] == str(endpoint.pk)
+        )
+
+        # The endpoint is in the list (model-level permission grants visibility).
+        # But settings must be redacted (no per-instance view_permission).
+        self.assertEqual(result["settings"], {})
+        self.assertNotIn(endpoint_secret, response.content.decode())
+
+    def test_list_user_with_change_permission_sees_endpoints(self):
+        """A user with model-level change_endpoint permission
+        must see all endpoints in the list. This is the permission that
+        the original issue (#24154) reported as broken."""
+        PolicyBinding.objects.create(
+            target=self.app,
+            policy=DummyPolicy.objects.create(
+                name=f"deny-{generate_id()}", result=False, wait_min=1, wait_max=2
+            ),
+            order=0,
+        )
+
+        user = create_test_user()
+        from django.contrib.auth.models import Permission
+
+        perm = Permission.objects.get(
+            content_type__app_label="authentik_providers_rac",
+            codename="change_endpoint",
+        )
+        user.user_permissions.add(perm)
+
+        self.client.force_login(user)
+
+        response = self.client.get(reverse("authentik_api:endpoint-list"))
+        self.assertEqual(response.status_code, 200)
+        pks = [r["pk"] for r in response.json()["results"]]
+        self.assertIn(str(self.allowed.pk), pks)
+        self.assertIn(str(self.denied.pk), pks)
+
+    def test_list_user_with_delete_permission_sees_endpoints(self):
+        """A user with model-level delete_endpoint permission
+        must see all endpoints in the list."""
+        user = create_test_user()
+        from django.contrib.auth.models import Permission
+
+        perm = Permission.objects.get(
+            content_type__app_label="authentik_providers_rac",
+            codename="delete_endpoint",
+        )
+        user.user_permissions.add(perm)
+
+        self.client.force_login(user)
+
+        response = self.client.get(reverse("authentik_api:endpoint-list"))
+        self.assertEqual(response.status_code, 200)
+        pks = [r["pk"] for r in response.json()["results"]]
+        self.assertIn(str(self.allowed.pk), pks)
+        self.assertIn(str(self.denied.pk), pks)
+
+    def test_list_user_with_add_permission_sees_endpoints(self):
+        """A user with model-level add_endpoint permission
+        must see all endpoints in the list."""
+        user = create_test_user()
+        from django.contrib.auth.models import Permission
+
+        perm = Permission.objects.get(
+            content_type__app_label="authentik_providers_rac",
+            codename="add_endpoint",
+        )
+        user.user_permissions.add(perm)
+
+        self.client.force_login(user)
+
+        response = self.client.get(reverse("authentik_api:endpoint-list"))
+        self.assertEqual(response.status_code, 200)
+        pks = [r["pk"] for r in response.json()["results"]]
+        self.assertIn(str(self.allowed.pk), pks)
+        self.assertIn(str(self.denied.pk), pks)


### PR DESCRIPTION
<!--
⚠️ Open this PR from a feature branch, not from main
-->

## Details

### What does this PR change?

- Adds `_has_model_level_rbac_perm()` method to `EndpointViewSet` that checks if a user has any of the four model-level RAC permissions (`view_endpoint`, `change_endpoint`, `delete_endpoint`, `add_endpoint`).
- Rewrites `_get_allowed_endpoints()` to check model-level permissions first, skipping the application-access filter (`AppAccessWithoutBindings`) when applicable.
- Adds 5 new test cases covering all four model-level RAC permissions and verifying that `settings` are still redacted for users without per-instance view permissions.

### Why is this change needed?

PR #24066 introduced a security backport that filters RAC endpoints by application-level access. This broke endpoint management for any user who has only model-level RAC permissions but no application-level grant — the list API (`GET /rac/endpoints/`) returns an empty list while the detail API (`GET /rac/endpoints/{uuid}/`) still returns the endpoint with redacted settings.

This PR fixes that regression while preserving the security intent: `settings` remain redacted for users without the per-instance `view_endpoint` permission.

### How was this tested?

- 5 new tests added in `test_endpoints_api.py`
- `test_list_user_with_model_permissions_sees_endpoints` — user with `view_endpoint` sees all endpoints despite denied application
- `test_list_user_with_model_permissions_settings_redacted` — verifies `settings` is empty without per-instance permission
- `test_list_user_with_change_permission_sees_endpoints` — verifies `change_endpoint` (original issue)
- `test_list_user_with_delete_permission_sees_endpoints` — verifies `delete_endpoint`
- `test_list_user_with_add_permission_sees_endpoints` — verifies `add_endpoint`
- All existing tests continue to pass

### Linked issues
closes #24154

---

## Checklist

- [ ] The project has been linted, built, and tested (`make all`)
- [ ] The documentation has been updated and formatted (`make docs`)