### PR TITLE
docs: fix broken link in 2026.11 release notes draft

### DIFF
--- a/website/docs/releases/2026/v2026.11.md
+++ b/website/docs/releases/2026/v2026.11.md
@@ -12,7 +12,7 @@ draft: true
 
 ## Upgrading
 
-This release does not introduce any new requirements. You can follow the upgrade instructions below; for more detailed information about upgrading authentik, refer to our [Upgrade documentation](../install-config/upgrade.mdx).
+This release does not introduce any new requirements. You can follow the upgrade instructions below; for more detailed information about upgrading authentik, refer to our [Upgrade documentation](../../install-config/upgrade.mdx).
 
 :::warning Upgrade in order and upgrade all components
 Upgrades MUST be performed sequentially by major version. If you are two or more major releases behind, you must first upgrade to each intermediate major release before upgrading to this one. Refer to our [Upgrade documentation](../../install-config/upgrade.mdx) for more information on upgrade sequence.


### PR DESCRIPTION
## Details

This fixes a broken link in 2026.11 release notes draft that prevents `make docs-watch` from working.

---

## Checklist
-   [x] The documentation has been updated and formatted (`make docs`)
