### PR TITLE
web/common: allow line-break in dom-purify

### DIFF
--- a/web/src/common/purify.ts
+++ b/web/src/common/purify.ts
@@ -108,6 +108,15 @@ export function sanitizeHTML(trustPolicy: AuthentikTrustPolicy, untrustedHTML: s
  * This configuration only allows text nodes and disallows all HTML tags.
  */
 export const DOM_PURIFY_STRICT = {
+    ALLOWED_TAGS: ["#text"],
+} as const satisfies DOMPurifyConfig;
+
+/**
+ * DOMPurify configuration for relaxed sanitization.
+ *
+ * This configuration allows text nodes and <br> tags.
+ */
+export const DOM_PURIFY_RELAXED = {
     ALLOWED_TAGS: ["#text", "br"],
 } as const satisfies DOMPurifyConfig;
 

--- a/web/src/common/purify.ts
+++ b/web/src/common/purify.ts
@@ -108,7 +108,7 @@ export function sanitizeHTML(trustPolicy: AuthentikTrustPolicy, untrustedHTML: s
  * This configuration only allows text nodes and disallows all HTML tags.
  */
 export const DOM_PURIFY_STRICT = {
-    ALLOWED_TAGS: ["#text"],
+    ALLOWED_TAGS: ["#text", "br"],
 } as const satisfies DOMPurifyConfig;
 
 /**

--- a/web/src/elements/mermaid/utils.ts
+++ b/web/src/elements/mermaid/utils.ts
@@ -1,6 +1,6 @@
 import MermaidStyles from "./mermaid.css";
 
-import { DOM_PURIFY_STRICT } from "#common/purify";
+import { DOM_PURIFY_RELAXED } from "#common/purify";
 import { ResolvedUITheme } from "#common/theme";
 
 import { MermaidThemeAdapter } from "#elements/mermaid/theme";
@@ -23,7 +23,7 @@ export const DefaultMermaidConfig: Readonly<MermaidConfig> = {
     },
     theme: "base",
     securityLevel: "strict",
-    dompurifyConfig: DOM_PURIFY_STRICT,
+    dompurifyConfig: DOM_PURIFY_RELAXED,
 };
 
 let lastActiveTheme: ResolvedUITheme | null = null;


### PR DESCRIPTION
why: fixes line-breaks being swallowed in mermaid

I dont think this has any security implications

cc @emilburzo
