### PR TITLE
web: e2e tests for user switching

### DIFF
--- a/web/e2e/fixtures/SessionFixture.ts
+++ b/web/e2e/fixtures/SessionFixture.ts
@@ -17,6 +17,11 @@ export interface LoginInit {
     page?: Page;
 }
 
+export interface CompletePasswordInit {
+    password?: string;
+    to?: URL | string;
+}
+
 export interface SessionFixtureInit extends PageFixtureInit {
     navigator: NavigatorFixture;
 }
@@ -127,6 +132,24 @@ export class SessionFixture extends PageFixture {
 
         await this.$passwordField.fill(password);
 
+        await this.$submitButton.click();
+
+        await this.navigator.waitForPathname(to);
+    }
+
+    /**
+     * Complete a password stage when identification was skipped
+     * (e.g. switching to a user that already has `pending_user` in the flow plan).
+     */
+    public async completePassword({
+        password = GOOD_PASSWORD,
+        to = SessionFixture.pathname,
+    }: CompletePasswordInit = {}): Promise<void> {
+        this.logger.info("Completing password stage...");
+
+        await this.$passwordStage.waitFor({ state: "visible" });
+
+        await this.$passwordField.fill(password);
         await this.$submitButton.click();
 
         await this.navigator.waitForPathname(to);

--- a/web/e2e/fixtures/UserSwitcherFixture.ts
+++ b/web/e2e/fixtures/UserSwitcherFixture.ts
@@ -1,0 +1,78 @@
+import { PageFixture } from "#e2e/fixtures/PageFixture";
+
+import { expect, Locator } from "@playwright/test";
+
+/**
+ * The header account switcher (`ak-user-switcher`), which owns both the multi-account
+ * entries and the sign-out affordance in the User and Admin interfaces.
+ */
+export class UserSwitcherFixture extends PageFixture {
+    static fixtureName = "UserSwitcher";
+
+    //#region Selectors
+
+    public $switcher = this.page.locator("ak-user-switcher");
+
+    public $toggle = this.$switcher.getByRole("button", { name: "Switch user" });
+
+    public $addUser = this.$switcher.getByRole("menuitem", { name: "Add another user" });
+
+    /**
+     * Signs the active account out. Rendered unconditionally, which makes it the
+     * sentinel for "the menu is open".
+     */
+    public $signOut = this.$switcher.getByRole("menuitem", { name: "Sign out current user" });
+
+    /**
+     * The menu entry for a single account.
+     *
+     * Entries are labelled with the account's display name and email, so an email
+     * pattern identifies one unambiguously under any `UserDisplay` setting.
+     */
+    public entry = (pattern: string | RegExp): Locator =>
+        this.$switcher.getByRole("menuitem", { name: pattern });
+
+    //#endregion
+
+    //#region Specific interactions
+
+    /**
+     * Open the menu, tolerating the session request settling mid-flight.
+     *
+     * `ak-dropdown` hides the menu from `connectedCallback`, so every re-render of
+     * `ak-user-switcher` that rebuilds the dropdown subtree closes an already-open menu.
+     * On a freshly loaded page the session response lands right about then, so a single
+     * toggle click is not reliably enough to leave the menu open.
+     */
+    public open = async (): Promise<void> => {
+        this.logger.info("Opening the account switcher...");
+
+        await expect(this.$toggle, "Switcher toggle is visible").toBeVisible({ timeout: 10_000 });
+
+        await expect(async () => {
+            if (await this.$signOut.isHidden()) {
+                await this.$toggle.click();
+            }
+
+            await expect(this.$signOut, "Switcher menu is open").toBeVisible({ timeout: 1_000 });
+        }).toPass({ timeout: 20_000 });
+    };
+
+    /**
+     * Open the menu and activate one of its entries.
+     *
+     * Entries cannot be asserted on before the menu is open: the closed `<menu>` carries
+     * `hidden`, which drops its whole subtree from the accessibility tree, so `menuitem`
+     * queries match nothing at all. Retrying around both the open and the click also
+     * absorbs entries that arrive with a late session response.
+     */
+    public select = async (target: Locator): Promise<void> => {
+        await expect(async () => {
+            await this.open();
+
+            await target.click({ timeout: 2_000 });
+        }).toPass({ timeout: 25_000 });
+    };
+
+    //#endregion
+}

--- a/web/e2e/index.ts
+++ b/web/e2e/index.ts
@@ -6,6 +6,7 @@ import { FormFixture } from "#e2e/fixtures/FormFixture";
 import { NavigatorFixture } from "#e2e/fixtures/NavigatorFixture";
 import { PointerFixture } from "#e2e/fixtures/PointerFixture";
 import { SessionFixture } from "#e2e/fixtures/SessionFixture";
+import { UserSwitcherFixture } from "#e2e/fixtures/UserSwitcherFixture";
 
 import { test as base } from "@playwright/test";
 
@@ -18,6 +19,7 @@ interface E2EFixturesTestScope {
     session: SessionFixture;
     pointer: PointerFixture;
     form: FormFixture;
+    switcher: UserSwitcherFixture;
 }
 
 interface E2EWorkerScope {
@@ -39,5 +41,9 @@ export const test = base.extend<E2EFixturesTestScope, E2EWorkerScope>({
 
     pointer: async ({ page }, use, { title: testName }) => {
         await use(new PointerFixture({ page, testName }));
+    },
+
+    switcher: async ({ page }, use, { title: testName }) => {
+        await use(new UserSwitcherFixture({ page, testName }));
     },
 });

--- a/web/test/browser/101-session-lifecycle.test.ts
+++ b/web/test/browser/101-session-lifecycle.test.ts
@@ -60,7 +60,7 @@ test.describe("Session Lifecycle", () => {
         await session.$identificationStage.waitFor({ state: "visible" });
     });
 
-    test("Remember me persists username", async ({ navigator, session, page }) => {
+    test("Remember me persists username", async ({ navigator, session, switcher, page }) => {
         await test.step("Verify identification stage", async () => {
             await expect(
                 session.$rememberMeCheckbox,
@@ -90,20 +90,23 @@ test.describe("Session Lifecycle", () => {
         });
 
         await test.step("Sign out and verify username is remembered", async () => {
-            const signOutLink = page.getByRole("link", { name: "Sign out" });
-
-            await expect(signOutLink, "Sign out link is visible").toBeVisible();
-
-            await signOutLink.click();
+            // Signing out lives inside the header account switcher, not as a bare
+            // header link — see `ak-user-switcher`.
+            await switcher.select(switcher.$signOut);
 
             await navigator.waitForPathname("/if/flow/default-authentication-flow/?next=%2F");
-            await session.$identificationStage.waitFor({ state: "visible" });
 
-            const passwordEmbedded = await session.$passwordField.isVisible();
+            // Remember-me lands on one of two stages: identification with the username
+            // pre-filled, or — when the remembered identity is restored outright — the
+            // password stage for that user.
+            await expect(
+                session.$identificationStage.or(session.$passwordStage),
+                "Sign out returns to the authentication flow",
+            ).toBeVisible({ timeout: 15_000 });
 
-            if (passwordEmbedded) {
-                // Password is embedded in the identification stage, so the Not-you UI never renders.
-                // Remember-me's only observable effect is the pre-filled username field.
+            if (await session.$identificationStage.isVisible()) {
+                // Remember-me's only observable effect here is the pre-filled username,
+                // so the Not-you UI never renders.
                 await expect(
                     session.$usernameField,
                     "Username pre-filled from remember-me",
@@ -111,9 +114,6 @@ test.describe("Session Lifecycle", () => {
 
                 return;
             }
-
-            await session.$submitButton.click();
-            await session.$passwordStage.waitFor({ state: "visible" });
 
             const notYouLink = page.getByRole("link", { name: "Not you?" });
 

--- a/web/test/browser/102-user-switching.test.ts
+++ b/web/test/browser/102-user-switching.test.ts
@@ -1,0 +1,345 @@
+import { expect, test } from "#e2e";
+import { FormFixture } from "#e2e/fixtures/FormFixture";
+import { NavigatorFixture } from "#e2e/fixtures/NavigatorFixture";
+import { GOOD_USERNAME, SessionFixture } from "#e2e/fixtures/SessionFixture";
+import { randomName } from "#e2e/utils/generators";
+
+import { IDGenerator } from "@goauthentik/core/id";
+import { series } from "@goauthentik/core/promises";
+
+import type { Page } from "@playwright/test";
+import { snakeCase } from "change-case";
+
+/**
+ * The domain of the brand seeded by `blueprints/default/default-brand.yaml`, which is
+ * the brand resolved for the test runner's origin.
+ */
+const DEFAULT_BRAND_DOMAIN = "authentik-default";
+
+/**
+ * The flow the default brand is pointed at for user switching.
+ *
+ * Reusing the default authentication flow is the configuration described in the feature
+ * docs, and it is what makes the "identification skipped, password requested" path
+ * observable: the switch plan carries `pending_user`, so the identification stage
+ * auto-completes and the flow opens on the password stage.
+ */
+const USER_SWITCH_FLOW = /default-authentication-flow/;
+
+/**
+ * The password assigned — through the admin UI — to the secondary account each test
+ * creates for itself. Long and unlike the generated username so Django's password
+ * validators accept it.
+ */
+const SECONDARY_PASSWORD = "e2e-user-switching-secondary";
+
+/**
+ * Every entry in the switcher menu is labelled with the account's email, whichever
+ * `UserDisplay` setting is in effect, so emails are what the tests match on.
+ *
+ * Passed as a plain string: role name matching is a case-insensitive substring match
+ * unless `exact` is set, so no pattern escaping is involved.
+ */
+const ADMIN_ENTRY_NAME = GOOD_USERNAME;
+
+interface SecondaryUser {
+    username: string;
+    displayName: string;
+    email: string;
+}
+
+test.describe("User switching", () => {
+    // Serial, because every test in here depends on one piece of global state: the
+    // default brand's user switch flow. `playwright.config.js` sets `fullyParallel`, so
+    // without this the per-worker `beforeAll` hooks below race each other writing the
+    // same brand, and the losing worker's Edit Brand modal never closes.
+    test.describe.configure({ mode: "serial" });
+
+    const secondaryUsers = new Map<string, SecondaryUser>();
+
+    //#region Lifecycle
+
+    test.beforeAll(
+        "Ensure the default brand has a user switch flow",
+        async ({ browser }, { title: testName }) => {
+            const context = await browser.newContext();
+            const page = await context.newPage();
+            const navigator = new NavigatorFixture(page, testName);
+            const form = new FormFixture(page, testName);
+            const session = new SessionFixture({ page, testName, navigator });
+
+            await test.step("Authenticate", async () =>
+                session.login({
+                    to: "/if/admin/#/core/brands",
+                    page,
+                }));
+
+            const $brand = await test.step("Find the default brand via search", () =>
+                form.search(DEFAULT_BRAND_DOMAIN, page));
+
+            await $brand.getByRole("button", { name: /^Edit .*Brand$/ }).click();
+
+            const dialog = page.getByRole("dialog", { name: "Edit Brand" });
+            await expect(dialog, "Edit modal opens after clicking edit").toBeVisible();
+
+            await form.setFormGroup("Default flows", true, dialog);
+
+            const $flowSearch = dialog.getByRole("textbox", { name: "User switch flow" });
+            const configuredFlow = await $flowSearch.inputValue();
+
+            if (USER_SWITCH_FLOW.test(configuredFlow)) {
+                // An earlier run already pointed the brand at the switch flow. Leaving
+                // the row alone keeps this hook read-only, so repeat runs cannot race
+                // each other writing the same brand.
+                await dialog.getByRole("button", { name: "Cancel" }).click();
+            } else {
+                await form.selectSearchValue("User switch flow", USER_SWITCH_FLOW, dialog);
+
+                await dialog.getByRole("button", { name: "Save Changes" }).click();
+            }
+
+            await expect(dialog, "Edit modal closes").toBeHidden({ timeout: 15_000 });
+
+            await context.close();
+        },
+    );
+
+    test.beforeEach("Seed secondary account details", async ({ page: _page }, { testId }) => {
+        const seed = IDGenerator.randomID(6);
+        const displayName = `${randomName(seed)} (${seed})`;
+        const username = snakeCase(displayName);
+
+        secondaryUsers.set(testId, {
+            username,
+            displayName,
+            email: `${username}@example.com`,
+        });
+    });
+
+    //#endregion
+
+    //#region Helpers
+
+    /**
+     * Create an internal, non-superuser account and give it a known password, entirely
+     * through the admin UI.
+     *
+     * The account is deliberately not a superuser: the "Admin interface" link in the
+     * User header then doubles as an independent signal of which account a switch
+     * actually landed on.
+     */
+    async function createSecondaryUser(
+        { form, page }: { form: FormFixture; page: Page },
+        user: SecondaryUser,
+    ): Promise<void> {
+        const { fill, search } = form;
+
+        // TODO: The use of `force: true` matches `300-users.test.ts` — buttons with
+        // slotted content are not considered visible by Playwright. Remove once native
+        // dialog modals are implemented.
+
+        await test.step("Create the secondary account", async () => {
+            const dialog = page.getByRole("dialog", { name: "New User Wizard" });
+
+            await page.getByRole("button", { name: "New User" }).click();
+
+            await expect(dialog, "Create dialog opens").toBeVisible();
+
+            await dialog.getByRole("radio", { name: "Internal" }).click({ force: true });
+
+            await series(
+                [fill, /^Username/, user.username, dialog],
+                [fill, /^Display Name/, user.displayName, dialog],
+                [fill, /^Email Address/, user.email, dialog],
+                [fill, /^Path/, "users", dialog],
+            );
+
+            await dialog.getByRole("button", { name: "Create" }).click();
+
+            await expect(dialog, "Create dialog closes after creating user").toBeHidden({
+                timeout: 10_000,
+            });
+        });
+
+        await test.step("Set the secondary account's password", async () => {
+            const $user = await search(user.username);
+
+            await expect($user, "Secondary account is visible").toBeVisible();
+
+            await $user.getByRole("button", { name: "Expand row" }).click();
+
+            const setPasswordButton = page.getByRole("button", { name: "Set password" });
+
+            await expect(setPasswordButton, "Set password button is revealed").toBeVisible();
+
+            await setPasswordButton.click();
+
+            const dialog = page.getByRole("dialog", { name: /password$/i });
+
+            await expect(dialog, "Set password dialog opens").toBeVisible();
+
+            await dialog.getByLabel("New Password").fill(SECONDARY_PASSWORD);
+            await dialog.getByRole("button", { name: "Set Password" }).click();
+
+            await expect(dialog, "Set password dialog closes after saving").toBeHidden({
+                timeout: 10_000,
+            });
+        });
+    }
+
+    //#endregion
+
+    //#region Tests
+
+    test("Add another user and switch back", async ({
+        session,
+        navigator,
+        switcher,
+        form,
+        page,
+    }, testInfo) => {
+        const user = secondaryUsers.get(testInfo.testId)!;
+
+        const adminEntry = switcher.entry(ADMIN_ENTRY_NAME);
+        const secondaryEntry = switcher.entry(user.username);
+        const adminInterfaceLink = page.getByRole("link", { name: "Admin interface" });
+
+        await test.step("Authenticate as the administrator", async () => {
+            await session.login({ to: "/if/admin/#/identity/users" });
+        });
+
+        await createSecondaryUser({ form, page }, user);
+
+        await test.step("Open the switcher as the administrator", async () => {
+            // A path carrying a hash fragment, so the return trip also proves that
+            // `next` survives fragment encoding through the switch endpoint.
+            await navigator.navigate("/if/user/#/settings");
+
+            await switcher.open();
+
+            await expect(
+                adminEntry,
+                "Administrator is listed and marked as the current account",
+            ).toBeDisabled();
+            await expect(switcher.$addUser, "Add another user is offered").toBeVisible();
+            await expect(
+                adminInterfaceLink,
+                "Admin interface link is available to the administrator",
+            ).toBeVisible();
+        });
+
+        await test.step("Add the secondary account", async () => {
+            await switcher.select(switcher.$addUser);
+
+            await expect(
+                session.$identificationStage,
+                "Adding a user starts a full authentication flow",
+            ).toBeVisible({ timeout: 15_000 });
+
+            await session.login({
+                username: user.username,
+                password: SECONDARY_PASSWORD,
+                to: "if/user/#/settings",
+            });
+        });
+
+        await test.step("Verify the secondary account is now active", async () => {
+            await switcher.open();
+
+            await expect(
+                secondaryEntry,
+                "Secondary account is marked as the current account",
+            ).toBeDisabled();
+            await expect(
+                adminEntry,
+                "Administrator remains selectable as a switch target",
+            ).toBeEnabled();
+            await expect(
+                adminInterfaceLink,
+                "Admin interface link is hidden for the non-superuser account",
+            ).toBeHidden();
+        });
+
+        await test.step("Switch back to the administrator", async () => {
+            await navigator.navigate("/if/user/#/library");
+
+            await switcher.select(adminEntry);
+
+            await expect(
+                session.$passwordStage,
+                "Switching opens on the password stage, identification having been skipped",
+            ).toBeVisible({ timeout: 15_000 });
+            await expect(
+                session.$identificationStage,
+                "Identification is not asked again for a known switch target",
+            ).toBeHidden();
+
+            await session.completePassword({ to: "if/user/#/library" });
+        });
+
+        await test.step("Verify the administrator is active again", async () => {
+            await switcher.open();
+
+            await expect(
+                adminEntry,
+                "Administrator is marked as the current account",
+            ).toBeDisabled();
+            await expect(
+                secondaryEntry,
+                "Secondary account remains selectable as a switch target",
+            ).toBeEnabled();
+            await expect(
+                adminInterfaceLink,
+                "Admin interface link is available again",
+            ).toBeVisible();
+        });
+    });
+
+    test("Switcher is available in the admin interface", async ({ session, switcher }) => {
+        await test.step("Authenticate as the administrator", async () => {
+            await session.login({ to: "/if/admin/#/administration/overview" });
+        });
+
+        await test.step("Open the switcher from the admin header", async () => {
+            await switcher.open();
+
+            await expect(
+                switcher.entry(ADMIN_ENTRY_NAME),
+                "Administrator is marked as the current account",
+            ).toBeDisabled();
+            await expect(switcher.$addUser, "Add another user is offered").toBeVisible();
+        });
+    });
+
+    test("Signing out the current user requires re-authentication", async ({
+        session,
+        switcher,
+        page,
+    }) => {
+        await test.step("Authenticate as the administrator", async () => {
+            await session.login({ to: "/if/user/#/library" });
+        });
+
+        await test.step("Sign out the current account", async () => {
+            await switcher.select(switcher.$signOut);
+
+            await expect(
+                session.$identificationStage,
+                "Signing out returns to the authentication flow",
+            ).toBeVisible({ timeout: 15_000 });
+        });
+
+        await test.step("Verify the user interface is no longer reachable", async () => {
+            // `navigator.navigate` cannot be used here: the interface bounces straight
+            // back to the authentication flow, so the requested pathname never settles.
+            await page.goto("/if/user/#/library");
+
+            await expect(
+                session.$identificationStage,
+                "The signed-out session cannot reach the user interface",
+            ).toBeVisible({ timeout: 15_000 });
+        });
+    });
+
+    //#endregion
+});


### PR DESCRIPTION
## Details

### What does this PR change?

Adds `web/test/browser/102-user-switching.test.ts`, covering the header account switcher end to end:

- Adding a second account from the switcher, then switching back to the first.
- The switcher's presence in the admin header (mounted via `ak-page-navbar`, a different path from the user header).
- Signing the current account out.

Supporting changes:

- New `switcher` fixture (`web/e2e/fixtures/UserSwitcherFixture.ts`) wrapping `ak-user-switcher`.
- New `session.completePassword()` helper for the switch flow, where identification is skipped because the plan already carries `pending_user`.

It also repairs `101-session-lifecycle`. Signing out moved into the switcher in a4548cfc56, so the old bare "Sign out" header link no longer existed and that assertion had been failing ever since — which meant every assertion after it in that step had never actually run. Un-skipping them surfaced that remember-me can land on the password stage rather than identification, so the step now handles both.

### Why is this change needed?

User switching (#22659) shipped with backend coverage but no browser coverage, and it silently broke an existing session-lifecycle assertion.

### How was this tested?

`npx playwright test 102-user-switching` against a local instance: 3 tests green, and stable across `--repeat-each=3` under the default parallel config.

Two things worth knowing for anyone extending this suite:

- `ak-dropdown` re-hides its menu from `connectedCallback`, so a re-render of `ak-user-switcher` closes an already-open menu. Opening is retried around that.
- While the menu is closed the `<menu>` carries `hidden`, which drops its subtree from the accessibility tree, so `menuitem` queries match nothing until it is open.

The suite points the default brand at a user switch flow itself, since nothing seeds that field and the feature is inert without it. That hook is read-only once configured, so repeat runs don't race on the brand row.

### Linked issues

Closes #24762

---

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
