### PR TITLE
root: pin pnpm 11.20.0 everywhere

### DIFF
--- a/lifecycle/aws/package.json
+++ b/lifecycle/aws/package.json
@@ -12,7 +12,7 @@
     },
     "engines": {
         "node": ">=24",
-        "pnpm": ">=11.9.0"
+        "pnpm": ">=11.20.0"
     },
     "devEngines": {
         "runtime": {
@@ -21,5 +21,5 @@
             "version": ">=24"
         }
     },
-    "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b"
+    "packageManager": "pnpm@11.20.0+sha512.9a6f330a95b66446ea088faf1521405a8a01f07fde7124cc9958dfed52d4bb436737e65b08f85f37b46fcba375092558ac51262b816844b22f63406ed166bfee"
 }

--- a/lifecycle/container/Dockerfile
+++ b/lifecycle/container/Dockerfile
@@ -2,7 +2,7 @@
 
 # Tag must track the root package.json `packageManager` version. ${BUILDPLATFORM}
 # keeps the binary's arch aligned with the builder stage on cross-arch builds.
-FROM --platform=${BUILDPLATFORM} ghcr.io/pnpm/pnpm:11.19.0@sha256:1c69b4492d1162f01481d634b3e93acc3aa8b550e80e6deb852c7991a1c5249c AS pnpm
+FROM --platform=${BUILDPLATFORM} ghcr.io/pnpm/pnpm:11.20.0@sha256:31cbb105d08d57866635f5e35e80cc17eff3de13ac26e719a58c173d8f824ae0 AS pnpm
 
 # Stage: Build webui
 FROM --platform=${BUILDPLATFORM} docker.io/library/node:26-trixie-slim@sha256:deae974a69e140f44f434ab29cb519fb5f8fe250fd364b8ca446bd0761acdc6a AS node-builder

--- a/lifecycle/container/Dockerfile
+++ b/lifecycle/container/Dockerfile
@@ -2,7 +2,7 @@
 
 # Tag must track the root package.json `packageManager` version. ${BUILDPLATFORM}
 # keeps the binary's arch aligned with the builder stage on cross-arch builds.
-FROM --platform=${BUILDPLATFORM} ghcr.io/pnpm/pnpm:11.20.0@sha256:31cbb105d08d57866635f5e35e80cc17eff3de13ac26e719a58c173d8f824ae0 AS pnpm
+FROM --platform=${BUILDPLATFORM} ghcr.io/pnpm/pnpm:11.20.0@sha256:d77573aba1649491010d3d252214be47197c0706417793cf393ac47cc324f315 AS pnpm
 
 # Stage: Build webui
 FROM --platform=${BUILDPLATFORM} docker.io/library/node:26-trixie-slim@sha256:deae974a69e140f44f434ab29cb519fb5f8fe250fd364b8ca446bd0761acdc6a AS node-builder

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     },
     "engines": {
         "node": ">=24",
-        "pnpm": ">=11.9.0"
+        "pnpm": ">=11.20.0"
     },
     "devEngines": {
         "runtime": {
@@ -41,6 +41,6 @@
             "version": ">=24"
         }
     },
-    "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
+    "packageManager": "pnpm@11.20.0+sha512.9a6f330a95b66446ea088faf1521405a8a01f07fde7124cc9958dfed52d4bb436737e65b08f85f37b46fcba375092558ac51262b816844b22f63406ed166bfee",
     "prettier": "@goauthentik/prettier-config"
 }

--- a/packages/client-ts/package.json
+++ b/packages/client-ts/package.json
@@ -19,7 +19,18 @@
         "prettier": "^3.8.1",
         "typescript": "^4.0 || ^5.0"
     },
-    "packageManager": "pnpm@11.5.1+sha512.93f7b57422ea7068257235b4c16eb60762eb68e1dc23723199cc739043ea9be2c4143274a399d8c6defa2b1176226d9ca1c4b63482d6200c1a8fbaa78c1d1485",
+    "engines": {
+        "node": ">=24",
+        "pnpm": ">=11.20.0"
+    },
+    "devEngines": {
+        "runtime": {
+            "name": "node",
+            "onFail": "warn",
+            "version": ">=24"
+        }
+    },
+    "packageManager": "pnpm@11.20.0+sha512.9a6f330a95b66446ea088faf1521405a8a01f07fde7124cc9958dfed52d4bb436737e65b08f85f37b46fcba375092558ac51262b816844b22f63406ed166bfee",
     "prettier": "@goauthentik/prettier-config",
     "sideEffects": false,
     "module": "./src/index.ts"

--- a/web/package.json
+++ b/web/package.json
@@ -292,7 +292,7 @@
     },
     "engines": {
         "node": ">=24",
-        "pnpm": ">=11.9.0"
+        "pnpm": ">=11.20.0"
     },
     "devEngines": {
         "runtime": {
@@ -301,6 +301,6 @@
             "version": ">=24"
         }
     },
-    "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
+    "packageManager": "pnpm@11.20.0+sha512.9a6f330a95b66446ea088faf1521405a8a01f07fde7124cc9958dfed52d4bb436737e65b08f85f37b46fcba375092558ac51262b816844b22f63406ed166bfee",
     "prettier": "./prettier.config.mjs"
 }

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,6 +1,6 @@
 # Tag must track the root package.json `packageManager` version. ${BUILDPLATFORM}
 # keeps the binary's arch aligned with the builder stage on cross-arch builds.
-FROM --platform=${BUILDPLATFORM} ghcr.io/pnpm/pnpm:11.20.0@sha256:31cbb105d08d57866635f5e35e80cc17eff3de13ac26e719a58c173d8f824ae0 AS pnpm
+FROM --platform=${BUILDPLATFORM} ghcr.io/pnpm/pnpm:11.20.0@sha256:d77573aba1649491010d3d252214be47197c0706417793cf393ac47cc324f315 AS pnpm
 
 FROM --platform=${BUILDPLATFORM} docker.io/library/node:26.5.1-trixie@sha256:a9875b5ccb02aa527cf7f2297b16ae425a0ff3da2f7d87fce3df41f04ffa0524 AS docs-builder
 

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,6 +1,6 @@
 # Tag must track the root package.json `packageManager` version. ${BUILDPLATFORM}
 # keeps the binary's arch aligned with the builder stage on cross-arch builds.
-FROM --platform=${BUILDPLATFORM} ghcr.io/pnpm/pnpm:11.19.0@sha256:1c69b4492d1162f01481d634b3e93acc3aa8b550e80e6deb852c7991a1c5249c AS pnpm
+FROM --platform=${BUILDPLATFORM} ghcr.io/pnpm/pnpm:11.20.0@sha256:31cbb105d08d57866635f5e35e80cc17eff3de13ac26e719a58c173d8f824ae0 AS pnpm
 
 FROM --platform=${BUILDPLATFORM} docker.io/library/node:26.5.1-trixie@sha256:a9875b5ccb02aa527cf7f2297b16ae425a0ff3da2f7d87fce3df41f04ffa0524 AS docs-builder
 

--- a/website/package.json
+++ b/website/package.json
@@ -52,7 +52,7 @@
     },
     "engines": {
         "node": ">=24",
-        "pnpm": ">=11.9.0"
+        "pnpm": ">=11.20.0"
     },
     "devEngines": {
         "runtime": {
@@ -61,6 +61,6 @@
             "version": ">=24"
         }
     },
-    "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
+    "packageManager": "pnpm@11.20.0+sha512.9a6f330a95b66446ea088faf1521405a8a01f07fde7124cc9958dfed52d4bb436737e65b08f85f37b46fcba375092558ac51262b816844b22f63406ed166bfee",
     "prettier": "@goauthentik/prettier-config"
 }


### PR DESCRIPTION
## Details

Split out of #24702 so the version change can be reviewed (and reverted) on its own.

Aligns every pnpm version reference on the latest release: `packageManager` and the `engines` floor in all four manifests, plus the `ghcr.io/pnpm/pnpm` image in both Dockerfiles. pnpm re-execs whatever `packageManager` pins, so while the references disagreed our container builds ran a second pnpm process behind the image's binary — with everything on 11.20.0 there's only one.

## Verification

- Frozen installs for the root, `web`, and `website` workspaces pass on 11.20.0 with no lockfile changes.
- corepack accepts the new `packageManager` hash; the image digest matches `docker buildx imagetools inspect`.

One caveat: raising the `engines` floor to `>=11.20.0` will hard-fail any environment whose pnpm can't self-switch (e.g. a misbehaving Netlify runner) — if a docs deploy breaks, the floor is the first thing to relax.
