### PR TITLE
web/admin: manage password lockout

### DIFF
--- a/web/src/admin/stages/password/PasswordStageForm.ts
+++ b/web/src/admin/stages/password/PasswordStageForm.ts
@@ -1,11 +1,15 @@
 import "#components/ak-text-input";
 import "#elements/ak-checkbox-group/ak-checkbox-group";
+import "#components/ak-number-input";
 import "#components/ak-switch-input";
+import "#components/ak-text-input";
 import "#elements/forms/FormGroup";
 import "#elements/forms/HorizontalFormElement";
 import "#elements/forms/SearchSelect/index";
 
 import { aki } from "#common/api/client";
+
+import { WithLicenseSummary } from "#elements/mixins/license";
 
 import { AKLabel } from "#components/ak-label";
 
@@ -27,7 +31,7 @@ import { html, TemplateResult } from "lit";
 import { customElement } from "lit/decorators.js";
 
 @customElement("ak-stage-password-form")
-export class PasswordStageForm extends BaseStageForm<PasswordStage> {
+export class PasswordStageForm extends WithLicenseSummary(BaseStageForm<PasswordStage>) {
     protected endpoints = {
         load: (stageUuid: string) => aki(StagesApi).stagesPasswordRetrieve({ stageUuid }),
         create: (passwordStageRequest: PasswordStage) =>
@@ -45,6 +49,55 @@ export class PasswordStageForm extends BaseStageForm<PasswordStage> {
                 return field === isField;
             }).length > 0
         );
+    }
+
+    protected renderLockoutSettings(): TemplateResult {
+        // Without an Enterprise license the lockout policy never runs; the settings
+        // stay visible but read-only.
+        const readOnly = !this.hasEnterpriseLicense;
+
+        return html`<ak-number-input
+                label=${msg("Failed attempts before lockout", {
+                    id: "password-stage.lockout-threshold.label",
+                })}
+                required
+                name="failedAttemptsBeforeLockout"
+                min=${0}
+                value="${this.instance?.failedAttemptsBeforeLockout ?? 0}"
+                ?readonly=${readOnly}
+                help=${readOnly
+                    ? msg("Password lockout requires an Enterprise license.", {
+                          id: "password-stage.lockout-threshold.enterprise",
+                      })
+                    : msg(
+                          "Lock password login after this many consecutive failed attempts, until an administrator unlocks it. Failed attempts against LDAP and Kerberos backends are not counted. Set to 0 to never lock.",
+                          { id: "password-stage.lockout-threshold.description" },
+                      )}
+            ></ak-number-input>
+            <ak-text-input
+                label=${msg("Last-attempt warning message", {
+                    id: "password-stage.last-attempt-warning-message.label",
+                })}
+                name="lastAttemptWarningMessage"
+                value=${this.instance?.lastAttemptWarningMessage ?? ""}
+                ?readonly=${readOnly}
+                help=${msg(
+                    "Warning shown when the user has one password attempt remaining. Leave blank to show no warning.",
+                    { id: "password-stage.last-attempt-warning-message.description" },
+                )}
+            ></ak-text-input>
+            <ak-text-input
+                label=${msg("Lockout message", {
+                    id: "password-stage.lockout-message.label",
+                })}
+                name="lockoutMessage"
+                value="${this.instance?.lockoutMessage ?? ""}"
+                ?readonly=${readOnly}
+                help=${msg(
+                    "Message shown when the user's password has been locked. Leave blank to show no message.",
+                    { id: "password-stage.lockout-message.description" },
+                )}
+            ></ak-text-input>`;
     }
 
     protected override renderForm(): TemplateResult {
@@ -165,10 +218,14 @@ export class PasswordStageForm extends BaseStageForm<PasswordStage> {
                         />
                         <p class="pf-c-form__helper-text">
                             ${msg(
-                                "How many attempts a user has before the flow is canceled. To lock the user out, use a reputation policy and a user_write stage.",
+                                "How many failed password attempts are allowed before the flow is canceled. This setting does not deactivate the user.",
+                                {
+                                    id: "password-stage.failed-attempts-before-cancel.description",
+                                },
                             )}
                         </p>
                     </ak-form-element-horizontal>
+                    ${this.renderLockoutSettings()}
                     <ak-switch-input
                         name="allowShowPassword"
                         label="Allow Show Password"

--- a/web/src/admin/users/UserInfoCard.ts
+++ b/web/src/admin/users/UserInfoCard.ts
@@ -3,6 +3,7 @@ import "#admin/users/UserForm";
 import "#admin/users/UserImpersonateForm";
 import "#admin/users/UserOffboardingForm";
 import "#admin/users/UserPasswordForm";
+import "#admin/users/UserPasswordLockForm";
 import "#components/ak-status-label";
 import "#elements/forms/ConfirmationForm";
 import "#elements/forms/ModalForm";
@@ -22,6 +23,7 @@ import { ToggleUserActivationButton } from "#admin/users/UserActiveForm";
 import { UserForm } from "#admin/users/UserForm";
 import { UserImpersonateForm } from "#admin/users/UserImpersonateForm";
 import Styles from "#admin/users/UserInfoCard.css";
+import { ToggleUserPasswordLockButton } from "#admin/users/UserPasswordLockForm";
 
 import {
     LifecycleApi,
@@ -133,6 +135,10 @@ export class UserInfoCard extends AKElement {
             </button>
 
             ${ToggleUserActivationButton(user, { className: "pf-m-block" })}
+            ${ToggleUserPasswordLockButton(user, {
+                className: "pf-m-block",
+                hasEnterpriseLicense: this.hasEnterpriseLicense,
+            })}
             ${showEnterpriseActions
                 ? html`<button
                       class="pf-c-button pf-m-danger pf-m-block"

--- a/web/src/admin/users/UserPasswordLockForm.ts
+++ b/web/src/admin/users/UserPasswordLockForm.ts
@@ -1,0 +1,96 @@
+import { aki } from "#common/api/client";
+import { formatDisambiguatedUserDisplayName } from "#common/users";
+
+import { modalInvoker } from "#elements/dialogs";
+import { DestructiveModelForm } from "#elements/forms/DestructiveModelForm";
+import { WithLocale } from "#elements/mixins/locale";
+import { SlottedTemplateResult } from "#elements/types";
+
+import { CoreApi, User, UserTypeEnum } from "@goauthentik/api";
+
+import { msg, str } from "@lit/localize";
+import { html, nothing } from "lit";
+import { customElement } from "lit/decorators.js";
+
+@customElement("ak-user-password-lock-form")
+export class UserPasswordLockForm extends WithLocale(DestructiveModelForm<User>) {
+    protected coreAPI = aki(CoreApi);
+
+    protected get locked(): boolean {
+        return !!this.instance?.passwordLocked;
+    }
+
+    protected override send(): Promise<unknown> {
+        if (!this.instance) {
+            return Promise.reject(new Error("No user instance provided"));
+        }
+        return this.locked
+            ? this.coreAPI.coreUsersUnlockPasswordCreate({ id: this.instance.pk })
+            : this.coreAPI.coreUsersLockPasswordCreate({ id: this.instance.pk });
+    }
+
+    public override formatSubmitLabel(): string {
+        return this.locked
+            ? msg("Unlock password login", { id: "user.action.password-unlock.label" })
+            : msg("Lock password login", { id: "user.action.password-lock.label" });
+    }
+
+    protected override formatHeadline(): string {
+        return this.locked
+            ? msg("Review password unlock", { id: "user.action.password-unlock-review.label" })
+            : msg("Review password lock", { id: "user.action.password-lock-review.label" });
+    }
+
+    protected override renderForm(): SlottedTemplateResult {
+        const displayName = this.instance
+            ? formatDisambiguatedUserDisplayName(this.instance, this.activeLanguageTag)
+            : msg("Unknown user");
+        return html`<p>
+            ${this.locked
+                ? msg(str`Allow ${displayName} to authenticate with a password again?`, {
+                      id: "user.action.password-unlock-confirm.description",
+                  })
+                : msg(
+                      str`Prevent ${displayName} from authenticating with a password? Existing sessions and other authentication methods are not affected.`,
+                      { id: "user.action.password-lock-confirm.description" },
+                  )}
+        </p>`;
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "ak-user-password-lock-form": UserPasswordLockForm;
+    }
+}
+
+export interface ToggleUserPasswordLockButtonProps {
+    className?: string;
+    hasEnterpriseLicense?: boolean;
+}
+
+export function ToggleUserPasswordLockButton(
+    user: User,
+    { className = "", hasEnterpriseLicense = false }: ToggleUserPasswordLockButtonProps = {},
+): SlottedTemplateResult {
+    const locked = !!user.passwordLocked;
+    const serviceAccount =
+        user.type === UserTypeEnum.ServiceAccount ||
+        user.type === UserTypeEnum.InternalServiceAccount;
+    // Unlocking never requires a license; locking does, and service accounts
+    // have no password to lock.
+    if (!locked && (!hasEnterpriseLicense || serviceAccount)) {
+        return nothing;
+    }
+
+    const label = locked
+        ? msg("Unlock password login", { id: "user.action.password-unlock.label" })
+        : msg("Lock password login", { id: "user.action.password-lock.label" });
+    return html`<button
+        class="pf-c-button pf-m-warning ${className}"
+        type="button"
+        ${modalInvoker(UserPasswordLockForm, { instance: user })}
+    >
+        ${label}
+    </button>`;
+}

--- a/web/src/components/ak-number-input.ts
+++ b/web/src/components/ak-number-input.ts
@@ -17,6 +17,9 @@ export class AkNumberInput extends HorizontalLightComponent<number> {
     @property({ type: Boolean, reflect: true })
     allowFloat = false;
 
+    @property({ type: Boolean, attribute: "readonly" })
+    readOnly = false;
+
     renderControl() {
         const setValue = (ev: InputEvent) => {
             const value = (ev.target as HTMLInputElement).value.trim();
@@ -42,6 +45,7 @@ export class AkNumberInput extends HorizontalLightComponent<number> {
             min=${ifDefined(this.min)}
             class="pf-c-form-control"
             ?required=${this.required}
+            ?readonly=${this.readOnly}
         />`;
     }
 }


### PR DESCRIPTION
## Details

Admin UI for password lockout: the password stage form gains the lockout threshold and message fields (visible but read-only without an Enterprise license), and the user details page gains lock/unlock password buttons. Unlocking never requires a license; service accounts cannot be locked.