### PR TITLE
blueprints: handle invalid yaml, add dry run to apply_blueprint

### DIFF
--- a/authentik/blueprints/api.py
+++ b/authentik/blueprints/api.py
@@ -23,7 +23,7 @@ from rest_framework.viewsets import ModelViewSet
 
 from authentik.api.validation import validate
 from authentik.blueprints.models import BlueprintInstance
-from authentik.blueprints.v1.common import Blueprint
+from authentik.blueprints.v1.common import Blueprint, EntryInvalidError
 from authentik.blueprints.v1.importer import Importer
 from authentik.blueprints.v1.oci import OCI_PREFIX
 from authentik.blueprints.v1.tasks import apply_blueprint, blueprints_find_dict
@@ -236,7 +236,10 @@ class BlueprintInstanceViewSet(UsedByMixin, ModelViewSet):
         else:
             raise ValidationError("Either path or file must be set")
         context = body.validated_data.get("context") or {}
-        importer = Importer.from_string(string_contents, context)
+        try:
+            importer = Importer.from_string(string_contents, context)
+        except EntryInvalidError as exc:
+            raise ValidationError(_("Invalid blueprint file: {exc}".format(exc=str(exc)))) from None
 
         check_blueprint_perms(importer.blueprint, request.user)
 

--- a/authentik/blueprints/management/commands/apply_blueprint.py
+++ b/authentik/blueprints/management/commands/apply_blueprint.py
@@ -17,11 +17,11 @@ class Command(BaseCommand):
     """Apply blueprint from commandline"""
 
     @no_translations
-    def handle(self, *args, **options):
+    def handle(self, *args, blueprints: list[str], dry_run: bool, **options):
         """Apply all blueprints in order, abort when one fails to import"""
         for tenant in Tenant.objects.filter(ready=True):
             with tenant:
-                for blueprint_path in options.get("blueprints", []):
+                for blueprint_path in blueprints:
                     content = BlueprintInstance(path=blueprint_path).retrieve()
                     importer = Importer.from_string(content)
                     valid, logs = importer.validate()
@@ -30,7 +30,11 @@ class Command(BaseCommand):
                         for log in logs:
                             self.stderr.write(f"\t{log.logger}: {log.event}: {log.attributes}")
                         sys_exit(1)
-                    importer.apply()
+                    if not dry_run:
+                        importer.apply()
+                    else:
+                        LOGGER.info("Dry-run enabled, not applying blueprint")
 
     def add_arguments(self, parser: ArgumentParser):
+        parser.add_argument("--dry-run", action="store_true", default=False)
         parser.add_argument("blueprints", nargs="+", type=str)

--- a/authentik/blueprints/v1/importer.py
+++ b/authentik/blueprints/v1/importer.py
@@ -20,6 +20,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.serializers import BaseSerializer, Serializer
 from structlog.stdlib import BoundLogger, get_logger
 from yaml import load
+from yaml.error import YAMLError
 
 from authentik.blueprints.v1.common import (
     Blueprint,
@@ -154,13 +155,16 @@ class Importer:
     @staticmethod
     def from_string(yaml_input: str, context: dict | None = None) -> Importer:
         """Parse YAML string and create blueprint importer from it"""
-        import_dict = load(yaml_input, BlueprintLoader)
+        try:
+            import_dict = load(yaml_input, BlueprintLoader)
+        except YAMLError as exc:
+            raise EntryInvalidError(exc) from exc
         try:
             _import = from_dict(
                 Blueprint, import_dict, config=Config(cast=[BlueprintEntryDesiredState])
             )
         except DaciteError as exc:
-            raise EntryInvalidError from exc
+            raise EntryInvalidError(exc) from exc
         return Importer(_import, context)
 
     @property


### PR DESCRIPTION
Currently uploading a blueprint with an invalid unicode character for example just caused a 405 error