### PR TITLE
enterprise/agents: fix enterprise required check for agents

### DIFF
--- a/authentik/enterprise/agents/api.py
+++ b/authentik/enterprise/agents/api.py
@@ -27,10 +27,11 @@ from authentik.core.models import (
     Token,
     TokenIntents,
     User,
+    UserTypes,
     default_token_duration,
 )
 from authentik.enterprise.agents.models import Agent
-from authentik.enterprise.api import EnterpriseRequiredMixin
+from authentik.enterprise.api import EnterpriseRequiredMixin, enterprise_action
 
 
 class AgentSerializer(EnterpriseRequiredMixin, PartialUserSerializer):
@@ -95,6 +96,7 @@ class AgentViewSet(
 
     @extend_schema(request=AgentCreateSerializer, responses={201: AgentCreatedSerializer})
     @validate(AgentCreateSerializer)
+    @enterprise_action
     def create(self, request: Request, body: AgentCreateSerializer) -> Response:
         parent: User = body.validated_data.get("parent") or request.user
         self_service_perm = request.user.has_perm("authentik_agents.add_agent_self_service")
@@ -108,6 +110,8 @@ class AgentViewSet(
                 raise PermissionDenied(_("You can only create agents for yourself."))
             if not self_service_perm:
                 raise PermissionDenied(_("Self-service agent creation is not enabled."))
+            if request.user.type != UserTypes.INTERNAL:
+                raise PermissionDenied(_("Only internal user accounts can create agents."))
 
         if self_service:
             # Self-service agents always expire with the tenant default and MIRROR their owner,

--- a/authentik/enterprise/agents/tests/test_agents.py
+++ b/authentik/enterprise/agents/tests/test_agents.py
@@ -4,8 +4,10 @@ from rest_framework.test import APIClient, APITestCase
 from authentik.core.models import Token, TokenIntents, UserTypes
 from authentik.core.tests.utils import create_test_admin_user, create_test_user
 from authentik.enterprise.agents.models import Agent
+from authentik.enterprise.tests import enterprise_test
 
 
+@enterprise_test()
 class AgentTests(APITestCase):
 
     def _grant_self_service_perm(self, user):


### PR DESCRIPTION
`EnterpriseRequiredMixin` didn't work correctly here as we're using a custom create method