### PR TITLE
website/docs: add gitguardian to 2026.8 release notes

### DIFF
--- a/website/docs/releases/2026/v2026.8.md
+++ b/website/docs/releases/2026/v2026.8.md
@@ -146,6 +146,7 @@ An integration is how authentik connects to third-party applications, directorie
 - [Dropbox Sign](https://integrations.goauthentik.io/documentation/dropbox-sign/)
 - [ExcaliDash](https://integrations.goauthentik.io/dashboards/excalidash/)
 - [FortiAnalyzer](https://integrations.goauthentik.io/monitoring/fortianalyzer/) (Thanks to @nicedevil007!)
+- [GitGuardian](https://integrations.goauthentik.io/security/gitguardian/)
 - [Gotify](https://integrations.goauthentik.io/monitoring/gotify/) (Thanks to @nicedevil007!)
 - [HubSpot](https://integrations.goauthentik.io/platforms/hubspot/)
 - [Icinga Web 2](https://integrations.goauthentik.io/monitoring/icinga/) (Thanks to @nicedevil007!)


### PR DESCRIPTION
Adds the GitGuardian integration guide to the 2026.8 release notes. Split out from goauthentik/authentik#23587 since integration docs aren't backported.