### PR TITLE
internal/outpost/ldap: type switching for uidNumber/gidNumber

### DIFF
--- a/internal/outpost/ldap/utils.go
+++ b/internal/outpost/ldap/utils.go
@@ -7,6 +7,22 @@ import (
 	api "goauthentik.io/packages/client-go"
 )
 
+func getAttributeString(attributes map[string]any, key string) (string, bool) {
+	val, ok := attributes[key]
+	if !ok || val == nil {
+		return "", false
+	}
+
+	switch v := val.(type) {
+	case string:
+		return v, true
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64), true
+	default:
+		return "", false
+	}
+}
+
 func (pi *ProviderInstance) GroupsForUser(user api.User) []string {
 	groups := make([]string, len(user.Groups))
 	for i, group := range user.GroupsObj {
@@ -48,7 +64,7 @@ func (pi *ProviderInstance) GetVirtualGroupDN(group string) string {
 }
 
 func (pi *ProviderInstance) GetUserUidNumber(user api.User) string {
-	uidNumber, ok := user.GetAttributes()["uidNumber"].(string)
+	uidNumber, ok := getAttributeString(user.GetAttributes(), "uidNumber")
 
 	if ok {
 		return uidNumber
@@ -58,7 +74,7 @@ func (pi *ProviderInstance) GetUserUidNumber(user api.User) string {
 }
 
 func (pi *ProviderInstance) GetUserGidNumber(user api.User) string {
-	gidNumber, ok := user.GetAttributes()["gidNumber"].(string)
+	gidNumber, ok := getAttributeString(user.GetAttributes(), "gidNumber")
 
 	if ok {
 		return gidNumber
@@ -68,7 +84,7 @@ func (pi *ProviderInstance) GetUserGidNumber(user api.User) string {
 }
 
 func (pi *ProviderInstance) GetGroupGidNumber(group api.Group) string {
-	gidNumber, ok := group.GetAttributes()["gidNumber"].(string)
+	gidNumber, ok := getAttributeString(group.GetAttributes(), "gidNumber")
 
 	if ok {
 		return gidNumber


### PR DESCRIPTION

## Details

### What does this PR change?

Treat both integer and string uidNumber/gidNumber attribute values equally.

### Why is this change needed?

When the uidNumber attribute was set as an integer without an explicit gidNumber, the system would generate a gidNumber instead of mapping the uidNumber. The mapping only worked if uidNumber was set as a string.

As uidNumber/gidNumber are commonly integers, avoid the need for faking strings in the user attributes by matching the behavior.

This also reduces implementation confusion, as the documentation states

> The gidNumber attribute of each virtual group is equal to the uidNumber of the user.

without imposing any limitations on the data type.

### How was this tested?

Define a user with a custom `uidNumber` attribute. Set the attribute to a number: first a string, then an integer one. Observe the result when querying the uidNumber/gidNumber attributes of the user and the users virtual group.

### Linked issues

<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
