### PR TITLE
website/docs: document require actions on next login

### DIFF
--- a/website/docs/users-sources/user/next_actions.mdx
+++ b/website/docs/users-sources/user/next_actions.mdx
@@ -1,0 +1,30 @@
+---
+title: Require actions on next login
+authentik_version: "2026.11"
+authentik_enterprise: true
+---
+
+You can require a user to complete one or more flows after their next successful login, before they can continue to authentik or an application. Typical uses are forcing a password change or requiring the user to set up an authenticator.
+
+## How it works
+
+The `goauthentik.io/user/next-actions` attribute on a user defines their required actions. Its value can be a single flow slug or a list of flow slugs.
+
+When a login flow reaches the [User Login stage](../../add-secure-apps/flows-stages/stages/user_login/index.mdx), authentik creates the user's session and marks it as restricted. The user sees a successful-login message, but authentik does not let that session continue to the user interface, an application authorization flow, or an API until all required flows are complete.
+
+authentik runs the required flows in the order they are listed. After the user completes a flow, authentik removes it from the attribute and starts the next one. After the final flow, authentik releases the session and resumes the page or application authorization that started the login. Sessions that already existed when an administrator assigned the actions are not restricted; the actions apply when the user next logs in.
+
+Any flow can be used as an action, except flows with the **Authentication** or **Invalidation** [designation](../../add-secure-apps/flows-stages/flow/index.mdx). authentik's [default flows](../../add-secure-apps/flows-stages/flow/default-flows.mdx) already cover changing the password (`default-password-change`) and setting up the various authenticator types (for example `default-authenticator-totp-setup`).
+
+For anything else, [create a flow](../../add-secure-apps/flows-stages/flow/index.mdx#create-a-flow) that walks the user through the action and use its slug. For example, a flow with a [Prompt stage](../../add-secure-apps/flows-stages/stages/prompt/index.mdx) followed by a [User Write stage](../../add-secure-apps/flows-stages/stages/user_write/index.mdx) can collect missing profile details, and a flow with a [Consent stage](../../add-secure-apps/flows-stages/stages/consent/index.mdx) can require the user to accept updated terms.
+
+If a listed flow doesn't exist or its policies deny the user, the session remains restricted until an administrator corrects or removes the attribute. An expired Enterprise license does not release a restricted session or skip actions on later logins. On deployments without an installed Enterprise license, authentik ignores this attribute.
+
+## Require an action for a user
+
+Set the `goauthentik.io/user/next-actions` attribute on the user, through the user API, a [blueprint](../../customize/blueprints/index.mdx), or from within a flow, for example with a [User Write stage](../../add-secure-apps/flows-stages/stages/user_write/index.mdx) in an enrollment flow:
+
+```yaml
+goauthentik.io/user/next-actions:
+    - default-password-change
+```

--- a/website/docs/users-sources/user/password_reset_on_login.mdx
+++ b/website/docs/users-sources/user/password_reset_on_login.mdx
@@ -5,6 +5,8 @@ sidebar_label: Password reset on login
 
 You can require users to reset their password on their next login, using expression policies, custom stages, and a custom user attribute. This guide explains how to configure this with the `default-authentication-flow`; however, the same steps apply to any authentication flow.
 
+With an authentik Enterprise license this is built in: set the `goauthentik.io/user/next-actions` attribute on the user to `default-password-change`. See [Require actions on next login](./next_actions.mdx). The rest of this guide configures the same behavior manually.
+
 Configuring forced password reset on next login involves the following steps:
 
     1. Creating two expression policies.

--- a/website/docs/users-sources/user/user_basic_operations.mdx
+++ b/website/docs/users-sources/user/user_basic_operations.mdx
@@ -146,6 +146,8 @@ As an administrator, you can reset a user's password.
 2. Either click the name of the user to display the full User details page, or click the chevron beside their name to expand the options.
 3. To reset the user's password, click **Reset password**, and then define the new value.
 
+To instead require the user to change their password on their next login, see [Require actions on next login](./next_actions.mdx).
+
 ### User resets their password
 
 If a [Recovery flow](#configure-a-recovery-flow) has been applied to the brand, users can reset their own passwords in the [User interface](../user/user-interface.mdx).


### PR DESCRIPTION
Documents how administrators assign next actions, what a restricted session can access, and how authentik resumes the original destination after every action is complete.