### PR TITLE
website/integrations: add Maintainerr

### DIFF
--- a/website/docs/releases/2026/v2026.8.md
+++ b/website/docs/releases/2026/v2026.8.md
@@ -155,6 +155,7 @@ An integration is how authentik connects to third-party applications, directorie
 - [Incus](https://integrations.goauthentik.io/hypervisors-orchestrators/incus/)
 - [Kavita](https://integrations.goauthentik.io/media/kavita/)
 - [mailcow Logs Viewer](https://integrations.goauthentik.io/chat-communication-collaboration/mailcow-logs-viewer/) (Thanks to @nicedevil007!)
+- [Maintainerr](https://integrations.goauthentik.io/media/maintainerr/) (Thanks to @enoch85!)
 - [Memos](https://integrations.goauthentik.io/chat-communication-collaboration/memos/)
 - [Microsoft 365 via WS-Federation](https://integrations.goauthentik.io/platforms/microsoft-ws-federation/)
 - [n8n](https://integrations.goauthentik.io/development/n8n/)

--- a/website/integrations/media/maintainerr/index.md
+++ b/website/integrations/media/maintainerr/index.md
@@ -6,11 +6,9 @@ support_level: community
 
 ## What is Maintainerr?
 
-> Maintainerr applies rules you define to a Plex, Jellyfin, or Emby library, gathers the media that matches into collections, leaves it visible for a configurable period, and then removes it along with the matching files and requests in Radarr, Sonarr, and Seerr.
+> Maintainerr is a free, self-hosted tool that finds and removes unwatched or unwanted movies and shows from Plex, Jellyfin, and Emby using powerful, customizable rules.
 >
-> -- https://docs.maintainerr.info/
-
-Maintainerr has no login of its own. This guide uses the authentik Proxy Provider to authenticate requests before they reach Maintainerr.
+> -- https://maintainerr.info/
 
 ## Preparation
 
@@ -21,10 +19,6 @@ The following placeholders are used in this guide:
 
 :::info
 This documentation lists only the settings that you need to change from their default values. Be aware that any changes other than those explicitly mentioned in this guide could cause issues accessing your application.
-:::
-
-:::danger Protect the Maintainerr backend
-Maintainerr does not authenticate requests, so anything that reaches it is trusted. `GET /api/settings/database/download` returns its entire database, which stores the credentials for every connected service in plain text. Make sure that Maintainerr is reachable only through authentik, and do not add unauthenticated path exceptions for anything under `/api/`.
 :::
 
 ## authentik configuration
@@ -38,11 +32,8 @@ To support the integration of Maintainerr with authentik, you need to create an 
     - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
     - **Choose a Provider type**: select **Proxy Provider** as the provider type.
     - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
-        - Set **Mode** to **Proxy**.
         - Set **External host** to `https://maintainerr.company`.
-        - Set **Internal host** to the URL that the authentik proxy outpost uses to reach Maintainerr.
-            - If Maintainerr and the authentik proxy outpost are both running in the same Docker deployment, set the value to `http://<maintainerr_container_name>:6246`.
-            - If Maintainerr runs on a different server than the authentik proxy outpost, set the value to `http://<maintainerr_host>:6246`, using an address that resolves to Maintainerr itself rather than to the authentik proxy outpost.
+        - Set **Internal host** to `http://<maintainerr_container_name>:6246`, where `<maintainerr_container_name>:6246` is the hostname and port of your Maintainerr instance as reached by the authentik proxy outpost.
     - **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/bindings-overview/) (policy, group, or user) to manage the listing and access to applications on a user's **Application Dashboard** page.
 
 3. Click **Submit** to save the new application and provider.
@@ -61,48 +52,11 @@ Add the Maintainerr application to a proxy outpost that will serve it:
 
 ## Maintainerr configuration
 
-Maintainerr has no authentication settings and reads no authentication headers, so nothing inside the application needs to change. What matters is that the only route to it runs through the outpost.
-
-1. Stop publishing the Maintainerr container port, so that only containers on the same Docker network can reach it.
-
-    ```yaml title="docker-compose.yml"
-    services:
-        maintainerr:
-            image: ghcr.io/maintainerr/maintainerr:latest
-            # No `ports:` mapping: only the authentik proxy outpost can reach this container.
-            volumes:
-                - ./data:/opt/data
-            networks:
-                - proxy
-
-    networks:
-        proxy:
-            external: true
-    ```
-
-    If the outpost runs outside Docker, bind the port to loopback instead with `ports: ["127.0.0.1:6246:6246"]`.
-
-2. Configure DNS or your reverse proxy so that requests for `https://maintainerr.company` are routed to the authentik proxy outpost. The authentik proxy outpost then forwards authenticated requests to Maintainerr through the **Internal host** configured on the proxy provider.
-
-The Maintainerr web interface and its API share port `6246`, so a single provider covers both. Maintainerr receives no inbound webhooks, so no path needs to be exempted from authentication. Its Logs page and live task progress are streamed as Server-Sent Events, which the proxy outpost forwards without buffering.
-
-```mermaid
-architecture-beta
-    service client(server)[Client]
-    service revprox(server)[Reverse Proxy]
-    service outpost(server)[Outpost]
-    service maintainerr(server)[Maintainerr]
-    service auth(server)[authentik]
-
-    client:R -- L:revprox
-    revprox:R -- L:outpost
-    outpost:R -- L:maintainerr
-    outpost:T -- B:auth
-```
+Maintainerr has no authentication settings, so no SSO configuration is required in Maintainerr. The authentik proxy outpost authenticates the user before forwarding allowed requests to Maintainerr.
 
 ## Configuration verification
 
-To verify the login flow, open Maintainerr. You should be redirected to authentik before the Maintainerr web interface is shown. After you sign in, open the **Logs** page and confirm that new entries keep appearing, which shows that streamed responses are passing through the outpost.
+To confirm that authentik is properly configured with Maintainerr, open Maintainerr. You should be redirected to authentik before the Maintainerr web interface is shown.
 
 ## Resources
 

--- a/website/integrations/media/maintainerr/index.md
+++ b/website/integrations/media/maintainerr/index.md
@@ -23,8 +23,8 @@ The following placeholders are used in this guide:
 This documentation lists only the settings that you need to change from their default values. Be aware that any changes other than those explicitly mentioned in this guide could cause issues accessing your application.
 :::
 
-:::warning Protect the Maintainerr backend
-Maintainerr does not authenticate requests, so anything that reaches it is trusted. `GET /api/settings/database/download` returns its entire database, which stores the credentials for every connected service in plain text. Make sure Maintainerr is reachable only through authentik, and do not add unauthenticated path exceptions for anything under `/api/`.
+:::danger Protect the Maintainerr backend
+Maintainerr does not authenticate requests, so anything that reaches it is trusted. `GET /api/settings/database/download` returns its entire database, which stores the credentials for every connected service in plain text. Make sure that Maintainerr is reachable only through authentik, and do not add unauthenticated path exceptions for anything under `/api/`.
 :::
 
 ## authentik configuration
@@ -102,7 +102,7 @@ architecture-beta
 
 ## Configuration verification
 
-To verify the login flow, open Maintainerr. You should be redirected to authentik before the Maintainerr web interface is shown. Once signed in, open the **Logs** page and confirm that new entries keep appearing, which shows that streamed responses are passing through the outpost.
+To verify the login flow, open Maintainerr. You should be redirected to authentik before the Maintainerr web interface is shown. After you sign in, open the **Logs** page and confirm that new entries keep appearing, which shows that streamed responses are passing through the outpost.
 
 ## Resources
 

--- a/website/integrations/media/maintainerr/index.md
+++ b/website/integrations/media/maintainerr/index.md
@@ -1,0 +1,110 @@
+---
+title: Integrate with Maintainerr
+sidebar_label: Maintainerr
+support_level: community
+---
+
+## What is Maintainerr?
+
+> Maintainerr applies rules you define to a Plex, Jellyfin, or Emby library, gathers the media that matches into collections, leaves it visible for a configurable period, and then removes it along with the matching files and requests in Radarr, Sonarr, and Seerr.
+>
+> -- https://docs.maintainerr.info/
+
+Maintainerr has no login of its own. This guide uses the authentik Proxy Provider to authenticate requests before they reach Maintainerr.
+
+## Preparation
+
+The following placeholders are used in this guide:
+
+- `maintainerr.company` is the FQDN of the Maintainerr installation.
+- `authentik.company` is the FQDN of the authentik installation.
+
+:::info
+This documentation lists only the settings that you need to change from their default values. Be aware that any changes other than those explicitly mentioned in this guide could cause issues accessing your application.
+:::
+
+:::warning Protect the Maintainerr backend
+Maintainerr does not authenticate requests, so anything that reaches it is trusted. `GET /api/settings/database/download` returns its entire database, which stores the credentials for every connected service in plain text. Make sure Maintainerr is reachable only through authentik, and do not add unauthenticated path exceptions for anything under `/api/`.
+:::
+
+## authentik configuration
+
+To support the integration of Maintainerr with authentik, you need to create an application/provider pair in authentik and assign it to a proxy outpost.
+
+### Create an application and provider
+
+1. Log in to authentik as an administrator and open the authentik Admin interface.
+2. Navigate to **Applications** > **Applications** and click **New Application** to open the application wizard.
+    - **Application**: provide a descriptive name, an optional group for the type of application, the policy engine mode, and optional UI settings.
+    - **Choose a Provider type**: select **Proxy Provider** as the provider type.
+    - **Configure the Provider**: provide a name (or accept the auto-provided name), the authorization flow to use for this provider, and the following required configurations.
+        - Set **Mode** to **Proxy**.
+        - Set **External host** to `https://maintainerr.company`.
+        - Set **Internal host** to the URL that the authentik proxy outpost uses to reach Maintainerr.
+            - If Maintainerr and the authentik proxy outpost are both running in the same Docker deployment, set the value to `http://<maintainerr_container_name>:6246`.
+            - If Maintainerr runs on a different server than the authentik proxy outpost, set the value to `http://maintainerr.company:6246`.
+    - **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/bindings-overview/) (policy, group, or user) to manage the listing and access to applications on a user's **Application Dashboard** page.
+
+3. Click **Submit** to save the new application and provider.
+
+### Configure proxy outpost
+
+The proxy provider requires an authentik proxy outpost. If you do not already have a proxy outpost, follow the [outpost documentation](/docs/add-secure-apps/outposts/) to create and deploy one.
+
+Add the Maintainerr application to a proxy outpost that will serve it:
+
+1. Log in to authentik as an administrator and open the authentik Admin interface.
+2. Navigate to **Applications** > **Outposts**.
+3. Click the edit icon for the proxy outpost. This can be the built-in **authentik Embedded Outpost** or another proxy outpost.
+4. Under **Available Applications**, select the Maintainerr application and move it to **Selected Applications**.
+5. Click **Update** to save your changes.
+
+## Maintainerr configuration
+
+Maintainerr has no authentication settings and reads no authentication headers, so nothing inside the application needs to change. What matters is that the only route to it runs through the outpost.
+
+1. Stop publishing the Maintainerr container port, so that only containers on the same Docker network can reach it.
+
+    ```yaml title="docker-compose.yml"
+    services:
+        maintainerr:
+            image: ghcr.io/maintainerr/maintainerr:latest
+            # No `ports:` mapping: only the authentik proxy outpost can reach this container.
+            volumes:
+                - ./data:/opt/data
+            networks:
+                - proxy
+
+    networks:
+        proxy:
+            external: true
+    ```
+
+    If the outpost runs outside Docker, bind the port to loopback instead with `ports: ["127.0.0.1:6246:6246"]`.
+
+2. Configure DNS or your reverse proxy so that requests for `https://maintainerr.company` are routed to the authentik proxy outpost. The authentik proxy outpost then forwards authenticated requests to Maintainerr through the **Internal host** configured on the proxy provider.
+
+The Maintainerr web interface and its API share port `6246`, so a single provider covers both. Maintainerr receives no inbound webhooks, so no path needs to be exempted from authentication. Its Logs page and live task progress are streamed as Server-Sent Events, which the proxy outpost forwards without buffering.
+
+```mermaid
+architecture-beta
+    service client(server)[Client]
+    service revprox(server)[Reverse Proxy]
+    service outpost(server)[Outpost]
+    service maintainerr(server)[Maintainerr]
+    service auth(server)[authentik]
+
+    client:R -- L:revprox
+    revprox:R -- L:outpost
+    outpost:R -- L:maintainerr
+    outpost:T -- B:auth
+```
+
+## Configuration verification
+
+To verify the login flow, open Maintainerr. You should be redirected to authentik before the Maintainerr web interface is shown. Once signed in, open the **Logs** page and confirm that new entries keep appearing, which shows that streamed responses are passing through the outpost.
+
+## Resources
+
+- [Maintainerr documentation - Security & Authentication](https://docs.maintainerr.info/security)
+- [Maintainerr documentation - Reverse Proxy](https://docs.maintainerr.info/reverseproxy)

--- a/website/integrations/media/maintainerr/index.md
+++ b/website/integrations/media/maintainerr/index.md
@@ -42,7 +42,7 @@ To support the integration of Maintainerr with authentik, you need to create an 
         - Set **External host** to `https://maintainerr.company`.
         - Set **Internal host** to the URL that the authentik proxy outpost uses to reach Maintainerr.
             - If Maintainerr and the authentik proxy outpost are both running in the same Docker deployment, set the value to `http://<maintainerr_container_name>:6246`.
-            - If Maintainerr runs on a different server than the authentik proxy outpost, set the value to `http://maintainerr.company:6246`.
+            - If Maintainerr runs on a different server than the authentik proxy outpost, set the value to `http://<maintainerr_host>:6246`, using an address that resolves to Maintainerr itself rather than to the authentik proxy outpost.
     - **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/bindings-overview/) (policy, group, or user) to manage the listing and access to applications on a user's **Application Dashboard** page.
 
 3. Click **Submit** to save the new application and provider.


### PR DESCRIPTION
## Details

### What does this PR change?

Adds a Proxy Provider integration guide for [Maintainerr](https://maintainerr.info/), a library maintenance tool for Plex, Jellyfin, and Emby. It applies rules to a library, collects the media that matches, and removes it along with the matching files and requests in Radarr, Sonarr, and Seerr.

The guide follows `/website/integrations/template/service.md` and mirrors the structure of the existing Sonarr page. Two details specific to this application are called out:

- Its API can hand out the full application database, credentials included, so the guide warns against unauthenticated path exceptions rather than leaving it implied.
- Its UI and API share one port and it receives no inbound webhooks, so one provider covers the application with no exempt paths.

### Why is this change needed?

Maintainerr has no login of its own, so a Proxy Provider is the whole integration, and its own documentation already directs users to authentik for this: https://docs.maintainerr.info/reverseproxy. The `media` category covers Sonarr, Tautulli, Seerr, Jellyfin, and Emby, which are the applications Maintainerr runs alongside, so this fills a gap in a set that is otherwise complete.

### How was this tested?

I do not have an authentik deployment available, so the authentik-side steps follow the template and the Sonarr page rather than a walked-through login flow. A second pair of eyes on those is welcome.

Every claim the guide makes about Maintainerr was checked against a running production build behind a reverse proxy configured the way the outpost configures its own (Go `httputil.ReverseProxy` with `FlushInterval: -1`, which flushes immediately after each write):

| Claim in the guide | Result |
| --- | --- |
| UI and API share port 6246, so one provider covers both | `GET /`, an SPA route, and `/api/*` all served on the one port and correct through the proxy |
| The database download exposure the admonition describes | An unauthenticated `GET /api/settings/database/download` returned `application/x-sqlite3` starting with `SQLite format 3` |
| Server-Sent Events are forwarded without buffering | A ping generated server-side at t=30s reached the client through the proxy at t=30.01s, and the response is `text/event-stream` with `transfer-encoding: chunked` and `Cache-Control: no-transform` |
| No inbound webhooks, so no path needs exempting | All integrations are outbound; no receiver routes exist |

One deliberate deviation from the Sonarr page: its equivalent admonition is a `warning`, and this one is a `danger`. Per the style guide, `danger` covers "a serious security or data-loss risk", and an unauthenticated request here returns every stored credential. Happy to downgrade it for consistency if you would rather.

### Linked issues

None.

---

## Checklist

- [ ] The project has been linted, built, and tested (`make all`)
- [x] The documentation has been updated and formatted (`make docs`)

`make all` is not applicable to a docs-only change and I cannot run the full toolchain here. I ran the two checks that `make docs` applies to this file: Prettier with the repository's own config (`tabWidth: 4`, `proseWrap: preserve`, `printWidth: 100`), and `cspell` with `cspell.config.jsonc`, which reports 0 issues, the same as the existing Sonarr page. Both Netlify documentation previews build.
