### PR TITLE
blueprints: run initial migration before flows are created

### DIFF
--- a/authentik/blueprints/migrations/0001_initial.py
+++ b/authentik/blueprints/migrations/0001_initial.py
@@ -73,6 +73,11 @@ class Migration(migrations.Migration):
 
     dependencies = [("authentik_flows", "0001_initial")]
 
+    # migration_blueprint_import below treats "a flow already exists" as "this is an existing
+    # install". That only holds if we run before any migration that creates a flow, which is
+    # otherwise up to how Django happens to order the plan.
+    run_before = [("authentik_core", "0040_provider_invalidation_flow")]
+
     operations = [
         migrations.CreateModel(
             name="BlueprintInstance",


### PR DESCRIPTION
## Details

### What does this PR change?

Adds `run_before = [("authentik_core", "0040_provider_invalidation_flow")]` to `authentik_blueprints.0001_initial`.

### Why is this change needed?

That migration disables every blueprint without the `blueprints.goauthentik.io/system: "true"` label when a flow already exists, on the assumption it runs before anything that creates one. `authentik_core.0040_provider_invalidation_flow` creates a flow, and since the agents app landed it runs first — Django sorts leaf nodes, `authentik_agents` now sorts ahead of `authentik_blueprints`, and it depends on `authentik_core.0063_actor`, pulling the whole core chain in front. Fresh installs therefore look like existing installs and come up with 19 of 31 blueprints disabled and no default authentication flow.

### How was this tested?

Compared migration plan positions before and after; the graph still loads clean, so no cycle:

| | before | after |
| --- | --- | --- |
| `authentik_blueprints.0001_initial` | 189 | 106 |
| `authentik_core.0040_provider_invalidation_flow` | 106 | 107 |

Note this does not repair an already-migrated database — the migration is recorded as applied, so existing broken installs still need their blueprints re-enabled by hand.

### Linked issues

closes #24879

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`) — `black` clean on the changed file, `make all` not run
-   [ ] The documentation has been updated and formatted (`make docs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
