### PR TITLE
docs/contributing: align contributor guidance with repo workflow

### DIFF
--- a/website/docs/developer-docs/contributing.md
+++ b/website/docs/developer-docs/contributing.md
@@ -40,8 +40,12 @@ authentik
 ├── admin - Administrative tasks and APIs, no models (Version updates, Metrics, system tasks)
 ├── api - General API Configuration (Routes, Schema and general API utilities)
 ├── blueprints - Handle managed models and their state.
+├── brands - Branding and theming for tenants
+├── commands - Management commands for the server
+├── common - Shared logic and utilities
 ├── core - Core authentik functionality, central routes, core Models
 ├── crypto - Cryptography, currently used to generate and hold Certificates and Private Keys
+├── endpoints - Custom API endpoints and connectivity logic
 ├── enterprise - Enterprise features, which are source available but not open source
 ├── events - Event Log, middleware and signals to generate signals
 ├── flows - Flows, the FlowPlanner and the FlowExecutor, used for all flows for authentication, authorization, etc
@@ -61,6 +65,7 @@ authentik
 │   ├── radius - Provides a RADIUS server that authenticates using flows
 │   ├── saml - SAML2 provider
 │   └── scim - SCIM provider
+├── rbac - Role-Based Access Control
 ├── recovery - Generate keys to use in case you lock yourself out
 ├── root - Root Django application, contains global settings and routes
 ├── sources
@@ -113,13 +118,23 @@ This section guides you through submitting an enhancement suggestion for authent
 
 When you are creating an enhancement suggestion, please fill in [the template](https://github.com/goauthentik/authentik/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=), including the steps that you imagine you would take if the feature you're requesting existed.
 
+### Tooling
+
+To maintain a fast and consistent development experience across a polyglot codebase, we use the following tools:
+
+- **Python**: We use [uv](https://github.com/astral-sh/uv) for extremely fast dependency management and runtime execution.
+- **TypeScript**: We use [pnpm](https://pnpm.io/) for efficient workspace management.
+- **Rust**: We use [cargo nextest](https://nextest.rs/) for high-performance test execution.
+
+Prefer using the targets in the root `Makefile` (e.g., `make install`, `make test`) as they wire up these tools with the correct configurations.
+
 ### Your first code contribution
 
 #### Local development
 
 authentik can be run locally, although depending on which part you want to work on, different prerequisites are required.
 
-This is documented in the [developer docs](./setup/frontend-dev-environment.mdx).
+This is documented in the [developer docs](./setup/full-dev-environment.mdx) (for a full setup) or [frontend-dev-environment.mdx](./setup/frontend-dev-environment.mdx) (for UI work only).
 
 ### Help with the docs
 
@@ -175,7 +190,7 @@ Please follow these steps to have your contribution considered by the maintainer
 2. After you submit your pull request, verify that all [status checks](https://help.github.com/articles/about-status-checks/) are passing <details><summary>What if the status checks are failing?</summary>If a status check is failing, and you believe that the failure is unrelated to your change, please leave a comment on the pull request explaining why you believe the failure is unrelated. A maintainer will re-run the status check for you. If we conclude that the failure was a false positive, then we will open an issue to track that problem with our status check suite.</details>
 3. Ensure your code has tests. While it is not always possible to test every single case, the majority of the code should be tested.
 
-While the prerequisites above must be satisfied prior to having your pull request reviewed, the reviewer(s) may ask you to complete additional design work, tests, or other changes before your pull request can be ultimately accepted.
+While the prerequisites above must be satisfied prior to having your pull request reviewed, the reviewer(s) may ask you to complete additional design work, tests, or other changes before your pull request be ultimately accepted.
 
 ## Style guides
 
@@ -205,6 +220,14 @@ The required Python version is defined in the repository's [`pyproject.toml`](ht
 - Add meaningful docstrings when possible.
 - Ensure any database migrations work properly from the last stable version (this is checked via CI)
 - If your code changes central functions, make sure nothing else is broken.
+
+### Other Language style guides
+
+We strive for consistency across our polyglot codebase. Please follow these general guidelines for our other languages:
+
+- **Rust**: Follow standard Rust idioms. Code is formatted with `rustfmt`.
+- **Go**: Follow standard Go idioms. We use `golangci-lint` to ensure code quality.
+- **TypeScript**: Follow the project's TypeScript and Lit guidelines. Code is formatted with Prettier and linted with ESLint.
 
 ### Documentation style guide
 

--- a/website/docs/developer-docs/contributing.md
+++ b/website/docs/developer-docs/contributing.md
@@ -190,7 +190,7 @@ Please follow these steps to have your contribution considered by the maintainer
 2. After you submit your pull request, verify that all [status checks](https://help.github.com/articles/about-status-checks/) are passing <details><summary>What if the status checks are failing?</summary>If a status check is failing, and you believe that the failure is unrelated to your change, please leave a comment on the pull request explaining why you believe the failure is unrelated. A maintainer will re-run the status check for you. If we conclude that the failure was a false positive, then we will open an issue to track that problem with our status check suite.</details>
 3. Ensure your code has tests. While it is not always possible to test every single case, the majority of the code should be tested.
 
-While the prerequisites above must be satisfied prior to having your pull request reviewed, the reviewer(s) may ask you to complete additional design work, tests, or other changes before your pull request be ultimately accepted.
+While the prerequisites above must be satisfied prior to having your pull request reviewed, the reviewer(s) may ask you to complete additional design work, tests, or other changes before your pull request can be ultimately accepted.
 
 ## Style guides
 
@@ -221,7 +221,7 @@ The required Python version is defined in the repository's [`pyproject.toml`](ht
 - Ensure any database migrations work properly from the last stable version (this is checked via CI)
 - If your code changes central functions, make sure nothing else is broken.
 
-### Other Language style guides
+### Other language style guides
 
 We strive for consistency across our polyglot codebase. Please follow these general guidelines for our other languages:
 


### PR DESCRIPTION
## Details

### What does this PR change?

Refreshes the contributor guidelines to accurately reflect the current authentik repository structure, local development setup, and language-specific tooling.

Key updates include:

- **Django Package Overview**: Updated the package list to reflect the current organization of top-level apps (including `brands`, `commands`, `common`, `endpoints`, and `rbac`).
- **Local Development**: Expanded guidance to provide direct links for both the full development environment and the frontend-only setup.
- **Tooling Guidance**: Added a dedicated section highlighting the use of `uv`, `pnpm`, and `cargo nextest`, while emphasizing the use of root `Makefile` targets for consistency.
- **Language Style Guides**: Included brief, actionable style guidance for Rust, Go, and TypeScript contributors.

### Why is this change needed?

The contributor documentation had drifted from the actual repository layout and available `Makefile` targets. These updates ensure that new and existing contributors have accurate instructions, reducing friction during environment setup and code submission.

### How was this tested?

Verified the updated documentation against the current filesystem structure, setup guides, and `Makefile` targets. As this PR only contains documentation changes, no functional testing was required.

---

## Checklist

- [x] The project has been linted, built, and tested (`make all`)
- [x] The documentation has been updated and formatted (`make docs`)
