### PR TITLE
rbac: use constant-time comparison in SecretKeyFilter

### DIFF
--- a/authentik/rbac/filters.py
+++ b/authentik/rbac/filters.py
@@ -1,5 +1,7 @@
 """RBAC API Filter"""
 
+from hmac import compare_digest
+
 from django.conf import settings
 from django.db.models import QuerySet
 from django_filters.rest_framework import DjangoFilterBackend
@@ -103,7 +105,7 @@ class SecretKeyFilter(DjangoFilterBackend):
     def filter_queryset(self, request: Request, queryset: QuerySet, view) -> QuerySet:
         auth_header = get_authorization_header(request)
         token = validate_auth(auth_header)
-        if token and token == settings.SECRET_KEY:
+        if token and compare_digest(token, settings.SECRET_KEY):
             return queryset
         queryset = ObjectFilter().filter_queryset(request, queryset, view)
         return super().filter_queryset(request, queryset, view)


### PR DESCRIPTION
Noticed SecretKeyFilter compares the incoming token against settings.SECRET_KEY with a plain `==`. That filter hands back the full queryset (bypassing object-level perms) when the key matches, and it's wired into the crypto and brands APIs, so the comparison is worth doing in constant time to avoid leaking anything through timing.

The rest of the codebase already does this - token_secret_key in authentik/api/authentication.py uses hmac.compare_digest for the exact same SECRET_KEY check, so this just brings the filter in line with that.

Behavior is unchanged for a correct key, and the None guard stays in front so we never hand compare_digest a null token.
