### PR TITLE
core: return the intended status code from error views for all request methods

### DIFF
--- a/authentik/core/tests/test_error_views.py
+++ b/authentik/core/tests/test_error_views.py
@@ -1,0 +1,69 @@
+"""Test the views wired up as django's handler400/403/404/500"""
+
+from django.test import RequestFactory, TestCase
+
+from authentik.core.tests.utils import create_test_brand
+from authentik.core.views.error import (
+    BadRequestView,
+    ForbiddenView,
+    NotFoundView,
+    ServerErrorView,
+)
+
+HANDLERS = (
+    (BadRequestView, 400),
+    (ForbiddenView, 403),
+    (NotFoundView, 404),
+    (ServerErrorView, 500),
+)
+UNSAFE_METHODS = ("post", "put", "patch", "delete")
+
+
+class TestErrorViews(TestCase):
+    """The error handlers must answer with their own status code for every request
+    method, not just GET.
+
+    Django calls handler400/403/404/500 with the request that failed, whatever its
+    method. A handler that only implements `get` answers a failing POST with 405
+    Method Not Allowed and drops its own status code -- which made an error on a
+    POST-only API endpoint surface to clients as `405`."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_get(self):
+        """A GET keeps returning the handler's own status code"""
+        for view, expected in HANDLERS:
+            with self.subTest(view=view.__name__):
+                response = view.as_view()(self.factory.get("/"))
+                self.assertEqual(response.status_code, expected)
+
+    def test_unsafe_methods(self):
+        """A POST/PUT/PATCH/DELETE must not be answered with 405"""
+        for view, expected in HANDLERS:
+            for method in UNSAFE_METHODS:
+                with self.subTest(view=view.__name__, method=method):
+                    request = getattr(self.factory, method)("/")
+                    response = view.as_view()(request)
+                    self.assertEqual(response.status_code, expected)
+                    self.assertNotIn("Allow", response)
+
+
+class TestErrorViewsRouting(TestCase):
+    """End-to-end: an unresolvable path must 404 regardless of request method.
+
+    The DRF router matches a detail route's id with `[^/.]+`, so an id containing a
+    dot never resolves and django raises Http404 before any view runs -- the
+    "invalid ID" case that reported 405 rather than a descriptive error."""
+
+    def setUp(self):
+        create_test_brand()
+
+    def test_unresolvable_api_path(self):
+        """Every method gets 404, and the error page still renders"""
+        url = "/api/v3/providers/scim/1.5/sync/object/"
+        for method in ("get", *UNSAFE_METHODS):
+            with self.subTest(method=method):
+                response = getattr(self.client, method)(url)
+                self.assertEqual(response.status_code, 404)
+                self.assertTemplateUsed(response, "if/error.html")

--- a/authentik/core/views/error.py
+++ b/authentik/core/views/error.py
@@ -26,41 +26,50 @@ class ServerErrorTemplateResponse(TemplateResponse, HttpResponseServerError):
     """Combine Template response with Http Code 500"""
 
 
-class BadRequestView(TemplateView):
+class ErrorView(TemplateView):
+    """Base for the views wired up as django's handler400/403/404/500.
+
+    Django invokes an error handler with the request that failed, whatever its
+    method. A plain TemplateView only implements `get`, so its `dispatch` answers
+    a failing POST/PUT/PATCH/DELETE with 405 Method Not Allowed and discards the
+    handler's own status code -- which is how an API error surfaced as a 405 with
+    an `Allow: GET, HEAD, OPTIONS` header. Render the page for every method so the
+    status code the handler stands for is the one the client sees.
+    """
+
+    template_name = "if/error.html"
+
+    def dispatch(self, request, *args, **kwargs):
+        return self.get(request, *args, **kwargs)
+
+
+class BadRequestView(ErrorView):
     """Show Bad Request message"""
 
     extra_context = {"title": "Bad Request"}
 
     response_class = BadRequestTemplateResponse
-    template_name = "if/error.html"
 
 
-class ForbiddenView(TemplateView):
+class ForbiddenView(ErrorView):
     """Show Forbidden message"""
 
     extra_context = {"title": "Forbidden"}
 
     response_class = ForbiddenTemplateResponse
-    template_name = "if/error.html"
 
 
-class NotFoundView(TemplateView):
+class NotFoundView(ErrorView):
     """Show Not Found message"""
 
     extra_context = {"title": "Not Found"}
 
     response_class = NotFoundTemplateResponse
-    template_name = "if/error.html"
 
 
-class ServerErrorView(TemplateView):
+class ServerErrorView(ErrorView):
     """Show Server Error message"""
 
     extra_context = {"title": "Server Error"}
 
     response_class = ServerErrorTemplateResponse
-    template_name = "if/error.html"
-
-    def dispatch(self, *args, **kwargs):  # pragma: no cover
-        """Little wrapper so django accepts this function"""
-        return super().dispatch(*args, **kwargs)

--- a/authentik/lib/sync/outgoing/api.py
+++ b/authentik/lib/sync/outgoing/api.py
@@ -1,6 +1,6 @@
 from django.db.models import Model
 from dramatiq.actor import Actor
-from dramatiq.results.errors import ResultFailure
+from dramatiq.results.errors import ResultError
 from drf_spectacular.utils import extend_schema
 from rest_framework.decorators import action
 from rest_framework.fields import BooleanField, CharField, ChoiceField
@@ -119,7 +119,11 @@ class OutgoingSyncProviderStatusMixin:
         )
         try:
             msg.get_result(block=True)
-        except ResultFailure:
+        # ResultFailure: the task ran and raised; its logs are the useful output.
+        # ResultTimeout/ResultMissing: the task is queued but hasn't reported yet.
+        # Neither is a server fault, so report whatever the task has logged so far
+        # rather than letting the error escape as a 500.
+        except ResultError:
             pass
         task: Task = msg.options["task"]
         task.refresh_from_db()

--- a/authentik/lib/sync/outgoing/api.py
+++ b/authentik/lib/sync/outgoing/api.py
@@ -119,10 +119,6 @@ class OutgoingSyncProviderStatusMixin:
         )
         try:
             msg.get_result(block=True)
-        # ResultFailure: the task ran and raised; its logs are the useful output.
-        # ResultTimeout/ResultMissing: the task is queued but hasn't reported yet.
-        # Neither is a server fault, so report whatever the task has logged so far
-        # rather than letting the error escape as a 500.
         except ResultError:
             pass
         task: Task = msg.options["task"]


### PR DESCRIPTION
## Details

### What does this PR change?

The four views wired up as django's `handler400/403/404/500` in `authentik/root/urls.py`
subclassed `TemplateView` directly. `TemplateView` only implements `get`, so its
`dispatch()` answers a failing `POST`/`PUT`/`PATCH`/`DELETE` with `405 Method Not
Allowed` and an `Allow: GET, HEAD, OPTIONS` header, discarding the status code the
handler stands for.

- Adds a shared `ErrorView` base in `authentik/core/views/error.py` that renders the
  error page for every request method, so `BadRequestView`/`ForbiddenView`/
  `NotFoundView`/`ServerErrorView` return 400/403/404/500 respectively regardless of
  method. This also removes the duplicated `template_name` and the
  `ServerErrorView.dispatch` `# pragma: no cover` wrapper it made redundant.
- Widens the dramatiq result handling in `OutgoingSyncProviderStatusMixin.sync_object`
  (`authentik/lib/sync/outgoing/api.py`) from `ResultFailure` to `ResultError`, so
  `ResultTimeout`/`ResultMissing` — a task that is queued but has not reported yet —
  returns the task's messages instead of escaping as an unhandled 500.
- Adds `authentik/core/tests/test_error_views.py` covering both the handler status
  codes per method and the end-to-end unresolvable-API-path case.

### Why is this change needed?

Reported in #24230: `POST /api/v3/providers/scim/{id}/sync/object/` with an invalid ID
returns `405 Method Not Allowed` instead of a descriptive error. The endpoint is not
actually at fault — it is the error handlers.

Two things combine:

1. The DRF router matches a detail route's id with `(?P<pk>[^/.]+)`, so an id
   containing a dot never resolves and django raises `Http404` at the resolver, before
   any view runs. `handler404` then answers the `POST` with 405 rather than 404.
2. If the sync task is queued but has not reported a result yet, `get_result()` raises
   `ResultTimeout`/`ResultMissing`, which was not caught. That unhandled exception
   reaches `handler500`, which likewise answers the `POST` with 405 instead of 500.

The defect is repo-wide, not SCIM-specific: any non-GET request that reaches an error
handler on any endpoint was reported as 405. `schema.yml` declares only 200/400/403 for
this operation, so a 405 is not a documented outcome and the web UI's
`SyncObjectForm.ts` has no way to surface it usefully.

### How was this tested?

`make all` could **not** be run in my environment, and I want to be upfront about that:
`uv sync --frozen` fails locally while building `dumb-init` (`'Compiler' object has no
attribute 'linker_exe'`) and then `psycopg-c` (`couldn't run 'pg_config'
--includedir`), and I have no docker/postgres available. So the django test suite and
the lint matrix could not execute against the real project. **Please rely on CI for
`make all`.**

What I did instead, to avoid submitting an unverified guess:

- Built a standalone django + DRF harness that imports the real `error.py` by path and
  drives the handlers through `RequestFactory`, plus a DRF `APIClient` reproducing the
  router-level 404 and the unhandled-exception paths.
- Confirmed the bug on unmodified source: each handler returns its intended code for
  `GET` but `405` for `POST`/`PUT`/`PATCH`/`DELETE`; a pk containing a dot and an
  unhandled exception both surface as 405.
- Confirmed the fix: all methods return the handler's own status code, and the
  `Allow` header is gone.
- Negative control: with the new test file kept and only `error.py` reverted, the test
  fails with 16 assertion failures, the first being `AssertionError: 405 != 500`.
- `ruff check` and `black --check` pass on the three touched files.

No serializers or viewsets changed shape, so no `make gen` output changes are expected.

### Linked issues

closes #24230

## Checklist

- [ ] The project has been linted, built, and tested (`make all`) — see "How was this
      tested?"; blocked locally by the `uv sync` build failures described above.
- [x] The documentation has been updated (n/a — no user-facing documentation change)
- [ ] The documentation has been formatted (`make docs`) — n/a, no docs touched

---

Disclosure: yes, I used agentic AI assistance while preparing this change. The
diagnosis, the repros, and the negative control described above are real and were run;
please review accordingly, and let me know if you would rather I close this.
