### PR TITLE
enterprise/endpoints/connectors/fleet: decrease page size

### DIFF
--- a/authentik/enterprise/endpoints/connectors/fleet/controller.py
+++ b/authentik/enterprise/endpoints/connectors/fleet/controller.py
@@ -67,7 +67,9 @@ class FleetController(BaseController[DBC]):
                     params={
                         "order_key": "hardware_serial",
                         "page": page,
-                        "per_page": 50,
+                        # Small page size as Fleet's API response, with the populate fields below
+                        # can be quite large and eat a lot of memory
+                        "per_page": 5,
                         "device_mapping": "true",
                         "populate_software": "true",
                         "populate_users": "true",

--- a/authentik/enterprise/endpoints/connectors/fleet/tests/test_connector.py
+++ b/authentik/enterprise/endpoints/connectors/fleet/tests/test_connector.py
@@ -35,11 +35,11 @@ class TestFleetConnector(APITestCase):
                 text=load_fixture("fixtures/cond_acc_profile.mobileconfig"),
             )
             mock.get(
-                "http://localhost/api/v1/fleet/hosts?order_key=hardware_serial&page=0&per_page=50&device_mapping=true&populate_software=true&populate_users=true",
+                "http://localhost/api/v1/fleet/hosts?order_key=hardware_serial&page=0&per_page=5&device_mapping=true&populate_software=true&populate_users=true",
                 json=TEST_HOST,
             )
             mock.get(
-                "http://localhost/api/v1/fleet/hosts?order_key=hardware_serial&page=1&per_page=50&device_mapping=true&populate_software=true&populate_users=true",
+                "http://localhost/api/v1/fleet/hosts?order_key=hardware_serial&page=1&per_page=5&device_mapping=true&populate_software=true&populate_users=true",
                 json={"hosts": []},
             )
             controller.sync_endpoints()
@@ -93,11 +93,11 @@ class TestFleetConnector(APITestCase):
                 text=load_fixture("fixtures/cond_acc_profile.mobileconfig"),
             )
             mock.get(
-                "http://localhost/api/v1/fleet/hosts?order_key=hardware_serial&page=0&per_page=50&device_mapping=true&populate_software=true&populate_users=true",
+                "http://localhost/api/v1/fleet/hosts?order_key=hardware_serial&page=0&per_page=5&device_mapping=true&populate_software=true&populate_users=true",
                 json=TEST_HOST,
             )
             mock.get(
-                "http://localhost/api/v1/fleet/hosts?order_key=hardware_serial&page=1&per_page=50&device_mapping=true&populate_software=true&populate_users=true",
+                "http://localhost/api/v1/fleet/hosts?order_key=hardware_serial&page=1&per_page=5&device_mapping=true&populate_software=true&populate_users=true",
                 json={"hosts": []},
             )
             controller.sync_endpoints()

--- a/authentik/enterprise/endpoints/connectors/fleet/tests/test_stage.py
+++ b/authentik/enterprise/endpoints/connectors/fleet/tests/test_stage.py
@@ -31,11 +31,11 @@ class FleetConnectorStageTests(FlowTestCase):
                 text=load_fixture("fixtures/cond_acc_profile.mobileconfig"),
             )
             mock.get(
-                "http://localhost/api/v1/fleet/hosts?order_key=hardware_serial&page=0&per_page=50&device_mapping=true&populate_software=true&populate_users=true",
+                "http://localhost/api/v1/fleet/hosts?order_key=hardware_serial&page=0&per_page=5&device_mapping=true&populate_software=true&populate_users=true",
                 json={"hosts": [loads(load_fixture("fixtures/host_macos.json"))]},
             )
             mock.get(
-                "http://localhost/api/v1/fleet/hosts?order_key=hardware_serial&page=1&per_page=50&device_mapping=true&populate_software=true&populate_users=true",
+                "http://localhost/api/v1/fleet/hosts?order_key=hardware_serial&page=1&per_page=5&device_mapping=true&populate_software=true&populate_users=true",
                 json={"hosts": []},
             )
             controller.sync_endpoints()


### PR DESCRIPTION
current page size of 50 + populate_software, populate_users and populate_policies leads to very large json which can cause RAM spikes, so this turns it down to a page size of 5. More requests but less constant RAM usage