### PR TITLE
web: bump dompurify from 3.4.12 to v3.4.13

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -145,7 +145,7 @@
         "country-flag-icons": "^1.6.20",
         "date-fns": "^4.4.0",
         "deepmerge-ts": "^7.1.5",
-        "dompurify": "^3.4.12",
+        "dompurify": "^3.4.13",
         "esbuild": "catalog:",
         "eslint": "catalog:",
         "eslint-plugin-lit": "^2.3.1",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -257,8 +257,8 @@ importers:
         specifier: ^7.1.5
         version: 7.1.5
       dompurify:
-        specifier: ^3.4.12
-        version: 3.4.12
+        specifier: ^3.4.13
+        version: 3.4.13
       esbuild:
         specifier: 'catalog:'
         version: 0.28.1
@@ -3524,9 +3524,6 @@ packages:
   domhandler@6.0.1:
     resolution: {integrity: sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==}
     engines: {node: '>=20.19.0'}
-
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   dompurify@3.4.13:
     resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
@@ -9751,10 +9748,6 @@ snapshots:
   domhandler@6.0.1:
     dependencies:
       domelementtype: 3.0.0
-
-  dompurify@3.4.12:
-    optionalDependencies:
-      '@types/trusted-types': 2.0.7
 
   dompurify@3.4.13:
     optionalDependencies:


### PR DESCRIPTION
Not exploitable in our codebase but better to ship the fix https://github.com/cure53/DOMPurify/security/advisories/GHSA-55q2-fjhq-7xh7