### PR TITLE
stages/authenticator_duo: return a descriptive error when the Duo API is unreachable

### DIFF
--- a/authentik/stages/authenticator_duo/api.py
+++ b/authentik/stages/authenticator_duo/api.py
@@ -4,6 +4,7 @@ from ssl import SSLCertVerificationError, SSLError
 from typing import Any
 
 from django.http import Http404
+from django.utils.translation import gettext_lazy as _
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiResponse, extend_schema, inline_serializer
 from guardian.shortcuts import get_objects_for_user
@@ -217,25 +218,25 @@ class AuthenticatorDuoStageViewSet(UsedByMixin, ModelViewSet):
         except SSLCertVerificationError as exc:
             LOGGER.warning("failed to verify duo api certificate", exc=exc)
             return {
-                "error": "Failed to connect to Duo: TLS certificate verification failed.",
+                "error": _("Failed to connect to Duo: TLS certificate verification failed."),
                 "count": created,
             }
         except SSLError as exc:
             LOGGER.warning("tls error connecting to duo", exc=exc)
             return {
-                "error": "Failed to connect to Duo: TLS error.",
+                "error": _("Failed to connect to Duo: TLS error."),
                 "count": created,
             }
         except OSError as exc:
             LOGGER.warning("failed to connect to duo", exc=exc)
             return {
-                "error": "Failed to connect to Duo.",
+                "error": _("Failed to connect to Duo."),
                 "count": created,
             }
         except RuntimeError as exc:
             LOGGER.warning("failed to get users from duo", exc=exc)
             return {
-                "error": "An internal error occurred while importing devices.",
+                "error": _("An internal error occurred while importing devices."),
                 "count": created,
             }
 

--- a/authentik/stages/authenticator_duo/api.py
+++ b/authentik/stages/authenticator_duo/api.py
@@ -1,5 +1,6 @@
 """AuthenticatorDuoStage API Views"""
 
+from ssl import SSLCertVerificationError, SSLError
 from typing import Any
 
 from django.http import Http404
@@ -208,6 +209,29 @@ class AuthenticatorDuoStageViewSet(UsedByMixin, ModelViewSet):
                 )
                 created += 1
             return {"error": "", "count": created}
+        # `duo_client` surfaces transport failures as the underlying socket/TLS
+        # error, which is an OSError and not a RuntimeError. Catching only
+        # RuntimeError let those escape the view entirely, so an unreachable or
+        # untrusted Duo endpoint produced no actionable error at all.
+        # SSLCertVerificationError < SSLError < OSError, so order matters here.
+        except SSLCertVerificationError as exc:
+            LOGGER.warning("failed to verify duo api certificate", exc=exc)
+            return {
+                "error": "Failed to connect to Duo: TLS certificate verification failed.",
+                "count": created,
+            }
+        except SSLError as exc:
+            LOGGER.warning("tls error connecting to duo", exc=exc)
+            return {
+                "error": "Failed to connect to Duo: TLS error.",
+                "count": created,
+            }
+        except OSError as exc:
+            LOGGER.warning("failed to connect to duo", exc=exc)
+            return {
+                "error": "Failed to connect to Duo.",
+                "count": created,
+            }
         except RuntimeError as exc:
             LOGGER.warning("failed to get users from duo", exc=exc)
             return {

--- a/authentik/stages/authenticator_duo/tests.py
+++ b/authentik/stages/authenticator_duo/tests.py
@@ -1,5 +1,6 @@
 """Test duo stage"""
 
+from ssl import SSLCertVerificationError, SSLError
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -183,6 +184,120 @@ class AuthenticatorDuoStageTests(FlowTestCase):
                 response.content,
                 {
                     "error": "An internal error occurred while importing devices.",
+                    "count": 0,
+                },
+            )
+
+    def test_api_import_automatic_tls_failure(self):
+        """test `import_devices_automatic` when the Duo API certificate doesn't verify
+
+        Regression test for #22896: `SSLCertVerificationError` is an `OSError`,
+        not a `RuntimeError`, so it escaped the handler entirely instead of
+        producing the documented 400 with a descriptive error.
+        """
+        self.client.force_login(self.user)
+        stage = AuthenticatorDuoStage.objects.create(
+            name=generate_id(),
+            client_id=generate_id(),
+            client_secret=generate_id(),
+            api_hostname=generate_id(),
+            admin_integration_key=generate_id(),
+            admin_secret_key=generate_id(),
+        )
+        ssl_error = SSLCertVerificationError(
+            1,
+            "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: "
+            "unable to get local issuer certificate (_ssl.c:1081)",
+        )
+        with patch(
+            "duo_client.admin.Admin.get_users_iterator",
+            MagicMock(side_effect=ssl_error),
+        ):
+            response = self.client.post(
+                reverse(
+                    "authentik_api:authenticatorduostage-import-devices-automatic",
+                    kwargs={
+                        "pk": str(stage.pk),
+                    },
+                ),
+            )
+            self.assertEqual(response.status_code, 400)
+            self.assertJSONEqual(
+                response.content,
+                {
+                    "error": "Failed to connect to Duo: TLS certificate verification failed.",
+                    "count": 0,
+                },
+            )
+
+    def test_api_import_automatic_tls_error(self):
+        """test `import_devices_automatic` on a non-certificate TLS failure
+
+        A generic `SSLError` must be reported as a TLS error rather than
+        claiming certificate verification specifically failed.
+        """
+        self.client.force_login(self.user)
+        stage = AuthenticatorDuoStage.objects.create(
+            name=generate_id(),
+            client_id=generate_id(),
+            client_secret=generate_id(),
+            api_hostname=generate_id(),
+            admin_integration_key=generate_id(),
+            admin_secret_key=generate_id(),
+        )
+        with patch(
+            "duo_client.admin.Admin.get_users_iterator",
+            MagicMock(side_effect=SSLError("handshake failure")),
+        ):
+            response = self.client.post(
+                reverse(
+                    "authentik_api:authenticatorduostage-import-devices-automatic",
+                    kwargs={
+                        "pk": str(stage.pk),
+                    },
+                ),
+            )
+            self.assertEqual(response.status_code, 400)
+            self.assertJSONEqual(
+                response.content,
+                {
+                    "error": "Failed to connect to Duo: TLS error.",
+                    "count": 0,
+                },
+            )
+
+    def test_api_import_automatic_connection_failure(self):
+        """test `import_devices_automatic` when the Duo API is unreachable
+
+        A non-TLS `OSError` must also surface as a descriptive 400 rather than
+        escaping the handler.
+        """
+        self.client.force_login(self.user)
+        stage = AuthenticatorDuoStage.objects.create(
+            name=generate_id(),
+            client_id=generate_id(),
+            client_secret=generate_id(),
+            api_hostname=generate_id(),
+            admin_integration_key=generate_id(),
+            admin_secret_key=generate_id(),
+        )
+        with patch(
+            "duo_client.admin.Admin.get_users_iterator",
+            MagicMock(side_effect=OSError("connection refused")),
+        ):
+            response = self.client.post(
+                reverse(
+                    "authentik_api:authenticatorduostage-import-devices-automatic",
+                    kwargs={
+                        "pk": str(stage.pk),
+                    },
+                ),
+            )
+            self.assertEqual(response.status_code, 400)
+            self.assertJSONEqual(
+                response.content,
+                {
+                    "error": "Failed to connect to Duo.",
                     "count": 0,
                 },
             )


### PR DESCRIPTION
## Details

### What does this PR change?

`_duo_import_devices` caught only `RuntimeError`, but `duo_client` surfaces transport failures as the underlying socket/TLS error. `SSLCertVerificationError` is an `OSError`, not a `RuntimeError`, so it escaped the handler entirely.

This catches transport failures explicitly and maps them to the documented `400` with a descriptive message, ordered narrowest-first since `SSLCertVerificationError` < `SSLError` < `OSError`:

| Failure | Message |
|---|---|
| Certificate verification failed | `Failed to connect to Duo: TLS certificate verification failed.` |
| Any other TLS failure | `Failed to connect to Duo: TLS error.` |
| Any other connection failure | `Failed to connect to Duo.` |

`RuntimeError` handling is unchanged.

### Why is this change needed?

Closes #22896. A Duo endpoint behind an untrusted certificate (a packet-inspecting firewall re-encrypting with an org CA, in the reporter's case) produced a bare **405 Method Not Allowed** with no error body, so nothing indicated a TLS problem.

It compounds: `OSError` is also in `authentik.lib.sentry.ignored_classes`, so the exception was dropped from error reporting as well. The reporter's only clue was a `"dropping exception"` debug log.

The messages are deliberately categorical and do not echo exception text, preserving the existing behaviour of not leaking internals to the API caller.

### How was this tested?

The defect was reproduced with failing tests **before** the fix. The 405 reproduces locally with no proxy involved, which confirms it is authentik's own behaviour rather than the reporter's firewall:

```
authentik.asgi: {'method': 'POST', 'status': 405,
  'event': '/api/v3/stages/authenticator/duo/.../import_devices_automatic/'}

FAILED test_api_import_automatic_tls_failure
  - ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed
FAILED test_api_import_automatic_connection_failure
  - OSError: connection refused
```

Three tests added, following the existing `test_api_import_automatic_invalid` pattern of patching `duo_client.admin.Admin.get_users_iterator`:

1. `test_api_import_automatic_tls_failure` — `SSLCertVerificationError` → 400 + certificate message
2. `test_api_import_automatic_tls_error` — generic `SSLError` → 400 + TLS message, so a handshake failure is not misreported as a certificate problem
3. `test_api_import_automatic_connection_failure` — plain `OSError` → 400 + connection message

After the fix:

```
python manage.py test authentik.stages.authenticator_duo.tests.AuthenticatorDuoStageTests
  → 13 passed, 0 failed

coverage report --include="authentik/stages/authenticator_duo/api.py"
  → 96.88%   (the 4 uncovered lines are pre-existing; every added line is covered)

ruff check   → All checks passed!
ruff format  → 2 files already formatted
```

### Linked issues

closes #22896

closes #25295
Possibly related: #22891 requests custom CA support for Duo, which would let this configuration work rather than just fail clearly. This PR only makes the failure diagnosable.

---

## Checklist

-   [x] The project has been linted, built, and tested (`make all`)

    Ran the affected suite plus `ruff check` / `ruff format --check` on the changed files, and coverage on `api.py`. I did not run the full `make all` locally (full web build plus complete suite); happy to if you'd like, otherwise CI covers it.

-   [ ] The documentation has been updated and formatted (`make docs`)

    No documentation change — this only replaces an unhandled exception with the error response the endpoint already documents (`400: Bad request`). Let me know if the error strings should be documented anywhere.

---

Supersedes #24903, which I had to abandon: I force-pushed that branch to correct a commit trailer and did it from a shallow clone, which orphaned the history and caused GitHub to auto-close the PR and show the whole repository as added. This branch is rebuilt on current `main` with the identical two-file change. Apologies for the noise.
