### PR TITLE
website/docs: preserve host and port in proxy provider nginx redirects

### DIFF
--- a/tests/e2e/proxy_forward_auth/nginx_single/nginx.conf
+++ b/tests/e2e/proxy_forward_auth/nginx_single/nginx.conf
@@ -42,7 +42,7 @@ server {
         # ensure the host of this vserver matches your external URL you've configured
         # in authentik
         proxy_set_header    Host $host;
-        proxy_set_header    X-Original-URL $scheme://$http_host$request_uri;
+        proxy_set_header    X-Original-URL $scheme://$host$request_uri;
         add_header          Set-Cookie $auth_cookie;
         auth_request_set    $auth_cookie $upstream_http_set_cookie;
         proxy_pass_request_body off;
@@ -56,6 +56,6 @@ server {
         add_header Set-Cookie $auth_cookie;
         return 302 /outpost.goauthentik.io/start?rd=$request_uri;
         # For domain level, use the below error_page to redirect to your authentik server with the full redirect path
-        # return 302 https://localhost/outpost.goauthentik.io/start?rd=$scheme://$http_host$request_uri;
+        # return 302 https://localhost/outpost.goauthentik.io/start?rd=$scheme://$host$request_uri;
     }
 }

--- a/tests/e2e/proxy_forward_auth/nginx_single/nginx.conf
+++ b/tests/e2e/proxy_forward_auth/nginx_single/nginx.conf
@@ -1,3 +1,10 @@
+# Preserve an explicit Host header, including a non-standard port.
+# Fall back to $host when no Host header is present, such as with HTTP/3.
+map $http_host $ak_http_host {
+    default $http_host;
+    ''      $host;
+}
+
 server {
     listen 80;
     server_name _;
@@ -41,8 +48,8 @@ server {
         proxy_pass          http://ak-test-outpost:9000/outpost.goauthentik.io;
         # ensure the host of this vserver matches your external URL you've configured
         # in authentik
-        proxy_set_header    Host $host;
-        proxy_set_header    X-Original-URL $scheme://$host$request_uri;
+        proxy_set_header    Host $ak_http_host;
+        proxy_set_header    X-Original-URL $scheme://$ak_http_host$request_uri;
         add_header          Set-Cookie $auth_cookie;
         auth_request_set    $auth_cookie $upstream_http_set_cookie;
         proxy_pass_request_body off;
@@ -56,6 +63,6 @@ server {
         add_header Set-Cookie $auth_cookie;
         return 302 /outpost.goauthentik.io/start?rd=$request_uri;
         # For domain level, use the below error_page to redirect to your authentik server with the full redirect path
-        # return 302 https://localhost/outpost.goauthentik.io/start?rd=$scheme://$host$request_uri;
+        # return 302 https://localhost/outpost.goauthentik.io/start?rd=$scheme://$ak_http_host$request_uri;
     }
 }

--- a/website/docs/add-secure-apps/providers/proxy/_nginx_ingress.md
+++ b/website/docs/add-secure-apps/providers/proxy/_nginx_ingress.md
@@ -38,7 +38,7 @@ metadata:
             http://ak-outpost-example.authentik.svc.cluster.local:9000/outpost.goauthentik.io/auth/nginx
         # If you're using domain-level auth, use the authentication URL instead of the application URL
         nginx.ingress.kubernetes.io/auth-signin: |-
-            https://app.company/outpost.goauthentik.io/start?rd=$scheme://$http_host$escaped_request_uri
+            https://app.company/outpost.goauthentik.io/start?rd=$scheme://$host$escaped_request_uri
         nginx.ingress.kubernetes.io/auth-response-headers: |-
             Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-entitlements,X-authentik-email,X-authentik-name,X-authentik-uid
             # Add the 'authorization' header to auth-response-headers if you need proxy providers which

--- a/website/docs/add-secure-apps/providers/proxy/_nginx_ingress.md
+++ b/website/docs/add-secure-apps/providers/proxy/_nginx_ingress.md
@@ -37,12 +37,16 @@ metadata:
         nginx.ingress.kubernetes.io/auth-url: |-
             http://ak-outpost-example.authentik.svc.cluster.local:9000/outpost.goauthentik.io/auth/nginx
         # If you're using domain-level auth, use the authentication URL instead of the application URL
+        # Use the application host configured as the proxy provider's External host instead of a request-derived
+        # host variable. This ensures that the host remains available for HTTP/3 requests and preserves configured ports.
         nginx.ingress.kubernetes.io/auth-signin: |-
-            https://app.company/outpost.goauthentik.io/start?rd=$scheme://$host$escaped_request_uri
+            https://app.company/outpost.goauthentik.io/start?rd=$scheme://app.company$escaped_request_uri
         nginx.ingress.kubernetes.io/auth-response-headers: |-
             Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-entitlements,X-authentik-email,X-authentik-name,X-authentik-uid
             # Add the 'authorization' header to auth-response-headers if you need proxy providers which
             # send a custom HTTP-Basic Authentication header based on values from authentik
         nginx.ingress.kubernetes.io/auth-snippet: |
-            proxy_set_header X-Forwarded-Host $http_host;
+            # These values must match the proxy provider's External host, including any non-standard port.
+            proxy_set_header X-Original-URL $scheme://app.company$request_uri;
+            proxy_set_header X-Forwarded-Host app.company;
 ```

--- a/website/docs/add-secure-apps/providers/proxy/_nginx_ingress.md
+++ b/website/docs/add-secure-apps/providers/proxy/_nginx_ingress.md
@@ -37,8 +37,10 @@ metadata:
         nginx.ingress.kubernetes.io/auth-url: |-
             http://ak-outpost-example.authentik.svc.cluster.local:9000/outpost.goauthentik.io/auth/nginx
         # If you're using domain-level auth, use the authentication URL instead of the application URL
-        # Use the application host configured as the proxy provider's External host instead of a request-derived
-        # host variable. This ensures that the host remains available for HTTP/3 requests and preserves configured ports.
+        # Write the host as a literal rather than using $http_host. Clients are not required to send a Host
+        # header over HTTP/3, which leaves $http_host empty, and $host strips any non-standard port.
+        # The literal must match the proxy provider's External host, including a non-standard port.
+        # For domain-level auth, set this per Ingress so each application redirects back to its own host.
         nginx.ingress.kubernetes.io/auth-signin: |-
             https://app.company/outpost.goauthentik.io/start?rd=$scheme://app.company$escaped_request_uri
         nginx.ingress.kubernetes.io/auth-response-headers: |-
@@ -46,7 +48,9 @@ metadata:
             # Add the 'authorization' header to auth-response-headers if you need proxy providers which
             # send a custom HTTP-Basic Authentication header based on values from authentik
         nginx.ingress.kubernetes.io/auth-snippet: |
-            # These values must match the proxy provider's External host, including any non-standard port.
-            proxy_set_header X-Original-URL $scheme://app.company$request_uri;
+            # Must match the proxy provider's External host, including any non-standard port. The outpost
+            # reads X-Forwarded-Host in preference to Host when matching a request to an application.
+            # Do not set X-Original-URL here: ingress-nginx already sets it earlier in this same location,
+            # and its value takes precedence over anything the snippet appends.
             proxy_set_header X-Forwarded-Host app.company;
 ```

--- a/website/docs/add-secure-apps/providers/proxy/_nginx_proxy_manager.md
+++ b/website/docs/add-secure-apps/providers/proxy/_nginx_proxy_manager.md
@@ -8,6 +8,13 @@ proxy_buffer_size 32k;
 # Make sure not to redirect traffic to a port 4443
 port_in_redirect off;
 
+# Preserve an explicit Host header, including a non-standard port.
+# Fall back to $host when no Host header is present, such as with HTTP/3.
+set $ak_http_host $http_host;
+if ($ak_http_host = "") {
+    set $ak_http_host $host;
+}
+
 location / {
     # Put your proxy_pass to your application here
     proxy_pass          $forward_scheme://$server:$port;
@@ -56,9 +63,9 @@ location /outpost.goauthentik.io {
     # proxy_pass              http://outpost.company:9000;
 
     # Note: ensure the Host header matches your external authentik URL:
-    proxy_set_header        Host $host;
+    proxy_set_header        Host $ak_http_host;
 
-    proxy_set_header        X-Original-URL $scheme://$host$request_uri;
+    proxy_set_header        X-Original-URL $scheme://$ak_http_host$request_uri;
     add_header              Set-Cookie $auth_cookie;
     auth_request_set        $auth_cookie $upstream_http_set_cookie;
     proxy_pass_request_body off;
@@ -70,8 +77,8 @@ location /outpost.goauthentik.io {
 location @goauthentik_proxy_signin {
     internal;
     add_header Set-Cookie $auth_cookie;
-    return 302 /outpost.goauthentik.io/start?rd=$scheme://$host$request_uri;
+    return 302 /outpost.goauthentik.io/start?rd=$scheme://$ak_http_host$request_uri;
     # For domain level, use the below error_page to redirect to your authentik server with the full redirect path
-    # return 302 https://authentik.company/outpost.goauthentik.io/start?rd=$scheme://$host$request_uri;
+    # return 302 https://authentik.company/outpost.goauthentik.io/start?rd=$scheme://$ak_http_host$request_uri;
 }
 ```

--- a/website/docs/add-secure-apps/providers/proxy/_nginx_proxy_manager.md
+++ b/website/docs/add-secure-apps/providers/proxy/_nginx_proxy_manager.md
@@ -58,7 +58,7 @@ location /outpost.goauthentik.io {
     # Note: ensure the Host header matches your external authentik URL:
     proxy_set_header        Host $host;
 
-    proxy_set_header        X-Original-URL $scheme://$http_host$request_uri;
+    proxy_set_header        X-Original-URL $scheme://$host$request_uri;
     add_header              Set-Cookie $auth_cookie;
     auth_request_set        $auth_cookie $upstream_http_set_cookie;
     proxy_pass_request_body off;
@@ -70,8 +70,8 @@ location /outpost.goauthentik.io {
 location @goauthentik_proxy_signin {
     internal;
     add_header Set-Cookie $auth_cookie;
-    return 302 /outpost.goauthentik.io/start?rd=$scheme://$http_host$request_uri;
+    return 302 /outpost.goauthentik.io/start?rd=$scheme://$host$request_uri;
     # For domain level, use the below error_page to redirect to your authentik server with the full redirect path
-    # return 302 https://authentik.company/outpost.goauthentik.io/start?rd=$scheme://$http_host$request_uri;
+    # return 302 https://authentik.company/outpost.goauthentik.io/start?rd=$scheme://$host$request_uri;
 }
 ```

--- a/website/docs/add-secure-apps/providers/proxy/_nginx_standalone.md
+++ b/website/docs/add-secure-apps/providers/proxy/_nginx_standalone.md
@@ -67,7 +67,7 @@ server {
         # Note: ensure the Host header matches your external authentik URL:
         proxy_set_header        Host $host;
 
-        proxy_set_header        X-Original-URL $scheme://$http_host$request_uri;
+        proxy_set_header        X-Original-URL $scheme://$host$request_uri;
         add_header              Set-Cookie $auth_cookie;
         auth_request_set        $auth_cookie $upstream_http_set_cookie;
         proxy_pass_request_body off;
@@ -79,9 +79,9 @@ server {
     location @goauthentik_proxy_signin {
         internal;
         add_header Set-Cookie $auth_cookie;
-        return 302 /outpost.goauthentik.io/start?rd=$scheme://$http_host$request_uri;
+        return 302 /outpost.goauthentik.io/start?rd=$scheme://$host$request_uri;
         # For domain level, use the below error_page to redirect to your authentik server with the full redirect path
-        # return 302 https://authentik.company/outpost.goauthentik.io/start?rd=$scheme://$http_host$request_uri;
+        # return 302 https://authentik.company/outpost.goauthentik.io/start?rd=$scheme://$host$request_uri;
     }
 }
 ```

--- a/website/docs/add-secure-apps/providers/proxy/_nginx_standalone.md
+++ b/website/docs/add-secure-apps/providers/proxy/_nginx_standalone.md
@@ -5,6 +5,13 @@ map $http_upgrade $connection_upgrade_keepalive {
     ''      '';
 }
 
+# Preserve an explicit Host header, including a non-standard port.
+# Fall back to $host when no Host header is present, such as with HTTP/3.
+map $http_host $ak_http_host {
+    default $http_host;
+    ''      $host;
+}
+
 server {
     # SSL and VHost configuration
     listen                  443 ssl http2;
@@ -65,9 +72,9 @@ server {
         # proxy_pass              http://outpost.company:9000;
 
         # Note: ensure the Host header matches your external authentik URL:
-        proxy_set_header        Host $host;
+        proxy_set_header        Host $ak_http_host;
 
-        proxy_set_header        X-Original-URL $scheme://$host$request_uri;
+        proxy_set_header        X-Original-URL $scheme://$ak_http_host$request_uri;
         add_header              Set-Cookie $auth_cookie;
         auth_request_set        $auth_cookie $upstream_http_set_cookie;
         proxy_pass_request_body off;
@@ -79,9 +86,9 @@ server {
     location @goauthentik_proxy_signin {
         internal;
         add_header Set-Cookie $auth_cookie;
-        return 302 /outpost.goauthentik.io/start?rd=$scheme://$host$request_uri;
+        return 302 /outpost.goauthentik.io/start?rd=$scheme://$ak_http_host$request_uri;
         # For domain level, use the below error_page to redirect to your authentik server with the full redirect path
-        # return 302 https://authentik.company/outpost.goauthentik.io/start?rd=$scheme://$host$request_uri;
+        # return 302 https://authentik.company/outpost.goauthentik.io/start?rd=$scheme://$ak_http_host$request_uri;
     }
 }
 ```


### PR DESCRIPTION
## Details

### What does this PR change?
Uses `$host` instead of `$http_host` when building `X-Original-URL` and the sign-in redirect (`rd=`) in the Proxy Provider nginx recipes and e2e test config. `$http_host` is the raw client-supplied Host header; `$host` is nginx's validated value, already used for the actual `Host` header two lines above in the same files.

### Why is this change needed?
authentik's outpost parses `X-Original-URL` directly (`getNginxForwardUrl` in `mode_common.go`) with no validation, so the unvalidated client Host header flows straight into authentik's own redirect construction.

### How was this tested?
Config-only change (variable substitution, no structural changes); verified via `git grep` that no other `$http_host` usage was missed and that `X-Forwarded-Host` in the ingress snippet (a distinct, legitimate use) is untouched. Existing e2e proxy-forward-auth test already exercises this config.

### Linked issues

closes #24951