### PR TITLE
sources/plex: handle friends lookup failures

### DIFF
--- a/authentik/sources/plex/plex.py
+++ b/authentik/sources/plex/plex.py
@@ -96,18 +96,27 @@ class PlexAuth:
 
     def check_friends_overlap(self, user_ident: int) -> bool:
         """Check if the user is a friend of the owner, or the owner themselves"""
-        friends_allowed = False
         _, owner_id = self.get_user_info()
-        owner_friends = self.get_friends()
+        if owner_id == user_ident:
+            return True
+        try:
+            owner_friends = self.get_friends()
+        except RequestException as exc:
+            status_code = exc.response.status_code if exc.response is not None else None
+            LOGGER.warning(
+                "Unable to fetch Plex friends",
+                exc_type=type(exc).__name__,
+                status_code=status_code,
+            )
+            return False
         for friend in owner_friends:
             if int(friend.get("id", "0")) == user_ident:
-                friends_allowed = True
                 LOGGER.info(
                     "allowing user for plex because of friend",
                     user=user_ident,
                 )
-        owner_allowed = owner_id == user_ident
-        return any([friends_allowed, owner_allowed])
+                return True
+        return False
 
 
 class PlexSourceFlowManager(SourceFlowManager):

--- a/authentik/sources/plex/tests.py
+++ b/authentik/sources/plex/tests.py
@@ -1,9 +1,10 @@
 """plex Source tests"""
 
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 from requests.exceptions import RequestException
 from requests_mock import Mocker
 
+from authentik.events.logs import capture_logs
 from authentik.events.models import Event, EventAction
 from authentik.lib.generators import generate_key
 from authentik.sources.plex.models import PlexSource
@@ -29,6 +30,51 @@ RESOURCES_RESPONSE = [
         "provides": "server",
     },
 ]
+
+
+class TestPlexAuth(SimpleTestCase):
+    """Plex authentication utility tests"""
+
+    def setUp(self):
+        self.source = PlexSource(name="test", slug="test")
+
+    def test_check_friends_overlap_owner(self):
+        """The Plex owner is allowed without requesting the friends endpoint"""
+        api = PlexAuth(self.source, generate_key())
+        with Mocker() as mocker:
+            mocker.get("https://plex.tv/api/v2/user", json=USER_INFO_RESPONSE)
+            friends = mocker.get("https://plex.tv/api/v2/friends", status_code=410)
+
+            self.assertTrue(api.check_friends_overlap(USER_INFO_RESPONSE["id"]))
+            self.assertFalse(friends.called)
+
+    def test_check_friends_overlap_fails_closed(self):
+        """A failed friends request does not grant friend-based access"""
+        token = "owner-secret-token"
+        api = PlexAuth(self.source, token)
+        with Mocker() as mocker:
+            mocker.get("https://plex.tv/api/v2/user", json=USER_INFO_RESPONSE)
+            friends = mocker.get("https://plex.tv/api/v2/friends", status_code=410)
+
+            with capture_logs() as logs:
+                self.assertFalse(api.check_friends_overlap(USER_INFO_RESPONSE["id"] + 1))
+            self.assertEqual(friends.call_count, 1)
+
+        warning = next(log for log in logs if log.event == "Unable to fetch Plex friends")
+        self.assertEqual(warning.attributes["exc_type"], "HTTPError")
+        self.assertEqual(warning.attributes["status_code"], 410)
+        self.assertNotIn(token, repr(warning))
+
+    def test_check_friends_overlap_friend(self):
+        """A matching friend is allowed"""
+        friend_id = USER_INFO_RESPONSE["id"] + 1
+        api = PlexAuth(self.source, generate_key())
+        with Mocker() as mocker:
+            mocker.get("https://plex.tv/api/v2/user", json=USER_INFO_RESPONSE)
+            friends = mocker.get("https://plex.tv/api/v2/friends", json=[{"id": friend_id}])
+
+            self.assertTrue(api.check_friends_overlap(friend_id))
+            self.assertEqual(friends.call_count, 1)
 
 
 class TestPlexSource(TestCase):


### PR DESCRIPTION
## Details

### What does this PR change?

- Recognizes the Plex owner before querying the friends endpoint.
- Treats Plex friends lookup request failures as no friend match, allowing the existing allowed-server check to continue.
- Logs only the exception type and HTTP status code without exposing the token-bearing request URL.
- Adds regression tests for owner short-circuiting, HTTP 410 fail-closed behavior, token-safe logging, and successful friend matching.

### Why is this change needed?

Plex's `/api/v2/friends` endpoint can return HTTP 410. When "Allow friends to authenticate" is enabled, that exception currently aborts authentication before authentik can check whether the user shares an allowed server.

The Plex owner should also be accepted without calling the friends endpoint.

### How was this tested?

- `uvx --from ruff==0.16.2 ruff check authentik/sources/plex/plex.py authentik/sources/plex/tests.py`
- `uvx --python 3.14 --from black==26.5.1 black --check authentik/sources/plex/plex.py authentik/sources/plex/tests.py`
- `uv run --python 3.14 --isolated --no-project python -m compileall -q authentik/sources/plex/plex.py authentik/sources/plex/tests.py`
- Targeted Python 3.14 requests-mock harness covering owner short-circuiting, HTTP 410 fail-closed behavior, token-safe warning fields, allowed-server fallback, and successful friend matching.

The full Django suite and `make all` were not run locally because the required PostgreSQL/Docker development environment was unavailable. The focused Django tests are included for validation in the supported CI environment.

### Linked issues

Closes #24774

### AI assistance

OpenAI Codex was used for repository inspection, implementation and test drafting, local verification, and review of the resulting diff.

---

## Checklist

- [ ] The project has been linted, built, and tested (`make all`)
- [ ] The documentation has been updated and formatted (`make docs`)

Documentation changes are not applicable to this narrowly scoped bug fix.