### PR TITLE
enterprise/endpoints/connectors/fleet: decrease page size

### DIFF
--- a/authentik/enterprise/endpoints/connectors/fleet/controller.py
+++ b/authentik/enterprise/endpoints/connectors/fleet/controller.py
@@ -69,9 +69,9 @@ class FleetController(BaseController[DBC]):
                         "page": page,
                         # Small page size as Fleet's API response, with the populate fields below
                         # can be quite large and eat a lot of memory
-                        "per_page": 5,
+                        "per_page": 1,
                         "device_mapping": "true",
-                        "populate_software": "true",
+                        "populate_software": "without_vulnerability_details",
                         "populate_users": "true",
                         "populate_policies": "true",
                     },

--- a/authentik/enterprise/endpoints/connectors/fleet/tests/test_connector.py
+++ b/authentik/enterprise/endpoints/connectors/fleet/tests/test_connector.py
@@ -35,11 +35,11 @@ class TestFleetConnector(APITestCase):
                 text=load_fixture("fixtures/cond_acc_profile.mobileconfig"),
             )
             mock.get(
-                "http://localhost/api/v1/fleet/hosts?order_key=hardware_serial&page=0&per_page=5&device_mapping=true&populate_software=true&populate_users=true",
+                "http://localhost/api/v1/fleet/hosts?order_key=hardware_serial&page=0&per_page=1&device_mapping=true&populate_software=without_vulnerability_details&populate_users=true",
                 json=TEST_HOST,
             )
             mock.get(
-                "http://localhost/api/v1/fleet/hosts?order_key=hardware_serial&page=1&per_page=5&device_mapping=true&populate_software=true&populate_users=true",
+                "http://localhost/api/v1/fleet/hosts?order_key=hardware_serial&page=1&per_page=1&device_mapping=true&populate_software=without_vulnerability_details&populate_users=true",
                 json={"hosts": []},
             )
             controller.sync_endpoints()
@@ -93,11 +93,11 @@ class TestFleetConnector(APITestCase):
                 text=load_fixture("fixtures/cond_acc_profile.mobileconfig"),
             )
             mock.get(
-                "http://localhost/api/v1/fleet/hosts?order_key=hardware_serial&page=0&per_page=5&device_mapping=true&populate_software=true&populate_users=true",
+                "http://localhost/api/v1/fleet/hosts?order_key=hardware_serial&page=0&per_page=1&device_mapping=true&populate_software=without_vulnerability_details&populate_users=true",
                 json=TEST_HOST,
             )
             mock.get(
-                "http://localhost/api/v1/fleet/hosts?order_key=hardware_serial&page=1&per_page=5&device_mapping=true&populate_software=true&populate_users=true",
+                "http://localhost/api/v1/fleet/hosts?order_key=hardware_serial&page=1&per_page=1&device_mapping=true&populate_software=without_vulnerability_details&populate_users=true",
                 json={"hosts": []},
             )
             controller.sync_endpoints()

--- a/authentik/enterprise/endpoints/connectors/fleet/tests/test_stage.py
+++ b/authentik/enterprise/endpoints/connectors/fleet/tests/test_stage.py
@@ -31,11 +31,11 @@ class FleetConnectorStageTests(FlowTestCase):
                 text=load_fixture("fixtures/cond_acc_profile.mobileconfig"),
             )
             mock.get(
-                "http://localhost/api/v1/fleet/hosts?order_key=hardware_serial&page=0&per_page=5&device_mapping=true&populate_software=true&populate_users=true",
+                "http://localhost/api/v1/fleet/hosts?order_key=hardware_serial&page=0&per_page=1&device_mapping=true&populate_software=without_vulnerability_details&populate_users=true",
                 json={"hosts": [loads(load_fixture("fixtures/host_macos.json"))]},
             )
             mock.get(
-                "http://localhost/api/v1/fleet/hosts?order_key=hardware_serial&page=1&per_page=5&device_mapping=true&populate_software=true&populate_users=true",
+                "http://localhost/api/v1/fleet/hosts?order_key=hardware_serial&page=1&per_page=1&device_mapping=true&populate_software=without_vulnerability_details&populate_users=true",
                 json={"hosts": []},
             )
             controller.sync_endpoints()


### PR DESCRIPTION
Turns out even with a page size of 5 we can have multi-megabyte JSON responses.

Change the page size to 1 can still lead to 5+ MB of JSON from a linux host.

This also sets populate_software to `without_vulnerability_details` which doesn't include all the CVE details which makes up a lot of data that we don't use, and trims it from 5.6 MB to 600kb
