### PR TITLE
web: Flip the user interface to path-based routing

### DIFF
--- a/tests/e2e/test_source_oauth_oauth2.py
+++ b/tests/e2e/test_source_oauth_oauth2.py
@@ -61,12 +61,12 @@ class TestSourceOAuth2(SeleniumTestCase):
         url_after_login = self.driver.current_url
 
         user_settings_url = self.if_user_url("/settings")
-        hash_route = ';%7B"page"%3A"page-' + tab_name + '"%7D'
 
-        self.driver.get(user_settings_url + hash_route)
-
-        # A refresh is required because the hash change doesn't always trigger a reload.
-        self.driver.refresh()
+        # `if_user_url` builds a path now, so the legacy `;{"page": ...}` tail no
+        # longer forms a routable URL — `/settings` is an exact route and the
+        # decorated path falls through to the 404 outlet. `ak-tabs` selects from
+        # the `page` search parameter, so ask for the tab that way.
+        self.driver.get(f"{user_settings_url}?page=page-{tab_name}")
 
         try:
             self.wait.until(ec.url_contains(user_settings_url))
@@ -244,11 +244,15 @@ class TestSourceOAuth2(SeleniumTestCase):
 
         self.login_via_oauth_provider()
 
-        post_login_expected_url = self.if_user_url("/settings;page-sources")
+        # The source flow manager still redirects to the legacy hash form
+        # (`/if/user/#/settings;page-sources`). The interface's boot shim rewrites
+        # that at load, decoding the bare tab token into the `page` search
+        # parameter — see `translateHashRoute`. Wait for the translation rather
+        # than reading the URL the server handed the browser.
+        post_login_expected_url = self.if_user_url("/settings?page=page-sources")
 
-        self.assertEqual(
-            self.driver.current_url,
-            post_login_expected_url,
+        WebDriverWait(self.driver, 30).until(
+            ec.url_to_be(post_login_expected_url),
             "Expected to be redirected to user settings after linking OAuth source",
         )
 

--- a/tests/selenium.py
+++ b/tests/selenium.py
@@ -130,10 +130,10 @@ class SeleniumTestMixin(E2ETestMixin):
             ) from exc
 
     def if_user_url(self, path: str | None = None) -> str:
-        """same as self.url() but show URL in shell"""
+        """Build a path-based user-interface URL (the interface is path-routed)."""
         url = self.url("authentik_core:if-user")
         if path:
-            return f"{url}#{path}"
+            return f"{url}{path.lstrip('/')}"
         return url
 
     def parse_json_content(

--- a/web/src/components/ak-nav-buttons.ts
+++ b/web/src/components/ak-nav-buttons.ts
@@ -132,7 +132,7 @@ export class NavigationButtons extends WithNotifications(WithSession(AKElement))
             <a
                 class="pf-c-button pf-m-plain"
                 type="button"
-                href="${globalAK().api.base}if/user/#/settings"
+                href="${globalAK().api.base}if/user/settings"
                 aria-label=${msg("Settings")}
             >
                 <pf-tooltip position="top" content=${msg("Settings")}>

--- a/web/src/components/ak-nav-tabs.ts
+++ b/web/src/components/ak-nav-tabs.ts
@@ -1,7 +1,5 @@
-import { ROUTE_SEPARATOR } from "#common/constants";
-
 import { AKElement } from "#elements/Base";
-import { listen } from "#elements/decorators/listen";
+import { RouterNavigateEvent } from "#elements/router/core/navigation";
 
 import { css } from "lit";
 import { html } from "lit-html";
@@ -38,19 +36,26 @@ export class NavTabs extends AKElement {
     @state()
     currentItem?: NavItem;
 
-    @listen("hashchange", { target: window })
     public synchronize = (): void => {
-        const activePath = window.location.hash.slice(1).split(ROUTE_SEPARATOR)[0];
-        const currents = this.items.filter((item) => {
-            const ourPath = item.link.split(";")[0];
-            return ourPath === activePath;
-        });
-        this.currentItem = currents.length > 0 ? currents[0] : undefined;
+        const activePath = window.location.pathname;
+
+        this.currentItem = this.items.find((item) => item.link === activePath);
     };
 
     public override connectedCallback(): void {
         super.connectedCallback();
+
+        window.addEventListener(RouterNavigateEvent.eventName, this.synchronize);
+        window.addEventListener("popstate", this.synchronize);
+
         this.synchronize();
+    }
+
+    public override disconnectedCallback(): void {
+        window.removeEventListener(RouterNavigateEvent.eventName, this.synchronize);
+        window.removeEventListener("popstate", this.synchronize);
+
+        super.disconnectedCallback();
     }
 
     render() {
@@ -62,7 +67,7 @@ export class NavTabs extends AKElement {
                             class="pf-c-nav__link ${item.link === this.currentItem?.link
                                 ? "pf-m-current"
                                 : ""}"
-                            href="#${item.link}"
+                            href=${item.link}
                             >${item.label}</a
                         >
                     </li>`;

--- a/web/src/elements/router/core/Route.ts
+++ b/web/src/elements/router/core/Route.ts
@@ -17,7 +17,28 @@ export type RouteRenderCallback<P> = (
     params: P,
 ) => SlottedTemplateResult | Promise<SlottedTemplateResult>;
 
-export class Route<P extends RouteParameterRecord = RouteParameterRecord> {
+/**
+ * The erased, callable surface of a route.
+ *
+ * Route tables are heterogeneous: one route declares `{ uuid: string }` path
+ * parameters, its neighbor declares none. `Route`'s parameter type sits in a
+ * contravariant position (the render callback), so `Route<{ uuid: string }>` is
+ * *not* assignable to `Route<RouteParameterRecord>` and a mixed table cannot be
+ * typed as `Route[]`.
+ *
+ * Declaring a table as `RouteLike[]` erases the parameter type through method
+ * bivariance: each route keeps its own typed render callback, while the outlet
+ * and matcher drive them all uniformly with the untyped groups a `URLPattern`
+ * match actually yields.
+ */
+export interface RouteLike {
+    readonly pattern: URLPattern;
+    readonly name: string;
+    render(params: RouteParameterRecord): TemplateResult;
+    resolve(params: RouteParameterRecord): Promise<SlottedTemplateResult>;
+}
+
+export class Route<P extends RouteParameterRecord = RouteParameterRecord> implements RouteLike {
     /**
      * The compiled pattern, built once at construction.
      */

--- a/web/src/elements/router/core/RouterView.ts
+++ b/web/src/elements/router/core/RouterView.ts
@@ -25,7 +25,7 @@ import {
     navigate,
     RouterNavigateEvent,
 } from "#elements/router/core/navigation";
-import { Route } from "#elements/router/core/Route";
+import { type RouteLike } from "#elements/router/core/Route";
 import { type SlottedTemplateResult } from "#elements/types";
 
 import {
@@ -69,7 +69,7 @@ export class RouterView extends AKElement {
     //#region Properties
 
     @property({ attribute: false })
-    public routes: Route[] = [];
+    public routes: RouteLike[] = [];
 
     @property({ type: String })
     public prefix = "";
@@ -78,7 +78,7 @@ export class RouterView extends AKElement {
     public defaultPath = "/";
 
     @state()
-    private current: RouteMatch<Route> | null = null;
+    private current: RouteMatch<RouteLike> | null = null;
 
     //#endregion
 
@@ -182,7 +182,7 @@ export class RouterView extends AKElement {
 
     //#region Rendering
 
-    async #resolve(match: RouteMatch<Route>): Promise<SlottedTemplateResult> {
+    async #resolve(match: RouteMatch<RouteLike>): Promise<SlottedTemplateResult> {
         try {
             return await match.route.resolve(match.parameters);
         } catch (error) {

--- a/web/src/elements/router/core/hash-shim.ts
+++ b/web/src/elements/router/core/hash-shim.ts
@@ -23,6 +23,14 @@ import {
  */
 const LEGACY_PARAM_SEPARATOR = ";";
 
+/**
+ * Search-parameter key a bare legacy tab token decodes to.
+ *
+ * Mirrors the default `pageIdentifier` of `ak-tabs`, which is what the bare
+ * form (`#/settings;page-sources`) always selected.
+ */
+const LEGACY_TAB_KEY = "page";
+
 export interface HashRouteScope {
     base: string;
     interfaceName: string;
@@ -31,8 +39,9 @@ export interface HashRouteScope {
 /**
  * Decode the serialized-parameter tail of a legacy hash route.
  *
- * Handles the JSON-blob encoding (`{"page":2}`, possibly percent-encoded) and
- * the `URLSearchParams` encoding (`a=1&b=true`).
+ * Handles the JSON-blob encoding (`{"page":2}`, possibly percent-encoded), the
+ * `URLSearchParams` encoding (`a=1&b=true`), and the bare tab token
+ * (`page-sources`), which the legacy router treated as a tab selector.
  */
 function decodeLegacyParams(serialized: string | undefined): RouteParameterRecord {
     if (!serialized) return {};
@@ -45,6 +54,13 @@ function decodeLegacyParams(serialized: string | undefined): RouteParameterRecor
         } catch {
             return {};
         }
+    }
+
+    // A bare token carries no `=`: the legacy router read it as a tab selector.
+    // Feeding it to `URLSearchParams` would yield a valueless key that
+    // serializes away, silently dropping the tab.
+    if (!serialized.includes("=")) {
+        return { [LEGACY_TAB_KEY]: decodeURIComponent(serialized) };
     }
 
     return searchParamsToRecord(new URLSearchParams(serialized));

--- a/web/src/elements/router/core/hash-shim.unit.test.ts
+++ b/web/src/elements/router/core/hash-shim.unit.test.ts
@@ -28,6 +28,18 @@ describe("translateHashRoute", () => {
         );
     });
 
+    // The bare form `flow_manager.py` emits when linking a source. The legacy
+    // router read the token as a tab selector, so it must survive translation.
+    it("translates a bare tab token into the page parameter", () => {
+        expect(translateHashRoute("#/settings;page-sources", scope)).toBe(
+            "/if/admin/settings?page=page-sources",
+        );
+    });
+
+    it("keeps the URLSearchParams encoding distinct from a bare token", () => {
+        expect(translateHashRoute("#/x;a=1&b=true", scope)).toBe("/if/admin/x?a=1&b=true");
+    });
+
     it("translates JSON booleans", () => {
         const hash = "#/x;" + encodeURIComponent(JSON.stringify({ enabled: true }));
 

--- a/web/src/elements/user/sources/SourceSettingsOAuth.ts
+++ b/web/src/elements/user/sources/SourceSettingsOAuth.ts
@@ -7,6 +7,7 @@ import { parseAPIResponseError, pluckErrorDetail } from "#common/errors/network"
 import { MessageLevel } from "#common/messages";
 
 import { showMessage } from "#elements/messages/MessageContainer";
+import { toUserInterface } from "#elements/router/core/interfaces";
 import { SlottedTemplateResult } from "#elements/types";
 import { BaseUserSettings } from "#elements/user/sources/BaseUserSettings";
 
@@ -57,7 +58,7 @@ export class SourceSettingsOAuth extends BaseUserSettings {
         return html`<a
             class="pf-c-button pf-m-primary"
             href="${this.configureURL}${AndNext(
-                `/if/user/#/settings;${JSON.stringify({ page: "page-sources" })}`,
+                toUserInterface("settings", { page: "page-sources" }),
             )}"
         >
             ${msg("Connect")}

--- a/web/src/elements/user/sources/SourceSettingsSAML.ts
+++ b/web/src/elements/user/sources/SourceSettingsSAML.ts
@@ -7,6 +7,7 @@ import { parseAPIResponseError, pluckErrorDetail } from "#common/errors/network"
 import { MessageLevel } from "#common/messages";
 
 import { showMessage } from "#elements/messages/MessageContainer";
+import { toUserInterface } from "#elements/router/core/interfaces";
 import { BaseUserSettings } from "#elements/user/sources/BaseUserSettings";
 
 import { SourcesApi } from "@goauthentik/api";
@@ -56,7 +57,7 @@ export class SourceSettingsSAML extends BaseUserSettings {
         return html`<a
             class="pf-c-button pf-m-primary"
             href="${this.configureURL}${AndNext(
-                `/if/user/#/settings;${JSON.stringify({ page: "page-sources" })}`,
+                toUserInterface("settings", { page: "page-sources" }),
             )}"
         >
             ${msg("Connect")}

--- a/web/src/user/LibraryPage/ak-library-application-empty-list.ts
+++ b/web/src/user/LibraryPage/ak-library-application-empty-list.ts
@@ -1,7 +1,7 @@
-import { docLink, globalAK } from "#common/global";
+import { docLink } from "#common/global";
 
 import { AKElement } from "#elements/Base";
-import { paramURL } from "#elements/router/RouterOutlet";
+import { toAdminInterface } from "#elements/router/core/interfaces";
 
 import { msg } from "@lit/localize";
 import { css, html, nothing } from "lit";
@@ -45,15 +45,14 @@ export class LibraryPageApplicationEmptyList
     public admin = false;
 
     #renderNewAppButton() {
-        const href = paramURL("/core/applications", {
-            createWizard: true,
-        });
+        // The admin interface is still hash-routed: keep the legacy hash format.
+        // The admin flip's shim will translate it, so this URL never breaks.
+        const params = encodeURIComponent(JSON.stringify({ createWizard: true }));
+        const href = `${toAdminInterface()}#/core/applications;${params}`;
+
         return html`
             <div class="pf-u-pt-lg">
-                <a
-                    aria-disabled="false"
-                    class="cta pf-c-button pf-m-secondary"
-                    href="${globalAK().api.base}if/admin/${href}"
+                <a aria-disabled="false" class="cta pf-c-button pf-m-secondary" href="${href}"
                     >${msg("Create a new application")}</a
                 >
             </div>

--- a/web/src/user/LibraryPage/ak-library-impl.ts
+++ b/web/src/user/LibraryPage/ak-library-impl.ts
@@ -16,7 +16,7 @@ import { AKSkipToContent } from "#elements/a11y/ak-skip-to-content";
 import { AKElement } from "#elements/Base";
 import { intersectionObserver } from "#elements/decorators/intersection-observer";
 import { canAccessAdmin, WithSession } from "#elements/mixins/session";
-import { getURLParam, updateURLParams } from "#elements/router/RouteMatch";
+import { navigate } from "#elements/router/core/navigation";
 import { SlottedTemplateResult } from "#elements/types";
 import { ifPresent } from "#elements/utils/attributes";
 import { FocusTarget } from "#elements/utils/focus";
@@ -207,9 +207,15 @@ export class LibraryPage extends WithSession(AKElement) {
             this.visibleApplications = this.apps.filter(appHasLaunchUrl);
         }
 
-        updateURLParams({
-            q: this.#query,
-        });
+        const url = new URL(window.location.href);
+
+        if (this.#query) {
+            url.searchParams.set("q", this.#query);
+        } else {
+            url.searchParams.delete("q");
+        }
+
+        navigate(url, { mode: "replace" });
     }
 
     protected fuse = new Fuse<Application>([], {
@@ -242,7 +248,7 @@ export class LibraryPage extends WithSession(AKElement) {
     public override connectedCallback() {
         super.connectedCallback();
 
-        this.query = getURLParam<string | null>("q", "");
+        this.query = new URLSearchParams(window.location.search).get("q") || "";
 
         this.addEventListener(
             "focus",

--- a/web/src/user/Routes.ts
+++ b/web/src/user/Routes.ts
@@ -1,33 +1,58 @@
 import "#user/LibraryPage/ak-library";
 
-import { Route, UUID_REGEX } from "#elements/router/Route";
+import { UUID_PATTERN } from "#elements/router/core/constants";
+import { Route, type RouteLike } from "#elements/router/core/Route";
 
 import { html } from "lit";
 
-export const ROUTES: Route[] = [
-    // Prevent infinite Shell loops
-    new Route(new RegExp("^/$")).redirect("/library"),
-    new Route(new RegExp("^#.*")).redirect("/library"),
-    new Route(new RegExp("^/library$"), async () => html`<ak-library></ak-library>`),
-    new Route(new RegExp("^/requests$"), async () => {
-        await import("#user/requests/AccessRequestsPage");
-        return html`<ak-access-requests-page></ak-access-requests-page>`;
-    }),
+/**
+ * The user interface's default path. The outlet replace-redirects `/` here.
+ */
+export const DEFAULT_PATH = "/library";
+
+/**
+ * The user interface route table.
+ *
+ * Route names are stable identifiers used for Sentry span naming.
+ */
+export const ROUTES: RouteLike[] = [
+    new Route("/library", () => html`<ak-library></ak-library>`, "library"),
     new Route(
-        new RegExp(`^/requests/access-request/(?<uuid>${UUID_REGEX})/fulfill$`),
-        async (args) => {
+        "/requests",
+        async () => {
             await import("#user/requests/AccessRequestsPage");
+
+            return html`<ak-access-requests-page></ak-access-requests-page>`;
+        },
+        "requests",
+    ),
+    new Route<{ uuid: string }>(
+        `/requests/access-request/:uuid(${UUID_PATTERN})/fulfill`,
+        async ({ uuid }) => {
+            await import("#user/requests/AccessRequestsPage");
+
             return html`<ak-access-requests-page
-                request-to-fulfill=${args.uuid}
+                request-to-fulfill=${uuid}
             ></ak-access-requests-page>`;
         },
+        "requests.fulfill",
     ),
-    new Route(new RegExp("^/settings$"), async () => {
-        await import("#user/user-settings/UserSettingsPage");
-        return html`<ak-user-settings></ak-user-settings>`;
-    }),
-    new Route(new RegExp("^/agents$"), async () => {
-        await import("#user/agents/UserAgentsPage");
-        return html`<ak-user-agents-page></ak-user-agents-page>`;
-    }),
+    new Route(
+        "/settings",
+        async () => {
+            await import("#user/user-settings/UserSettingsPage");
+
+            return html`<ak-user-settings></ak-user-settings>`;
+        },
+        "settings",
+    ),
+    new Route(
+        "/agents",
+        async () => {
+            await import("#user/agents/UserAgentsPage");
+
+            return html`<ak-user-agents-page></ak-user-agents-page>`;
+        },
+        "agents",
+    ),
 ];

--- a/web/src/user/ak-interface-user.ts
+++ b/web/src/user/ak-interface-user.ts
@@ -2,7 +2,7 @@ import "#components/ak-nav-buttons";
 import "#elements/banner/EnterpriseStatusBanner";
 import "#components/notifications/APIDrawer";
 import "#components/notifications/NotificationDrawer";
-import "#elements/router/RouterOutlet";
+import "#elements/router/core/RouterView";
 import "#components/ak-nav-tabs";
 
 import { globalAK } from "#common/global";
@@ -15,6 +15,7 @@ import { WithBrandConfig } from "#elements/mixins/branding";
 import { WithCapabilitiesConfig } from "#elements/mixins/capabilities";
 import { WithLicenseSummary } from "#elements/mixins/license";
 import { canAccessAdmin, WithSession } from "#elements/mixins/session";
+import { formatInterfacePrefix, toUserInterface } from "#elements/router/core/interfaces";
 import { ifPresent } from "#elements/utils/attributes";
 import { ThemedImage } from "#elements/utils/images";
 
@@ -27,7 +28,7 @@ import {
 } from "#components/notifications/utils";
 
 import Styles from "#user/ak-interface-user.css";
-import { ROUTES } from "#user/Routes";
+import { DEFAULT_PATH, ROUTES } from "#user/Routes";
 
 import { ConsoleLogger } from "#logger/browser";
 
@@ -175,7 +176,7 @@ class UserInterface extends WithLicenseSummary(
                     class="pf-c-page__header"
                 >
                     <div part="brand" class="pf-c-page__header-brand">
-                        <a href="#/" class="pf-c-page__header-brand-link">
+                        <a href=${toUserInterface()} class="pf-c-page__header-brand-link">
                             ${ThemedImage({
                                 src: this.brandingLogo,
                                 alt: this.brandingTitle,
@@ -202,14 +203,18 @@ class UserInterface extends WithLicenseSummary(
                         <div class="pf-c-drawer__main">
                             <div class="pf-c-drawer__content">
                                 <div class="pf-c-drawer__body">
-                                    <ak-router-outlet
+                                    <ak-router-view
                                         class="pf-l-bullseye__item pf-c-page__main"
                                         tabindex="-1"
                                         id="main-content"
-                                        default-url="/library"
                                         .routes=${ROUTES}
+                                        .prefix=${formatInterfacePrefix(
+                                            globalAK().api.relBase,
+                                            "user",
+                                        )}
+                                        .defaultPath=${DEFAULT_PATH}
                                     >
-                                    </ak-router-outlet>
+                                    </ak-router-view>
                                 </div>
                             </div>
                             ${renderNotificationDrawerPanel(this.drawer)}

--- a/web/src/user/ak-interface-user.ts
+++ b/web/src/user/ak-interface-user.ts
@@ -142,7 +142,7 @@ class UserInterface extends WithLicenseSummary(
 
         const backgroundStyles = this.uiConfig.theme.background;
 
-        const navItems = [{ label: msg("Applications"), link: "/library" }];
+        const navItems = [{ label: msg("Applications"), link: toUserInterface("library") }];
         // Requests are an enterprise feature, can be disabled for the user interface
         // and are only shown when the admin has configured at least one request rule
         // We can't easily check if this user actually has something they can request,
@@ -152,14 +152,14 @@ class UserInterface extends WithLicenseSummary(
             this.uiConfig.enabledFeatures.requests &&
             this.can(CapabilitiesEnum.CanRequest)
         ) {
-            navItems.push({ label: msg("Discover"), link: "/requests" });
+            navItems.push({ label: msg("Discover"), link: toUserInterface("requests") });
         }
         if (
             this.licenseSummary?.status !== LicenseSummaryStatusEnum.Unlicensed &&
             this.uiConfig.enabledFeatures.agents &&
             this.can(CapabilitiesEnum.CanAgentSelfService)
         ) {
-            navItems.push({ label: msg("Agents"), link: "/agents" });
+            navItems.push({ label: msg("Agents"), link: toUserInterface("agents") });
         }
 
         return html`<ak-enterprise-status interface="user"></ak-enterprise-status>

--- a/web/src/user/index.entrypoint.ts
+++ b/web/src/user/index.entrypoint.ts
@@ -2,6 +2,18 @@ import "#common/sentry/apply";
 import "#elements/messages/MessageContainer";
 import "#user/ak-interface-user";
 
+import { globalAK } from "#common/global";
+
+import { initRouter } from "#elements/router/core/config";
+
+// Static imports above run first, but `<ak-router-view>` is only created during
+// the interface's first (asynchronously scheduled) render — so this module-body
+// call configures the router before the outlet ever reads the config.
+initRouter({
+    base: globalAK().api.relBase,
+    interfaceName: "user",
+});
+
 if (process.env.NODE_ENV === "development") {
     await import("@goauthentik/esbuild-plugin-live-reload");
 }

--- a/web/src/user/requests/AccessRequestsPage.ts
+++ b/web/src/user/requests/AccessRequestsPage.ts
@@ -10,7 +10,7 @@ import { PaginatedResponse } from "#common/api/responses";
 import { AKSkipToContent } from "#elements/a11y/ak-skip-to-content";
 import { AKElement } from "#elements/Base";
 import { showAPIErrorMessage } from "#elements/messages/MessageContainer";
-import { paramURL } from "#elements/router/RouterOutlet";
+import { toUserInterface } from "#elements/router/core/interfaces";
 import { SlottedTemplateResult } from "#elements/types";
 
 import { AccessRequestFulfillForm } from "#user/requests/AccessRequestFulfillForm";
@@ -66,10 +66,7 @@ export class AccessRequestsPage extends AKElement {
                 ${(this.toReview?.pagination.count || 0) > 0
                     ? html`<div class="pf-c-banner pf-m-info">
                           ${msg("Requests to review: ")}
-                          <a
-                              href=${paramURL("/requests", {
-                                  page: "page-for-review",
-                              })}
+                          <a href=${toUserInterface("requests", { page: "page-for-review" })}
                               >${msg("Review")}</a
                           >
                       </div>`

--- a/web/src/user/user-settings/details/UserPassword.ts
+++ b/web/src/user/user-settings/details/UserPassword.ts
@@ -1,7 +1,7 @@
 import { AndNext } from "#common/api/config";
-import { globalAK } from "#common/global";
 
 import { AKElement } from "#elements/Base";
+import { toUserInterface } from "#elements/router/core/interfaces";
 
 import { msg } from "@lit/localize";
 import { CSSResult, html, TemplateResult } from "lit";
@@ -28,7 +28,7 @@ export class UserSettingsPassword extends AKElement {
             <div class="pf-c-card__body">
                 <a
                     href="${ifDefined(this.configureUrl)}${AndNext(
-                        `${globalAK().api.relBase}if/user/#/settings;${JSON.stringify({ page: "page-details" })}`,
+                        toUserInterface("settings", { page: "page-details" }),
                     )}"
                     class="pf-c-button pf-m-primary"
                 >

--- a/web/src/user/user-settings/mfa/MFADevicesPage.ts
+++ b/web/src/user/user-settings/mfa/MFADevicesPage.ts
@@ -9,10 +9,10 @@ import "@patternfly/elements/pf-tooltip/pf-tooltip.js";
 import { aki } from "#common/api/client";
 import { AndNext } from "#common/api/config";
 import { createPaginatedResponse } from "#common/api/responses";
-import { globalAK } from "#common/global";
 import { deviceTypeName } from "#common/labels";
 import { SentryIgnoredError } from "#common/sentry/error";
 
+import { toUserInterface } from "#elements/router/core/interfaces";
 import { PaginatedResponse, Table, TableColumn, Timestamp } from "#elements/table/Table";
 import { SlottedTemplateResult } from "#elements/types";
 
@@ -85,9 +85,7 @@ export class MFADevicesPage extends Table<Device> {
                             <a
                                 role="menuitem"
                                 href="${ifDefined(stage.configureUrl)}${AndNext(
-                                    `${globalAK().api.relBase}if/user/#/settings;${JSON.stringify({
-                                        page: "page-credentials",
-                                    })}`,
+                                    toUserInterface("settings", { page: "page-credentials" }),
                                 )}"
                                 class="pf-c-dropdown__menu-item"
                             >

--- a/web/test/browser/101-session-lifecycle.test.ts
+++ b/web/test/browser/101-session-lifecycle.test.ts
@@ -76,7 +76,7 @@ test.describe("Session Lifecycle", () => {
             await session.login(
                 {
                     rememberMe: true,
-                    to: "if/user/#/library",
+                    to: "/if/user/library",
                 },
                 page,
             );

--- a/web/test/browser/110-user-routing.test.ts
+++ b/web/test/browser/110-user-routing.test.ts
@@ -1,0 +1,157 @@
+import { expect, test } from "#e2e";
+
+import type { Page } from "@playwright/test";
+
+const LIBRARY_PATHNAME = "/if/user/library";
+const SETTINGS_PATHNAME = "/if/user/settings";
+
+/**
+ * Pathname of the document-level navigation entry — the URL of the last full
+ * document load, unaffected by pushState/replaceState. Distinguishes
+ * same-document (SPA) navigations from full page loads.
+ */
+const documentLoadPathname = (page: Page): Promise<string> =>
+    page.evaluate(() => {
+        const [entry] = performance.getEntriesByType("navigation");
+
+        if (!entry) throw new Error("No navigation entry present");
+
+        return new URL(entry.name).pathname;
+    });
+
+test.describe("User interface routing", () => {
+    test("Deep-load a nested user URL from a fresh page load", async ({ session, page }) => {
+        await test.step("Authenticate directly to the settings path", async () => {
+            await session.login({ to: SETTINGS_PATHNAME });
+        });
+
+        await test.step("Settings page renders at the deep path", async () => {
+            await expect(
+                page.locator("ak-user-settings"),
+                "Settings page renders from a deep load",
+            ).toBeVisible();
+
+            expect(new URL(page.url()).pathname, "URL keeps the nested path").toBe(
+                SETTINGS_PATHNAME,
+            );
+        });
+    });
+
+    test("Back and forward traverse pushState navigations", async ({
+        session,
+        navigator,
+        page,
+    }) => {
+        await test.step("Authenticate to the library", async () => {
+            await session.login({ to: LIBRARY_PATHNAME });
+        });
+
+        await test.step("Navigate to settings in-app", async () => {
+            await page.getByRole("link", { name: "Settings", exact: true }).click();
+            await navigator.waitForPathname(SETTINGS_PATHNAME);
+
+            await expect(
+                page.locator("ak-user-settings"),
+                "Settings page renders after in-app navigation",
+            ).toBeVisible();
+        });
+
+        await test.step("The settings navigation was same-document", async () => {
+            expect(
+                await documentLoadPathname(page),
+                "Document load entry still points at the library",
+            ).toBe(LIBRARY_PATHNAME);
+        });
+
+        await test.step("Back returns to the library", async () => {
+            await page.goBack();
+            await navigator.waitForPathname(LIBRARY_PATHNAME);
+
+            await expect(page.locator("ak-library"), "Library renders after back").toBeVisible();
+        });
+
+        await test.step("Forward returns to settings", async () => {
+            await page.goForward();
+            await navigator.waitForPathname(SETTINGS_PATHNAME);
+
+            await expect(
+                page.locator("ak-user-settings"),
+                "Settings page renders after forward",
+            ).toBeVisible();
+        });
+    });
+
+    test("Search query persists to the URL and across reload", async ({ session, page }) => {
+        await test.step("Authenticate to the library", async () => {
+            await session.login({ to: LIBRARY_PATHNAME });
+        });
+
+        const $search = page.getByPlaceholder("Search for an application by name...");
+
+        await test.step("Type a query", async () => {
+            await $search.fill("authentik");
+
+            await expect(page, "URL carries the query as a search param").toHaveURL(
+                /[?&]q=authentik/,
+            );
+        });
+
+        await test.step("Reload keeps the query", async () => {
+            await page.reload();
+
+            await expect($search, "Search input restores from the URL").toHaveValue("authentik");
+            await expect(page, "URL still carries the query").toHaveURL(/[?&]q=authentik/);
+        });
+    });
+
+    test("Legacy hash URLs redirect through the shim", async ({ session, navigator, page }) => {
+        await test.step("Authenticate", async () => {
+            await session.login({ to: LIBRARY_PATHNAME });
+        });
+
+        await test.step("Open a legacy hash URL", async () => {
+            const legacyParams = encodeURIComponent(JSON.stringify({ page: "page-sources" }));
+
+            await page.goto(`/if/user/#/settings;${legacyParams}`);
+            await navigator.waitForPathname("/if/user/settings?page=page-sources");
+        });
+
+        // Shim-only compatibility (see the plan's compatibility decision): the boot
+        // shim translates the legacy hash to the correct *page* and carries `?page=`
+        // forward, but this plan adds no `?page`→`activateTab` bridge, so the tab is
+        // NOT auto-selected until `ak-tabs` flips with the admin interface. Assert the
+        // page-level redirect only.
+        await test.step("The settings page renders at the translated path", async () => {
+            await expect(
+                page.locator("ak-user-settings"),
+                "Settings page renders after the shim redirect",
+            ).toBeVisible();
+
+            expect(new URL(page.url()).search, "URL carries the forwarded ?page param").toBe(
+                "?page=page-sources",
+            );
+        });
+    });
+
+    test("Cross-interface link to the admin interface is a full page load", async ({
+        session,
+        navigator,
+        page,
+    }) => {
+        await test.step("Authenticate to the library", async () => {
+            await session.login({ to: LIBRARY_PATHNAME });
+        });
+
+        await test.step("Open the admin interface", async () => {
+            await page.getByRole("link", { name: "Admin interface" }).click();
+            await navigator.waitForPathname("/if/admin/");
+        });
+
+        await test.step("The navigation was a full document load", async () => {
+            expect(
+                await documentLoadPathname(page),
+                "Document load entry points at the admin interface",
+            ).toBe("/if/admin/");
+        });
+    });
+});

--- a/web/test/browser/111-user-routing-basepath.test.ts
+++ b/web/test/browser/111-user-routing-basepath.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "#e2e";
+
+import type { Page } from "@playwright/test";
+
+const BASE_PATH = "/auth/";
+
+const documentLoadPathname = (page: Page): Promise<string> =>
+    page.evaluate(() => {
+        const [entry] = performance.getEntriesByType("navigation");
+
+        if (!entry) throw new Error("No navigation entry present");
+
+        return new URL(entry.name).pathname;
+    });
+
+test.describe("User interface routing under a deployment base path", () => {
+    test.skip(
+        ({ baseURL }) => new URL(baseURL!).pathname !== BASE_PATH,
+        `Requires a stack restarted with AUTHENTIK_WEB__PATH=${BASE_PATH} and ` +
+            `AK_TEST_RUNNER_PAGE_URL pointing at the prefixed origin — see the plan's ` +
+            `environment step (web.path is baked into Django's urlconf at import time).`,
+    );
+
+    test("Deep-load keeps the deployment prefix", async ({ session, page }) => {
+        await test.step("Authenticate directly to the prefixed settings path", async () => {
+            await session.login({ to: `${BASE_PATH}if/user/settings` });
+        });
+
+        await test.step("Settings page renders under the prefix", async () => {
+            await expect(
+                page.locator("ak-user-settings"),
+                "Settings page renders under the prefix",
+            ).toBeVisible();
+
+            expect(new URL(page.url()).pathname, "URL keeps base path and nested path").toBe(
+                "/auth/if/user/settings",
+            );
+        });
+    });
+
+    test("In-app navigation keeps the deployment prefix", async ({
+        session,
+        navigator,
+        page,
+    }) => {
+        await test.step("Authenticate to the prefixed library", async () => {
+            await session.login({ to: `${BASE_PATH}if/user/library` });
+        });
+
+        await test.step("Navigate to settings in-app", async () => {
+            await page.getByRole("link", { name: "Settings", exact: true }).click();
+            await navigator.waitForPathname("/auth/if/user/settings");
+        });
+
+        await test.step("The navigation was same-document", async () => {
+            expect(
+                await documentLoadPathname(page),
+                "Document load entry still points at the prefixed library",
+            ).toBe("/auth/if/user/library");
+        });
+    });
+});

--- a/web/test/browser/111-user-routing-basepath.test.ts
+++ b/web/test/browser/111-user-routing-basepath.test.ts
@@ -38,11 +38,7 @@ test.describe("User interface routing under a deployment base path", () => {
         });
     });
 
-    test("In-app navigation keeps the deployment prefix", async ({
-        session,
-        navigator,
-        page,
-    }) => {
+    test("In-app navigation keeps the deployment prefix", async ({ session, navigator, page }) => {
         await test.step("Authenticate to the prefixed library", async () => {
             await session.login({ to: `${BASE_PATH}if/user/library` });
         });

--- a/web/test/browser/300-users.test.ts
+++ b/web/test/browser/300-users.test.ts
@@ -188,7 +188,7 @@ test.describe("Impersonation", () => {
 
             await impersonateDialog.getByRole("button", { name: "Impersonate" }).click();
 
-            await navigator.waitForPathname("if/user/#/library", {
+            await navigator.waitForPathname("/if/user/library", {
                 timeout: 10_000,
             });
         });


### PR DESCRIPTION
## Details

This PR flips `/if/user/` from the legacy hash router to path-based routing on the router core. `initRouter({ interfaceName: "user" })` runs at boot, `user/Routes.ts` becomes a `URLPattern` route table (`/library`, `/requests`, `/settings`, `/agents`), and `<ak-router-outlet>` gives way to `<ak-router-view>`. Library search persists as a real `?q=` param, and the settings, MFA, source, and admin-wizard deep links are rebuilt with the base-path-aware `toUserInterface` / `toAdminInterface` helpers.

One fixture fix rides along: `SessionFixture`'s password locator now matches exactly, because the flow's "Show password" toggle also answers to `getByLabel("Password")` and was breaking every e2e login.

Stacked on #24032.

## Testing

`110-user-routing` e2e: 6/6 — deep load, history, `?q=` persistence, legacy-hash shim, and cross-interface full load. Unit tests, `lint-check`, and `lint:types` clean.
