### PR TITLE
core: Redirect source linking to the path-based user settings URL

### DIFF
--- a/authentik/core/sources/flow_manager.py
+++ b/authentik/core/sources/flow_manager.py
@@ -412,7 +412,7 @@ class SourceFlowManager:
             reverse(
                 "authentik_core:if-user",
             )
-            + "#/settings;page-sources"
+            + "settings?page=page-sources"
         )
 
     def handle_enroll(

--- a/authentik/core/tests/test_source_flow_manager.py
+++ b/authentik/core/tests/test_source_flow_manager.py
@@ -86,7 +86,7 @@ class TestSourceFlowManager(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(
             response.url,
-            reverse("authentik_core:if-user") + "#/settings;page-sources",
+            reverse("authentik_core:if-user") + "settings?page=page-sources",
         )
 
     def test_authenticated_auth_forwards_kwargs(self):

--- a/tests/e2e/test_source_oauth_oauth2.py
+++ b/tests/e2e/test_source_oauth_oauth2.py
@@ -61,12 +61,8 @@ class TestSourceOAuth2(SeleniumTestCase):
         url_after_login = self.driver.current_url
 
         user_settings_url = self.if_user_url("/settings")
-        hash_route = ';%7B"page"%3A"page-' + tab_name + '"%7D'
 
-        self.driver.get(user_settings_url + hash_route)
-
-        # A refresh is required because the hash change doesn't always trigger a reload.
-        self.driver.refresh()
+        self.driver.get(f"{user_settings_url}?page=page-{tab_name}")
 
         try:
             self.wait.until(ec.url_contains(user_settings_url))
@@ -244,7 +240,7 @@ class TestSourceOAuth2(SeleniumTestCase):
 
         self.login_via_oauth_provider()
 
-        post_login_expected_url = self.if_user_url("/settings;page-sources")
+        post_login_expected_url = self.if_user_url("/settings?page=page-sources")
 
         self.assertEqual(
             self.driver.current_url,


### PR DESCRIPTION
When an authenticated user links a social/OAuth source, `SourceFlowManager.handle_existing_link` redirects them to the user settings "Connected services" tab. Updates that redirect from the legacy hash form to the path-based `?page` form the flipped user interface understands:

`…/if/user/#/settings;page-sources` → `…/if/user/settings?page=page-sources`

## Tests updated
- Unit: `test_source_flow_manager.py::test_authenticated_link`.
- Selenium e2e (`test_source_oauth_oauth2.py`): the post-link URL assertion and `find_settings_tab_panel` now use the path + `?page=` form instead of the `#…;{json}` hash suffix.

## Base
**Stacked on #25008** (the admin flip), not `main` — the redirect's tab selection depends on `ak-tabs` reading `?page=` search params, which lands with the admin flip. Merges after the flip stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)