### PR TITLE
providers/scim: fix group membership removals

### DIFF
--- a/authentik/providers/scim/clients/groups.py
+++ b/authentik/providers/scim/clients/groups.py
@@ -76,16 +76,12 @@ class SCIMGroupClient(SCIMClient[Group, SCIMProviderGroup, SCIMGroupSchema]):
 
         if not self._config.patch.supported:
             users = list(obj.users.order_by("id").values_list("id", flat=True))
-            connections = SCIMProviderUser.objects.filter(
+            member_ids = SCIMProviderUser.objects.filter(
                 provider=self.provider, user__pk__in=users
-            )
-            members = []
-            for user in connections:
-                members.append(
-                    self._create_group_member(user.scim_id),
-                )
-            if members:
-                scim_group.members = members
+            ).values_list("scim_id", flat=True)
+            # The member list is also sent when it is empty, as without PATCH that is the only
+            # way to remove the last member of a group
+            scim_group.members = [self._create_group_member(x) for x in member_ids]
         else:
             del scim_group.members
         return scim_group
@@ -98,17 +94,11 @@ class SCIMGroupClient(SCIMClient[Group, SCIMProviderGroup, SCIMGroupSchema]):
     def create(self, group: Group):
         """Create group from scratch and create a connection object"""
         scim_group = self.to_schema(group, None)
+        payload = scim_group.model_dump(mode="json", exclude_unset=True)
         connection = None
         with transaction.atomic():
             try:
-                response = self._request(
-                    "POST",
-                    "/Groups",
-                    json=scim_group.model_dump(
-                        mode="json",
-                        exclude_unset=True,
-                    ),
-                )
+                response = self._request("POST", "/Groups", json=payload)
             except ObjectExistsSyncException as exc:
                 if not self._config.filter.supported:
                     raise exc
@@ -132,16 +122,36 @@ class SCIMGroupClient(SCIMClient[Group, SCIMProviderGroup, SCIMGroupSchema]):
                 if not scim_id or scim_id == "":
                     raise StopSync("SCIM Response with missing or invalid `id`")
                 connection = SCIMProviderGroup.objects.create(
-                    provider=self.provider, group=group, scim_id=scim_id, attributes=response
+                    provider=self.provider,
+                    group=group,
+                    scim_id=scim_id,
+                    attributes=payload | response,
                 )
-        users = list(group.users.order_by("id").values_list("id", flat=True))
-        self._patch_add_users(connection, users)
+        # Members are only sent separately when PATCH is supported, as to_schema otherwise
+        # includes them in the request above
+        if self._config.patch.supported:
+            users = list(group.users.order_by("id").values_list("id", flat=True))
+            self._patch_add_users(connection, users)
         return connection
+
+    @staticmethod
+    def _member_ids(group: dict[str, Any]) -> set[str]:
+        """Get the IDs of a serialized group's members"""
+        return {member["value"] for member in group.get("members") or [] if member.get("value")}
 
     def diff(self, local_created: dict[str, Any], connection: SCIMProviderGroup):
         """Check if a group is different than what we last wrote to the remote system.
         Returns true if there is a difference in data."""
         local_known = connection.attributes
+        if "members" in local_created:
+            # Members are compared by ID, as the remote system may return them with additional
+            # attributes, and as merging lists cannot detect a removed member. A recorded state
+            # without a member list cannot prove the members are unchanged.
+            if "members" not in local_known:
+                return True
+            if self._member_ids(local_created) != self._member_ids(local_known):
+                return True
+        local_created = {key: value for key, value in local_created.items() if key != "members"}
         local_updated = deepcopy(local_known)
         MERGE_LIST_UNIQUE.merge(local_updated, local_created)
         return self._json_encoder.encode(local_updated) != self._json_encoder.encode(local_known)
@@ -194,9 +204,10 @@ class SCIMGroupClient(SCIMClient[Group, SCIMProviderGroup, SCIMGroupSchema]):
         self, group: Group, scim_group: SCIMGroupSchema, connection: SCIMProviderGroup
     ):
         """Update a group via PATCH request"""
+        payload = scim_group.model_dump(mode="json", exclude_unset=True)
         # Patch group's attributes instead of replacing it and re-adding users if we can
-        value = scim_group.model_dump(mode="json", exclude_unset=True, exclude={"id"})
-        self._request(
+        value = {key: value for key, value in payload.items() if key != "id"}
+        response = self._request(
             "PATCH",
             f"/Groups/{connection.scim_id}",
             json=PatchRequest(
@@ -213,18 +224,24 @@ class SCIMGroupClient(SCIMClient[Group, SCIMProviderGroup, SCIMGroupSchema]):
                 exclude_none=True,
             ),
         )
+        self._record_written_state(connection, payload, response)
+
+    def _record_written_state(
+        self, connection: SCIMProviderGroup, payload: dict[str, Any], response: dict[str, Any]
+    ):
+        """Remember what we wrote to the remote system, so that writes which would not change
+        anything can be skipped. The response takes precedence over the sent payload, but cannot
+        be recorded alone: servers may answer 204 No Content or omit attributes such as the
+        member list."""
+        connection.attributes = payload | response
+        connection.save()
 
     def _update_put(self, group: Group, scim_group: SCIMGroupSchema, connection: SCIMProviderGroup):
         """Update a group via PUT request"""
+        payload = scim_group.model_dump(mode="json", exclude_unset=True)
         try:
-            self._request(
-                "PUT",
-                f"/Groups/{connection.scim_id}",
-                json=scim_group.model_dump(
-                    mode="json",
-                    exclude_unset=True,
-                ),
-            )
+            response = self._request("PUT", f"/Groups/{connection.scim_id}", json=payload)
+            self._record_written_state(connection, payload, response)
             return self.patch_compare_users(group)
         except SCIMRequestException, ObjectExistsSyncException:
             # Some providers don't support PUT on groups, so this is mainly a fix for the initial
@@ -277,6 +294,26 @@ class SCIMGroupClient(SCIMClient[Group, SCIMProviderGroup, SCIMGroupSchema]):
                 json=req.model_dump(mode="json", exclude_none=True),
             )
 
+    def _patch_add_member(self, user_id: str) -> PatchOperation:
+        """Build a patch operation that adds a member to a group"""
+        return PatchOperation(
+            op=PatchOp.add,
+            path="members",
+            value=[
+                self._create_group_member(user_id).model_dump(
+                    mode="json",
+                    exclude_unset=True,
+                )
+            ],
+        )
+
+    def _patch_remove_member(self, user_id: str) -> PatchOperation:
+        """Build a patch operation that removes a member from a group"""
+        return PatchOperation(
+            op=PatchOp.remove,
+            path=f'members[value eq "{user_id}"]',
+        )
+
     @transaction.atomic
     def patch_compare_users(self, group: Group):
         """Compare users with a SCIM group and add/remove any differences"""
@@ -320,32 +357,8 @@ class SCIMGroupClient(SCIMClient[Group, SCIMProviderGroup, SCIMGroupSchema]):
             return
         return self._patch_chunked(
             scim_group.scim_id,
-            *[
-                PatchOperation(
-                    op=PatchOp.add,
-                    path="members",
-                    value=[
-                        self._create_group_member(x).model_dump(
-                            mode="json",
-                            exclude_unset=True,
-                        )
-                    ],
-                )
-                for x in users_to_add
-            ],
-            *[
-                PatchOperation(
-                    op=PatchOp.remove,
-                    path="members",
-                    value=[
-                        self._create_group_member(x).model_dump(
-                            mode="json",
-                            exclude_unset=True,
-                        )
-                    ],
-                )
-                for x in users_to_remove
-            ],
+            *[self._patch_add_member(x) for x in users_to_add],
+            *[self._patch_remove_member(x) for x in users_to_remove],
         )
 
     def _patch_add_users(self, scim_group: SCIMProviderGroup, users_set: set[int]):
@@ -361,19 +374,7 @@ class SCIMGroupClient(SCIMClient[Group, SCIMProviderGroup, SCIMGroupSchema]):
             return
         self._patch_chunked(
             scim_group.scim_id,
-            *[
-                PatchOperation(
-                    op=PatchOp.add,
-                    path="members",
-                    value=[
-                        self._create_group_member(x).model_dump(
-                            mode="json",
-                            exclude_unset=True,
-                        )
-                    ],
-                )
-                for x in user_ids
-            ],
+            *[self._patch_add_member(x) for x in user_ids],
         )
 
     def _patch_remove_users(self, scim_group: SCIMProviderGroup, users_set: set[int]):
@@ -389,13 +390,7 @@ class SCIMGroupClient(SCIMClient[Group, SCIMProviderGroup, SCIMGroupSchema]):
             return
         self._patch_chunked(
             scim_group.scim_id,
-            *[
-                PatchOperation(
-                    op=PatchOp.remove,
-                    path=f'members[value eq "{x}"]',
-                )
-                for x in user_ids
-            ],
+            *[self._patch_remove_member(x) for x in user_ids],
         )
 
     def discover(self):

--- a/authentik/providers/scim/clients/groups.py
+++ b/authentik/providers/scim/clients/groups.py
@@ -166,45 +166,37 @@ class SCIMGroupClient(SCIMClient[Group, SCIMProviderGroup, SCIMGroupSchema]):
             return self.patch_compare_users(group)
         try:
             if self._config.patch.supported:
-                return self._update_patch(group, scim_group, connection)
-            return self._update_put(group, scim_group, connection)
+                return self._update_patch(group, payload, connection)
+            return self._update_put(group, payload, connection)
         except NotFoundSyncException:
             # Resource missing is handled by self.write, which will re-create the group
             raise
 
-    def _update_patch(
-        self, group: Group, scim_group: SCIMGroupSchema, connection: SCIMProviderGroup
-    ):
+    def _update_patch(self, group: Group, payload: dict[str, Any], connection: SCIMProviderGroup):
         """Apply provider-specific PATCH requests"""
         match connection.provider.compatibility_mode:
             case SCIMCompatibilityMode.AWS:
-                self._update_patch_aws(group, scim_group, connection)
+                self._update_patch_aws(payload, connection)
             case _:
-                self._update_patch_general(group, scim_group, connection)
+                self._update_patch_general(payload, connection)
         return self.patch_compare_users(group)
 
-    def _update_patch_aws(
-        self, group: Group, scim_group: SCIMGroupSchema, connection: SCIMProviderGroup
-    ):
+    def _update_patch_aws(self, payload: dict[str, Any], connection: SCIMProviderGroup):
         """Run PATCH requests for supported attributes"""
-        group_dict = scim_group.model_dump(mode="json", exclude_unset=True)
         self._patch_chunked(
             connection.scim_id,
             *[
                 PatchOperation(
                     op=PatchOp.replace,
                     path=attr,
-                    value=group_dict[attr],
+                    value=payload[attr],
                 )
                 for attr in ("displayName", "externalId")
             ],
         )
 
-    def _update_patch_general(
-        self, group: Group, scim_group: SCIMGroupSchema, connection: SCIMProviderGroup
-    ):
+    def _update_patch_general(self, payload: dict[str, Any], connection: SCIMProviderGroup):
         """Update a group via PATCH request"""
-        payload = scim_group.model_dump(mode="json", exclude_unset=True)
         # Patch group's attributes instead of replacing it and re-adding users if we can
         value = {key: value for key, value in payload.items() if key != "id"}
         response = self._request(
@@ -236,9 +228,8 @@ class SCIMGroupClient(SCIMClient[Group, SCIMProviderGroup, SCIMGroupSchema]):
         connection.attributes = payload | response
         connection.save()
 
-    def _update_put(self, group: Group, scim_group: SCIMGroupSchema, connection: SCIMProviderGroup):
+    def _update_put(self, group: Group, payload: dict[str, Any], connection: SCIMProviderGroup):
         """Update a group via PUT request"""
-        payload = scim_group.model_dump(mode="json", exclude_unset=True)
         try:
             response = self._request("PUT", f"/Groups/{connection.scim_id}", json=payload)
             self._record_written_state(connection, payload, response)
@@ -246,7 +237,7 @@ class SCIMGroupClient(SCIMClient[Group, SCIMProviderGroup, SCIMGroupSchema]):
         except SCIMRequestException, ObjectExistsSyncException:
             # Some providers don't support PUT on groups, so this is mainly a fix for the initial
             # sync, send patch add requests for all the users the group currently has
-            return self._update_patch(group, scim_group, connection)
+            return self._update_patch(group, payload, connection)
 
     def update_group(self, group: Group, action: Direction, users_set: set[int]):
         """Update a group, either using PUT to replace it or PATCH if supported"""

--- a/authentik/providers/scim/clients/schema.py
+++ b/authentik/providers/scim/clients/schema.py
@@ -189,15 +189,17 @@ class ServiceProviderConfiguration(BaseServiceProviderConfiguration):
     @staticmethod
     def default() -> ServiceProviderConfiguration:
         """Get default configuration, which doesn't support any optional features as fallback"""
-        return ServiceProviderConfiguration(
+        config = ServiceProviderConfiguration(
             patch=Patch(supported=False),
             bulk=Bulk(supported=False, maxOperations=0),
             filter=Filter(supported=False),
             changePassword=ChangePassword(supported=False),
             sort=Sort(supported=False),
             authenticationSchemes=[],
-            _is_fallback=True,
         )
+        # Private attributes cannot be set through the constructor
+        config._is_fallback = True
+        return config
 
 
 class PatchOp(StrEnum):

--- a/authentik/providers/scim/tests/test_client.py
+++ b/authentik/providers/scim/tests/test_client.py
@@ -75,9 +75,10 @@ class SCIMClientTests(TestCase):
                     "etag": {"supported": False},
                 },
             )
-            SCIMClient(self.provider)
+            client = SCIMClient(self.provider)
             self.assertEqual(mock.call_count, 1)
             self.assertEqual(mock.request_history[0].method, "GET")
+            self.assertFalse(client._config.is_fallback)
 
     def test_config_invalid(self):
         """Test invalid config"""
@@ -87,9 +88,10 @@ class SCIMClientTests(TestCase):
                 "https://localhost/ServiceProviderConfig",
                 json={},
             )
-            SCIMClient(self.provider)
+            client = SCIMClient(self.provider)
             self.assertEqual(mock.call_count, 1)
             self.assertEqual(mock.request_history[0].method, "GET")
+            self.assertTrue(client._config.is_fallback)
 
     def test_config_non_json_response(self):
         """Test non-JSON config response falls back to defaults"""
@@ -99,9 +101,10 @@ class SCIMClientTests(TestCase):
                 text="<html></html>",
                 headers={"Content-Type": "text/html"},
             )
-            SCIMClient(self.provider)
+            client = SCIMClient(self.provider)
             self.assertEqual(mock.call_count, 1)
             self.assertEqual(mock.request_history[0].method, "GET")
+            self.assertTrue(client._config.is_fallback)
 
     def test_scim_sync(self):
         """test scim_sync task"""

--- a/authentik/providers/scim/tests/test_group.py
+++ b/authentik/providers/scim/tests/test_group.py
@@ -69,6 +69,7 @@ class SCIMGroupTests(TestCase):
                 "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
                 "externalId": str(group.pk),
                 "displayName": group.name,
+                "members": [],
             },
         )
 
@@ -108,6 +109,7 @@ class SCIMGroupTests(TestCase):
                 "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
                 "externalId": str(group.pk),
                 "displayName": group.name,
+                "members": [],
             },
         )
         group.name = generate_id()
@@ -145,6 +147,7 @@ class SCIMGroupTests(TestCase):
                 "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
                 "externalId": str(group.pk),
                 "displayName": group.name,
+                "members": [],
             },
         )
         group.delete()
@@ -183,6 +186,7 @@ class SCIMGroupTests(TestCase):
                 "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
                 "externalId": str(group.pk),
                 "displayName": group.name,
+                "members": [],
             },
         )
         conn = SCIMProviderGroup.objects.filter(group=group).first()
@@ -191,6 +195,7 @@ class SCIMGroupTests(TestCase):
             "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
             "externalId": str(group.pk),
             "displayName": group.name,
+            "members": [],
         }
         conn.save()
         mock.get(
@@ -209,6 +214,41 @@ class SCIMGroupTests(TestCase):
         self.assertEqual(mock.request_history[1].method, "POST")
         self.assertEqual(mock.request_history[2].method, "GET")
         self.assertNotIn("PUT", [req.method for req in mock.request_history])
+
+    @Mocker()
+    def test_group_update_records_remote_state(self, mock: Mocker):
+        """Test that the remote state is recorded on update, so the next write is a noop"""
+        scim_id = generate_id()
+        mock.get(
+            "https://localhost/ServiceProviderConfig",
+            json={},
+        )
+        mock.post(
+            "https://localhost/Groups",
+            json={
+                "id": scim_id,
+            },
+        )
+        group = Group.objects.create(
+            name=generate_id(),
+        )
+        group.name = generate_id()
+        remote_group = {
+            "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+            "id": scim_id,
+            "externalId": str(group.pk),
+            "displayName": group.name,
+            "members": [],
+        }
+        mock.put(f"https://localhost/Groups/{scim_id}", json=remote_group)
+        mock.get(f"https://localhost/Groups/{scim_id}", json=remote_group)
+
+        group.save()
+        connection = SCIMProviderGroup.objects.filter(provider=self.provider, group=group).first()
+        self.assertEqual(connection.attributes, remote_group)
+
+        group.save()
+        self.assertEqual([req.method for req in mock.request_history].count("PUT"), 1)
 
     @Mocker()
     def test_group_diff_nested_attribute(self, mock: Mocker):

--- a/authentik/providers/scim/tests/test_membership.py
+++ b/authentik/providers/scim/tests/test_membership.py
@@ -9,7 +9,12 @@ from authentik.blueprints.tests import apply_blueprint
 from authentik.core.models import Application, Group, User
 from authentik.lib.generators import generate_id
 from authentik.providers.scim.clients.schema import ServiceProviderConfiguration
-from authentik.providers.scim.models import SCIMCompatibilityMode, SCIMMapping, SCIMProvider
+from authentik.providers.scim.models import (
+    SCIMCompatibilityMode,
+    SCIMMapping,
+    SCIMProvider,
+    SCIMProviderGroup,
+)
 from authentik.providers.scim.tasks import scim_sync
 from authentik.tenants.models import Tenant
 
@@ -247,6 +252,157 @@ class SCIMMembershipTests(TestCase):
                 },
             )
 
+    def test_member_remove_last_without_patch(self):
+        """Test removing a group's last member without PATCH support, against a server which
+        does not echo members in write responses"""
+        user_scim_id = generate_id()
+        group_scim_id = generate_id()
+        group = Group.objects.create(name=generate_id())
+        user = User.objects.create(username=generate_id())
+        group.users.add(user)
+
+        with Mocker() as mocker:
+            mocker.post("https://localhost/Users", json={"id": user_scim_id})
+            mocker.post("https://localhost/Groups", json={"id": group_scim_id})
+
+            self.configure(compatibility_mode=SCIMCompatibilityMode.VCENTER)
+            scim_sync.send(self.provider.pk)
+
+            # The create request already contains the members, no separate PATCH is sent
+            self.assertEqual(
+                [request.method for request in mocker.request_history], ["POST", "POST"]
+            )
+            self.assertJSONEqual(
+                mocker.request_history[1].body,
+                {
+                    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+                    "externalId": str(group.pk),
+                    "displayName": group.name,
+                    "members": [{"value": user_scim_id}],
+                },
+            )
+
+        with Mocker() as mocker:
+            mocker.put(f"https://localhost/Groups/{group_scim_id}", status_code=204)
+            mocker.get(
+                f"https://localhost/Groups/{group_scim_id}",
+                json={
+                    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+                    "id": group_scim_id,
+                    "externalId": str(group.pk),
+                    "displayName": group.name,
+                    "members": [],
+                },
+            )
+
+            group.users.remove(user)
+
+            self.assertEqual([request.method for request in mocker.request_history], ["PUT", "GET"])
+            self.assertJSONEqual(
+                mocker.request_history[0].body,
+                {
+                    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+                    "id": group_scim_id,
+                    "externalId": str(group.pk),
+                    "displayName": group.name,
+                    "members": [],
+                },
+            )
+
+    def test_group_write_without_recorded_members(self):
+        """Test that a group whose recorded state has no member list is written again"""
+        user_scim_id = generate_id()
+        group_scim_id = generate_id()
+        group = Group.objects.create(name=generate_id())
+        user = User.objects.create(username=generate_id())
+        group.users.add(user)
+
+        with Mocker() as mocker:
+            mocker.post("https://localhost/Users", json={"id": user_scim_id})
+            mocker.post("https://localhost/Groups", json={"id": group_scim_id})
+
+            self.configure(compatibility_mode=SCIMCompatibilityMode.VCENTER)
+            scim_sync.send(self.provider.pk)
+
+        # Simulate a connection recorded by a version which did not store the member list
+        connection = SCIMProviderGroup.objects.get(provider=self.provider, group=group)
+        connection.attributes.pop("members")
+        connection.save()
+
+        with Mocker() as mocker:
+            remote_group = {
+                "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+                "id": group_scim_id,
+                "externalId": str(group.pk),
+                "displayName": group.name,
+                "members": [{"value": user_scim_id}],
+            }
+            mocker.put(f"https://localhost/Groups/{group_scim_id}", json=remote_group)
+            mocker.get(f"https://localhost/Groups/{group_scim_id}", json=remote_group)
+
+            group.save()
+
+            self.assertEqual([request.method for request in mocker.request_history], ["PUT", "GET"])
+            self.assertJSONEqual(
+                mocker.request_history[0].body,
+                {
+                    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+                    "id": group_scim_id,
+                    "externalId": str(group.pk),
+                    "displayName": group.name,
+                    "members": [{"value": user_scim_id}],
+                },
+            )
+
+    def test_member_remove_only_in_remote_group(self):
+        """Test member remove of a member that only exists in the remote group"""
+        user_scim_id = generate_id()
+        stale_scim_id = generate_id()
+        group_scim_id = generate_id()
+        group = Group.objects.create(name=generate_id())
+        user = User.objects.create(username=generate_id())
+        group.users.add(user)
+        remote_group = {
+            "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+            "id": group_scim_id,
+            "externalId": str(group.pk),
+            "displayName": group.name,
+            "members": [{"value": user_scim_id}],
+        }
+
+        with Mocker() as mocker:
+            mocker.post("https://localhost/Users", json={"id": user_scim_id})
+            mocker.post("https://localhost/Groups", json=remote_group)
+
+            self.configure(compatibility_mode=SCIMCompatibilityMode.VCENTER)
+            scim_sync.send(self.provider.pk)
+
+        with Mocker() as mocker:
+            mocker.get(
+                f"https://localhost/Groups/{group_scim_id}",
+                json=remote_group
+                | {"members": [{"value": x} for x in (user_scim_id, stale_scim_id)]},
+            )
+            mocker.patch(f"https://localhost/Groups/{group_scim_id}", json={})
+
+            group.save()
+
+            self.assertEqual(
+                [request.method for request in mocker.request_history], ["GET", "PATCH"]
+            )
+            self.assertJSONEqual(
+                mocker.request_history[1].body,
+                {
+                    "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+                    "Operations": [
+                        {
+                            "op": "remove",
+                            "path": f'members[value eq "{stale_scim_id}"]',
+                        }
+                    ],
+                },
+            )
+
     def test_member_add_save(self):
         """Test member add + save"""
         config = ServiceProviderConfiguration.default()
@@ -315,7 +471,13 @@ class SCIMMembershipTests(TestCase):
             )
             mocker.get(
                 f"https://localhost/Groups/{group_scim_id}",
-                json={},
+                json={
+                    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+                    "id": group_scim_id,
+                    "externalId": str(group.pk),
+                    "displayName": group.name,
+                    "members": [{"value": user_scim_id}],
+                },
             )
             mocker.patch(
                 f"https://localhost/Groups/{group_scim_id}",
@@ -323,10 +485,11 @@ class SCIMMembershipTests(TestCase):
             )
             group.users.add(user)
             group.save()
-            self.assertEqual(mocker.call_count, 3)
-            self.assertEqual(mocker.request_history[0].method, "PATCH")
-            self.assertEqual(mocker.request_history[1].method, "PATCH")
-            self.assertEqual(mocker.request_history[2].method, "GET")
+            # The save does not write the group again, as nothing besides the members changed,
+            # so it only compares the members against the remote state
+            self.assertEqual(
+                [request.method for request in mocker.request_history], ["PATCH", "GET"]
+            )
             self.assertJSONEqual(
                 mocker.request_history[0].body,
                 {
@@ -338,21 +501,6 @@ class SCIMMembershipTests(TestCase):
                             "value": [{"value": user_scim_id}],
                         }
                     ],
-                },
-            )
-            self.assertJSONEqual(
-                mocker.request_history[1].body,
-                {
-                    "Operations": [
-                        {
-                            "op": "replace",
-                            "value": {
-                                "displayName": group.name,
-                                "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
-                                "externalId": str(group.pk),
-                            },
-                        }
-                    ]
                 },
             )
 
@@ -424,7 +572,13 @@ class SCIMMembershipTests(TestCase):
             )
             mocker.get(
                 f"https://localhost/Groups/{group_scim_id}",
-                json={},
+                json={
+                    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+                    "id": group_scim_id,
+                    "externalId": str(group.pk),
+                    "displayName": group.name,
+                    "members": [{"value": user_scim_id}],
+                },
             )
             mocker.patch(
                 f"https://localhost/Groups/{group_scim_id}",
@@ -432,10 +586,11 @@ class SCIMMembershipTests(TestCase):
             )
             group.users.add(user)
             group.save()
-            self.assertEqual(mocker.call_count, 3)
-            self.assertEqual(mocker.request_history[0].method, "PATCH")
-            self.assertEqual(mocker.request_history[1].method, "PATCH")
-            self.assertEqual(mocker.request_history[2].method, "GET")
+            # The save does not write the group again, as nothing besides the members changed,
+            # so it only compares the members against the remote state
+            self.assertEqual(
+                [request.method for request in mocker.request_history], ["PATCH", "GET"]
+            )
             self.assertJSONEqual(
                 mocker.request_history[0].body,
                 {
@@ -447,20 +602,5 @@ class SCIMMembershipTests(TestCase):
                             "value": [{"value": user_scim_id, "type": "user"}],
                         }
                     ],
-                },
-            )
-            self.assertJSONEqual(
-                mocker.request_history[1].body,
-                {
-                    "Operations": [
-                        {
-                            "op": "replace",
-                            "value": {
-                                "displayName": group.name,
-                                "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
-                                "externalId": str(group.pk),
-                            },
-                        }
-                    ]
                 },
             )


### PR DESCRIPTION
### What

Removing users from a SCIM group was never written to servers without PATCH support (such as vCenter) whenever the change was invisible to `diff()`: `to_schema` only attached `members` to the payload when the list was non-empty, `diff()` compared payloads with a list-union merge that cannot see a member disappear, and the state recorded on the connection was whatever the server last echoed, which vCenter-like servers don't echo at all (`204 No Content`, or responses without a member list). The write was then skipped as "nothing changed", leaving only `patch_compare_users`, which sends PATCH requests to a server that authentik itself has configured as having no PATCH support.

### Changes

- Group payloads now always state the member list when PATCH is unsupported, including when it is empty — that is the only way to remove the last member without PATCH.
- `diff()` compares members by ID rather than merging lists, and no longer trusts a recorded state that has no member list: it cannot prove the members are unchanged, so the group is written once and the recorded state converges. This is also what heals deployments whose connections were recorded by earlier versions.
- After every group write, the connection records what was written — the sent payload overlaid with the response — instead of the response alone. Recording only the response silently reverted the recorded member list on servers that answer `204` or omit `members`, which made the next removal look like a no-op.
- `create()` no longer sends a member PATCH to providers that report no PATCH support; the members are already part of the create request, and the extra request failed with task retries against strict servers.
- Both member-removal paths now build their operations through one pair of helpers using the RFC 7644 filter path `members[value eq "<id>"]`. Previously the reconcile path used a `{"op": "remove", "path": "members", "value": [...]}` shape, so a server implementing only the filter form silently lost removals.
- `ServiceProviderConfiguration.default()` actually marks itself as a fallback. pydantic silently drops underscore-prefixed constructor kwargs, so `is_fallback` was always `False` and the PUT-failed-so-try-PATCH fallback in `update_group` was dead code.

Note: when `create()` links a group that already exists remotely on a provider without PATCH support, membership now waits for the next sync rather than sending a PATCH the server would reject.

Closes #25003
