### PR TITLE
web: Fix content_left/right layouts.

### DIFF
--- a/web/src/styles/authentik/components/Login/login-layout.css
+++ b/web/src/styles/authentik/components/Login/login-layout.css
@@ -266,11 +266,7 @@
     }
 
     .pf-c-login[data-layout^="content"] {
-        display: flex;
-        flex-flow: row wrap;
-
-        place-content: space-between;
-        gap: var(--pf-global--spacer--lg);
+        grid-template-rows: [header] auto [content] 1fr;
 
         .pf-c-login__main,
         .pf-c-login__footer {
@@ -278,8 +274,28 @@
         }
     }
 
+    .pf-c-login[data-layout="content_left"] {
+        grid-template-columns:
+            1fr [main] var(--ak-c-login__main-ColumnWidth) [footer] var(
+                --ak-c-login__main-ColumnWidth
+            )
+            1fr;
+
+        grid-template-areas:
+            "header header header header"
+            ". main footer .";
+    }
+
     .pf-c-login[data-layout="content_right"] {
-        flex-direction: row-reverse;
+        grid-template-columns:
+            1fr [footer] var(--ak-c-login__main-ColumnWidth) [main] var(
+                --ak-c-login__main-ColumnWidth
+            )
+            1fr;
+
+        grid-template-areas:
+            "header header header header"
+            ". footer main .";
     }
 
     .pf-c-login[data-layout="sidebar_left"],


### PR DESCRIPTION
## Details

Small adjustment to our flow layouts where the card has some odd sizing. Previously this layout used a flex positioning which couldn't define a visually stable column on first render. This caused the contents to compress before a challenge is loaded.

The fix migrates the layout to match our other variations, using CSS grid areas which solve the visual stability issues. This layout needs improvement in the new future -- likely after the design system settles.  

Closes #24968