### PR TITLE
web: Auto focus password field after login error.

### DIFF
--- a/web/src/flow/stages/identification/IdentificationStage.ts
+++ b/web/src/flow/stages/identification/IdentificationStage.ts
@@ -265,6 +265,13 @@ export class IdentificationStage extends BaseStage<
 
     protected override onSubmitFailure(): void {
         this.#captcha.onFailure();
+
+        const passwordField = this.passwordFieldRef.value;
+
+        if (passwordField) {
+            passwordField.focus();
+            passwordField.select();
+        }
     }
 
     #dispatchChallengeToHost = (challenge: LoginChallengeTypes) => {


### PR DESCRIPTION
## Details

This PR adds a small quality of life fix to the identification stage, auto focusing the password field when an error is returned. It's possible that the user may need to correct the username field, but focusing on the password field seems to be a more common situation.