### PR TITLE
web/flow: display API-sent messages

### DIFF
--- a/web/src/flow/FlowExecutor.ts
+++ b/web/src/flow/FlowExecutor.ts
@@ -17,7 +17,7 @@ import { configureSentry } from "#common/sentry/index";
 import { applyBackgroundImageProperty } from "#common/theme";
 
 import { Interface } from "#elements/Interface";
-import { showAPIErrorMessage } from "#elements/messages/MessageContainer";
+import { showAPIErrorMessage, showMessage } from "#elements/messages/MessageContainer";
 import { WithBrandConfig } from "#elements/mixins/branding";
 import { LitPropertyRecord, SlottedTemplateResult } from "#elements/types";
 import { exportParts } from "#elements/utils/attributes";
@@ -29,6 +29,7 @@ import {
     AKFlowUpdateChallengeRequest,
 } from "#flow/events";
 import { StageMapping } from "#flow/FlowExecutorStageFactory";
+import { flowMessages } from "#flow/messages";
 import { BaseStage } from "#flow/stages/base";
 import type { FlowChallengeResponseRequestBody, StageHost, SubmitOptions } from "#flow/types";
 
@@ -243,6 +244,14 @@ export class FlowExecutor extends WithBrandConfig(Interface) implements StageHos
         document.title = match(this.challenge?.flowInfo?.title)
             .with(P.nullish, () => this.brandingTitle)
             .otherwise((title) => `${title} - ${this.brandingTitle}`);
+
+        if (changedProperties.has("challenge")) {
+            // Messages ride along with the challenge they were queued during, and the server
+            // considers them delivered once sent, so each challenge is shown exactly once.
+            for (const message of flowMessages(this.challenge?.messages)) {
+                showMessage(message);
+            }
+        }
 
         if (changedProperties.has("challenge") && this.challenge?.flowInfo) {
             this.layout = this.challenge?.flowInfo?.layout || FlowExecutor.DefaultLayout;

--- a/web/src/flow/FlowExecutor.ts
+++ b/web/src/flow/FlowExecutor.ts
@@ -189,6 +189,10 @@ export class FlowExecutor extends WithBrandConfig(Interface) implements StageHos
                 : this.ownerDocument.body;
 
         applyBackgroundImageProperty(background, { target });
+
+        for (const message of flowMessages(this.challenge?.flowInfo?.messages)) {
+            showMessage(message);
+        }
     }
 
     //#region Listeners
@@ -244,14 +248,6 @@ export class FlowExecutor extends WithBrandConfig(Interface) implements StageHos
         document.title = match(this.challenge?.flowInfo?.title)
             .with(P.nullish, () => this.brandingTitle)
             .otherwise((title) => `${title} - ${this.brandingTitle}`);
-
-        if (changedProperties.has("challenge")) {
-            // Messages ride along with the challenge they were queued during, and the server
-            // considers them delivered once sent, so each challenge is shown exactly once.
-            for (const message of flowMessages(this.challenge?.messages)) {
-                showMessage(message);
-            }
-        }
 
         if (changedProperties.has("challenge") && this.challenge?.flowInfo) {
             this.layout = this.challenge?.flowInfo?.layout || FlowExecutor.DefaultLayout;

--- a/web/src/flow/messages.ts
+++ b/web/src/flow/messages.ts
@@ -1,0 +1,45 @@
+/**
+ * @file Messages sent to the client as part of a flow challenge.
+ */
+
+import { APIMessage, MessageLevel } from "#common/messages";
+
+import { FlowMessage, FlowMessageLevelEnum } from "@goauthentik/api";
+
+/**
+ * Map the level of a message sent as flow data to the level used by the interface.
+ *
+ * @remarks
+ * `debug` has no counterpart in the interface, and is displayed as info. The server only ever
+ * sends it when the message level is lowered from its default.
+ */
+export function flowMessageLevel(level: FlowMessageLevelEnum): MessageLevel {
+    switch (level) {
+        case FlowMessageLevelEnum.Error:
+            return MessageLevel.error;
+        case FlowMessageLevelEnum.Warning:
+            return MessageLevel.warning;
+        case FlowMessageLevelEnum.Success:
+            return MessageLevel.success;
+        default:
+            return MessageLevel.info;
+    }
+}
+
+/**
+ * Convert the messages attached to a challenge into messages ready to be displayed.
+ *
+ * @remarks
+ * The server attaches a message to a single challenge and considers it delivered from then on, so
+ * callers must display these as soon as a challenge is received. Redirect challenges never carry
+ * messages, since the client navigates away before they could be read; those are delivered by the
+ * page navigated to instead.
+ */
+export function flowMessages(messages: FlowMessage[] | null | undefined): APIMessage[] {
+    if (!messages) return [];
+
+    return messages.map(({ level, message }) => ({
+        level: flowMessageLevel(level),
+        message,
+    }));
+}

--- a/web/src/user/user-settings/details/UserSettingsFlowExecutor.ts
+++ b/web/src/user/user-settings/details/UserSettingsFlowExecutor.ts
@@ -11,6 +11,7 @@ import { WithBrandConfig } from "#elements/mixins/branding";
 import { WithSession } from "#elements/mixins/session";
 import { SlottedTemplateResult } from "#elements/types";
 
+import { flowMessages } from "#flow/messages";
 import type { StageHost } from "#flow/types";
 
 import {
@@ -47,6 +48,12 @@ export class UserSettingsFlowExecutor
         const previousValue = this.#challenge;
 
         this.#challenge = value;
+
+        // Messages ride along with the challenge they were queued during, and the server
+        // considers them delivered once sent, so each challenge is shown exactly once.
+        for (const message of flowMessages(value?.messages)) {
+            showMessage(message);
+        }
 
         this.requestUpdate("challenge", previousValue);
     }

--- a/web/src/user/user-settings/details/UserSettingsFlowExecutor.ts
+++ b/web/src/user/user-settings/details/UserSettingsFlowExecutor.ts
@@ -51,7 +51,7 @@ export class UserSettingsFlowExecutor
 
         // Messages ride along with the challenge they were queued during, and the server
         // considers them delivered once sent, so each challenge is shown exactly once.
-        for (const message of flowMessages(value?.messages)) {
+        for (const message of flowMessages(value?.flowInfo?.messages)) {
             showMessage(message);
         }
 

--- a/web/test/unit/flow-messages.test.ts
+++ b/web/test/unit/flow-messages.test.ts
@@ -1,0 +1,51 @@
+import { MessageLevel } from "#common/messages";
+
+import { flowMessageLevel, flowMessages } from "#flow/messages";
+
+import { FlowMessage, FlowMessageLevelEnum } from "@goauthentik/api";
+
+import { describe, expect, it } from "vitest";
+
+const makeFlowMessage = (level: FlowMessageLevelEnum, message: string): FlowMessage => ({
+    level,
+    message,
+});
+
+describe("flowMessageLevel", () => {
+    it("maps each level the server can send to its interface counterpart", () => {
+        expect(flowMessageLevel(FlowMessageLevelEnum.Error)).toBe(MessageLevel.error);
+        expect(flowMessageLevel(FlowMessageLevelEnum.Warning)).toBe(MessageLevel.warning);
+        expect(flowMessageLevel(FlowMessageLevelEnum.Success)).toBe(MessageLevel.success);
+        expect(flowMessageLevel(FlowMessageLevelEnum.Info)).toBe(MessageLevel.info);
+    });
+
+    it("displays debug as info, as the interface has no debug level", () => {
+        expect(flowMessageLevel(FlowMessageLevelEnum.Debug)).toBe(MessageLevel.info);
+    });
+
+    it("displays a level added by a newer server as info", () => {
+        expect(flowMessageLevel(FlowMessageLevelEnum.UnknownDefaultOpenApi)).toBe(
+            MessageLevel.info,
+        );
+    });
+});
+
+describe("flowMessages", () => {
+    it("converts every message attached to a challenge", () => {
+        const messages = [
+            makeFlowMessage(FlowMessageLevelEnum.Success, "Email successfully sent."),
+            makeFlowMessage(FlowMessageLevelEnum.Error, "Failed to authenticate."),
+        ];
+
+        expect(flowMessages(messages)).toEqual([
+            { level: MessageLevel.success, message: "Email successfully sent." },
+            { level: MessageLevel.error, message: "Failed to authenticate." },
+        ]);
+    });
+
+    it("returns nothing for a challenge without messages", () => {
+        expect(flowMessages(undefined)).toEqual([]);
+        expect(flowMessages(null)).toEqual([]);
+        expect(flowMessages([])).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Details

heavily claude assisted

### What does this PR change?

### Why is this change needed?

### How was this tested?

### Linked issues

<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>