### PR TITLE
website/docs: add 2026.8 release note for task status change

### DIFF
--- a/website/docs/releases/2026/v2026.8.md
+++ b/website/docs/releases/2026/v2026.8.md
@@ -109,6 +109,11 @@ As part of our ongoing project to improve the performance and resource consumpti
 
 This currently does not bring any improvements, but is a stepping stone for us to couple the Django core and the proxying Rust closer together, to avoid wasting resources. Stay tuned for more in following releases!
 
+### Task status reflects task logs
+
+A task can log an error and still finish, for example a sync that failed for a single object. Those tasks were marked successful, and because the **System Tasks** page hides successful tasks by default, they were invisible. They now show as errors or warnings, so failures that were already occurring may start appearing there after upgrading. Tasks that ran before the upgrade keep their old status until they run
+again.
+
 ### Small general improvements
 
 - **Application Dashboard**: Users can switch between the existing card grid and a new compact list view. The selected view is remembered in the browser.

--- a/website/docs/releases/2026/v2026.8.md
+++ b/website/docs/releases/2026/v2026.8.md
@@ -111,8 +111,7 @@ This currently does not bring any improvements, but is a stepping stone for us t
 
 ### Task status reflects task logs
 
-A task can log an error and still finish, for example a sync that failed for a single object. Those tasks were marked successful, and because the **System Tasks** page hides successful tasks by default, they were invisible. They now show as errors or warnings, so failures that were already occurring may start appearing there after upgrading. Tasks that ran before the upgrade keep their old status until they run
-again.
+A task can log an error and still finish, for example a sync that failed for a single object. Those tasks were marked successful, and because the **System Tasks** page hides successful tasks by default, they were invisible. They now show as errors or warnings, so failures that were already occurring may start appearing there after upgrading. Tasks that ran before the upgrade keep their old status until they run again.
 
 ### Small general improvements
 


### PR DESCRIPTION
Add notes about #24792 

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
