### PR TITLE
web: Fix mangled nested CSS in compatibility mode.

### DIFF
--- a/web/bundler/style-loader-plugin/node.js
+++ b/web/bundler/style-loader-plugin/node.js
@@ -135,6 +135,21 @@ export function styleLoaderPlugin({
                     bundle: true,
                     write: false,
                     minify: build.initialOptions.minify || false,
+                    /**
+                     * Lower (un-nest) native CSS nesting in component shadow styles.
+                     *
+                     * Flattening here keeps declarations and nested rules in separate
+                     * top-level rules that ShadyCSS can process intact.
+                     *
+                     * ShadyCSS predates native CSS nesting.
+                     * Internally, `stringify` drops a rule's own declarations whenever
+                     * that rule also contains nested rules, discarding them while retaining the nested rules.
+                     *
+                     * We should remove this after compatibility mode drops.
+                     *
+                     * @expires 2026-12-01
+                     */
+                    supported: { nesting: false },
                     logLevel: "silent",
                     loader: { ".woff": "empty", ".woff2": "empty" },
                     plugins: [

--- a/web/src/flow/stages/captcha/CaptchaStage.css
+++ b/web/src/flow/stages/captcha/CaptchaStage.css
@@ -23,14 +23,8 @@ ak-stage-captcha[theme="dark"].style-scope {
 }
 
 .ak-interactive-challenge {
-    /**
-     * We use & here to hint to the ShadyDOM polyfill that this rule is meant
-     * for the iframe itself, not the contents of the iframe.
-     */
-    & {
-        width: 100%;
-        min-height: 65px;
-    }
+    width: 100%;
+    min-height: 65px;
 
     &[data-ready="loading"] {
         background-color: var(--captcha-background-from);

--- a/web/src/flow/stages/identification/styles.css
+++ b/web/src/flow/stages/identification/styles.css
@@ -1,17 +1,15 @@
 fieldset[name="login-sources"],
 ak-stage-identification.style-scope fieldset[name="login-sources"] {
-    & {
-        --ak-c-login-sources-padding-inline: var(--pf-global--spacer--xl);
+    --ak-c-login-sources-padding-inline: var(--pf-global--spacer--xl);
 
-        flex: 1 1 auto;
-        display: flex;
-        flex-flow: row wrap;
-        justify-content: center;
-        gap: var(--pf-global--spacer--sm);
+    flex: 1 1 auto;
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: center;
+    gap: var(--pf-global--spacer--sm);
 
-        padding-inline: var(--ak-c-login-sources-padding-inline) !important;
-        padding-block-start: var(--pf-global--spacer--md) !important;
-    }
+    padding-inline: var(--ak-c-login-sources-padding-inline) !important;
+    padding-block-start: var(--pf-global--spacer--md) !important;
 
     .source-button {
         display: flex;
@@ -50,10 +48,7 @@ ak-stage-identification.style-scope fieldset[name="login-sources"] {
 }
 
 .captcha-container {
-    /* compatibility-mode-fix */
-    & {
-        position: relative;
-    }
+    position: relative;
 
     .faux-input {
         position: absolute;

--- a/web/src/styles/authentik/components/Login/login-layout.css
+++ b/web/src/styles/authentik/components/Login/login-layout.css
@@ -266,36 +266,50 @@
     }
 
     .pf-c-login[data-layout^="content"] {
-        grid-template-rows: [header] auto [content] 1fr;
+        grid-template-rows:
+            [header] auto
+            [content] auto
+            [footer] minmax(2em, 1fr);
 
         .pf-c-login__main,
         .pf-c-login__footer {
             align-self: center;
         }
+
+        .pf-c-login__header {
+            /* Fix to unify PF's header adjustment at 1200px with our breakpoint. */
+            margin-top: var(--pf-c-login__header--xl--MarginTop);
+        }
+
+        .pf-c-login__footer {
+            grid-area: aside;
+        }
     }
 
     .pf-c-login[data-layout="content_left"] {
         grid-template-columns:
-            1fr [main] var(--ak-c-login__main-ColumnWidth) [footer] var(
-                --ak-c-login__main-ColumnWidth
-            )
+            1fr
+            [main] var(--ak-c-login__main-ColumnWidth)
+            [aside] var(--ak-c-login__main-ColumnWidth)
             1fr;
 
         grid-template-areas:
             "header header header header"
-            ". main footer .";
+            ". main aside ."
+            "footer footer footer footer";
     }
 
     .pf-c-login[data-layout="content_right"] {
         grid-template-columns:
-            1fr [footer] var(--ak-c-login__main-ColumnWidth) [main] var(
-                --ak-c-login__main-ColumnWidth
-            )
+            1fr
+            [aside] var(--ak-c-login__main-ColumnWidth)
+            [main] var(--ak-c-login__main-ColumnWidth)
             1fr;
 
         grid-template-areas:
             "header header header header"
-            ". footer main .";
+            ". aside main ."
+            "footer footer footer footer";
     }
 
     .pf-c-login[data-layout="sidebar_left"],


### PR DESCRIPTION
## Details

Follow up to #25025, this PR fixes compatibility mode by configuring ESBuild to not emit nested CSS. ShadyCSS predates native CSS nesting. Internally, `stringify` drops a rule's own declarations whenever that rule also contains nested rules, discarding them while retaining the nested rules.

Flattening CSS keeps declarations and nested rules in separate top-level rules that ShadyCSS can process intact. This can be removed after compatibility mode drops.

Additionally, a small revision to the original #25025, a placeholder footer gap is retained to keep similar row proportions to the stacked layout. Vertical alignment of the card and aside content is still out of reach given the identification stage's dynamic sizing, but this gets a bit closer visually. 