### PR TITLE
providers/scim: accept a service provider that reports bulk as unsupported

### DIFF
--- a/authentik/providers/scim/clients/schema.py
+++ b/authentik/providers/scim/clients/schema.py
@@ -171,7 +171,15 @@ class GroupMember(BaseGroupMember):
 
 
 class Bulk(BaseBulk):
-    maxOperations: int = Field()
+    # RFC 7644 Section 5 only defines the bulk limits alongside bulk support, so a
+    # service provider that answers `"bulk": {"supported": false}` and nothing else is
+    # conforming. Requiring the field made that response fail validation, which sent
+    # `get_service_provider_config()` to its fallback and reported `patch` and `filter`
+    # as unsupported regardless of what the provider actually advertised.
+    #
+    # 0 is the value the fallback itself uses, and `_patch_chunked` already reads any
+    # value below 1 as "no limit declared".
+    maxOperations: int = Field(default=0)
 
 
 class ServiceProviderConfiguration(BaseServiceProviderConfiguration):

--- a/authentik/providers/scim/tests/test_client.py
+++ b/authentik/providers/scim/tests/test_client.py
@@ -68,7 +68,7 @@ class SCIMClientTests(TestCase):
                         }
                     ],
                     "patch": {"supported": True},
-                    "bulk": {"supported": False, "maxOperations": 1, "maxPayloadSize": 1048576},
+                    "bulk": {"supported": False},
                     "filter": {"supported": True, "maxResults": 50},
                     "changePassword": {"supported": False},
                     "sort": {"supported": False},

--- a/authentik/providers/scim/tests/test_client.py
+++ b/authentik/providers/scim/tests/test_client.py
@@ -79,6 +79,35 @@ class SCIMClientTests(TestCase):
             self.assertEqual(mock.call_count, 1)
             self.assertEqual(mock.request_history[0].method, "GET")
 
+    def test_config_bulk_unsupported_without_max_operations(self):
+        """A provider that reports bulk as unsupported may omit the bulk limits.
+
+        RFC 7644 Section 5 only defines maxOperations alongside bulk support, so
+        such a response is conforming and must not push the client onto its
+        fallback config -- doing so reports patch and filter as unsupported
+        regardless of what the provider advertised, which silently disables
+        PATCH updates and the filtered lookup that adopts existing objects."""
+        with Mocker() as mock:
+            mock: Mocker
+            mock.get(
+                "https://localhost/ServiceProviderConfig",
+                json={
+                    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"],
+                    "authenticationSchemes": [],
+                    "patch": {"supported": True},
+                    "bulk": {"supported": False},
+                    "filter": {"supported": True, "maxResults": 50},
+                    "changePassword": {"supported": False},
+                    "sort": {"supported": False},
+                    "etag": {"supported": False},
+                },
+            )
+            client = SCIMClient(self.provider)
+            self.assertFalse(client._config.is_fallback)
+            self.assertTrue(client._config.patch.supported)
+            self.assertTrue(client._config.filter.supported)
+            self.assertEqual(client._config.bulk.maxOperations, 0)
+
     def test_config_invalid(self):
         """Test invalid config"""
         with Mocker() as mock:


### PR DESCRIPTION
Closes #25056.

## What

`ServiceProviderConfiguration` requires `bulk.maxOperations`. RFC 7644 §5 only
defines the bulk limits alongside bulk support, so a provider that answers
`"bulk": {"supported": false}` and nothing else is conforming — and today that
response fails validation. `get_service_provider_config()` then falls back to
`ServiceProviderConfiguration.default()`, which reports `patch.supported: false`
and `filter.supported: false` regardless of what the provider actually
advertised.

Nothing logs that the fallback was taken, and the two false values change
behaviour well away from the parse:

- `SCIMGroupClient.update()` takes `_update_put` instead of `_update_patch`.
- `SCIMUserClient.create()` skips its 409 recovery — `if not
  self._config.filter.supported: raise exc` — so an object that already exists
  remotely can never be adopted, and the create is retried indefinitely.

Against a provider that implements PATCH but not PUT, provisioning appears to
work — accounts are created — while every subsequent update fails.

## Why `0`

`ServiceProviderConfiguration.default()` already constructs
`Bulk(supported=False, maxOperations=0)`, and the one consumer already treats
anything below 1 as "no limit declared":

```python
# authentik/providers/scim/clients/groups.py
chunk_size = self._config.bulk.maxOperations
if chunk_size < 1:
    chunk_size = len(ops)
```

So `0` is the value this codebase already means by it, and no call site changes.

## Reproduction

Google Cloud Identity's inbound SCIM endpoint (GA 2026-07-09) answers:

```json
{
  "schemas": ["urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"],
  "patch":  {"supported": true},
  "bulk":   {"supported": false},
  "filter": {"supported": true, "maxResults": 50},
  "changePassword": {"supported": false},
  "sort":   {"supported": false},
  "etag":   {"supported": false},
  "authenticationSchemes": [ ... ]
}
```

Before:

```
ValidationError: 1 validation error for ServiceProviderConfiguration
bulk.maxOperations
  Field required [type=missing, input_value={'supported': False}, input_type=dict]

>>> client._config.patch.supported, client._config.filter.supported
(False, False)
```

After: the response parses, and both report `True`.

## Tests

Adds `test_config_bulk_unsupported_without_max_operations` to
`authentik/providers/scim/tests/test_client.py`, asserting the client does not
fall back and that `patch`/`filter` survive.

I have not been able to run the full suite locally (it needs the Postgres/Redis
stack); the change was verified against a running 2026.5.4 instance by applying
the same default at runtime and re-reading the parsed config.

## Note on #16678

This is upstream of #16678. That issue asks for `SCIMUserClient.update()` to
branch on `self._config.patch.supported` the way `SCIMGroupClient.update()`
already does, which is a real and separate gap. But adding that branch alone
would not help a provider like this one, because `patch.supported` is already
`False` before it is consulted.
