### PR TITLE
ci: require test-rust to pass

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -476,6 +476,7 @@ jobs:
       - test-unittest
       - test-integration
       - test-e2e
+      - test-rust
     runs-on: ubuntu-latest
     steps:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1


### PR DESCRIPTION
Now that we actually use that code, that test shouldn't be optional