### PR TITLE
website/docs: correct authenticator stage deletion behavior

### DIFF
--- a/website/docs/add-secure-apps/flows-stages/stages/authenticator_duo/index.mdx
+++ b/website/docs/add-secure-apps/flows-stages/stages/authenticator_duo/index.mdx
@@ -12,10 +12,16 @@ This stage connects authentik to Duo and stores a Duo-backed authenticator for t
 ## Configuration options
 
 - **API Hostname**: the Duo API hostname for your tenant.
-- **Client ID**: Duo Auth API client identifier.
-- **Client Secret**: Duo Auth API secret.
-- **Admin integration key**: optional Duo Admin API integration key, used for importing existing Duo users and authenticators.
-- **Admin secret key**: optional Duo Admin API secret, used together with the admin integration key.
+
+Under **Duo Auth API**:
+
+- **Integration key**: Duo Auth API integration key.
+- **Secret key**: Duo Auth API secret.
+
+Under **Duo Admin API (optional)**:
+
+- **Integration key**: optional Duo Admin API integration key, used for importing existing Duo users and authenticators.
+- **Secret key**: optional Duo Admin API secret, used together with the Admin API integration key.
 - **Authenticator type name**: optional friendly name shown to the user in self-service settings.
 - **Configuration flow**: optional authenticated flow that lets users enroll this authenticator from user settings.
 
@@ -28,7 +34,7 @@ To require Duo during authentication, add an [Authenticator Validation stage](..
 ## Notes
 
 - Duo authenticators created through this stage are tied to the stage because authentik needs that stage's API credentials during authentication.
-- Deleting the stage also removes the Duo authenticators associated with it.
+- Because of that link, the stage cannot be deleted while authenticators created through it still exist. Delete those authenticators first, then delete the stage.
 
 ### Import existing Duo authenticators
 

--- a/website/docs/add-secure-apps/flows-stages/stages/authenticator_email/index.mdx
+++ b/website/docs/add-secure-apps/flows-stages/stages/authenticator_email/index.mdx
@@ -49,6 +49,7 @@ To use the enrolled address during login, add an [Authenticator Validation stage
 
 ## Notes
 
+- Email authenticators created through this stage are tied to it, so the stage cannot be deleted while any of those authenticators still exist. Delete the authenticators first, then delete the stage.
 - If **Use global connection settings** is enabled, configure the global email settings first. See the installation docs for [Docker Compose](../../../../install-config/install/docker-compose#email-configuration-optional-but-recommended) and [Kubernetes](../../../../install-config/install/kubernetes#email-configuration-optional-but-recommended).
 - This stage is separate from the general-purpose [Email stage](../email/index.mdx), which is used for email verification and recovery.
 - If the user already has an email address on their account, authentik can use that address during enrollment instead of prompting for a new address.

--- a/website/docs/add-secure-apps/flows-stages/stages/authenticator_sms/index.mdx
+++ b/website/docs/add-secure-apps/flows-stages/stages/authenticator_sms/index.mdx
@@ -34,6 +34,8 @@ If you enable **Verify only**, phone numbers enrolled through this stage cannot 
 
 ## Notes
 
+SMS authenticators created through this stage are tied to it, so the stage cannot be deleted while any of those authenticators still exist. Delete the authenticators first, then delete the stage.
+
 ### Twilio
 
 For the Twilio provider, create a messaging service and collect the **Account SID**, **Auth token**, and a usable sender number from the Twilio console.


### PR DESCRIPTION
Found while auditing 2026.8 docs for staleness ahead of the release — see the [Slack thread](https://authentiksecurity.slack.com/archives/C08C0SJ4V6D/p1786634134866959).

### Stage deletion

`DuoDevice`, `SMSDevice`, and `EmailDevice` moved from `on_delete=CASCADE` to `on_delete=PROTECT` on their `stage` foreign key in 2026.8 (`authenticator_duo/0008`, `authenticator_sms/0010`, `authenticator_email/0004`). Deleting one of these stages while devices are enrolled against it now fails rather than deleting the devices.

The Duo page stated the old behavior outright:

> Deleting the stage also removes the Duo authenticators associated with it.

The SMS and Email pages said nothing either way. All three now describe the protected behavior.

### Duo configuration options

Separately, the Duo page listed **Client ID**, **Client secret**, **Admin integration key**, and **Admin secret key**. Those are the API field names, not the form labels — `AuthenticatorDuoStageForm.ts` renders **Integration key** and **Secret key** twice, grouped under **Duo Auth API** and **Duo Admin API (optional)**. Corrected, and **API hostname** matched to the form's **API Hostname**.

Worth flagging separately: there is no DRF exception handler for `ProtectedError`, so the blocked delete surfaces as an unhandled 500 rather than a clean 400. That is a product issue rather than a docs one and is not addressed here.