### PR TITLE
website/docs: correct worker healthcheck claim and outpost list

### DIFF
--- a/website/docs/sys-mgmt/ops/monitoring.mdx
+++ b/website/docs/sys-mgmt/ops/monitoring.mdx
@@ -10,13 +10,13 @@ Configure your monitoring software to send requests to `/-/health/live/`, which 
 
 ## Worker monitoring
 
-The worker container can be monitored by running `ak healthcheck` in the worker container. This will check that the worker is running and ensure that a PostgreSQL connection can be established correctly.
+The worker container can be monitored by running `ak healthcheck` in the worker container. This checks that the worker process is running and responding.
 
-You can also send HTTP requests to `/-/health/ready/`, which will return `HTTP 200` if a PostgreSQL connection can be established correctly.
+You can also send HTTP requests to `/-/health/ready/`, which will return `HTTP 200` if the worker processes are responding and a PostgreSQL connection can be established correctly. The worker serves this on the port set by [`AUTHENTIK_LISTEN__HTTP`](../../install-config/configuration/configuration.mdx#authentik_listen__http).
 
 ## Outpost monitoring
 
-Both kinds of outpost (proxy and LDAP) listen on a separate port (9300) and can be monitored by sending HTTP requests to `/outpost.goauthentik.io/ping`.
+All outposts (proxy, LDAP, RADIUS, and RAC) listen on a separate port (9300) and can be monitored by sending HTTP requests to `/outpost.goauthentik.io/ping`.
 
 ---
 


### PR DESCRIPTION
Found while auditing 2026.8 docs for staleness ahead of the release — see the [Slack thread](https://authentiksecurity.slack.com/archives/C08C0SJ4V6D/p1786634134866959).

### `ak healthcheck` no longer verifies the database

The page claimed:

> This will check that the worker is running **and ensure that a PostgreSQL connection can be established correctly**.

The healthcheck moved to the Rust entrypoint (#23556, #24320). In worker mode it requests `/-/health/live/` over the worker socket, and `health_live` in `src/worker/healthcheck.rs` only checks that the worker processes are alive and responding — no database access. `health_ready` is the handler that runs `sqlx::query("SELECT 1")`.

So the command confirms the worker is up and nothing more. The PostgreSQL clause is dropped.

### `/-/health/ready/` — corrected mid-review

An earlier revision of this PR claimed the worker served this only on a unix socket and that an external HTTP probe could not reach it. **That was wrong**, and thanks to whoever flagged it. `src/worker/mod.rs` binds the health router on `listen.http` as well as the socket when running in worker mode:

```rust
// Only run HTTP server in worker mode, in allinone mode, they're handled by the server.
if Mode::get() == Mode::Worker {
    let router = healthcheck::build_router(Arc::clone(&workers));
    for addr in config::get().listen.http.iter().copied() {
        ak_axum::server::start_plain(tasks, "worker", router.clone(), addr)?;
    }
    ...
```

and `health_ready` does check the database. The original sentence was accurate; it is restored, with the port it is served on added since that was not stated before.

### Outpost count

"Both kinds of outpost (proxy and LDAP)" predates the RADIUS and RAC outposts. All four serve `/outpost.goauthentik.io/ping` on 9300 — the Go outposts via `internal/outpost/ak/metrics.go` and the Rust proxy via its own route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
