### PR TITLE
website/docs: mark deprecated PostgreSQL options and fix listen settings

### DIFF
--- a/website/docs/install-config/configuration/configuration.mdx
+++ b/website/docs/install-config/configuration/configuration.mdx
@@ -184,6 +184,10 @@ These settings control connection persistence and behavior, which is particularl
 
 - `AUTHENTIK_POSTGRESQL__CONN_OPTIONS`
 
+    :::info Deprecated
+    Deprecated as of version 2026.5 and will be removed in a future version. If you rely on a specific parameter, open an issue so we can discuss an alternative.
+    :::
+
     Additional `libpq` connection parameters for the primary database connection.
 
     A list of supported parameter keywords can be found in the [PostgreSQL documentation](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS).
@@ -213,11 +217,15 @@ For the first replica, use index `0`:
 - `AUTHENTIK_POSTGRESQL__READ_REPLICAS__0__CONN_MAX_AGE`
 - `AUTHENTIK_POSTGRESQL__READ_REPLICAS__0__CONN_HEALTH_CHECKS`
 - `AUTHENTIK_POSTGRESQL__READ_REPLICAS__0__DISABLE_SERVER_SIDE_CURSORS`
-- `AUTHENTIK_POSTGRESQL__READ_REPLICAS__0__CONN_OPTIONS`
+- `AUTHENTIK_POSTGRESQL__READ_REPLICAS__0__CONN_OPTIONS` (deprecated, see above)
 
 Use index `1`, `2`, and so on for additional replicas.
 
 - `AUTHENTIK_POSTGRESQL__REPLICA_CONN_OPTIONS`
+
+    :::info Deprecated
+    Deprecated as of version 2026.5 and will be removed in a future version. If you rely on a specific parameter, open an issue so we can discuss an alternative.
+    :::
 
     Additional `libpq` connection parameters for all read replica connections.
 
@@ -262,7 +270,7 @@ To run the bulk of ORM traffic through a transaction-pooling pooler while keepin
 - `AUTHENTIK_POSTGRESQL__DIRECT__SSLROOTCERT`
 - `AUTHENTIK_POSTGRESQL__DIRECT__SSLCERT`
 - `AUTHENTIK_POSTGRESQL__DIRECT__SSLKEY`
-- `AUTHENTIK_POSTGRESQL__DIRECT__CONN_OPTIONS`
+- `AUTHENTIK_POSTGRESQL__DIRECT__CONN_OPTIONS` (deprecated, see above)
 
 Any setting left unset falls back to the corresponding top-level `AUTHENTIK_POSTGRESQL__*` value, so the common case of "same database, different endpoint" only requires `AUTHENTIK_POSTGRESQL__DIRECT__HOST` (and optionally `AUTHENTIK_POSTGRESQL__DIRECT__PORT`).
 
@@ -407,6 +415,14 @@ Applies to LDAP outposts.
 
 Defaults to `[::]:6636`.
 
+##### `AUTHENTIK_LISTEN__RADIUS`
+
+List of comma-separated `address:port` values for RADIUS.
+
+Applies to RADIUS outposts.
+
+Defaults to `[::]:1812`.
+
 ##### `AUTHENTIK_LISTEN__METRICS`
 
 List of comma-separated `address:port` values for Prometheus metrics.
@@ -417,9 +433,9 @@ Defaults to `[::]:9300`.
 
 ##### `AUTHENTIK_LISTEN__DEBUG`
 
-Listening address:port for Go Debugging metrics.
+Listening address:port for Go debugging metrics.
 
-Applies to all, except the worker.
+Applies to the LDAP, RADIUS, and RAC outposts, which are the remaining Go components.
 
 Defaults to `0.0.0.0:9900`.
 


### PR DESCRIPTION
Found while auditing 2026.8 docs for staleness ahead of the release — see the [Slack thread](https://authentiksecurity.slack.com/archives/C08C0SJ4V6D/p1786634134866959).

### `CONN_OPTIONS` deprecation

2026.5 deprecated these ("will be removed in the next version"), and 2026.8 restated it. The configuration reference absorbed neither — all four members were documented as ordinary settings with usage guidance, while the **Deprecated Settings** section lists only `USE_PGBOUNCER` and `USE_PGPOOL`:

- `AUTHENTIK_POSTGRESQL__CONN_OPTIONS`
- `AUTHENTIK_POSTGRESQL__REPLICA_CONN_OPTIONS`
- `AUTHENTIK_POSTGRESQL__READ_REPLICAS__0__CONN_OPTIONS`
- `AUTHENTIK_POSTGRESQL__DIRECT__CONN_OPTIONS` — added in 2026.8, i.e. a new member of a family on its way out, documented with no caveat

Notes are inline at each rather than collected in the trailing section, since the four are spread across the page and a reader configuring replicas will not scroll to the end.

### `AUTHENTIK_LISTEN__RADIUS`

Undocumented, though `internal/outpost/radius/radius.go` reads it and it defaults to `[::]:1812`. The reference covered HTTP, HTTPS, LDAP, LDAPS, and METRICS but skipped RADIUS.

### `AUTHENTIK_LISTEN__DEBUG` scope

Documented as applying to "all, except the worker". After the Rust rewrite, `Listen.Debug` is only read by `internal/debug/debug.go`, so it now applies to the LDAP, RADIUS, and RAC outposts alone.

### Not included: `AUTHENTIK_POSTGRESQL__USE_POOL`

I had this on the list as an undocumented setting, but it is inert — `authentik/lib/config.py` force-disables it:

```python
# FIXME: Temporarily force pool to be deactivated.
# See https://github.com/goauthentik/authentik/issues/14320
pool_options = False
```

Documenting it as functional would be wrong, so it is deliberately left out until #14320 is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
