### PR TITLE
website/docs: document debugging the Rust components

### DIFF
--- a/website/docs/developer-docs/setup/debugging.md
+++ b/website/docs/developer-docs/setup/debugging.md
@@ -58,6 +58,24 @@ After re-creating the containers with `AUTHENTIK_DEBUGGER` set to `true` and the
 
 If the authentik instance is running on a remote server, the `.vscode/launch.json` file needs to be adjusted to point to the IP of the remote server. Alternatively, you can forward the debug port via an SSH tunnel, using `-L 9901:127.0.0.1:9901`.
 
-## authentik Server / Outposts (Golang)
+## authentik Server / Proxy outpost (Rust)
 
-Outposts, as well as some auxiliary code of the authentik server, are written in Go. These components can be debugged using standard Golang tooling, such as [Delve](https://github.com/go-delve/delve).
+The authentik server entrypoint and the proxy outpost are written in Rust. The server accepts incoming requests, serves static assets, and forwards the rest to the Python core; the Python core itself is covered in the section above.
+
+These components can be debugged with standard Rust tooling, such as [`rust-gdb`, `rust-lldb`](https://doc.rust-lang.org/book/appendix-04-useful-development-tools.html), or the [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb) extension for Visual Studio Code. Build a debug binary with `cargo build` and run the component you want to inspect, for example `cargo run -- server` or `cargo run -- proxy`.
+
+### Async runtime inspection
+
+Because these components are asynchronous, a stack trace is often less useful than a view of the task runtime. authentik embeds [tokio-console](https://github.com/tokio-rs/console) support for this.
+
+Set `AUTHENTIK_LISTEN__DEBUG_TOKIO` to an `address:port` to start the console subscriber, then connect with the `tokio-console` client. The setting is unset by default, and no console server is started when it is empty.
+
+### Log levels
+
+Rust log levels are configured per-crate with `AUTHENTIK_LOG__RUST_LOG__*`, for example `AUTHENTIK_LOG__RUST_LOG__SQLX` to change SQL query logging. When `AUTHENTIK_DEBUG` is enabled, logs are written in a compact human-readable format with thread IDs and source locations; otherwise they are emitted as JSON.
+
+## Outposts (Go)
+
+The LDAP, RADIUS, and RAC outposts are written in Go. These components can be debugged using standard Golang tooling, such as [Delve](https://github.com/go-delve/delve).
+
+They also expose a Go debug listener, configured with [`AUTHENTIK_LISTEN__DEBUG`](../../install-config/configuration/configuration.mdx#authentik_listen__debug).

--- a/website/docs/developer-docs/setup/full-dev-environment.mdx
+++ b/website/docs/developer-docs/setup/full-dev-environment.mdx
@@ -31,7 +31,7 @@ Before you begin, ensure you have the following tools installed. You can run the
 
 ### Understanding the architecture
 
-authentik is primarily a Django application running under gunicorn, proxied by a Go application that serves static files. Most functions and classes have type hints and docstrings. For better code navigation, we recommend installing a Python type-checking extension in your IDE.
+authentik is primarily a Django application running under gunicorn, proxied by a Rust application that serves static files. Most functions and classes have type hints and docstrings. For better code navigation, we recommend installing a Python type-checking extension in your IDE.
 
 ## 1. Prepare your local working repository
 


### PR DESCRIPTION
Found while auditing 2026.8 docs for staleness ahead of the release — see the [Slack thread](https://authentiksecurity.slack.com/archives/C08C0SJ4V6D/p1786634134866959).

### `debugging.md`

The page's second and final section was headed "authentik Server / Outposts (Golang)" and opened:

> Outposts, as well as some auxiliary code of the authentik server, are written in Go.

After 2026.8 the server and proxy outpost are Rust; LDAP, RADIUS, and RAC are still Go (their Dockerfiles still run `go build`). So the heading was wrong about the server, right about three of four outposts, and there was no Rust guidance at all — for what is now the whole front of the request path.

Split into a Rust section and a Go section. The Rust section covers:

- debugger tooling and how to run a single component (`cargo run -- server`, `cargo run -- proxy`)
- **tokio-console**, which is already wired up — `packages/ak-common/src/tracing.rs` starts a `console_subscriber::ConsoleLayer` when `listen.debug_tokio` is set. This was undocumented, and `debug_tokio` was commented out in `default.yml` during 2026.8, so it is off unless explicitly set.
- the per-crate `AUTHENTIK_LOG__RUST_LOG__*` levels, also undocumented

The Go section now also points at `AUTHENTIK_LISTEN__DEBUG`, which is the listener those outposts actually serve.

### `full-dev-environment.mdx`

> authentik is primarily a Django application running under gunicorn, proxied by a **Go** application that serves static files.

gunicorn is still accurate; the front proxy is not. `lifecycle/ak` routes `server`, `worker`, and `allinone` to the `authentik` Rust binary, implemented in `src/server/`. The page's own prerequisites list (line 22) already requires Rust, so it contradicted itself — and this is the first architectural sentence a new contributor reads.

Note: the `AUTHENTIK_LISTEN__DEBUG` scope correction referenced by the new Go section is in #25074.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
