### PR TITLE
website/docs: correct proxy unauthenticated path regex reference

### DIFF
--- a/website/docs/add-secure-apps/providers/proxy/index.md
+++ b/website/docs/add-secure-apps/providers/proxy/index.md
@@ -102,7 +102,9 @@ Logging out of a provider invalidates all sessions for that user within the resp
 
 To allow unauthenticated requests to specific paths or URLs, use the **Unauthenticated Paths** or **Unauthenticated URLs** field on the proxy provider.
 
-Each new line is interpreted as a regular expression and is compiled and checked using the standard Golang regex parser.
+Each new line is interpreted as a regular expression and is compiled and checked using the Rust [`regex`](https://docs.rs/regex/latest/regex/#syntax) crate.
+
+A pattern that fails to compile is skipped, and a warning is written to the outpost logs. The remaining patterns still apply, so a typo silently leaves a path authenticated rather than causing an error.
 
 The behavior of this field changes depending on the selected mode.
 


### PR DESCRIPTION
Found while auditing 2026.8 docs for staleness ahead of the release — see the [Slack thread](https://authentiksecurity.slack.com/archives/C08C0SJ4V6D/p1786634134866959).

The **Allow unauthenticated requests** section said patterns are "compiled and checked using the standard Golang regex parser".

The shipped proxy outpost is the Rust binary — `lifecycle/container/proxy.Dockerfile` builds `cargo build --package authentik --no-default-features --features proxy` — and patterns compile through the Rust `regex` crate:

```rust
// src/outpost/proxy/allowlist.rs
Regex::new(pattern)
    .inspect_err(|err| warn!(?err, pattern, "failed to compile skip_path_regex"))
    .ok()
```

Both are RE2-family and the syntax overlaps heavily, so existing patterns keep working — but the doc pointed readers at the wrong reference for any edge case. `cmd/proxy/` and `internal/outpost/proxyv2/` still exist in the tree but are not what gets built.

That snippet also shows undocumented behavior worth stating: a pattern that fails to compile is dropped with a warning and the rest still apply, so a typo silently leaves a path authenticated rather than surfacing an error.

### Not included

I had also flagged three links in `endpoint-devices/device-compliance/device-compliance-policy.md` as broken. **They are not** — Docusaurus resolves relative links against the URL route rather than the file path, so `../../` from `/endpoint-devices/device-compliance/device-compliance-policy/` correctly reaches `/endpoint-devices/`. Changing them to `../` broke the build. My link scanner resolved against the filesystem, which was the wrong model; the Docusaurus build is the authoritative check and it reports the tree as clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
