### PR TITLE
website/docs: match stage and property mapping labels to the UI

### DIFF
--- a/website/docs/add-secure-apps/flows-stages/stages/authenticator_webauthn/index.mdx
+++ b/website/docs/add-secure-apps/flows-stages/stages/authenticator_webauthn/index.mdx
@@ -22,7 +22,7 @@ Enrolled authenticators can later be used with the [Authenticator Validation sta
 - **Authenticator Attachment**: restrict enrollment to platform authenticators, cross-platform authenticators, or leave it unrestricted.
 - **Hints**: browser hints that influence which authenticator is preferred during enrollment.
 - **Device type restrictions**: limit enrollment to specific WebAuthn device types.
-- **Maximum attempts**: maximum number of failed registration attempts before the stage denies access. A value of `0` disables the limit.
+- **Maximum registration attempts**: maximum number of failed registration attempts before the stage denies access. A value of `0` disables the limit.
 - **Authenticator type name**: optional friendly name shown to the user in self-service settings.
 - **Configuration flow**: optional authenticated flow that lets users enroll this authenticator from user settings.
 

--- a/website/docs/add-secure-apps/flows-stages/stages/captcha/index.mdx
+++ b/website/docs/add-secure-apps/flows-stages/stages/captcha/index.mdx
@@ -19,8 +19,8 @@ It can either be bound to a flow or embedded inside the [Identification stage](.
 - **Score Minimum Threshold**: minimum accepted score for score-based providers.
 - **Score Maximum Threshold**: maximum accepted score for score-based providers.
 - **Error on Invalid Score**: show an error immediately when the score is outside the configured threshold. If disabled, the flow continues and policies can inspect the result from context.
-- **JS URL**: JavaScript loader URL for the provider.
-- **API URL**: verification endpoint URL for the provider.
+- **JavaScript URL**: JavaScript loader URL for the provider.
+- **API Verification URL**: verification endpoint URL for the provider.
 - **Request Content Type**: content type used when authentik verifies the CAPTCHA token with the provider.
 
 ## Flow integration
@@ -44,8 +44,8 @@ Recommended defaults for reCAPTCHA:
 - **Interactive**: disabled for score-based reCAPTCHA
 - **Score Minimum Threshold**: `0.5`
 - **Score Maximum Threshold**: `1.0`
-- **JS URL**: `https://www.recaptcha.net/recaptcha/api.js`
-- **API URL**: `https://www.recaptcha.net/recaptcha/api/siteverify`
+- **JavaScript URL**: `https://www.recaptcha.net/recaptcha/api.js`
+- **API Verification URL**: `https://www.recaptcha.net/recaptcha/api/siteverify`
 
 ![](./captcha-admin.png)
 
@@ -56,8 +56,8 @@ See https://docs.hcaptcha.com/switch.
 Recommended values:
 
 - **Interactive**: enabled
-- **JS URL**: `https://js.hcaptcha.com/1/api.js`
-- **API URL**: `https://api.hcaptcha.com/siteverify`
+- **JavaScript URL**: `https://js.hcaptcha.com/1/api.js`
+- **API Verification URL**: `https://api.hcaptcha.com/siteverify`
 
 Score thresholds only apply to hCaptcha Enterprise.
 
@@ -74,8 +74,8 @@ Recommended values:
 - **Public Key**: public Cap endpoint for the site key path, for example `https://cap.example.com/site-key/`
 - **Private Key**: Cap secret key
 - **Interactive**: enabled
-- **JS URL**: self-hosted Cap widget asset, for example `https://cap.example.com/assets/widget.js`. If you use a CDN, pin a reviewed release such as `https://cdn.jsdelivr.net/npm/cap-widget@<version>` instead of the unversioned package URL. See [Cap releases](https://github.com/tiagozip/cap/releases).
-- **API URL**: Cap verification endpoint, for example `https://cap.example.com/site-key/siteverify`
+- **JavaScript URL**: self-hosted Cap widget asset, for example `https://cap.example.com/assets/widget.js`. If you use a CDN, pin a reviewed release such as `https://cdn.jsdelivr.net/npm/cap-widget@<version>` instead of the unversioned package URL. See [Cap releases](https://github.com/tiagozip/cap/releases).
+- **API Verification URL**: Cap verification endpoint, for example `https://cap.example.com/site-key/siteverify`
 - **Request Content Type**: JSON
 
 Cap does not use score thresholds.
@@ -89,8 +89,8 @@ Recommended values:
 - **Public Key**: Turnstile site key
 - **Private Key**: Turnstile secret key
 - **Interactive**: enable when using invisible or managed Turnstile modes
-- **JS URL**: `https://challenges.cloudflare.com/turnstile/v0/api.js`
-- **API URL**: `https://challenges.cloudflare.com/turnstile/v0/siteverify`
+- **JavaScript URL**: `https://challenges.cloudflare.com/turnstile/v0/api.js`
+- **API Verification URL**: `https://challenges.cloudflare.com/turnstile/v0/siteverify`
 
 Turnstile does not use score thresholds.
 

--- a/website/docs/add-secure-apps/providers/saml/index.mdx
+++ b/website/docs/add-secure-apps/providers/saml/index.mdx
@@ -103,7 +103,7 @@ The following property mappings are automatically added when you create a new SA
 | authentik default SAML Mapping: Username                      | `http://schemas.goauthentik.io/2021/02/saml/username`                        |
 | authentik default SAML Mapping: WindowsAccountName (Username) | `http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname` |
 
-The default SAML property mappings can be viewed on the **Property Mappings** page of the admin interface by disabling the **Hide managed mappings** toggle.
+The default SAML property mappings can be viewed on the **Property Mappings** page of the Admin interface by setting the **Managed** filter to **All**.
 
 ### Custom SAML property mappings
 


### PR DESCRIPTION
Found while auditing 2026.8 docs for staleness ahead of the release — see the [Slack thread](https://authentiksecurity.slack.com/archives/C08C0SJ4V6D/p1786634134866959).

Unlike the other PRs in this batch, none of these are 2026.8 regressions — all three predate `version/2026.5.0`, verified by diffing the form files at both tags. They surfaced from the same sweep and are real, so they are fixed here rather than discarded.

### Captcha stage — **JS URL** and **API URL**

`CaptchaStageForm.ts` labels these **JavaScript URL** and **API Verification URL**. The docs used the short names in 10 places across 5 provider sections — the generic field list plus every per-provider recipe.

Worth noting for the release: the **Cap** provider section is new content added for 2026.8, and it copied the stale convention. Each release entrenches this further, which is why it is worth doing now.

### WebAuthn setup stage — **Maximum attempts**

The field is **Maximum registration attempts**.

### SAML provider — the **Hide managed mappings** toggle

> …can be viewed on the **Property Mappings** page of the admin interface by disabling the **Hide managed mappings** toggle.

There is no such toggle. `PropertyMappingListPage.ts` renders a filter select:

```ts
.options=${[
    { label: msg("Hide managed"), value: true },
    { label: msg("All"), value: false },
]}
group=${msg("Managed")}
```

The reader has to set the **Managed** filter to **All**, so the instruction as written could not be followed. Also capitalizes "Admin interface" per the style guide.

### Not included: the wider casing audit

Matching every bolded `**Label**` in the docs against `msg()` strings in `web/src` turns up 86 distinct case-only mismatches across 151 occurrences — and they run in **both** directions (25 pairs where the docs are more capitalized than the UI, 60 where they are less). That points at inconsistency in the product rather than drift in the docs: the captcha form alone has `Public Key` and `Score Minimum Threshold` next to `Interactive` and `Provider Type`.

The style guide requires bolding UI elements but says nothing about reproducing their case, so there is no rule to fix them against. That needs a ruling before it is worth 151 edits, so it is deliberately out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
