### PR TITLE
website/docs: document ForceAuthn and typed AKQL JSON values

### DIFF
--- a/website/docs/add-secure-apps/providers/saml/index.mdx
+++ b/website/docs/add-secure-apps/providers/saml/index.mdx
@@ -153,6 +153,14 @@ In authentik, it's also possible to configure the default SAML NameID policy use
 By default, users are free to change their email addresses. Therefore, it is recommended to either: avoid using a user's email address as the NameID attribute or, if possible, disallow changing email addresses.
 :::
 
+## ForceAuthn:ak-version[2026.8]
+
+An SP can set the `ForceAuthn` attribute on its `AuthnRequest` to require that the user authenticates again, even when they already have a valid authentik session.
+
+authentik honors this attribute. When an incoming `AuthnRequest` sets `ForceAuthn="true"`, the user is sent through the provider's authentication flow before the SSO flow continues. If the provider does not have an authentication flow configured, authentik uses the authentication flow configured for the associated brand. This behaves similarly to `prompt=login` for OAuth 2.0 and OpenID Connect providers. Once the user has re-authenticated, the SSO flow proceeds normally.
+
+This requires no configuration on the provider, and it applies to any SP that sets the attribute. If users of an existing application are prompted to sign in again more often after upgrading to 2026.8, check whether that SP sets `ForceAuthn`.
+
 ## AuthnContextClassRef
 
 The AuthnContextClassRef attribute appears in the SAML assertion and contains a URI that describes the assurance level, such as password, multi-factor, or smartcard authentication. SPs use this information to understand and verify how the user was authenticated by an IdP.

--- a/website/docs/sys-mgmt/akql.mdx
+++ b/website/docs/sys-mgmt/akql.mdx
@@ -165,6 +165,18 @@ attributes.department = "engineering"
 context.geo.country = "Germany"
 ```
 
+Values inside JSON fields can be strings, Booleans, or numbers:ak-version[2026.8], so a numeric attribute is matched by its value rather than its text form.
+
+**Examples**:
+
+```text
+attributes.seat_count > 5
+```
+
+```text
+attributes.onboarded = True
+```
+
 For related objects and JSON objects, query a nested value such as `user.username`, `brand.name`, or `context.http_request.path`. A comparison against the root object, such as `user = "bob"`, is not valid AKQL.
 
 Autocomplete suggests a known subset of nested paths. You can still query other JSON key paths that exist in the stored data.


### PR DESCRIPTION
Found while auditing 2026.8 docs for staleness ahead of the release — see the [Slack thread](https://authentiksecurity.slack.com/archives/C08C0SJ4V6D/p1786634134866959).

Two 2026.8 behavior changes appear only in the release notes and nowhere in the docs.

### SAML `ForceAuthn`

`authentik/providers/saml/views/sso.py` now re-authenticates when the SP requests it:

```python
# If the SP requested ForceAuthn, we must re-authenticate the user regardless of
# any existing session, mirroring the OIDC provider's prompt=login handling.
if auth_n_request and auth_n_request.force_authn:
    reauth_response = self.check_force_authn(request)
```

`ForceAuthn` appeared nowhere in `website/docs/` outside the release notes. This matters more than a typical new feature: it needs no configuration, applies to any SP that sets the attribute, and changes login behavior for existing applications the moment an instance is upgraded. The new section says so explicitly, so anyone investigating "users are being asked to sign in more often since 2026.8" lands on the answer.

### AKQL typed JSON values

#24028 gave `JSONSearchField` `value_types = [str, bool, int, float, Decimal]`, so JSON fields now match Booleans and numbers rather than only strings. The **JSON and nested fields** section showed only string comparisons, so nothing was wrong — it just did not say the capability exists. Adds a note and two examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
