### PR TITLE
core: delete all user sessions when user is deactivated

### DIFF
--- a/authentik/core/api/users.py
+++ b/authentik/core/api/users.py
@@ -84,7 +84,6 @@ from authentik.core.models import (
     USER_PATH_SERVICE_ACCOUNT,
     USERNAME_MAX_LENGTH,
     Group,
-    Session,
     Token,
     TokenIntents,
     User,
@@ -1117,11 +1116,3 @@ class UserViewSet(
                 )
             }
         )
-
-    def partial_update(self, request: Request, *args, **kwargs) -> Response:
-        response = super().partial_update(request, *args, **kwargs)
-        instance: User = self.get_object()
-        if not instance.is_active:
-            Session.objects.filter(authenticatedsession__user=instance).delete()
-            LOGGER.debug("Deleted user's sessions", user=instance.username)
-        return response

--- a/authentik/core/signals.py
+++ b/authentik/core/signals.py
@@ -1,5 +1,8 @@
 """authentik core signals"""
 
+from contextlib import contextmanager
+from contextvars import ContextVar
+
 from channels.layers import get_channel_layer
 from django.contrib.auth.signals import user_logged_in
 from django.core.cache import cache
@@ -33,6 +36,25 @@ admin_authenticated_session_deleted = Signal()
 
 LOGGER = get_logger()
 
+_CTX_INHIBIT_DEACTIVATION_SESSION_DELETE = ContextVar[bool](
+    "authentik_core_inhibit_deactivation_session_delete",
+    default=False,
+)
+
+
+@contextmanager
+def deactivation_inhibit_session_delete():
+    """
+    Prevent user_deactivated_delete_sessions from deleting sessions when a
+    deactivated user is saved, for callers that revoke sessions themselves
+    (e.g. enterprise revocation).
+    """
+    token = _CTX_INHIBIT_DEACTIVATION_SESSION_DELETE.set(True)
+    try:
+        yield
+    finally:
+        _CTX_INHIBIT_DEACTIVATION_SESSION_DELETE.reset(token)
+
 
 @receiver(post_save, sender=Application)
 def post_save_application(sender: type[Model], instance, created: bool, **_):
@@ -62,6 +84,17 @@ def user_logged_in_session(sender, request: HttpRequest, user: User, **_):
             build_device_group(device_cookie),
             {"type": "event.session.authenticated"},
         )
+
+
+@receiver(post_save, sender=User)
+def user_deactivated_delete_sessions(sender: type[Model], instance: User, **_):
+    """Delete all of a user's sessions when they are deactivated"""
+    if instance.is_active:
+        return
+    if _CTX_INHIBIT_DEACTIVATION_SESSION_DELETE.get():
+        return
+    Session.objects.filter(authenticatedsession__user=instance).delete()
+    LOGGER.debug("Deleted deactivated user's sessions", user=instance.username)
 
 
 @receiver(post_delete, sender=AuthenticatedSession)

--- a/authentik/core/signals.py
+++ b/authentik/core/signals.py
@@ -36,24 +36,46 @@ admin_authenticated_session_deleted = Signal()
 
 LOGGER = get_logger()
 
-_CTX_INHIBIT_DEACTIVATION_SESSION_DELETE = ContextVar[bool](
-    "authentik_core_inhibit_deactivation_session_delete",
+_CTX_INHIBIT_DEACTIVATION_SESSION_CLEANUP = ContextVar[bool](
+    "authentik_core_inhibit_deactivation_session_cleanup",
+    default=False,
+)
+_CTX_INHIBIT_DEACTIVATION_TOKEN_CLEANUP = ContextVar[bool](
+    "authentik_core_inhibit_deactivation_token_cleanup",
     default=False,
 )
 
 
 @contextmanager
-def deactivation_inhibit_session_delete():
+def deactivation_inhibit_cleanup(*, sessions: bool = True, tokens: bool = True):
     """
-    Prevent user_deactivated_delete_sessions from deleting sessions when a
-    deactivated user is saved, for callers that revoke sessions themselves
-    (e.g. enterprise revocation).
+    Prevent the automatic cleanup that runs when a deactivated user is saved,
+    for callers that revoke sessions and/or tokens themselves (e.g. enterprise
+    revocation). `sessions` inhibits session deletion, `tokens` inhibits
+    provider token revocation; both are inhibited by default. Nested uses can
+    add inhibition but not remove the outer context's.
     """
-    token = _CTX_INHIBIT_DEACTIVATION_SESSION_DELETE.set(True)
+    reset_sessions = _CTX_INHIBIT_DEACTIVATION_SESSION_CLEANUP.set(
+        _CTX_INHIBIT_DEACTIVATION_SESSION_CLEANUP.get() or sessions
+    )
+    reset_tokens = _CTX_INHIBIT_DEACTIVATION_TOKEN_CLEANUP.set(
+        _CTX_INHIBIT_DEACTIVATION_TOKEN_CLEANUP.get() or tokens
+    )
     try:
         yield
     finally:
-        _CTX_INHIBIT_DEACTIVATION_SESSION_DELETE.reset(token)
+        _CTX_INHIBIT_DEACTIVATION_SESSION_CLEANUP.reset(reset_sessions)
+        _CTX_INHIBIT_DEACTIVATION_TOKEN_CLEANUP.reset(reset_tokens)
+
+
+def deactivation_session_cleanup_inhibited() -> bool:
+    """Whether deactivation session cleanup is inhibited in the current context"""
+    return _CTX_INHIBIT_DEACTIVATION_SESSION_CLEANUP.get()
+
+
+def deactivation_token_cleanup_inhibited() -> bool:
+    """Whether deactivation token cleanup is inhibited in the current context"""
+    return _CTX_INHIBIT_DEACTIVATION_TOKEN_CLEANUP.get()
 
 
 @receiver(post_save, sender=Application)
@@ -91,7 +113,7 @@ def user_deactivated_delete_sessions(sender: type[Model], instance: User, **_):
     """Delete all of a user's sessions when they are deactivated"""
     if instance.is_active:
         return
-    if _CTX_INHIBIT_DEACTIVATION_SESSION_DELETE.get():
+    if deactivation_session_cleanup_inhibited():
         return
     Session.objects.filter(authenticatedsession__user=instance).delete()
     LOGGER.debug("Deleted deactivated user's sessions", user=instance.username)

--- a/authentik/core/tests/test_signals.py
+++ b/authentik/core/tests/test_signals.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 
 from authentik.blueprints.v1.importer import Importer
 from authentik.core.models import AuthenticatedSession, Session, User
-from authentik.core.signals import deactivation_inhibit_session_delete
+from authentik.core.signals import deactivation_inhibit_cleanup
 from authentik.core.tests.utils import create_test_session, create_test_user
 from authentik.lib.generators import generate_id
 
@@ -43,18 +43,29 @@ class TestUserDeactivatedSignal(TestCase):
         self.assertFalse(AuthenticatedSession.objects.filter(user=user).exists())
 
     def test_deactivate_inhibited(self):
-        """deactivation_inhibit_session_delete leaves the user's sessions alone"""
+        """deactivation_inhibit_cleanup leaves the user's sessions alone"""
         user = create_test_user()
         session = create_test_session(user)
 
         user.is_active = False
-        with deactivation_inhibit_session_delete():
+        with deactivation_inhibit_cleanup():
             user.save()
 
         self.assertFalse(user.is_active)
         self.assertTrue(Session.objects.filter(session_key=session.session.session_key).exists())
         # Once the context manager exits, deactivating saves delete sessions again
         user.save()
+        self.assertFalse(Session.objects.filter(session_key=session.session.session_key).exists())
+
+    def test_deactivate_inhibit_tokens_only(self):
+        """Inhibiting only token cleanup still deletes sessions"""
+        user = create_test_user()
+        session = create_test_session(user)
+
+        user.is_active = False
+        with deactivation_inhibit_cleanup(sessions=False, tokens=True):
+            user.save()
+
         self.assertFalse(Session.objects.filter(session_key=session.session.session_key).exists())
 
     def test_deactivate_via_blueprint(self):

--- a/authentik/core/tests/test_signals.py
+++ b/authentik/core/tests/test_signals.py
@@ -1,0 +1,80 @@
+"""Test core signals"""
+
+from django.test import TestCase
+
+from authentik.blueprints.v1.importer import Importer
+from authentik.core.models import AuthenticatedSession, Session, User
+from authentik.core.signals import deactivation_inhibit_session_delete
+from authentik.core.tests.utils import create_test_session, create_test_user
+from authentik.lib.generators import generate_id
+
+
+class TestUserDeactivatedSignal(TestCase):
+    """Test that deactivating a user always deletes their sessions"""
+
+    def test_deactivate_deletes_sessions(self):
+        """Saving a deactivated user deletes all their sessions"""
+        user = create_test_user()
+        sessions = [create_test_session(user) for _ in range(3)]
+        other_user = create_test_user()
+        other_session = create_test_session(other_user)
+        self.assertEqual(AuthenticatedSession.objects.filter(user=user).count(), 3)
+
+        user.is_active = False
+        user.save()
+
+        for session in sessions:
+            self.assertFalse(
+                Session.objects.filter(session_key=session.session.session_key).exists()
+            )
+        self.assertFalse(AuthenticatedSession.objects.filter(user=user).exists())
+        # Other users' sessions are untouched
+        self.assertTrue(
+            Session.objects.filter(session_key=other_session.session.session_key).exists()
+        )
+
+    def test_create_inactive_user(self):
+        """A user can be created as inactive and saved again without errors"""
+        user = User.objects.create(username=generate_id(), name=generate_id(), is_active=False)
+        user.name = generate_id()
+        user.save()
+        user.save(update_fields=["name"])
+        self.assertFalse(user.is_active)
+        self.assertFalse(AuthenticatedSession.objects.filter(user=user).exists())
+
+    def test_deactivate_inhibited(self):
+        """deactivation_inhibit_session_delete leaves the user's sessions alone"""
+        user = create_test_user()
+        session = create_test_session(user)
+
+        user.is_active = False
+        with deactivation_inhibit_session_delete():
+            user.save()
+
+        self.assertFalse(user.is_active)
+        self.assertTrue(Session.objects.filter(session_key=session.session.session_key).exists())
+        # Once the context manager exits, deactivating saves delete sessions again
+        user.save()
+        self.assertFalse(Session.objects.filter(session_key=session.session.session_key).exists())
+
+    def test_deactivate_via_blueprint(self):
+        """Deactivating a user via blueprint deletes their sessions"""
+        user = create_test_user()
+        session = create_test_session(user)
+
+        importer = Importer.from_string(f"""version: 1
+entries:
+  - model: authentik_core.user
+    state: present
+    identifiers:
+      username: {user.username}
+    attrs:
+      name: {user.name}
+      is_active: false
+""")
+        self.assertTrue(importer.validate()[0])
+        self.assertTrue(importer.apply())
+
+        user.refresh_from_db()
+        self.assertFalse(user.is_active)
+        self.assertFalse(Session.objects.filter(session_key=session.session.session_key).exists())

--- a/authentik/core/tests/test_users_api.py
+++ b/authentik/core/tests/test_users_api.py
@@ -22,6 +22,7 @@ from authentik.core.tests.utils import (
     create_test_admin_user,
     create_test_brand,
     create_test_flow,
+    create_test_session,
     create_test_user,
 )
 from authentik.flows.models import FlowAuthenticationRequirement, FlowDesignation
@@ -531,6 +532,28 @@ class TestUsersAPI(APITestCase):
         response = self.client.patch(
             reverse("authentik_api:user-detail", kwargs={"pk": user.pk}),
             data={
+                "is_active": False,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+
+        self.assertFalse(Session.objects.filter(session_key=session_id).exists())
+        self.assertFalse(
+            AuthenticatedSession.objects.filter(session__session_key=session_id).exists()
+        )
+
+    def test_session_delete_put(self):
+        """Ensure sessions are deleted when a user is deactivated via PUT"""
+        user = create_test_admin_user()
+        session = create_test_session(user)
+        session_id = session.session.session_key
+
+        self.client.force_login(self.admin)
+        response = self.client.put(
+            reverse("authentik_api:user-detail", kwargs={"pk": user.pk}),
+            data={
+                "username": user.username,
+                "name": user.name,
                 "is_active": False,
             },
         )

--- a/authentik/enterprise/lifecycle/offboarding/actions.py
+++ b/authentik/enterprise/lifecycle/offboarding/actions.py
@@ -10,6 +10,7 @@ from django.utils.translation import gettext as _
 from structlog.stdlib import get_logger
 
 from authentik.core.models import User
+from authentik.core.signals import deactivation_inhibit_session_delete
 from authentik.enterprise.core.revocation import revoke_user_access
 from authentik.enterprise.lifecycle.offboarding.models import OffboardingAction
 from authentik.events.models import Event, EventAction
@@ -57,7 +58,8 @@ def offboard_user(
 
     if action == OffboardingAction.DEACTIVATE:
         user.is_active = False
-        user.save(update_fields=["is_active"])
+        with deactivation_inhibit_session_delete():
+            user.save(update_fields=["is_active"])
     elif action == OffboardingAction.DELETE:
         user.delete()
     else:

--- a/authentik/enterprise/lifecycle/offboarding/actions.py
+++ b/authentik/enterprise/lifecycle/offboarding/actions.py
@@ -10,7 +10,7 @@ from django.utils.translation import gettext as _
 from structlog.stdlib import get_logger
 
 from authentik.core.models import User
-from authentik.core.signals import deactivation_inhibit_session_delete
+from authentik.core.signals import deactivation_inhibit_cleanup
 from authentik.enterprise.core.revocation import revoke_user_access
 from authentik.enterprise.lifecycle.offboarding.models import OffboardingAction
 from authentik.events.models import Event, EventAction
@@ -58,7 +58,7 @@ def offboard_user(
 
     if action == OffboardingAction.DEACTIVATE:
         user.is_active = False
-        with deactivation_inhibit_session_delete():
+        with deactivation_inhibit_cleanup(sessions=not revoke_sessions, tokens=not revoke_tokens):
             user.save(update_fields=["is_active"])
     elif action == OffboardingAction.DELETE:
         user.delete()

--- a/authentik/enterprise/stages/account_lockdown/stage.py
+++ b/authentik/enterprise/stages/account_lockdown/stage.py
@@ -11,7 +11,7 @@ from dramatiq.composition import group
 from dramatiq.results.errors import ResultTimeout
 
 from authentik.core.models import User, UserTypes
-from authentik.core.signals import deactivation_inhibit_session_delete
+from authentik.core.signals import deactivation_inhibit_cleanup
 from authentik.enterprise.core.revocation import revoke_user_access
 from authentik.enterprise.stages.account_lockdown.models import AccountLockdownStage
 from authentik.events.models import Event, EventAction
@@ -90,7 +90,12 @@ class AccountLockdownStageView(StageView):
         if stage.set_unusable_password:
             user.set_unusable_password()
         if stage.deactivate_user:
-            with sync_outgoing_inhibit_dispatch(), deactivation_inhibit_session_delete():
+            with (
+                sync_outgoing_inhibit_dispatch(),
+                deactivation_inhibit_cleanup(
+                    sessions=not stage.delete_sessions, tokens=not stage.revoke_tokens
+                ),
+            ):
                 user.save()
             return
         user.save()

--- a/authentik/enterprise/stages/account_lockdown/stage.py
+++ b/authentik/enterprise/stages/account_lockdown/stage.py
@@ -11,6 +11,7 @@ from dramatiq.composition import group
 from dramatiq.results.errors import ResultTimeout
 
 from authentik.core.models import User, UserTypes
+from authentik.core.signals import deactivation_inhibit_session_delete
 from authentik.enterprise.core.revocation import revoke_user_access
 from authentik.enterprise.stages.account_lockdown.models import AccountLockdownStage
 from authentik.events.models import Event, EventAction
@@ -89,7 +90,7 @@ class AccountLockdownStageView(StageView):
         if stage.set_unusable_password:
             user.set_unusable_password()
         if stage.deactivate_user:
-            with sync_outgoing_inhibit_dispatch():
+            with sync_outgoing_inhibit_dispatch(), deactivation_inhibit_session_delete():
                 user.save()
             return
         user.save()

--- a/authentik/providers/oauth2/signals.py
+++ b/authentik/providers/oauth2/signals.py
@@ -8,6 +8,7 @@ from authentik.common.oauth.constants import (
     PLAN_CONTEXT_OIDC_LOGOUT_IFRAME_SESSIONS,
 )
 from authentik.core.models import AuthenticatedSession, ProviderPropertyMapping, User
+from authentik.core.signals import deactivation_token_cleanup_inhibited
 from authentik.flows.models import in_memory_stage
 from authentik.providers.iframe_logout import IframeLogoutStageView
 from authentik.providers.oauth2.models import (
@@ -121,6 +122,8 @@ def user_session_deleted_oauth_backchannel_logout_and_tokens_removal(
 def user_deactivated(sender, instance: User, **_):
     """Remove user tokens when deactivated"""
     if instance.is_active:
+        return
+    if deactivation_token_cleanup_inhibited():
         return
     AccessToken.objects.including_expired().filter(user=instance).delete()
     RefreshToken.objects.including_expired().filter(user=instance).delete()

--- a/authentik/providers/oauth2/tests/test_revoke.py
+++ b/authentik/providers/oauth2/tests/test_revoke.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from authentik.core.models import Application, AuthenticatedSession, Session
+from authentik.core.signals import deactivation_inhibit_cleanup
 from authentik.core.tests.utils import create_test_admin_user, create_test_cert, create_test_flow
 from authentik.lib.generators import generate_id
 from authentik.providers.oauth2.id_token import IDToken
@@ -232,6 +233,67 @@ class TesOAuth2Revoke(OAuthTestCase):
         self.assertEqual(AccessToken.objects.including_expired().all().count(), 0)
         self.assertEqual(RefreshToken.objects.including_expired().all().count(), 0)
         self.assertEqual(DeviceToken.objects.including_expired().all().count(), 0)
+
+    def test_revoke_user_deactivated_inhibited(self):
+        """Test tokens are kept when deactivation cleanup is inhibited"""
+        AccessToken.objects.create(
+            provider=self.provider,
+            user=self.user,
+            token=generate_id(),
+            auth_time=timezone.now(),
+            _scope="openid user profile",
+            _id_token=json.dumps(
+                asdict(
+                    IDToken("foo", "bar"),
+                )
+            ),
+        )
+        RefreshToken.objects.create(
+            provider=self.provider,
+            user=self.user,
+            token=generate_id(),
+            auth_time=timezone.now(),
+            _scope="openid user profile",
+            _id_token=json.dumps(
+                asdict(
+                    IDToken("foo", "bar"),
+                )
+            ),
+        )
+        DeviceToken.objects.create(
+            provider=self.provider,
+            user=self.user,
+            _scope="openid user profile",
+        )
+
+        self.user.is_active = False
+        with deactivation_inhibit_cleanup():
+            self.user.save()
+
+        self.assertEqual(AccessToken.objects.including_expired().all().count(), 1)
+        self.assertEqual(RefreshToken.objects.including_expired().all().count(), 1)
+        self.assertEqual(DeviceToken.objects.including_expired().all().count(), 1)
+
+    def test_revoke_user_deactivated_inhibit_sessions_only(self):
+        """Test tokens are still revoked when only session cleanup is inhibited"""
+        AccessToken.objects.create(
+            provider=self.provider,
+            user=self.user,
+            token=generate_id(),
+            auth_time=timezone.now(),
+            _scope="openid user profile",
+            _id_token=json.dumps(
+                asdict(
+                    IDToken("foo", "bar"),
+                )
+            ),
+        )
+
+        self.user.is_active = False
+        with deactivation_inhibit_cleanup(sessions=True, tokens=False):
+            self.user.save()
+
+        self.assertEqual(AccessToken.objects.including_expired().all().count(), 0)
 
     def test_revoke_provider_fed(self):
         """Test revoke with federation. self.provider is a confidential

--- a/authentik/sources/kerberos/tests/test_sync.py
+++ b/authentik/sources/kerberos/tests/test_sync.py
@@ -1,7 +1,8 @@
 """Kerberos Source sync tests"""
 
 from authentik.blueprints.tests import apply_blueprint
-from authentik.core.models import User
+from authentik.core.models import Session, User
+from authentik.core.tests.utils import create_test_session
 from authentik.lib.generators import generate_id
 from authentik.sources.kerberos.models import KerberosSource, KerberosSourcePropertyMapping
 from authentik.sources.kerberos.sync import KerberosSync
@@ -40,6 +41,21 @@ class TestKerberosSync(KerberosTestCase):
         self.assertFalse(
             User.objects.filter(username=self.realm.nfs_princ.rsplit("@", 1)[0]).exists()
         )
+
+    def test_sync_deactivate_expired_principal(self):
+        """Test that a user whose principal expired is deactivated and their sessions deleted"""
+        KerberosSync(self.source, Task()).sync()
+
+        user = User.objects.get(username=self.realm.user_princ.rsplit("@", 1)[0])
+        self.assertTrue(user.is_active)
+        session = create_test_session(user)
+
+        self.realm.run_kadminl(f'modprinc -expire "yesterday" {self.realm.user_princ}')
+        KerberosSync(self.source, Task()).sync()
+
+        user.refresh_from_db()
+        self.assertFalse(user.is_active)
+        self.assertFalse(Session.objects.filter(session_key=session.session.session_key).exists())
 
     def test_sync_mapping(self):
         """Test property mappings"""

--- a/authentik/sources/ldap/tests/test_sync.py
+++ b/authentik/sources/ldap/tests/test_sync.py
@@ -8,8 +8,8 @@ from ldap3.core.exceptions import LDAPInvalidFilterError
 from ldap3.utils.conv import escape_filter_chars
 
 from authentik.blueprints.tests import apply_blueprint
-from authentik.core.models import Group, User
-from authentik.core.tests.utils import create_test_admin_user
+from authentik.core.models import Group, Session, User
+from authentik.core.tests.utils import create_test_admin_user, create_test_session
 from authentik.events.models import Event, EventAction
 from authentik.lib.generators import generate_id, generate_key
 from authentik.lib.sync.outgoing.exceptions import StopSync
@@ -252,6 +252,32 @@ class LDAPSyncTests(TestCase):
             self.assertTrue(User.objects.filter(username="user0_sn").exists())
             self.assertFalse(User.objects.filter(username="user1_sn").exists())
             self.assertFalse(User.objects.get(username="user-nsaccountlock").is_active)
+
+    def test_sync_users_freeipa_deactivate_deletes_sessions(self):
+        """Test that a user deactivated by sync (nsaccountlock) has their sessions deleted"""
+        self.source.object_uniqueness_field = "uid"
+        self.source.user_property_mappings.set(
+            LDAPSourcePropertyMapping.objects.filter(
+                Q(managed__startswith="goauthentik.io/sources/ldap/default")
+                | Q(managed__startswith="goauthentik.io/sources/ldap/openldap")
+            )
+        )
+        user = User.objects.create(username="user-nsaccountlock", is_active=True)
+        UserLDAPSourceConnection.objects.create(
+            user=user,
+            source=self.source,
+            identifier="user-nsaccountlock",
+        )
+        session = create_test_session(user)
+        connection = MagicMock(return_value=mock_freeipa_connection(LDAP_PASSWORD))
+        with patch("authentik.sources.ldap.models.LDAPSource.connection", connection):
+            user_sync = UserLDAPSynchronizer(self.source, Task())
+            user_sync.sync_full()
+            user.refresh_from_db()
+            self.assertFalse(user.is_active)
+            self.assertFalse(
+                Session.objects.filter(session_key=session.session.session_key).exists()
+            )
 
     def test_sync_groups_freeipa_memberOf(self):
         """Test group sync when membership is derived from memberOf user attribute"""

--- a/authentik/sources/scim/tests/test_users.py
+++ b/authentik/sources/scim/tests/test_users.py
@@ -6,7 +6,8 @@ from uuid import uuid4
 from django.urls import reverse
 from rest_framework.test import APITestCase
 
-from authentik.core.tests.utils import create_test_user
+from authentik.core.models import Session
+from authentik.core.tests.utils import create_test_session, create_test_user
 from authentik.events.models import Event, EventAction
 from authentik.lib.generators import generate_id
 from authentik.providers.scim.clients.schema import User as SCIMUserSchema
@@ -213,6 +214,40 @@ class TestSCIMUsers(APITestCase):
             HTTP_AUTHORIZATION=f"Bearer {self.source.token.key}",
         )
         self.assertEqual(response.status_code, 200)
+
+    def test_user_update_deactivate(self):
+        """Test user deactivated via update deletes their sessions"""
+        user = create_test_user()
+        session = create_test_session(user)
+        existing = SCIMSourceUser.objects.create(source=self.source, user=user, external_id=uuid4())
+        response = self.client.put(
+            reverse(
+                "authentik_sources_scim:v2-users",
+                kwargs={
+                    "source_slug": self.source.slug,
+                    "user_id": str(user.uuid),
+                },
+            ),
+            data=dumps(
+                {
+                    "id": str(existing.pk),
+                    "userName": user.username,
+                    "active": False,
+                    "emails": [
+                        {
+                            "primary": True,
+                            "value": user.email,
+                        }
+                    ],
+                }
+            ),
+            content_type=SCIM_CONTENT_TYPE,
+            HTTP_AUTHORIZATION=f"Bearer {self.source.token.key}",
+        )
+        self.assertEqual(response.status_code, 200)
+        user.refresh_from_db()
+        self.assertFalse(user.is_active)
+        self.assertFalse(Session.objects.filter(session_key=session.session.session_key).exists())
 
     def test_user_update_patch(self):
         """Test user update (patch)"""


### PR DESCRIPTION
<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?

This pr changes deleting user sessions when a user is deactivated to a signal. This guarantees it catches all ways a user can be set to is_active = false.

### Why is this change needed?

The previous way required specifically hitting the api to set is_active = false to delete their sessions. Otherwise, we had to rely on fallbacks to clear it, and certain things like scim syncs or blueprints would sidestep immediately deleting the sessions

### How was this tested?

create a user, log them in, import a blueprint that set them to is_active = false, verify that the session still existed in the database.

### Linked issues

closes #25081

By fixing the deactivation and handling it in the core signal, we actually fix our OIDC backchannel logout bug

closes #20420

<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
