### PR TITLE
events: fix "Apps with most usage" splitting when an application is renamed

### DIFF
--- a/authentik/events/api/events.py
+++ b/authentik/events/api/events.py
@@ -4,7 +4,8 @@ from collections import OrderedDict
 from datetime import timedelta
 
 import django_filters
-from django.db.models import Count, ExpressionWrapper, F, QuerySet
+from django.contrib.postgres.aggregates import ArrayAgg
+from django.db.models import Count, ExpressionWrapper, F, Func, JSONField, QuerySet
 from django.db.models import DateTimeField as DjangoDateTimeField
 from django.db.models.fields.json import KeyTextTransform, KeyTransform
 from django.db.models.functions import TruncHour
@@ -37,6 +38,12 @@ from authentik.lib.utils.reflection import ConditionalInheritance
 from authentik.lib.utils.time import timedelta_from_string, timedelta_string_validator
 
 AGGR_MAX_AGE = timedelta(days=90)
+
+
+class ArrayFirst(Func):
+    """Get the first element of an array expression"""
+
+    template = "(%(expressions)s)[1]"
 
 
 class EventVolumeSerializer(PassiveSerializer):
@@ -238,14 +245,24 @@ class EventViewSet(
     def top_per_user(self, request: Request, query: TopPerUserSerializer):
         """Get the top_n events grouped by user count"""
         top_n = query.validated_data.get("top_n")
+        application = KeyTransform("authorized_application", "context")
         events = (
             self.filter_queryset(self.get_queryset())
             .exclude(context__authorized_application=None)
-            .annotate(application=KeyTransform("authorized_application", "context"))
+            .annotate(application_pk=KeyTextTransform("pk", application))
             .annotate(user_pk=KeyTextTransform("pk", "user"))
-            .values("application")
-            .annotate(counted_events=Count("application"))
+            # Group by the application's primary key and not the serialized application
+            # itself, as otherwise renaming an application splits its usage in two
+            .values("application_pk")
+            .annotate(counted_events=Count("pk"))
             .annotate(unique_users=Count("user_pk", distinct=True))
+            # The application is only stored as it was serialized when the event was
+            # created, so use the details of the most recent event of each application
+            .annotate(
+                application=ArrayFirst(
+                    ArrayAgg(application, order_by="-created"), output_field=JSONField()
+                )
+            )
             .values("unique_users", "application", "counted_events")
             .order_by("-counted_events")[:top_n]
         )

--- a/authentik/events/tests/test_api.py
+++ b/authentik/events/tests/test_api.py
@@ -9,6 +9,7 @@ from django.utils.http import urlencode
 from django.utils.timezone import now
 from rest_framework.test import APITestCase
 
+from authentik.core.models import Application
 from authentik.core.tests.utils import create_test_admin_user, create_test_user
 from authentik.events.models import (
     Event,
@@ -17,7 +18,7 @@ from authentik.events.models import (
     NotificationSeverity,
     TransportMode,
 )
-from authentik.events.utils import model_to_dict
+from authentik.events.utils import model_to_dict, sanitize_dict
 from authentik.lib.generators import generate_id
 from authentik.providers.oauth2.models import OAuth2Provider
 
@@ -102,6 +103,34 @@ class TestEventsAPI(APITestCase):
         self.assertJSONEqual(
             response.content,
             [{"application": {"name": "foo"}, "counted_events": 1, "unique_users": 0}],
+        )
+
+    def test_top_n_renamed_application(self):
+        """Test top_per_user with an application that has been renamed"""
+        uid = generate_id()
+        application = Application.objects.create(name=uid, slug=uid)
+        Event.new(EventAction.AUTHORIZE_APPLICATION, authorized_application=application).set_user(
+            self.user
+        ).save()
+        application.name = generate_id()
+        application.save()
+        Event.new(EventAction.AUTHORIZE_APPLICATION, authorized_application=application).set_user(
+            self.user
+        ).save()
+        response = self.client.get(
+            reverse("authentik_api:event-top-per-user"),
+            data={"action": EventAction.AUTHORIZE_APPLICATION},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertJSONEqual(
+            response.content,
+            [
+                {
+                    "application": sanitize_dict(model_to_dict(application)),
+                    "counted_events": 2,
+                    "unique_users": 1,
+                }
+            ],
         )
 
     def test_actions(self):


### PR DESCRIPTION
The "Apps with most usage" list grouped events by the whole serialized application stored in the event context. That blob includes the name, so renaming an app started a new group and split its usage across two rows.

This groups by the application pk from the context instead. The context only holds the app as it looked when the event was written, so the details in the response come from the newest event per pk, via ArrayAgg ordered by created and a small ArrayFirst Func to take the first element. The row then keeps its count and shows the current name. ArrayAgg is Postgres only.

Test is in authentik/events/tests/test_api.py: record an event, rename the app, record another, check the endpoint returns one row with counted_events=2 and the new name. It fails on main with two rows. I could not run the suite locally, so please check CI.

Closes #21782

Closes #25278