### PR TITLE
providers/oauth2: honor RBAC for token APIs

### DIFF
--- a/authentik/providers/oauth2/api/tokens.py
+++ b/authentik/providers/oauth2/api/tokens.py
@@ -3,7 +3,6 @@
 from json import dumps
 
 from django_filters.rest_framework import DjangoFilterBackend
-from guardian.shortcuts import get_anonymous_user
 from rest_framework import mixins
 from rest_framework.fields import CharField, ListField, SerializerMethodField
 from rest_framework.filters import OrderingFilter, SearchFilter
@@ -14,6 +13,7 @@ from authentik.core.api.used_by import UsedByMixin
 from authentik.core.api.users import UserSerializer
 from authentik.core.api.utils import MetaNameSerializer, ModelSerializer
 from authentik.providers.oauth2.models import AccessToken, AuthorizationCode, RefreshToken
+from authentik.rbac.filters import ObjectFilter
 
 
 class ExpiringBaseGrantModelSerializer(ModelSerializer, MetaNameSerializer):
@@ -67,16 +67,11 @@ class AuthorizationCodeViewSet(
     filterset_fields = ["user", "provider"]
     ordering = ["provider", "expires"]
     filter_backends = [
+        ObjectFilter,
         DjangoFilterBackend,
         OrderingFilter,
         SearchFilter,
     ]
-
-    def get_queryset(self):
-        user = self.request.user if self.request else get_anonymous_user()
-        if user.is_superuser:
-            return super().get_queryset()
-        return super().get_queryset().filter(user=user.pk)
 
 
 class RefreshTokenViewSet(
@@ -93,16 +88,11 @@ class RefreshTokenViewSet(
     filterset_fields = ["user", "provider"]
     ordering = ["provider", "expires"]
     filter_backends = [
+        ObjectFilter,
         DjangoFilterBackend,
         OrderingFilter,
         SearchFilter,
     ]
-
-    def get_queryset(self):
-        user = self.request.user if self.request else get_anonymous_user()
-        if user.is_superuser:
-            return super().get_queryset()
-        return super().get_queryset().filter(user=user.pk)
 
 
 class AccessTokenViewSet(
@@ -119,13 +109,8 @@ class AccessTokenViewSet(
     filterset_fields = ["user", "provider"]
     ordering = ["provider", "expires"]
     filter_backends = [
+        ObjectFilter,
         DjangoFilterBackend,
         OrderingFilter,
         SearchFilter,
     ]
-
-    def get_queryset(self):
-        user = self.request.user if self.request else get_anonymous_user()
-        if user.is_superuser:
-            return super().get_queryset()
-        return super().get_queryset().filter(user=user.pk)

--- a/authentik/providers/oauth2/tests/test_api.py
+++ b/authentik/providers/oauth2/tests/test_api.py
@@ -5,16 +5,20 @@ from sys import version_info
 from unittest import skipUnless
 
 from django.urls import reverse
+from django.utils import timezone
 from rest_framework.test import APITestCase
 
 from authentik.blueprints.tests import apply_blueprint
 from authentik.core.models import Application
-from authentik.core.tests.utils import create_test_admin_user, create_test_flow
+from authentik.core.tests.utils import create_test_admin_user, create_test_flow, create_test_user
 from authentik.lib.generators import generate_id
 from authentik.providers.oauth2.models import (
+    AccessToken,
+    AuthorizationCode,
     OAuth2Provider,
     RedirectURI,
     RedirectURIMatchingMode,
+    RefreshToken,
     ScopeMapping,
 )
 
@@ -51,6 +55,54 @@ class TestAPI(APITestCase):
         self.assertEqual(response.status_code, 200)
         body = loads(response.content.decode())
         self.assertEqual(body["issuer"], "http://testserver/application/o/test/")
+
+    def test_global_token_view_permission(self):
+        """Test that global view permissions are honored for all grant APIs"""
+        service_account = create_test_user()
+        token_owner = create_test_user()
+        self.client.force_login(service_account)
+
+        grants = [
+            (
+                AuthorizationCode,
+                "authorization_codes",
+                "authorizationcode",
+                {"code": generate_id()},
+            ),
+            (
+                RefreshToken,
+                "refresh_tokens",
+                "refreshtoken",
+                {"token": generate_id(), "_id_token": "{}"},
+            ),
+            (
+                AccessToken,
+                "access_tokens",
+                "accesstoken",
+                {"token": generate_id(), "_id_token": "{}"},
+            ),
+        ]
+        for model, endpoint, model_name, fields in grants:
+            for action in ("view", "delete"):
+                service_account.assign_perms_to_managed_role(
+                    f"authentik_providers_oauth2.{action}_{model_name}"
+                )
+            grant = model.objects.create(
+                provider=self.provider,
+                user=token_owner,
+                auth_time=timezone.now(),
+                expiring=False,
+                **fields,
+            )
+
+            response = self.client.get(f"/api/v3/oauth2/{endpoint}/")
+
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json()["results"][0]["user"]["pk"], token_owner.pk)
+
+            response = self.client.delete(f"/api/v3/oauth2/{endpoint}/{grant.pk}/")
+
+            self.assertEqual(response.status_code, 204)
 
     # https://github.com/goauthentik/authentik/pull/5918
     @skipUnless(version_info >= (3, 11, 4), "This behaviour is only Python 3.11.4 and up")


### PR DESCRIPTION
## Details

### What does this PR change?

Restore the RBAC object filter on the authorization-code, refresh-token, and access-token API viewsets. Remove the user-only queryset restriction that prevented globally authorized service accounts from viewing or deleting grants belonging to other users.

### Why is this change needed?

These viewsets override the repository-wide filter backends and then restrict non-superusers to their own grants. As a result, a service account with global `view_*` or `delete_*` OAuth2 grant permissions cannot perform least-privilege token administration. This blocks use cases such as revoking a user's refresh tokens during logout-all-devices workflows.

The regression test covers list and delete access for all three grant APIs using a non-superuser with only the corresponding global permissions.

### How was this tested?

- `ruff check authentik/providers/oauth2/api/tokens.py authentik/providers/oauth2/tests/test_api.py`
- `black --check authentik/providers/oauth2/api/tokens.py authentik/providers/oauth2/tests/test_api.py`
- `python3 -m compileall -q authentik/providers/oauth2/api/tokens.py authentik/providers/oauth2/tests/test_api.py`
- `git diff --check`

The targeted pytest was attempted, but dependency provisioning stalled in the isolated environment before the test could start.

### Linked issues

Closes #24374

---

## Checklist

-   [x] The project files changed in this PR have been linted and formatted
-   [ ] The full project test suite has been run
-   [ ] The documentation has been updated and formatted (`make docs`)
