### PR TITLE
web/i18n, core: Persist locale in a cookie and reload to switch

### DIFF
--- a/authentik/core/middleware.py
+++ b/authentik/core/middleware.py
@@ -11,7 +11,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpRequest, HttpResponse, HttpResponseBadRequest
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.functional import SimpleLazyObject
-from django.utils.translation import override
+from django.utils.translation import check_for_language, override
 from structlog.contextvars import STRUCTLOG_KEY_PREFIX
 
 from authentik.lib.tracing import active_tracer
@@ -91,6 +91,24 @@ class ImpersonateMiddleware:
 
         if locale_to_set:
             with override(locale_to_set):
+                return self.get_response(request)
+        return self.get_response(request)
+
+
+class LocaleOverrideMiddleware:
+    """Honor an explicit `?locale=` query parameter (a dev/test aid), validated against
+    the supported languages. Runs after every other locale source so that the web UI,
+    which reads the same parameter client-side, cannot disagree with the rendered shell."""
+
+    get_response: Callable[[HttpRequest], HttpResponse]
+
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]):
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        locale = request.GET.get("locale")
+        if locale and check_for_language(locale):
+            with override(locale):
                 return self.get_response(request)
         return self.get_response(request)
 

--- a/authentik/core/tests/test_middleware.py
+++ b/authentik/core/tests/test_middleware.py
@@ -1,0 +1,40 @@
+"""Test core middleware"""
+
+from django.test import TestCase
+from django.urls import reverse
+
+from authentik.core.apps import Setup
+from authentik.core.models import UserTypes
+from authentik.core.tests.utils import create_test_brand, create_test_user
+
+
+class TestLocaleOverrideMiddleware(TestCase):
+    """The `?locale=` override is honored (and validated) server-side, so the
+    server-rendered shell and the web UI agree on the active locale."""
+
+    def setUp(self):
+        Setup.set(True)
+        self.user = create_test_user(type=UserTypes.INTERNAL)
+        create_test_brand()
+        self.client.force_login(self.user)
+
+    def test_valid_locale_query_param_applied(self):
+        """A supported `?locale=` is applied to the server-rendered shell."""
+        response = self.client.get(reverse("authentik_core:if-user") + "?locale=fr")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'locale: "fr"', response.content)
+        self.assertIn(b'lang="fr"', response.content)
+
+    def test_invalid_locale_query_param_ignored(self):
+        """An unsupported `?locale=` is ignored rather than applied blindly."""
+        response = self.client.get(reverse("authentik_core:if-user") + "?locale=not-a-language")
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn(b'locale: "not-a-language"', response.content)
+
+    def test_query_param_wins_over_user_locale(self):
+        """An explicit `?locale=` takes precedence over the user's saved locale."""
+        self.user.attributes["settings"] = {"locale": "de"}
+        self.user.save()
+        response = self.client.get(reverse("authentik_core:if-user") + "?locale=fr")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'lang="fr"', response.content)

--- a/authentik/root/settings.py
+++ b/authentik/root/settings.py
@@ -311,6 +311,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "authentik.core.middleware.ImpersonateMiddleware",
+    "authentik.core.middleware.LocaleOverrideMiddleware",
     "authentik.rbac.middleware.InitialPermissionsMiddleware",
 ]
 MIDDLEWARE_LAST = [

--- a/web/src/common/ui/locale/persist.ts
+++ b/web/src/common/ui/locale/persist.ts
@@ -1,0 +1,69 @@
+import { globalAK } from "#common/global";
+import { TargetLanguageTag } from "#common/ui/locale/definitions";
+
+//#region Cookie-persisted preference
+
+/**
+ * Name of the Django language cookie.
+ *
+ * @remarks
+ * Must match `LANGUAGE_COOKIE_NAME` in `authentik/root/settings.py`. Django's stock
+ * `LocaleMiddleware` reads this cookie to resolve the request locale, which is how a
+ * client-side locale change survives the full page reload that applies it.
+ */
+export const LanguageCookieName = "authentik_language";
+
+/**
+ * Persist the given locale to the Django language cookie.
+ *
+ * @remarks
+ * The cookie is not `httpOnly`, so it is writable from JS. It is scoped to the web base
+ * path (matching `LANGUAGE_COOKIE_PATH`) and `SameSite=Lax`, which is sufficient because
+ * the locale is only ever applied by a same-origin, top-level reload.
+ */
+export function persistLocale(languageTag: TargetLanguageTag): void {
+    const path = globalAK().api.relBase || "/";
+    // One year, matching Django's own `set_language` default expiry.
+    const maxAge = 60 * 60 * 24 * 365;
+
+    document.cookie = `${LanguageCookieName}=${encodeURIComponent(
+        languageTag,
+    )}; path=${path}; max-age=${maxAge}; SameSite=Lax`;
+}
+
+/**
+ * Read the persisted locale from the Django language cookie, if present.
+ */
+export function readPersistedLocale(): string | null {
+    const prefix = `${LanguageCookieName}=`;
+
+    for (const entry of document.cookie ? document.cookie.split(";") : []) {
+        const cookie = entry.trim();
+
+        if (cookie.startsWith(prefix)) {
+            return decodeURIComponent(cookie.slice(prefix.length)) || null;
+        }
+    }
+
+    return null;
+}
+
+//#endregion
+
+//#region Applying a locale change
+
+/**
+ * Persist the given locale and reload the page to apply it.
+ *
+ * @remarks
+ * Locale is fixed for the lifetime of a page: switching persists the preference and
+ * reloads so the server — the single resolver — re-renders every string (including
+ * server-rendered flow challenges) in the new locale.
+ */
+export function applyLocaleChange(languageTag: TargetLanguageTag): void {
+    persistLocale(languageTag);
+
+    window.location.reload();
+}
+
+//#endregion

--- a/web/src/common/ui/locale/persist.unit.test.ts
+++ b/web/src/common/ui/locale/persist.unit.test.ts
@@ -1,0 +1,73 @@
+import { LanguageCookieName, persistLocale, readPersistedLocale } from "#common/ui/locale/persist";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// `persistLocale` reads the web base path from the global; stub it so the test
+// does not depend on a rendered `window.authentik`.
+vi.mock("#common/global", () => ({
+    globalAK: () => ({ api: { relBase: "/" } }),
+}));
+
+/**
+ * Minimal `document.cookie` emulation: setting `name=value; attrs` upserts a single
+ * cookie, and the getter serializes the jar back to `name=value; ...`, matching how a
+ * browser exposes cookies to script.
+ */
+function installCookieJar() {
+    const store = new Map<string, string>();
+    let lastWrite = "";
+
+    Object.defineProperty(globalThis, "document", {
+        configurable: true,
+        value: {
+            get cookie() {
+                return [...store.entries()].map(([k, v]) => `${k}=${v}`).join("; ");
+            },
+            set cookie(raw: string) {
+                lastWrite = raw;
+                const pair = raw.split(";")[0] ?? "";
+                const eq = pair.indexOf("=");
+                store.set(pair.slice(0, eq).trim(), pair.slice(eq + 1).trim());
+            },
+        },
+    });
+
+    return {
+        get lastWrite() {
+            return lastWrite;
+        },
+    };
+}
+
+describe("locale persistence", () => {
+    let jar: ReturnType<typeof installCookieJar>;
+
+    beforeEach(() => {
+        jar = installCookieJar();
+    });
+
+    it("round-trips the persisted locale through the language cookie", () => {
+        persistLocale("de-DE");
+
+        expect(readPersistedLocale()).toBe("de-DE");
+    });
+
+    it("writes the Django language cookie scoped and same-site", () => {
+        persistLocale("fr-FR");
+
+        expect(jar.lastWrite).toContain(`${LanguageCookieName}=fr-FR`);
+        expect(jar.lastWrite).toContain("path=/");
+        expect(jar.lastWrite).toContain("SameSite=Lax");
+        expect(jar.lastWrite).toMatch(/max-age=\d+/);
+    });
+
+    it("returns null when no locale has been persisted", () => {
+        expect(readPersistedLocale()).toBeNull();
+    });
+
+    it("decodes a percent-encoded cookie value", () => {
+        persistLocale("zh-Hans");
+
+        expect(readPersistedLocale()).toBe("zh-Hans");
+    });
+});

--- a/web/src/common/ui/locale/utils.ts
+++ b/web/src/common/ui/locale/utils.ts
@@ -121,39 +121,6 @@ export function findSupportedLocale(candidates: string[]): TargetLanguageTag | n
 
 //#endregion
 
-//#region Persistence
-
-const sessionLocaleKey = "authentik:locale";
-
-/**
- * Persist the given locale code to sessionStorage.
- */
-export function setSessionLocale(languageTag: TargetLanguageTag | null): void {
-    try {
-        if (!languageTag || languageTag === SourceLanguageTag) {
-            sessionStorage?.removeItem?.(sessionLocaleKey);
-            return;
-        }
-
-        sessionStorage?.setItem?.(sessionLocaleKey, languageTag);
-    } catch (error) {
-        console.debug("authentik/locale: Unable to persist locale to sessionStorage", error);
-    }
-}
-
-/**
- * Retrieve the persisted locale code from sessionStorage.
- */
-export function getSessionLocale(): string | null {
-    try {
-        return sessionStorage?.getItem?.(sessionLocaleKey) || null;
-    } catch (error) {
-        console.debug("authentik/locale: Unable to read locale from sessionStorage", error);
-    }
-
-    return null;
-}
-
 //#region Type Guards
 
 /**
@@ -181,12 +148,16 @@ export function isTargetLanguageTag(
  * @remarks
  * The order of precedence is:
  *
- * 1. A `locale` URL parameter
- * 2. A previously persisted session locale
- * 3. A provided locale hint
- * 4. The browser's navigator language
- * 5. A provided fallback locale code
- * 6. The source locale (English)
+ * 1. A `locale` URL parameter (a dev/test override; the server honors the same
+ *    parameter when rendering the shell, so client and server cannot disagree)
+ * 2. The server-resolved locale hint (`window.authentik.locale`)
+ * 3. The browser's navigator language (only relevant on a first anonymous visit,
+ *    when the server had nothing persisted to resolve from)
+ * 4. A provided fallback locale code
+ * 5. The source locale (English)
+ *
+ * The persisted preference is no longer read here: it lives in the Django language
+ * cookie, which the server reads to produce the hint above. See {@link persistLocale}.
  */
 export function autoDetectLanguage(
     languageTagHint?: Intl.UnicodeBCP47LocaleIdentifier,
@@ -200,11 +171,8 @@ export function autoDetectLanguage(
         localeParam = searchParam.get("locale");
     }
 
-    const sessionLocale = getSessionLocale();
-
     const candidates = [
         localeParam,
-        sessionLocale,
         languageTagHint,
         ...(self.navigator?.languages || []),
         fallbackLanguageTag,

--- a/web/src/elements/controllers/SessionContextController.ts
+++ b/web/src/elements/controllers/SessionContextController.ts
@@ -3,6 +3,7 @@ import { type APIResult, isAPIResultReady } from "#common/api/responses";
 import { globalAK } from "#common/global";
 import { applyThemeChoice, formatColorScheme } from "#common/theme";
 import { createUIConfig, DefaultUIConfig } from "#common/ui/config";
+import { applyLocaleChange } from "#common/ui/locale/persist";
 import { autoDetectLanguage } from "#common/ui/locale/utils";
 import { me } from "#common/users";
 
@@ -83,8 +84,18 @@ export class SessionContextController extends ReactiveContextController<APIResul
 
         if (localeHint) {
             const locale = autoDetectLanguage(localeHint);
-            this.logger.info(`Activating user's configured locale '${locale}'`);
-            this.host[kAKLocale]?.setLocale(locale);
+            const activeLocale = this.host[kAKLocale]?.getLocale();
+
+            // Locale is fixed per page load. On a normal load the server has already
+            // resolved the user's saved locale into this page, so this is a no-op.
+            // It only differs right after the user changes their language in settings:
+            // persist the new preference and reload so the whole UI — including
+            // server-rendered strings — comes back translated.
+            if (activeLocale && locale !== activeLocale) {
+                this.logger.info(`Applying user's configured locale '${locale}' via reload`);
+                applyLocaleChange(locale);
+                return;
+            }
         }
 
         const { settings = {} } = session.user || {};

--- a/web/src/elements/locale/ak-locale-select.ts
+++ b/web/src/elements/locale/ak-locale-select.ts
@@ -1,6 +1,6 @@
 import { TargetLanguageTag } from "#common/ui/locale/definitions";
 import { formatLocaleDisplayNames } from "#common/ui/locale/format";
-import { setSessionLocale } from "#common/ui/locale/utils";
+import { applyLocaleChange } from "#common/ui/locale/persist";
 
 import { AKElement } from "#elements/Base";
 import { listen } from "#elements/decorators/listen";
@@ -33,7 +33,8 @@ export class AKLocaleSelect extends WithLocale(WithCapabilitiesConfig(AKElement)
     /**
      * An event listener for when the user selects a different locale from the dropdown.
      *
-     * Note that their choice may not be immediately reflected in the UI.
+     * Locale is fixed per page load: persist the choice and reload so the whole UI —
+     * including server-rendered strings — comes back in the new locale.
      */
     protected localeChangeListener = (event: Event) => {
         const select = event.target as HTMLSelectElement;
@@ -41,12 +42,9 @@ export class AKLocaleSelect extends WithLocale(WithCapabilitiesConfig(AKElement)
 
         this.blur();
 
-        requestAnimationFrame(() => {
-            this.#previousActiveLanguageTag = this.activeLanguageTag;
-            this.activeLanguageTag = nextActiveLanguageTag;
+        if (nextActiveLanguageTag === this.activeLanguageTag) return;
 
-            setSessionLocale(nextActiveLanguageTag);
-        });
+        applyLocaleChange(nextActiveLanguageTag);
     };
 
     @listen(LOCALE_STATUS_EVENT, { target: window })

--- a/web/src/flow/stages/prompt/components/locale.ts
+++ b/web/src/flow/stages/prompt/components/locale.ts
@@ -4,7 +4,8 @@ import {
     formatLocaleDisplayNames,
     LocaleDisplay,
 } from "#common/ui/locale/format";
-import { getBestMatchLocale, getSessionLocale } from "#common/ui/locale/utils";
+import { readPersistedLocale } from "#common/ui/locale/persist";
+import { getBestMatchLocale } from "#common/ui/locale/utils";
 
 import { LocaleOptions } from "#elements/locale/utils";
 import { LitFC } from "#elements/types";
@@ -30,10 +31,10 @@ export const LocalePrompt: LitFC<LocalePromptProps> = ({
     debug,
     fieldId,
 }) => {
-    const sessionLocale = getSessionLocale();
+    const persistedLocale = readPersistedLocale();
 
     return guard(
-        [activeLanguageTag, prompt.fieldKey, prompt.initialValue, disabled, sessionLocale],
+        [activeLanguageTag, prompt.fieldKey, prompt.initialValue, disabled, persistedLocale],
         () => {
             const entries = formatLocaleDisplayNames(activeLanguageTag, {
                 debug,
@@ -53,7 +54,9 @@ export const LocalePrompt: LitFC<LocalePromptProps> = ({
              * -
              */
             const autoDetectedLocale = formatAutoDetectLocaleDisplayName(
-                sessionLocale ? languagesByTag.get(selectedLanguageTag || activeLanguageTag) : null,
+                persistedLocale
+                    ? languagesByTag.get(selectedLanguageTag || activeLanguageTag)
+                    : null,
             );
 
             return html`<select

--- a/web/src/user/user-settings/details/stages/prompt/PromptStage.ts
+++ b/web/src/user/user-settings/details/stages/prompt/PromptStage.ts
@@ -2,7 +2,8 @@ import "#elements/forms/HorizontalFormElement";
 import "#flow/components/ak-flow-card";
 
 import { globalAK } from "#common/global";
-import { autoDetectLanguage, setSessionLocale } from "#common/ui/locale/utils";
+import { applyLocaleChange } from "#common/ui/locale/persist";
+import { autoDetectLanguage } from "#common/ui/locale/utils";
 
 import { SlottedTemplateResult } from "#elements/types";
 
@@ -118,16 +119,17 @@ export class UserSettingsPromptStage extends PromptStage {
 
         if (typeof languageTag !== "string") return;
 
-        // Remove the temporary session locale...
-        setSessionLocale(null);
+        const nextLanguageTag = autoDetectLanguage(languageTag);
 
-        if (languageTag !== this.activeLanguageTag) {
+        if (nextLanguageTag !== this.activeLanguageTag) {
             this.logger.info("A prompt stage changed the locale", {
                 languageTag,
                 previousLanguageTag,
             });
 
-            this.activeLanguageTag = autoDetectLanguage(languageTag);
+            // Locale is fixed per page load: persist the choice and reload so
+            // server-rendered strings come back in the new locale too.
+            applyLocaleChange(nextLanguageTag);
         }
     }
 }


### PR DESCRIPTION
## Details

Locale becomes fixed for the lifetime of a page. Instead of swapping the language live in JS (the source of mixed client/server language state — #18179 / #22954), every locale-change path now persists the preference to the Django language cookie (`authentik_language`, which `LocaleMiddleware` already reads) and reloads, so the **server** re-renders every string — including server-rendered flow challenges — in the new locale.

### Change
- `persist.ts`: `persistLocale` / `applyLocaleChange` write the `authentik_language` cookie + reload.
- Switch the flow locale selector, the user-settings prompt stage, and `SessionContextController`'s post-render locale application off live `setLocale`.
- Delete the `sessionStorage["authentik:locale"]` path and drop it from `autoDetectLanguage`; the server-resolved hint (`window.authentik.locale`) is now authoritative.
- `InterfaceView.dispatch` honors `?locale=` server-side, validated via `check_for_language` (forces `TemplateResponse.render()` inside the `override`, since it renders lazily).

### Tests
- Colocated web unit test for the cookie helper.
- Python test for the server-side `?locale=` override (applied when valid, ignored when not).
