### PR TITLE
web/i18n, core: prevent flash of untranslated content

### DIFF
--- a/authentik/core/templates/base/skeleton.html
+++ b/authentik/core/templates/base/skeleton.html
@@ -30,6 +30,7 @@
 
         <style data-id="brand-css">{{ brand_css }}</style>
         <script src="{% versioned_script 'dist/poly-%v.js' %}" type="module"></script>
+        {% locale_modulepreload %}
         {% block head %}
         {% endblock %}
         {% for key, value in html_meta.items %}

--- a/authentik/core/templatetags/authentik_core.py
+++ b/authentik/core/templatetags/authentik_core.py
@@ -1,14 +1,78 @@
 """authentik core tags"""
 
+from functools import lru_cache
+from json import JSONDecodeError, loads
+
 from django import template
+from django.contrib.staticfiles import finders
 from django.templatetags.static import static as static_loader
+from django.utils.safestring import mark_safe
+from django.utils.translation import get_language
 
 from authentik import authentik_full_version
 
 register = template.Library()
+
+LOCALE_MANIFEST_PATH = "dist/manifest.json"
+# Neither the source locale nor the pseudo-locale ship a catalog worth preloading.
+SOURCE_LANGUAGE = "en"
+PSEUDO_LOCALE = "en-xa"
 
 
 @register.simple_tag()
 def versioned_script(path: str) -> str:
     """Wrapper around {% static %} tag that supports setting the version"""
     return static_loader(path.replace("%v", authentik_full_version()))
+
+
+@lru_cache
+def read_locale_manifest() -> dict[str, str]:
+    """Read the manifest emitted by the web build, mapping each locale tag to its
+    content-hashed catalog chunk. A missing or malformed manifest is read as no catalogs
+    being known, so the interface still renders, just without the preload."""
+    result = finders.find(LOCALE_MANIFEST_PATH)
+    if not result:
+        return {}
+    try:
+        with open(result, encoding="utf8") as _file:
+            manifest = loads(_file.read())
+    except OSError, JSONDecodeError:
+        return {}
+    if not isinstance(manifest, dict):
+        return {}
+    return manifest
+
+
+def resolve_catalog_tag(manifest: dict[str, str], language_code: str | None) -> str | None:
+    """Map an active language code to a catalog tag in the manifest, mirroring the web
+    client's best match: an exact (case-insensitive) tag wins, otherwise the first catalog
+    sharing the base language."""
+    if not language_code:
+        return None
+    normalized = language_code.lower()
+    by_language_code = {tag.lower(): tag for tag in manifest}
+    if normalized in by_language_code:
+        return by_language_code[normalized]
+    base_language = normalized.split("-", 1)[0]
+    if base_language == SOURCE_LANGUAGE:
+        return None
+    for lowered, tag in by_language_code.items():
+        if lowered == PSEUDO_LOCALE:
+            continue
+        if lowered.split("-", 1)[0] == base_language:
+            return tag
+    return None
+
+
+@register.simple_tag()
+def locale_modulepreload() -> str:
+    """Preload the active locale's catalog chunk, so the browser fetches it before the
+    entry bundle boots instead of after, removing the flash of untranslated content.
+    Emits nothing for the source locale, or when the build manifest is unavailable."""
+    manifest = read_locale_manifest()
+    tag = resolve_catalog_tag(manifest, get_language())
+    if not tag:
+        return ""
+    href = static_loader(f"dist/{manifest[tag]}")
+    # href comes from our own build manifest, not from user input.
+    return mark_safe(f'<link rel="modulepreload" href="{href}">')  # nosec

--- a/authentik/core/tests/test_templatetags.py
+++ b/authentik/core/tests/test_templatetags.py
@@ -1,0 +1,99 @@
+"""Tests for authentik_core template tags"""
+
+from tempfile import NamedTemporaryFile
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.utils import translation
+
+from authentik.core.templatetags.authentik_core import (
+    locale_modulepreload,
+    read_locale_manifest,
+    resolve_catalog_tag,
+)
+
+MANIFEST = {
+    "de-DE": "chunks/de.abc123.js",
+    "fr-FR": "chunks/fr.def456.js",
+    "zh-Hans": "chunks/zhs.789.js",
+    "zh-Hant": "chunks/zht.012.js",
+    "en-XA": "chunks/pseudo.345.js",
+}
+
+MANIFEST_LOADER = "authentik.core.templatetags.authentik_core.read_locale_manifest"
+MANIFEST_FINDER = "authentik.core.templatetags.authentik_core.finders.find"
+
+
+class TestResolveCatalogTag(TestCase):
+    """The Django language code is mapped to a catalog tag present in the manifest."""
+
+    def test_exact_tag_is_returned(self):
+        self.assertEqual(resolve_catalog_tag(MANIFEST, "de-DE"), "de-DE")
+
+    def test_match_is_case_insensitive(self):
+        self.assertEqual(resolve_catalog_tag(MANIFEST, "de-de"), "de-DE")
+        self.assertEqual(resolve_catalog_tag(MANIFEST, "zh-hans"), "zh-Hans")
+
+    def test_base_language_matches_regional_catalog(self):
+        self.assertEqual(resolve_catalog_tag(MANIFEST, "fr"), "fr-FR")
+
+    def test_english_resolves_to_no_catalog(self):
+        self.assertIsNone(resolve_catalog_tag(MANIFEST, "en"))
+
+    def test_english_never_resolves_to_pseudo_locale(self):
+        """`en` must not fall through to the `en-XA` pseudo catalog."""
+        self.assertNotEqual(resolve_catalog_tag(MANIFEST, "en"), "en-XA")
+
+    def test_unknown_language_resolves_to_no_catalog(self):
+        self.assertIsNone(resolve_catalog_tag(MANIFEST, "xx"))
+
+    def test_empty_language_resolves_to_no_catalog(self):
+        self.assertIsNone(resolve_catalog_tag(MANIFEST, ""))
+
+
+class TestReadLocaleManifest(TestCase):
+    """A missing or malformed manifest is read as no catalogs being known, so a stale or
+    half-written build directory cannot take the interface down."""
+
+    def setUp(self):
+        read_locale_manifest.cache_clear()
+        self.addCleanup(read_locale_manifest.cache_clear)
+
+    def test_missing_manifest(self):
+        """A manifest the static finder cannot locate."""
+        with patch(MANIFEST_FINDER, return_value=None):
+            self.assertEqual(read_locale_manifest(), {})
+
+    def test_malformed_manifest(self):
+        """A manifest that is not valid JSON."""
+        with NamedTemporaryFile(mode="w", suffix=".json") as manifest_file:
+            manifest_file.write("{not json")
+            manifest_file.flush()
+            with patch(MANIFEST_FINDER, return_value=manifest_file.name):
+                self.assertEqual(read_locale_manifest(), {})
+
+    def test_unexpected_manifest_shape(self):
+        """A manifest holding valid JSON that is not an object."""
+        with NamedTemporaryFile(mode="w", suffix=".json") as manifest_file:
+            manifest_file.write("[]")
+            manifest_file.flush()
+            with patch(MANIFEST_FINDER, return_value=manifest_file.name):
+                self.assertEqual(read_locale_manifest(), {})
+
+
+class TestLocaleModulePreload(TestCase):
+    """The template tag emits a modulepreload for the active locale's catalog."""
+
+    def test_emits_modulepreload_for_active_locale(self):
+        with patch(MANIFEST_LOADER, return_value=MANIFEST), translation.override("de"):
+            html = locale_modulepreload()
+        self.assertIn('rel="modulepreload"', html)
+        self.assertIn("/static/dist/chunks/de.abc123.js", html)
+
+    def test_emits_nothing_for_english(self):
+        with patch(MANIFEST_LOADER, return_value=MANIFEST), translation.override("en"):
+            self.assertEqual(locale_modulepreload(), "")
+
+    def test_emits_nothing_without_manifest(self):
+        with patch(MANIFEST_LOADER, return_value={}), translation.override("de"):
+            self.assertEqual(locale_modulepreload(), "")

--- a/web/bundler/locale-manifest-plugin/node.js
+++ b/web/bundler/locale-manifest-plugin/node.js
@@ -1,0 +1,97 @@
+/**
+ * @file Locale manifest plugin for ESBuild.
+ *
+ * @import { BaseLogger } from "pino"
+ * @import { Metafile, Plugin } from "esbuild"
+ */
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+import { ConsoleLogger } from "#logger/node";
+import { DistDirectory } from "#paths/node";
+
+const pluginName = "locale-manifest-plugin";
+
+/**
+ * The name of the manifest emitted into {@linkcode DistDirectory}.
+ */
+export const LocaleManifestFileName = "manifest.json";
+
+/**
+ * ESBuild reports each locale catalog as a dynamic-import chunk whose sole "own" input is
+ * `src/locales/<tag>.ts`, i.e. the input identifies the chunk's language tag.
+ */
+const LocaleInputPattern = /(?:^|\/)src\/locales\/([^/]+)\.[cm]?[jt]s$/;
+
+/**
+ * Maps each locale tag to the `dist`-relative path of its catalog chunk.
+ *
+ * @param {Metafile} metafile
+ * @returns {Record<string, string>}
+ */
+function createLocaleManifest(metafile) {
+    /**
+     * @type {Record<string, string>}
+     */
+    const manifest = {};
+
+    for (const [outputPath, output] of Object.entries(metafile.outputs)) {
+        if (!outputPath.endsWith(".js")) continue;
+
+        for (const inputPath of Object.keys(output.inputs)) {
+            const match = LocaleInputPattern.exec(inputPath);
+
+            if (!match) continue;
+
+            // Paths are stored relative to `dist` so the server can resolve them through
+            // `{% static %}`, regardless of the directory the build ran in.
+            const distIndex = outputPath.lastIndexOf("dist/");
+
+            manifest[match[1]] =
+                distIndex === -1 ? outputPath : outputPath.slice(distIndex + "dist/".length);
+
+            break;
+        }
+    }
+
+    return manifest;
+}
+
+/**
+ * @typedef LocaleManifestPluginOptions
+ *
+ * @property {BaseLogger} [logger]
+ */
+
+/**
+ * Emit a manifest mapping each locale tag to its content-hashed catalog chunk.
+ *
+ * The server reads the manifest to `modulepreload` the catalog for the request's locale,
+ * so the chunk is fetched before the entry bundle boots, i.e. without a flash of
+ * untranslated text.
+ *
+ * @param {LocaleManifestPluginOptions} [options]
+ * @returns {Plugin}
+ */
+export function localeManifestPlugin({ logger = ConsoleLogger.child({ name: pluginName }) } = {}) {
+    return {
+        name: pluginName,
+        setup(build) {
+            build.initialOptions.metafile = true;
+
+            build.onEnd(async ({ metafile }) => {
+                if (!metafile) return;
+
+                const manifest = createLocaleManifest(metafile);
+
+                await fs.writeFile(
+                    path.join(DistDirectory, LocaleManifestFileName),
+                    JSON.stringify(manifest, null, 2),
+                );
+
+                logger.info(`Wrote locale manifest (${Object.keys(manifest).length} catalogs)`);
+            });
+        },
+    };
+}

--- a/web/scripts/build-web.mjs
+++ b/web/scripts/build-web.mjs
@@ -14,6 +14,7 @@ import { copyAssets } from "./build-assets.mjs";
  *
  * @import { BuildOptions, Plugin } from "esbuild";
  */
+import { localeManifestPlugin } from "#bundler/locale-manifest-plugin/node";
 import { mdxPlugin } from "#bundler/mdx-plugin/node";
 import { styleLoaderPlugin } from "#bundler/style-loader-plugin/node";
 import { createBundleDefinitions } from "#bundler/utils/node";
@@ -203,6 +204,7 @@ async function doWatch() {
     const buildOptions = createESBuildOptions(entryPoints, [
         ...developmentPlugins,
         styleLoaderPlugin({ logger, watch: true }),
+        localeManifestPlugin({ logger }),
     ]);
 
     const buildContext = await esbuild.context(buildOptions);
@@ -232,7 +234,10 @@ async function doWatch() {
 async function doBuild() {
     logger.info(`🤖 Building entry points:\n\t${entryPointsDescription}`);
 
-    const buildOptions = createESBuildOptions(entryPoints, [styleLoaderPlugin({ logger })]);
+    const buildOptions = createESBuildOptions(entryPoints, [
+        styleLoaderPlugin({ logger }),
+        localeManifestPlugin({ logger }),
+    ]);
 
     await esbuild.build(buildOptions);
 


### PR DESCRIPTION
## Details

This PR preloads the locale catalog, preventing a flash of untranslated text. 

The locale catalog chunk previously downloaded only after the entry bundle booted, so a non-English page briefly rendered in English. The server now tells the browser which catalog to fetch up front.

### Change
- `build-web.mjs`: `localeManifestPlugin` emits `dist/manifest.json` (esbuild metafile → locale tag → content-hashed chunk path), for both build and watch.
- `{% locale_modulepreload %}` template tag reads that manifest (cached in-process, tolerant of a missing/malformed file) and emits `<link rel="modulepreload">` for the request's resolved locale; source locale and `en-XA` emit nothing. Wired into `skeleton.html`.

### Tests
- Template-tag tests: catalog-tag resolution (exact / case-insensitive / base-language / `en` → none / pseudo never auto-matched) and the tag output (emits for active locale, empty for English, empty without a manifest).
