### PR TITLE
web: Fix issues surrounding text field focus behavior.

### DIFF
--- a/web/src/elements/utils/focus.ts
+++ b/web/src/elements/utils/focus.ts
@@ -2,6 +2,8 @@
  * @fileoverview Utilities for DOM element interaction, focus management, and event handling.
  */
 
+import { isInteractiveElement, isInteractiveTextElement } from "#elements/utils/interactivity";
+
 import { createRef, ref, Ref } from "lit/directives/ref.js";
 
 export interface FocusErrorOptions extends ErrorOptions {
@@ -73,7 +75,9 @@ export function isActiveElement(
  *
  * @category DOM
  */
-export function isFocusable(target: Element | null | undefined): target is HTMLElement {
+export function isFocusable<T extends Element | null | undefined>(
+    target: T,
+): target is NonNullable<T> & HTMLElement {
     try {
         assertFocusable(target);
         return true;
@@ -117,4 +121,29 @@ export class FocusTarget<T extends HTMLElement = HTMLElement> {
     public toEventListener(options?: FocusOptions) {
         return () => this.focus(options);
     }
+}
+
+/**
+ * Given a collection of potentially focusable inputs, find the first which is
+ * blank and shaped like an interactive text field.
+ */
+export function findEmptyFocusCandidate<T extends HTMLInputElement | null | undefined>(
+    ...inputs: T[]
+): T | null {
+    const { activeElement } = document;
+    const candidates = inputs.filter(isFocusable);
+
+    if (activeElement !== document.body && isInteractiveElement(activeElement)) {
+        const activeElementIndex = candidates.findIndex((element) => element === activeElement);
+
+        if (activeElementIndex !== -1 && isInteractiveTextElement(activeElement)) {
+            return null;
+        }
+    }
+
+    const blankElements = candidates.filter((element) => !element.value && element.required);
+
+    const [focusTarget] = blankElements;
+
+    return focusTarget || null;
 }

--- a/web/src/elements/utils/interactivity.ts
+++ b/web/src/elements/utils/interactivity.ts
@@ -1,5 +1,5 @@
 export const InteractiveElementsQuery =
-    "[href],input,button,i,[role='button'],select,[tabindex]:not([tabindex='-1'])";
+    "[href],input,button,i,[role='button'],select,textarea,[tabindex]:not([tabindex='-1'])";
 
 export function isInteractiveElement(
     target: EventTarget | Element | null | undefined,
@@ -23,4 +23,36 @@ export function isInteractiveElement(
     return (
         visible && (tabIndex === 0 || tabIndex === -1 || target.matches(InteractiveElementsQuery))
     );
+}
+
+const TextLikeInputTypes = new Set([
+    "text",
+    "url",
+    "password",
+    "email",
+    "date",
+    "month",
+    "week",
+    "number",
+    "tel",
+    "time",
+]);
+
+/**
+ * Type predicate to determine if a given a target element is shaped like a text field.
+ *
+ * @see {@linkcode isInteractiveElement} to narrow the input to this function.
+ */
+export function isInteractiveTextElement(
+    target: HTMLElement,
+): target is HTMLInputElement | HTMLTextAreaElement {
+    if (target instanceof HTMLTextAreaElement) {
+        return true;
+    }
+
+    if (target instanceof HTMLInputElement) {
+        return TextLikeInputTypes.has(target.type);
+    }
+
+    return false;
 }

--- a/web/src/flow/components/ak-flow-password-input.ts
+++ b/web/src/flow/components/ak-flow-password-input.ts
@@ -1,6 +1,5 @@
 import { AKElement } from "#elements/Base";
-import { bound } from "#elements/decorators/bound";
-import { isActiveElement } from "#elements/utils/focus";
+import { isActiveElement, isFocusable } from "#elements/utils/focus";
 
 import { AKFormErrors, ErrorProp } from "#components/ak-field-errors";
 import { AKLabel } from "#components/ak-label";
@@ -147,8 +146,7 @@ export class InputPassword extends AKElement {
      *
      * @param event The event that triggered the visibility toggle.
      */
-    @bound
-    togglePasswordVisibility(event?: PointerEvent) {
+    togglePasswordVisibility = (event?: PointerEvent) => {
         event?.stopPropagation();
         event?.preventDefault();
 
@@ -163,15 +161,14 @@ export class InputPassword extends AKElement {
         input.type = input.type === "password" ? "text" : "password";
 
         this.syncVisibilityToggle(input);
-    }
+    };
 
     /**
      * Listen for key events, synchronizing the caps lock indicators.
      */
-    @bound
-    capsLockListener(event: KeyboardEvent) {
+    capsLockListener = (event: KeyboardEvent) => {
         this.capsLock = event.getModifierState("CapsLock");
-    }
+    };
 
     //#region Lifecycle
 
@@ -238,7 +235,7 @@ export class InputPassword extends AKElement {
      * Must support both older browsers and shadyDom; we'll keep using this in-line,
      * but it'll still be in the scope of the parent element, not an independent shadowDOM.
      */
-    createRenderRoot() {
+    protected override createRenderRoot() {
         return this;
     }
 
@@ -272,7 +269,18 @@ export class InputPassword extends AKElement {
 
         iconElement.classList.remove(Visibility.Mask.icon, Visibility.Reveal.icon);
         iconElement.classList.add(masked ? Visibility.Reveal.icon : Visibility.Mask.icon);
+
+        requestAnimationFrame(this.focus);
     }
+
+    public override focus = (): void => {
+        const inputElement = this.inputRef.value;
+
+        if (isFocusable(inputElement)) {
+            inputElement.focus();
+            inputElement.select();
+        }
+    };
 
     renderVisibilityToggle() {
         if (!this.allowShowPassword) return nothing;
@@ -311,7 +319,7 @@ export class InputPassword extends AKElement {
     }
 
     render() {
-        return html` ${AKLabel({ required: this.required, htmlFor: this.inputID }, this.label)}
+        return html`${AKLabel({ required: this.required, htmlFor: this.inputID }, this.label)}
             <div class="pf-c-form__group">
                 <div class="pf-c-form__group-control">
                     <div class="pf-c-input-group">

--- a/web/src/flow/providers/oauth2/DeviceCode.ts
+++ b/web/src/flow/providers/oauth2/DeviceCode.ts
@@ -38,7 +38,7 @@ export class OAuth2DeviceCode extends BaseStage<
                     ${AKLabel({ required: true, htmlFor: "device-code-input" }, msg("Device Code"))}
 
                     <input
-                        ${this.autofocusTarget.toRef()}
+                        ${this.primaryFocusTarget.toRef()}
                         id="device-code-input"
                         type="text"
                         name="code"

--- a/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStageCode.ts
+++ b/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStageCode.ts
@@ -40,7 +40,7 @@ export class AuthenticatorValidateStageWebCode extends BaseDeviceStage<
                     staticDevice ? msg("Static token") : msg("Authentication code"),
                 )}
                 <input
-                    ${this.autofocusTarget.toRef()}
+                    ${this.primaryFocusTarget.toRef()}
                     id="validation-code-input"
                     aria-describedby="validation-code-help"
                     type="text"

--- a/web/src/flow/stages/base.ts
+++ b/web/src/flow/stages/base.ts
@@ -5,7 +5,7 @@ import { pluckErrorDetail } from "#common/errors/network";
 import { AKElement } from "#elements/Base";
 import { intersectionObserver } from "#elements/decorators/intersection-observer";
 import { WithLocale } from "#elements/mixins/locale";
-import { FocusTarget } from "#elements/utils/focus";
+import { findEmptyFocusCandidate, FocusTarget } from "#elements/utils/focus";
 
 import { FlowUserDetails } from "#flow/FormStatic";
 import { IBaseStage, StageChallengeLike, StageHost } from "#flow/types";
@@ -55,22 +55,35 @@ export abstract class BaseStage<Tin extends StageChallengeLike, Tout = unknown>
     @intersectionObserver()
     public visible = false;
 
-    protected autofocusTarget = new FocusTarget<HTMLInputElement>();
-    focus = this.autofocusTarget.focus;
+    protected primaryFocusTarget = new FocusTarget<HTMLInputElement>();
+    protected secondaryFocusTarget = new FocusTarget<HTMLInputElement>();
+
+    public override focus = (): void => {
+        const focusTarget = findEmptyFocusCandidate(
+            this.primaryFocusTarget.target,
+            this.secondaryFocusTarget.target,
+        );
+
+        if (!focusTarget) {
+            this.logger.info("Skipping focus. No empty candidate.");
+            return;
+        }
+
+        this.logger.info("Attempting to focus");
+        focusTarget.focus();
+    };
 
     #visibilityListener = () => {
         if (document.visibilityState !== "visible") return;
         if (!this.visible) return;
 
-        if (!this.autofocusTarget.target) return;
-
-        this.autofocusTarget.focus();
+        this.focus();
     };
 
     public override connectedCallback(): void {
         super.connectedCallback();
 
-        this.addEventListener("focus", this.autofocusTarget.toEventListener());
+        this.addEventListener("focus", this.focus);
 
         document.addEventListener("visibilitychange", this.#visibilityListener);
     }
@@ -78,7 +91,7 @@ export abstract class BaseStage<Tin extends StageChallengeLike, Tout = unknown>
     public override disconnectedCallback(): void {
         super.disconnectedCallback();
 
-        this.removeEventListener("focus", this.autofocusTarget.toEventListener());
+        this.removeEventListener("focus", this.focus);
 
         document.removeEventListener("visibilitychange", this.#visibilityListener);
     }
@@ -88,13 +101,10 @@ export abstract class BaseStage<Tin extends StageChallengeLike, Tout = unknown>
 
         // We're especially mindful of how often this runs to avoid
         // unnecessary focus and in-fighting between the user's chosen focus target.
-        if (
-            changed.has("visible") &&
-            changed.get("visible") !== this.visible &&
-            this.visible &&
-            this.autofocusTarget.target
-        ) {
-            this.autofocusTarget.focus();
+        if (changed.has("visible") && changed.get("visible") !== this.visible && this.visible) {
+            requestAnimationFrame(() => {
+                this.focus();
+            });
         }
     }
 

--- a/web/src/flow/stages/identification/IdentificationStage.ts
+++ b/web/src/flow/stages/identification/IdentificationStage.ts
@@ -34,7 +34,7 @@ import { kebabCase } from "change-case";
 
 import { msg, str } from "@lit/localize";
 import { html, nothing, PropertyValues, ReactiveControllerHost } from "lit";
-import { createRef, ref } from "lit-html/directives/ref.js";
+import { ref } from "lit-html/directives/ref.js";
 import { customElement, property } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
 
@@ -80,8 +80,6 @@ export class IdentificationStage extends BaseStage<
     @property({ type: String, attribute: "input-id" })
     public inputID = "ak-identifier-input";
 
-    protected passwordFieldRef = createRef<HTMLInputElement>();
-
     #form?: HTMLFormElement;
 
     public defaultUserIdentification: string | null = null;
@@ -118,12 +116,9 @@ export class IdentificationStage extends BaseStage<
             });
 
             this.#createHelperForm();
-        }
-    }
 
-    public override connectedCallback(): void {
-        super.connectedCallback();
-        this.addEventListener("focus", this.autofocusTarget.toEventListener());
+            this.focus();
+        }
     }
 
     public override disconnectedCallback(): void {
@@ -132,7 +127,9 @@ export class IdentificationStage extends BaseStage<
         cancelAnimationFrame(this.#prepareRememberMeFrame);
     }
 
-    public override firstUpdated(): void {
+    public override firstUpdated(changedProperties: PropertyValues<this>): void {
+        super.firstUpdated(changedProperties);
+
         this.focus();
     }
 
@@ -155,8 +152,8 @@ export class IdentificationStage extends BaseStage<
         if (!this.rememberMeController) {
             this.rememberMeController = new RememberMeController(this, {
                 identificationFieldID: this.inputID,
-                identificationFieldRef: this.autofocusTarget.reference,
-                passwordFieldRef: this.passwordFieldRef,
+                identificationFieldRef: this.primaryFocusTarget.reference,
+                passwordFieldRef: this.secondaryFocusTarget.reference,
                 pendingUserIdentifier,
             });
 
@@ -266,7 +263,7 @@ export class IdentificationStage extends BaseStage<
     protected override onSubmitFailure(): void {
         this.#captcha.onFailure();
 
-        const passwordField = this.passwordFieldRef.value;
+        const passwordField = this.secondaryFocusTarget.target;
 
         if (passwordField) {
             passwordField.focus();
@@ -300,7 +297,7 @@ export class IdentificationStage extends BaseStage<
         }
 
         return html`<input
-            ${ref(this.autofocusTarget.reference)}
+            ${ref(this.primaryFocusTarget.reference)}
             id=${id}
             type=${type}
             name="uidField"
@@ -320,7 +317,7 @@ export class IdentificationStage extends BaseStage<
     protected renderPasswordFields(challenge: IdentificationChallenge) {
         const { allowShowPassword } = challenge;
         return html`<ak-flow-input-password
-            .inputRef=${this.passwordFieldRef}
+            .inputRef=${this.secondaryFocusTarget.reference}
             label=${msg("Password")}
             input-id="ak-stage-identification-password"
             class="pf-c-form__group"

--- a/web/src/flow/stages/identification/controllers/RememberMeController.ts
+++ b/web/src/flow/stages/identification/controllers/RememberMeController.ts
@@ -2,6 +2,7 @@ import { StorageAccessor } from "#common/storage";
 import { getCookie } from "#common/utils";
 
 import { ReactiveElementHost } from "#elements/types";
+import { findEmptyFocusCandidate } from "#elements/utils/focus";
 
 import type { IdentificationStage } from "#flow/stages/identification/IdentificationStage";
 
@@ -156,7 +157,7 @@ export class RememberMeController implements ReactiveController {
             return;
         }
 
-        const focusTarget = passwordField && usernameField?.value ? passwordField : usernameField;
+        const focusTarget = findEmptyFocusCandidate(usernameField, passwordField);
 
         if (focusTarget) {
             focusTarget.focus();


### PR DESCRIPTION
## Details

This PR fixes several issues surrounding our text field focusing, such as:

- When moving between partially completed forms on the identification stage
- When tabbing in and out of the browser to copy a password from a password manager
- When using the keyboard to move between form elements
- When toggling the password field's visibility