### PR TITLE
web/flow: fix remember-me being cleared by CSRF token rotation

### DIFF
--- a/web/src/flow/stages/identification/controllers/RememberMeController.ts
+++ b/web/src/flow/stages/identification/controllers/RememberMeController.ts
@@ -67,6 +67,12 @@ export class RememberMeController implements ReactiveController {
     protected logger = ConsoleLogger.prefix("controller/remember-me");
     protected autoSubmitAttempts = 0;
 
+    /**
+     * Whether the feature is currently on, seeded from {@linkcode defaultChecked} so that a
+     * returning user records keystrokes without having to re-toggle the switch.
+     */
+    protected rememberMeEnabled: boolean;
+
     constructor(
         protected host: ReactiveElementHost<IdentificationStage>,
         {
@@ -90,14 +96,25 @@ export class RememberMeController implements ReactiveController {
             persistedUserIdentifier || this.host.challenge?.pendingUserIdentifier || null;
 
         this.defaultChecked = !!persistedUserIdentifier;
+        this.rememberMeEnabled = this.defaultChecked;
     }
 
-    // After the page is updated, if everything is ready to go, do the autosubmit.
+    // After the page is updated, reconcile the keystroke listener against the current state, then,
+    // if everything is ready to go, do the autosubmit.
+    //
+    // The listener is bound here rather than in `hostConnected` because the username field is
+    // reached through a `ref`, which Lit only populates once the host has rendered.
     public hostUpdated() {
+        this.#reconcileUsernameInputListener();
+
         if (this.canAutoSubmit() && this.autoSubmitAttempts === 0) {
             this.autoSubmitAttempts++;
             this.host.submitForm?.();
         }
+    }
+
+    public hostDisconnected() {
+        this.#detachUsernameInputListener();
     }
 
     //#region Event Listeners
@@ -112,6 +129,45 @@ export class RememberMeController implements ReactiveController {
             RememberMeStorage.user.write(value);
         });
     };
+
+    /**
+     * The username field the keystroke listener is currently bound to, if any.
+     *
+     * Tracked so that reconciliation is idempotent across re-renders, and so the listener follows
+     * the field if Lit swaps in a new element.
+     */
+    #attachedUsernameField: HTMLInputElement | null = null;
+
+    /**
+     * Bind or unbind the keystroke listener so it matches {@linkcode rememberMeEnabled}.
+     */
+    #reconcileUsernameInputListener() {
+        const { usernameField } = this;
+
+        if (!this.rememberMeEnabled || !usernameField) {
+            this.#detachUsernameInputListener();
+            return;
+        }
+
+        this.#attachUsernameInputListener(usernameField);
+    }
+
+    #attachUsernameInputListener(usernameField: HTMLInputElement) {
+        if (this.#attachedUsernameField === usernameField) return;
+
+        this.#detachUsernameInputListener();
+
+        usernameField.addEventListener("input", this.inputListener, {
+            passive: true,
+        });
+
+        this.#attachedUsernameField = usernameField;
+    }
+
+    #detachUsernameInputListener() {
+        this.#attachedUsernameField?.removeEventListener("input", this.inputListener);
+        this.#attachedUsernameField = null;
+    }
 
     //#endregion
 
@@ -131,13 +187,16 @@ export class RememberMeController implements ReactiveController {
         const checkbox = event.target as HTMLInputElement;
         const { usernameField, passwordField } = this;
 
+        this.rememberMeEnabled = checkbox.checked;
+
         if (!checkbox.checked) {
             this.logger.debug("Disabling remember me");
 
             RememberMeStorage.reset();
 
+            this.#detachUsernameInputListener();
+
             if (usernameField) {
-                usernameField.removeEventListener("input", this.inputListener);
                 usernameField.focus();
                 usernameField.select();
             }
@@ -161,9 +220,7 @@ export class RememberMeController implements ReactiveController {
 
         RememberMeStorage.user.write(usernameField.value);
 
-        usernameField.addEventListener("input", this.inputListener, {
-            passive: true,
-        });
+        this.#attachUsernameInputListener(usernameField);
     };
 
     /**

--- a/web/src/flow/stages/identification/controllers/RememberMeController.ts
+++ b/web/src/flow/stages/identification/controllers/RememberMeController.ts
@@ -1,5 +1,4 @@
 import { StorageAccessor } from "#common/storage";
-import { getCookie } from "#common/utils";
 
 import { ReactiveElementHost } from "#elements/types";
 
@@ -13,15 +12,14 @@ import { createRef, Ref } from "lit-html/directives/ref.js";
 
 export class RememberMeStorage {
     static readonly user = StorageAccessor.local("authentik-remember-me-user");
+    /**
+     * @deprecated Retained only to clean up state written by earlier versions.
+     */
     static readonly session = StorageAccessor.local("authentik-remember-me-session");
     static reset = () => {
         this.user.delete();
         this.session.delete();
     };
-}
-
-function readSessionID() {
-    return (getCookie("authentik_csrf") ?? "").substring(0, 8);
 }
 
 export interface RememberMeControllerInit {
@@ -44,9 +42,8 @@ export interface RememberMeControllerInit {
  * phase. If not present: record the username as it is typed in, and store it when the user proceeds
  * to the next phase.
  *
- * Uses a "we've been here before during the current session" heuristic to determine if the user
- * came back to this view after reaching the identity proof phase, indicating they pressed the "not
- * you?" link, at which point it begins again to record the username as it is typed in.
+ * The stored username is only cleared by an explicit user action: switching the toggle off, or
+ * following the "Not you?" link, which calls {@linkcode RememberMeStorage.reset}.
  */
 export class RememberMeController implements ReactiveController {
     static readonly styles = [
@@ -69,7 +66,6 @@ export class RememberMeController implements ReactiveController {
 
     protected logger = ConsoleLogger.prefix("controller/remember-me");
     protected autoSubmitAttempts = 0;
-    protected currentSessionID = readSessionID();
 
     constructor(
         protected host: ReactiveElementHost<IdentificationStage>,
@@ -83,12 +79,10 @@ export class RememberMeController implements ReactiveController {
         this.passwordFieldRef = passwordFieldRef || null;
         this.identificationFieldID = identificationFieldID;
 
-        const persistedSessionID = RememberMeStorage.session.read();
-
-        if (persistedSessionID && persistedSessionID !== this.currentSessionID) {
-            this.logger.debug("Session ID mismatch, clearing remembered username");
-            RememberMeStorage.user.delete();
-        }
+        // Discard state written by earlier versions, which keyed the remembered username to a
+        // CSRF-derived session ID. Django rotates the CSRF token on every successful login, so
+        // that value can never match on a subsequent visit.
+        RememberMeStorage.session.delete();
 
         const persistedUserIdentifier = RememberMeStorage.user.read();
 
@@ -166,7 +160,6 @@ export class RememberMeController implements ReactiveController {
         this.logger.debug("Enabling remember me for user");
 
         RememberMeStorage.user.write(usernameField.value);
-        RememberMeStorage.session.write(this.currentSessionID);
 
         usernameField.addEventListener("input", this.inputListener, {
             passive: true,

--- a/web/src/flow/stages/identification/controllers/RememberMeController.unit.test.ts
+++ b/web/src/flow/stages/identification/controllers/RememberMeController.unit.test.ts
@@ -1,0 +1,117 @@
+import type { ReactiveElementHost } from "#elements/types";
+
+import type { IdentificationStage } from "#flow/stages/identification/IdentificationStage";
+
+import type { IdentificationChallenge } from "@goauthentik/api";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createRef } from "lit-html/directives/ref.js";
+
+const USER_KEY = "authentik-remember-me-user";
+const SESSION_KEY = "authentik-remember-me-session";
+
+class MemoryStorage implements Storage {
+    #items = new Map<string, string>();
+
+    public get length() {
+        return this.#items.size;
+    }
+
+    public key(index: number) {
+        return [...this.#items.keys()][index] ?? null;
+    }
+
+    public getItem(key: string) {
+        return this.#items.get(key) ?? null;
+    }
+
+    public setItem(key: string, value: string) {
+        this.#items.set(key, value);
+    }
+
+    public removeItem(key: string) {
+        this.#items.delete(key);
+    }
+
+    public clear() {
+        this.#items.clear();
+    }
+}
+
+const localStorage = new MemoryStorage();
+
+vi.stubGlobal("self", { localStorage });
+vi.stubGlobal("localStorage", localStorage);
+vi.stubGlobal("document", { cookie: "authentik_csrf=NEWTOKEN0123456789" });
+
+// Imported lazily so that the storage stubs above are in place when the module's
+// `StorageAccessor` instances are created.
+const { RememberMeController, RememberMeStorage } =
+    await import("#flow/stages/identification/controllers/RememberMeController");
+
+function createController(challenge?: Partial<IdentificationChallenge>) {
+    const host = {
+        challenge,
+    } as ReactiveElementHost<IdentificationStage>;
+
+    return new RememberMeController(host, {
+        pendingUserIdentifier: null,
+        identificationFieldRef: createRef<HTMLInputElement>(),
+        passwordFieldRef: null,
+        identificationFieldID: "identification",
+    });
+}
+
+describe("RememberMeController", () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it("prefills the remembered username", () => {
+        localStorage.setItem(USER_KEY, "user@example.com");
+
+        const controller = createController();
+
+        expect(controller.defaultUserIdentification).toBe("user@example.com");
+        expect(controller.defaultChecked).toBe(true);
+    });
+
+    it("keeps the remembered username after the CSRF token rotates", () => {
+        // Django rotates the CSRF token on every successful login, so a session ID derived
+        // from it never matches on the next visit. The remembered username must survive.
+        localStorage.setItem(USER_KEY, "user@example.com");
+        localStorage.setItem(SESSION_KEY, "OLDTOKEN");
+
+        const controller = createController();
+
+        expect(controller.defaultUserIdentification).toBe("user@example.com");
+        expect(controller.defaultChecked).toBe(true);
+        expect(localStorage.getItem(USER_KEY)).toBe("user@example.com");
+    });
+
+    it("discards the legacy session ID written by earlier versions", () => {
+        localStorage.setItem(USER_KEY, "user@example.com");
+        localStorage.setItem(SESSION_KEY, "OLDTOKEN");
+
+        createController();
+
+        expect(localStorage.getItem(SESSION_KEY)).toBeNull();
+    });
+
+    it("falls back to the challenge's pending user identifier", () => {
+        const controller = createController({ pendingUserIdentifier: "pending@example.com" });
+
+        expect(controller.defaultUserIdentification).toBe("pending@example.com");
+        expect(controller.defaultChecked).toBe(false);
+    });
+
+    it("clears the remembered username on an explicit reset", () => {
+        localStorage.setItem(USER_KEY, "user@example.com");
+
+        RememberMeStorage.reset();
+
+        expect(createController().defaultUserIdentification).toBeNull();
+        expect(createController().defaultChecked).toBe(false);
+    });
+});

--- a/web/src/flow/stages/identification/controllers/RememberMeController.unit.test.ts
+++ b/web/src/flow/stages/identification/controllers/RememberMeController.unit.test.ts
@@ -43,24 +43,69 @@ const localStorage = new MemoryStorage();
 
 vi.stubGlobal("self", { localStorage });
 vi.stubGlobal("localStorage", localStorage);
-vi.stubGlobal("document", { cookie: "authentik_csrf=NEWTOKEN0123456789" });
+
+// The keystroke listener defers its write to the next frame. Run it inline so tests can assert
+// on storage synchronously.
+vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    callback(0);
+    return 0;
+});
+vi.stubGlobal("cancelAnimationFrame", () => {});
 
 // Imported lazily so that the storage stubs above are in place when the module's
 // `StorageAccessor` instances are created.
 const { RememberMeController, RememberMeStorage } =
     await import("#flow/stages/identification/controllers/RememberMeController");
 
+/**
+ * A stand-in for the username `input`, since unit tests run without a DOM. Only the surface the
+ * controller actually touches is implemented.
+ */
+function createUsernameField(value = "") {
+    const inputListeners = new Set<(event: InputEvent) => void>();
+
+    return {
+        value,
+        addEventListener(_type: string, listener: (event: InputEvent) => void) {
+            inputListeners.add(listener);
+        },
+        removeEventListener(_type: string, listener: (event: InputEvent) => void) {
+            inputListeners.delete(listener);
+        },
+        focus: vi.fn(),
+        select: vi.fn(),
+
+        /**
+         * Simulate the user typing, dispatching an `input` event to whatever the controller bound.
+         */
+        type(nextValue: string) {
+            this.value = nextValue;
+
+            for (const listener of inputListeners) {
+                listener({ target: this } as unknown as InputEvent);
+            }
+        },
+    };
+}
+
 function createController(challenge?: Partial<IdentificationChallenge>) {
     const host = {
         challenge,
     } as ReactiveElementHost<IdentificationStage>;
 
-    return new RememberMeController(host, {
+    const identificationFieldRef = createRef<HTMLInputElement>();
+    const usernameField = createUsernameField();
+
+    identificationFieldRef.value = usernameField as unknown as HTMLInputElement;
+
+    const controller = new RememberMeController(host, {
         pendingUserIdentifier: null,
-        identificationFieldRef: createRef<HTMLInputElement>(),
+        identificationFieldRef,
         passwordFieldRef: null,
         identificationFieldID: "identification",
     });
+
+    return { controller, usernameField };
 }
 
 describe("RememberMeController", () => {
@@ -71,19 +116,20 @@ describe("RememberMeController", () => {
     it("prefills the remembered username", () => {
         localStorage.setItem(USER_KEY, "user@example.com");
 
-        const controller = createController();
+        const { controller } = createController();
 
         expect(controller.defaultUserIdentification).toBe("user@example.com");
         expect(controller.defaultChecked).toBe(true);
     });
 
-    it("keeps the remembered username after the CSRF token rotates", () => {
-        // Django rotates the CSRF token on every successful login, so a session ID derived
-        // from it never matches on the next visit. The remembered username must survive.
+    it("keeps the remembered username despite a stale legacy session ID", () => {
+        // Earlier versions invalidated the username whenever the stored session ID -- derived from
+        // the CSRF token, which Django rotates on every successful login -- failed to match. The
+        // username must now survive that leftover value.
         localStorage.setItem(USER_KEY, "user@example.com");
         localStorage.setItem(SESSION_KEY, "OLDTOKEN");
 
-        const controller = createController();
+        const { controller } = createController();
 
         expect(controller.defaultUserIdentification).toBe("user@example.com");
         expect(controller.defaultChecked).toBe(true);
@@ -100,7 +146,7 @@ describe("RememberMeController", () => {
     });
 
     it("falls back to the challenge's pending user identifier", () => {
-        const controller = createController({ pendingUserIdentifier: "pending@example.com" });
+        const { controller } = createController({ pendingUserIdentifier: "pending@example.com" });
 
         expect(controller.defaultUserIdentification).toBe("pending@example.com");
         expect(controller.defaultChecked).toBe(false);
@@ -111,7 +157,49 @@ describe("RememberMeController", () => {
 
         RememberMeStorage.reset();
 
-        expect(createController().defaultUserIdentification).toBeNull();
-        expect(createController().defaultChecked).toBe(false);
+        expect(createController().controller.defaultUserIdentification).toBeNull();
+        expect(createController().controller.defaultChecked).toBe(false);
+    });
+
+    it("records keystrokes for a returning user who never re-toggles the switch", () => {
+        localStorage.setItem(USER_KEY, "alice@example.com");
+
+        const { controller, usernameField } = createController();
+
+        expect(controller.defaultChecked).toBe(true);
+
+        // Lit populates the field ref during render, so the controller binds on the first update.
+        controller.hostUpdated();
+
+        usernameField.type("bob@example.com");
+
+        expect(localStorage.getItem(USER_KEY)).toBe("bob@example.com");
+    });
+
+    it("stops recording keystrokes once the switch is toggled off", () => {
+        localStorage.setItem(USER_KEY, "alice@example.com");
+
+        const { controller, usernameField } = createController();
+
+        controller.hostUpdated();
+        controller.toggleChangeListener({
+            target: { checked: false },
+        } as unknown as Event);
+
+        usernameField.type("bob@example.com");
+
+        expect(localStorage.getItem(USER_KEY)).toBeNull();
+    });
+
+    it("does not record keystrokes for a first-time visitor", () => {
+        const { controller, usernameField } = createController();
+
+        expect(controller.defaultChecked).toBe(false);
+
+        controller.hostUpdated();
+
+        usernameField.type("bob@example.com");
+
+        expect(localStorage.getItem(USER_KEY)).toBeNull();
     });
 });


### PR DESCRIPTION
### Details

The identification stage's "Remember me on this device" toggle never is cleared on login, the next visit the username is not prefilled and the toggle is unchecked.

`RememberMeController` derived a "session ID" from the first 8 characters of the `authentik_csrf` cookie, stored it alongside the username, and deleted the stored username whenever the two no longer matched. Django rotates the CSRF token on login, so that value can never match on the user's next visit.

**Reproduction (no login required)**

1. Open a flow page with an identification stage that has `enable_remember_me` on.
2. In the browser console: `localStorage.setItem("authentik-remember-me-user", "user@example.com"); localStorage.setItem("authentik-remember-me-session", "OLDTOKEN")`.
3. Reload — `authentik-remember-me-user` is deleted, the field is empty, the toggle unchecked.

**Fix**

The stored username is now cleared only by an explicit user action: switching the toggle off, or following the "Not you?" link, which already calls `RememberMeStorage.reset()` from `FormStatic`. The legacy `authentik-remember-me-session` key is deleted so state written by earlier versions is cleaned up.

Adds `RememberMeController.unit.test.ts` covering the behavior, including a regression case asserting the username survives a rotated CSRF cookie (fails on `main`, passes here).

### Checklist

- [x] Local tests pass (`cd web && pnpm test`)
- [x] The code has been formatted (`make lint-fix`)