### PR TITLE
website/docs: release 2026.8: clarify hash_password prompt wording

### DIFF
--- a/website/docs/releases/2026/v2026.8.md
+++ b/website/docs/releases/2026/v2026.8.md
@@ -17,7 +17,7 @@ slug: "/releases/2026.8"
 
 ### `hash_password` management command security improvements
 
-The `hash_password` management command no longer accepts a password as a positional command-line argument. Run the command without arguments to enter the password at a hidden interactive prompt:
+The `hash_password` management command no longer accepts a password as a positional command-line argument (password was visible in the process list). Run the command without arguments to enter the password in a hidden interactive prompt:
 
 ```bash
 docker compose run --rm server hash_password


### PR DESCRIPTION

<img width="500" height="517" alt="az53er" src="https://github.com/user-attachments/assets/39cc6d97-46f9-4ac3-b96b-f4557dc9f4ab" />

Ironically took 5 times longer than a manual edit would have taken. 

Clarify the 2026.8 hash_password breaking-change note:
- keep calling it the hash_password management command
- at → in a hidden interactive prompt
- note that the password was visible in the process list, before the second sentence