### PR TITLE
web/policies: add last updated column to policies list

### DIFF
--- a/authentik/policies/api/policies.py
+++ b/authentik/policies/api/policies.py
@@ -69,6 +69,7 @@ class PolicySerializer(ModelSerializer, MetaNameSerializer):
             "verbose_name_plural",
             "meta_model_name",
             "bound_to",
+            "last_updated",
         ]
         depth = 3
 
@@ -91,6 +92,7 @@ class PolicyViewSet(
     }
     search_fields = ["name"]
     ordering = ["name"]
+    ordering_fields = ["name", "last_updated"]
 
     def get_queryset(self):  # pragma: no cover
         return Policy.objects.select_subclasses().prefetch_related("bindings", "promptstage_set")

--- a/web/src/admin/policies/PolicyListPage.ts
+++ b/web/src/admin/policies/PolicyListPage.ts
@@ -18,7 +18,7 @@ import { aki } from "#common/api/client";
 import { IconEditButtonByTagName, modalInvoker } from "#elements/dialogs";
 import { IconPermissionButton } from "#elements/dialogs/components/IconPermissionButton";
 import { PFColor } from "#elements/Label";
-import { PaginatedResponse, TableColumn } from "#elements/table/Table";
+import { PaginatedResponse, TableColumn, Timestamp } from "#elements/table/Table";
 import { TablePage } from "#elements/table/TablePage";
 import { SlottedTemplateResult } from "#elements/types";
 
@@ -55,6 +55,7 @@ export class PolicyListPage extends TablePage<Policy> {
         // ---
         [msg("Name"), "name"],
         [msg("Type")],
+        [msg("Last updated"), "last_updated"],
         [msg("Actions")],
     ];
 
@@ -69,6 +70,7 @@ export class PolicyListPage extends TablePage<Policy> {
                           ${msg("Warning: Policy is not assigned.")}
                       </ak-label>`}`,
             html`${item.verboseName}`,
+            Timestamp((item as Policy & { lastUpdated?: Date }).lastUpdated),
             html`<div class="ak-c-table__actions">
                 ${IconEditButtonByTagName(item.component, item.pk)}
                 ${IconPermissionButton(item.name, {


### PR DESCRIPTION
## Fixes
#24224

## Description
Policies-only slice of the "Last edited" column request.

`Policy` already inherits `CreatedUpdatedModel.last_updated`. This PR:
- Exposes `last_updated` on `PolicySerializer`
- Allows ordering by `name` and `last_updated`
- Adds a sortable Last updated column on `PolicyListPage`, matching the Reputation Scores `Timestamp(...)` pattern

Other tables (providers, flows, mappings, files) are out of scope and would need model/migration work.

Schema/TS client regen is left for CI / maintainers if required; the UI reads `lastUpdated` from the API response.