### PR TITLE
web/elements/table: show scrollbar instead of overflowing off the page

### DIFF
--- a/web/src/admin/admin-overview/cards/RecentEventsCard.css
+++ b/web/src/admin/admin-overview/cards/RecentEventsCard.css
@@ -3,7 +3,3 @@
     --pf-c-card__title--FontSize: var(--pf-global--FontSize--md);
     --pf-c-card__title--FontWeight: var(--pf-global--FontWeight--bold);
 }
-
-[part="table-container"] {
-    overflow-x: auto;
-}

--- a/web/src/elements/Tabs.css
+++ b/web/src/elements/Tabs.css
@@ -55,10 +55,6 @@ ak-tabs[vertical] {
     [role="tabpanel"] {
         padding-inline-start: 0 !important;
     }
-
-    .pf-c-card__body > *::part(table-container) {
-        overflow-x: auto;
-    }
 }
 
 .pf-c-tabs__link {

--- a/web/src/elements/table/Table.css
+++ b/web/src/elements/table/Table.css
@@ -198,6 +198,7 @@ time {
 
 [part="table-container"] {
     overflow-x: auto;
+    overflow-y: hidden;
 }
 
 .pf-c-table {

--- a/web/src/elements/table/Table.css
+++ b/web/src/elements/table/Table.css
@@ -196,6 +196,10 @@ time {
     display: contents;
 }
 
+[part="table-container"] {
+    overflow-x: auto;
+}
+
 .pf-c-table {
     @container (width > 1200px) {
         --pf-c-table--cell--MinWidth: 9em;

--- a/web/src/styles/authentik/components/Table/table.css
+++ b/web/src/styles/authentik/components/Table/table.css
@@ -28,6 +28,18 @@
     }
 }
 
+.pf-c-table .pf-c-table__check {
+    position: sticky;
+    left: -1px;
+    background: var(--pf-c-table--BackgroundColor);
+    z-index: 1;
+
+    @media (width < 768px) {
+        box-shadow: -0.5px 0px inset var(--pf-global--BorderColor--300);
+        --pf-c-table--m-compact--cell--first-last-child--PaddingLeft: var(--pf-global--spacer--sm);
+    }
+}
+
 .pf-c-table thead .pf-c-table__check {
     text-align: center;
     min-width: 3rem;


### PR DESCRIPTION
## Details
### What does this PR change?

Fixes tables overflowing off the screen on smaller displays.

Before
<img width="2441" height="1484" alt="image" src="https://github.com/user-attachments/assets/e0e7aad6-f059-4294-8b61-999810be80ac" />

After
<img width="1224" height="747" alt="image" src="https://github.com/user-attachments/assets/71766400-b6ac-4354-b26f-b1a488272f44" />


### Why is this change needed?

Some tables overflow off the edge of the screen, making some columns impossible to see.

### How was this tested?
Manual testing.

### Linked issues

Closes #24732

---

## Checklist

-   [x] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
