### PR TITLE
core: declare authorization_flow and invalidation_flow as nullable in root provider list

### DIFF
--- a/authentik/core/api/providers.py
+++ b/authentik/core/api/providers.py
@@ -57,8 +57,7 @@ class ProviderSerializer(ModelSerializer, MetaNameSerializer):
         # providers without their specific type,
         # setting whether authorization_flow/invalidation_flow are required
         # is up to the child serializer
-        extra_kwargs = {
-        }
+        extra_kwargs = {}
         extra_write_kwargs = {
             "authorization_flow": {"required": True, "allow_null": False},
             "invalidation_flow": {"required": True, "allow_null": False},

--- a/authentik/core/api/providers.py
+++ b/authentik/core/api/providers.py
@@ -53,7 +53,13 @@ class ProviderSerializer(ModelSerializer, MetaNameSerializer):
             "verbose_name_plural",
             "meta_model_name",
         ]
+        # This serializer is only a general read serializer for listing/reading
+        # providers without their specific type,
+        # setting whether authorization_flow/invalidation_flow are required
+        # is up to the child serializer
         extra_kwargs = {
+        }
+        extra_write_kwargs = {
             "authorization_flow": {"required": True, "allow_null": False},
             "invalidation_flow": {"required": True, "allow_null": False},
         }

--- a/authentik/enterprise/providers/ws_federation/api/providers.py
+++ b/authentik/enterprise/providers/ws_federation/api/providers.py
@@ -99,7 +99,7 @@ class WSFederationProviderSerializer(EnterpriseRequiredMixin, SAMLProviderSerial
             "url_wsfed",
             "url_issuer",
         ]
-        extra_kwargs = ProviderSerializer.Meta.extra_kwargs
+        extra_kwargs = ProviderSerializer.Meta.extra_write_kwargs
 
 
 class WSFederationProviderViewSet(SAMLProviderViewSet):

--- a/authentik/providers/ldap/api.py
+++ b/authentik/providers/ldap/api.py
@@ -43,7 +43,7 @@ class LDAPProviderSerializer(ProviderSerializer):
             "bind_mode",
             "mfa_support",
         ]
-        extra_kwargs = ProviderSerializer.Meta.extra_kwargs
+        extra_kwargs = ProviderSerializer.Meta.extra_write_kwargs
 
 
 class LDAPProviderFilter(FilterSet):

--- a/authentik/providers/oauth2/api/providers.py
+++ b/authentik/providers/oauth2/api/providers.py
@@ -95,7 +95,7 @@ class OAuth2ProviderSerializer(ProviderSerializer):
             "jwt_federation_sources",
             "jwt_federation_providers",
         ]
-        extra_kwargs = ProviderSerializer.Meta.extra_kwargs
+        extra_kwargs = ProviderSerializer.Meta.extra_write_kwargs
 
 
 class OAuth2ProviderSetupURLs(PassiveSerializer):

--- a/authentik/providers/proxy/api.py
+++ b/authentik/providers/proxy/api.py
@@ -100,7 +100,7 @@ class ProxyProviderSerializer(ProviderSerializer):
             "refresh_token_validity",
             "outpost_set",
         ]
-        extra_kwargs = ProviderSerializer.Meta.extra_kwargs
+        extra_kwargs = ProviderSerializer.Meta.extra_write_kwargs
 
 
 class ProxyProviderViewSet(UsedByMixin, ModelViewSet):

--- a/authentik/providers/radius/api/providers.py
+++ b/authentik/providers/radius/api/providers.py
@@ -52,7 +52,7 @@ class RadiusProviderSerializer(
             "mfa_support",
             "certificate",
         ]
-        extra_kwargs = ProviderSerializer.Meta.extra_kwargs
+        extra_kwargs = ProviderSerializer.Meta.extra_write_kwargs
 
 
 class RadiusProviderViewSet(UsedByMixin, ModelViewSet):

--- a/authentik/providers/saml/api/providers.py
+++ b/authentik/providers/saml/api/providers.py
@@ -286,7 +286,7 @@ class SAMLProviderSerializer(ProviderSerializer):
             "url_slo_post",
             "url_slo_redirect",
         ]
-        extra_kwargs = ProviderSerializer.Meta.extra_kwargs
+        extra_kwargs = ProviderSerializer.Meta.extra_write_kwargs
 
 
 class SAMLMetadataSerializer(PassiveSerializer):

--- a/packages/client-go/model_provider.go
+++ b/packages/client-go/model_provider.go
@@ -26,10 +26,10 @@ type Provider struct {
 	// Flow used for authentication when the associated application is accessed by an un-authenticated user.
 	AuthenticationFlow NullableString `json:"authentication_flow,omitempty"`
 	// Flow used when authorizing this provider.
-	AuthorizationFlow string `json:"authorization_flow"`
+	AuthorizationFlow NullableString `json:"authorization_flow,omitempty"`
 	// Flow used ending the session from a provider.
-	InvalidationFlow string   `json:"invalidation_flow"`
-	PropertyMappings []string `json:"property_mappings,omitempty"`
+	InvalidationFlow NullableString `json:"invalidation_flow,omitempty"`
+	PropertyMappings []string       `json:"property_mappings,omitempty"`
 	// Get object component so that we know how to edit the object
 	Component string `json:"component"`
 	// Internal application name, used in URLs.
@@ -55,12 +55,10 @@ type _Provider Provider
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewProvider(pk int32, name string, authorizationFlow string, invalidationFlow string, component string, assignedApplicationSlug NullableString, assignedApplicationName NullableString, assignedBackchannelApplicationSlug NullableString, assignedBackchannelApplicationName NullableString, verboseName string, verboseNamePlural string, metaModelName string) *Provider {
+func NewProvider(pk int32, name string, component string, assignedApplicationSlug NullableString, assignedApplicationName NullableString, assignedBackchannelApplicationSlug NullableString, assignedBackchannelApplicationName NullableString, verboseName string, verboseNamePlural string, metaModelName string) *Provider {
 	this := Provider{}
 	this.Pk = pk
 	this.Name = name
-	this.AuthorizationFlow = authorizationFlow
-	this.InvalidationFlow = invalidationFlow
 	this.Component = component
 	this.AssignedApplicationSlug = assignedApplicationSlug
 	this.AssignedApplicationName = assignedApplicationName
@@ -171,52 +169,90 @@ func (o *Provider) UnsetAuthenticationFlow() {
 	o.AuthenticationFlow.Unset()
 }
 
-// GetAuthorizationFlow returns the AuthorizationFlow field value
+// GetAuthorizationFlow returns the AuthorizationFlow field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *Provider) GetAuthorizationFlow() string {
-	if o == nil {
+	if o == nil || IsNil(o.AuthorizationFlow.Get()) {
 		var ret string
 		return ret
 	}
-
-	return o.AuthorizationFlow
+	return *o.AuthorizationFlow.Get()
 }
 
-// GetAuthorizationFlowOk returns a tuple with the AuthorizationFlow field value
+// GetAuthorizationFlowOk returns a tuple with the AuthorizationFlow field value if set, nil otherwise
 // and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *Provider) GetAuthorizationFlowOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
-	return &o.AuthorizationFlow, true
+	return o.AuthorizationFlow.Get(), o.AuthorizationFlow.IsSet()
 }
 
-// SetAuthorizationFlow sets field value
+// HasAuthorizationFlow returns a boolean if a field has been set.
+func (o *Provider) HasAuthorizationFlow() bool {
+	if o != nil && o.AuthorizationFlow.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetAuthorizationFlow gets a reference to the given NullableString and assigns it to the AuthorizationFlow field.
 func (o *Provider) SetAuthorizationFlow(v string) {
-	o.AuthorizationFlow = v
+	o.AuthorizationFlow.Set(&v)
 }
 
-// GetInvalidationFlow returns the InvalidationFlow field value
+// SetAuthorizationFlowNil sets the value for AuthorizationFlow to be an explicit nil
+func (o *Provider) SetAuthorizationFlowNil() {
+	o.AuthorizationFlow.Set(nil)
+}
+
+// UnsetAuthorizationFlow ensures that no value is present for AuthorizationFlow, not even an explicit nil
+func (o *Provider) UnsetAuthorizationFlow() {
+	o.AuthorizationFlow.Unset()
+}
+
+// GetInvalidationFlow returns the InvalidationFlow field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *Provider) GetInvalidationFlow() string {
-	if o == nil {
+	if o == nil || IsNil(o.InvalidationFlow.Get()) {
 		var ret string
 		return ret
 	}
-
-	return o.InvalidationFlow
+	return *o.InvalidationFlow.Get()
 }
 
-// GetInvalidationFlowOk returns a tuple with the InvalidationFlow field value
+// GetInvalidationFlowOk returns a tuple with the InvalidationFlow field value if set, nil otherwise
 // and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *Provider) GetInvalidationFlowOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
-	return &o.InvalidationFlow, true
+	return o.InvalidationFlow.Get(), o.InvalidationFlow.IsSet()
 }
 
-// SetInvalidationFlow sets field value
+// HasInvalidationFlow returns a boolean if a field has been set.
+func (o *Provider) HasInvalidationFlow() bool {
+	if o != nil && o.InvalidationFlow.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetInvalidationFlow gets a reference to the given NullableString and assigns it to the InvalidationFlow field.
 func (o *Provider) SetInvalidationFlow(v string) {
-	o.InvalidationFlow = v
+	o.InvalidationFlow.Set(&v)
+}
+
+// SetInvalidationFlowNil sets the value for InvalidationFlow to be an explicit nil
+func (o *Provider) SetInvalidationFlowNil() {
+	o.InvalidationFlow.Set(nil)
+}
+
+// UnsetInvalidationFlow ensures that no value is present for InvalidationFlow, not even an explicit nil
+func (o *Provider) UnsetInvalidationFlow() {
+	o.InvalidationFlow.Unset()
 }
 
 // GetPropertyMappings returns the PropertyMappings field value if set, zero value otherwise.
@@ -466,8 +502,12 @@ func (o Provider) ToMap() (map[string]interface{}, error) {
 	if o.AuthenticationFlow.IsSet() {
 		toSerialize["authentication_flow"] = o.AuthenticationFlow.Get()
 	}
-	toSerialize["authorization_flow"] = o.AuthorizationFlow
-	toSerialize["invalidation_flow"] = o.InvalidationFlow
+	if o.AuthorizationFlow.IsSet() {
+		toSerialize["authorization_flow"] = o.AuthorizationFlow.Get()
+	}
+	if o.InvalidationFlow.IsSet() {
+		toSerialize["invalidation_flow"] = o.InvalidationFlow.Get()
+	}
 	if !IsNil(o.PropertyMappings) {
 		toSerialize["property_mappings"] = o.PropertyMappings
 	}
@@ -494,8 +534,6 @@ func (o *Provider) UnmarshalJSON(data []byte) (err error) {
 	requiredProperties := []string{
 		"pk",
 		"name",
-		"authorization_flow",
-		"invalidation_flow",
 		"component",
 		"assigned_application_slug",
 		"assigned_application_name",

--- a/packages/client-rust/src/models/provider.rs
+++ b/packages/client-rust/src/models/provider.rs
@@ -27,11 +27,21 @@ pub struct Provider {
     )]
     pub authentication_flow: Option<Option<uuid::Uuid>>,
     /// Flow used when authorizing this provider.
-    #[serde(rename = "authorization_flow")]
-    pub authorization_flow: uuid::Uuid,
+    #[serde(
+        rename = "authorization_flow",
+        default,
+        with = "::serde_with::rust::double_option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub authorization_flow: Option<Option<uuid::Uuid>>,
     /// Flow used ending the session from a provider.
-    #[serde(rename = "invalidation_flow")]
-    pub invalidation_flow: uuid::Uuid,
+    #[serde(
+        rename = "invalidation_flow",
+        default,
+        with = "::serde_with::rust::double_option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub invalidation_flow: Option<Option<uuid::Uuid>>,
     #[serde(rename = "property_mappings", skip_serializing_if = "Option::is_none")]
     pub property_mappings: Option<Vec<uuid::Uuid>>,
     /// Get object component so that we know how to edit the object
@@ -77,8 +87,6 @@ impl Provider {
     pub fn new(
         pk: i32,
         name: String,
-        authorization_flow: uuid::Uuid,
-        invalidation_flow: uuid::Uuid,
         component: String,
         assigned_application_slug: Option<String>,
         assigned_application_name: Option<String>,
@@ -92,8 +100,8 @@ impl Provider {
             pk,
             name,
             authentication_flow: None,
-            authorization_flow,
-            invalidation_flow,
+            authorization_flow: None,
+            invalidation_flow: None,
             property_mappings: None,
             component,
             assigned_application_slug,

--- a/packages/client-ts/src/models/Provider.ts
+++ b/packages/client-ts/src/models/Provider.ts
@@ -41,13 +41,13 @@ export interface Provider {
      * @type {string}
      * @memberof Provider
      */
-    authorizationFlow: string;
+    authorizationFlow?: string | null;
     /**
      * Flow used ending the session from a provider.
      * @type {string}
      * @memberof Provider
      */
-    invalidationFlow: string;
+    invalidationFlow?: string | null;
     /**
      *
      * @type {Array<string>}
@@ -110,20 +110,6 @@ export interface Provider {
 export function instanceOfProvider(value: object): value is Provider {
     if (!("pk" in value) || value["pk"] === undefined) return false;
     if (!("name" in value) || value["name"] === undefined) return false;
-    if (
-        (!("authorizationFlow" in (value as Record<string, any>)) &&
-            !("authorization_flow" in (value as Record<string, any>))) ||
-        ((value as Record<string, any>)["authorizationFlow"] === undefined &&
-            (value as Record<string, any>)["authorization_flow"] === undefined)
-    )
-        return false;
-    if (
-        (!("invalidationFlow" in (value as Record<string, any>)) &&
-            !("invalidation_flow" in (value as Record<string, any>))) ||
-        ((value as Record<string, any>)["invalidationFlow"] === undefined &&
-            (value as Record<string, any>)["invalidation_flow"] === undefined)
-    )
-        return false;
     if (!("component" in value) || value["component"] === undefined) return false;
     if (
         (!("assignedApplicationSlug" in (value as Record<string, any>)) &&
@@ -194,8 +180,18 @@ export function ProviderFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
                 : json["authentication_flow"] === null
                   ? null
                   : json["authentication_flow"],
-        authorizationFlow: json["authorization_flow"],
-        invalidationFlow: json["invalidation_flow"],
+        authorizationFlow:
+            json["authorization_flow"] === undefined
+                ? undefined
+                : json["authorization_flow"] === null
+                  ? null
+                  : json["authorization_flow"],
+        invalidationFlow:
+            json["invalidation_flow"] === undefined
+                ? undefined
+                : json["invalidation_flow"] === null
+                  ? null
+                  : json["invalidation_flow"],
         propertyMappings: json["property_mappings"] == null ? undefined : json["property_mappings"],
         component: json["component"],
         assignedApplicationSlug: json["assigned_application_slug"],

--- a/schema.yml
+++ b/schema.yml
@@ -55215,10 +55215,12 @@ components:
         authorization_flow:
           type: string
           format: uuid
+          nullable: true
           description: Flow used when authorizing this provider.
         invalidation_flow:
           type: string
           format: uuid
+          nullable: true
           description: Flow used ending the session from a provider.
         property_mappings:
           type: array
@@ -55266,9 +55268,7 @@ components:
       - assigned_application_slug
       - assigned_backchannel_application_name
       - assigned_backchannel_application_slug
-      - authorization_flow
       - component
-      - invalidation_flow
       - meta_model_name
       - name
       - pk


### PR DESCRIPTION
technically a slightly breaking API change, however to make it more correct

the fields are declared as nullablle to on the database, however required by OIDC/SAML/etc but not required for LDAP/SSF/GWS/Entra

For the listing part we currently return `null` in these fields already and our schema is incorrect