### PR TITLE
web: keep sticky form actions below nav menus

### DIFF
--- a/web/src/elements/forms/Form.css
+++ b/web/src/elements/forms/Form.css
@@ -25,7 +25,7 @@ select[multiple] {
     justify-content: space-between;
     position: sticky;
     inset-block-start: 0;
-    z-index: var(--pf-global--ZIndex--md);
+    z-index: var(--pf-global--ZIndex--xs);
     background: var(--pf-c-card--BackgroundColor);
     padding-block-start: var(--pf-global--spacer--md);
     margin-top: calc(-1 * var(--pf-c-card--first-child--PaddingTop));


### PR DESCRIPTION
the sticky 'Save changes" bar is using overlay z-index (md = 300) which is above patternfly dropdown menus (sm = 200), so it paints over the user menu

Before:

<img width="978" height="484" alt="image" src="https://github.com/user-attachments/assets/1d253237-2ff5-4607-980d-5aa523f6d8ea" />

After:

<img width="463" height="241" alt="image" src="https://github.com/user-attachments/assets/0e5501a6-34dc-4813-a3b9-f153b978f5c7" />