### PR TITLE
core: set days=1 as default token duration for new installs

### DIFF
--- a/authentik/tenants/migrations/0002_tenant_default_token_duration_and_more.py
+++ b/authentik/tenants/migrations/0002_tenant_default_token_duration_and_more.py
@@ -18,7 +18,7 @@ class Migration(migrations.Migration):
             model_name="tenant",
             name="default_token_duration",
             field=models.TextField(
-                default=CONFIG.get("default_token_duration", "minutes=30"),
+                default=CONFIG.get("default_token_duration", "days=1"),
                 help_text="Default token duration",
                 validators=[authentik.lib.utils.time.timedelta_string_validator],
             ),


### PR DESCRIPTION
Closes #25236

`DEFAULT_TOKEN_DURATION` has been `days=1` since #9426, but no default tenant ever got it. `0001` creates the tenant row, `0002` backfills `minutes=30` into it, and `0003` only changes the default for rows inserted later.

This sets the default in `0002` instead, as discussed in the issue. New installs get `days=1`, existing ones are untouched.

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
