### PR TITLE
ci: pin golangci-lint to v2.12.2

### DIFF
--- a/.github/workflows/ci-outpost.yml
+++ b/.github/workflows/ci-outpost.yml
@@ -38,7 +38,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v8
         with:
-          version: latest
+          version: v2.12.2
           args: --timeout 5000s --verbose
           skip-cache: true
   test-unittest:


### PR DESCRIPTION
Fixes CI failures, like [this one](https://github.com/goauthentik/authentik/actions/runs/32350136165/job/96367341192?pr=25351). 

Due to golangci/golangci-lint#6733, caused by dominikh/go-tools#1725.

