### PR TITLE
core: Per-request caching for serialized users

### DIFF
--- a/authentik/core/api/groups.py
+++ b/authentik/core/api/groups.py
@@ -138,6 +138,28 @@ class PartialUserSerializer(ModelSerializer):
     attributes = JSONDictField(required=False)
     uid = CharField(read_only=True)
 
+    def to_representation(self, instance):
+        """Override to use request-level cache for serialized users.
+
+        When the same user appears in multiple groups, we cache their serialized
+        representation to avoid redundant serialization work.
+        """
+        request = self.context.get('request')
+        cache = getattr(request, '_user_serialization_cache', None) if request else None
+        
+        if cache is not None:
+            # Check if already serialized
+            if instance.pk in cache:
+                return cache[instance.pk]
+            
+            # Serialize and cache
+            result = super().to_representation(instance)
+            cache[instance.pk] = result
+            return result
+        
+        # No cache available, serialize normally
+        return super().to_representation(instance)
+
     class Meta:
         model = User
         fields = PARTIAL_USER_SERIALIZER_MODEL_FIELDS + ["uid"]
@@ -209,7 +231,8 @@ class GroupSerializer(AttributesMixinSerializer, ModelSerializer):
     def get_users_obj(self, instance: Group) -> list[PartialUserSerializer] | None:
         if not self._should_include_users:
             return None
-        return PartialUserSerializer(instance.users, many=True).data
+        # Use .all() to access prefetched data and pass context for cache
+        return PartialUserSerializer(instance.users.all(), many=True, context=self.context).data
 
     @extend_schema_field(RelatedGroupSerializer(many=True))
     def get_children_obj(self, instance: Group) -> list[RelatedGroupSerializer] | None:
@@ -369,6 +392,15 @@ class GroupViewSet(UsedByMixin, ModelViewSet):
         SessionAuthentication,
         AgentAuth,
     ]
+
+    def initialize_request(self, request, *args, **kwargs):
+        """Initialize request with a cache for serialized users.
+        This cache prevents re-serializing the same user when they appear in
+        multiple groups within the same request."""
+
+        request = super().initialize_request(request, *args, **kwargs)
+        request._user_serialization_cache = {}
+        return request
 
     def get_ql_fields(self):
         return [


### PR DESCRIPTION
<!--
👋 Hi there! Welcome.

Please check the Contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute
-->

## Details

Improve execution time for calls to groups/.

For situations where a huge number of groups exists and a huge number of users scattered around them, we can save time avoiding re-serialization, if the serialization result for each user is cached by request.

This has the tradeoff of creating a cache per request. The invalidation model is simple as it only lives for the period of the request and therefore it's expected a low-memory footprint , if page_size is within a reasonable value.

<!--
Explain what this PR changes, what the rationale behind the change is, if any new requirements are introduced or any breaking changes caused by this PR.

Ideally also link an Issue for context that this PR will close using `closes #`
-->

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)
