### PR TITLE
web/user: fix missing enterprise check on agents tab in user interface

### DIFF
--- a/web/src/user/ak-interface-user.ts
+++ b/web/src/user/ak-interface-user.ts
@@ -157,8 +157,9 @@ class UserInterface extends WithLicenseSummary(
             navItems.push({ label: msg("Discover"), link: "/requests" });
         }
         if (
-            this.can(CapabilitiesEnum.CanAgentSelfService) &&
-            this.uiConfig.enabledFeatures.agents
+            this.licenseSummary?.status !== LicenseSummaryStatusEnum.Unlicensed &&
+            this.uiConfig.enabledFeatures.agents &&
+            this.can(CapabilitiesEnum.CanAgentSelfService)
         ) {
             navItems.push({ label: msg("Agents"), link: "/agents" });
         }


### PR DESCRIPTION
We accidentally didn't check the current license status